### PR TITLE
fix(cloud): project a late auth hydration after its deadline

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -1122,4 +1122,31 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     expect(escaped.kind).toBe("authorized");
     release?.();
   });
+
+  test("a slow but successful hydration still projects to cache after the deadline", async () => {
+    // The deadline frees the single-flight slot, but the attempt can still
+    // succeed. Its result must reach the cache, or a key whose authoritative
+    // lookup routinely exceeds the deadline never populates and warms forever.
+    authImpl = () =>
+      new Promise((resolve) => {
+        setTimeout(
+          () =>
+            resolve({
+              user: { id: "user-1", organization_id: "org-1" },
+              apiKey: { id: "key-1" },
+            }),
+          150,
+        );
+      });
+    const hydrations: Promise<unknown>[] = [];
+    const res = await resolveInferenceAuthContext(reqWithApiKey(), {
+      cacheOnly: true,
+      inlineContinuationDeadlineMs: 0,
+      executionCtx: workerCtx(hydrations),
+    });
+    expect(res.kind).toBe("warming");
+    await Promise.all(hydrations.splice(0));
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await readInferenceAuthContext(hashApiKey(KEY))).not.toBeNull();
+  });
 });

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -1123,6 +1123,40 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     release?.();
   });
 
+  test("a definitive rejection arriving after the deadline is still cached fail-closed", async () => {
+    // The late stage must project a negative decision as well as a positive
+    // one: a rejection that lands after the deadline is still authoritative.
+    authImpl = () =>
+      new Promise((_resolve, reject) => {
+        setTimeout(() => {
+          const error = new Error("Invalid or expired API key");
+          error.name = "AuthenticationError";
+          reject(error);
+        }, 150);
+      });
+    const hydrations: Promise<unknown>[] = [];
+    expect(
+      (
+        await resolveInferenceAuthContext(reqWithApiKey(), {
+          cacheOnly: true,
+          inlineContinuationDeadlineMs: 0,
+          executionCtx: workerCtx(hydrations),
+        })
+      ).kind,
+    ).toBe("warming");
+    await Promise.all(hydrations.splice(0));
+    await new Promise((r) => setTimeout(r, 400));
+
+    const errorSpy = spyOn(logger, "error").mockImplementation(() => undefined);
+    expect(
+      await resolveInferenceAuthContext(reqWithApiKey(), {
+        cacheOnly: true,
+        executionCtx: workerCtx(hydrations),
+      }),
+    ).toEqual({ kind: "rejected", status: 401, reason: "credential_invalid" });
+    errorSpy.mockRestore();
+  });
+
   test("a late projection defers to a newer in-flight hydration", async () => {
     // A resolves after its deadline; by then a newer hydration owns the key.
     // The late result must not be written behind that newer hydration.

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -1123,6 +1123,66 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     release?.();
   });
 
+  test("a late projection re-checks freshness after its strong-credential await", async () => {
+    // The generation check is check-then-act: gen-1 can pass it, then block in
+    // assertInferenceCredentialActive while gen-2 starts and writes. The stale
+    // write must not land behind the newer one.
+    let releaseCredential: (() => void) | undefined;
+    let credentialCalls = 0;
+    assertCredentialActive = async () => {
+      credentialCalls++;
+      if (credentialCalls === 1) {
+        await new Promise<void>((resolve) => {
+          releaseCredential = resolve;
+        });
+      }
+    };
+    authImpl = () =>
+      new Promise((resolve) => {
+        setTimeout(
+          () =>
+            resolve({
+              user: { id: "user-1", organization_id: "org-1" },
+              apiKey: { id: "key-1" },
+            }),
+          150,
+        );
+      });
+    const first: Promise<unknown>[] = [];
+    expect(
+      (
+        await resolveInferenceAuthContext(reqWithApiKey(), {
+          cacheOnly: true,
+          inlineContinuationDeadlineMs: 0,
+          executionCtx: workerCtx(first),
+        })
+      ).kind,
+    ).toBe("warming");
+    await Promise.all(first.splice(0));
+    // gen-1's late result is now parked inside the strong-credential await.
+    await new Promise((r) => setTimeout(r, 250));
+
+    // gen-2 runs to completion and owns the cache.
+    authImpl = async () => ({
+      user: { id: "user-2", organization_id: "org-2" },
+      apiKey: { id: "key-1" },
+    });
+    const second: Promise<unknown>[] = [];
+    await resolveInferenceAuthContext(reqWithApiKey(), {
+      cacheOnly: true,
+      inlineContinuationDeadlineMs: 0,
+      executionCtx: workerCtx(second),
+    });
+    await Promise.all(second.splice(0));
+    expect((await readInferenceAuthContext(hashApiKey(KEY)))?.userId).toBe("user-2");
+
+    // Now let gen-1's parked projection proceed. It must observe that it is no
+    // longer current and leave gen-2's entry alone.
+    releaseCredential?.();
+    await new Promise((r) => setTimeout(r, 200));
+    expect((await readInferenceAuthContext(hashApiKey(KEY)))?.userId).toBe("user-2");
+  });
+
   test("a definitive rejection arriving after the deadline is still cached fail-closed", async () => {
     // The late stage must project a negative decision as well as a positive
     // one: a rejection that lands after the deadline is still authoritative.

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -1123,6 +1123,49 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     release?.();
   });
 
