### PR TITLE
perf(cloud): fuse generative credential and balance admission

### DIFF
--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -105,6 +105,7 @@ const requireGenerativeRouteCaller = mock(
   }),
 );
 const charactersGetById = mock();
+const assertInferenceCredentialActive = mock(async () => undefined);
 class InsufficientCreditsError extends Error {
   constructor(
     public readonly required: number,
@@ -123,9 +124,15 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 }));
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: (error: unknown) =>
+    error instanceof ApiError ? error : null,
   getGenerativeExecutionContext: () => undefined,
   resolveInferenceCredentialAdmissionDenial: () => null,
   requireGenerativeRouteCaller,
+}));
+
+mock.module("@/lib/services/inference-credential-revocation", () => ({
+  assertInferenceCredentialActive,
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
@@ -237,6 +244,8 @@ beforeEach(() => {
   markProviderDispatched.mockReset();
   markProviderDispatched.mockResolvedValue(undefined);
   charactersGetById.mockReset();
+  assertInferenceCredentialActive.mockReset();
+  assertInferenceCredentialActive.mockResolvedValue(undefined);
   requireGenerativeRouteCaller.mockReset();
   requireUserOrApiKeyWithOrg.mockReset();
 
@@ -334,8 +343,34 @@ describe("Agent A2A billing", () => {
     expect(streamText).not.toHaveBeenCalled();
     expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(2);
     for (const [, options] of requireGenerativeRouteCaller.mock.calls) {
-      expect(options).toMatchObject({ deferStrongCredentialCheck: false });
+      expect(options).toMatchObject({ deferStrongCredentialCheck: true });
     }
+    expect(assertInferenceCredentialActive).toHaveBeenCalledTimes(2);
+    expect(assertInferenceCredentialActive).toHaveBeenCalledWith(
+      ORG_ID,
+      inferenceCredential,
+    );
+  });
+
+  test("checks the deferred credential once when JSON parsing terminates before any resource or provider work", async () => {
+    const response = await app.request("/agents/agent-1/a2a", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-json",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: -32700, message: "Parse error" },
+    });
+    expect(assertInferenceCredentialActive).toHaveBeenCalledTimes(1);
+    expect(assertInferenceCredentialActive).toHaveBeenCalledWith(
+      ORG_ID,
+      inferenceCredential,
+    );
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
   });
 
   test("standing denial precedes agent lookup and preserves its safe reason", async () => {
@@ -376,6 +411,7 @@ describe("Agent A2A billing", () => {
     expect(admitOrganizationInference).toHaveBeenCalledWith(
       expect.objectContaining({ credential: inferenceCredential }),
     );
+    expect(assertInferenceCredentialActive).not.toHaveBeenCalled();
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
     expect(recordCreatorEarnings).toHaveBeenCalledWith(

--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -86,6 +86,11 @@ const admitOrganizationInference = mock(
     };
   },
 );
+const inferenceCredential = {
+  kind: "api_key" as const,
+  credentialId: "key-1",
+  userId: USER_ID,
+};
 const charactersGetById = mock();
 class InsufficientCreditsError extends Error {
   constructor(
@@ -106,11 +111,13 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   getGenerativeExecutionContext: () => undefined,
+  resolveInferenceCredentialAdmissionDenial: () => null,
   requireGenerativeRouteCaller: async () => ({
     user: { id: USER_ID, organization_id: ORG_ID },
     apiKeyId: null,
     appScopeId: null,
     authSource: "compatibility",
+    credential: inferenceCredential,
   }),
 }));
 
@@ -322,6 +329,9 @@ describe("Agent A2A billing", () => {
     };
 
     expect(response.status).toBe(200);
+    expect(admitOrganizationInference).toHaveBeenCalledWith(
+      expect.objectContaining({ credential: inferenceCredential }),
+    );
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
     expect(recordCreatorEarnings).toHaveBeenCalledWith(

--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -17,6 +17,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 // `mock.module` is process-global: spread the real auth module so this file's
 // partial mock (only `requireUserOrApiKeyWithOrg`) does not drop the other auth
 // exports (e.g. `requireUserOrApiKey`) for later test files in the same run.
@@ -91,6 +92,18 @@ const inferenceCredential = {
   credentialId: "key-1",
   userId: USER_ID,
 };
+const requireGenerativeRouteCaller = mock(
+  async (
+    _c?: unknown,
+    _options?: { deferStrongCredentialCheck?: boolean },
+  ) => ({
+    user: { id: USER_ID, organization_id: ORG_ID },
+    apiKeyId: null,
+    appScopeId: null,
+    authSource: "compatibility" as const,
+    credential: inferenceCredential,
+  }),
+);
 const charactersGetById = mock();
 class InsufficientCreditsError extends Error {
   constructor(
@@ -112,13 +125,7 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   getGenerativeExecutionContext: () => undefined,
   resolveInferenceCredentialAdmissionDenial: () => null,
-  requireGenerativeRouteCaller: async () => ({
-    user: { id: USER_ID, organization_id: ORG_ID },
-    apiKeyId: null,
-    appScopeId: null,
-    authSource: "compatibility",
-    credential: inferenceCredential,
-  }),
+  requireGenerativeRouteCaller,
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
@@ -230,9 +237,17 @@ beforeEach(() => {
   markProviderDispatched.mockReset();
   markProviderDispatched.mockResolvedValue(undefined);
   charactersGetById.mockReset();
+  requireGenerativeRouteCaller.mockReset();
   requireUserOrApiKeyWithOrg.mockReset();
 
   charactersGetById.mockResolvedValue(makeCharacter());
+  requireGenerativeRouteCaller.mockResolvedValue({
+    user: { id: USER_ID, organization_id: ORG_ID },
+    apiKeyId: null,
+    appScopeId: null,
+    authSource: "compatibility",
+    credential: inferenceCredential,
+  });
   requireUserOrApiKeyWithOrg.mockResolvedValue({
     id: USER_ID,
     organization_id: ORG_ID,
@@ -317,6 +332,35 @@ describe("Agent A2A billing", () => {
     });
     expect(reserve).not.toHaveBeenCalled();
     expect(streamText).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(2);
+    for (const [, options] of requireGenerativeRouteCaller.mock.calls) {
+      expect(options).toMatchObject({ deferStrongCredentialCheck: false });
+    }
+  });
+
+  test("standing denial precedes agent lookup and preserves its safe reason", async () => {
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
+      new ApiError(403, "access_denied", "Organization is inactive", {
+        reason: "organization_inactive",
+      }),
+    );
+
+    const response = await app.request("/agents/agent-1/a2a", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-json",
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: -32002,
+        message: "Organization is inactive",
+        data: { reason: "organization_inactive" },
+      },
+      id: null,
+    });
+    expect(charactersGetById).not.toHaveBeenCalled();
   });
 
   test("settles once and records creator earnings on the happy path", async () => {

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 // `mock.module` is process-global: spread the real auth module so this file's
 // partial mock (only `requireUserOrApiKeyWithOrg`) does not drop the other auth
 // exports (e.g. `requireUserOrApiKey`) for later test files in the same run.
@@ -83,6 +85,19 @@ const inferenceCredential = {
   credentialId: "key-1",
   userId: USER_ID,
 };
+const requireGenerativeRouteCaller = mock(
+  async (
+    _c?: unknown,
+    _options?: { deferStrongCredentialCheck?: boolean },
+  ) => ({
+    user: { id: USER_ID, organization_id: ORG_ID },
+    apiKeyId: null,
+    appScopeId: null,
+    authSource: "compatibility" as const,
+    credential: inferenceCredential,
+  }),
+);
+const charactersGetById = mock();
 class InsufficientCreditsError extends Error {
   constructor(
     public readonly required: number,
@@ -103,17 +118,11 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   getGenerativeExecutionContext: () => undefined,
   resolveInferenceCredentialAdmissionDenial: () => null,
-  requireGenerativeRouteCaller: async () => ({
-    user: { id: USER_ID, organization_id: ORG_ID },
-    apiKeyId: null,
-    appScopeId: null,
-    authSource: "compatibility",
-    credential: inferenceCredential,
-  }),
+  requireGenerativeRouteCaller,
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
-  charactersService: { getById: mock() },
+  charactersService: { getById: charactersGetById },
 }));
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
@@ -134,7 +143,12 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
-const { handleToolCall } = await import("../agents/[id]/mcp/route");
+const { default: mcpRoute, handleToolCall } = await import(
+  "../agents/[id]/mcp/route"
+);
+
+const app = new Hono();
+app.route("/agents/:id/mcp", mcpRoute);
 
 function textStream(text: string) {
   return (async function* stream() {
@@ -201,6 +215,16 @@ async function callChat() {
 }
 
 beforeEach(() => {
+  requireGenerativeRouteCaller.mockReset();
+  requireGenerativeRouteCaller.mockResolvedValue({
+    user: { id: USER_ID, organization_id: ORG_ID },
+    apiKeyId: null,
+    appScopeId: null,
+    authSource: "compatibility",
+    credential: inferenceCredential,
+  });
+  charactersGetById.mockReset();
+  charactersGetById.mockResolvedValue(makeCharacter());
   getLanguageModel.mockClear();
   streamText.mockReset();
   resolveAnthropicThinkingBudgetTokens.mockReset();
@@ -230,6 +254,43 @@ beforeEach(() => {
 });
 
 describe("Agent MCP billing", () => {
+  test("standing denial precedes character lookup and preserves its safe reason", async () => {
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
+      new ApiError(403, "access_denied", "Organization is inactive", {
+        reason: "organization_inactive",
+      }),
+    );
+
+    const response = await app.request("/agents/agent-1/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{malformed",
+    });
+    const body = (await response.json()) as {
+      jsonrpc?: string;
+      error?: { code: number; message: string; data?: { reason?: string } };
+      id?: string | number | null;
+    };
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({
+      jsonrpc: "2.0",
+      error: {
+        code: -32002,
+        message: "Organization is inactive",
+        data: { reason: "organization_inactive" },
+      },
+      id: null,
+    });
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
+    expect(charactersGetById).not.toHaveBeenCalled();
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
   test("reserves the marked-up estimate before invoking the model", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
 

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -78,6 +78,11 @@ const admitOrganizationInference = mock(
     };
   },
 );
+const inferenceCredential = {
+  kind: "api_key" as const,
+  credentialId: "key-1",
+  userId: USER_ID,
+};
 class InsufficientCreditsError extends Error {
   constructor(
     public readonly required: number,
@@ -97,11 +102,13 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   getGenerativeExecutionContext: () => undefined,
+  resolveInferenceCredentialAdmissionDenial: () => null,
   requireGenerativeRouteCaller: async () => ({
     user: { id: USER_ID, organization_id: ORG_ID },
     apiKeyId: null,
     appScopeId: null,
     authSource: "compatibility",
+    credential: inferenceCredential,
   }),
 }));
 
@@ -138,6 +145,7 @@ function textStream(text: string) {
 function makeContext() {
   return {
     env: {},
+    get: () => undefined,
     json: (body: unknown, status?: number) =>
       Response.json(body, { status: status ?? 200 }),
   };
@@ -184,7 +192,11 @@ async function callChat() {
       arguments: { message: "hello", model: "gpt-5-mini" },
     },
     "rpc-1",
-    { id: USER_ID, organization_id: ORG_ID },
+    {
+      id: USER_ID,
+      organization_id: ORG_ID,
+      credential: inferenceCredential,
+    },
   );
 }
 
@@ -224,6 +236,9 @@ describe("Agent MCP billing", () => {
     const response = await callChat();
 
     expect(response.status).toBe(200);
+    expect(admitOrganizationInference).toHaveBeenCalledWith(
+      expect.objectContaining({ credential: inferenceCredential }),
+    );
     expect(reserve).toHaveBeenCalledTimes(1);
     const reserveParams = reserve.mock.calls[0]?.[0] as { amount: number };
     expect(reserveParams).toMatchObject({

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -98,6 +98,7 @@ const requireGenerativeRouteCaller = mock(
   }),
 );
 const charactersGetById = mock();
+const assertInferenceCredentialActive = mock(async () => undefined);
 class InsufficientCreditsError extends Error {
   constructor(
     public readonly required: number,
@@ -116,9 +117,15 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 }));
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: (error: unknown) =>
+    error instanceof ApiError ? error : null,
   getGenerativeExecutionContext: () => undefined,
   resolveInferenceCredentialAdmissionDenial: () => null,
   requireGenerativeRouteCaller,
+}));
+
+mock.module("@/lib/services/inference-credential-revocation", () => ({
+  assertInferenceCredentialActive,
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
@@ -171,6 +178,8 @@ function makeCharacter() {
     name: "Markup Agent",
     user_id: "owner-1",
     organization_id: "creator-org",
+    is_public: true,
+    mcp_enabled: true,
     monetization_enabled: true,
     inference_markup_percentage: "500",
     system: null,
@@ -209,8 +218,28 @@ async function callChat() {
     {
       id: USER_ID,
       organization_id: ORG_ID,
-      credential: inferenceCredential,
+      credentialForAdmission: () => inferenceCredential,
     },
+  );
+}
+
+function callRouteChat() {
+  return app.request(
+    "/agents/agent-1/mcp",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          name: "chat",
+          arguments: { message: "hello", model: "gpt-5-mini" },
+        },
+        id: "rpc-1",
+      }),
+    },
+    {},
   );
 }
 
@@ -224,6 +253,8 @@ beforeEach(() => {
     credential: inferenceCredential,
   });
   charactersGetById.mockReset();
+  assertInferenceCredentialActive.mockReset();
+  assertInferenceCredentialActive.mockResolvedValue(undefined);
   charactersGetById.mockResolvedValue(makeCharacter());
   getLanguageModel.mockClear();
   streamText.mockReset();
@@ -284,22 +315,44 @@ describe("Agent MCP billing", () => {
     });
     expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ deferStrongCredentialCheck: false }),
+      expect.objectContaining({ deferStrongCredentialCheck: true }),
     );
     expect(charactersGetById).not.toHaveBeenCalled();
     expect(admitOrganizationInference).not.toHaveBeenCalled();
     expect(streamText).not.toHaveBeenCalled();
   });
 
+  test("checks the deferred credential once when JSON parsing terminates before any resource or provider work", async () => {
+    const response = await app.request("/agents/agent-1/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{malformed",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: -32700, message: "Parse error" },
+    });
+    expect(assertInferenceCredentialActive).toHaveBeenCalledTimes(1);
+    expect(assertInferenceCredentialActive).toHaveBeenCalledWith(
+      ORG_ID,
+      inferenceCredential,
+    );
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(reserve).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
   test("reserves the marked-up estimate before invoking the model", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
 
-    const response = await callChat();
+    const response = await callRouteChat();
 
     expect(response.status).toBe(200);
     expect(admitOrganizationInference).toHaveBeenCalledWith(
       expect.objectContaining({ credential: inferenceCredential }),
     );
+    expect(assertInferenceCredentialActive).not.toHaveBeenCalled();
     expect(reserve).toHaveBeenCalledTimes(1);
     const reserveParams = reserve.mock.calls[0]?.[0] as { amount: number };
     expect(reserveParams).toMatchObject({

--- a/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
@@ -256,6 +256,35 @@ beforeEach(() => {
 });
 
 describe("/v1/chat Worker cache hot path", () => {
+  test("malformed request resolves auth once without deferral or provider admission", async () => {
+    const executionCtx = {
+      waitUntil() {},
+      passThroughOnException() {},
+      props: {},
+    } as unknown as ExecutionContext;
+    const response = await chatRoute.fetch(
+      new Request("https://api.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer eliza_cached",
+        },
+        body: JSON.stringify({ messages: [] }),
+      }),
+      {} as never,
+      executionCtx,
+    );
+
+    expect(response.status).toBe(400);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+  });
+
   test("enabled Worker admission rejects a missing execution context without database fallback", async () => {
     const response = await chatRoute.fetch(
       new Request("https://api.test/", {

--- a/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
@@ -12,6 +12,7 @@ import * as languageModelActual from "@/lib/providers/language-model";
 import * as appsActual from "@/lib/services/apps";
 import * as contentModerationActual from "@/lib/services/content-moderation";
 import * as inferenceAuthActual from "@/lib/services/inference-auth-context";
+import * as inferenceCredentialRevocationActual from "@/lib/services/inference-credential-revocation";
 import * as modelCatalogActual from "@/lib/services/model-catalog";
 import * as teamPoolActual from "@/lib/services/team-credential-pool";
 
@@ -29,12 +30,14 @@ let poolHydration: Promise<void> | null = null;
 let catalogCacheState: "ready" | "warming" = "ready";
 let catalogHydration: Promise<void> | null = null;
 let platformCredentialConfigured = true;
+const assertInferenceCredentialActive = mock(async () => undefined);
 
 const resolveInferenceAuthContext = mock(
   async (
     _request: Request,
     options: {
       cacheOnly?: boolean;
+      deferStrongCredentialCheck?: boolean;
       executionCtx?: { waitUntil(promise: Promise<unknown>): void };
     } = {},
   ) => {
@@ -51,12 +54,26 @@ const resolveInferenceAuthContext = mock(
         apiKeyId: API_KEY_ID,
         keyHash: "a".repeat(64),
       },
+      ...(options.deferStrongCredentialCheck
+        ? {
+            credential: {
+              kind: "api_key" as const,
+              credentialId: API_KEY_ID,
+              userId: USER,
+            },
+          }
+        : {}),
     };
   },
 );
 mock.module("@/lib/services/inference-auth-context", () => ({
   ...inferenceAuthActual,
   resolveInferenceAuthContext,
+}));
+mock.module("@/lib/services/inference-credential-revocation", () => ({
+  ...inferenceCredentialRevocationActual,
+  assertInferenceCredentialActive,
+  isInferenceStrongRevocationEnabled: () => true,
 }));
 
 const requireAuthOrApiKeyWithOrg = mock(async () => {
@@ -317,6 +334,7 @@ beforeEach(() => {
   cacheOnlyPoolSelection.mockClear();
   calculateCost.mockClear();
   admitAppInferenceCacheOnly.mockClear();
+  assertInferenceCredentialActive.mockClear();
   assertInferenceAppAffiliateSupported.mockClear();
   settle.mockClear();
   settleUnknown.mockClear();
@@ -338,6 +356,7 @@ test("warm Worker request reaches provider with authoritative stores tripwired",
   expect(cacheOnlyCatalogLookup).toHaveBeenCalledTimes(1);
   expect(cacheOnlyPoolSelection).toHaveBeenCalledTimes(1);
   expect(admitAppInferenceCacheOnly).toHaveBeenCalledTimes(1);
+  expect(assertInferenceCredentialActive).not.toHaveBeenCalled();
   expect(requireAuthOrApiKeyWithOrg).not.toHaveBeenCalled();
   expect(authoritativeAppLookup).not.toHaveBeenCalled();
   expect(authoritativeCatalogLookup).not.toHaveBeenCalled();

--- a/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
@@ -364,6 +364,30 @@ test("warm Worker request reaches provider with authoritative stores tripwired",
   expect(shouldBlockUser).not.toHaveBeenCalled();
 });
 
+test("malformed Worker request performs one standalone strong auth check and no admission", async () => {
+  const background: Promise<unknown>[] = [];
+  const malformed = new Request("https://api.example/api/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": "eliza_test",
+    },
+    body: JSON.stringify({ model: "gpt-4o-mini" }),
+  });
+
+  const response = await handleChatCompletionsPOST(malformed, {
+    executionCtx: executionCtx(background),
+  });
+
+  expect(response.status).toBe(400);
+  expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+  expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+    deferStrongCredentialCheck: false,
+  });
+  expect(admitAppInferenceCacheOnly).not.toHaveBeenCalled();
+  expect(generateText).not.toHaveBeenCalled();
+});
+
 test("preserves a cached standing 503 before provider dispatch", async () => {
   resolveInferenceAuthContext.mockResolvedValueOnce({
     kind: "rejected",

--- a/packages/cloud/api/__tests__/embeddings-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-cache-hotpath.test.ts
@@ -107,7 +107,10 @@ function makeExecutionCtx() {
   };
 }
 
-function post(ctx: ExecutionContext) {
+function post(
+  ctx: ExecutionContext,
+  bodyOverrides: Record<string, unknown> = {},
+) {
   return embeddingsRoute.request(
     "/",
     {
@@ -119,6 +122,7 @@ function post(ctx: ExecutionContext) {
       body: JSON.stringify({
         model: "text-embedding-3-small",
         input: "cache-only hot path",
+        ...bodyOverrides,
       }),
     },
     {},
@@ -177,6 +181,19 @@ beforeEach(() => {
 });
 
 describe("POST /api/v1/embeddings Worker cache hot path", () => {
+  test("malformed request resolves auth once without deferral or provider admission", async () => {
+    const { ctx } = makeExecutionCtx();
+    const response = await post(ctx, { input: undefined });
+
+    expect(response.status).toBe(400);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      deferStrongCredentialCheck: false,
+    });
+    expect(admitOrganizationInference).not.toHaveBeenCalled();
+    expect(embed).not.toHaveBeenCalled();
+  });
+
   test("enabled Worker admission rejects a missing execution context without authoritative fallback", async () => {
     const response = await embeddingsRoute.request(
       "/",

--- a/packages/cloud/api/__tests__/generative-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/generative-cache-hotpath.test.ts
@@ -15,25 +15,92 @@ const routePaths = [
   "v1/generate-sfx/route.ts",
 ] as const;
 
+const providerBackedRouteCall =
+  /\b(?:admitOrganizationInference|admitFlatGenerativeOperation|admitAppInference(?:CacheOnly)?|run(?:Flat|Metered)ProviderOperation|handle(?:ChatCompletions|GenerateImage)POST|runAppReview|promoteApp|generateAssetBundle|postAppTweet|postAnnouncement|generateAppTweet|generateAnnouncement)\s*\(/;
+
+function callCount(source: string, symbol: string): number {
+  return [...source.matchAll(new RegExp(`\\b${symbol}\\s*\\(`, "g"))].length;
+}
+
+/**
+ * A route which defers its strong credential proof must keep auth, guard, and
+ * the lazy admission handoff in one handler in that order. A route without the
+ * deferred option retains the eager strong check and therefore has no guard.
+ */
+function expectFusedDeferredCredentialRoute(source: string, routePath: string) {
+  const callerCount = callCount(source, "requireGenerativeRouteCaller");
+  if (callerCount === 0) return;
+
+  expect(callerCount, `${routePath} must resolve its caller once`).toBe(1);
+  const defersCredential = source.includes("deferStrongCredentialCheck");
+  const guardCount = callCount(source, "deferredCredentialAdmissionGuard");
+  if (!defersCredential) {
+    expect(
+      guardCount,
+      `${routePath} must not orphan a guard from eager auth`,
+    ).toBe(0);
+    return;
+  }
+
+  expect(
+    guardCount,
+    `${routePath} must create one deferred credential guard`,
+  ).toBe(1);
+  expect(
+    callCount(source, "credentialForAdmission"),
+    `${routePath} must hand the deferred proof to admission`,
+  ).toBeGreaterThan(0);
+  const callerOffset = source.indexOf("requireGenerativeRouteCaller(");
+  const guardOffset = source.indexOf("deferredCredentialAdmissionGuard(");
+  const admissionOffset = source.indexOf("credentialForAdmission(");
+  expect(
+    guardOffset,
+    `${routePath} must create its guard after authenticating the caller`,
+  ).toBeGreaterThan(callerOffset);
+  expect(
+    admissionOffset,
+    `${routePath} must consume the lazy proof after creating its guard`,
+  ).toBeGreaterThan(guardOffset);
+}
+
 describe("canonical generative cache-only hot path", () => {
-  test("every route that directly invokes canonical admission is reverse-inventoried behind shared auth", async () => {
+  test("reverse-inventories direct, flat-operation, and delegated provider routes behind shared auth", async () => {
     const routeRoot = new URL("../", import.meta.url);
-    const admissionCall =
-      /\b(?:admitOrganizationInference|admitFlatGenerativeOperation|admitAppInference(?:CacheOnly)?)\s*\(/;
     const sharedAuthOrCanonicalDelegate =
       /\b(?:requireGenerativeRouteCaller|resolveInferenceAuthContext|handleChatCompletionsPOST|handleGenerateImagePOST)\b/;
-    const admittedRoutes: string[] = [];
+    const providerBackedRoutes: string[] = [];
 
     for await (const routePath of new Bun.Glob("**/route.ts").scan({
       cwd: routeRoot.pathname,
     })) {
       const source = await Bun.file(new URL(routePath, routeRoot)).text();
-      if (!admissionCall.test(source)) continue;
-      admittedRoutes.push(routePath);
+      if (!providerBackedRouteCall.test(source)) continue;
+      providerBackedRoutes.push(routePath);
       expect(source, routePath).toMatch(sharedAuthOrCanonicalDelegate);
+      expectFusedDeferredCredentialRoute(source, routePath);
     }
 
-    expect(admittedRoutes.length).toBeGreaterThan(0);
+    expect(providerBackedRoutes).toContain(
+      "elevenlabs/voices/verify/[id]/route.ts",
+    );
+    expect(providerBackedRoutes).toContain("v1/apps/[id]/chat/route.ts");
+    expect(providerBackedRoutes).toContain("v1/apps/[id]/review/route.ts");
+    expect(providerBackedRoutes).toContain("v1/generate-image/route.ts");
+  });
+
+  test("detects a deferred provider route that bypasses the credential guard", () => {
+    const bypassedRoute = `
+      async function post(c) {
+        const caller = await requireGenerativeRouteCaller(c, {
+          deferStrongCredentialCheck: true,
+        });
+        return runFlatProviderOperation(caller, operation, dispatch);
+      }
+    `;
+
+    expect(() =>
+      expectFusedDeferredCredentialRoute(bypassedRoute, "fixture/route.ts"),
+    ).toThrow(/deferred credential guard/);
   });
 
   for (const routePath of routePaths) {
@@ -81,6 +148,9 @@ describe("canonical generative cache-only hot path", () => {
       expect(source).toContain("getByIdCacheOnly");
       expect(source).toContain("requireGenerativeRouteCaller");
       expect(source).toContain("admitOrganizationInference");
+      expect(source).toContain("deferStrongCredentialCheck: true");
+      expect(source).toContain("deferredCredentialAdmissionGuard");
+      expect(source).toContain("credentialForAdmission");
       expect(source).not.toMatch(/from\s+["']@\/db\//);
       expect(source).not.toContain("creditsService.reserve");
       expect(source).not.toContain("requireUserOrApiKeyWithOrg");

--- a/packages/cloud/api/__tests__/generative-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/generative-cache-hotpath.test.ts
@@ -16,6 +16,26 @@ const routePaths = [
 ] as const;
 
 describe("canonical generative cache-only hot path", () => {
+  test("every route that directly invokes canonical admission is reverse-inventoried behind shared auth", async () => {
+    const routeRoot = new URL("../", import.meta.url);
+    const admissionCall =
+      /\b(?:admitOrganizationInference|admitFlatGenerativeOperation|admitAppInference(?:CacheOnly)?)\s*\(/;
+    const sharedAuthOrCanonicalDelegate =
+      /\b(?:requireGenerativeRouteCaller|resolveInferenceAuthContext|handleChatCompletionsPOST|handleGenerateImagePOST)\b/;
+    const admittedRoutes: string[] = [];
+
+    for await (const routePath of new Bun.Glob("**/route.ts").scan({
+      cwd: routeRoot.pathname,
+    })) {
+      const source = await Bun.file(new URL(routePath, routeRoot)).text();
+      if (!admissionCall.test(source)) continue;
+      admittedRoutes.push(routePath);
+      expect(source, routePath).toMatch(sharedAuthOrCanonicalDelegate);
+    }
+
+    expect(admittedRoutes.length).toBeGreaterThan(0);
+  });
+
   for (const routePath of routePaths) {
     test(`${routePath} uses combined auth and flat admission`, async () => {
       const source = await Bun.file(

--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -303,7 +303,10 @@ function postMessages(
   });
 }
 
-function postMessagesInWorker(extraHeaders: Record<string, string> = {}) {
+function postMessagesInWorker(
+  extraHeaders: Record<string, string> = {},
+  bodyOverrides: Record<string, unknown> = {},
+) {
   return messagesRoute.request(
     "/",
     {
@@ -317,6 +320,7 @@ function postMessagesInWorker(extraHeaders: Record<string, string> = {}) {
         model: "claude-3-5-sonnet-20241022",
         max_tokens: 16,
         messages: [{ role: "user", content: "hello" }],
+        ...bodyOverrides,
       }),
     },
     {},
@@ -329,6 +333,18 @@ function postMessagesInWorker(extraHeaders: Record<string, string> = {}) {
 }
 
 describe("/v1/messages IAC fast path", () => {
+  test("malformed request resolves auth once without deferral or provider admission", async () => {
+    const response = await postMessagesInWorker({}, { messages: [] });
+
+    expect(response.status).toBe(400);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      deferStrongCredentialCheck: false,
+    });
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
   test("enabled Worker admission rejects a missing execution context without authoritative fallback", async () => {
     const response = await messagesRoute.request(
       "/",

--- a/packages/cloud/api/__tests__/paid-app-routes-standing-gate.test.ts
+++ b/packages/cloud/api/__tests__/paid-app-routes-standing-gate.test.ts
@@ -31,6 +31,17 @@ const generateDiscordAnnouncement = mock(async () => "preview");
 const deductCredits = mock(async () => ({ success: true }));
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: (error: unknown) => error,
+  deferredCredentialAdmissionGuard: () => ({
+    credentialForAdmission: () => undefined,
+    async [Symbol.asyncDispose]() {},
+  }),
+  getGenerativeOperationContext: () => ({
+    organizationId: "org-1",
+    userId: "user-1",
+    apiKeyId: null,
+    requestId: "request-1",
+  }),
   requireGenerativeRouteCaller,
 }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -15,6 +15,7 @@ import { streamText } from "ai";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
+  asGenerativeCacheApiError,
   getGenerativeExecutionContext,
   requireGenerativeRouteCaller,
   resolveInferenceCredentialAdmissionDenial,
@@ -55,6 +56,7 @@ import {
   type UserCharacter,
 } from "@/lib/services/characters/characters";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
@@ -140,8 +142,13 @@ export function generateAgentCard(character: UserCharacter, baseUrl: string) {
 const app = new Hono<AppEnv>();
 
 function a2aAuthError(c: AppContext, error: unknown, id: JsonRpcId | null) {
-  if (!(error instanceof ApiError)) throw error;
-  if (error.status === 429) {
+  const boundaryError =
+    asGenerativeCacheApiError(error, {
+      route: "agent_a2a",
+      traceId: c.get("traceId") ?? c.get("requestId"),
+    }) ?? error;
+  if (!(boundaryError instanceof ApiError)) throw boundaryError;
+  if (boundaryError.status === 429) {
     return c.json(
       {
         jsonrpc: "2.0",
@@ -151,7 +158,7 @@ function a2aAuthError(c: AppContext, error: unknown, id: JsonRpcId | null) {
       429,
     );
   }
-  if (error.status === 503) {
+  if (boundaryError.status === 503) {
     return c.json(
       {
         jsonrpc: "2.0",
@@ -164,22 +171,24 @@ function a2aAuthError(c: AppContext, error: unknown, id: JsonRpcId | null) {
       503,
     );
   }
-  if (error.status !== 401 && error.status !== 403) throw error;
+  if (boundaryError.status !== 401 && boundaryError.status !== 403) {
+    throw boundaryError;
+  }
   const reason =
-    typeof error.details?.reason === "string"
-      ? error.details.reason
+    typeof boundaryError.details?.reason === "string"
+      ? boundaryError.details.reason
       : undefined;
   return c.json(
     {
       jsonrpc: "2.0",
       error: {
         code: -32002,
-        message: error.message,
+        message: boundaryError.message,
         ...(reason ? { data: { reason } } : {}),
       },
       id,
     },
-    error.status,
+    boundaryError.status,
   );
 }
 
@@ -220,29 +229,52 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 app.post("/", async (c) => {
   const id = c.req.param("id");
   const executionCtx = getGenerativeExecutionContext(c);
-  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
-    caller = await requireGenerativeRouteCaller(c, {
+    const caller = await requireGenerativeRouteCaller(c, {
       compatibility: "hono",
       rateLimitEndpoint: "standard",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
     });
-  } catch (error) {
-    return a2aAuthError(c, error, null);
-  }
-  if (!id) return c.json({ error: "Missing id" }, 400);
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
+    if (!id) return c.json({ error: "Missing id" }, 400);
 
-  const characterResolution = executionCtx
-    ? await charactersService.getByIdCacheOnly(id, { executionCtx })
-    : {
-        kind: "ready" as const,
-        character: (await charactersService.getById(id)) ?? null,
-      };
-  if (characterResolution.kind !== "ready") {
-    // A cache-only miss cannot distinguish a real agent from an unknown id.
-    // Confirm only the negative case authoritatively; an existing cold agent
-    // still gets the retryable response and never joins Postgres to dispatch.
-    if (!(await charactersService.getById(id))) {
+    const characterResolution = executionCtx
+      ? await charactersService.getByIdCacheOnly(id, { executionCtx })
+      : {
+          kind: "ready" as const,
+          character: (await charactersService.getById(id)) ?? null,
+        };
+    if (characterResolution.kind !== "ready") {
+      // A cache-only miss cannot distinguish a real agent from an unknown id.
+      // Confirm only the negative case authoritatively; an existing cold agent
+      // still gets the retryable response and never joins Postgres to dispatch.
+      if (!(await charactersService.getById(id))) {
+        return c.json(
+          {
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Agent not found" },
+            id: null,
+          },
+          404,
+        );
+      }
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: {
+            code: -32004,
+            message: "Agent cache is warming; retry shortly",
+          },
+          id: null,
+        },
+        503,
+      );
+    }
+    const character = characterResolution.character;
+    if (!character) {
       return c.json(
         {
           jsonrpc: "2.0",
@@ -252,102 +284,84 @@ app.post("/", async (c) => {
         404,
       );
     }
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32004,
-          message: "Agent cache is warming; retry shortly",
+    if (!character.is_public || !character.a2a_enabled) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Agent not accessible" },
+          id: null,
         },
-        id: null,
-      },
-      503,
-    );
-  }
-  const character = characterResolution.character;
-  if (!character) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Agent not found" },
-        id: null,
-      },
-      404,
-    );
-  }
-  if (!character.is_public || !character.a2a_enabled) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Agent not accessible" },
-        id: null,
-      },
-      403,
-    );
-  }
+        403,
+      );
+    }
 
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    // error-policy:J1 the JSON-RPC transport boundary distinguishes invalid
-    // JSON syntax from a syntactically valid but malformed request envelope.
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J1 the JSON-RPC transport boundary distinguishes invalid
+      // JSON syntax from a syntactically valid but malformed request envelope.
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32700, message: "Parse error" },
+          id: null,
+        },
+        400,
+      );
+    }
+    const validation = A2AJsonRpcRequestSchema.safeParse(body);
+    if (!validation.success) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32600, message: "Invalid Request" },
+          id: jsonRpcIdFromUnknown(body),
+        },
+        400,
+      );
+    }
+
+    const { method, params, id: rpcId } = validation.data;
+    if (method === "chat") {
+      // Keep the handler inside the using scope so admission consumes the
+      // deferred proof before its terminal-path disposal check can run.
+      return await handleChat(c, character, params ?? {}, rpcId, {
+        id: caller.user.id,
+        organization_id: caller.user.organization_id,
+        apiKeyId: caller.apiKeyId,
+        admissionSnapshot: caller.admissionSnapshot,
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+        executionCtx,
+      });
+    }
+
+    if (method === "getAgentInfo") {
+      return c.json({
+        jsonrpc: "2.0",
+        result: {
+          name: character.name,
+          bio: character.bio,
+          category: character.category,
+          tags: character.tags,
+          monetizationEnabled: character.monetization_enabled,
+          markupPercentage: character.inference_markup_percentage,
+        },
+        id: rpcId,
+      });
+    }
+
     return c.json(
       {
         jsonrpc: "2.0",
-        error: { code: -32700, message: "Parse error" },
-        id: null,
+        error: { code: -32601, message: "Method not found" },
+        id: rpcId,
       },
       400,
     );
+  } catch (error) {
+    return a2aAuthError(c, error, null);
   }
-  const validation = A2AJsonRpcRequestSchema.safeParse(body);
-  if (!validation.success) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32600, message: "Invalid Request" },
-        id: jsonRpcIdFromUnknown(body),
-      },
-      400,
-    );
-  }
-
-  const { method, params, id: rpcId } = validation.data;
-  if (method === "chat") {
-    return handleChat(c, character, params ?? {}, rpcId, {
-      id: caller.user.id,
-      organization_id: caller.user.organization_id,
-      apiKeyId: caller.apiKeyId,
-      admissionSnapshot: caller.admissionSnapshot,
-      credential: caller.credential,
-      executionCtx,
-    });
-  }
-
-  if (method === "getAgentInfo") {
-    return c.json({
-      jsonrpc: "2.0",
-      result: {
-        name: character.name,
-        bio: character.bio,
-        category: character.category,
-        tags: character.tags,
-        monetizationEnabled: character.monetization_enabled,
-        markupPercentage: character.inference_markup_percentage,
-      },
-      id: rpcId,
-    });
-  }
-
-  return c.json(
-    {
-      jsonrpc: "2.0",
-      error: { code: -32601, message: "Method not found" },
-      id: rpcId,
-    },
-    400,
-  );
 });
 
 async function handleChat(
@@ -370,7 +384,7 @@ async function handleChat(
     organization_id: string;
     apiKeyId: string | null;
     admissionSnapshot?: InferenceAdmissionSnapshot;
-    credential?: InferenceCredentialCheck;
+    credentialForAdmission?: () => InferenceCredentialCheck | undefined;
     executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   },
 ): Promise<Response> {
@@ -446,7 +460,7 @@ async function handleChat(
       },
       executionCtx: authUser.executionCtx,
       admissionSnapshot: authUser.admissionSnapshot,
-      credential: authUser.credential,
+      credential: authUser.credentialForAdmission?.(),
     });
   } catch (error) {
     // error-policy:J1 the route boundary translates the expected credit

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -139,6 +139,50 @@ export function generateAgentCard(character: UserCharacter, baseUrl: string) {
 
 const app = new Hono<AppEnv>();
 
+function a2aAuthError(c: AppContext, error: unknown, id: JsonRpcId | null) {
+  if (!(error instanceof ApiError)) throw error;
+  if (error.status === 429) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32005, message: "Rate limit exceeded" },
+        id,
+      },
+      429,
+    );
+  }
+  if (error.status === 503) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32004,
+          message: "Authorization cache unavailable; retry shortly",
+        },
+        id,
+      },
+      503,
+    );
+  }
+  if (error.status !== 401 && error.status !== 403) throw error;
+  const reason =
+    typeof error.details?.reason === "string"
+      ? error.details.reason
+      : undefined;
+  return c.json(
+    {
+      jsonrpc: "2.0",
+      error: {
+        code: -32002,
+        message: error.message,
+        ...(reason ? { data: { reason } } : {}),
+      },
+      id,
+    },
+    error.status,
+  );
+}
+
 function getAnthropicCotEnv(env: AppEnv["Bindings"]): AnthropicCotEnv {
   return {
     ANTHROPIC_COT_BUDGET:
@@ -175,9 +219,19 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 
 app.post("/", async (c) => {
   const id = c.req.param("id");
+  const executionCtx = getGenerativeExecutionContext(c);
+  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
+  try {
+    caller = await requireGenerativeRouteCaller(c, {
+      compatibility: "hono",
+      rateLimitEndpoint: "standard",
+      deferStrongCredentialCheck: false,
+    });
+  } catch (error) {
+    return a2aAuthError(c, error, null);
+  }
   if (!id) return c.json({ error: "Missing id" }, 400);
 
-  const executionCtx = getGenerativeExecutionContext(c);
   const characterResolution = executionCtx
     ? await charactersService.getByIdCacheOnly(id, { executionCtx })
     : {
@@ -260,59 +314,6 @@ app.post("/", async (c) => {
   }
 
   const { method, params, id: rpcId } = validation.data;
-  const willAdmitInference =
-    method === "chat" && A2AChatParamsSchema.safeParse(params ?? {}).success;
-
-  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
-  try {
-    caller = await requireGenerativeRouteCaller(c, {
-      compatibility: "hono",
-      rateLimitEndpoint: "standard",
-      deferStrongCredentialCheck: willAdmitInference,
-    });
-  } catch (error) {
-    // error-policy:J1 the public JSON-RPC boundary preserves retryable
-    // admission failures while translating credential failures without
-    // exposing session or API-key internals.
-    if (error instanceof ApiError && error.status === 429) {
-      return c.json(
-        {
-          jsonrpc: "2.0",
-          error: { code: -32005, message: "Rate limit exceeded" },
-          id: rpcId,
-        },
-        429,
-      );
-    }
-    if (error instanceof ApiError && error.status === 503) {
-      return c.json(
-        {
-          jsonrpc: "2.0",
-          error: {
-            code: -32004,
-            message: "Authorization cache unavailable; retry shortly",
-          },
-          id: rpcId,
-        },
-        503,
-      );
-    }
-    if (
-      !(error instanceof ApiError) ||
-      (error.status !== 401 && error.status !== 403)
-    ) {
-      throw error;
-    }
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32002, message: "Authentication required" },
-        id: rpcId,
-      },
-      error.status,
-    );
-  }
-
   if (method === "chat") {
     return handleChat(c, character, params ?? {}, rpcId, {
       id: caller.user.id,

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import {
   getGenerativeExecutionContext,
   requireGenerativeRouteCaller,
+  resolveInferenceCredentialAdmissionDenial,
 } from "@/api-app/lib/generative-route-auth";
 import { UntrustedA2AChatMessagesSchema } from "@/lib/api/a2a/chat-messages";
 import {
@@ -55,6 +56,7 @@ import {
 } from "@/lib/services/characters/characters";
 import { InsufficientCreditsError } from "@/lib/services/credits";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
+import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -258,12 +260,15 @@ app.post("/", async (c) => {
   }
 
   const { method, params, id: rpcId } = validation.data;
+  const willAdmitInference =
+    method === "chat" && A2AChatParamsSchema.safeParse(params ?? {}).success;
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
     caller = await requireGenerativeRouteCaller(c, {
       compatibility: "hono",
       rateLimitEndpoint: "standard",
+      deferStrongCredentialCheck: willAdmitInference,
     });
   } catch (error) {
     // error-policy:J1 the public JSON-RPC boundary preserves retryable
@@ -314,6 +319,7 @@ app.post("/", async (c) => {
       organization_id: caller.user.organization_id,
       apiKeyId: caller.apiKeyId,
       admissionSnapshot: caller.admissionSnapshot,
+      credential: caller.credential,
       executionCtx,
     });
   }
@@ -363,6 +369,7 @@ async function handleChat(
     organization_id: string;
     apiKeyId: string | null;
     admissionSnapshot?: InferenceAdmissionSnapshot;
+    credential?: InferenceCredentialCheck;
     executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   },
 ): Promise<Response> {
@@ -438,10 +445,29 @@ async function handleChat(
       },
       executionCtx: authUser.executionCtx,
       admissionSnapshot: authUser.admissionSnapshot,
+      credential: authUser.credential,
     });
   } catch (error) {
     // error-policy:J1 the route boundary translates the expected credit
     // refusal and lets unexpected reservation failures reach the owner path.
+    const denial = resolveInferenceCredentialAdmissionDenial(error, {
+      route: "agent_a2a",
+      traceId: c.get("traceId") ?? c.get("requestId"),
+    });
+    if (denial) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: {
+            code: -32002,
+            message: denial.message,
+            data: { reason: denial.reason },
+          },
+          id: rpcId,
+        },
+        denial.status,
+      );
+    }
     if (error instanceof InsufficientCreditsError) {
       return c.json({
         jsonrpc: "2.0",

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -75,6 +75,54 @@ const ChatArgumentsSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
+function mcpAuthError(
+  c: AppContext,
+  error: unknown,
+  id: string | number | null,
+) {
+  if (!(error instanceof ApiError)) throw error;
+  if (error.status === 429) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: { code: -32005, message: "Rate limit exceeded" },
+        id,
+      },
+      429,
+    );
+  }
+  if (error.status === 503) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32004,
+          message: "Authorization cache unavailable; retry shortly",
+        },
+        id,
+      },
+      503,
+    );
+  }
+  if (error.status !== 401 && error.status !== 403) throw error;
+  const reason =
+    typeof error.details?.reason === "string"
+      ? error.details.reason
+      : undefined;
+  return c.json(
+    {
+      jsonrpc: "2.0",
+      error: {
+        code: -32002,
+        message: error.message,
+        ...(reason ? { data: { reason } } : {}),
+      },
+      id,
+    },
+    error.status,
+  );
+}
+
 function getAnthropicCotEnv(env: AppEnv["Bindings"]): AnthropicCotEnv {
   return {
     ANTHROPIC_COT_BUDGET:
@@ -149,9 +197,19 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 
 app.post("/", async (c) => {
   const id = c.req.param("id");
+  const executionCtx = getGenerativeExecutionContext(c);
+  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
+  try {
+    caller = await requireGenerativeRouteCaller(c, {
+      compatibility: "hono",
+      rateLimitEndpoint: "standard",
+      deferStrongCredentialCheck: false,
+    });
+  } catch (error) {
+    return mcpAuthError(c, error, null);
+  }
   if (!id) return c.json({ error: "Missing id" }, 400);
 
-  const executionCtx = getGenerativeExecutionContext(c);
   const characterResolution = executionCtx
     ? await charactersService.getByIdCacheOnly(id, { executionCtx })
     : {
@@ -232,66 +290,6 @@ app.post("/", async (c) => {
   }
 
   const { method, params, id: rpcId } = validation.data;
-  const parsedToolCallForAdmission =
-    method === "tools/call"
-      ? ToolCallParamsSchema.safeParse(params ?? {})
-      : null;
-  const willAdmitInference =
-    parsedToolCallForAdmission?.success === true &&
-    parsedToolCallForAdmission.data.name === "chat" &&
-    ChatArgumentsSchema.safeParse(parsedToolCallForAdmission.data.arguments)
-      .success;
-
-  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
-  try {
-    caller = await requireGenerativeRouteCaller(c, {
-      compatibility: "hono",
-      rateLimitEndpoint: "standard",
-      deferStrongCredentialCheck: willAdmitInference,
-    });
-  } catch (error) {
-    // error-policy:J1 the public JSON-RPC boundary preserves retryable
-    // admission failures while translating credential failures without
-    // exposing session or API-key internals.
-    if (error instanceof ApiError && error.status === 429) {
-      return c.json(
-        {
-          jsonrpc: "2.0",
-          error: { code: -32005, message: "Rate limit exceeded" },
-          id: rpcId,
-        },
-        429,
-      );
-    }
-    if (error instanceof ApiError && error.status === 503) {
-      return c.json(
-        {
-          jsonrpc: "2.0",
-          error: {
-            code: -32004,
-            message: "Authorization cache unavailable; retry shortly",
-          },
-          id: rpcId,
-        },
-        503,
-      );
-    }
-    if (
-      !(error instanceof ApiError) ||
-      (error.status !== 401 && error.status !== 403)
-    ) {
-      throw error;
-    }
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32002, message: "Authentication required" },
-        id: rpcId,
-      },
-      error.status,
-    );
-  }
-
   switch (method) {
     case "initialize":
       return c.json({

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -16,6 +16,7 @@ import { z } from "zod";
 import {
   getGenerativeExecutionContext,
   requireGenerativeRouteCaller,
+  resolveInferenceCredentialAdmissionDenial,
 } from "@/api-app/lib/generative-route-auth";
 import { ApiError } from "@/lib/api/cloud-worker-errors";
 import { CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS } from "@/lib/cors-constants";
@@ -42,6 +43,7 @@ import { agentMonetizationService } from "@/lib/services/agent-monetization";
 import { charactersService } from "@/lib/services/characters/characters";
 import { InsufficientCreditsError } from "@/lib/services/credits";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
+import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -230,12 +232,22 @@ app.post("/", async (c) => {
   }
 
   const { method, params, id: rpcId } = validation.data;
+  const parsedToolCallForAdmission =
+    method === "tools/call"
+      ? ToolCallParamsSchema.safeParse(params ?? {})
+      : null;
+  const willAdmitInference =
+    parsedToolCallForAdmission?.success === true &&
+    parsedToolCallForAdmission.data.name === "chat" &&
+    ChatArgumentsSchema.safeParse(parsedToolCallForAdmission.data.arguments)
+      .success;
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
     caller = await requireGenerativeRouteCaller(c, {
       compatibility: "hono",
       rateLimitEndpoint: "standard",
+      deferStrongCredentialCheck: willAdmitInference,
     });
   } catch (error) {
     // error-policy:J1 the public JSON-RPC boundary preserves retryable
@@ -325,6 +337,7 @@ app.post("/", async (c) => {
         organization_id: caller.user.organization_id,
         apiKeyId: caller.apiKeyId,
         admissionSnapshot: caller.admissionSnapshot,
+        credential: caller.credential,
         executionCtx,
       });
 
@@ -363,6 +376,7 @@ export async function handleToolCall(
     organization_id: string;
     apiKeyId?: string | null;
     admissionSnapshot?: InferenceAdmissionSnapshot;
+    credential?: InferenceCredentialCheck;
     executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   },
 ): Promise<Response> {
@@ -476,10 +490,29 @@ export async function handleToolCall(
         },
         executionCtx: authUser.executionCtx,
         admissionSnapshot: authUser.admissionSnapshot,
+        credential: authUser.credential,
       });
     } catch (error) {
       // error-policy:J1 the route boundary translates the expected credit
       // refusal and lets unexpected reservation failures reach the owner path.
+      const denial = resolveInferenceCredentialAdmissionDenial(error, {
+        route: "agent_mcp",
+        traceId: c.get("traceId") ?? c.get("requestId"),
+      });
+      if (denial) {
+        return c.json(
+          {
+            jsonrpc: "2.0",
+            error: {
+              code: -32002,
+              message: denial.message,
+              data: { reason: denial.reason },
+            },
+            id: rpcId,
+          },
+          denial.status,
+        );
+      }
       if (error instanceof InsufficientCreditsError) {
         return c.json({
           jsonrpc: "2.0",

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -14,6 +14,7 @@ import { streamText } from "ai";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
+  asGenerativeCacheApiError,
   getGenerativeExecutionContext,
   requireGenerativeRouteCaller,
   resolveInferenceCredentialAdmissionDenial,
@@ -42,6 +43,7 @@ import {
 import { agentMonetizationService } from "@/lib/services/agent-monetization";
 import { charactersService } from "@/lib/services/characters/characters";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
@@ -80,8 +82,13 @@ function mcpAuthError(
   error: unknown,
   id: string | number | null,
 ) {
-  if (!(error instanceof ApiError)) throw error;
-  if (error.status === 429) {
+  const boundaryError =
+    asGenerativeCacheApiError(error, {
+      route: "agent_mcp",
+      traceId: c.get("traceId") ?? c.get("requestId"),
+    }) ?? error;
+  if (!(boundaryError instanceof ApiError)) throw boundaryError;
+  if (boundaryError.status === 429) {
     return c.json(
       {
         jsonrpc: "2.0",
@@ -91,7 +98,7 @@ function mcpAuthError(
       429,
     );
   }
-  if (error.status === 503) {
+  if (boundaryError.status === 503) {
     return c.json(
       {
         jsonrpc: "2.0",
@@ -104,22 +111,24 @@ function mcpAuthError(
       503,
     );
   }
-  if (error.status !== 401 && error.status !== 403) throw error;
+  if (boundaryError.status !== 401 && boundaryError.status !== 403) {
+    throw boundaryError;
+  }
   const reason =
-    typeof error.details?.reason === "string"
-      ? error.details.reason
+    typeof boundaryError.details?.reason === "string"
+      ? boundaryError.details.reason
       : undefined;
   return c.json(
     {
       jsonrpc: "2.0",
       error: {
         code: -32002,
-        message: error.message,
+        message: boundaryError.message,
         ...(reason ? { data: { reason } } : {}),
       },
       id,
     },
-    error.status,
+    boundaryError.status,
   );
 }
 
@@ -198,28 +207,51 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 app.post("/", async (c) => {
   const id = c.req.param("id");
   const executionCtx = getGenerativeExecutionContext(c);
-  let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
-    caller = await requireGenerativeRouteCaller(c, {
+    const caller = await requireGenerativeRouteCaller(c, {
       compatibility: "hono",
       rateLimitEndpoint: "standard",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
     });
-  } catch (error) {
-    return mcpAuthError(c, error, null);
-  }
-  if (!id) return c.json({ error: "Missing id" }, 400);
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
+    if (!id) return c.json({ error: "Missing id" }, 400);
 
-  const characterResolution = executionCtx
-    ? await charactersService.getByIdCacheOnly(id, { executionCtx })
-    : {
-        kind: "ready" as const,
-        character: (await charactersService.getById(id)) ?? null,
-      };
-  if (characterResolution.kind !== "ready") {
-    // Confirm only the negative cold-cache case. Existing agents remain
-    // fail-closed until their cached character is ready for inference.
-    if (!(await charactersService.getById(id))) {
+    const characterResolution = executionCtx
+      ? await charactersService.getByIdCacheOnly(id, { executionCtx })
+      : {
+          kind: "ready" as const,
+          character: (await charactersService.getById(id)) ?? null,
+        };
+    if (characterResolution.kind !== "ready") {
+      // Confirm only the negative cold-cache case. Existing agents remain
+      // fail-closed until their cached character is ready for inference.
+      if (!(await charactersService.getById(id))) {
+        return c.json(
+          {
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Agent not found" },
+            id: null,
+          },
+          404,
+        );
+      }
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: {
+            code: -32004,
+            message: "Agent cache is warming; retry shortly",
+          },
+          id: null,
+        },
+        503,
+      );
+    }
+    const character = characterResolution.character;
+    if (!character) {
       return c.json(
         {
           jsonrpc: "2.0",
@@ -229,128 +261,111 @@ app.post("/", async (c) => {
         404,
       );
     }
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32004,
-          message: "Agent cache is warming; retry shortly",
-        },
-        id: null,
-      },
-      503,
-    );
-  }
-  const character = characterResolution.character;
-  if (!character) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Agent not found" },
-        id: null,
-      },
-      404,
-    );
-  }
-  if (!character.is_public || !character.mcp_enabled) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "MCP not accessible" },
-        id: null,
-      },
-      403,
-    );
-  }
-
-  let body: unknown;
-  try {
-    body = await c.req.json();
-  } catch {
-    // error-policy:J1 the JSON-RPC boundary translates malformed JSON.
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32700, message: "Parse error" },
-        id: null,
-      },
-      400,
-    );
-  }
-  const validation = MCPRequestSchema.safeParse(body);
-  if (!validation.success) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: { code: -32700, message: "Parse error" },
-        id: null,
-      },
-      400,
-    );
-  }
-
-  const { method, params, id: rpcId } = validation.data;
-  switch (method) {
-    case "initialize":
-      return c.json({
-        jsonrpc: "2.0",
-        result: {
-          protocolVersion: "2024-11-05",
-          serverInfo: { name: character.name, version: "1.0.0" },
-          capabilities: { tools: {} },
-        },
-        id: rpcId,
-      });
-
-    case "tools/list":
-      return c.json({
-        jsonrpc: "2.0",
-        result: {
-          tools: [
-            {
-              name: "chat",
-              description: `Send a message to ${character.name}`,
-              inputSchema: {
-                type: "object",
-                properties: {
-                  message: { type: "string" },
-                  model: { type: "string" },
-                },
-                required: ["message"],
-              },
-            },
-            {
-              name: "get_info",
-              description: `Get information about ${character.name}`,
-              inputSchema: { type: "object", properties: {} },
-            },
-          ],
-        },
-        id: rpcId,
-      });
-
-    case "tools/call":
-      return handleToolCall(c, character, params ?? {}, rpcId, {
-        id: caller.user.id,
-        organization_id: caller.user.organization_id,
-        apiKeyId: caller.apiKeyId,
-        admissionSnapshot: caller.admissionSnapshot,
-        credential: caller.credential,
-        executionCtx,
-      });
-
-    case "ping":
-      return c.json({ jsonrpc: "2.0", result: {}, id: rpcId });
-
-    default:
+    if (!character.is_public || !character.mcp_enabled) {
       return c.json(
         {
           jsonrpc: "2.0",
-          error: { code: -32601, message: "Method not found" },
-          id: rpcId,
+          error: { code: -32001, message: "MCP not accessible" },
+          id: null,
+        },
+        403,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J1 the JSON-RPC boundary translates malformed JSON.
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32700, message: "Parse error" },
+          id: null,
         },
         400,
       );
+    }
+    const validation = MCPRequestSchema.safeParse(body);
+    if (!validation.success) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32700, message: "Parse error" },
+          id: null,
+        },
+        400,
+      );
+    }
+
+    const { method, params, id: rpcId } = validation.data;
+    switch (method) {
+      case "initialize":
+        return c.json({
+          jsonrpc: "2.0",
+          result: {
+            protocolVersion: "2024-11-05",
+            serverInfo: { name: character.name, version: "1.0.0" },
+            capabilities: { tools: {} },
+          },
+          id: rpcId,
+        });
+
+      case "tools/list":
+        return c.json({
+          jsonrpc: "2.0",
+          result: {
+            tools: [
+              {
+                name: "chat",
+                description: `Send a message to ${character.name}`,
+                inputSchema: {
+                  type: "object",
+                  properties: {
+                    message: { type: "string" },
+                    model: { type: "string" },
+                  },
+                  required: ["message"],
+                },
+              },
+              {
+                name: "get_info",
+                description: `Get information about ${character.name}`,
+                inputSchema: { type: "object", properties: {} },
+              },
+            ],
+          },
+          id: rpcId,
+        });
+
+      case "tools/call":
+        // The handler must settle its admission handoff before the using scope
+        // checks a terminal exit, so this intentionally awaits before return.
+        return await handleToolCall(c, character, params ?? {}, rpcId, {
+          id: caller.user.id,
+          organization_id: caller.user.organization_id,
+          apiKeyId: caller.apiKeyId,
+          admissionSnapshot: caller.admissionSnapshot,
+          credentialForAdmission: () =>
+            credentialGuard.credentialForAdmission(),
+          executionCtx,
+        });
+
+      case "ping":
+        return c.json({ jsonrpc: "2.0", result: {}, id: rpcId });
+
+      default:
+        return c.json(
+          {
+            jsonrpc: "2.0",
+            error: { code: -32601, message: "Method not found" },
+            id: rpcId,
+          },
+          400,
+        );
+    }
+  } catch (error) {
+    return mcpAuthError(c, error, null);
   }
 });
 
@@ -374,7 +389,7 @@ export async function handleToolCall(
     organization_id: string;
     apiKeyId?: string | null;
     admissionSnapshot?: InferenceAdmissionSnapshot;
-    credential?: InferenceCredentialCheck;
+    credentialForAdmission?: () => InferenceCredentialCheck | undefined;
     executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   },
 ): Promise<Response> {
@@ -488,7 +503,7 @@ export async function handleToolCall(
         },
         executionCtx: authUser.executionCtx,
         admissionSnapshot: authUser.admissionSnapshot,
-        credential: authUser.credential,
+        credential: authUser.credentialForAdmission?.(),
       });
     } catch (error) {
       // error-policy:J1 the route boundary translates the expected credit

--- a/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
@@ -150,7 +150,6 @@ async function __hono_GET(c: AppContext) {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       compatibility: "raw",
-      deferStrongCredentialCheck: true,
     });
     const { user } = caller;
     const voiceId = c.req.param("id")!;

--- a/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/verify/[id]/route.ts
@@ -150,6 +150,7 @@ async function __hono_GET(c: AppContext) {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       compatibility: "raw",
+      deferStrongCredentialCheck: true,
     });
     const { user } = caller;
     const voiceId = c.req.param("id")!;

--- a/packages/cloud/api/fal/proxy/route.standing.test.ts
+++ b/packages/cloud/api/fal/proxy/route.standing.test.ts
@@ -3,10 +3,35 @@
 import { expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import { ApiError } from "@/lib/api/cloud-worker-errors";
+import * as aiPricingActual from "@/lib/services/ai-pricing";
 
 const invokeFalProxy = mock(
   async () => new Response("upstream", { status: 200 }),
 );
+let routeCallerError: ApiError | null = new ApiError(
+  403,
+  "access_denied",
+  "Account is inactive",
+  { reason: "account_inactive" },
+);
+let admissionError: ApiError | null = null;
+const admitFlatGenerativeOperation = mock(async () => {
+  if (admissionError) throw admissionError;
+  throw new Error("unexpected admission success");
+});
+const requireGenerativeRouteCaller = mock(async () => {
+  if (routeCallerError) throw routeCallerError;
+  return {
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: undefined,
+    credential: {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    },
+  };
+});
 
 mock.module("@fal-ai/server-proxy", () => ({
   DEFAULT_ALLOWED_URL_PATTERNS: [],
@@ -17,17 +42,20 @@ mock.module("@fal-ai/server-proxy", () => ({
 mock.module("@fal-ai/server-proxy/hono", () => ({
   createRouteHandler: () => invokeFalProxy,
 }));
+mock.module("@/lib/services/ai-pricing", () => ({
+  ...aiPricingActual,
+  calculateVideoGenerationCostFromCatalog: async () => ({
+    totalCost: 0.1,
+    baseTotalCost: 0.1,
+    platformMarkup: 0,
+  }),
+}));
 mock.module("@/api-app/lib/generative-route-auth", () => ({
-  admitFlatGenerativeOperation: mock(async () => {
-    throw new Error("admission must not run after standing denial");
-  }),
-  asGenerativeCacheApiError: () => null,
+  admitFlatGenerativeOperation,
+  asGenerativeCacheApiError: (error: unknown) =>
+    error instanceof ApiError ? error : null,
   getGenerativeExecutionContext: () => undefined,
-  requireGenerativeRouteCaller: mock(async () => {
-    throw new ApiError(403, "access_denied", "Account is inactive", {
-      reason: "account_inactive",
-    });
-  }),
+  requireGenerativeRouteCaller,
 }));
 mock.module("@/lib/utils/logger", () => ({
   logger: { error: mock(() => undefined) },
@@ -41,7 +69,7 @@ test("standing denial prevents fal pricing, credit admission, and provider dispa
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "x-fal-target-url": "fal-ai/test",
+      "x-fal-target-url": "fal-ai/veo3",
     },
     body: "{}",
   });
@@ -51,6 +79,32 @@ test("standing denial prevents fal pricing, credit admission, and provider dispa
     code: "access_denied",
     error: "Account is inactive",
     details: { reason: "account_inactive" },
+  });
+  expect(invokeFalProxy).not.toHaveBeenCalled();
+});
+
+test("combined credential denial is returned before fal provider dispatch", async () => {
+  routeCallerError = null;
+  admissionError = new ApiError(
+    401,
+    "authentication_required",
+    "Authentication required",
+    { reason: "credential_inactive" },
+  );
+  const response = await app.request("/fal/proxy", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fal-target-url": "fal-ai/veo3",
+    },
+    body: JSON.stringify({ model: "fal-ai/veo3" }),
+  });
+
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toMatchObject({
+    code: "authentication_required",
+    error: "Authentication required",
+    details: { reason: "credential_inactive" },
   });
   expect(invokeFalProxy).not.toHaveBeenCalled();
 });

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -171,6 +171,8 @@ async function priceFalMutation(c: Context<AppEnv>): Promise<{
 
 const handle: Handler<AppEnv> = async (c) => {
   const isMutation = c.req.method === "POST" || c.req.method === "PUT";
+  const willAdmitMutation =
+    isMutation && Boolean(c.req.header(TARGET_URL_HEADER));
   let admission: Awaited<
     ReturnType<typeof admitFlatGenerativeOperation>
   > | null = null;
@@ -181,6 +183,7 @@ const handle: Handler<AppEnv> = async (c) => {
   try {
     caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: willAdmitMutation,
     });
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
@@ -205,6 +208,7 @@ const handle: Handler<AppEnv> = async (c) => {
         apiKeyId: caller.apiKeyId,
         cost: pricedMutation.cost,
         admissionSnapshot: caller.admissionSnapshot,
+        credential: caller.credential,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -180,18 +180,37 @@ const handle: Handler<AppEnv> = async (c) => {
     null;
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
 
+  if (willAdmitMutation) {
+    try {
+      pricedMutation = await priceFalMutation(c);
+    } catch (error) {
+      if (error instanceof Error && error.message === "missing_target") {
+        return c.json({ error: "Invalid request" }, 400);
+      }
+      if (
+        error instanceof Error &&
+        error.message.startsWith("Unpriced fal endpoint")
+      ) {
+        return c.json({ error: error.message }, 400);
+      }
+      logger.error("[fal proxy] Failed to price mutation", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return c.json({ error: "fal pricing unavailable" }, 503);
+    }
+  }
+
   try {
     caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: willAdmitMutation,
+      deferStrongCredentialCheck: Boolean(pricedMutation),
     });
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 
-  if (isMutation && c.req.header(TARGET_URL_HEADER)) {
+  if (pricedMutation) {
     try {
-      pricedMutation = await priceFalMutation(c);
       const billingContext: BillingContext = {
         organizationId: caller.user.organization_id,
         userId: caller.user.id,
@@ -211,6 +230,8 @@ const handle: Handler<AppEnv> = async (c) => {
         credential: caller.credential,
       });
     } catch (error) {
+      const admissionError = asGenerativeCacheApiError(error);
+      if (admissionError) return failureResponse(c, admissionError);
       if (error instanceof InsufficientCreditsError) {
         return c.json(
           {
@@ -221,20 +242,7 @@ const handle: Handler<AppEnv> = async (c) => {
           402,
         );
       }
-      if (error instanceof Error && error.message === "missing_target") {
-        return c.json({ error: "Invalid request" }, 400);
-      }
-      if (
-        error instanceof Error &&
-        error.message.startsWith("Unpriced fal endpoint")
-      ) {
-        return c.json({ error: error.message }, 400);
-      }
-
-      logger.error("[fal proxy] Failed to price mutation", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return c.json({ error: "fal pricing unavailable" }, 503);
+      throw error;
     }
   }
 

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -30,6 +30,7 @@ import {
 } from "@/lib/services/ai-pricing";
 import { getSupportedVideoModelDefinition } from "@/lib/services/ai-pricing-definitions";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -202,70 +203,78 @@ const handle: Handler<AppEnv> = async (c) => {
   }
 
   try {
-    caller = await requireGenerativeRouteCaller(c, {
-      rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: Boolean(pricedMutation),
-    });
-  } catch (error) {
-    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
-  }
-  if (pendingResponse) return pendingResponse;
-
-  if (pricedMutation) {
     try {
-      const billingContext: BillingContext = {
-        organizationId: caller.user.organization_id,
-        userId: caller.user.id,
-        apiKeyId: caller.apiKeyId,
-        model: pricedMutation.model,
-        provider: "fal",
-        billingSource: "fal",
-        requestId: `fal-proxy:${crypto.randomUUID()}`,
-        description: `fal.ai ${pricedMutation.model}`,
-      };
-      admission = await admitFlatGenerativeOperation({
-        c,
-        context: billingContext,
-        apiKeyId: caller.apiKeyId,
-        cost: pricedMutation.cost,
-        admissionSnapshot: caller.admissionSnapshot,
-        credential: caller.credential,
+      caller = await requireGenerativeRouteCaller(c, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: Boolean(pricedMutation),
       });
     } catch (error) {
-      const admissionError = asGenerativeCacheApiError(error);
-      if (admissionError) return failureResponse(c, admissionError);
-      if (error instanceof InsufficientCreditsError) {
-        return c.json(
-          {
-            error: "Insufficient credits",
-            required: error.required,
-            available: error.available,
-          },
-          402,
+      return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
+    }
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
+    if (pendingResponse) return pendingResponse;
+
+    if (pricedMutation) {
+      try {
+        const billingContext: BillingContext = {
+          organizationId: caller.user.organization_id,
+          userId: caller.user.id,
+          apiKeyId: caller.apiKeyId,
+          model: pricedMutation.model,
+          provider: "fal",
+          billingSource: "fal",
+          requestId: `fal-proxy:${crypto.randomUUID()}`,
+          description: `fal.ai ${pricedMutation.model}`,
+        };
+        admission = await admitFlatGenerativeOperation({
+          c,
+          context: billingContext,
+          apiKeyId: caller.apiKeyId,
+          cost: pricedMutation.cost,
+          admissionSnapshot: caller.admissionSnapshot,
+          credential: credentialGuard.credentialForAdmission(),
+        });
+      } catch (error) {
+        const admissionError = asGenerativeCacheApiError(error);
+        if (admissionError) return failureResponse(c, admissionError);
+        if (error instanceof InsufficientCreditsError) {
+          return c.json(
+            {
+              error: "Insufficient credits",
+              required: error.required,
+              available: error.available,
+            },
+            402,
+          );
+        }
+        throw error;
+      }
+    }
+
+    try {
+      await admission?.markProviderDispatched?.();
+      const response = await invokeFalProxy(c);
+
+      if (admission && pricedMutation) {
+        await retainFalSettlement(
+          c,
+          admission.settle(response.ok ? pricedMutation.cost.totalCost : 0),
+          response.ok ? "settle" : "release",
         );
+      }
+
+      return response;
+    } catch (error) {
+      if (admission) {
+        await retainFalSettlement(c, admission.settle(0), "release");
       }
       throw error;
     }
-  }
-
-  try {
-    await admission?.markProviderDispatched?.();
-    const response = await invokeFalProxy(c);
-
-    if (admission && pricedMutation) {
-      await retainFalSettlement(
-        c,
-        admission.settle(response.ok ? pricedMutation.cost.totalCost : 0),
-        response.ok ? "settle" : "release",
-      );
-    }
-
-    return response;
   } catch (error) {
-    if (admission) {
-      await retainFalSettlement(c, admission.settle(0), "release");
-    }
-    throw error;
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 };
 

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -178,6 +178,7 @@ const handle: Handler<AppEnv> = async (c) => {
   > | null = null;
   let pricedMutation: Awaited<ReturnType<typeof priceFalMutation>> | null =
     null;
+  let pendingResponse: Response | undefined;
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
 
   if (willAdmitMutation) {
@@ -185,18 +186,18 @@ const handle: Handler<AppEnv> = async (c) => {
       pricedMutation = await priceFalMutation(c);
     } catch (error) {
       if (error instanceof Error && error.message === "missing_target") {
-        return c.json({ error: "Invalid request" }, 400);
-      }
-      if (
+        pendingResponse = c.json({ error: "Invalid request" }, 400);
+      } else if (
         error instanceof Error &&
         error.message.startsWith("Unpriced fal endpoint")
       ) {
-        return c.json({ error: error.message }, 400);
+        pendingResponse = c.json({ error: error.message }, 400);
+      } else {
+        logger.error("[fal proxy] Failed to price mutation", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        pendingResponse = c.json({ error: "fal pricing unavailable" }, 503);
       }
-      logger.error("[fal proxy] Failed to price mutation", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return c.json({ error: "fal pricing unavailable" }, 503);
     }
   }
 
@@ -208,6 +209,7 @@ const handle: Handler<AppEnv> = async (c) => {
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
+  if (pendingResponse) return pendingResponse;
 
   if (pricedMutation) {
     try {

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -278,7 +278,9 @@ app.post("/", async (c) => {
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
-    caller = await requireGenerativeRouteCaller(c);
+    caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
   } catch (error) {
     logger.warn("[MCP Proxy] Caller admission denied", {
       mcpId,
@@ -566,6 +568,7 @@ app.post("/", async (c) => {
         },
         apiKeyId: caller.apiKeyId,
         admissionSnapshot: caller.admissionSnapshot,
+        credential: caller.credential,
         cost: {
           baseTotalCost: chargeReceipt.baseAmountUsd,
           platformMarkup:

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -35,6 +35,7 @@ import { safeFetch } from "@/lib/security/safe-fetch";
 import { affiliatesService } from "@/lib/services/affiliates";
 import { containersService } from "@/lib/services/containers";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { userMcpsService } from "@/lib/services/user-mcps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -279,10 +280,7 @@ app.post("/", async (c) => {
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
     caller = await requireGenerativeRouteCaller(c, {
-      // MCP existence, visibility, endpoint safety, and JSON-RPC validity are
-      // resolved after caller identity. Any may stop before admission, so this
-      // route must perform the standalone strong check rather than defer it.
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
     });
   } catch (error) {
     logger.warn("[MCP Proxy] Caller admission denied", {
@@ -296,503 +294,522 @@ app.post("/", async (c) => {
     });
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
-  const user = caller.user;
-
-  const mcp = await userMcpsService.getById(mcpId);
-
-  if (!mcp) {
-    return c.json({ error: "MCP not found" }, 404);
-  }
-
-  if (mcp.status !== "live") {
-    return c.json({ error: "MCP is not available" }, 404);
-  }
-
-  // Owner-or-public gate (mirrors the GET handler): getById is unscoped and the
-  // catalog hides private MCPs, so without this a non-owner org could INVOKE
-  // another org's private live MCP — hitting the owner's backend/credentials
-  // while the caller is billed (cross-tenant IDOR, #11838). Public MCPs stay
-  // invokable by anyone (the monetization model); private MCPs are owner-only.
-  const { allowed } = resolveMcpProxyView({
-    mcpOrganizationId: mcp.organization_id,
-    mcpIsPublic: mcp.is_public,
-    viewerOrganizationId: user.organization_id,
-  });
-  if (!allowed) {
-    return c.json({ error: "MCP not found" }, 404);
-  }
-
-  const creditsRequired = Number(mcp.credits_per_request || "1");
-  let affiliateOwnerId: string | undefined;
-  let affiliateCodeId: string | undefined;
-
-  const referrerPromise = affiliatesService
-    .getReferrer(user.id)
-    .catch((error: Error | string) => {
-      logger.error("[MCP Proxy] Failed to resolve affiliate referrer", {
-        mcpId,
-        userId: user.id,
-        error: typeof error === "string" ? error : error.message,
-      });
-      return null;
-    });
-  const referrer = await referrerPromise;
-  if (referrer) {
-    affiliateOwnerId = referrer.user_id;
-    affiliateCodeId = referrer.id;
-  }
-
-  const {
-    markupCredits: affiliateFeeCredits,
-    platformFeeCredits,
-    totalCredits: totalCreditsRequired,
-  } = calculateCreditMarkup({
-    baseCredits: creditsRequired,
-    markupPercent: referrer ? Number(referrer.markup_percent) : 0,
-    platformFeeRate: referrer ? DEFAULT_PLATFORM_FEE_RATE : 0,
-  });
-  const chargeReceipt = mcpUsageChargeReceiptFromLegacyPoints({
-    basePoints: creditsRequired,
-    affiliateFeePoints: affiliateFeeCredits,
-    platformFeePoints: platformFeeCredits,
-  });
-
-  const requestId = `mcp-proxy:${mcp.id}:${crypto.randomUUID()}`;
-  let admission:
-    | Awaited<ReturnType<typeof admitFlatGenerativeOperation>>
-    | undefined;
-  const executionCtx = getGenerativeExecutionContext(c);
-  let providerDispatchStarted = false;
-  const retainAccounting = async (
-    task: Promise<unknown>,
-    operation: string,
-    metadata: Record<string, unknown> = {},
-  ): Promise<void> => {
-    const observed = task.catch((error) => {
-      // error-policy:J7 durable admission keeps the charge recoverable while
-      // operators receive the complete accounting failure context.
-      logger.error("[MCP Proxy] Background accounting failed", {
-        mcpId,
-        organizationId: user.organization_id,
-        requestId,
-        operation,
-        ...metadata,
-        error: error instanceof Error ? error.message : String(error),
-        errorName: error instanceof Error ? error.name : "unknown",
-      });
-    });
-    if (executionCtx) executionCtx.waitUntil(observed);
-    else await observed;
-  };
-  const settleFailure = async (
-    reason: string,
-    metadata: Record<string, unknown> = {},
-  ): Promise<void> => {
-    const activeAdmission = admission;
-    if (!activeAdmission) return;
-    await retainAccounting(
-      providerDispatchStarted
-        ? activeAdmission.settleUnknown()
-        : activeAdmission.settle(0),
-      providerDispatchStarted ? "settle_unknown" : "release_admission",
-      { reason, ...metadata },
-    );
-  };
-
-  // Own the wall-clock bound before every untrusted post-admission wait.
-  // Creating the timer after endpoint DNS or inbound parsing left those
-  // awaits able to retain the Worker request and the debit indefinitely.
-  const hop = createMcpProxyHopDeadline(c.req.raw.signal);
-  const refundDeadline = async (): Promise<Response> => {
-    logger.warn("[MCP Proxy] MCP hop exceeded the proxy deadline", {
-      mcpId,
-      timeoutMs: hop.timeoutMs,
-    });
-    await settleFailure("upstream_deadline_exceeded", {
-      timeoutMs: hop.timeoutMs,
-    });
-    return c.json({ error: "MCP endpoint timed out" }, 504);
-  };
-  const hopAborted = (error?: unknown): boolean =>
-    isMcpProxyHopDeadline(hop.signal, error) || hop.signal.aborted;
-
-  let targetUrl: string;
-  // External (user-configured) endpoints are fetched through safeFetch below,
-  // which re-validates AND pins the resolved IP for the actual request (closing
-  // the validate-then-fetch TOCTOU / DNS-rebind window on the Node path).
-  // Container endpoints resolve to a platform-internal load-balancer URL on the
-  // private tailnet, which safeFetch would (correctly) reject as a private IP —
-  // so those stay on the platform fetch.
-  let isExternalEndpoint = false;
-
   try {
-    if (mcp.endpoint_type === "external" && mcp.external_endpoint) {
-      let parsed: URL;
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
+    const user = caller.user;
+
+    const mcp = await userMcpsService.getById(mcpId);
+
+    if (!mcp) {
+      return c.json({ error: "MCP not found" }, 404);
+    }
+
+    if (mcp.status !== "live") {
+      return c.json({ error: "MCP is not available" }, 404);
+    }
+
+    // Owner-or-public gate (mirrors the GET handler): getById is unscoped and the
+    // catalog hides private MCPs, so without this a non-owner org could INVOKE
+    // another org's private live MCP — hitting the owner's backend/credentials
+    // while the caller is billed (cross-tenant IDOR, #11838). Public MCPs stay
+    // invokable by anyone (the monetization model); private MCPs are owner-only.
+    const { allowed } = resolveMcpProxyView({
+      mcpOrganizationId: mcp.organization_id,
+      mcpIsPublic: mcp.is_public,
+      viewerOrganizationId: user.organization_id,
+    });
+    if (!allowed) {
+      return c.json({ error: "MCP not found" }, 404);
+    }
+
+    const creditsRequired = Number(mcp.credits_per_request || "1");
+    let affiliateOwnerId: string | undefined;
+    let affiliateCodeId: string | undefined;
+
+    const referrerPromise = affiliatesService
+      .getReferrer(user.id)
+      .catch((error: Error | string) => {
+        logger.error("[MCP Proxy] Failed to resolve affiliate referrer", {
+          mcpId,
+          userId: user.id,
+          error: typeof error === "string" ? error : error.message,
+        });
+        return null;
+      });
+    const referrer = await referrerPromise;
+    if (referrer) {
+      affiliateOwnerId = referrer.user_id;
+      affiliateCodeId = referrer.id;
+    }
+
+    const {
+      markupCredits: affiliateFeeCredits,
+      platformFeeCredits,
+      totalCredits: totalCreditsRequired,
+    } = calculateCreditMarkup({
+      baseCredits: creditsRequired,
+      markupPercent: referrer ? Number(referrer.markup_percent) : 0,
+      platformFeeRate: referrer ? DEFAULT_PLATFORM_FEE_RATE : 0,
+    });
+    const chargeReceipt = mcpUsageChargeReceiptFromLegacyPoints({
+      basePoints: creditsRequired,
+      affiliateFeePoints: affiliateFeeCredits,
+      platformFeePoints: platformFeeCredits,
+    });
+
+    const requestId = `mcp-proxy:${mcp.id}:${crypto.randomUUID()}`;
+    let admission:
+      | Awaited<ReturnType<typeof admitFlatGenerativeOperation>>
+      | undefined;
+    const executionCtx = getGenerativeExecutionContext(c);
+    let providerDispatchStarted = false;
+    const retainAccounting = async (
+      task: Promise<unknown>,
+      operation: string,
+      metadata: Record<string, unknown> = {},
+    ): Promise<void> => {
+      const observed = task.catch((error) => {
+        // error-policy:J7 durable admission keeps the charge recoverable while
+        // operators receive the complete accounting failure context.
+        logger.error("[MCP Proxy] Background accounting failed", {
+          mcpId,
+          organizationId: user.organization_id,
+          requestId,
+          operation,
+          ...metadata,
+          error: error instanceof Error ? error.message : String(error),
+          errorName: error instanceof Error ? error.name : "unknown",
+        });
+      });
+      if (executionCtx) executionCtx.waitUntil(observed);
+      else await observed;
+    };
+    const settleFailure = async (
+      reason: string,
+      metadata: Record<string, unknown> = {},
+    ): Promise<void> => {
+      const activeAdmission = admission;
+      if (!activeAdmission) return;
+      await retainAccounting(
+        providerDispatchStarted
+          ? activeAdmission.settleUnknown()
+          : activeAdmission.settle(0),
+        providerDispatchStarted ? "settle_unknown" : "release_admission",
+        { reason, ...metadata },
+      );
+    };
+
+    // Own the wall-clock bound before every untrusted post-admission wait.
+    // Creating the timer after endpoint DNS or inbound parsing left those
+    // awaits able to retain the Worker request and the debit indefinitely.
+    const hop = createMcpProxyHopDeadline(c.req.raw.signal);
+    const refundDeadline = async (): Promise<Response> => {
+      logger.warn("[MCP Proxy] MCP hop exceeded the proxy deadline", {
+        mcpId,
+        timeoutMs: hop.timeoutMs,
+      });
+      await settleFailure("upstream_deadline_exceeded", {
+        timeoutMs: hop.timeoutMs,
+      });
+      return c.json({ error: "MCP endpoint timed out" }, 504);
+    };
+    const hopAborted = (error?: unknown): boolean =>
+      isMcpProxyHopDeadline(hop.signal, error) || hop.signal.aborted;
+
+    let targetUrl: string;
+    // External (user-configured) endpoints are fetched through safeFetch below,
+    // which re-validates AND pins the resolved IP for the actual request (closing
+    // the validate-then-fetch TOCTOU / DNS-rebind window on the Node path).
+    // Container endpoints resolve to a platform-internal load-balancer URL on the
+    // private tailnet, which safeFetch would (correctly) reject as a private IP —
+    // so those stay on the platform fetch.
+    let isExternalEndpoint = false;
+
+    try {
+      if (mcp.endpoint_type === "external" && mcp.external_endpoint) {
+        let parsed: URL;
+        try {
+          parsed = await raceWithAbort(
+            assertSafeOutboundUrl(mcp.external_endpoint, {
+              signal: hop.signal,
+            }),
+            hop.signal,
+          );
+        } catch (error) {
+          // error-policy:J1 hop abort maps to 504 settlement; other failures stay 400.
+          if (hopAborted(error)) {
+            return await refundDeadline();
+          }
+          logger.warn("[MCP Proxy] Blocked unsafe external endpoint", {
+            mcpId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          await settleFailure("unsafe_endpoint");
+          return c.json({ error: "Unsafe external MCP endpoint" }, 400);
+        }
+        targetUrl = parsed.toString();
+        isExternalEndpoint = true;
+      } else if (mcp.endpoint_type === "container" && mcp.container_id) {
+        let container: Awaited<ReturnType<typeof containersService.getById>>;
+        try {
+          container = await raceWithAbort(
+            containersService.getById(mcp.container_id, mcp.organization_id),
+            hop.signal,
+          );
+        } catch (error) {
+          // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
+          if (hopAborted(error)) {
+            return await refundDeadline();
+          }
+          logger.error("[MCP Proxy] Failed to resolve MCP container", {
+            mcpId,
+            containerId: mcp.container_id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          await settleFailure("container_lookup_failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return c.json({ error: "MCP container not available" }, 502);
+        }
+        if (!container?.load_balancer_url) {
+          await settleFailure("container_unavailable");
+          return c.json({ error: "MCP container not available" }, 503);
+        }
+        targetUrl = `${container.load_balancer_url}${mcp.endpoint_path || "/mcp"}`;
+      } else {
+        await settleFailure("endpoint_misconfigured");
+        return c.json({ error: "MCP endpoint not configured" }, 500);
+      }
+
+      let proxyBody: McpProxyJson;
       try {
-        parsed = await raceWithAbort(
-          assertSafeOutboundUrl(mcp.external_endpoint, { signal: hop.signal }),
+        proxyBody = await raceWithAbort(
+          parseJsonBody(c.req.raw, MAX_PROXY_REQUEST_BODY_BYTES, {
+            signal: hop.signal,
+          }),
           hop.signal,
         );
       } catch (error) {
-        // error-policy:J1 hop abort maps to 504 settlement; other failures stay 400.
+        // error-policy:J1 hop abort maps to 504 settlement; overflow stays 413.
         if (hopAborted(error)) {
           return await refundDeadline();
         }
-        logger.warn("[MCP Proxy] Blocked unsafe external endpoint", {
+        if (error instanceof McpProxyBodyTooLargeError) {
+          logger.warn(
+            "[MCP Proxy] Request body exceeded the proxy byte budget",
+            {
+              mcpId,
+              bytes: error.bytes,
+              maxBytes: error.maxBytes,
+            },
+          );
+          await settleFailure("request_body_too_large", {
+            maxBytes: error.maxBytes,
+          });
+          return c.json({ error: "MCP request body is too large" }, 413);
+        }
+        if (error instanceof McpProxyMalformedUtf8Error) {
+          logger.warn("[MCP Proxy] Request body is not valid UTF-8", {
+            mcpId,
+            bytes: error.bytes,
+          });
+          await settleFailure("request_body_malformed_utf8", {
+            bytes: error.bytes,
+          });
+          return c.json({ error: "MCP request body is not valid UTF-8" }, 400);
+        }
+        logger.warn("[MCP Proxy] Invalid JSON request body", {
           mcpId,
           error: error instanceof Error ? error.message : String(error),
         });
-        await settleFailure("unsafe_endpoint");
-        return c.json({ error: "Unsafe external MCP endpoint" }, 400);
+        await settleFailure("invalid_json");
+        return c.json({ error: "Invalid MCP request body" }, 400);
       }
-      targetUrl = parsed.toString();
-      isExternalEndpoint = true;
-    } else if (mcp.endpoint_type === "container" && mcp.container_id) {
-      let container: Awaited<ReturnType<typeof containersService.getById>>;
+      const toolName = toolNameFromRpcBody(proxyBody);
+
+      const proxyRequestInit: RequestInit = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(c.req.header("accept") && {
+            Accept: c.req.header("accept"),
+          }),
+        },
+        body: JSON.stringify(proxyBody),
+      };
+
       try {
-        container = await raceWithAbort(
-          containersService.getById(mcp.container_id, mcp.organization_id),
-          hop.signal,
-        );
+        admission = await admitFlatGenerativeOperation({
+          c,
+          context: {
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId: caller.apiKeyId,
+            model: `mcp/${mcp.id}`,
+            provider: "mcp",
+            billingSource: "selfhosted",
+            requestId,
+            description: `MCP: ${mcp.name}`,
+            metadata: {
+              mcp_id: mcp.id,
+              mcp_name: mcp.name,
+              base_credits: creditsRequired.toFixed(4),
+              affiliate_fee: affiliateFeeCredits.toFixed(4),
+              platform_fee: platformFeeCredits.toFixed(4),
+              total_credits_charged: totalCreditsRequired.toFixed(4),
+              base_amount_usd: formatOrganizationCreditUsd(
+                chargeReceipt.baseAmountUsd,
+              ),
+              affiliate_fee_usd: formatOrganizationCreditUsd(
+                chargeReceipt.affiliateFeeUsd,
+              ),
+              platform_fee_usd: formatOrganizationCreditUsd(
+                chargeReceipt.platformFeeUsd,
+              ),
+              total_amount_usd: formatOrganizationCreditUsd(
+                chargeReceipt.totalAmountUsd,
+              ),
+              credit_unit: ORGANIZATION_CREDIT_UNIT,
+              ...(affiliateOwnerId && { affiliate_owner_id: affiliateOwnerId }),
+              ...(affiliateCodeId && { affiliate_code_id: affiliateCodeId }),
+            },
+          },
+          apiKeyId: caller.apiKeyId,
+          admissionSnapshot: caller.admissionSnapshot,
+          credential: credentialGuard.credentialForAdmission(),
+          cost: {
+            baseTotalCost: chargeReceipt.baseAmountUsd,
+            platformMarkup:
+              chargeReceipt.totalAmountUsd - chargeReceipt.baseAmountUsd,
+            totalCost: chargeReceipt.totalAmountUsd,
+          },
+        });
+      } catch (error) {
+        if (error instanceof InsufficientCreditsError) {
+          return c.json(
+            {
+              error: "Insufficient credits",
+              creditUnit: ORGANIZATION_CREDIT_UNIT,
+              requiredUsd: chargeReceipt.totalAmountUsd,
+              /** @deprecated Legacy MCP pricing points (100 points = $1). */
+              required: totalCreditsRequired,
+              balance: error.available,
+            },
+            402,
+          );
+        }
+        logger.error("[MCP Proxy] Flat admission failed", {
+          mcpId,
+          organizationId: user.organization_id,
+          requestId,
+          error: error instanceof Error ? error.message : String(error),
+          errorName: error instanceof Error ? error.name : "unknown",
+        });
+        return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
+      }
+      const activeAdmission = admission;
+
+      let mcpResponse: Response;
+      try {
+        await activeAdmission.markProviderDispatched?.();
+        providerDispatchStarted = true;
+        if (isExternalEndpoint) {
+          // safeFetch validates + IP-pins the request and (redirect: "error")
+          // rejects any redirect — the single SSRF guard for outbound-from-user
+          // fetches, replacing the prior validate-then-raw-fetch pair. Race the
+          // await so a DNS lookup that never settles still hits the 504 refund.
+          mcpResponse = await raceWithAbort(
+            safeFetch(targetUrl, {
+              ...proxyRequestInit,
+              redirect: "error",
+              signal: hop.signal,
+            }),
+            hop.signal,
+          );
+        } else {
+          // Platform-internal container LB URL (private tailnet) — not a user-input
+          // SSRF surface; keep the platform fetch with the manual redirect block.
+          mcpResponse = await raceWithAbort(
+            fetch(targetUrl, {
+              ...proxyRequestInit,
+              redirect: "manual",
+              signal: hop.signal,
+            }),
+            hop.signal,
+          );
+          if (mcpResponse.status >= 300 && mcpResponse.status < 400) {
+            throw new Error("External MCP redirects are not allowed");
+          }
+        }
       } catch (error) {
         // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
         if (hopAborted(error)) {
           return await refundDeadline();
         }
-        logger.error("[MCP Proxy] Failed to resolve MCP container", {
+        logger.error("[MCP Proxy] Failed to reach MCP endpoint", {
           mcpId,
-          containerId: mcp.container_id,
+          targetUrl,
           error: error instanceof Error ? error.message : String(error),
         });
-        await settleFailure("container_lookup_failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return c.json({ error: "MCP container not available" }, 502);
+        await settleFailure("upstream_unreachable");
+        return c.json({ error: "Failed to reach MCP endpoint" }, 502);
       }
-      if (!container?.load_balancer_url) {
-        await settleFailure("container_unavailable");
-        return c.json({ error: "MCP container not available" }, 503);
-      }
-      targetUrl = `${container.load_balancer_url}${mcp.endpoint_path || "/mcp"}`;
-    } else {
-      await settleFailure("endpoint_misconfigured");
-      return c.json({ error: "MCP endpoint not configured" }, 500);
-    }
 
-    let proxyBody: McpProxyJson;
-    try {
-      proxyBody = await raceWithAbort(
-        parseJsonBody(c.req.raw, MAX_PROXY_REQUEST_BODY_BYTES, {
-          signal: hop.signal,
-        }),
-        hop.signal,
-      );
-    } catch (error) {
-      // error-policy:J1 hop abort maps to 504 settlement; overflow stays 413.
-      if (hopAborted(error)) {
-        return await refundDeadline();
-      }
-      if (error instanceof McpProxyBodyTooLargeError) {
-        logger.warn("[MCP Proxy] Request body exceeded the proxy byte budget", {
-          mcpId,
-          bytes: error.bytes,
-          maxBytes: error.maxBytes,
-        });
-        await settleFailure("request_body_too_large", {
-          maxBytes: error.maxBytes,
-        });
-        return c.json({ error: "MCP request body is too large" }, 413);
-      }
-      if (error instanceof McpProxyMalformedUtf8Error) {
-        logger.warn("[MCP Proxy] Request body is not valid UTF-8", {
-          mcpId,
-          bytes: error.bytes,
-        });
-        await settleFailure("request_body_malformed_utf8", {
-          bytes: error.bytes,
-        });
-        return c.json({ error: "MCP request body is not valid UTF-8" }, 400);
-      }
-      logger.warn("[MCP Proxy] Invalid JSON request body", {
-        mcpId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await settleFailure("invalid_json");
-      return c.json({ error: "Invalid MCP request body" }, 400);
-    }
-    const toolName = toolNameFromRpcBody(proxyBody);
-
-    const proxyRequestInit: RequestInit = {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(c.req.header("accept") && {
-          Accept: c.req.header("accept"),
-        }),
-      },
-      body: JSON.stringify(proxyBody),
-    };
-
-    try {
-      admission = await admitFlatGenerativeOperation({
-        c,
-        context: {
-          organizationId: user.organization_id,
-          userId: user.id,
-          apiKeyId: caller.apiKeyId,
-          model: `mcp/${mcp.id}`,
-          provider: "mcp",
-          billingSource: "selfhosted",
-          requestId,
-          description: `MCP: ${mcp.name}`,
-          metadata: {
-            mcp_id: mcp.id,
-            mcp_name: mcp.name,
-            base_credits: creditsRequired.toFixed(4),
-            affiliate_fee: affiliateFeeCredits.toFixed(4),
-            platform_fee: platformFeeCredits.toFixed(4),
-            total_credits_charged: totalCreditsRequired.toFixed(4),
-            base_amount_usd: formatOrganizationCreditUsd(
-              chargeReceipt.baseAmountUsd,
-            ),
-            affiliate_fee_usd: formatOrganizationCreditUsd(
-              chargeReceipt.affiliateFeeUsd,
-            ),
-            platform_fee_usd: formatOrganizationCreditUsd(
-              chargeReceipt.platformFeeUsd,
-            ),
-            total_amount_usd: formatOrganizationCreditUsd(
-              chargeReceipt.totalAmountUsd,
-            ),
-            credit_unit: ORGANIZATION_CREDIT_UNIT,
-            ...(affiliateOwnerId && { affiliate_owner_id: affiliateOwnerId }),
-            ...(affiliateCodeId && { affiliate_code_id: affiliateCodeId }),
-          },
-        },
-        apiKeyId: caller.apiKeyId,
-        admissionSnapshot: caller.admissionSnapshot,
-        credential: caller.credential,
-        cost: {
-          baseTotalCost: chargeReceipt.baseAmountUsd,
-          platformMarkup:
-            chargeReceipt.totalAmountUsd - chargeReceipt.baseAmountUsd,
-          totalCost: chargeReceipt.totalAmountUsd,
-        },
-      });
-    } catch (error) {
-      if (error instanceof InsufficientCreditsError) {
-        return c.json(
+      let responseBody: string;
+      try {
+        // The far end of this read is a URL the MCP's owner chose. Charge the
+        // budget before the bytes are retained — a catch below can report a read
+        // failure but cannot give back memory the isolate has already spent.
+        const budgeted = await readBodyTextWithinBudget(
+          mcpResponse,
+          MAX_PROXY_RESPONSE_BODY_BYTES,
           {
-            error: "Insufficient credits",
-            creditUnit: ORGANIZATION_CREDIT_UNIT,
-            requiredUsd: chargeReceipt.totalAmountUsd,
-            /** @deprecated Legacy MCP pricing points (100 points = $1). */
-            required: totalCreditsRequired,
-            balance: error.available,
+            signal: hop.signal,
+            onCancelFailure: (label, cancelError) => {
+              // error-policy:J6 best-effort teardown for a body already rejected.
+              logger.warn(
+                "[MCP Proxy] Failed to cancel oversized MCP response",
+                {
+                  mcpId,
+                  label,
+                  errorType:
+                    cancelError instanceof Error ? cancelError.name : "unknown",
+                },
+              );
+            },
           },
-          402,
         );
-      }
-      logger.error("[MCP Proxy] Flat admission failed", {
-        mcpId,
-        organizationId: user.organization_id,
-        requestId,
-        error: error instanceof Error ? error.message : String(error),
-        errorName: error instanceof Error ? error.name : "unknown",
-      });
-      return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
-    }
-    const activeAdmission = admission;
-
-    let mcpResponse: Response;
-    try {
-      await activeAdmission.markProviderDispatched?.();
-      providerDispatchStarted = true;
-      if (isExternalEndpoint) {
-        // safeFetch validates + IP-pins the request and (redirect: "error")
-        // rejects any redirect — the single SSRF guard for outbound-from-user
-        // fetches, replacing the prior validate-then-raw-fetch pair. Race the
-        // await so a DNS lookup that never settles still hits the 504 refund.
-        mcpResponse = await raceWithAbort(
-          safeFetch(targetUrl, {
-            ...proxyRequestInit,
-            redirect: "error",
-            signal: hop.signal,
-          }),
-          hop.signal,
-        );
-      } else {
-        // Platform-internal container LB URL (private tailnet) — not a user-input
-        // SSRF surface; keep the platform fetch with the manual redirect block.
-        mcpResponse = await raceWithAbort(
-          fetch(targetUrl, {
-            ...proxyRequestInit,
-            redirect: "manual",
-            signal: hop.signal,
-          }),
-          hop.signal,
-        );
-        if (mcpResponse.status >= 300 && mcpResponse.status < 400) {
-          throw new Error("External MCP redirects are not allowed");
-        }
-      }
-    } catch (error) {
-      // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
-      if (hopAborted(error)) {
-        return await refundDeadline();
-      }
-      logger.error("[MCP Proxy] Failed to reach MCP endpoint", {
-        mcpId,
-        targetUrl,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await settleFailure("upstream_unreachable");
-      return c.json({ error: "Failed to reach MCP endpoint" }, 502);
-    }
-
-    let responseBody: string;
-    try {
-      // The far end of this read is a URL the MCP's owner chose. Charge the
-      // budget before the bytes are retained — a catch below can report a read
-      // failure but cannot give back memory the isolate has already spent.
-      const budgeted = await readBodyTextWithinBudget(
-        mcpResponse,
-        MAX_PROXY_RESPONSE_BODY_BYTES,
-        {
-          signal: hop.signal,
-          onCancelFailure: (label, cancelError) => {
-            // error-policy:J6 best-effort teardown for a body already rejected.
-            logger.warn("[MCP Proxy] Failed to cancel oversized MCP response", {
+        if (!budgeted.ok) {
+          if (budgeted.reason === "deadline") {
+            return await refundDeadline();
+          }
+          if (budgeted.reason === "malformed-utf8") {
+            logger.warn("[MCP Proxy] MCP response is not valid UTF-8", {
               mcpId,
-              label,
-              errorType:
-                cancelError instanceof Error ? cancelError.name : "unknown",
+              status: mcpResponse.status,
+              receivedBytes: budgeted.bytes,
             });
-          },
-        },
-      );
-      if (!budgeted.ok) {
-        if (budgeted.reason === "deadline") {
+            await settleFailure("mcp_response_malformed_utf8", {
+              status: mcpResponse.status,
+            });
+            return c.json({ error: "MCP response is not valid UTF-8" }, 502);
+          }
+          logger.warn(
+            "[MCP Proxy] MCP response exceeded the proxy byte budget",
+            {
+              mcpId,
+              status: mcpResponse.status,
+              receivedBytes: budgeted.bytes,
+              maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+            },
+          );
+          await settleFailure("mcp_response_too_large", {
+            status: mcpResponse.status,
+            maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+          });
+          return c.json({ error: "MCP response is too large" }, 502);
+        }
+        responseBody = budgeted.text;
+      } catch (error) {
+        // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
+        if (hopAborted(error)) {
           return await refundDeadline();
         }
-        if (budgeted.reason === "malformed-utf8") {
-          logger.warn("[MCP Proxy] MCP response is not valid UTF-8", {
-            mcpId,
-            status: mcpResponse.status,
-            receivedBytes: budgeted.bytes,
-          });
-          await settleFailure("mcp_response_malformed_utf8", {
-            status: mcpResponse.status,
-          });
-          return c.json({ error: "MCP response is not valid UTF-8" }, 502);
-        }
-        logger.warn("[MCP Proxy] MCP response exceeded the proxy byte budget", {
+        logger.error("[MCP Proxy] Failed to read MCP response body", {
           mcpId,
           status: mcpResponse.status,
-          receivedBytes: budgeted.bytes,
-          maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+          error: error instanceof Error ? error.message : String(error),
         });
-        await settleFailure("mcp_response_too_large", {
+        await settleFailure("mcp_response_read_failed", {
           status: mcpResponse.status,
-          maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+          error: error instanceof Error ? error.message : String(error),
         });
-        return c.json({ error: "MCP response is too large" }, 502);
+        return c.json({ error: "Failed to read MCP response" }, 502);
       }
-      responseBody = budgeted.text;
-    } catch (error) {
-      // error-policy:J1 hop abort maps to 504 settlement; other failures stay 502.
-      if (hopAborted(error)) {
-        return await refundDeadline();
-      }
-      logger.error("[MCP Proxy] Failed to read MCP response body", {
-        mcpId,
-        status: mcpResponse.status,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await settleFailure("mcp_response_read_failed", {
-        status: mcpResponse.status,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return c.json({ error: "Failed to read MCP response" }, 502);
-    }
 
-    // A 2xx transport does NOT mean the tool call succeeded: MCP speaks JSON-RPC
-    // 2.0, so a failed call is delivered as HTTP 200 with an `{ error: {...} }`
-    // envelope. Billing on `mcpResponse.ok` alone charged the caller for a call
-    // the MCP never completed (#11637 at the HTTP layer, still open at the RPC
-    // layer). Refund on an explicit JSON-RPC error instead of success-shaping it.
-    const rpcErrored = mcpResponse.ok && isJsonRpcErrorResponse(responseBody);
-    if (mcpResponse.ok && !rpcErrored) {
-      const accountingTask = (async () => {
-        const reconciliation = await activeAdmission.settle(
-          chargeReceipt.totalAmountUsd,
-        );
-        if (reconciliation?.adjustmentType === "uncollected_overage") {
-          logger.error("[MCP Proxy] Final charge was not collected", {
-            mcpId,
-            organizationId: user.organization_id,
-            requestId,
-            reserved: reconciliation.reservedAmount,
-            actual: reconciliation.actualCost,
-          });
-          return;
-        }
-        await userMcpsService.recordUsageWithoutDeduction({
-          mcpId: mcp.id,
-          organizationId: user.organization_id,
-          userId: user.id,
-          toolName,
-          creditsCharged: creditsRequired,
-          affiliateFeeCredits,
-          platformFeeCredits,
-          chargeReceipt,
-          affiliateOwnerId,
-          affiliateCodeId,
-          metadata: {
-            responseTime: Date.now() - startTime,
-            success: true,
-            preChargeTransactionId:
-              activeAdmission.reservation?.reservationTransactionId ??
+      // A 2xx transport does NOT mean the tool call succeeded: MCP speaks JSON-RPC
+      // 2.0, so a failed call is delivered as HTTP 200 with an `{ error: {...} }`
+      // envelope. Billing on `mcpResponse.ok` alone charged the caller for a call
+      // the MCP never completed (#11637 at the HTTP layer, still open at the RPC
+      // layer). Refund on an explicit JSON-RPC error instead of success-shaping it.
+      const rpcErrored = mcpResponse.ok && isJsonRpcErrorResponse(responseBody);
+      if (mcpResponse.ok && !rpcErrored) {
+        const accountingTask = (async () => {
+          const reconciliation = await activeAdmission.settle(
+            chargeReceipt.totalAmountUsd,
+          );
+          if (reconciliation?.adjustmentType === "uncollected_overage") {
+            logger.error("[MCP Proxy] Final charge was not collected", {
+              mcpId,
+              organizationId: user.organization_id,
               requestId,
-            totalCreditsCharged: totalCreditsRequired,
+              reserved: reconciliation.reservedAmount,
+              actual: reconciliation.actualCost,
+            });
+            return;
+          }
+          await userMcpsService.recordUsageWithoutDeduction({
+            mcpId: mcp.id,
+            organizationId: user.organization_id,
+            userId: user.id,
+            toolName,
+            creditsCharged: creditsRequired,
             affiliateFeeCredits,
             platformFeeCredits,
-          },
-        });
-      })();
-      await retainAccounting(accountingTask, "settle_and_record_usage", {
-        toolName,
-        status: mcpResponse.status,
-      });
-    } else if (rpcErrored) {
-      // Protocol-level failure over a 2xx transport: refund and do not bill. The
-      // caller still receives the MCP's error envelope verbatim below.
-      logger.warn(
-        "[MCP Proxy] MCP returned a JSON-RPC error over 2xx; refunding",
-        {
-          mcpId,
-          status: mcpResponse.status,
+            chargeReceipt,
+            affiliateOwnerId,
+            affiliateCodeId,
+            metadata: {
+              responseTime: Date.now() - startTime,
+              success: true,
+              preChargeTransactionId:
+                activeAdmission.reservation?.reservationTransactionId ??
+                requestId,
+              totalCreditsCharged: totalCreditsRequired,
+              affiliateFeeCredits,
+              platformFeeCredits,
+            },
+          });
+        })();
+        await retainAccounting(accountingTask, "settle_and_record_usage", {
           toolName,
-        },
-      );
-      await settleFailure("mcp_jsonrpc_error", {
-        status: mcpResponse.status,
-      });
-    } else {
-      await settleFailure("mcp_call_failed", { status: mcpResponse.status });
-    }
+          status: mcpResponse.status,
+        });
+      } else if (rpcErrored) {
+        // Protocol-level failure over a 2xx transport: refund and do not bill. The
+        // caller still receives the MCP's error envelope verbatim below.
+        logger.warn(
+          "[MCP Proxy] MCP returned a JSON-RPC error over 2xx; refunding",
+          {
+            mcpId,
+            status: mcpResponse.status,
+            toolName,
+          },
+        );
+        await settleFailure("mcp_jsonrpc_error", {
+          status: mcpResponse.status,
+        });
+      } else {
+        await settleFailure("mcp_call_failed", { status: mcpResponse.status });
+      }
 
-    return new Response(responseBody, {
-      status: mcpResponse.status,
-      headers: {
-        "Content-Type":
-          mcpResponse.headers.get("content-type") || "application/json",
-        "X-MCP-Id": mcp.id,
-        "X-MCP-Name": mcp.name,
-      },
-    });
-  } finally {
-    hop.clear();
+      return new Response(responseBody, {
+        status: mcpResponse.status,
+        headers: {
+          "Content-Type":
+            mcpResponse.headers.get("content-type") || "application/json",
+          "X-MCP-Id": mcp.id,
+          "X-MCP-Name": mcp.name,
+        },
+      });
+    } finally {
+      hop.clear();
+    }
+  } catch (error) {
+    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
 });
 

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -279,7 +279,10 @@ app.post("/", async (c) => {
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
     caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
+      // MCP existence, visibility, endpoint safety, and JSON-RPC validity are
+      // resolved after caller identity. Any may stop before admission, so this
+      // route must perform the standalone strong check rather than defer it.
+      deferStrongCredentialCheck: false,
     });
   } catch (error) {
     logger.warn("[MCP Proxy] Caller admission denied", {

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -63,6 +63,7 @@ const enforceOrgRateLimit = vi.fn();
 const inferenceRateLimitConfig = vi.fn();
 const assertInferenceCredentialActive = vi.fn();
 const loggerWarn = vi.fn();
+const loggerError = vi.fn();
 
 vi.mock("@/lib/api/cloud-worker-errors", () => ({ ApiError }));
 vi.mock("@/lib/services/ai-pricing/cache", () => ({
@@ -98,7 +99,7 @@ vi.mock("@/lib/services/inference-admission-snapshot", () => ({
   inferenceRateLimitConfig,
 }));
 vi.mock("@/lib/utils/logger", () => ({
-  logger: { warn: loggerWarn },
+  logger: { error: loggerError, warn: loggerWarn },
 }));
 
 if (typeof Bun !== "undefined") {
@@ -112,9 +113,18 @@ if (typeof Bun !== "undefined") {
     resolveInferenceAuthContext,
   }));
   bunTest.mock.module("@/lib/services/inference-credential-revocation", () => ({
+    assertInferenceCredentialActive,
     InferenceCredentialRevokedError,
     inferenceCredentialRevocationReason,
   }));
+  bunTest.mock.module(
+    "../../../shared/src/lib/services/inference-credential-revocation",
+    () => ({
+      assertInferenceCredentialActive,
+      InferenceCredentialRevokedError,
+      inferenceCredentialRevocationReason,
+    }),
+  );
   bunTest.mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
   bunTest.mock.module("@/lib/auth/workers-hono-auth", () => ({
     requireUserOrApiKeyWithOrg,
@@ -135,7 +145,7 @@ if (typeof Bun !== "undefined") {
     inferenceRateLimitConfig,
   }));
   bunTest.mock.module("@/lib/utils/logger", () => ({
-    logger: { warn: loggerWarn },
+    logger: { error: loggerError, warn: loggerWarn },
   }));
 }
 
@@ -157,6 +167,7 @@ describe("deferredCredentialAdmissionGuard", () => {
   beforeEach(() => {
     assertInferenceCredentialActive.mockReset();
     assertInferenceCredentialActive.mockResolvedValue(undefined);
+    loggerError.mockReset();
   });
 
   test("performs one standalone check when a route exits before admission", async () => {
@@ -194,6 +205,86 @@ describe("deferredCredentialAdmissionGuard", () => {
     await guard[Symbol.asyncDispose]();
 
     expect(assertInferenceCredentialActive).not.toHaveBeenCalled();
+  });
+
+  test("maps an early-return disposal rejection to its safe standing denial", async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    assertInferenceCredentialActive.mockRejectedValueOnce(
+      new InferenceCredentialRevokedError("credential_revoked"),
+    );
+
+    let caught: unknown;
+    try {
+      await (async () => {
+        await using _guard = deferredCredentialAdmissionGuard({
+          organizationId: () => "org-1",
+          credential: () => credential,
+        });
+        return "terminal-response-before-resource-or-provider-work";
+      })();
+    } catch (error) {
+      // error-policy:J1 the test captures the route-boundary translation input.
+      caught = error;
+    }
+
+    const mapped = asGenerativeCacheApiError(caught, {
+      route: "terminal-test",
+      traceId: "trace-terminal",
+    });
+    expect(mapped?.status).toBe(401);
+    expect(mapped?.details).toEqual({ reason: "credential_inactive" });
+    expect(assertInferenceCredentialActive).toHaveBeenCalledTimes(1);
+  });
+
+  test("unwraps disposal revocation when it suppresses a body failure without logging secrets", async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    assertInferenceCredentialActive.mockRejectedValueOnce(
+      new InferenceCredentialRevokedError("session_revoked"),
+    );
+
+    let caught: unknown;
+    try {
+      await using _guard = deferredCredentialAdmissionGuard({
+        organizationId: () => "org-1",
+        credential: () => credential,
+      });
+      throw new Error("secret-request-body bearer-private-value");
+    } catch (error) {
+      // error-policy:J1 the test captures the route-boundary translation input.
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).name).toBe("SuppressedError");
+    const mapped = asGenerativeCacheApiError(caught, {
+      route: "body-throw-test",
+      traceId: "trace-suppressed",
+    });
+    expect(mapped?.status).toBe(401);
+    expect(mapped?.details).toEqual({ reason: "credential_inactive" });
+    expect(loggerError).toHaveBeenCalledWith(
+      "[InferenceAuth] deferred revocation suppressed an earlier route failure",
+      {
+        route: "body-throw-test",
+        traceId: "trace-suppressed",
+        credentialReason: "session_revoked",
+        suppressedError: { name: "Error" },
+      },
+    );
+    expect(JSON.stringify(loggerError.mock.calls)).not.toContain(
+      "secret-request-body",
+    );
+    expect(JSON.stringify(loggerError.mock.calls)).not.toContain(
+      "bearer-private-value",
+    );
   });
 });
 

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -47,7 +47,11 @@ class InferenceCredentialRevokedError extends Error {
 }
 
 function inferenceCredentialRevocationReason(reason: string) {
-  return reason === "credential_revoked" ? "credential_inactive" : reason;
+  return reason === "credential_revoked" ||
+    reason === "session_revoked" ||
+    reason === "session_binding_revoked"
+    ? "credential_inactive"
+    : reason;
 }
 
 const resolveInferenceAuthContext = vi.fn();
@@ -333,6 +337,18 @@ describe("asGenerativeCacheApiError", () => {
       }),
     );
   });
+
+  test.each(["session_revoked", "session_binding_revoked"])(
+    "maps Steward %s to the same 401 standing contract",
+    (reason) => {
+      const mapped = asGenerativeCacheApiError(
+        new InferenceCredentialRevokedError(reason),
+      );
+      expect(mapped?.status).toBe(401);
+      expect(mapped?.code).toBe("authentication_required");
+      expect(mapped?.details).toEqual({ reason: "credential_inactive" });
+    },
+  );
 
   test("maps AiPricingCacheWarmingError to a retryable 503", () => {
     const mapped = asGenerativeCacheApiError(new AiPricingCacheWarmingError());

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -39,6 +39,17 @@ class AiPricingCacheUnavailableError extends Error {
   }
 }
 
+class InferenceCredentialRevokedError extends Error {
+  constructor(readonly reason: string) {
+    super(`Inference credential rejected: ${reason}`);
+    this.name = "InferenceCredentialRevokedError";
+  }
+}
+
+function inferenceCredentialRevocationReason(reason: string) {
+  return reason === "credential_revoked" ? "credential_inactive" : reason;
+}
+
 const resolveInferenceAuthContext = vi.fn();
 const requireAuthOrApiKeyWithOrg = vi.fn();
 const requireUserOrApiKeyWithOrg = vi.fn();
@@ -55,6 +66,10 @@ vi.mock("@/lib/services/ai-pricing/cache", () => ({
 }));
 vi.mock("@/lib/services/inference-auth-context", () => ({
   resolveInferenceAuthContext,
+}));
+vi.mock("@/lib/services/inference-credential-revocation", () => ({
+  InferenceCredentialRevokedError,
+  inferenceCredentialRevocationReason,
 }));
 vi.mock("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
 vi.mock("@/lib/auth/workers-hono-auth", () => ({
@@ -81,6 +96,10 @@ if (typeof Bun !== "undefined") {
   }));
   bunTest.mock.module("@/lib/services/inference-auth-context", () => ({
     resolveInferenceAuthContext,
+  }));
+  bunTest.mock.module("@/lib/services/inference-credential-revocation", () => ({
+    InferenceCredentialRevokedError,
+    inferenceCredentialRevocationReason,
   }));
   bunTest.mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
   bunTest.mock.module("@/lib/auth/workers-hono-auth", () => ({
@@ -110,8 +129,10 @@ const {
   admitFlatGenerativeOperation,
   asGenerativeCacheApiError,
   getGenerativeExecutionContext,
+  getGenerativeOperationContext,
   getGenerativePricingCacheOptions,
   requireGenerativeRouteCaller,
+  resolveInferenceCredentialAdmissionDenial,
   resolveInferenceAuthStandingDenial,
 } = await import("./generative-route-auth");
 
@@ -285,6 +306,34 @@ describe("getGenerativePricingCacheOptions", () => {
 });
 
 describe("asGenerativeCacheApiError", () => {
+  test("maps a fused credential refusal without losing the standing reason", () => {
+    const error = new InferenceCredentialRevokedError("credential_revoked");
+    const denial = resolveInferenceCredentialAdmissionDenial(error, {
+      route: "generate-image",
+      traceId: "trace-1",
+    });
+    const mapped = asGenerativeCacheApiError(error);
+
+    expect(denial).toEqual({
+      status: 401,
+      type: "authentication_error",
+      code: "authentication_required",
+      message: "API key is inactive",
+      reason: "credential_inactive",
+    });
+    expect(mapped).toBeInstanceOf(ApiError);
+    expect(mapped?.status).toBe(401);
+    expect(mapped?.details).toEqual({ reason: "credential_inactive" });
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[InferenceAuth] blocked provider dispatch at route boundary",
+      expect.objectContaining({
+        route: "generate-image",
+        traceId: "trace-1",
+        reason: "credential_inactive",
+      }),
+    );
+  });
+
   test("maps AiPricingCacheWarmingError to a retryable 503", () => {
     const mapped = asGenerativeCacheApiError(new AiPricingCacheWarmingError());
     expect(mapped).toBeInstanceOf(ApiError);
@@ -529,6 +578,33 @@ describe("admitFlatGenerativeOperation", () => {
       flatCost: FLAT_COST,
       admissionSnapshot: snapshot,
     });
+  });
+
+  test("threads the exact deferred credential into Worker flat admission", async () => {
+    const { c, executionCtx } = workerContext();
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    admitOrganizationInference.mockResolvedValueOnce({
+      mode: "durable_object_debit",
+      settle: async () => null,
+      settleUnknown: async () => null,
+    });
+
+    await admitFlatGenerativeOperation({
+      c: c as never,
+      context: billingContext(),
+      apiKeyId: "key-1",
+      cost: FLAT_COST,
+      admissionSnapshot: admissionSnapshot(),
+      credential,
+    });
+
+    expect(admitOrganizationInference).toHaveBeenCalledWith(
+      expect.objectContaining({ executionCtx, credential }),
+    );
   });
 
   test("wraps Inference Warming failures from Worker admission as 503", async () => {
@@ -785,6 +861,41 @@ describe("requireGenerativeRouteCaller", () => {
     expect(store.get("apiKeyId")).toBe("key-1");
     expect(caller.apiKeyId).toBe("key-1");
     expect(caller.appScopeId).toBe("app-1");
+  });
+
+  test("defers only for a declared admission consumer and preserves the exact credential", async () => {
+    const { c } = workerContext({ requestId: "req-fused" });
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      ...apiKeyAuthorized,
+      credential,
+    });
+
+    const caller = await requireGenerativeRouteCaller(c as never, {
+      deferStrongCredentialCheck: true,
+    });
+    const operationContext = getGenerativeOperationContext(c as never, caller);
+
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).toMatchObject({
+      deferStrongCredentialCheck: true,
+    });
+    expect(caller.credential).toBe(credential);
+    expect(operationContext.credential).toBe(credential);
+  });
+
+  test("keeps standalone validation when no admission consumer is declared", async () => {
+    const { c } = workerContext();
+    resolveInferenceAuthContext.mockResolvedValueOnce(apiKeyAuthorized);
+
+    await requireGenerativeRouteCaller(c as never);
+
+    expect(resolveInferenceAuthContext.mock.calls[0]?.[1]).not.toHaveProperty(
+      "deferStrongCredentialCheck",
+    );
   });
 
   test("returns null appScopeId when the field is absent from ctx", async () => {

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -61,6 +61,7 @@ const reserveFlatUsageCredits = vi.fn();
 const admitOrganizationInference = vi.fn();
 const enforceOrgRateLimit = vi.fn();
 const inferenceRateLimitConfig = vi.fn();
+const assertInferenceCredentialActive = vi.fn();
 const loggerWarn = vi.fn();
 
 vi.mock("@/lib/api/cloud-worker-errors", () => ({ ApiError }));
@@ -72,9 +73,18 @@ vi.mock("@/lib/services/inference-auth-context", () => ({
   resolveInferenceAuthContext,
 }));
 vi.mock("@/lib/services/inference-credential-revocation", () => ({
+  assertInferenceCredentialActive,
   InferenceCredentialRevokedError,
   inferenceCredentialRevocationReason,
 }));
+vi.mock(
+  "../../../shared/src/lib/services/inference-credential-revocation",
+  () => ({
+    assertInferenceCredentialActive,
+    InferenceCredentialRevokedError,
+    inferenceCredentialRevocationReason,
+  }),
+);
 vi.mock("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
 vi.mock("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
@@ -139,6 +149,53 @@ const {
   resolveInferenceCredentialAdmissionDenial,
   resolveInferenceAuthStandingDenial,
 } = await import("./generative-route-auth");
+const { deferredCredentialAdmissionGuard } = await import(
+  "../../../shared/src/lib/services/deferred-credential-admission-guard"
+);
+
+describe("deferredCredentialAdmissionGuard", () => {
+  beforeEach(() => {
+    assertInferenceCredentialActive.mockReset();
+    assertInferenceCredentialActive.mockResolvedValue(undefined);
+  });
+
+  test("performs one standalone check when a route exits before admission", async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    const guard = deferredCredentialAdmissionGuard({
+      organizationId: () => "org-1",
+      credential: () => credential,
+    });
+
+    await guard[Symbol.asyncDispose]();
+
+    expect(assertInferenceCredentialActive).toHaveBeenCalledTimes(1);
+    expect(assertInferenceCredentialActive).toHaveBeenCalledWith(
+      "org-1",
+      credential,
+    );
+  });
+
+  test("leaves the exact credential for atomic admission without a standalone check", async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    const guard = deferredCredentialAdmissionGuard({
+      organizationId: () => "org-1",
+      credential: () => credential,
+    });
+
+    expect(guard.credentialForAdmission()).toBe(credential);
+    await guard[Symbol.asyncDispose]();
+
+    expect(assertInferenceCredentialActive).not.toHaveBeenCalled();
+  });
+});
 
 const FLAT_COST = {
   totalCost: 1.25,
@@ -763,6 +820,7 @@ describe("requireGenerativeRouteCaller", () => {
     requireUserOrApiKeyWithOrg.mockReset();
     enforceOrgRateLimit.mockReset();
     inferenceRateLimitConfig.mockReset();
+    assertInferenceCredentialActive.mockReset();
     requireAuthOrApiKeyWithOrg.mockResolvedValue({
       user: { id: "user-1", organization_id: "org-1" },
       apiKey: { id: "key-raw" },
@@ -776,6 +834,7 @@ describe("requireGenerativeRouteCaller", () => {
       windowMs: 1000,
       maxRequests: 10,
     });
+    assertInferenceCredentialActive.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -784,6 +843,7 @@ describe("requireGenerativeRouteCaller", () => {
     requireUserOrApiKeyWithOrg.mockReset();
     enforceOrgRateLimit.mockReset();
     inferenceRateLimitConfig.mockReset();
+    assertInferenceCredentialActive.mockReset();
   });
 
   test("uses raw compatibility auth when no Worker context is present", async () => {
@@ -901,6 +961,7 @@ describe("requireGenerativeRouteCaller", () => {
     });
     expect(caller.credential).toBe(credential);
     expect(operationContext.credential).toBe(credential);
+    expect(assertInferenceCredentialActive).not.toHaveBeenCalled();
   });
 
   test("keeps standalone validation when no admission consumer is declared", async () => {
@@ -979,6 +1040,35 @@ describe("requireGenerativeRouteCaller", () => {
       code: "rate_limit_exceeded",
       message: "Rate limit exceeded",
     });
+  });
+
+  test("consumes a deferred credential before returning a rate-limit failure", async () => {
+    const { c } = workerContext();
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      ...apiKeyAuthorized,
+      credential,
+    });
+    enforceOrgRateLimit.mockResolvedValueOnce(
+      new Response("slow down", { status: 429 }),
+    );
+
+    await expect(
+      requireGenerativeRouteCaller(c as never, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: true,
+      }),
+    ).rejects.toMatchObject({ status: 429, code: "rate_limit_exceeded" });
+    expect(assertInferenceCredentialActive).toHaveBeenCalledTimes(1);
+    expect(assertInferenceCredentialActive).toHaveBeenCalledWith(
+      "org-1",
+      credential,
+    );
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
   });
 
   test("throws service_unavailable when the limiter returns a non-429 failure", async () => {

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -147,8 +147,38 @@ export function resolveInferenceCredentialAdmissionDenial(
   error: unknown,
   logContext?: { route: string; traceId?: string },
 ): InferenceAuthStandingDenial | null {
-  if (!(error instanceof InferenceCredentialRevokedError)) return null;
-  const reason = inferenceCredentialRevocationReason(error.reason);
+  let credentialError = error;
+  if (
+    error instanceof Error &&
+    error.name === "SuppressedError" &&
+    "error" in error &&
+    error.error instanceof InferenceCredentialRevokedError
+  ) {
+    credentialError = error.error;
+    const suppressed = "suppressed" in error ? error.suppressed : undefined;
+    const suppressedError =
+      suppressed instanceof Error
+        ? {
+            name: suppressed.name,
+            ...(suppressed instanceof ApiError
+              ? { code: suppressed.code, status: suppressed.status }
+              : {}),
+          }
+        : { name: typeof suppressed };
+    logger.error(
+      "[InferenceAuth] deferred revocation suppressed an earlier route failure",
+      {
+        route: logContext?.route ?? "unavailable",
+        traceId: logContext?.traceId ?? "unavailable",
+        credentialReason: error.error.reason,
+        suppressedError,
+      },
+    );
+  }
+  if (!(credentialError instanceof InferenceCredentialRevokedError)) {
+    return null;
+  }
+  const reason = inferenceCredentialRevocationReason(credentialError.reason);
   return resolveInferenceAuthStandingDenial(
     {
       kind: "rejected",
@@ -262,8 +292,14 @@ export async function requireGenerativeKnownIdentity(
   };
 }
 
-export function asGenerativeCacheApiError(error: unknown): ApiError | null {
-  const admissionDenial = resolveInferenceCredentialAdmissionDenial(error);
+export function asGenerativeCacheApiError(
+  error: unknown,
+  logContext?: { route: string; traceId?: string },
+): ApiError | null {
+  const admissionDenial = resolveInferenceCredentialAdmissionDenial(
+    error,
+    logContext,
+  );
   if (admissionDenial) {
     return new ApiError(
       admissionDenial.status,

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -20,6 +20,11 @@ import type {
   InferenceAdmissionSnapshot,
   InferenceAuthRejectionReason,
 } from "@/lib/services/inference-auth-cache";
+import {
+  type InferenceCredentialCheck,
+  InferenceCredentialRevokedError,
+  inferenceCredentialRevocationReason,
+} from "@/lib/services/inference-credential-revocation";
 import type { EndpointType } from "@/lib/services/org-rate-limits";
 import type { OrganizationInferenceAdmission } from "@/lib/services/organization-inference-admission";
 import { logger } from "@/lib/utils/logger";
@@ -33,6 +38,8 @@ export interface GenerativeRouteCaller {
   apiKeyId: string | null;
   authSource: "combined_cache" | "compatibility";
   admissionSnapshot?: InferenceAdmissionSnapshot;
+  /** Strong proof that the next paid admission must consume atomically. */
+  credential?: InferenceCredentialCheck;
   appScopeId: string | null;
 }
 
@@ -134,6 +141,23 @@ export function resolveInferenceAuthStandingDenial(
   return denial;
 }
 
+/** Maps a combined admission-gate credential refusal to the same route contract. */
+export function resolveInferenceCredentialAdmissionDenial(
+  error: unknown,
+  logContext?: { route: string; traceId?: string },
+): InferenceAuthStandingDenial | null {
+  if (!(error instanceof InferenceCredentialRevokedError)) return null;
+  const reason = inferenceCredentialRevocationReason(error.reason);
+  return resolveInferenceAuthStandingDenial(
+    {
+      kind: "rejected",
+      status: reason === "credential_inactive" ? 401 : 403,
+      reason,
+    },
+    logContext,
+  );
+}
+
 export function getGenerativeExecutionContext(
   c: AppContext,
 ): { waitUntil(promise: Promise<unknown>): void } | undefined {
@@ -157,6 +181,7 @@ export function getGenerativeOperationContext(
     apiKeyId: caller.apiKeyId,
     requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
     admissionSnapshot: caller.admissionSnapshot,
+    credential: caller.credential,
     executionCtx: getGenerativeExecutionContext(c),
   };
 }
@@ -233,6 +258,17 @@ export async function requireGenerativeKnownIdentity(
 }
 
 export function asGenerativeCacheApiError(error: unknown): ApiError | null {
+  const admissionDenial = resolveInferenceCredentialAdmissionDenial(error);
+  if (admissionDenial) {
+    return new ApiError(
+      admissionDenial.status,
+      admissionDenial.code,
+      admissionDenial.message,
+      {
+        reason: admissionDenial.reason,
+      },
+    );
+  }
   if (
     error instanceof AiPricingCacheWarmingError ||
     error instanceof AiPricingCacheUnavailableError ||
@@ -257,6 +293,7 @@ export async function admitFlatGenerativeOperation(params: {
   cost: FlatBillingCost;
   idempotencyKey?: string;
   admissionSnapshot?: InferenceAdmissionSnapshot;
+  credential?: InferenceCredentialCheck;
 }): Promise<OrganizationInferenceAdmission> {
   const executionCtx = getGenerativeExecutionContext(params.c);
   const { provider, billingSource, requestId } = params.context;
@@ -309,6 +346,7 @@ export async function admitFlatGenerativeOperation(params: {
       executionCtx,
       flatCost: params.cost,
       admissionSnapshot: params.admissionSnapshot,
+      ...(params.credential ? { credential: params.credential } : {}),
     });
   } catch (error) {
     if (
@@ -344,6 +382,11 @@ export async function requireGenerativeRouteCaller(
      * Zero preserves an immediate retryable warming response.
      */
     awaitWarmingMs?: number;
+    /**
+     * This route has a mandatory paid admission before provider dispatch and
+     * will thread the returned credential into that admission consumer.
+     */
+    deferStrongCredentialCheck?: boolean;
   } = {},
 ): Promise<GenerativeRouteCaller> {
   const executionCtx = getGenerativeExecutionContext(c);
@@ -377,6 +420,9 @@ export async function requireGenerativeRouteCaller(
       cacheOnly: Boolean(executionCtx),
       executionCtx,
       inlineContinuationDeadlineMs: options.awaitWarmingMs,
+      ...(options.deferStrongCredentialCheck === true
+        ? { deferStrongCredentialCheck: true }
+        : {}),
     });
   const resolution = await resolveCallerAuth();
 
@@ -429,6 +475,7 @@ export async function requireGenerativeRouteCaller(
       apiKeyId: resolution.ctx.apiKeyId,
       authSource: "combined_cache",
       admissionSnapshot: resolution.ctx.admission,
+      credential: resolution.credential,
       appScopeId:
         "appScopeId" in resolution.ctx ? resolution.ctx.appScopeId : null,
     };

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -21,6 +21,7 @@ import type {
   InferenceAuthRejectionReason,
 } from "@/lib/services/inference-auth-cache";
 import {
+  assertInferenceCredentialActive,
   type InferenceCredentialCheck,
   InferenceCredentialRevokedError,
   inferenceCredentialRevocationReason,
@@ -174,6 +175,9 @@ export function getGenerativeExecutionContext(
 export function getGenerativeOperationContext(
   c: AppContext,
   caller: GenerativeRouteCaller,
+  options: {
+    credentialForAdmission?: () => InferenceCredentialCheck | undefined;
+  } = {},
 ): GenerativeOperationContext {
   return {
     organizationId: caller.user.organization_id,
@@ -182,6 +186,7 @@ export function getGenerativeOperationContext(
     requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
     admissionSnapshot: caller.admissionSnapshot,
     credential: caller.credential,
+    ...options,
     executionCtx: getGenerativeExecutionContext(c),
   };
 }
@@ -431,44 +436,57 @@ export async function requireGenerativeRouteCaller(
       id: resolution.ctx.userId,
       organization_id: resolution.ctx.orgId,
     };
-    c.set("user", user);
-    c.set("authMethod", resolution.ctx.apiKeyId ? "api_key" : "session");
-    if (resolution.ctx.apiKeyId) {
-      c.set("apiKeyId", resolution.ctx.apiKeyId);
-    }
-    if (options.rateLimitEndpoint) {
-      const [{ enforceOrgRateLimit }, { inferenceRateLimitConfig }] =
-        await Promise.all([
-          import("@/lib/middleware/rate-limit"),
-          import("@/lib/services/inference-admission-snapshot"),
-        ]);
-      const limited = await enforceOrgRateLimit(
-        resolution.ctx.orgId,
-        options.rateLimitEndpoint,
-        {
-          // The combined decision carries the rate policy only when the hot
-          // cache is enabled. Development and integration Workers still have
-          // an execution context, but their authoritative origin decision has
-          // no snapshot and must retain the compatibility limiter path.
-          cacheOnly: Boolean(resolution.ctx.admission),
-          executionCtx,
-          config: inferenceRateLimitConfig(
-            resolution.ctx.admission,
-            options.rateLimitEndpoint,
-          ),
-        },
-      );
-      if (limited) {
-        throw new ApiError(
-          limited.status,
-          limited.status === 429
-            ? "rate_limit_exceeded"
-            : "service_unavailable",
-          limited.status === 429
-            ? "Rate limit exceeded"
-            : "Rate limiter is unavailable",
+    try {
+      c.set("user", user);
+      c.set("authMethod", resolution.ctx.apiKeyId ? "api_key" : "session");
+      if (resolution.ctx.apiKeyId) {
+        c.set("apiKeyId", resolution.ctx.apiKeyId);
+      }
+      if (options.rateLimitEndpoint) {
+        const [{ enforceOrgRateLimit }, { inferenceRateLimitConfig }] =
+          await Promise.all([
+            import("@/lib/middleware/rate-limit"),
+            import("@/lib/services/inference-admission-snapshot"),
+          ]);
+        const limited = await enforceOrgRateLimit(
+          resolution.ctx.orgId,
+          options.rateLimitEndpoint,
+          {
+            // The combined decision carries the rate policy only when the hot
+            // cache is enabled. Development and integration Workers still have
+            // an execution context, but their authoritative origin decision has
+            // no snapshot and must retain the compatibility limiter path.
+            cacheOnly: Boolean(resolution.ctx.admission),
+            executionCtx,
+            config: inferenceRateLimitConfig(
+              resolution.ctx.admission,
+              options.rateLimitEndpoint,
+            ),
+          },
+        );
+        if (limited) {
+          throw new ApiError(
+            limited.status,
+            limited.status === 429
+              ? "rate_limit_exceeded"
+              : "service_unavailable",
+            limited.status === 429
+              ? "Rate limit exceeded"
+              : "Rate limiter is unavailable",
+          );
+        }
+      }
+    } catch (error) {
+      // A deferred credential may leave this helper only through its admission
+      // consumer. If a post-resolution boundary fails first, consume the same
+      // proof with the standalone strong check before exposing that failure.
+      if (resolution.credential) {
+        await assertInferenceCredentialActive(
+          resolution.ctx.orgId,
+          resolution.credential,
         );
       }
+      throw error;
     }
     return {
       user,

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
@@ -17,6 +17,7 @@ import {
   requireGenerativeRouteCaller,
 } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
 import {
   type GenerativeOperationContext,
@@ -98,13 +99,19 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
     return await __hono_POST(
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
-      getGenerativeOperationContext(c, caller),
+      getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     );
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
@@ -98,7 +98,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: false,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
@@ -98,6 +98,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -217,7 +217,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: false,
     });
     return await __hono_POST(
       c,

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -21,6 +21,7 @@ import {
   appPromotionAssetsService,
 } from "@/lib/services/app-promotion-assets";
 import { appsService } from "@/lib/services/apps";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { retainGenerativeTask } from "@/lib/services/generative-operation";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -39,9 +40,14 @@ async function __hono_POST(
   c: AppContext,
   { params }: RouteContext<{ id: string }>,
   caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
+  operationOptions: Parameters<typeof getGenerativeOperationContext>[2],
 ) {
   const { user } = caller;
-  const operationContext = getGenerativeOperationContext(c, caller);
+  const operationContext = getGenerativeOperationContext(
+    c,
+    caller,
+    operationOptions,
+  );
   const { id } = await params;
 
   const app = await appsService.getById(id);
@@ -217,12 +223,19 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
     return await __hono_POST(
       c,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
+      {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      },
     );
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -217,6 +217,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
     return await __hono_POST(
       c,

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -250,13 +251,19 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
     return await __hono_POST(
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
-      getGenerativeOperationContext(c, caller),
+      getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     );
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -250,7 +250,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: false,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -250,6 +250,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -14,6 +14,7 @@ import {
   appPromotionService,
   type PromotionConfig,
 } from "@/lib/services/app-promotion";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -178,6 +179,7 @@ async function __hono_POST(
   c: AppContext,
   { params }: RouteContext<{ id: string }>,
   caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>,
+  operationOptions: Parameters<typeof getGenerativeOperationContext>[2],
 ) {
   const { user } = caller;
   const { id } = await params;
@@ -274,7 +276,7 @@ async function __hono_POST(
     user.id,
     id,
     config,
-    getGenerativeOperationContext(c, caller),
+    getGenerativeOperationContext(c, caller, operationOptions),
   );
 
   logger.info("[Promote API] Promotion complete", {
@@ -298,12 +300,19 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
     return await __hono_POST(
       c,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
+      {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      },
     );
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -298,7 +298,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: false,
     });
     return await __hono_POST(
       c,

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -298,6 +298,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
     return await __hono_POST(
       c,

--- a/packages/cloud/api/v1/apps/[id]/review/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/review/route.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { getLatestAppReview, runAppReview } from "@/lib/services/app-review";
 import { appsService } from "@/lib/services/apps";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -36,7 +37,11 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
     const { user } = caller;
     const appId = c.req.param("id");
@@ -55,7 +60,9 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
     const review = await runAppReview({
       app: appRow,
       triggeredByUserId: user.id,
-      operationContext: getGenerativeOperationContext(c, caller),
+      operationContext: getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     });
 
     logger.info("[AppReview API] Submitted app for review", {

--- a/packages/cloud/api/v1/apps/[id]/review/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/review/route.ts
@@ -36,6 +36,7 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
     const { user } = caller;
     const appId = c.req.param("id");

--- a/packages/cloud/api/v1/apps/[id]/review/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/review/route.ts
@@ -36,7 +36,7 @@ app.post("/", rateLimit(RateLimitPresets.CRITICAL), async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: false,
     });
     const { user } = caller;
     const appId = c.req.param("id");

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
@@ -103,6 +103,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
@@ -17,6 +17,7 @@ import {
   requireGenerativeRouteCaller,
 } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import {
   type GenerativeOperationContext,
   isGenerativeOperationAdmissionError,
@@ -103,13 +104,19 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
     return await __hono_POST(
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
-      getGenerativeOperationContext(c, caller),
+      getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     );
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
@@ -103,7 +103,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: false,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
@@ -93,7 +93,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: false,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
@@ -93,6 +93,7 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
     return await __hono_POST(
       c.req.raw,

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import {
   type GenerativeOperationContext,
   isGenerativeOperationAdmissionError,
@@ -93,13 +94,19 @@ __hono_app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
-      deferStrongCredentialCheck: false,
+      deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
     return await __hono_POST(
       c.req.raw,
       { params: Promise.resolve({ id: c.req.param("id")! }) },
       caller,
-      getGenerativeOperationContext(c, caller),
+      getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     );
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.json.test.ts
@@ -50,6 +50,7 @@ describe("POST /api/v1/browser/sessions/:id/command malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(executeHostedBrowserCommand).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).not.toHaveBeenCalled();
   });
 
   test("canonical JSON still executes a command", async () => {
@@ -59,6 +60,10 @@ describe("POST /api/v1/browser/sessions/:id/command malformed JSON", () => {
       body: JSON.stringify({ subaction: "reload" }),
     });
     expect(response.status).toBe(200);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: true }),
+    );
     expect(executeHostedBrowserCommand).toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.json.test.ts
@@ -50,7 +50,11 @@ describe("POST /api/v1/browser/sessions/:id/command malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(executeHostedBrowserCommand).not.toHaveBeenCalled();
-    expect(requireGenerativeRouteCaller).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
   });
 
   test("canonical JSON still executes a command", async () => {
@@ -60,6 +64,7 @@ describe("POST /api/v1/browser/sessions/:id/command malformed JSON", () => {
       body: JSON.stringify({ subaction: "reload" }),
     });
     expect(response.status).toBe(200);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(2);
     expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ deferStrongCredentialCheck: true }),

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
@@ -53,9 +53,6 @@ async function handlePOST(
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
     const { id } = await context.params;
     const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
@@ -73,6 +70,10 @@ async function handlePOST(
         { status: 400 },
       );
     }
+
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
 
     const result = await executeHostedBrowserCommand(id, bodyResult.data, {
       apiKeyId: caller.apiKeyId,

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
@@ -55,27 +55,35 @@ async function handlePOST(
   try {
     const { id } = await context.params;
     const decodedRawBody = await decodeRequestJson(c.req);
+    let pendingResponse: Response | undefined;
+    let body: z.infer<typeof commandSchema> | undefined;
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
-      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-    }
-    const rawBody = decodedRawBody.value;
-    const bodyResult = commandSchema.safeParse(rawBody);
-    if (!bodyResult.success) {
-      return Response.json(
-        {
-          error: "Invalid browser command",
-          details: bodyResult.error.flatten(),
-        },
+      pendingResponse = Response.json(
+        { error: "Invalid JSON body" },
         { status: 400 },
       );
+    } else {
+      const bodyResult = commandSchema.safeParse(decodedRawBody.value);
+      if (bodyResult.success) {
+        body = bodyResult.data;
+      } else {
+        pendingResponse = Response.json(
+          {
+            error: "Invalid browser command",
+            details: bodyResult.error.flatten(),
+          },
+          { status: 400 },
+        );
+      }
     }
 
     const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    if (pendingResponse) return pendingResponse;
 
-    const result = await executeHostedBrowserCommand(id, bodyResult.data, {
+    const result = await executeHostedBrowserCommand(id, body!, {
       apiKeyId: caller.apiKeyId,
       organizationId: caller.user.organization_id,
       requestSource: "api",

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
@@ -20,6 +20,7 @@ import {
   executeHostedBrowserCommand,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -81,6 +82,10 @@ async function handlePOST(
     const caller = await requireGenerativeRouteCaller(c, {
       deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
     if (pendingResponse) return pendingResponse;
 
     const result = await executeHostedBrowserCommand(id, body!, {
@@ -88,7 +93,9 @@ async function handlePOST(
       organizationId: caller.user.organization_id,
       requestSource: "api",
       userId: caller.user.id,
-      operationContext: getGenerativeOperationContext(c, caller),
+      operationContext: getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     });
 
     return Response.json(result);

--- a/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/command/route.ts
@@ -53,7 +53,9 @@ async function handlePOST(
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { id } = await context.params;
     const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.json.test.ts
@@ -51,6 +51,11 @@ describe("POST /api/v1/browser/sessions/:id/navigate malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(navigateHostedBrowserSession).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
   });
 
   test("canonical JSON still navigates", async () => {
@@ -60,6 +65,10 @@ describe("POST /api/v1/browser/sessions/:id/navigate malformed JSON", () => {
       body: JSON.stringify({ url: "https://example.com" }),
     });
     expect(response.status).toBe(200);
+    expect(requireGenerativeRouteCaller).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: true }),
+    );
     expect(navigateHostedBrowserSession).toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
@@ -32,9 +32,6 @@ async function handlePOST(
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
     const { id } = await context.params;
     const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
@@ -52,6 +49,10 @@ async function handlePOST(
         { status: 400 },
       );
     }
+
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
 
     const session = await navigateHostedBrowserSession(
       id,

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
@@ -20,6 +20,7 @@ import {
   logHostedBrowserFailure,
   navigateHostedBrowserSession,
 } from "@/lib/services/browser-tools";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -60,6 +61,10 @@ async function handlePOST(
     const caller = await requireGenerativeRouteCaller(c, {
       deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
     if (pendingResponse) return pendingResponse;
 
     const session = await navigateHostedBrowserSession(id, body!.url, {
@@ -67,7 +72,9 @@ async function handlePOST(
       organizationId: caller.user.organization_id,
       requestSource: "api",
       userId: caller.user.id,
-      operationContext: getGenerativeOperationContext(c, caller),
+      operationContext: getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     });
 
     return Response.json({ session });

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
@@ -34,37 +34,41 @@ async function handlePOST(
   try {
     const { id } = await context.params;
     const decodedRawBody = await decodeRequestJson(c.req);
+    let pendingResponse: Response | undefined;
+    let body: z.infer<typeof navigateSchema> | undefined;
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
-      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-    }
-    const rawBody = decodedRawBody.value;
-    const bodyResult = navigateSchema.safeParse(rawBody);
-    if (!bodyResult.success) {
-      return Response.json(
-        {
-          error: "Invalid navigate request",
-          details: bodyResult.error.flatten(),
-        },
+      pendingResponse = Response.json(
+        { error: "Invalid JSON body" },
         { status: 400 },
       );
+    } else {
+      const bodyResult = navigateSchema.safeParse(decodedRawBody.value);
+      if (bodyResult.success) {
+        body = bodyResult.data;
+      } else {
+        pendingResponse = Response.json(
+          {
+            error: "Invalid navigate request",
+            details: bodyResult.error.flatten(),
+          },
+          { status: 400 },
+        );
+      }
     }
 
     const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    if (pendingResponse) return pendingResponse;
 
-    const session = await navigateHostedBrowserSession(
-      id,
-      bodyResult.data.url,
-      {
-        apiKeyId: caller.apiKeyId,
-        organizationId: caller.user.organization_id,
-        requestSource: "api",
-        userId: caller.user.id,
-        operationContext: getGenerativeOperationContext(c, caller),
-      },
-    );
+    const session = await navigateHostedBrowserSession(id, body!.url, {
+      apiKeyId: caller.apiKeyId,
+      organizationId: caller.user.organization_id,
+      requestSource: "api",
+      userId: caller.user.id,
+      operationContext: getGenerativeOperationContext(c, caller),
+    });
 
     return Response.json({ session });
   } catch (error) {

--- a/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/navigate/route.ts
@@ -32,7 +32,9 @@ async function handlePOST(
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { id } = await context.params;
     const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {

--- a/packages/cloud/api/v1/browser/sessions/[id]/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/route.ts
@@ -23,7 +23,9 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 async function handleGET(c: AppContext, context: RouteContext<{ id: string }>) {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { id } = await context.params;
     const session = await getHostedBrowserSession(id, {
       apiKeyId: caller.apiKeyId,
@@ -44,7 +46,9 @@ async function handleDELETE(
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { id } = await context.params;
     const result = await deleteHostedBrowserSession(id, {
       apiKeyId: caller.apiKeyId,

--- a/packages/cloud/api/v1/browser/sessions/[id]/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/route.ts
@@ -23,9 +23,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 async function handleGET(c: AppContext, context: RouteContext<{ id: string }>) {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
     const session = await getHostedBrowserSession(id, {
       apiKeyId: caller.apiKeyId,
@@ -46,9 +44,7 @@ async function handleDELETE(
   context: RouteContext<{ id: string }>,
 ) {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
     const result = await deleteHostedBrowserSession(id, {
       apiKeyId: caller.apiKeyId,

--- a/packages/cloud/api/v1/browser/sessions/[id]/snapshot/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/snapshot/route.ts
@@ -22,9 +22,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 async function handleGET(c: AppContext, context: RouteContext<{ id: string }>) {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
+    const caller = await requireGenerativeRouteCaller(c);
     const { id } = await context.params;
     const snapshot = await getHostedBrowserSnapshot(id, {
       apiKeyId: caller.apiKeyId,

--- a/packages/cloud/api/v1/browser/sessions/[id]/snapshot/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/[id]/snapshot/route.ts
@@ -22,7 +22,9 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 async function handleGET(c: AppContext, context: RouteContext<{ id: string }>) {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { id } = await context.params;
     const snapshot = await getHostedBrowserSnapshot(id, {
       apiKeyId: caller.apiKeyId,

--- a/packages/cloud/api/v1/browser/sessions/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.json.test.ts
@@ -54,7 +54,11 @@ describe("POST /api/v1/browser/sessions malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(createHostedBrowserSession).not.toHaveBeenCalled();
-    expect(requireGenerativeRouteCaller).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
   });
 
   test("canonical JSON still creates a session", async () => {

--- a/packages/cloud/api/v1/browser/sessions/route.json.test.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.json.test.ts
@@ -6,15 +6,16 @@ const createHostedBrowserSession = mock(async () => ({
   id: "sess-1",
   url: "https://example.com",
 }));
+const requireGenerativeRouteCaller = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKeyId: null,
+  authSource: "combined_cache",
+  appScopeId: null,
+}));
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   asGenerativeCacheApiError: () => null,
-  requireGenerativeRouteCaller: async () => ({
-    user: { id: "user-1", organization_id: "org-1" },
-    apiKeyId: null,
-    authSource: "combined_cache",
-    appScopeId: null,
-  }),
+  requireGenerativeRouteCaller,
   getGenerativeOperationContext: () => ({
     organizationId: "org-1",
     userId: "user-1",
@@ -39,6 +40,7 @@ const { default: app } = await import("./route");
 describe("POST /api/v1/browser/sessions malformed JSON", () => {
   beforeEach(() => {
     createHostedBrowserSession.mockClear();
+    requireGenerativeRouteCaller.mockClear();
   });
 
   test("returns 400 instead of 500 and never creates a session", async () => {
@@ -52,6 +54,7 @@ describe("POST /api/v1/browser/sessions malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(createHostedBrowserSession).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).not.toHaveBeenCalled();
   });
 
   test("canonical JSON still creates a session", async () => {
@@ -61,6 +64,10 @@ describe("POST /api/v1/browser/sessions malformed JSON", () => {
       body: JSON.stringify({ url: "https://example.com" }),
     });
     expect(response.status).toBe(200);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: true }),
+    );
     expect(createHostedBrowserSession).toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -56,28 +56,33 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const decodedBody = await decodeRequestJson(c.req);
+    let pendingResponse: Response | undefined;
+    let body: z.infer<typeof createSessionSchema> | undefined;
     if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    const rawBody = decodedBody.value;
-    const bodyResult = createSessionSchema.safeParse(rawBody);
-    if (!bodyResult.success) {
-      return c.json(
-        {
-          error: "Invalid browser session request",
-          details: bodyResult.error.flatten(),
-        },
-        400,
-      );
+      pendingResponse = c.json({ error: "Invalid JSON body" }, 400);
+    } else {
+      const bodyResult = createSessionSchema.safeParse(decodedBody.value);
+      if (bodyResult.success) {
+        body = bodyResult.data;
+      } else {
+        pendingResponse = c.json(
+          {
+            error: "Invalid browser session request",
+            details: bodyResult.error.flatten(),
+          },
+          400,
+        );
+      }
     }
 
     const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    if (pendingResponse) return pendingResponse;
     const { user } = caller;
 
-    const session = await createHostedBrowserSession(bodyResult.data, {
+    const session = await createHostedBrowserSession(body!, {
       apiKeyId: caller.apiKeyId,
       organizationId: user.organization_id,
       requestSource: "api",

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -37,9 +37,7 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.get("/", async (c) => {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
+    const caller = await requireGenerativeRouteCaller(c);
     const { user } = caller;
     const sessions = await listHostedBrowserSessions({
       apiKeyId: null,
@@ -57,10 +55,6 @@ app.get("/", async (c) => {
 
 app.post("/", async (c) => {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
-    const { user } = caller;
     const decodedBody = await decodeRequestJson(c.req);
     if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
@@ -77,6 +71,11 @@ app.post("/", async (c) => {
         400,
       );
     }
+
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
+    const { user } = caller;
 
     const session = await createHostedBrowserSession(bodyResult.data, {
       apiKeyId: caller.apiKeyId,

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -20,6 +20,7 @@ import {
   listHostedBrowserSessions,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -79,6 +80,10 @@ app.post("/", async (c) => {
     const caller = await requireGenerativeRouteCaller(c, {
       deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
     if (pendingResponse) return pendingResponse;
     const { user } = caller;
 
@@ -87,7 +92,9 @@ app.post("/", async (c) => {
       organizationId: user.organization_id,
       requestSource: "api",
       userId: user.id,
-      operationContext: getGenerativeOperationContext(c, caller),
+      operationContext: getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     });
     return c.json({ session });
   } catch (error) {

--- a/packages/cloud/api/v1/browser/sessions/route.ts
+++ b/packages/cloud/api/v1/browser/sessions/route.ts
@@ -37,7 +37,9 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.get("/", async (c) => {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { user } = caller;
     const sessions = await listHostedBrowserSessions({
       apiKeyId: null,
@@ -55,7 +57,9 @@ app.get("/", async (c) => {
 
 app.post("/", async (c) => {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { user } = caller;
     const decodedBody = await decodeRequestJson(c.req);
     if (!decodedBody.ok) {

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1,7 +1,11 @@
 /** Implements the OpenAI-compatible chat-completions boundary and its streaming accounting. */
 import { Hono } from "hono";
-import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
+import {
+  resolveInferenceAuthStandingDenial,
+  resolveInferenceCredentialAdmissionDenial,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 /**
@@ -1247,6 +1251,10 @@ export async function handleChatCompletionsPOST(
     let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
     let admissionCredential: InferenceCredentialCheck | undefined;
     let appScopeId: string | null = null;
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => user?.organization_id,
+      credential: () => admissionCredential,
+    });
 
     const deferStrongCredentialCheck =
       requestIsValid &&
@@ -1771,7 +1779,7 @@ export async function handleChatCompletionsPOST(
             affiliateCode,
             executionCtx: options.executionCtx,
             admissionSnapshot,
-            credential: admissionCredential,
+            credential: credentialGuard.credentialForAdmission(),
           });
           settleReservation = admission.settle;
           settleUnknown = admission.settleUnknown;
@@ -1808,7 +1816,7 @@ export async function handleChatCompletionsPOST(
           affiliateCode,
           executionCtx: options.executionCtx,
           admissionSnapshot,
-          credential: admissionCredential,
+          credential: credentialGuard.credentialForAdmission(),
         });
         settleReservation = admission.settle;
         settleUnknown = admission.settleUnknown;
@@ -2029,6 +2037,27 @@ export async function handleChatCompletionsPOST(
         await settleReservation?.(0);
       }
     });
+    const credentialDenial = resolveInferenceCredentialAdmissionDenial(error, {
+      route: "chat_completions",
+      traceId,
+    });
+    if (credentialDenial) {
+      return attachPreforwardTelemetry(
+        addCorsHeaders(
+          Response.json(
+            {
+              error: {
+                message: credentialDenial.message,
+                type: credentialDenial.type,
+                code: credentialDenial.code,
+                details: { reason: credentialDenial.reason },
+              },
+            },
+            { status: credentialDenial.status },
+          ),
+        ),
+      );
+    }
     const rawMessage = redactPromptCacheKey(
       error instanceof Error ? error.message : String(error),
       promptCacheKeyForRedaction,

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1215,26 +1215,27 @@ export async function handleChatCompletionsPOST(
 
   try {
     const request = (await req.json().catch(() => null)) as ChatRequest | null;
-    if (
-      !request?.model ||
-      !Array.isArray(request.messages) ||
-      !request.messages.length
-    ) {
-      return attachPreforwardTelemetry(
-        addCorsHeaders(
-          Response.json(
-            {
-              error: {
-                message: "Missing required fields: model and messages",
-                type: "invalid_request_error",
-                code: "missing_required_parameter",
+    const requestIsValid = Boolean(
+      request?.model &&
+        Array.isArray(request.messages) &&
+        request.messages.length,
+    );
+    const invalidRequestResponse = !requestIsValid
+      ? attachPreforwardTelemetry(
+          addCorsHeaders(
+            Response.json(
+              {
+                error: {
+                  message: "Missing required fields: model and messages",
+                  type: "invalid_request_error",
+                  code: "missing_required_parameter",
+                },
               },
-            },
-            { status: 400 },
+              { status: 400 },
+            ),
           ),
-        ),
-      );
-    }
+        )
+      : undefined;
 
     // 1. Authenticate (+ moderation). API-key and Steward-session requests
     // resolve auth + org + moderation from a combined cache decision. On one
@@ -1248,7 +1249,9 @@ export async function handleChatCompletionsPOST(
     let appScopeId: string | null = null;
 
     const deferStrongCredentialCheck =
-      Boolean(options.executionCtx) && isInferenceStrongRevocationEnabled();
+      requestIsValid &&
+      Boolean(options.executionCtx) &&
+      isInferenceStrongRevocationEnabled();
     const resolution = await resolveInferenceAuthContext(req, {
       traceId,
       executionCtx: options.executionCtx,
@@ -1396,6 +1399,14 @@ export async function handleChatCompletionsPOST(
       throw error;
     }
     if (orgRateLimited) return orgRateLimited;
+
+    if (
+      !request?.model ||
+      !Array.isArray(request.messages) ||
+      !request.messages.length
+    ) {
+      return invalidRequestResponse!;
+    }
 
     // 2. Prepare app monetization lookup
     const requestedAppId = options.requiredAppId ?? req.headers.get("X-App-Id");

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1214,6 +1214,28 @@ export async function handleChatCompletionsPOST(
   let promptCacheKeyForRedaction: string | undefined;
 
   try {
+    const request = (await req.json().catch(() => null)) as ChatRequest | null;
+    if (
+      !request?.model ||
+      !Array.isArray(request.messages) ||
+      !request.messages.length
+    ) {
+      return attachPreforwardTelemetry(
+        addCorsHeaders(
+          Response.json(
+            {
+              error: {
+                message: "Missing required fields: model and messages",
+                type: "invalid_request_error",
+                code: "missing_required_parameter",
+              },
+            },
+            { status: 400 },
+          ),
+        ),
+      );
+    }
+
     // 1. Authenticate (+ moderation). API-key and Steward-session requests
     // resolve auth + org + moderation from a combined cache decision. On one
     // true cold miss, Workers may consume the retained authoritative decision
@@ -1350,11 +1372,6 @@ export async function handleChatCompletionsPOST(
             config: inferenceRateLimitConfig(admissionSnapshot, "completions"),
           })
         : Promise.resolve(null);
-    const requestPromise = req
-      .json()
-      // error-policy:J3 malformed JSON becomes the same typed invalid request path as a missing body.
-      .catch(() => null) as Promise<ChatRequest | null>;
-
     let orgRateLimited: Response | null;
     try {
       orgRateLimited = await orgRateLimitPromise;
@@ -1406,30 +1423,6 @@ export async function handleChatCompletionsPOST(
     // (and echoes the raw parse text); the sibling agents routes already guard
     // this. Also require `messages` to be an ARRAY so a non-array value can't
     // slip past the length check and TypeError later in `messages.filter(...)`.
-    const request = await requestPromise;
-
-    // 4. Validate
-    if (
-      !request?.model ||
-      !Array.isArray(request.messages) ||
-      !request.messages.length
-    ) {
-      return attachPreforwardTelemetry(
-        addCorsHeaders(
-          Response.json(
-            {
-              error: {
-                message: "Missing required fields: model and messages",
-                type: "invalid_request_error",
-                code: "missing_required_parameter",
-              },
-            },
-            { status: 400 },
-          ),
-        ),
-      );
-    }
-
     // Collapse decorated Cerebras ids (e.g. "openai/gpt-oss-120b:nitro" emitted
     // by dedicated agents) to the bare Cerebras id so pricing, routing, and
     // billing all agree and route to cerebras-direct instead of OpenRouter.
@@ -1729,12 +1722,6 @@ export async function handleChatCompletionsPOST(
         settleReservation = async () => null;
         settleUnknown = async () => null;
       } else if (useAppCredits && appId && monetizedApp) {
-        if (admissionCredential) {
-          await assertInferenceCredentialActive(
-            user.organization_id,
-            admissionCredential,
-          );
-        }
         assertInferenceAppAffiliateSupported(appId, affiliateCode);
         const { totalCost } = await calculateCost(
           normalizedModel,

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1773,6 +1773,7 @@ export async function handleChatCompletionsPOST(
             affiliateCode,
             executionCtx: options.executionCtx,
             admissionSnapshot,
+            credential: admissionCredential,
           });
           settleReservation = admission.settle;
           settleUnknown = admission.settleUnknown;

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -62,6 +62,7 @@ import {
   DEFAULT_OUTPUT_TOKENS,
   InsufficientCreditsError,
 } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { generationsService } from "@/lib/services/generations";
 import { inferenceRateLimitConfig } from "@/lib/services/inference-admission-snapshot";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
@@ -264,6 +265,11 @@ app.post("/", async (c) => {
     let moderationAlreadyChecked = false;
     let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
     let admissionCredential: InferenceCredentialCheck | undefined;
+    let guardOrganizationId: string | undefined;
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => guardOrganizationId,
+      credential: () => admissionCredential,
+    });
 
     if (executionCtx) {
       const authResolution = await resolveInferenceAuthContext(c.req.raw, {
@@ -310,6 +316,7 @@ app.post("/", async (c) => {
           id: authResolution.ctx.userId,
           organization_id: authResolution.ctx.orgId,
         };
+        guardOrganizationId = user.organization_id ?? undefined;
         apiKey = authResolution.ctx.apiKeyId
           ? { id: authResolution.ctx.apiKeyId }
           : undefined;
@@ -617,7 +624,7 @@ app.post("/", async (c) => {
           affiliateCode,
           executionCtx,
           admissionSnapshot,
-          credential: admissionCredential,
+          credential: credentialGuard.credentialForAdmission(),
         });
         settleReservation = admission.settle;
         settleUnknownReservation = admission.settleUnknown;
@@ -925,6 +932,20 @@ app.post("/", async (c) => {
         await settleUnknownReservation?.();
       }
     });
+    const credentialDenial = resolveInferenceCredentialAdmissionDenial(error, {
+      route: "chat",
+      traceId: c.get("traceId") ?? c.get("requestId"),
+    });
+    if (credentialDenial) {
+      return c.json(
+        {
+          error: credentialDenial.message,
+          code: credentialDenial.code,
+          reason: credentialDenial.reason,
+        },
+        credentialDenial.status,
+      );
+    }
     logger.error("chat-api", "Error processing chat", {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -237,18 +237,21 @@ app.post("/", async (c) => {
 
   try {
     const decodedBody = await decodeRequestJson(c.req);
-    if (!decodedBody.ok) {
-      // error-policy:J3 malformed JSON is invalid request input.
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    const body = decodedBody.value;
-    if (!body || typeof body !== "object") {
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    const preflightMessages = (body as { messages?: unknown }).messages;
-    if (!Array.isArray(preflightMessages) || preflightMessages.length === 0) {
-      return c.json({ error: "At least one message is required" }, 400);
-    }
+    const body = decodedBody.ok ? decodedBody.value : undefined;
+    const bodyIsObject = Boolean(body && typeof body === "object");
+    const preflightMessages = bodyIsObject
+      ? (body as { messages?: unknown }).messages
+      : undefined;
+    const requestIsValid =
+      bodyIsObject &&
+      Array.isArray(preflightMessages) &&
+      preflightMessages.length > 0;
+    const invalidRequestResponse =
+      !decodedBody.ok || !bodyIsObject
+        ? c.json({ error: "Invalid JSON body" }, 400)
+        : !requestIsValid
+          ? c.json({ error: "At least one message is required" }, 400)
+          : undefined;
 
     let user: ChatBillingUser;
     let apiKey: ApiKeyIdentity | undefined;
@@ -266,7 +269,7 @@ app.post("/", async (c) => {
       const authResolution = await resolveInferenceAuthContext(c.req.raw, {
         executionCtx,
         cacheOnly: true,
-        deferStrongCredentialCheck: true,
+        deferStrongCredentialCheck: requestIsValid,
       });
       if (authResolution.kind === "warming") {
         return retryableWarmingResponse(c, "Authentication");
@@ -313,7 +316,9 @@ app.post("/", async (c) => {
         moderationAlreadyChecked = true;
         admissionSnapshot = authResolution.ctx.admission;
         admissionCredential = authResolution.credential;
+        if (invalidRequestResponse) return invalidRequestResponse;
       } else {
+        if (invalidRequestResponse) return invalidRequestResponse;
         const anonymousResolution = await resolveAnonymousChatContext(
           c.req.raw,
           executionCtx,
@@ -377,6 +382,8 @@ app.post("/", async (c) => {
         isAnonymous = true;
       }
     }
+
+    if (invalidRequestResponse) return invalidRequestResponse;
 
     if (user.organization_id) {
       let orgRateLimited: Response | null;

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -9,7 +9,10 @@
 import { assertModelOutputComplete } from "@elizaos/core";
 import { convertToModelMessages, streamText, type UIMessage } from "ai";
 import { Hono } from "hono";
-import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
+import {
+  resolveInferenceAuthStandingDenial,
+  resolveInferenceCredentialAdmissionDenial,
+} from "@/api-app/lib/generative-route-auth";
 import type { AnonymousSession } from "@/db/repositories/anonymous-sessions";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { getCurrentUser } from "@/lib/auth/workers-hono-auth";
@@ -64,6 +67,7 @@ import { inferenceRateLimitConfig } from "@/lib/services/inference-admission-sna
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import { InferenceBalanceCacheWarmingError } from "@/lib/services/inference-billing-fast-path";
+import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import { isKnownUnacceptedProviderError } from "@/lib/services/inference-provider-outcome";
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
 import { usageService } from "@/lib/services/usage";
@@ -242,11 +246,13 @@ app.post("/", async (c) => {
     let anonymousCredential: AnonymousChatGateCredential | null = null;
     let moderationAlreadyChecked = false;
     let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
+    let admissionCredential: InferenceCredentialCheck | undefined;
 
     if (executionCtx) {
       const authResolution = await resolveInferenceAuthContext(c.req.raw, {
         executionCtx,
         cacheOnly: true,
+        deferStrongCredentialCheck: true,
       });
       if (authResolution.kind === "warming") {
         return retryableWarmingResponse(c, "Authentication");
@@ -292,6 +298,7 @@ app.post("/", async (c) => {
           : undefined;
         moderationAlreadyChecked = true;
         admissionSnapshot = authResolution.ctx.admission;
+        admissionCredential = authResolution.credential;
       } else {
         const anonymousResolution = await resolveAnonymousChatContext(
           c.req.raw,
@@ -599,12 +606,27 @@ app.post("/", async (c) => {
           affiliateCode,
           executionCtx,
           admissionSnapshot,
+          credential: admissionCredential,
         });
         settleReservation = admission.settle;
         settleUnknownReservation = admission.settleUnknown;
         markProviderDispatched = admission.markProviderDispatched;
         billingReservation = admission.reservation;
       } catch (error) {
+        const denial = resolveInferenceCredentialAdmissionDenial(error, {
+          route: "chat",
+          traceId: c.get("traceId") ?? c.get("requestId"),
+        });
+        if (denial) {
+          return c.json(
+            {
+              error: denial.message,
+              code: denial.code,
+              reason: denial.reason,
+            },
+            denial.status,
+          );
+        }
         if (error instanceof InsufficientCreditsError) {
           return c.json(
             { error: "Insufficient balance", details: error.message },

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -236,6 +236,20 @@ app.post("/", async (c) => {
   let providerDispatchStarted = false;
 
   try {
+    const decodedBody = await decodeRequestJson(c.req);
+    if (!decodedBody.ok) {
+      // error-policy:J3 malformed JSON is invalid request input.
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const body = decodedBody.value;
+    if (!body || typeof body !== "object") {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+    const preflightMessages = (body as { messages?: unknown }).messages;
+    if (!Array.isArray(preflightMessages) || preflightMessages.length === 0) {
+      return c.json({ error: "At least one message is required" }, 400);
+    }
+
     let user: ChatBillingUser;
     let apiKey: ApiKeyIdentity | undefined;
     let isAnonymous = false;
@@ -393,16 +407,6 @@ app.post("/", async (c) => {
         throw error;
       }
       if (orgRateLimited) return orgRateLimited;
-    }
-
-    const decodedBody = await decodeRequestJson(c.req);
-    if (!decodedBody.ok) {
-      // error-policy:J3 malformed JSON is invalid request input.
-      return c.json({ error: "Invalid JSON body" }, 400);
-    }
-    const body = decodedBody.value;
-    if (!body || typeof body !== "object") {
-      return c.json({ error: "Invalid JSON body" }, 400);
     }
 
     const {

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -103,6 +103,23 @@ app.post("/", async (c) => {
   let billed = false;
   let providerDispatched = false;
   try {
+    const request = (await c.req
+      .json()
+      .catch(() => null)) as EmbeddingsRequest | null;
+    if (!request?.model || !request.input) {
+      return c.json(
+        {
+          error: {
+            message: "Missing required fields: model and input",
+            type: "invalid_request_error",
+            param: !request?.model ? "model" : "input",
+            code: "missing_required_parameter",
+          },
+        },
+        400,
+      );
+    }
+
     // Resolve auth (+ org + moderation) in a SINGLE cache read for API-key
     // inference requests (#9899) — the same fast-path as /v1/chat/completions.
     // This route is on the agent reply hot path: the always-on
@@ -206,11 +223,6 @@ app.post("/", async (c) => {
     // Guard a malformed/empty body to a 400 instead of a 500 (mirrors the agents
     // routes). An unguarded parse throws a SyntaxError that failureResponse maps
     // to 500 on this always-on agent-recall hot path.
-    const requestPromise = c.req.json().catch(() => {
-      // error-policy:J3 malformed JSON becomes an explicit invalid-request
-      // signal and is never interpreted as a valid empty payload.
-      return null;
-    }) as Promise<EmbeddingsRequest | null>;
     let orgRateLimited: Response | null;
     try {
       orgRateLimited = await orgRateLimitPromise;
@@ -238,21 +250,6 @@ app.post("/", async (c) => {
       throw error;
     }
     if (orgRateLimited) return orgRateLimited;
-    const request = await requestPromise;
-
-    if (!request?.model || !request.input) {
-      return c.json(
-        {
-          error: {
-            message: "Missing required fields: model and input",
-            type: "invalid_request_error",
-            param: !request?.model ? "model" : "input",
-            code: "missing_required_parameter",
-          },
-        },
-        400,
-      );
-    }
 
     if (Array.isArray(request.input) && request.input.length === 0) {
       return c.json(

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -106,19 +106,20 @@ app.post("/", async (c) => {
     const request = (await c.req
       .json()
       .catch(() => null)) as EmbeddingsRequest | null;
-    if (!request?.model || !request.input) {
-      return c.json(
-        {
-          error: {
-            message: "Missing required fields: model and input",
-            type: "invalid_request_error",
-            param: !request?.model ? "model" : "input",
-            code: "missing_required_parameter",
+    const requestIsValid = Boolean(request?.model && request.input);
+    const invalidRequestResponse = !requestIsValid
+      ? c.json(
+          {
+            error: {
+              message: "Missing required fields: model and input",
+              type: "invalid_request_error",
+              param: !request?.model ? "model" : "input",
+              code: "missing_required_parameter",
+            },
           },
-        },
-        400,
-      );
-    }
+          400,
+        )
+      : undefined;
 
     // Resolve auth (+ org + moderation) in a SINGLE cache read for API-key
     // inference requests (#9899) — the same fast-path as /v1/chat/completions.
@@ -133,7 +134,7 @@ app.post("/", async (c) => {
     const resolution = await resolveInferenceAuthContext(c.req.raw, {
       executionCtx,
       cacheOnly: Boolean(executionCtx),
-      deferStrongCredentialCheck: Boolean(executionCtx),
+      deferStrongCredentialCheck: Boolean(executionCtx) && requestIsValid,
     });
     if (resolution.kind === "warming") {
       return c.json(
@@ -223,6 +224,8 @@ app.post("/", async (c) => {
     // Guard a malformed/empty body to a 400 instead of a 500 (mirrors the agents
     // routes). An unguarded parse throws a SyntaxError that failureResponse maps
     // to 500 on this always-on agent-recall hot path.
+    if (!request?.model || !request.input) return invalidRequestResponse!;
+
     let orgRateLimited: Response | null;
     try {
       orgRateLimited = await orgRateLimitPromise;

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -10,7 +10,10 @@
 
 import { APICallError, embed, embedMany, RetryError } from "ai";
 import { Hono } from "hono";
-import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
+import {
+  resolveInferenceAuthStandingDenial,
+  resolveInferenceCredentialAdmissionDenial,
+} from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
@@ -35,6 +38,7 @@ import { inferenceRateLimitConfig } from "@/lib/services/inference-admission-sna
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import { InferenceBalanceCacheWarmingError } from "@/lib/services/inference-billing-fast-path";
+import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import { isPassthroughEmbeddingsEnabled } from "@/lib/services/inference-passthrough";
 import { isKnownUnacceptedProviderError } from "@/lib/services/inference-provider-outcome";
 import {
@@ -69,6 +73,7 @@ app.post("/", async (c) => {
   let billingReservation: CreditReservation | undefined;
   let executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined;
   let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
+  let admissionCredential: InferenceCredentialCheck | undefined;
   try {
     const candidate = c.executionCtx;
     executionCtx =
@@ -111,6 +116,7 @@ app.post("/", async (c) => {
     const resolution = await resolveInferenceAuthContext(c.req.raw, {
       executionCtx,
       cacheOnly: Boolean(executionCtx),
+      deferStrongCredentialCheck: Boolean(executionCtx),
     });
     if (resolution.kind === "warming") {
       return c.json(
@@ -168,6 +174,7 @@ app.post("/", async (c) => {
       };
       apiKeyId = resolution.ctx.apiKeyId;
       admissionSnapshot = resolution.ctx.admission;
+      admissionCredential = resolution.credential;
     } else {
       if (executionCtx) {
         return c.json(
@@ -320,6 +327,7 @@ app.post("/", async (c) => {
         affiliateCode,
         executionCtx,
         admissionSnapshot,
+        credential: admissionCredential,
       });
       settleReservation = admission.settle;
       settleUnknown = admission.settleUnknown;
@@ -328,6 +336,23 @@ app.post("/", async (c) => {
     } catch (error) {
       // error-policy:J1 the route boundary exposes cached credit decisions and
       // cache readiness without falling through to authoritative storage.
+      const denial = resolveInferenceCredentialAdmissionDenial(error, {
+        route: "embeddings",
+        traceId: c.get("traceId") ?? c.get("requestId"),
+      });
+      if (denial) {
+        return c.json(
+          {
+            error: {
+              message: denial.message,
+              type: denial.type,
+              code: denial.code,
+              details: { reason: denial.reason },
+            },
+          },
+          denial.status,
+        );
+      }
       if (error instanceof InsufficientCreditsError) {
         return c.json(
           {

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -34,6 +34,7 @@ import {
 } from "@/lib/providers/language-model";
 import { billUsage, InsufficientCreditsError } from "@/lib/services/ai-billing";
 import type { CreditReservation } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { inferenceRateLimitConfig } from "@/lib/services/inference-admission-snapshot";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
@@ -103,6 +104,11 @@ app.post("/", async (c) => {
   let billed = false;
   let providerDispatched = false;
   try {
+    let guardOrganizationId: string | undefined;
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => guardOrganizationId,
+      credential: () => admissionCredential,
+    });
     const request = (await c.req
       .json()
       .catch(() => null)) as EmbeddingsRequest | null;
@@ -190,6 +196,7 @@ app.post("/", async (c) => {
         id: resolution.ctx.userId,
         organization_id: resolution.ctx.orgId,
       };
+      guardOrganizationId = user.organization_id;
       apiKeyId = resolution.ctx.apiKeyId;
       admissionSnapshot = resolution.ctx.admission;
       admissionCredential = resolution.credential;
@@ -327,7 +334,7 @@ app.post("/", async (c) => {
         affiliateCode,
         executionCtx,
         admissionSnapshot,
-        credential: admissionCredential,
+        credential: credentialGuard.credentialForAdmission(),
       });
       settleReservation = admission.settle;
       settleUnknown = admission.settleUnknown;
@@ -621,6 +628,24 @@ app.post("/", async (c) => {
       } else {
         await observedRelease;
       }
+    }
+
+    const credentialDenial = resolveInferenceCredentialAdmissionDenial(error, {
+      route: "embeddings",
+      traceId: c.get("traceId") ?? c.get("requestId"),
+    });
+    if (credentialDenial) {
+      return c.json(
+        {
+          error: {
+            message: credentialDenial.message,
+            type: credentialDenial.type,
+            code: credentialDenial.code,
+            details: { reason: credentialDenial.reason },
+          },
+        },
+        credentialDenial.status,
+      );
     }
 
     logger.error("[Embeddings] Error", {

--- a/packages/cloud/api/v1/extract/route.ts
+++ b/packages/cloud/api/v1/extract/route.ts
@@ -19,6 +19,7 @@ import {
   extractHostedPage,
   logHostedBrowserFailure,
 } from "@/lib/services/browser-tools";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -64,6 +65,10 @@ app.post("/", async (c) => {
     const caller = await requireGenerativeRouteCaller(c, {
       deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
     if (pendingResponse) return pendingResponse;
     if (!body) throw new Error("Validated extract request was not retained");
     const { user } = caller;
@@ -73,7 +78,9 @@ app.post("/", async (c) => {
       organizationId: user.organization_id,
       requestSource: "api",
       userId: user.id,
-      operationContext: getGenerativeOperationContext(c, caller),
+      operationContext: getGenerativeOperationContext(c, caller, {
+        credentialForAdmission: () => credentialGuard.credentialForAdmission(),
+      }),
     });
 
     return c.json(result);

--- a/packages/cloud/api/v1/extract/route.ts
+++ b/packages/cloud/api/v1/extract/route.ts
@@ -39,29 +39,36 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {
-    const caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
-    const { user } = caller;
     const decodedBody = await decodeRequestJson(c.req);
+    let pendingResponse: Response | undefined;
+    let body: z.infer<typeof extractRequestSchema> | undefined;
     if (!decodedBody.ok) {
       // error-policy:J3 malformed JSON is invalid request input.
-      return c.json({ success: false, error: "Invalid JSON body" }, 400);
-    }
-    const body = decodedBody.value;
-    const bodyResult = extractRequestSchema.safeParse(body);
-
-    if (!bodyResult.success) {
-      return c.json(
-        {
-          error: "Invalid extract request",
-          details: bodyResult.error.flatten(),
-        },
+      pendingResponse = c.json(
+        { success: false, error: "Invalid JSON body" },
         400,
       );
+    } else {
+      const bodyResult = extractRequestSchema.safeParse(decodedBody.value);
+      if (bodyResult.success) body = bodyResult.data;
+      else {
+        pendingResponse = c.json(
+          {
+            error: "Invalid extract request",
+            details: bodyResult.error.flatten(),
+          },
+          400,
+        );
+      }
     }
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: pendingResponse === undefined,
+    });
+    if (pendingResponse) return pendingResponse;
+    if (!body) throw new Error("Validated extract request was not retained");
+    const { user } = caller;
 
-    const result = await extractHostedPage(bodyResult.data, {
+    const result = await extractHostedPage(body, {
       apiKeyId: caller.apiKeyId,
       organizationId: user.organization_id,
       requestSource: "api",

--- a/packages/cloud/api/v1/extract/route.ts
+++ b/packages/cloud/api/v1/extract/route.ts
@@ -39,7 +39,9 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {
-    const caller = await requireGenerativeRouteCaller(c);
+    const caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
     const { user } = caller;
     const decodedBody = await decodeRequestJson(c.req);
     if (!decodedBody.ok) {

--- a/packages/cloud/api/v1/generate-image/route.ts
+++ b/packages/cloud/api/v1/generate-image/route.ts
@@ -16,6 +16,7 @@ import {
 import { admitAppInferenceCacheOnly } from "@/lib/services/app-inference-admission";
 import { appsService } from "@/lib/services/apps";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import {
   executeImageGeneration,
   imageGenerationRequestSchema,
@@ -48,9 +49,12 @@ export async function handleGenerateImagePOST(
     const { user, apiKeyId, admissionSnapshot, credential, appScopeId } =
       await requireGenerativeRouteCaller(c, {
         rateLimitEndpoint: "strict",
-        deferStrongCredentialCheck:
-          pendingResponse === undefined && !options.requiredAppId,
+        deferStrongCredentialCheck: pendingResponse === undefined,
       });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => user.organization_id,
+      credential: () => credential,
+    });
     if (pendingResponse) return pendingResponse;
     if (!requestResult.success) throw requestResult.error;
     const request = requestResult.data;
@@ -124,7 +128,7 @@ export async function handleGenerateImagePOST(
             affiliateCode: context.affiliateCode,
             executionCtx,
             admissionSnapshot,
-            credential,
+            credential: credentialGuard.credentialForAdmission(),
             metadata: {
               endpoint: "apps.generate-image",
               numImages: request.numImages,
@@ -138,7 +142,7 @@ export async function handleGenerateImagePOST(
           apiKeyId,
           cost,
           admissionSnapshot,
-          credential,
+          credential: credentialGuard.credentialForAdmission(),
         });
         return { kind: "organization" as const, admission };
       },

--- a/packages/cloud/api/v1/generate-image/route.ts
+++ b/packages/cloud/api/v1/generate-image/route.ts
@@ -31,11 +31,29 @@ export async function handleGenerateImagePOST(
   options: { requiredAppId?: string } = {},
 ): Promise<Response> {
   try {
+    const requestResult = imageGenerationRequestSchema.safeParse(
+      await c.req.json().catch(() => undefined),
+    );
+    let pendingResponse: Response | undefined;
+    if (!requestResult.success) {
+      pendingResponse = failureResponse(c, requestResult.error);
+    } else if (!c.env.BLOB) {
+      pendingResponse = jsonError(
+        c,
+        503,
+        "R2 storage is not configured",
+        "internal_error",
+      );
+    }
     const { user, apiKeyId, admissionSnapshot, credential, appScopeId } =
       await requireGenerativeRouteCaller(c, {
         rateLimitEndpoint: "strict",
-        deferStrongCredentialCheck: true,
+        deferStrongCredentialCheck:
+          pendingResponse === undefined && !options.requiredAppId,
       });
+    if (pendingResponse) return pendingResponse;
+    if (!requestResult.success) throw requestResult.error;
+    const request = requestResult.data;
     const executionCtx = getGenerativeExecutionContext(c);
     let inferenceApp: Awaited<ReturnType<typeof appsService.getById>> | null =
       null;
@@ -69,16 +87,6 @@ export async function handleGenerateImagePOST(
         return jsonError(c, 403, "Access denied to this app", "access_denied");
       }
     }
-    if (!c.env.BLOB) {
-      return jsonError(
-        c,
-        503,
-        "R2 storage is not configured",
-        "internal_error",
-      );
-    }
-
-    const request = imageGenerationRequestSchema.parse(await c.req.json());
     const idempotencyKey = c.req.header("Idempotency-Key")?.trim();
     const requestId =
       options.requiredAppId && idempotencyKey

--- a/packages/cloud/api/v1/generate-image/route.ts
+++ b/packages/cloud/api/v1/generate-image/route.ts
@@ -31,8 +31,11 @@ export async function handleGenerateImagePOST(
   options: { requiredAppId?: string } = {},
 ): Promise<Response> {
   try {
-    const { user, apiKeyId, admissionSnapshot, appScopeId } =
-      await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
+    const { user, apiKeyId, admissionSnapshot, credential, appScopeId } =
+      await requireGenerativeRouteCaller(c, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: true,
+      });
     const executionCtx = getGenerativeExecutionContext(c);
     let inferenceApp: Awaited<ReturnType<typeof appsService.getById>> | null =
       null;
@@ -113,6 +116,7 @@ export async function handleGenerateImagePOST(
             affiliateCode: context.affiliateCode,
             executionCtx,
             admissionSnapshot,
+            credential,
             metadata: {
               endpoint: "apps.generate-image",
               numImages: request.numImages,
@@ -126,6 +130,7 @@ export async function handleGenerateImagePOST(
           apiKeyId,
           cost,
           admissionSnapshot,
+          credential,
         });
         return { kind: "organization" as const, admission };
       },

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -149,8 +149,11 @@ app.post("/", async (c) => {
   let chargeSettled = false;
 
   try {
-    const { user, apiKeyId, admissionSnapshot } =
-      await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
+    const { user, apiKeyId, admissionSnapshot, credential } =
+      await requireGenerativeRouteCaller(c, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: true,
+      });
     const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
@@ -286,6 +289,7 @@ app.post("/", async (c) => {
         apiKeyId,
         cost,
         admissionSnapshot,
+        credential,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/services/ai-pricing-definitions";
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { generationsService } from "@/lib/services/generations";
 import {
   checkGenerativeProviderHealth,
@@ -181,6 +182,10 @@ app.post("/", async (c) => {
         rateLimitEndpoint: "strict",
         deferStrongCredentialCheck: willAdmit,
       });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => user.organization_id,
+      credential: () => credential,
+    });
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
       return c.json({ error: "Invalid JSON body" }, 400);
@@ -315,7 +320,7 @@ app.post("/", async (c) => {
         apiKeyId,
         cost,
         admissionSnapshot,
-        credential,
+        credential: credentialGuard.credentialForAdmission(),
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -149,12 +149,38 @@ app.post("/", async (c) => {
   let chargeSettled = false;
 
   try {
+    const decodedRawBody = await decodeRequestJson(c.req);
+    const preflight = decodedRawBody.ok
+      ? musicRequestSchema.safeParse(decodedRawBody.value)
+      : undefined;
+    const preflightRequest = preflight?.success ? preflight.data : undefined;
+    const preflightDefinition = preflightRequest
+      ? getSupportedMusicModelDefinition(preflightRequest.model)
+      : undefined;
+    const preflightProvider = preflightRequest
+      ? (preflightRequest.provider ?? preflightDefinition?.provider)
+      : undefined;
+    const willAdmit = Boolean(
+      preflightRequest &&
+        preflightDefinition &&
+        preflightProvider === preflightDefinition.provider &&
+        !(
+          preflightProvider === "fal" && preflightRequest.prompt.length > 2000
+        ) &&
+        !(
+          preflightDefinition.durationControl === "unsupported" &&
+          preflightRequest.durationSeconds !== undefined
+        ) &&
+        providerConfigured(c.env, preflightProvider) &&
+        !checkGenerativeProviderHealth(
+          `music:${preflightProvider}:${preflightRequest.model}`,
+        ).degraded,
+    );
     const { user, apiKeyId, admissionSnapshot, credential } =
       await requireGenerativeRouteCaller(c, {
         rateLimitEndpoint: "strict",
-        deferStrongCredentialCheck: true,
+        deferStrongCredentialCheck: willAdmit,
       });
-    const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
       return c.json({ error: "Invalid JSON body" }, 400);

--- a/packages/cloud/api/v1/generate-prompts/route.ts
+++ b/packages/cloud/api/v1/generate-prompts/route.ts
@@ -32,6 +32,7 @@ app.post("/", async (c) => {
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
+      deferStrongCredentialCheck: true,
     });
 
     const body = ((await c.req.json().catch(() => ({}))) ?? {}) as {
@@ -93,6 +94,7 @@ Random seed: ${promptSeed}`;
       estimatedOutputTokens: 128,
       executionCtx,
       admissionSnapshot: caller.admissionSnapshot,
+      credential: caller.credential,
     });
     await admission.markProviderDispatched?.();
     providerDispatchStarted = true;

--- a/packages/cloud/api/v1/generate-prompts/route.ts
+++ b/packages/cloud/api/v1/generate-prompts/route.ts
@@ -18,6 +18,7 @@ import {
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { estimateTokens } from "@/lib/pricing";
 import { billUsage } from "@/lib/services/ai-billing";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -33,6 +34,10 @@ app.post("/", async (c) => {
     const caller = await requireGenerativeRouteCaller(c, {
       rateLimitEndpoint: "strict",
       deferStrongCredentialCheck: true,
+    });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
     });
 
     const body = ((await c.req.json().catch(() => ({}))) ?? {}) as {
@@ -94,7 +99,7 @@ Random seed: ${promptSeed}`;
       estimatedOutputTokens: 128,
       executionCtx,
       admissionSnapshot: caller.admissionSnapshot,
-      credential: caller.credential,
+      credential: credentialGuard.credentialForAdmission(),
     });
     await admission.markProviderDispatched?.();
     providerDispatchStarted = true;

--- a/packages/cloud/api/v1/generate-sfx/route.json.test.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.json.test.ts
@@ -96,7 +96,11 @@ describe("POST /api/v1/generate-sfx malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(assertSafeForPublicUse).not.toHaveBeenCalled();
-    expect(requireGenerativeRouteCaller).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
     expect(generateAudio).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/v1/generate-sfx/route.json.test.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.json.test.ts
@@ -13,13 +13,14 @@ const generateAudio = mock(async () => ({
   raw: {},
 }));
 const markProviderDispatched = mock(async () => undefined);
+const requireGenerativeRouteCaller = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKeyId: null,
+  admissionSnapshot: null,
+}));
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
-  requireGenerativeRouteCaller: async () => ({
-    user: { id: "user-1", organization_id: "org-1" },
-    apiKeyId: null,
-    admissionSnapshot: null,
-  }),
+  requireGenerativeRouteCaller,
   admitFlatGenerativeOperation: async () => ({
     reservation: { reconcile: async () => undefined },
     settle: async () => undefined,
@@ -95,6 +96,7 @@ describe("POST /api/v1/generate-sfx malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(assertSafeForPublicUse).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).not.toHaveBeenCalled();
     expect(generateAudio).not.toHaveBeenCalled();
   });
 
@@ -108,6 +110,10 @@ describe("POST /api/v1/generate-sfx malformed JSON", () => {
       { ELEVENLABS_API_KEY: "el-test-key" },
     );
     expect(response.status).toBe(200);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: true }),
+    );
     expect(generateAudio).toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -122,11 +122,6 @@ app.post("/", async (c) => {
   let chargeSettled = false;
 
   try {
-    const { user, apiKeyId, admissionSnapshot, credential } =
-      await requireGenerativeRouteCaller(c, {
-        rateLimitEndpoint: "strict",
-        deferStrongCredentialCheck: true,
-      });
     const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
@@ -165,6 +160,12 @@ app.post("/", async (c) => {
         "internal_error",
       );
     }
+
+    const { user, apiKeyId, admissionSnapshot, credential } =
+      await requireGenerativeRouteCaller(c, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: true,
+      });
 
     const durationSeconds =
       request.durationSeconds ?? definition.defaultParameters.durationSeconds;

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -122,8 +122,11 @@ app.post("/", async (c) => {
   let chargeSettled = false;
 
   try {
-    const { user, apiKeyId, admissionSnapshot } =
-      await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
+    const { user, apiKeyId, admissionSnapshot, credential } =
+      await requireGenerativeRouteCaller(c, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: true,
+      });
     const decodedRawBody = await decodeRequestJson(c.req);
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
@@ -205,6 +208,7 @@ app.post("/", async (c) => {
         apiKeyId,
         cost,
         admissionSnapshot,
+        credential,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -123,15 +123,20 @@ app.post("/", async (c) => {
 
   try {
     const decodedRawBody = await decodeRequestJson(c.req);
+    let pendingResponse: Response | undefined;
+    let request: z.infer<typeof sfxRequestSchema> | undefined;
+    let definition: ReturnType<typeof getSupportedSfxModelDefinition>;
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
-      return c.json({ error: "Invalid JSON body" }, 400);
+      pendingResponse = c.json({ error: "Invalid JSON body" }, 400);
+    } else {
+      const parsed = sfxRequestSchema.safeParse(decodedRawBody.value);
+      if (parsed.success) request = parsed.data;
+      else pendingResponse = failureResponse(c, parsed.error);
     }
-    const rawBody = decodedRawBody.value;
-    const request = sfxRequestSchema.parse(rawBody);
-    const definition = getSupportedSfxModelDefinition(request.model);
-    if (!definition) {
-      return jsonError(
+    if (request) definition = getSupportedSfxModelDefinition(request.model);
+    if (request && !definition) {
+      pendingResponse = jsonError(
         c,
         400,
         `Unsupported SFX model: ${request.model}`,
@@ -140,20 +145,24 @@ app.post("/", async (c) => {
           supportedModels: SUPPORTED_SFX_MODEL_IDS,
         },
       );
-    }
-    if (
+    } else if (
+      request &&
+      definition &&
       request.durationSeconds !== undefined &&
       request.durationSeconds > definition.defaultParameters.maxDurationSeconds
     ) {
-      return jsonError(
+      pendingResponse = jsonError(
         c,
         400,
         `${request.model} supports at most ${definition.defaultParameters.maxDurationSeconds}s per clip`,
         "validation_error",
       );
-    }
-    if (!providerConfigured(c.env, definition.provider)) {
-      return jsonError(
+    } else if (
+      request &&
+      definition &&
+      !providerConfigured(c.env, definition.provider)
+    ) {
+      pendingResponse = jsonError(
         c,
         503,
         `${definition.provider} SFX generation is not configured`,
@@ -164,8 +173,12 @@ app.post("/", async (c) => {
     const { user, apiKeyId, admissionSnapshot, credential } =
       await requireGenerativeRouteCaller(c, {
         rateLimitEndpoint: "strict",
-        deferStrongCredentialCheck: true,
+        deferStrongCredentialCheck: pendingResponse === undefined,
       });
+    if (pendingResponse) return pendingResponse;
+    if (!request || !definition) {
+      throw new Error("Validated SFX request was not retained");
+    }
 
     const durationSeconds =
       request.durationSeconds ?? definition.defaultParameters.durationSeconds;

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/services/ai-pricing-definitions";
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { generationsService } from "@/lib/services/generations";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
@@ -175,6 +176,10 @@ app.post("/", async (c) => {
         rateLimitEndpoint: "strict",
         deferStrongCredentialCheck: pendingResponse === undefined,
       });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => user.organization_id,
+      credential: () => credential,
+    });
     if (pendingResponse) return pendingResponse;
     if (!request || !definition) {
       throw new Error("Validated SFX request was not retained");
@@ -222,7 +227,7 @@ app.post("/", async (c) => {
         apiKeyId,
         cost,
         admissionSnapshot,
-        credential,
+        credential: credentialGuard.credentialForAdmission(),
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -167,8 +167,11 @@ app.post("/", async (c) => {
   let activeBillingRequestId: string | null = null;
 
   try {
-    const { user, apiKeyId, admissionSnapshot } =
-      await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
+    const { user, apiKeyId, admissionSnapshot, credential } =
+      await requireGenerativeRouteCaller(c, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: true,
+      });
     const request = videoRequestSchema.parse(await c.req.json());
     const requestedDefinition = request.model
       ? getSupportedVideoModelDefinition(request.model)
@@ -284,6 +287,7 @@ app.post("/", async (c) => {
           cost: candidate.cost,
           idempotencyKey: candidate.billingContext.requestId ?? undefined,
           admissionSnapshot,
+          credential,
         });
       } catch (error) {
         // error-policy:J1 the HTTP boundary translates insufficient-credit

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -167,41 +167,47 @@ app.post("/", async (c) => {
   let activeBillingRequestId: string | null = null;
 
   try {
-    const { user, apiKeyId, admissionSnapshot, credential } =
-      await requireGenerativeRouteCaller(c, {
-        rateLimitEndpoint: "strict",
-        deferStrongCredentialCheck: true,
-      });
-    const request = videoRequestSchema.parse(await c.req.json());
-    const requestedDefinition = request.model
+    const requestResult = videoRequestSchema.safeParse(
+      await c.req.json().catch(() => undefined),
+    );
+    const request = requestResult.success ? requestResult.data : undefined;
+    const requestedDefinition = request?.model
       ? getSupportedVideoModelDefinition(request.model)
       : undefined;
-    if (request.model && !requestedDefinition) {
-      return jsonError(
-        c,
-        400,
-        `Unsupported video model: ${request.model}`,
-        "validation_error",
-        {
-          supportedModels: SUPPORTED_VIDEO_MODEL_IDS,
-        },
-      );
-    }
-
-    const definitions = requestedDefinition
-      ? [requestedDefinition]
-      : requireDefaultVideoModelDefinitions();
+    const definitions = requestResult.success
+      ? requestedDefinition
+        ? [requestedDefinition]
+        : requireDefaultVideoModelDefinitions()
+      : [];
     const apiKeys = collectVideoProviderApiKeys(c.env);
     const providerCandidates = getConfiguredVideoProviderCandidates(
       definitions,
       apiKeys,
     );
-    if (providerCandidates.length === 0) {
+    let pendingResponse: Response | undefined;
+    if (!requestResult.success) {
+      pendingResponse = failureResponse(c, requestResult.error);
+    } else if (requestResult.data.model && !requestedDefinition) {
+      pendingResponse = jsonError(
+        c,
+        400,
+        `Unsupported video model: ${requestResult.data.model}`,
+        "validation_error",
+        { supportedModels: SUPPORTED_VIDEO_MODEL_IDS },
+      );
+    } else if (providerCandidates.length === 0) {
       const message = requestedDefinition
         ? `${providerDisplayName(requestedDefinition)} video generation is not configured`
         : "Video generation is not configured";
-      return jsonError(c, 503, message, "internal_error");
+      pendingResponse = jsonError(c, 503, message, "internal_error");
     }
+    const { user, apiKeyId, admissionSnapshot, credential } =
+      await requireGenerativeRouteCaller(c, {
+        rateLimitEndpoint: "strict",
+        deferStrongCredentialCheck: pendingResponse === undefined,
+      });
+    if (pendingResponse) return pendingResponse;
+    if (!request) throw new Error("Validated video request was not retained");
 
     await contentSafetyService.assertSafeForPublicUse({
       surface: "media_generation_prompt",

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -46,6 +46,7 @@ import {
 } from "@/lib/services/ai-pricing-definitions";
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { generationsService } from "@/lib/services/generations";
 import { persistPendingVideoSettlement } from "@/lib/services/pending-video-settlement";
 import { logger } from "@/lib/utils/logger";
@@ -206,6 +207,10 @@ app.post("/", async (c) => {
         rateLimitEndpoint: "strict",
         deferStrongCredentialCheck: pendingResponse === undefined,
       });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => user.organization_id,
+      credential: () => credential,
+    });
     if (pendingResponse) return pendingResponse;
     if (!request) throw new Error("Validated video request was not retained");
 
@@ -293,7 +298,7 @@ app.post("/", async (c) => {
           cost: candidate.cost,
           idempotencyKey: candidate.billingContext.requestId ?? undefined,
           admissionSnapshot,
-          credential,
+          credential: credentialGuard.credentialForAdmission(),
         });
       } catch (error) {
         // error-policy:J1 the HTTP boundary translates insufficient-credit

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -86,6 +86,7 @@ import type {
   CreditReconciliationResult,
   CreditReservation,
 } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { inferenceRateLimitConfig } from "@/lib/services/inference-admission-snapshot";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
@@ -600,547 +601,572 @@ app.post("/", async (c) => {
   let moderationAlreadyChecked = false;
   let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
   let admissionCredential: InferenceCredentialCheck | undefined;
+  let guardOrganizationId: string | undefined;
   try {
-    const resolution = await resolveInferenceAuthContext(c.req.raw, {
-      executionCtx,
-      traceId,
-      cacheOnly: Boolean(executionCtx),
-      deferStrongCredentialCheck: Boolean(executionCtx) && requestIsValid,
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => guardOrganizationId,
+      credential: () => admissionCredential,
     });
-    if (resolution.kind === "warming") {
-      return anthropicError(
-        "api_error",
-        "Authorization cache is warming. Retry shortly.",
-        503,
-      );
-    }
-    if (resolution.kind === "suspended") {
-      const denial = resolveInferenceAuthStandingDenial(resolution, {
-        route: "messages",
-        traceId,
-      });
-      return anthropicError(denial.type, denial.message, denial.status);
-    }
-    if (resolution.kind === "rejected") {
-      const denial = resolveInferenceAuthStandingDenial(resolution, {
-        route: "messages",
-        traceId,
-      });
-      return anthropicError(
-        denial.type,
-        denial.message,
-        denial.status,
-        denial.retryAfterSeconds
-          ? { "Retry-After": String(denial.retryAfterSeconds) }
-          : undefined,
-      );
-    }
-    if (resolution.kind === "authorized") {
-      user = {
-        id: resolution.ctx.userId,
-        organization_id: resolution.ctx.orgId,
-      };
-      apiKey = resolution.ctx.apiKeyId ? { id: resolution.ctx.apiKeyId } : null;
-      admissionSnapshot = resolution.ctx.admission;
-      admissionCredential = resolution.credential;
-      // The resolver already verified not-suspended (cache hit = at populate;
-      // origin miss = just now), so the synchronous moderation read is skipped.
-      moderationAlreadyChecked = true;
-    } else {
-      if (executionCtx) {
-        return anthropicError(
-          "authentication_error",
-          "Authentication required.",
-          401,
-        );
-      }
-      const auth = await requireUserOrApiKeyWithOrg(c);
-      user = { id: auth.id, organization_id: auth.organization_id };
-      // Workers auth shim does not surface the apiKey row; attribution by
-      // apiKey id requires a separate lookup.
-      apiKey = await getRequestApiKeyId(c);
-    }
-  } catch (error) {
-    // error-policy:J1 resolver infrastructure and typed auth failures retain
-    // their status; an unexpected failure is an Anthropic-shaped 500, never a
-    // fabricated authentication rejection.
-    const status = getErrorStatusCode(error);
-    if (status === 401 || status === 403 || status === 503) {
-      const denial = resolveInferenceAuthStandingDenial(
-        { kind: "rejected", status },
-        { route: "messages", traceId },
-      );
-      return anthropicError(
-        denial.type,
-        denial.message,
-        denial.status,
-        denial.retryAfterSeconds
-          ? { "Retry-After": String(denial.retryAfterSeconds) }
-          : undefined,
-      );
-    }
-    logger.error("[Messages] inference auth resolver failed", {
-      traceId,
-      status,
-      errorName: error instanceof Error ? error.name : "NonErrorThrown",
-    });
-    return anthropicError(
-      "api_error",
-      "Authorization could not be completed.",
-      status >= 400 && status <= 599 ? status : 500,
-    );
-  }
-  if (!requestIsValid || !request) return invalidRequestResponse!;
-  const tAuth = performance.now();
-
-  let orgRateLimited: Response | null;
-  try {
-    orgRateLimited = await enforceOrgRateLimit(
-      user.organization_id,
-      "completions",
-      {
-        cacheOnly: Boolean(executionCtx),
+    try {
+      const resolution = await resolveInferenceAuthContext(c.req.raw, {
         executionCtx,
-        config: inferenceRateLimitConfig(admissionSnapshot, "completions"),
-      },
-    );
-  } catch (error) {
-    // error-policy:J1 preserve the Anthropic error envelope while the
-    // cache-only policy hydrates off path.
-    if (error instanceof OrgRateLimitCacheNotReadyError) {
-      return anthropicError(
-        "api_error",
-        "Rate-limit authorization cache is warming. Retry shortly.",
-        503,
-        { "Retry-After": "1" },
-      );
-    }
-    throw error;
-  }
-  if (orgRateLimited) {
-    const headers = new Headers(orgRateLimited.headers);
-    headers.delete("Content-Type");
-    headers.delete("Content-Length");
-    if (orgRateLimited.status === 429) {
-      return anthropicError(
-        "rate_limit_error",
-        "Organization rate limit exceeded.",
-        429,
-        headers,
-      );
-    }
-    return anthropicError(
-      "api_error",
-      "Rate-limit authorization is unavailable. Retry shortly.",
-      503,
-      headers,
-    );
-  }
-
-  const requestedAppId = c.req.header("X-App-Id");
-  let appId: string | null = null;
-  let useAppCredits = false;
-  let monetizedApp: NonNullable<
-    Awaited<ReturnType<typeof appsService.getById>>
-  > | null = null;
-  if (requestedAppId) {
-    if (executionCtx) {
-      const appResolution =
-        await appsService.getAuthorizedMonetizedAppForUserCacheOnly(
-          requestedAppId,
-          user,
-          { executionCtx },
-        );
-      if (appResolution.kind !== "ready") {
+        traceId,
+        cacheOnly: Boolean(executionCtx),
+        deferStrongCredentialCheck: Boolean(executionCtx) && requestIsValid,
+      });
+      if (resolution.kind === "warming") {
         return anthropicError(
           "api_error",
-          "Application authorization cache is warming. Retry shortly.",
+          "Authorization cache is warming. Retry shortly.",
+          503,
+        );
+      }
+      if (resolution.kind === "suspended") {
+        const denial = resolveInferenceAuthStandingDenial(resolution, {
+          route: "messages",
+          traceId,
+        });
+        return anthropicError(denial.type, denial.message, denial.status);
+      }
+      if (resolution.kind === "rejected") {
+        const denial = resolveInferenceAuthStandingDenial(resolution, {
+          route: "messages",
+          traceId,
+        });
+        return anthropicError(
+          denial.type,
+          denial.message,
+          denial.status,
+          denial.retryAfterSeconds
+            ? { "Retry-After": String(denial.retryAfterSeconds) }
+            : undefined,
+        );
+      }
+      if (resolution.kind === "authorized") {
+        user = {
+          id: resolution.ctx.userId,
+          organization_id: resolution.ctx.orgId,
+        };
+        guardOrganizationId = user.organization_id;
+        apiKey = resolution.ctx.apiKeyId
+          ? { id: resolution.ctx.apiKeyId }
+          : null;
+        admissionSnapshot = resolution.ctx.admission;
+        admissionCredential = resolution.credential;
+        // The resolver already verified not-suspended (cache hit = at populate;
+        // origin miss = just now), so the synchronous moderation read is skipped.
+        moderationAlreadyChecked = true;
+      } else {
+        if (executionCtx) {
+          return anthropicError(
+            "authentication_error",
+            "Authentication required.",
+            401,
+          );
+        }
+        const auth = await requireUserOrApiKeyWithOrg(c);
+        user = { id: auth.id, organization_id: auth.organization_id };
+        // Workers auth shim does not surface the apiKey row; attribution by
+        // apiKey id requires a separate lookup.
+        apiKey = await getRequestApiKeyId(c);
+      }
+    } catch (error) {
+      // error-policy:J1 resolver infrastructure and typed auth failures retain
+      // their status; an unexpected failure is an Anthropic-shaped 500, never a
+      // fabricated authentication rejection.
+      const status = getErrorStatusCode(error);
+      if (status === 401 || status === 403 || status === 503) {
+        const denial = resolveInferenceAuthStandingDenial(
+          { kind: "rejected", status },
+          { route: "messages", traceId },
+        );
+        return anthropicError(
+          denial.type,
+          denial.message,
+          denial.status,
+          denial.retryAfterSeconds
+            ? { "Retry-After": String(denial.retryAfterSeconds) }
+            : undefined,
+        );
+      }
+      logger.error("[Messages] inference auth resolver failed", {
+        traceId,
+        status,
+        errorName: error instanceof Error ? error.name : "NonErrorThrown",
+      });
+      return anthropicError(
+        "api_error",
+        "Authorization could not be completed.",
+        status >= 400 && status <= 599 ? status : 500,
+      );
+    }
+    if (!requestIsValid || !request) return invalidRequestResponse!;
+    const tAuth = performance.now();
+
+    let orgRateLimited: Response | null;
+    try {
+      orgRateLimited = await enforceOrgRateLimit(
+        user.organization_id,
+        "completions",
+        {
+          cacheOnly: Boolean(executionCtx),
+          executionCtx,
+          config: inferenceRateLimitConfig(admissionSnapshot, "completions"),
+        },
+      );
+    } catch (error) {
+      // error-policy:J1 preserve the Anthropic error envelope while the
+      // cache-only policy hydrates off path.
+      if (error instanceof OrgRateLimitCacheNotReadyError) {
+        return anthropicError(
+          "api_error",
+          "Rate-limit authorization cache is warming. Retry shortly.",
           503,
           { "Retry-After": "1" },
         );
       }
-      monetizedApp = appResolution.app;
-    } else {
-      monetizedApp =
-        (await appsService.getAuthorizedMonetizedAppForUser(
-          requestedAppId,
-          user,
-        )) ?? null;
+      throw error;
     }
-    appId = monetizedApp?.id ?? null;
-    useAppCredits = Boolean(monetizedApp?.monetization_enabled);
-  }
-
-  const model = normalizeModelId(request.model);
-  const provider = getProviderFromModel(model);
-  const normalizedModel = normalizeModelName(model);
-  const systemPrompt = normalizeSystemPrompt(request.system);
-
-  let shouldBlockUser = false;
-  if (!moderationAlreadyChecked) {
-    if (executionCtx) {
-      const moderationResolution =
-        await contentModerationService.shouldBlockUserCacheOnly(user.id, {
-          executionCtx,
-        });
-      if (moderationResolution.kind !== "ready") {
+    if (orgRateLimited) {
+      const headers = new Headers(orgRateLimited.headers);
+      headers.delete("Content-Type");
+      headers.delete("Content-Length");
+      if (orgRateLimited.status === 429) {
         return anthropicError(
-          "api_error",
-          "Moderation authorization cache is warming. Retry shortly.",
-          503,
+          "rate_limit_error",
+          "Organization rate limit exceeded.",
+          429,
+          headers,
         );
       }
-      shouldBlockUser = moderationResolution.blocked;
-    } else {
-      shouldBlockUser = await contentModerationService.shouldBlockUser(user.id);
-    }
-  }
-  if (shouldBlockUser) {
-    return anthropicError(
-      "permission_error",
-      "Your account has been suspended due to policy violations.",
-      403,
-    );
-  }
-
-  const lastUserMessage = request.messages
-    .filter((message) => message.role === "user")
-    .pop();
-  if (lastUserMessage) {
-    const content = getMessageContentForEstimate(lastUserMessage);
-    if (content) {
-      const moderationTask = contentModerationService.moderateInBackground(
-        content,
-        user.id,
-        undefined,
-        (result) => {
-          logger.warn("[Messages API] Async moderation detected violation", {
-            userId: user.id,
-            categories: result.flaggedCategories,
-          });
-        },
+      return anthropicError(
+        "api_error",
+        "Rate-limit authorization is unavailable. Retry shortly.",
+        503,
+        headers,
       );
-      executionCtx?.waitUntil(moderationTask);
     }
-  }
 
-  const estimateMessages: Array<{ content: string | undefined }> = [];
-  if (systemPrompt) {
-    estimateMessages.push({ content: systemPrompt });
-  }
-  for (const message of request.messages) {
-    estimateMessages.push({ content: getMessageContentForEstimate(message) });
-  }
-
-  const estimatedInputTokens = estimateInputTokens(estimateMessages);
-  // Reserve against the same caller-authored ceiling enforced at the provider
-  // boundary. Reasoning configuration never silently increases generation or
-  // spend authority.
-  const reservationCotBudget = resolveAnthropicThinkingBudgetTokens(
-    model,
-    process.env,
-  );
-  const estimatedOutputTokens =
-    messagesEffectiveMaxTokens(
-      request.max_tokens,
-      reservationCotBudget,
-      model,
-    ) ?? request.max_tokens;
-  const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
-  const billingSource: PricingBillingSource =
-    resolveAiProviderSource(model) ?? "bitrouter";
-  // One server-generated identity spans admission, settlement, affiliate
-  // earnings, and audit records. A client-controlled retry key is intentionally
-  // kept separate because two delivered requests must produce two charges.
-  const requestId = crypto.randomUUID();
-  const tBeforeReserve = performance.now();
-
-  if (useAppCredits && appId && monetizedApp) {
-    // #10423: prefer the request-stable key (Idempotency-Key/X-Request-Id via
-    // the bootstrap ALS) so a client retry of the SAME request dedupes the
-    // creator-earnings legs; a fresh uuid per invocation would never match.
-    const idempotencyKey = getRequestIdempotencyKey() ?? crypto.randomUUID();
-
-    try {
-      assertInferenceAppAffiliateSupported(appId, affiliateCode);
-      const { totalCost } = await calculateCost(
-        normalizedModel,
-        provider,
-        estimatedInputTokens,
-        estimatedOutputTokens,
-        billingSource,
-        executionCtx ? { cacheOnly: true, executionCtx } : undefined,
-      );
-      const metadata = {
-        model,
-        provider,
-        billingSource,
-        estimatedInputTokens,
-        estimatedOutputTokens,
-        streaming: Boolean(request.stream),
-      };
+    const requestedAppId = c.req.header("X-App-Id");
+    let appId: string | null = null;
+    let useAppCredits = false;
+    let monetizedApp: NonNullable<
+      Awaited<ReturnType<typeof appsService.getById>>
+    > | null = null;
+    if (requestedAppId) {
       if (executionCtx) {
-        const admission = await admitAppInferenceCacheOnly({
-          appId,
-          app: monetizedApp,
-          userId: user.id,
-          organizationId: user.organization_id,
-          estimatedBaseCostUsd: totalCost,
-          description: `Messages API: ${model}`,
-          idempotencyKey,
-          metadata,
-          requestId,
+        const appResolution =
+          await appsService.getAuthorizedMonetizedAppForUserCacheOnly(
+            requestedAppId,
+            user,
+            { executionCtx },
+          );
+        if (appResolution.kind !== "ready") {
+          return anthropicError(
+            "api_error",
+            "Application authorization cache is warming. Retry shortly.",
+            503,
+            { "Retry-After": "1" },
+          );
+        }
+        monetizedApp = appResolution.app;
+      } else {
+        monetizedApp =
+          (await appsService.getAuthorizedMonetizedAppForUser(
+            requestedAppId,
+            user,
+          )) ?? null;
+      }
+      appId = monetizedApp?.id ?? null;
+      useAppCredits = Boolean(monetizedApp?.monetization_enabled);
+    }
+
+    const model = normalizeModelId(request.model);
+    const provider = getProviderFromModel(model);
+    const normalizedModel = normalizeModelName(model);
+    const systemPrompt = normalizeSystemPrompt(request.system);
+
+    let shouldBlockUser = false;
+    if (!moderationAlreadyChecked) {
+      if (executionCtx) {
+        const moderationResolution =
+          await contentModerationService.shouldBlockUserCacheOnly(user.id, {
+            executionCtx,
+          });
+        if (moderationResolution.kind !== "ready") {
+          return anthropicError(
+            "api_error",
+            "Moderation authorization cache is warming. Retry shortly.",
+            503,
+          );
+        }
+        shouldBlockUser = moderationResolution.blocked;
+      } else {
+        shouldBlockUser = await contentModerationService.shouldBlockUser(
+          user.id,
+        );
+      }
+    }
+    if (shouldBlockUser) {
+      return anthropicError(
+        "permission_error",
+        "Your account has been suspended due to policy violations.",
+        403,
+      );
+    }
+
+    const lastUserMessage = request.messages
+      .filter((message) => message.role === "user")
+      .pop();
+    if (lastUserMessage) {
+      const content = getMessageContentForEstimate(lastUserMessage);
+      if (content) {
+        const moderationTask = contentModerationService.moderateInBackground(
+          content,
+          user.id,
+          undefined,
+          (result) => {
+            logger.warn("[Messages API] Async moderation detected violation", {
+              userId: user.id,
+              categories: result.flaggedCategories,
+            });
+          },
+        );
+        executionCtx?.waitUntil(moderationTask);
+      }
+    }
+
+    const estimateMessages: Array<{ content: string | undefined }> = [];
+    if (systemPrompt) {
+      estimateMessages.push({ content: systemPrompt });
+    }
+    for (const message of request.messages) {
+      estimateMessages.push({ content: getMessageContentForEstimate(message) });
+    }
+
+    const estimatedInputTokens = estimateInputTokens(estimateMessages);
+    // Reserve against the same caller-authored ceiling enforced at the provider
+    // boundary. Reasoning configuration never silently increases generation or
+    // spend authority.
+    const reservationCotBudget = resolveAnthropicThinkingBudgetTokens(
+      model,
+      process.env,
+    );
+    const estimatedOutputTokens =
+      messagesEffectiveMaxTokens(
+        request.max_tokens,
+        reservationCotBudget,
+        model,
+      ) ?? request.max_tokens;
+    const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
+    const billingSource: PricingBillingSource =
+      resolveAiProviderSource(model) ?? "bitrouter";
+    // One server-generated identity spans admission, settlement, affiliate
+    // earnings, and audit records. A client-controlled retry key is intentionally
+    // kept separate because two delivered requests must produce two charges.
+    const requestId = crypto.randomUUID();
+    const tBeforeReserve = performance.now();
+
+    if (useAppCredits && appId && monetizedApp) {
+      // #10423: prefer the request-stable key (Idempotency-Key/X-Request-Id via
+      // the bootstrap ALS) so a client retry of the SAME request dedupes the
+      // creator-earnings legs; a fresh uuid per invocation would never match.
+      const idempotencyKey = getRequestIdempotencyKey() ?? crypto.randomUUID();
+
+      try {
+        assertInferenceAppAffiliateSupported(appId, affiliateCode);
+        const { totalCost } = await calculateCost(
+          normalizedModel,
+          provider,
+          estimatedInputTokens,
+          estimatedOutputTokens,
+          billingSource,
+          executionCtx ? { cacheOnly: true, executionCtx } : undefined,
+        );
+        const metadata = {
           model,
           provider,
           billingSource,
+          estimatedInputTokens,
+          estimatedOutputTokens,
+          streaming: Boolean(request.stream),
+        };
+        if (executionCtx) {
+          const admission = await admitAppInferenceCacheOnly({
+            appId,
+            app: monetizedApp,
+            userId: user.id,
+            organizationId: user.organization_id,
+            estimatedBaseCostUsd: totalCost,
+            description: `Messages API: ${model}`,
+            idempotencyKey,
+            metadata,
+            requestId,
+            model,
+            provider,
+            billingSource,
+            affiliateCode,
+            executionCtx,
+            admissionSnapshot,
+            credential: credentialGuard.credentialForAdmission(),
+          });
+          settleReservation = admission.settle;
+          settleUnknownReservation = admission.settleUnknown;
+          markProviderDispatched = admission.markProviderDispatched;
+        } else {
+          const reservation = await appCreditsService.reserveInferenceCredits({
+            appId,
+            userId: user.id,
+            estimatedBaseCost: totalCost,
+            description: `Messages API: ${model}`,
+            idempotencyKey,
+            metadata,
+            app: monetizedApp,
+          });
+          const settle = createCreditReservationSettler(reservation);
+          settleReservation = settle;
+          settleUnknownReservation = () => settle(reservation.reservedAmount);
+        }
+      } catch (error) {
+        // error-policy:J1 admission failures become terminal Anthropic responses
+        // before any provider dispatch.
+        const denial = resolveInferenceCredentialAdmissionDenial(error, {
+          route: "messages",
+          traceId,
+        });
+        if (denial) {
+          return anthropicError(denial.type, denial.message, denial.status);
+        }
+        if (error instanceof InferenceAppAffiliateUnsupportedError) {
+          return anthropicError(
+            "invalid_request_error",
+            "App monetization and affiliate attribution cannot be combined.",
+            400,
+          );
+        }
+        if (error instanceof InsufficientCreditsError) {
+          return anthropicError(
+            "billing_error",
+            `Insufficient cloud credits. Required: $${error.required.toFixed(4)}`,
+            402,
+          );
+        }
+        if (
+          error instanceof InferenceBalanceCacheWarmingError ||
+          error instanceof AiPricingCacheWarmingError ||
+          error instanceof AiPricingCacheUnavailableError
+        ) {
+          return anthropicError(
+            "api_error",
+            "Billing authorization is warming. Retry shortly.",
+            503,
+          );
+        }
+
+        throw error;
+      }
+    } else {
+      try {
+        const admission = await admitOrganizationInference({
+          context: {
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId: apiKey?.id,
+            model,
+            provider,
+            billingSource,
+            affiliateCode,
+            requestId,
+          },
+          estimatedInputTokens,
+          estimatedOutputTokens,
+          apiKeyId: apiKey?.id,
           affiliateCode,
           executionCtx,
           admissionSnapshot,
-          credential: admissionCredential,
+          credential: credentialGuard.credentialForAdmission(),
         });
         settleReservation = admission.settle;
         settleUnknownReservation = admission.settleUnknown;
         markProviderDispatched = admission.markProviderDispatched;
-      } else {
-        const reservation = await appCreditsService.reserveInferenceCredits({
-          appId,
-          userId: user.id,
-          estimatedBaseCost: totalCost,
-          description: `Messages API: ${model}`,
-          idempotencyKey,
-          metadata,
-          app: monetizedApp,
+        billingReservation = admission.reservation;
+      } catch (error) {
+        // error-policy:J1 admission failures become terminal Anthropic responses
+        // before any provider dispatch.
+        const denial = resolveInferenceCredentialAdmissionDenial(error, {
+          route: "messages",
+          traceId,
         });
-        const settle = createCreditReservationSettler(reservation);
-        settleReservation = settle;
-        settleUnknownReservation = () => settle(reservation.reservedAmount);
-      }
-    } catch (error) {
-      // error-policy:J1 admission failures become terminal Anthropic responses
-      // before any provider dispatch.
-      const denial = resolveInferenceCredentialAdmissionDenial(error, {
-        route: "messages",
-        traceId,
-      });
-      if (denial) {
-        return anthropicError(denial.type, denial.message, denial.status);
-      }
-      if (error instanceof InferenceAppAffiliateUnsupportedError) {
-        return anthropicError(
-          "invalid_request_error",
-          "App monetization and affiliate attribution cannot be combined.",
-          400,
-        );
-      }
-      if (error instanceof InsufficientCreditsError) {
-        return anthropicError(
-          "billing_error",
-          `Insufficient cloud credits. Required: $${error.required.toFixed(4)}`,
-          402,
-        );
-      }
-      if (
-        error instanceof InferenceBalanceCacheWarmingError ||
-        error instanceof AiPricingCacheWarmingError ||
-        error instanceof AiPricingCacheUnavailableError
-      ) {
-        return anthropicError(
-          "api_error",
-          "Billing authorization is warming. Retry shortly.",
-          503,
-        );
-      }
+        if (denial) {
+          return anthropicError(denial.type, denial.message, denial.status);
+        }
+        if (error instanceof InsufficientCreditsError) {
+          return anthropicError(
+            "billing_error",
+            `Insufficient credits. Required: $${error.required.toFixed(4)}`,
+            402,
+          );
+        }
+        if (error instanceof InferenceBalanceCacheWarmingError) {
+          return anthropicError(
+            "api_error",
+            "Billing authorization is warming. Retry shortly.",
+            503,
+          );
+        }
 
-      throw error;
+        throw error;
+      }
     }
-  } else {
-    try {
-      const admission = await admitOrganizationInference({
-        context: {
-          organizationId: user.organization_id,
-          userId: user.id,
-          apiKeyId: apiKey?.id,
-          model,
-          provider,
-          billingSource,
-          affiliateCode,
-          requestId,
-        },
-        estimatedInputTokens,
-        estimatedOutputTokens,
-        apiKeyId: apiKey?.id,
-        affiliateCode,
-        executionCtx,
-        admissionSnapshot,
-        credential: admissionCredential,
-      });
-      settleReservation = admission.settle;
-      settleUnknownReservation = admission.settleUnknown;
-      markProviderDispatched = admission.markProviderDispatched;
-      billingReservation = admission.reservation;
-    } catch (error) {
-      // error-policy:J1 admission failures become terminal Anthropic responses
-      // before any provider dispatch.
-      const denial = resolveInferenceCredentialAdmissionDenial(error, {
-        route: "messages",
-        traceId,
-      });
-      if (denial) {
-        return anthropicError(denial.type, denial.message, denial.status);
-      }
-      if (error instanceof InsufficientCreditsError) {
-        return anthropicError(
-          "billing_error",
-          `Insufficient credits. Required: $${error.required.toFixed(4)}`,
-          402,
-        );
-      }
-      if (error instanceof InferenceBalanceCacheWarmingError) {
-        return anthropicError(
-          "api_error",
-          "Billing authorization is warming. Retry shortly.",
-          503,
-        );
-      }
 
-      throw error;
-    }
-  }
-
-  if (!settleReservation || !settleUnknownReservation) {
-    throw new Error(
-      "[Messages API] inference admission did not return terminal settlers",
-    );
-  }
-  const tAfterReserve = performance.now();
-
-  // The outer AI SDK invocation is the last gateway-controlled boundary.
-  // Model doGenerate/doStream dispatch occurs later inside the SDK and is not
-  // represented as provider latency by this preforward snapshot.
-  let gatewayHandoffAt: number | undefined;
-  const gatewayHandoffTelemetry: GatewayHandoffTelemetry = {
-    capture: () => {
-      gatewayHandoffAt ??= performance.now();
-    },
-    emit: () => {
-      if (gatewayHandoffAt === undefined || preforwardTiming) return;
-      preforwardTiming = snapshotGatewayPreforwardTiming({
-        authMs: tAuth - telemetryStartedAt,
-        middleMs: tBeforeReserve - tAuth,
-        reserveMs: tAfterReserve - tBeforeReserve,
-        setupMs: gatewayHandoffAt - tAfterReserve,
-        totalMs: gatewayHandoffAt - telemetryStartedAt,
-      });
-      logger.info("[Messages API][preforward]", {
-        traceId,
-        model,
-        authMs: preforwardTiming.authMs,
-        midReadsMs: preforwardTiming.middleMs,
-        reserveMs: preforwardTiming.reserveMs,
-        setupMs: preforwardTiming.setupMs,
-        totalMs: preforwardTiming.totalMs,
-        stream: Boolean(request.stream),
-      });
-    },
-  };
-
-  try {
-    // Payload conversion is throwable (convertTools rejects a malformed-but-
-    // valid `tools` array); keep it inside the settle-refunding try so a
-    // conversion throw refunds the reservation instead of stranding the debit
-    // the caller was just charged (refund-gap class, #11795).
-    const messages = anthropicMessagesToModelMessages(request.messages);
-    const tools = convertTools(request.tools);
-    const toolChoice = mapToolChoice(request.tool_choice);
-    const safeParams = getSafeModelParams(model, {
-      temperature: request.temperature,
-      topP: request.top_p,
-      topK: request.top_k,
-      stopSequences: request.stop_sequences,
-    });
-
-    const preforwardResponse = request.stream
-      ? await handleStream(
-          model,
-          systemPrompt,
-          messages,
-          request,
-          user,
-          apiKey,
-          affiliateCode,
-          startTime,
-          estimatedInputTokens,
-          safeParams,
-          tools,
-          toolChoice,
-          c.req.raw.signal,
-          routeTimeoutMs,
-          settleReservation,
-          settleUnknownReservation,
-          billingReservation,
-          billingSource,
-          requestId,
-          executionCtx,
-          gatewayHandoffTelemetry,
-          markProviderDispatched,
-        )
-      : await handleNonStream(
-          model,
-          systemPrompt,
-          messages,
-          request,
-          user,
-          apiKey,
-          affiliateCode,
-          startTime,
-          safeParams,
-          tools,
-          toolChoice,
-          c.req.raw.signal,
-          routeTimeoutMs,
-          settleReservation,
-          settleUnknownReservation,
-          billingReservation,
-          billingSource,
-          requestId,
-          executionCtx,
-          gatewayHandoffTelemetry,
-          markProviderDispatched,
-        );
-    if (!preforwardTiming) {
-      throw new Error("[Messages API] gateway handoff timing was not captured");
-    }
-    return attachPreforwardTelemetry(preforwardResponse);
-  } catch (error) {
-    await settleOffResponsePath(executionCtx, async () => {
-      if (
-        gatewayHandoffAt === undefined ||
-        isProviderConfigurationError(error)
-      ) {
-        await settleReservation?.(0);
-      } else {
-        await settleUnknownReservation?.();
-      }
-    });
-    const message = error instanceof Error ? error.message : String(error);
-    // A provider-configuration failure (unknown model / unconfigured gateway)
-    // carries internal setup guidance in its message — return a clean,
-    // model-scoped 400 instead of leaking it as a 500 api_error (#13913 for the
-    // sibling /v1/chat/completions boundary).
-    if (isProviderConfigurationError(error)) {
-      logger.error("[Messages API] Provider configuration error", {
-        error: message,
-      });
-      return attachPreforwardTelemetry(
-        anthropicError(
-          "invalid_request_error",
-          modelNotAvailableMessage(model),
-          400,
-        ),
+    if (!settleReservation || !settleUnknownReservation) {
+      throw new Error(
+        "[Messages API] inference admission did not return terminal settlers",
       );
     }
-    logger.error("[Messages API] Error", { traceId, error: message });
-    return attachPreforwardTelemetry(anthropicError("api_error", message, 500));
+    const tAfterReserve = performance.now();
+
+    // The outer AI SDK invocation is the last gateway-controlled boundary.
+    // Model doGenerate/doStream dispatch occurs later inside the SDK and is not
+    // represented as provider latency by this preforward snapshot.
+    let gatewayHandoffAt: number | undefined;
+    const gatewayHandoffTelemetry: GatewayHandoffTelemetry = {
+      capture: () => {
+        gatewayHandoffAt ??= performance.now();
+      },
+      emit: () => {
+        if (gatewayHandoffAt === undefined || preforwardTiming) return;
+        preforwardTiming = snapshotGatewayPreforwardTiming({
+          authMs: tAuth - telemetryStartedAt,
+          middleMs: tBeforeReserve - tAuth,
+          reserveMs: tAfterReserve - tBeforeReserve,
+          setupMs: gatewayHandoffAt - tAfterReserve,
+          totalMs: gatewayHandoffAt - telemetryStartedAt,
+        });
+        logger.info("[Messages API][preforward]", {
+          traceId,
+          model,
+          authMs: preforwardTiming.authMs,
+          midReadsMs: preforwardTiming.middleMs,
+          reserveMs: preforwardTiming.reserveMs,
+          setupMs: preforwardTiming.setupMs,
+          totalMs: preforwardTiming.totalMs,
+          stream: Boolean(request.stream),
+        });
+      },
+    };
+
+    try {
+      // Payload conversion is throwable (convertTools rejects a malformed-but-
+      // valid `tools` array); keep it inside the settle-refunding try so a
+      // conversion throw refunds the reservation instead of stranding the debit
+      // the caller was just charged (refund-gap class, #11795).
+      const messages = anthropicMessagesToModelMessages(request.messages);
+      const tools = convertTools(request.tools);
+      const toolChoice = mapToolChoice(request.tool_choice);
+      const safeParams = getSafeModelParams(model, {
+        temperature: request.temperature,
+        topP: request.top_p,
+        topK: request.top_k,
+        stopSequences: request.stop_sequences,
+      });
+
+      const preforwardResponse = request.stream
+        ? await handleStream(
+            model,
+            systemPrompt,
+            messages,
+            request,
+            user,
+            apiKey,
+            affiliateCode,
+            startTime,
+            estimatedInputTokens,
+            safeParams,
+            tools,
+            toolChoice,
+            c.req.raw.signal,
+            routeTimeoutMs,
+            settleReservation,
+            settleUnknownReservation,
+            billingReservation,
+            billingSource,
+            requestId,
+            executionCtx,
+            gatewayHandoffTelemetry,
+            markProviderDispatched,
+          )
+        : await handleNonStream(
+            model,
+            systemPrompt,
+            messages,
+            request,
+            user,
+            apiKey,
+            affiliateCode,
+            startTime,
+            safeParams,
+            tools,
+            toolChoice,
+            c.req.raw.signal,
+            routeTimeoutMs,
+            settleReservation,
+            settleUnknownReservation,
+            billingReservation,
+            billingSource,
+            requestId,
+            executionCtx,
+            gatewayHandoffTelemetry,
+            markProviderDispatched,
+          );
+      if (!preforwardTiming) {
+        throw new Error(
+          "[Messages API] gateway handoff timing was not captured",
+        );
+      }
+      return attachPreforwardTelemetry(preforwardResponse);
+    } catch (error) {
+      await settleOffResponsePath(executionCtx, async () => {
+        if (
+          gatewayHandoffAt === undefined ||
+          isProviderConfigurationError(error)
+        ) {
+          await settleReservation?.(0);
+        } else {
+          await settleUnknownReservation?.();
+        }
+      });
+      const message = error instanceof Error ? error.message : String(error);
+      // A provider-configuration failure (unknown model / unconfigured gateway)
+      // carries internal setup guidance in its message — return a clean,
+      // model-scoped 400 instead of leaking it as a 500 api_error (#13913 for the
+      // sibling /v1/chat/completions boundary).
+      if (isProviderConfigurationError(error)) {
+        logger.error("[Messages API] Provider configuration error", {
+          error: message,
+        });
+        return attachPreforwardTelemetry(
+          anthropicError(
+            "invalid_request_error",
+            modelNotAvailableMessage(model),
+            400,
+          ),
+        );
+      }
+      logger.error("[Messages API] Error", { traceId, error: message });
+      return attachPreforwardTelemetry(
+        anthropicError("api_error", message, 500),
+      );
+    }
+  } catch (error) {
+    const denial = resolveInferenceCredentialAdmissionDenial(error, {
+      route: "messages",
+      traceId,
+    });
+    if (denial) {
+      return anthropicError(denial.type, denial.message, denial.status);
+    }
+    throw error;
   }
 });
 

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -563,26 +563,24 @@ app.post("/", async (c) => {
     );
   }
   const decodedBody = await decodeRequestJson(c.req);
-  if (!decodedBody.ok) {
-    // error-policy:J3 malformed JSON is invalid request input.
-    return anthropicError("invalid_request_error", "Invalid JSON body", 400);
-  }
-  const body = decodedBody.value;
-  if (!body || typeof body !== "object") {
-    return anthropicError("invalid_request_error", "Invalid JSON body", 400);
-  }
-  const request = body as AnthropicMessagesRequest;
-  if (
-    !request.model ||
-    request.max_tokens == null ||
-    !request.messages?.length
-  ) {
-    return anthropicError(
-      "invalid_request_error",
-      "Missing required fields: model, max_tokens, messages",
-      400,
-    );
-  }
+  const body = decodedBody.ok ? decodedBody.value : undefined;
+  const request =
+    body && typeof body === "object"
+      ? (body as AnthropicMessagesRequest)
+      : undefined;
+  const requestIsValid = Boolean(
+    request?.model && request.max_tokens != null && request.messages?.length,
+  );
+  const invalidRequestResponse =
+    !decodedBody.ok || !request
+      ? anthropicError("invalid_request_error", "Invalid JSON body", 400)
+      : !requestIsValid
+        ? anthropicError(
+            "invalid_request_error",
+            "Missing required fields: model, max_tokens, messages",
+            400,
+          )
+        : undefined;
 
   let settleReservation:
     | ((actualCost: number) => Promise<CreditReconciliationResult | null>)
@@ -607,7 +605,7 @@ app.post("/", async (c) => {
       executionCtx,
       traceId,
       cacheOnly: Boolean(executionCtx),
-      deferStrongCredentialCheck: Boolean(executionCtx),
+      deferStrongCredentialCheck: Boolean(executionCtx) && requestIsValid,
     });
     if (resolution.kind === "warming") {
       return anthropicError(
@@ -692,6 +690,7 @@ app.post("/", async (c) => {
       status >= 400 && status <= 599 ? status : 500,
     );
   }
+  if (!requestIsValid || !request) return invalidRequestResponse!;
   const tAuth = performance.now();
 
   let orgRateLimited: Response | null;

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -25,7 +25,10 @@ import {
   type UserModelMessage,
 } from "ai";
 import { Hono } from "hono";
-import { resolveInferenceAuthStandingDenial } from "@/api-app/lib/generative-route-auth";
+import {
+  resolveInferenceAuthStandingDenial,
+  resolveInferenceCredentialAdmissionDenial,
+} from "@/api-app/lib/generative-route-auth";
 import { getErrorStatusCode } from "@/lib/api/errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
@@ -87,6 +90,7 @@ import { inferenceRateLimitConfig } from "@/lib/services/inference-admission-sna
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import { InferenceBalanceCacheWarmingError } from "@/lib/services/inference-billing-fast-path";
+import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import {
   isKnownPreDispatchProviderConfigurationError,
   isKnownUnacceptedProviderError,
@@ -575,11 +579,13 @@ app.post("/", async (c) => {
   // because their timestamped signatures are not reusable cache identities.
   let moderationAlreadyChecked = false;
   let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
+  let admissionCredential: InferenceCredentialCheck | undefined;
   try {
     const resolution = await resolveInferenceAuthContext(c.req.raw, {
       executionCtx,
       traceId,
       cacheOnly: Boolean(executionCtx),
+      deferStrongCredentialCheck: Boolean(executionCtx),
     });
     if (resolution.kind === "warming") {
       return anthropicError(
@@ -616,6 +622,7 @@ app.post("/", async (c) => {
       };
       apiKey = resolution.ctx.apiKeyId ? { id: resolution.ctx.apiKeyId } : null;
       admissionSnapshot = resolution.ctx.admission;
+      admissionCredential = resolution.credential;
       // The resolver already verified not-suspended (cache hit = at populate;
       // origin miss = just now), so the synchronous moderation read is skipped.
       moderationAlreadyChecked = true;
@@ -892,6 +899,7 @@ app.post("/", async (c) => {
           affiliateCode,
           executionCtx,
           admissionSnapshot,
+          credential: admissionCredential,
         });
         settleReservation = admission.settle;
         settleUnknownReservation = admission.settleUnknown;
@@ -913,6 +921,13 @@ app.post("/", async (c) => {
     } catch (error) {
       // error-policy:J1 admission failures become terminal Anthropic responses
       // before any provider dispatch.
+      const denial = resolveInferenceCredentialAdmissionDenial(error, {
+        route: "messages",
+        traceId,
+      });
+      if (denial) {
+        return anthropicError(denial.type, denial.message, denial.status);
+      }
       if (error instanceof InferenceAppAffiliateUnsupportedError) {
         return anthropicError(
           "invalid_request_error",
@@ -960,6 +975,7 @@ app.post("/", async (c) => {
         affiliateCode,
         executionCtx,
         admissionSnapshot,
+        credential: admissionCredential,
       });
       settleReservation = admission.settle;
       settleUnknownReservation = admission.settleUnknown;
@@ -968,6 +984,13 @@ app.post("/", async (c) => {
     } catch (error) {
       // error-policy:J1 admission failures become terminal Anthropic responses
       // before any provider dispatch.
+      const denial = resolveInferenceCredentialAdmissionDenial(error, {
+        route: "messages",
+        traceId,
+      });
+      if (denial) {
+        return anthropicError(denial.type, denial.message, denial.status);
+      }
       if (error instanceof InsufficientCreditsError) {
         return anthropicError(
           "billing_error",

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -562,6 +562,28 @@ app.post("/", async (c) => {
       503,
     );
   }
+  const decodedBody = await decodeRequestJson(c.req);
+  if (!decodedBody.ok) {
+    // error-policy:J3 malformed JSON is invalid request input.
+    return anthropicError("invalid_request_error", "Invalid JSON body", 400);
+  }
+  const body = decodedBody.value;
+  if (!body || typeof body !== "object") {
+    return anthropicError("invalid_request_error", "Invalid JSON body", 400);
+  }
+  const request = body as AnthropicMessagesRequest;
+  if (
+    !request.model ||
+    request.max_tokens == null ||
+    !request.messages?.length
+  ) {
+    return anthropicError(
+      "invalid_request_error",
+      "Missing required fields: model, max_tokens, messages",
+      400,
+    );
+  }
+
   let settleReservation:
     | ((actualCost: number) => Promise<CreditReconciliationResult | null>)
     | null = null;
@@ -748,30 +770,6 @@ app.post("/", async (c) => {
     }
     appId = monetizedApp?.id ?? null;
     useAppCredits = Boolean(monetizedApp?.monetization_enabled);
-  }
-
-  const decodedBody = await decodeRequestJson(c.req);
-  if (!decodedBody.ok) {
-    // error-policy:J3 malformed JSON is invalid request input.
-    return anthropicError("invalid_request_error", "Invalid JSON body", 400);
-  }
-  const body = decodedBody.value;
-
-  if (!body || typeof body !== "object") {
-    return anthropicError("invalid_request_error", "Invalid JSON body", 400);
-  }
-
-  const request = body as AnthropicMessagesRequest;
-  if (
-    !request.model ||
-    request.max_tokens == null ||
-    !request.messages?.length
-  ) {
-    return anthropicError(
-      "invalid_request_error",
-      "Missing required fields: model, max_tokens, messages",
-      400,
-    );
   }
 
   const model = normalizeModelId(request.model);

--- a/packages/cloud/api/v1/rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/rpc/[chain]/route.ts
@@ -40,6 +40,7 @@ async function __hono_POST(
   const config = rpcConfigForChain(normalized);
   const caller = await requireGenerativeRouteCaller(c, {
     rateLimitEndpoint: "standard",
+    deferStrongCredentialCheck: true,
   });
   const executionCtx = getGenerativeExecutionContext(c);
   if (executionCtx && !caller.admissionSnapshot) {
@@ -57,6 +58,7 @@ async function __hono_POST(
       ...(caller.apiKeyId ? { apiKey: { id: caller.apiKeyId } } : {}),
     },
     admissionSnapshot: caller.admissionSnapshot,
+    credential: caller.credential,
     executionCtx,
     requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
   });

--- a/packages/cloud/api/v1/rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/rpc/[chain]/route.ts
@@ -4,6 +4,7 @@ import {
   getGenerativeExecutionContext,
   requireGenerativeRouteCaller,
 } from "@/api-app/lib/generative-route-auth";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { createHandler } from "@/lib/services/proxy/engine";
 import {
@@ -42,6 +43,10 @@ async function __hono_POST(
     rateLimitEndpoint: "standard",
     deferStrongCredentialCheck: chainIsValid,
   });
+  await using credentialGuard = deferredCredentialAdmissionGuard({
+    organizationId: () => caller.user.organization_id,
+    credential: () => caller.credential,
+  });
   if (pendingResponse) return pendingResponse;
   if (!chainIsValid) throw new Error("Validated RPC chain was not retained");
   const config = rpcConfigForChain(normalized);
@@ -62,6 +67,7 @@ async function __hono_POST(
     },
     admissionSnapshot: caller.admissionSnapshot,
     credential: caller.credential,
+    credentialForAdmission: () => credentialGuard.credentialForAdmission(),
     executionCtx,
     requestId: c.get("requestId") ?? c.get("traceId") ?? crypto.randomUUID(),
   });

--- a/packages/cloud/api/v1/rpc/[chain]/route.ts
+++ b/packages/cloud/api/v1/rpc/[chain]/route.ts
@@ -27,21 +27,24 @@ async function __hono_POST(
   const { chain } = await params;
   const normalized = chain.toLowerCase();
 
-  if (!isValidRpcChain(normalized)) {
-    return applyCorsHeaders(
-      Response.json(
-        { error: "Unsupported chain", supported: [...SUPPORTED_RPC_CHAINS] },
-        { status: 400 },
-      ),
-      CORS_METHODS,
-    );
-  }
+  const chainIsValid = isValidRpcChain(normalized);
+  const pendingResponse = !chainIsValid
+    ? applyCorsHeaders(
+        Response.json(
+          { error: "Unsupported chain", supported: [...SUPPORTED_RPC_CHAINS] },
+          { status: 400 },
+        ),
+        CORS_METHODS,
+      )
+    : undefined;
 
-  const config = rpcConfigForChain(normalized);
   const caller = await requireGenerativeRouteCaller(c, {
     rateLimitEndpoint: "standard",
-    deferStrongCredentialCheck: true,
+    deferStrongCredentialCheck: chainIsValid,
   });
+  if (pendingResponse) return pendingResponse;
+  if (!chainIsValid) throw new Error("Validated RPC chain was not retained");
+  const config = rpcConfigForChain(normalized);
   const executionCtx = getGenerativeExecutionContext(c);
   if (executionCtx && !caller.admissionSnapshot) {
     return applyCorsHeaders(

--- a/packages/cloud/api/v1/search/route.json.test.ts
+++ b/packages/cloud/api/v1/search/route.json.test.ts
@@ -1,5 +1,6 @@
 /** Verifies the hosted-search JSON boundary with deterministic auth and provider mocks. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 import {
   getGenerativeOperationContext,
   paidBoundaryState,
@@ -15,6 +16,8 @@ const executeHostedGoogleSearch = mock(
   ) => ({ results: [] }),
 );
 mock.module("@/api-app/lib/generative-route-auth", () => ({
+  asGenerativeCacheApiError: (error: unknown) =>
+    error instanceof ApiError ? error : null,
   getGenerativeOperationContext,
   requireGenerativeKnownIdentity,
   requireGenerativeRouteCaller,
@@ -83,14 +86,24 @@ describe("POST /api/v1/search malformed JSON", () => {
   });
 
   test("standing denial performs one combined auth read and never dispatches search", async () => {
-    paidBoundaryState.routeError = new Error("cached standing denied");
+    paidBoundaryState.routeError = new ApiError(
+      401,
+      "authentication_required",
+      "Authentication required",
+      { reason: "credential_inactive" },
+    );
     const response = await app.request("/", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ query: "elizaos" }),
     });
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "authentication_required",
+      error: "Authentication required",
+      details: { reason: "credential_inactive" },
+    });
     expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
     expect(getGenerativeOperationContext).not.toHaveBeenCalled();
     expect(executeHostedGoogleSearch).not.toHaveBeenCalled();

--- a/packages/cloud/api/v1/search/route.json.test.ts
+++ b/packages/cloud/api/v1/search/route.json.test.ts
@@ -52,6 +52,11 @@ describe("POST /api/v1/search malformed JSON", () => {
       error: "Invalid JSON body",
     });
     expect(executeHostedGoogleSearch).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
   });
 
   test("preserves non-syntax request decoding failures as server errors", async () => {
@@ -82,6 +87,10 @@ describe("POST /api/v1/search malformed JSON", () => {
     expect(response.status).toBe(200);
     expect(executeHostedGoogleSearch).toHaveBeenCalled();
     expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: true }),
+    );
     expect(getGenerativeOperationContext).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/cloud/api/v1/search/route.ts
+++ b/packages/cloud/api/v1/search/route.ts
@@ -2,6 +2,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import {
+  asGenerativeCacheApiError,
   getGenerativeOperationContext,
   requireGenerativeRouteCaller,
 } from "@/api-app/lib/generative-route-auth";
@@ -78,6 +79,9 @@ async function handlePOST(c: AppContext) {
     logger.error("[/api/v1/search] Request failed", {
       error: error instanceof Error ? error.message : String(error),
     });
+
+    const admissionError = asGenerativeCacheApiError(error);
+    if (admissionError) return failureResponse(c, admissionError);
 
     return Response.json(
       {

--- a/packages/cloud/api/v1/search/route.ts
+++ b/packages/cloud/api/v1/search/route.ts
@@ -54,6 +54,7 @@ async function handlePOST(c: AppContext) {
     const caller = await requireGenerativeRouteCaller(c, {
       compatibility: "raw",
       rateLimitEndpoint: "standard",
+      deferStrongCredentialCheck: true,
     });
     const result = await executeHostedGoogleSearch(
       {

--- a/packages/cloud/api/v1/search/route.ts
+++ b/packages/cloud/api/v1/search/route.ts
@@ -32,17 +32,21 @@ const searchRequestSchema = z.object({
 async function handlePOST(c: AppContext) {
   try {
     let raw: unknown;
+    let pendingResponse: Response | undefined;
     try {
       raw = await c.req.raw.json();
     } catch (error) {
       if (!(error instanceof SyntaxError)) throw error;
       // error-policy:J3 malformed JSON is an explicit invalid request.
-      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+      pendingResponse = Response.json(
+        { error: "Invalid JSON body" },
+        { status: 400 },
+      );
     }
     const bodyResult = searchRequestSchema.safeParse(raw);
 
     if (!bodyResult.success) {
-      return Response.json(
+      pendingResponse ??= Response.json(
         {
           error: "Invalid search request",
           details: bodyResult.error.flatten(),
@@ -51,12 +55,14 @@ async function handlePOST(c: AppContext) {
       );
     }
 
-    const body = bodyResult.data;
     const caller = await requireGenerativeRouteCaller(c, {
       compatibility: "raw",
       rateLimitEndpoint: "standard",
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    if (pendingResponse) return pendingResponse;
+    if (!bodyResult.success) throw bodyResult.error;
+    const body = bodyResult.data;
     const result = await executeHostedGoogleSearch(
       {
         query: body.query,

--- a/packages/cloud/api/v1/search/route.ts
+++ b/packages/cloud/api/v1/search/route.ts
@@ -12,6 +12,7 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { executeHostedGoogleSearch } from "@/lib/services/google-search";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -60,6 +61,10 @@ async function handlePOST(c: AppContext) {
       rateLimitEndpoint: "standard",
       deferStrongCredentialCheck: pendingResponse === undefined,
     });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
     if (pendingResponse) return pendingResponse;
     if (!bodyResult.success) throw bodyResult.error;
     const body = bodyResult.data;
@@ -75,7 +80,10 @@ async function handlePOST(c: AppContext) {
         endDate: body.endDate,
       },
       {
-        ...getGenerativeOperationContext(c, caller),
+        ...getGenerativeOperationContext(c, caller, {
+          credentialForAdmission: () =>
+            credentialGuard.credentialForAdmission(),
+        }),
         requestSource: "api",
       },
     );

--- a/packages/cloud/api/v1/voice/clone/route.standing.test.ts
+++ b/packages/cloud/api/v1/voice/clone/route.standing.test.ts
@@ -14,7 +14,12 @@ class ApiError extends Error {
   }
 }
 
-const requireGenerativeRouteCaller = mock<() => Promise<unknown>>(async () => {
+const requireGenerativeRouteCaller = mock<
+  (
+    context?: unknown,
+    options?: { deferStrongCredentialCheck?: boolean },
+  ) => Promise<unknown>
+>(async () => {
   throw new ApiError(403, "access_denied", "Account is inactive", {
     reason: "account_inactive",
   });
@@ -119,7 +124,32 @@ mock.module("@/lib/utils/logger", () => ({
 const { default: voiceCloneRoute } = await import("./route");
 const app = new Hono().route("/v1/voice/clone", voiceCloneRoute);
 
+test("invalid form performs one standalone strong check without admission", async () => {
+  requireGenerativeRouteCaller.mockClear();
+  admitFlatGenerativeOperation.mockClear();
+  calculateVoiceCloneCostFromCatalog.mockClear();
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+  }));
+
+  const response = await app.request(
+    "/v1/voice/clone",
+    { method: "POST", body: new FormData() },
+    { ELEVENLABS_API_KEY: "configured" },
+  );
+
+  expect(response.status).toBe(400);
+  expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+  expect(requireGenerativeRouteCaller.mock.calls[0]?.[1]).toMatchObject({
+    deferStrongCredentialCheck: false,
+  });
+  expect(calculateVoiceCloneCostFromCatalog).not.toHaveBeenCalled();
+  expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+});
+
 test("cached bad standing denies before pricing, admission, provider, or storage", async () => {
+  requireGenerativeRouteCaller.mockClear();
   const providerFetch = mock(async () => new Response("provider"));
   const originalFetch = globalThis.fetch;
   globalThis.fetch = providerFetch as unknown as typeof fetch;

--- a/packages/cloud/api/v1/voice/clone/route.standing.test.ts
+++ b/packages/cloud/api/v1/voice/clone/route.standing.test.ts
@@ -58,7 +58,8 @@ const createUsage = mock(async () => undefined);
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   admitFlatGenerativeOperation,
-  asGenerativeCacheApiError: () => null,
+  asGenerativeCacheApiError: (error: unknown) =>
+    error instanceof ApiError ? error : null,
   getGenerativeExecutionContext: () => undefined,
   requireGenerativeRouteCaller,
 }));
@@ -125,9 +126,16 @@ test("cached bad standing denies before pricing, admission, provider, or storage
   const blobPut = mock(async () => undefined);
 
   try {
+    const form = new FormData();
+    form.set("name", "Denied Voice");
+    form.set("cloneType", "instant");
+    form.set(
+      "file0",
+      new File([new Uint8Array([1])], "sample.wav", { type: "audio/wav" }),
+    );
     const response = await app.request(
       "/v1/voice/clone",
-      { method: "POST" },
+      { method: "POST", body: form },
       { ELEVENLABS_API_KEY: "configured", BLOB: { put: blobPut } },
     );
 
@@ -148,7 +156,63 @@ test("cached bad standing denies before pricing, admission, provider, or storage
   }
 });
 
+test("combined credential denial is sanitized before ElevenLabs dispatch", async () => {
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    credential: {
+      kind: "api_key",
+      credentialId: "key-1",
+      userId: "user-1",
+    },
+  }));
+  calculateVoiceCloneCostFromCatalog.mockImplementationOnce(async () => ({
+    totalCost: 1,
+    baseTotalCost: 0.8,
+    platformMarkup: 0.2,
+    pricingSource: "catalog",
+  }));
+  admitFlatGenerativeOperation.mockImplementationOnce(async () => {
+    throw new ApiError(
+      401,
+      "authentication_required",
+      "Authentication required",
+      { reason: "credential_inactive" },
+    );
+  });
+  const providerFetch = mock(async () => new Response("provider"));
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+  const form = new FormData();
+  form.set("name", "Revoked Voice");
+  form.set("cloneType", "instant");
+  form.set(
+    "file0",
+    new File([new Uint8Array([1])], "sample.wav", { type: "audio/wav" }),
+  );
+
+  try {
+    const response = await app.request(
+      "/v1/voice/clone",
+      { method: "POST", body: form },
+      { ELEVENLABS_API_KEY: "configured", BLOB: { put: mock() } },
+    );
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "authentication_required",
+      error: "Authentication required",
+      details: { reason: "credential_inactive" },
+    });
+    expect(createCloningJob).not.toHaveBeenCalled();
+    expect(providerFetch).not.toHaveBeenCalled();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("admits before ElevenLabs and settles the flat charge without a readback", async () => {
+  admitFlatGenerativeOperation.mockClear();
+  createUsage.mockClear();
   requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
     user: { id: "user-1", organization_id: "org-1" },
     apiKeyId: "key-1",

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -100,6 +100,9 @@ app.post("/", async (c) => {
   let totalSize = 0;
   let fileCount = 0;
   let voiceName = "";
+  let description: string | undefined;
+  let settings: Record<string, unknown> = {};
+  let files: File[] = [];
 
   // Track partial state so the catch branch can delete R2 and DB orphans
   // when the clone fails before we've successfully persisted a `user_voices`
@@ -111,9 +114,10 @@ app.post("/", async (c) => {
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
     const apiKey = c.env.ELEVENLABS_API_KEY;
+    let pendingConfigResponse: Response | undefined;
     if (!apiKey) {
       logger.error("[Voice Clone API] ELEVENLABS_API_KEY not configured");
-      return jsonError(
+      pendingConfigResponse = jsonError(
         c,
         500,
         "Voice cloning is not configured",
@@ -121,89 +125,103 @@ app.post("/", async (c) => {
       );
     }
 
-    const formData = await c.req.formData();
+    let validationError: unknown;
+    try {
+      const formData = await c.req.formData();
 
-    const nameField = formData.get("name");
-    if (typeof nameField !== "string" || nameField.length === 0) {
-      throw ValidationError("Missing required field: name");
-    }
-    voiceName = nameField;
+      const nameField = formData.get("name");
+      if (typeof nameField !== "string" || nameField.length === 0) {
+        throw ValidationError("Missing required field: name");
+      }
+      voiceName = nameField;
 
-    const cloneTypeField = formData.get("cloneType");
-    if (cloneTypeField !== "instant" && cloneTypeField !== "professional") {
-      throw ValidationError(
-        "Invalid cloneType. Must be 'instant' or 'professional'",
-      );
-    }
-    cloneType = cloneTypeField;
+      const cloneTypeField = formData.get("cloneType");
+      if (cloneTypeField !== "instant" && cloneTypeField !== "professional") {
+        throw ValidationError(
+          "Invalid cloneType. Must be 'instant' or 'professional'",
+        );
+      }
+      cloneType = cloneTypeField;
 
-    const descriptionField = formData.get("description");
-    const description =
-      typeof descriptionField === "string" && descriptionField.length > 0
-        ? descriptionField
-        : undefined;
+      const descriptionField = formData.get("description");
+      description =
+        typeof descriptionField === "string" && descriptionField.length > 0
+          ? descriptionField
+          : undefined;
 
-    const settingsField = formData.get("settings");
-    let settings: Record<string, unknown> = {};
-    if (typeof settingsField === "string" && settingsField.length > 0) {
-      try {
-        const parsed: unknown = JSON.parse(settingsField);
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          settings = parsed as Record<string, unknown>;
-        } else {
-          throw ValidationError("settings must be a JSON object");
+      const settingsField = formData.get("settings");
+      settings = {};
+      if (typeof settingsField === "string" && settingsField.length > 0) {
+        try {
+          const parsed: unknown = JSON.parse(settingsField);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            settings = parsed as Record<string, unknown>;
+          } else {
+            throw ValidationError("settings must be a JSON object");
+          }
+        } catch {
+          throw ValidationError("Invalid settings JSON");
         }
-      } catch {
-        throw ValidationError("Invalid settings JSON");
       }
-    }
 
-    const files: File[] = [];
-    for (const [key, value] of formData.entries()) {
-      if (!key.startsWith("file")) continue;
-      if (!isUploadedFile(value)) continue;
-      files.push(value);
-    }
-
-    if (files.length === 0) {
-      throw ValidationError("At least one audio file is required");
-    }
-    if (files.length > MAX_FILES) {
-      throw ValidationError(`Maximum ${MAX_FILES} files allowed`);
-    }
-
-    for (const file of files) {
-      if (file.size === 0) {
-        throw ValidationError(`File "${file.name}" is empty`);
+      files = [];
+      for (const [key, value] of formData.entries()) {
+        if (!key.startsWith("file")) continue;
+        if (!isUploadedFile(value)) continue;
+        files.push(value);
       }
-      if (file.size > MAX_FILE_SIZE) {
+
+      if (files.length === 0) {
+        throw ValidationError("At least one audio file is required");
+      }
+      if (files.length > MAX_FILES) {
+        throw ValidationError(`Maximum ${MAX_FILES} files allowed`);
+      }
+
+      for (const file of files) {
+        if (file.size === 0) {
+          throw ValidationError(`File "${file.name}" is empty`);
+        }
+        if (file.size > MAX_FILE_SIZE) {
+          throw ValidationError(
+            `File "${file.name}" exceeds maximum size of ${MAX_FILE_SIZE / 1024 / 1024}MB`,
+          );
+        }
+        const isAudio =
+          file.type.startsWith("audio/") ||
+          file.type === "" ||
+          file.type.startsWith("video/mp4");
+        if (!isAudio) {
+          throw ValidationError(
+            `File "${file.name}" has invalid type "${file.type}". Only audio files are allowed.`,
+          );
+        }
+        totalSize += file.size;
+      }
+      if (totalSize > MAX_TOTAL_SIZE) {
         throw ValidationError(
-          `File "${file.name}" exceeds maximum size of ${MAX_FILE_SIZE / 1024 / 1024}MB`,
+          `Total file size exceeds ${MAX_TOTAL_SIZE / 1024 / 1024}MB limit`,
         );
       }
-      const isAudio =
-        file.type.startsWith("audio/") ||
-        file.type === "" ||
-        file.type.startsWith("video/mp4");
-      if (!isAudio) {
-        throw ValidationError(
-          `File "${file.name}" has invalid type "${file.type}". Only audio files are allowed.`,
-        );
-      }
-      totalSize += file.size;
+      fileCount = files.length;
+    } catch (error) {
+      // error-policy:J1 validation is emitted only after the one strong-auth
+      // resolver call below, so malformed protected requests cannot bypass it.
+      validationError = error;
     }
-    if (totalSize > MAX_TOTAL_SIZE) {
-      throw ValidationError(
-        `Total file size exceeds ${MAX_TOTAL_SIZE / 1024 / 1024}MB limit`,
-      );
-    }
-    fileCount = files.length;
 
     caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
+      deferStrongCredentialCheck:
+        pendingConfigResponse === undefined && validationError === undefined,
     });
     user = caller.user;
     apiKeyId = caller.apiKeyId;
+    if (pendingConfigResponse) return pendingConfigResponse;
+    if (!apiKey) throw new Error("Voice-clone provider key was not retained");
+    if (validationError) throw validationError;
+    if (!cloneType || !voiceName || files.length === 0) {
+      throw new Error("Validated voice-clone request was not retained");
+    }
 
     logger.info(
       `[Voice Clone API] Creating ${cloneType} voice clone: ${voiceName}`,

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -43,6 +43,7 @@ import {
 import { type BillingContext, billFlatUsage } from "@/lib/services/ai-billing";
 import { calculateVoiceCloneCostFromCatalog } from "@/lib/services/ai-pricing";
 import { InsufficientCreditsError } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { usageService } from "@/lib/services/usage";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -214,6 +215,10 @@ app.post("/", async (c) => {
       deferStrongCredentialCheck:
         pendingConfigResponse === undefined && validationError === undefined,
     });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => caller.user.organization_id,
+      credential: () => caller.credential,
+    });
     user = caller.user;
     apiKeyId = caller.apiKeyId;
     if (pendingConfigResponse) return pendingConfigResponse;
@@ -253,7 +258,7 @@ app.post("/", async (c) => {
         apiKeyId,
         cost: cloneCost,
         admissionSnapshot: caller.admissionSnapshot,
-        credential: caller.credential,
+        credential: credentialGuard.credentialForAdmission(),
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -110,7 +110,9 @@ app.post("/", async (c) => {
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
-    caller = await requireGenerativeRouteCaller(c);
+    caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
   } catch (error) {
     return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
   }
@@ -237,6 +239,7 @@ app.post("/", async (c) => {
         apiKeyId,
         cost: cloneCost,
         admissionSnapshot: caller.admissionSnapshot,
+        credential: caller.credential,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -110,16 +110,6 @@ app.post("/", async (c) => {
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
-    caller = await requireGenerativeRouteCaller(c, {
-      deferStrongCredentialCheck: true,
-    });
-  } catch (error) {
-    return failureResponse(c, asGenerativeCacheApiError(error) ?? error);
-  }
-  user = caller.user;
-  apiKeyId = caller.apiKeyId;
-
-  try {
     const apiKey = c.env.ELEVENLABS_API_KEY;
     if (!apiKey) {
       logger.error("[Voice Clone API] ELEVENLABS_API_KEY not configured");
@@ -208,6 +198,12 @@ app.post("/", async (c) => {
       );
     }
     fileCount = files.length;
+
+    caller = await requireGenerativeRouteCaller(c, {
+      deferStrongCredentialCheck: true,
+    });
+    user = caller.user;
+    apiKeyId = caller.apiKeyId;
 
     logger.info(
       `[Voice Clone API] Creating ${cloneType} voice clone: ${voiceName}`,
@@ -444,6 +440,7 @@ app.post("/", async (c) => {
     );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+    const admissionError = asGenerativeCacheApiError(error);
 
     // Deletion pass runs only when we have partial state to undo (i.e.
     // the user_voices row was never written). Once that row is committed,
@@ -571,6 +568,8 @@ app.post("/", async (c) => {
           }),
       );
     }
+
+    if (admissionError) return failureResponse(c, admissionError);
 
     if (error instanceof Error) {
       const lower = errorMessage.toLowerCase();

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -465,11 +465,12 @@ async function __hono_POST(c: AppContext) {
     }
     request = sizeCheckedRequest;
 
-    const { user, apiKeyId, admissionSnapshot } =
+    const { user, apiKeyId, admissionSnapshot, credential } =
       await requireGenerativeRouteCaller(c, {
         compatibility: "raw",
         rateLimitEndpoint: "strict",
         awaitWarmingMs: 1500,
+        deferStrongCredentialCheck: true,
       });
     const affiliateCode = request.headers.get("X-Affiliate-Code");
     const billingRequestId = `voice-stt:${crypto.randomUUID()}`;
@@ -591,6 +592,7 @@ async function __hono_POST(c: AppContext) {
           apiKeyId,
           cost: sttCost,
           admissionSnapshot,
+          credential,
         });
       } catch (error) {
         if (error instanceof InsufficientCreditsError) {
@@ -1191,6 +1193,7 @@ async function __hono_POST(c: AppContext) {
         apiKeyId,
         cost: sttCost,
         admissionSnapshot,
+        credential,
       });
       reservation = admission.reservation;
       settleUnknown = admission.settleUnknown;

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -47,6 +47,7 @@ import {
   type CreditReservation,
   InsufficientCreditsError,
 } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { getElevenLabsService } from "@/lib/services/elevenlabs";
 import { usageService } from "@/lib/services/usage";
 import { logger } from "@/lib/utils/logger";
@@ -461,6 +462,9 @@ async function __hono_POST(c: AppContext) {
       multipartBodyLimit,
     );
     if (sizeCheckedRequest instanceof Response) {
+      // Intentional transport-limit exception: reject and cancel oversized
+      // multipart bytes before any authentication cache, database, billing,
+      // or provider work. Route tests assert this pre-auth resource boundary.
       return sizeCheckedRequest;
     }
     request = sizeCheckedRequest;
@@ -470,10 +474,12 @@ async function __hono_POST(c: AppContext) {
         compatibility: "raw",
         rateLimitEndpoint: "strict",
         awaitWarmingMs: 1500,
-        // Multipart content/signature validation can still stop before the
-        // paid admission below, so this route must not defer strong checking.
-        deferStrongCredentialCheck: false,
+        deferStrongCredentialCheck: true,
       });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => user.organization_id,
+      credential: () => credential,
+    });
     const affiliateCode = request.headers.get("X-Affiliate-Code");
     const billingRequestId = `voice-stt:${crypto.randomUUID()}`;
 
@@ -594,7 +600,7 @@ async function __hono_POST(c: AppContext) {
           apiKeyId,
           cost: sttCost,
           admissionSnapshot,
-          credential,
+          credential: credentialGuard.credentialForAdmission(),
         });
       } catch (error) {
         if (error instanceof InsufficientCreditsError) {
@@ -1195,7 +1201,7 @@ async function __hono_POST(c: AppContext) {
         apiKeyId,
         cost: sttCost,
         admissionSnapshot,
-        credential,
+        credential: credentialGuard.credentialForAdmission(),
       });
       reservation = admission.reservation;
       settleUnknown = admission.settleUnknown;

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -470,7 +470,9 @@ async function __hono_POST(c: AppContext) {
         compatibility: "raw",
         rateLimitEndpoint: "strict",
         awaitWarmingMs: 1500,
-        deferStrongCredentialCheck: true,
+        // Multipart content/signature validation can still stop before the
+        // paid admission below, so this route must not defer strong checking.
+        deferStrongCredentialCheck: false,
       });
     const affiliateCode = request.headers.get("X-Affiliate-Code");
     const billingRequestId = `voice-stt:${crypto.randomUUID()}`;

--- a/packages/cloud/api/v1/voice/tts/route.json.test.ts
+++ b/packages/cloud/api/v1/voice/tts/route.json.test.ts
@@ -3,6 +3,11 @@ import { afterAll, describe, expect, mock, test } from "bun:test";
 
 const assertSafeForPublicUse = mock(async () => undefined);
 const markProviderDispatched = mock(async () => undefined);
+const requireGenerativeRouteCaller = mock(async () => ({
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKeyId: null,
+  admissionSnapshot: null,
+}));
 const realFetch = globalThis.fetch;
 const fetchMock = mock(
   async (...args: Parameters<typeof fetch>): Promise<Response> => {
@@ -24,11 +29,7 @@ const fetchMock = mock(
 globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
-  requireGenerativeRouteCaller: async () => ({
-    user: { id: "user-1", organization_id: "org-1" },
-    apiKeyId: null,
-    admissionSnapshot: null,
-  }),
+  requireGenerativeRouteCaller,
   admitFlatGenerativeOperation: async () => ({
     reservation: undefined,
     settleUnknown: undefined,
@@ -138,6 +139,11 @@ describe("POST /api/v1/voice/tts malformed JSON", () => {
     });
     expect(assertSafeForPublicUse).not.toHaveBeenCalled();
     expect(markProviderDispatched).not.toHaveBeenCalled();
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: false }),
+    );
   });
 
   test("canonical JSON still synthesizes speech", async () => {
@@ -150,6 +156,10 @@ describe("POST /api/v1/voice/tts malformed JSON", () => {
       { CARTESIA_API_KEY: "cartesia-key" },
     );
     expect(response.status).toBe(200);
+    expect(requireGenerativeRouteCaller).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deferStrongCredentialCheck: true }),
+    );
     expect(markProviderDispatched).toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -179,11 +179,12 @@ async function __hono_POST(c: AppContext) {
   const timings: TtsTimings = {};
 
   try {
-    const { user, apiKeyId, admissionSnapshot } =
+    const { user, apiKeyId, admissionSnapshot, credential } =
       await requireGenerativeRouteCaller(c, {
         compatibility: "raw",
         rateLimitEndpoint: "strict",
         awaitWarmingMs: 1500,
+        deferStrongCredentialCheck: true,
       });
     timings.authMs = Date.now() - requestStart;
     const admissionStart = Date.now();
@@ -600,6 +601,7 @@ async function __hono_POST(c: AppContext) {
         apiKeyId,
         cost: billingCost,
         admissionSnapshot,
+        credential,
         idempotencyKey: ttsIdempotencyKey ?? undefined,
       });
       reservation = admission.reservation;

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -179,67 +179,59 @@ async function __hono_POST(c: AppContext) {
   const timings: TtsTimings = {};
 
   try {
-    const { user, apiKeyId, admissionSnapshot, credential } =
-      await requireGenerativeRouteCaller(c, {
-        compatibility: "raw",
-        rateLimitEndpoint: "strict",
-        awaitWarmingMs: 1500,
-        deferStrongCredentialCheck: true,
-      });
-    timings.authMs = Date.now() - requestStart;
-    const admissionStart = Date.now();
-
     const decodedRawBody = await decodeRequestJson(request);
+    let pendingResponse: Response | undefined;
+    let body: z.infer<typeof TtsBody> | undefined;
     if (!decodedRawBody.ok) {
       // error-policy:J3 malformed JSON is an explicit invalid request.
-      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
-    }
-    const rawBody = decodedRawBody.value;
-    const parsed = TtsBody.safeParse(rawBody);
-    if (!parsed.success) {
-      return Response.json(
-        { error: "Invalid request body", details: parsed.error.flatten() },
+      pendingResponse = Response.json(
+        { error: "Invalid JSON body" },
         { status: 400 },
       );
+    } else {
+      const parsed = TtsBody.safeParse(decodedRawBody.value);
+      if (parsed.success) body = parsed.data;
+      else {
+        pendingResponse = Response.json(
+          { error: "Invalid request body", details: parsed.error.flatten() },
+          { status: 400 },
+        );
+      }
     }
-    const { text, voiceId, modelId } = parsed.data;
     const kokoroBaseUrl = env.KOKORO_TTS_URL?.trim();
     const cartesiaApiKey = env.CARTESIA_API_KEY?.trim();
     const cartesiaVoiceId = resolveCartesiaVoiceId(env);
-    const providerSelection = selectTtsProvider({
-      voiceId,
-      cartesiaConfigured: Boolean(cartesiaApiKey),
-      kokoroConfigured: Boolean(kokoroBaseUrl),
-    });
-    // WAV output is opt-in and bypasses the MP3-shaped first-line cache (a
-    // different codec); billing/usage are identical to the MP3 path.
-    const wantWav = parsed.data.format === "wav";
-
-    if (!text) {
-      return Response.json({ error: "No text provided" }, { status: 400 });
-    }
-
-    if (text.length === 0) {
-      return Response.json({ error: "Text cannot be empty" }, { status: 400 });
-    }
-
-    if (text.length > MAX_TEXT_LENGTH) {
-      return Response.json(
+    const providerSelection = body
+      ? selectTtsProvider({
+          voiceId: body.voiceId,
+          cartesiaConfigured: Boolean(cartesiaApiKey),
+          kokoroConfigured: Boolean(kokoroBaseUrl),
+        })
+      : undefined;
+    if (body && !body.text) {
+      pendingResponse = Response.json(
+        { error: "No text provided" },
+        { status: 400 },
+      );
+    } else if (body && body.text.length === 0) {
+      pendingResponse = Response.json(
+        { error: "Text cannot be empty" },
+        { status: 400 },
+      );
+    } else if (body && body.text.length > MAX_TEXT_LENGTH) {
+      pendingResponse = Response.json(
         {
           error: `Text too long. Maximum length is ${MAX_TEXT_LENGTH} characters`,
         },
         { status: 400 },
       );
-    }
-
-    if (!providerSelection.ok) {
-      timings.admissionMs = Date.now() - admissionStart;
+    } else if (providerSelection && !providerSelection.ok) {
       logger.warn?.("[Voice TTS API] TTS provider selection failed", {
         provider: providerSelection.provider,
         fallbackReason: providerSelection.fallbackReason,
         code: providerSelection.code,
       });
-      return Response.json(
+      pendingResponse = Response.json(
         {
           error: providerSelection.error,
           code: providerSelection.code,
@@ -253,6 +245,28 @@ async function __hono_POST(c: AppContext) {
         },
       );
     }
+
+    const willAdmit =
+      pendingResponse === undefined &&
+      providerSelection?.ok === true &&
+      providerSelection.provider !== "kokoro";
+    const { user, apiKeyId, admissionSnapshot, credential } =
+      await requireGenerativeRouteCaller(c, {
+        compatibility: "raw",
+        rateLimitEndpoint: "strict",
+        awaitWarmingMs: 1500,
+        deferStrongCredentialCheck: willAdmit,
+      });
+    timings.authMs = Date.now() - requestStart;
+    const admissionStart = Date.now();
+    if (pendingResponse) return pendingResponse;
+    if (!body || !providerSelection?.ok) {
+      throw new Error("Validated TTS request was not retained");
+    }
+    const { text, voiceId, modelId } = body;
+    // WAV output is opt-in and bypasses the MP3-shaped first-line cache (a
+    // different codec); billing/usage are identical to the MP3 path.
+    const wantWav = body.format === "wav";
 
     await contentSafetyService.assertSafeForPublicUse({
       surface: "media_generation_prompt",

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -50,6 +50,7 @@ import {
   type CreditReservation,
   InsufficientCreditsError,
 } from "@/lib/services/credits";
+import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { getElevenLabsService } from "@/lib/services/elevenlabs";
 import { drainPcm16ToWav } from "@/lib/services/pcm16-wav";
 import { recordCustomVoiceUsage } from "@/lib/services/tts-custom-voice-usage";
@@ -257,6 +258,10 @@ async function __hono_POST(c: AppContext) {
         awaitWarmingMs: 1500,
         deferStrongCredentialCheck: willAdmit,
       });
+    await using credentialGuard = deferredCredentialAdmissionGuard({
+      organizationId: () => user.organization_id,
+      credential: () => credential,
+    });
     timings.authMs = Date.now() - requestStart;
     const admissionStart = Date.now();
     if (pendingResponse) return pendingResponse;
@@ -615,7 +620,7 @@ async function __hono_POST(c: AppContext) {
         apiKeyId,
         cost: billingCost,
         admissionSnapshot,
-        credential,
+        credential: credentialGuard.credentialForAdmission(),
         idempotencyKey: ttsIdempotencyKey ?? undefined,
       });
       reservation = admission.reservation;

--- a/packages/cloud/shared/src/lib/services/app-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-inference-admission.test.ts
@@ -209,17 +209,24 @@ beforeEach(() => {
 
 describe("admitAppInferenceCacheOnly", () => {
   test("uses the Durable Object lease as the sole pre-dispatch WAL", async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
     const pending = deferred<Awaited<ReturnType<typeof reserveImpl>>>();
     reserveImpl = () => pending.promise;
     const background: Promise<unknown>[] = [];
-    const admission = await admitAppInferenceCacheOnly(
-      params({ waitUntil: (promise) => background.push(promise) }),
-    );
+    const admission = await admitAppInferenceCacheOnly({
+      ...params({ waitUntil: (promise) => background.push(promise) }),
+      credential,
+    });
     const leaseParams = acquireInferenceAdmissionLease.mock.calls.at(-1)?.[0] as
       | {
           requestId: string;
           estimatedCostUsd: number;
           recovery: unknown;
+          credential: unknown;
         }
       | undefined;
     if (!leaseParams) throw new Error("expected inference admission lease");
@@ -227,6 +234,7 @@ describe("admitAppInferenceCacheOnly", () => {
     expect(admission.mode).toBe("deferred_app_reservation");
     expect(admission.estimatedTotalCostUsd).toBeCloseTo(1.2);
     expect(leaseParams.estimatedCostUsd).toBeCloseTo(1.2);
+    expect(leaseParams.credential).toBe(credential);
     expect(leaseParams.recovery).toEqual({
       version: 1,
       kind: "app",

--- a/packages/cloud/shared/src/lib/services/app-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/app-inference-admission.ts
@@ -38,6 +38,7 @@ import {
   getGateBalanceHint,
   InferenceBalanceCacheWarmingError,
 } from "./inference-billing-fast-path";
+import type { InferenceCredentialCheck } from "./inference-credential-revocation";
 
 export interface AppInferenceAdmissionExecutionContext {
   waitUntil(promise: Promise<unknown>): void;
@@ -60,6 +61,8 @@ export interface AppInferenceAdmissionParams {
   executionCtx: AppInferenceAdmissionExecutionContext;
   /** Combined auth-cache projection; skips the separate balance KV read. */
   admissionSnapshot?: InferenceAdmissionSnapshot;
+  /** Strong standing proof consumed atomically by the app balance lease. */
+  credential?: InferenceCredentialCheck;
 }
 
 export interface AppInferenceAdmission {
@@ -223,6 +226,7 @@ export async function admitAppInferenceCacheOnly(
           inferenceMarkupPercentage: params.app.inference_markup_percentage ?? null,
         },
       },
+      ...(params.credential ? { credential: params.credential } : {}),
       executionCtx: params.executionCtx,
     });
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/deferred-credential-admission-guard.ts
+++ b/packages/cloud/shared/src/lib/services/deferred-credential-admission-guard.ts
@@ -1,0 +1,31 @@
+/** Ensures every deferred strong credential proof reaches exactly one admission boundary. */
+
+import type { InferenceCredentialCheck } from "./inference-credential-revocation";
+
+/**
+ * Routes pass `credentialForAdmission()` to each atomic paid admission. Any
+ * return or throw before the first admission performs the standalone strong
+ * check during async disposal; multi-operation routes reuse the exact proof.
+ */
+export function deferredCredentialAdmissionGuard(params: {
+  organizationId(): string | undefined;
+  credential(): InferenceCredentialCheck | undefined;
+}) {
+  let admissionStarted = false;
+  return {
+    credentialForAdmission(): InferenceCredentialCheck | undefined {
+      admissionStarted = true;
+      return params.credential();
+    },
+    async [Symbol.asyncDispose](): Promise<void> {
+      const credential = params.credential();
+      if (admissionStarted || !credential) return;
+      const organizationId = params.organizationId();
+      if (!organizationId) {
+        throw new Error("Deferred inference credential is missing its organization");
+      }
+      const { assertInferenceCredentialActive } = await import("./inference-credential-revocation");
+      await assertInferenceCredentialActive(organizationId, credential);
+    },
+  };
+}

--- a/packages/cloud/shared/src/lib/services/generative-operation.test.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.test.ts
@@ -9,25 +9,26 @@ let settleUnknown = mock(async () => {
   events.push("settleUnknown");
   return null;
 });
+const admitOrganizationInference = mock(async () => {
+  events.push("admit");
+  if (admissionError) throw admissionError;
+  return {
+    mode: "cache_admission",
+    affiliateAttribution: null,
+    markProviderDispatched: mock(async () => {
+      events.push("mark");
+    }),
+    settle: mock(async (cost: number) => {
+      events.push("settle");
+      settledCosts.push(cost);
+      return null;
+    }),
+    settleUnknown,
+  };
+});
 
 mock.module("./organization-inference-admission", () => ({
-  admitOrganizationInference: mock(async () => {
-    events.push("admit");
-    if (admissionError) throw admissionError;
-    return {
-      mode: "cache_admission",
-      affiliateAttribution: null,
-      markProviderDispatched: mock(async () => {
-        events.push("mark");
-      }),
-      settle: mock(async (cost: number) => {
-        events.push("settle");
-        settledCosts.push(cost);
-        return null;
-      }),
-      settleUnknown,
-    };
-  }),
+  admitOrganizationInference,
 }));
 
 const {
@@ -62,12 +63,18 @@ beforeEach(() => {
 
 describe("runFlatProviderOperation", () => {
   test("admits before marking and marks immediately before provider dispatch", async () => {
-    await runFlatProviderOperation(context, operation, async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    await runFlatProviderOperation({ ...context, credential }, operation, async () => {
       events.push("provider");
       return "ok";
     });
 
     expect(events).toEqual(["admit", "mark", "provider", "settle"]);
+    expect(admitOrganizationInference.mock.calls.at(-1)?.[0].credential).toBe(credential);
   });
 
   test("does not dispatch or mark when admission denies", async () => {

--- a/packages/cloud/shared/src/lib/services/generative-operation.test.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.test.ts
@@ -77,6 +77,35 @@ describe("runFlatProviderOperation", () => {
     expect(admitOrganizationInference.mock.calls.at(-1)?.[0].credential).toBe(credential);
   });
 
+  test("reuses one exact deferred credential across multiple atomic admissions", async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+    const credentialForAdmission = mock(() => credential);
+    const provider = mock(async () => "ok");
+    const firstCall = admitOrganizationInference.mock.calls.length;
+
+    await runFlatProviderOperation(
+      { ...context, credential, credentialForAdmission },
+      operation,
+      provider,
+    );
+    await runFlatProviderOperation(
+      { ...context, credential, credentialForAdmission },
+      { ...operation, operation: "second_generation" },
+      provider,
+    );
+
+    const admissions = admitOrganizationInference.mock.calls.slice(firstCall);
+    expect(credentialForAdmission).toHaveBeenCalledTimes(2);
+    expect(admissions).toHaveLength(2);
+    expect(admissions.map(([params]) => params.credential)).toEqual([credential, credential]);
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(events).toEqual(["admit", "mark", "settle", "admit", "mark", "settle"]);
+  });
+
   test("does not dispatch or mark when admission denies", async () => {
     admissionError = new Error("cached standing denied");
     const provider = mock(async () => "unexpected");

--- a/packages/cloud/shared/src/lib/services/generative-operation.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.ts
@@ -17,6 +17,8 @@ export interface GenerativeOperationContext {
   admissionSnapshot?: InferenceAdmissionSnapshot;
   /** Strong standing proof consumed by the operation's admission lease. */
   credential?: InferenceCredentialCheck;
+  /** Marks the deferred proof consumed only when paid admission begins. */
+  credentialForAdmission?: () => InferenceCredentialCheck | undefined;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }
 
@@ -107,7 +109,12 @@ async function admitFlatCost(
         platformMarkup: 0,
       },
       admissionSnapshot: context.admissionSnapshot,
-      ...(context.credential ? { credential: context.credential } : {}),
+      ...(() => {
+        const credential = context.credentialForAdmission
+          ? context.credentialForAdmission()
+          : context.credential;
+        return credential ? { credential } : {};
+      })(),
       executionCtx: context.executionCtx,
     });
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/generative-operation.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.ts
@@ -6,6 +6,7 @@
 import { logger } from "../utils/logger";
 import type { PricingBillingSource } from "./ai-pricing-definitions";
 import type { InferenceAdmissionSnapshot } from "./inference-auth-cache";
+import type { InferenceCredentialCheck } from "./inference-credential-revocation";
 import { admitOrganizationInference } from "./organization-inference-admission";
 
 export interface GenerativeOperationContext {
@@ -14,6 +15,8 @@ export interface GenerativeOperationContext {
   apiKeyId: string | null;
   requestId: string;
   admissionSnapshot?: InferenceAdmissionSnapshot;
+  /** Strong standing proof consumed by the operation's admission lease. */
+  credential?: InferenceCredentialCheck;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }
 
@@ -104,6 +107,7 @@ async function admitFlatCost(
         platformMarkup: 0,
       },
       admissionSnapshot: context.admissionSnapshot,
+      ...(context.credential ? { credential: context.credential } : {}),
       executionCtx: context.executionCtx,
     });
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
@@ -67,6 +67,8 @@ export function inferenceCredentialRevocationReason(reason: string): InferenceAu
     case "subject_moderation_disabled":
       return "moderation_blocked";
     case "credential_revoked":
+    case "session_revoked":
+    case "session_binding_revoked":
       return "credential_inactive";
     default:
       return "credential_invalid";

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -288,7 +288,11 @@ describe("resolveInferenceSessionAuthContext", () => {
       useAuthCache: true,
     });
 
-    expect(result).toEqual({ kind: "rejected", status: 401 });
+    expect(result).toEqual({
+      kind: "rejected",
+      status: 401,
+      reason: "credential_inactive",
+    });
     expect(userReads).toBe(0);
     expect(moderationReads).toBe(0);
   });
@@ -311,7 +315,11 @@ describe("resolveInferenceSessionAuthContext", () => {
         cacheOnly: true,
         useAuthCache: true,
       }),
-    ).toEqual({ kind: "rejected", status: 401 });
+    ).toEqual({
+      kind: "rejected",
+      status: 401,
+      reason: "credential_inactive",
+    });
   });
 
   test("concurrent cold requests share one authoritative hydration", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -186,7 +186,7 @@ async function enforceStrongSessionBoundary(
   } catch (error) {
     if (error instanceof InferenceCredentialRevokedError) {
       return error.reason === "session_revoked" || error.reason === "session_binding_revoked"
-        ? { kind: "rejected", status: 401 }
+        ? { kind: "rejected", status: 401, reason: "credential_inactive" }
         : { kind: "suspended", userId: resolved.ctx.userId };
     }
     throw error;

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -9,6 +9,7 @@
 
 import { calculateCost, normalizeModelName } from "../pricing";
 import { createCreditReservationSettler } from "../utils/credit-reservation";
+import { logger } from "../utils/logger";
 import type { AffiliateBillingAttribution } from "./affiliate-billing-attribution";
 import { AFFILIATE_PAYOUT_CONTRACT_VERSION } from "./affiliate-payout-outbox";
 import type { BillingContext, FlatBillingCost } from "./ai-billing";
@@ -60,7 +61,10 @@ import {
   createLedgerDebitSettler,
   resolveInferenceBillingLedger,
 } from "./inference-billing-ledger";
-import type { InferenceCredentialCheck } from "./inference-credential-revocation";
+import {
+  type InferenceCredentialCheck,
+  InferenceCredentialRevokedError,
+} from "./inference-credential-revocation";
 
 export type InferenceAdmissionMode =
   | "durable_object_debit"
@@ -391,6 +395,20 @@ export async function admitOrganizationInference(
         executionCtx: params.executionCtx,
       });
     } catch (error) {
+      if (error instanceof InferenceCredentialRevokedError) {
+        // error-policy:J2 preserve the typed combined-gate refusal after
+        // attaching the full admission identity needed for diagnostics.
+        logger.warn(
+          "[OrganizationInferenceAdmission] blocked provider dispatch at combined credential and balance gate",
+          {
+            organizationId: params.context.organizationId,
+            userId: params.context.userId,
+            requestId: params.context.requestId,
+            credentialKind: params.credential?.kind ?? "unavailable",
+            reason: error.reason,
+          },
+        );
+      }
       if (error instanceof InferenceAdmissionLeaseRejectedError) {
         throw new InsufficientCreditsError(
           error.requiredUsd,

--- a/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
@@ -7,6 +7,7 @@
 import { afterAll, beforeEach, expect, mock, test } from "bun:test";
 import * as authActual from "../../auth";
 import * as creditsActual from "../credits";
+import { InferenceCredentialRevokedError } from "../inference-credential-revocation";
 import * as admissionActual from "../organization-inference-admission";
 import type { ServiceConfig } from "./types";
 
@@ -135,4 +136,36 @@ test("combined RPC admission denial performs zero provider dispatch", async () =
   expect(response.status).toBe(402);
   expect(work).not.toHaveBeenCalled();
   expect(legacyAuth).not.toHaveBeenCalled();
+});
+
+test("combined credential denial is a safe standing response with zero dispatch", async () => {
+  admit.mockRejectedValueOnce(new InferenceCredentialRevokedError("session_binding_revoked"));
+  const work = mock(async () => ({ response: new Response("not reached") }));
+  const handler = createHandler(config, work, {
+    auth: { user: { id: "user-1", organization_id: "org-1" } },
+    admissionSnapshot: snapshot,
+    credential: {
+      kind: "steward_session",
+      userId: "user-1",
+      stewardUserId: "steward-1",
+      issuedAt: 1,
+    },
+    executionCtx: { waitUntil: () => undefined },
+    requestId: "rpc-revoked",
+  });
+
+  const response = await handler(
+    new Request("https://api.test/api/v1/rpc/ethereum", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", id: 1 }),
+    }),
+  );
+
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toMatchObject({
+    error: "Authentication required",
+    code: "authentication_required",
+    details: { reason: "credential_inactive" },
+  });
+  expect(work).not.toHaveBeenCalled();
 });

--- a/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
@@ -58,6 +58,11 @@ afterAll(() => {
 });
 
 test("combined RPC admission orders mark before dispatch and defers settlement", async () => {
+  const credential = {
+    kind: "api_key" as const,
+    credentialId: "key-1",
+    userId: "user-1",
+  };
   const order: string[] = [];
   let finishSettlement: (() => void) | undefined;
   const settlement = new Promise<void>((resolve) => {
@@ -87,6 +92,7 @@ test("combined RPC admission orders mark before dispatch and defers settlement",
       apiKey: { id: "key-1" },
     },
     admissionSnapshot: snapshot,
+    credential,
     executionCtx: { waitUntil: (promise) => retained.push(promise) },
     requestId: "rpc-1",
   });
@@ -103,6 +109,7 @@ test("combined RPC admission orders mark before dispatch and defers settlement",
   expect(legacyAuth).not.toHaveBeenCalled();
   expect(admit).toHaveBeenCalledTimes(1);
   expect(admit.mock.calls[0]?.[0].admissionSnapshot).toBe(snapshot);
+  expect(admit.mock.calls[0]?.[0].credential).toBe(credential);
   expect(retained).toHaveLength(1);
   finishSettlement?.();
   await Promise.all(retained);

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -12,6 +12,7 @@ import { withRateLimit } from "../../middleware/rate-limit";
 import { logger } from "../../utils/logger";
 import { creditsService, InsufficientCreditsError } from "../credits";
 import type { InferenceAdmissionSnapshot } from "../inference-auth-cache";
+import type { InferenceCredentialCheck } from "../inference-credential-revocation";
 import { admitOrganizationInference } from "../organization-inference-admission";
 import { usageService } from "../usage";
 import { PricingNotFoundError } from "./pricing";
@@ -37,6 +38,7 @@ export interface ProxyCombinedAdmission {
     apiKey?: { id: string };
   };
   admissionSnapshot?: InferenceAdmissionSnapshot;
+  credential?: InferenceCredentialCheck;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   requestId: string;
 }
@@ -254,6 +256,7 @@ export function createHandler(
           },
           executionCtx: combinedAdmission.executionCtx,
           admissionSnapshot: combinedAdmission.admissionSnapshot,
+          ...(combinedAdmission.credential ? { credential: combinedAdmission.credential } : {}),
         });
       } else {
         const reservation = await creditsService.reserve({

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -43,6 +43,7 @@ export interface ProxyCombinedAdmission {
   };
   admissionSnapshot?: InferenceAdmissionSnapshot;
   credential?: InferenceCredentialCheck;
+  credentialForAdmission?: () => InferenceCredentialCheck | undefined;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   requestId: string;
 }
@@ -260,7 +261,12 @@ export function createHandler(
           },
           executionCtx: combinedAdmission.executionCtx,
           admissionSnapshot: combinedAdmission.admissionSnapshot,
-          ...(combinedAdmission.credential ? { credential: combinedAdmission.credential } : {}),
+          ...(() => {
+            const credential = combinedAdmission.credentialForAdmission
+              ? combinedAdmission.credentialForAdmission()
+              : combinedAdmission.credential;
+            return credential ? { credential } : {};
+          })(),
         });
       } else {
         const reservation = await creditsService.reserve({

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -12,7 +12,11 @@ import { withRateLimit } from "../../middleware/rate-limit";
 import { logger } from "../../utils/logger";
 import { creditsService, InsufficientCreditsError } from "../credits";
 import type { InferenceAdmissionSnapshot } from "../inference-auth-cache";
-import type { InferenceCredentialCheck } from "../inference-credential-revocation";
+import {
+  type InferenceCredentialCheck,
+  InferenceCredentialRevokedError,
+  inferenceCredentialRevocationReason,
+} from "../inference-credential-revocation";
 import { admitOrganizationInference } from "../organization-inference-admission";
 import { usageService } from "../usage";
 import { PricingNotFoundError } from "./pricing";
@@ -477,6 +481,31 @@ export function createHandler(
             available: error.available,
           },
           { status: 402 },
+        );
+      }
+
+      if (error instanceof InferenceCredentialRevokedError) {
+        const reason = inferenceCredentialRevocationReason(error.reason);
+        const status =
+          reason === "credential_inactive" || reason === "credential_invalid" ? 401 : 403;
+        logger.warn(
+          "[Proxy Engine] blocked provider dispatch at combined credential and balance gate",
+          {
+            serviceId: config.id,
+            requestId: combinedAdmission?.requestId ?? "unavailable",
+            organizationId: combinedAdmission?.auth.user.organization_id ?? "unavailable",
+            userId: combinedAdmission?.auth.user.id ?? "unavailable",
+            credentialKind: combinedAdmission?.credential?.kind ?? "unavailable",
+            reason,
+          },
+        );
+        return Response.json(
+          {
+            error: status === 401 ? "Authentication required" : "Access denied",
+            code: status === 401 ? "authentication_required" : "access_denied",
+            details: { reason },
+          },
+          { status },
         );
       }
 


### PR DESCRIPTION
Closes #30253

## What changed

- carries the exact `InferenceCredentialCheck` through generative route, operation, organization, app, and proxy combined admission
- resolves each protected route caller once and wraps deferred proofs in a shared async-disposal guard
- consumes a deferred proof at every atomic paid admission; multi-operation routes reuse the same immutable credential for each admission
- performs one standalone strong check on invalid, unavailable, not-found, no-op, rate-limit-failed, dependency-failed, and other pre-admission exits
- leaves successful paid paths fused: no standalone strong check before the combined credential + balance admission
- removes the duplicate standalone check from monetized-app chat admission while retaining it for pooled no-op reservations
- maps fused credential refusal to safe protocol-native 401/403 responses before provider dispatch
- maps Steward session revocation consistently to 401 `credential_inactive`
- preserves one combined standing-cache read, async cache projection, and no update readback
- reverse-derives the guarded-route inventory from canonical admission call sites so new paid routes cannot silently bypass the resolver contract

## Covered route boundaries

Direct chat/completions, chat, messages, embeddings, A2A, agent MCP, fal, search, voice clone, STT, TTS, SFX, image/video/music/prompt generation, browser create/command/navigate/read/no-op routes, extract, RPC, MCP proxy, ElevenLabs verification, app review/automation/promotion wrappers, and multi-operation promotion flows. Realtime token mint and Hugging Face asset proxy remain intentional standalone exceptions; STT transport-size rejection remains an explicit pre-auth resource-limit exception.

## Exact-head verification

- Head: `524d160685a7659e10344011eb1c41988fe60409`
- Base: `8ade9fba1d55ccb840cdd57bd72958644a42d7be` (#30267 squash)
- focused route/admission/security tests: **323 passed, 0 failed, 1 intentional STT skip** across isolated files
- Cloud shared typecheck: pass
- Cloud API typecheck: pass
- router contract: pass (708 mounted routes)
- production Worker dry-run bundle: pass (28,393.92 KiB / 6,835.70 KiB gzip)
- `bun run verify:cloud`: pass (84/84 tasks, 4m27s)
- Biome: pass on every changed TypeScript file and both Cloud packages
- `git diff --check`: pass

## Evidence

- guard tests prove successful rate limiting leaves the exact deferred proof untouched for fused admission, while rate-limit failure performs one standalone check and no admission/provider call
- terminal-path tests prove one resolver call, a standalone strong check, and zero admission/provider calls
- multi-operation tests prove one resolver, N admissions receiving the identical credential, and N provider dispatches only after their respective admission
- A2A/MCP tests prove standing denial precedes character cache/DB access and preserves the sanitized reason in protocol-native JSON-RPC
- reverse-derived inventory covers every canonical organization/app/flat admission route
- frontend screenshots/video: N/A; no frontend surface changed
- live-provider trajectory: N/A; provider doubles prove suppression at the paid boundary