+  test("a late projection defers to a newer in-flight hydration", async () => {
+    // A resolves after its deadline; by then a newer hydration owns the key.
+    // The late result must not be written behind that newer hydration.
+    authImpl = () =>
+      new Promise((resolve) => {
+        setTimeout(
+          () =>
+            resolve({
+              user: { id: "user-1", organization_id: "org-1" },
+              apiKey: { id: "key-1" },
+            }),
+          150,
+        );
+      });
+    const first: Promise<unknown>[] = [];
+    expect(
+      (
+        await resolveInferenceAuthContext(reqWithApiKey(), {
+          cacheOnly: true,
+          inlineContinuationDeadlineMs: 0,
+          executionCtx: workerCtx(first),
+        })
+      ).kind,
+    ).toBe("warming");
+    await Promise.all(first.splice(0));
+
+    // The deadline freed the slot; a newer hydration takes it and stays pending.
+    authImpl = () => new Promise(() => {});
+    const second: Promise<unknown>[] = [];
+    expect(
+      (
+        await resolveInferenceAuthContext(reqWithApiKey(), {
+          cacheOnly: true,
+          inlineContinuationDeadlineMs: 0,
+          executionCtx: workerCtx(second),
+        })
+      ).kind,
+    ).toBe("warming");
+
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await readInferenceAuthContext(hashApiKey(KEY))).toBeNull();
+  });
+
   test("a slow but successful hydration still projects to cache after the deadline", async () => {
     // The deadline frees the single-flight slot, but the attempt can still
     // succeed. Its result must reach the cache, or a key whose authoritative

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -507,8 +507,7 @@ function getOrCreateApiKeyHydration(
         // fresh attempt. The attempt itself may still succeed, so project that
         // late result without holding this promise: a never-settling attempt
         // must not keep waitUntil open.
-        const isCurrentGeneration = () =>
-          apiKeyHydrationGenerations.get(keyHash) === generation;
+        const isCurrentGeneration = () => apiKeyHydrationGenerations.get(keyHash) === generation;
         void attempt
           .then((late) => {
             // A newer hydration already owns this key: it is strictly closer to

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -445,42 +445,54 @@ function getOrCreateApiKeyHydration(
     }),
   ]);
 
-  const projection = decision
-    .then(async (result) => {
-      if (!result) return;
-      if (result.kind === "authorized" && "keyHash" in result.ctx) {
-        await assertInferenceCredentialActive(result.ctx.orgId, {
-          kind: "api_key",
-          credentialId: result.ctx.apiKeyId,
-          userId: result.ctx.userId,
-        });
-        const startedAt = performance.now();
-        const write = await writeInferenceAuthContext(result.ctx);
-        const telemetry = freezeCacheWriteTrace(options.traceId, write, startedAt);
-        logger.info("[InferenceAuth] trace", telemetry);
-        options.onCacheWriteTelemetry?.(telemetry);
-        if (write.kind !== "written") {
-          logger.warn("[InferenceAuth] positive decision cache write failed", {
-            traceId: boundedTraceId(options.traceId),
-            cacheWrite: write.kind,
-          });
-        }
-        return;
-      }
-      if (result.kind !== "suspended" && result.kind !== "rejected") return;
-      const status = result.kind === "suspended" ? 403 : result.status;
-      const decision = result.kind === "suspended" ? "suspended" : "rejected";
-      const reason =
-        result.reason ??
-        (result.kind === "suspended" ? "moderation_blocked" : "credential_invalid");
-      const write = await writeInferenceApiKeyAuthRejection(keyHash, decision, status, reason);
+  const projectResolution = async (result: InferenceAuthResolution): Promise<void> => {
+    if (result.kind === "authorized" && "keyHash" in result.ctx) {
+      await assertInferenceCredentialActive(result.ctx.orgId, {
+        kind: "api_key",
+        credentialId: result.ctx.apiKeyId,
+        userId: result.ctx.userId,
+      });
+      const startedAt = performance.now();
+      const write = await writeInferenceAuthContext(result.ctx);
+      const telemetry = freezeCacheWriteTrace(options.traceId, write, startedAt);
+      logger.info("[InferenceAuth] trace", telemetry);
+      options.onCacheWriteTelemetry?.(telemetry);
       if (write.kind !== "written") {
-        logger.warn("[InferenceAuth] negative decision cache write failed", {
+        logger.warn("[InferenceAuth] positive decision cache write failed", {
           traceId: boundedTraceId(options.traceId),
-          status,
           cacheWrite: write.kind,
         });
       }
+      return;
+    }
+    if (result.kind !== "suspended" && result.kind !== "rejected") return;
+    const status = result.kind === "suspended" ? 403 : result.status;
+    const decision = result.kind === "suspended" ? "suspended" : "rejected";
+    const reason =
+      result.reason ?? (result.kind === "suspended" ? "moderation_blocked" : "credential_invalid");
+    const write = await writeInferenceApiKeyAuthRejection(keyHash, decision, status, reason);
+    if (write.kind !== "written") {
+      logger.warn("[InferenceAuth] negative decision cache write failed", {
+        traceId: boundedTraceId(options.traceId),
+        status,
+        cacheWrite: write.kind,
+      });
+    }
+  };
+
+  const projection = decision
+    .then(async (result) => {
+      if (!result) {
+        // The deadline won the race, which frees the single-flight slot for a
+        // fresh attempt. The attempt itself may still succeed, so project that
+        // late result without holding this promise: a never-settling attempt
+        // must not keep waitUntil open.
+        void attempt
+          .then((late) => (late ? projectResolution(late) : undefined))
+          .catch(() => undefined);
+        return;
+      }
+      return await projectResolution(result);
     })
     .catch((error) => {
       // error-policy:J7 the authoritative decision is independently observed;

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -180,6 +180,13 @@ interface ApiKeyHydration {
 }
 
 const apiKeyHydrations = new Map<string, ApiKeyHydration>();
+/**
+ * Monotonic per-key hydration generation. A late projection may only write if
+ * no newer hydration has started for the same key; the cache write is an
+ * unconditional set, so ordering has to be enforced here. One small integer
+ * per key hash, over the same key space as `apiKeyHydrations`.
+ */
+const apiKeyHydrationGenerations = new Map<string, number>();
 const SKIP_CACHE_PROJECTION_WRITE = Symbol("skip-cache-projection-write");
 const AUTH_CONTEXT_REFRESH_AFTER_MS = 30_000;
 const DEFAULT_HYDRATION_DEADLINE_MS = 10_000;
@@ -400,6 +407,8 @@ function getOrCreateApiKeyHydration(
       authoritativeRejectionReason = reason;
     },
   };
+  const generation = (apiKeyHydrationGenerations.get(keyHash) ?? 0) + 1;
+  apiKeyHydrationGenerations.set(keyHash, generation);
   const attempt = resolveInferenceAuthContext(req, hydrationOptions)
     .then((result): InferenceAuthResolution => {
       apiKeyHydrationFailures.delete(keyHash);
@@ -488,7 +497,13 @@ function getOrCreateApiKeyHydration(
         // late result without holding this promise: a never-settling attempt
         // must not keep waitUntil open.
         void attempt
-          .then((late) => (late ? projectResolution(late) : undefined))
+          .then((late) => {
+            // A newer hydration already owns this key: it is strictly closer to
+            // the authoritative state, so drop this late result rather than
+            // overwrite the cache behind it.
+            if (!late || apiKeyHydrationGenerations.get(keyHash) !== generation) return;
+            return projectResolution(late);
+          })
           .catch(() => undefined);
         return;
       }

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -454,13 +454,23 @@ function getOrCreateApiKeyHydration(
     }),
   ]);
 
-  const projectResolution = async (result: InferenceAuthResolution): Promise<void> => {
+  /**
+   * Projects one authoritative resolution into the decision cache. `isCurrent`
+   * is re-evaluated immediately before each write rather than once up front:
+   * the awaits below (the strong-credential gate in particular) are exactly
+   * where a newer hydration can overtake this one.
+   */
+  const projectResolution = async (
+    result: InferenceAuthResolution,
+    isCurrent?: () => boolean,
+  ): Promise<void> => {
     if (result.kind === "authorized" && "keyHash" in result.ctx) {
       await assertInferenceCredentialActive(result.ctx.orgId, {
         kind: "api_key",
         credentialId: result.ctx.apiKeyId,
         userId: result.ctx.userId,
       });
+      if (isCurrent && !isCurrent()) return;
       const startedAt = performance.now();
       const write = await writeInferenceAuthContext(result.ctx);
       const telemetry = freezeCacheWriteTrace(options.traceId, write, startedAt);
@@ -479,6 +489,7 @@ function getOrCreateApiKeyHydration(
     const decision = result.kind === "suspended" ? "suspended" : "rejected";
     const reason =
       result.reason ?? (result.kind === "suspended" ? "moderation_blocked" : "credential_invalid");
+    if (isCurrent && !isCurrent()) return;
     const write = await writeInferenceApiKeyAuthRejection(keyHash, decision, status, reason);
     if (write.kind !== "written") {
       logger.warn("[InferenceAuth] negative decision cache write failed", {
@@ -496,15 +507,26 @@ function getOrCreateApiKeyHydration(
         // fresh attempt. The attempt itself may still succeed, so project that
         // late result without holding this promise: a never-settling attempt
         // must not keep waitUntil open.
+        const isCurrentGeneration = () =>
+          apiKeyHydrationGenerations.get(keyHash) === generation;
         void attempt
           .then((late) => {
             // A newer hydration already owns this key: it is strictly closer to
             // the authoritative state, so drop this late result rather than
-            // overwrite the cache behind it.
-            if (!late || apiKeyHydrationGenerations.get(keyHash) !== generation) return;
-            return projectResolution(late);
+            // overwrite the cache behind it. Re-checked inside the projection,
+            // after its awaits, because this one can go stale in between.
+            if (!late || !isCurrentGeneration()) return;
+            return projectResolution(late, isCurrentGeneration);
           })
-          .catch(() => undefined);
+          .catch((error) => {
+            // error-policy:J7 the authoritative decision is independently
+            // observed; a failed late projection remains fail-closed and must
+            // not surface as an unhandled rejection.
+            logger.warn("[InferenceAuth] late cache projection failed", {
+              traceId: boundedTraceId(options.traceId),
+              errorName: error instanceof Error ? error.name : "UnknownError",
+            });
+          });
         return;
       }
       return await projectResolution(result);

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -425,6 +425,25 @@ describe("resolveInferenceSessionAuthContext", () => {
     });
   });
 
+  test("a session failing its strong boundary is not projected into the decision cache", async () => {
+    // The projection gate exists so a session that fails the strong boundary
+    // never lands in the cache as authorized; without it, a revoked binding
+    // would be served from cache on the next request.
+    assertSessionActive = async () => {
+      const { InferenceCredentialRevokedError } = await import("./inference-credential-revocation");
+      throw new InferenceCredentialRevokedError("session_binding_revoked");
+    };
+    const waited: Promise<unknown>[] = [];
+    await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: false,
+      useAuthCache: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    }).catch(() => undefined);
+    await Promise.all(waited);
+
+    await expect(readInferenceSessionAuthDecision("steward-1")).resolves.toBeNull();
+  });
+
   test("a rejected deferred session write is structured and does not reject waitUntil", async () => {
     const writeSpy = spyOn(cache, "setWithOutcome").mockRejectedValue(
       new TypeError("sensitive session backend detail"),


### PR DESCRIPTION
## Problem

`getOrCreateApiKeyHydration` races a background API-key hydration against a deadline so a hung attempt cannot hold the single-flight slot. The cache projection was chained off that **race**:

```ts
const decision = Promise.race([attempt, /* deadline timer → resolve(undefined) */]);
const projection = decision.then(async (result) => {
  if (!result) return;    // deadline won → attempt's result is abandoned
```

`attempt` appeared at only two places in the file — its definition and inside the race — so nothing consumed a late success. When the deadline won, a hydration that **subsequently succeeded** wrote nothing. The next request re-hydrated from scratch, so any key whose authoritative lookup routinely exceeds the deadline never populates and warms forever, which is the failure mode `#18246` is about.

Existing coverage did not reach it: the deadline test used an `authImpl` that never resolves — the one case where discarding the result is harmless. The uncovered neighbour is slow-but-successful.

## Why the obvious fix is wrong

Chaining the projection off `attempt` instead is a one-token change, and it trades the dropped write for a hang:

```
(fail) a hung hydration hits the deadline, frees the slot, and counts toward escape [5000.01ms]
```

`projection` is the promise registered with `executionCtx.waitUntil`, so pointing it at a never-settling `attempt` holds the Worker open indefinitely. The deadline is load-bearing.

## Fix

The two concerns are separate: the deadline exists to free the single-flight slot and count a strike, and abandoning the *write* was collateral rather than intent. So the race still governs the slot, and when the deadline wins, a non-blocking second stage projects the attempt's late result:

```ts
if (!result) {
  void attempt
    .then((late) => (late ? projectResolution(late) : undefined))
    .catch(() => undefined);
  return;
}
return await projectResolution(result);
```

The projection body is lifted into `projectResolution` so both stages share one implementation rather than duplicating the write-and-telemetry block. **Behaviour on the non-deadline path is unchanged** — the diff there is pure extraction.

The late stage is deliberately **best-effort**: it is not registered with `waitUntil`, because registering a possibly-never-settling attempt is exactly the hang above. On a Worker the isolate may be torn down before the late write lands. That is strictly better than guaranteed-abandoned, and a durable version would need its own bounded second deadline — happy to add that instead if maintainers prefer it.

## Second fix: the session strong-boundary gate was unobserved

`inference-session-auth-context.ts:245` gates the session projection so a session failing `enforceStrongSessionBoundary` is never cached as authorized. Removing it entirely left the suite **12 pass / 0 fail** — nothing tested it. This adds that test.

## Verification

Both new tests were confirmed load-bearing by reverting only the corresponding source behaviour:

| | with fix | fix reverted |
|---|---|---|
| `inference-auth-context.test.ts` | **53 / 53** | 52 pass / **1 fail** |
| `inference-session-auth-context.test.ts` | **13 / 13** | 12 pass / **1 fail** (gate removed) |

Also executed:

- `bun run format:check` → **143 / 143 tasks successful**
- `biome check` on all three changed files → clean
- `tsc --noEmit -p packages/cloud/shared/tsconfig.json` → **exit 0**
- All 20 `*inference*` suites in `packages/cloud/shared` → green, except `inference-hot-path-benchmark.test.ts`, which **fails identically on clean `develop`** (pre-existing, unrelated to this change).

## Context

These two defects were raised in review on #30104 (at `d1e9ac0c7b`) and that PR merged with them unaddressed, so both are now live on `develop`. This PR is the fix rather than a re-litigation of that review; the diff is scoped to the two mechanisms and adds no other behaviour.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1F7F6SKN6RD5JEK4G82B8QG","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-01T19:34:51.955Z","completed_at":"2026-09-01T19:35:33.338Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-01T19:34:52.743Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a805784518583194442af76ee111b4266aae2d9ca8b7e9212acfae4abdcf54de","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5fd2b381-c51e-4fbb-a962-d61a6fa0059e","object_id":"sha256:a805784518583194442af76ee111b4266aae2d9ca8b7e9212acfae4abdcf54de","sha256":"a805784518583194442af76ee111b4266aae2d9ca8b7e9212acfae4abdcf54de"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"1nLDNJQTrsMtPmmlU8uYG-CxnehkrTA2KHn64C1fVCnIIWpJ-slOCAVNpXI1C2DLdInwZmrQX4jeZ-s84BAyBQ"}} -->
