### PR TITLE
fix(cloud): gate durable provider work by standing

### DIFF
--- a/packages/cloud/api/__tests__/credential-broker-lifecycle-standing.test.ts
+++ b/packages/cloud/api/__tests__/credential-broker-lifecycle-standing.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
 const requireAuthOrApiKeyWithOrg = mock();
+const resolveInferenceAuthContext = mock();
 const findWithOrganizationForWrite = mock();
 const shouldBlockUser = mock();
 const callProvider = mock();
@@ -15,6 +16,9 @@ const warn = mock();
 const error = mock();
 
 mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
+mock.module("@/lib/services/inference-auth-context", () => ({
+  resolveInferenceAuthContext,
+}));
 mock.module("@/db/repositories/users", () => ({
   usersRepository: { findWithOrganizationForWrite },
 }));
@@ -44,6 +48,7 @@ const app = new Hono().route("/connections/:id/broker", brokerRoute);
 describe("credential broker raw lifecycle standing", () => {
   beforeEach(() => {
     requireAuthOrApiKeyWithOrg.mockReset();
+    resolveInferenceAuthContext.mockReset();
     findWithOrganizationForWrite.mockReset();
     shouldBlockUser.mockReset();
     callProvider.mockReset();
@@ -68,7 +73,13 @@ describe("credential broker raw lifecycle standing", () => {
         id: "user-1",
         organization_id: "org-1",
         is_active: false,
-        organization: { id: "org-1", is_active: true },
+        organization: {
+          id: "org-1",
+          is_active: true,
+          account_lifecycle_state: "active",
+          account_lifecycle_revision: 1,
+          account_deletion_request_id: null,
+        },
       },
       "account_inactive",
     ],
@@ -79,7 +90,51 @@ describe("credential broker raw lifecycle standing", () => {
         id: "user-1",
         organization_id: "org-1",
         is_active: true,
-        organization: { id: "org-1", is_active: false },
+        organization: {
+          id: "org-1",
+          is_active: false,
+          account_lifecycle_state: "active",
+          account_lifecycle_revision: 1,
+          account_deletion_request_id: null,
+        },
+      },
+      "organization_inactive",
+    ],
+    [
+      "wallet with lifecycle fence",
+      {
+        "x-wallet-address": "0x0000000000000000000000000000000000000001",
+        "x-wallet-signature": "signed",
+        "x-timestamp": "1",
+      },
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: true,
+        organization: {
+          id: "org-1",
+          is_active: true,
+          account_lifecycle_state: "deletion_irreversible",
+          account_lifecycle_revision: 2,
+          account_deletion_request_id: null,
+        },
+      },
+      "organization_inactive",
+    ],
+    [
+      "mobile key with deletion request",
+      { "x-api-key": "eliza_mobile_test" },
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: true,
+        organization: {
+          id: "org-1",
+          is_active: true,
+          account_lifecycle_state: "active",
+          account_lifecycle_revision: 2,
+          account_deletion_request_id: "00000000-0000-4000-8000-000000000001",
+        },
       },
       "organization_inactive",
     ],
@@ -103,9 +158,14 @@ describe("credential broker raw lifecycle standing", () => {
         details: { reason },
       });
       expect(requireAuthOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+      expect(resolveInferenceAuthContext).not.toHaveBeenCalled();
       expect(findWithOrganizationForWrite).toHaveBeenCalledTimes(1);
       expect(shouldBlockUser).not.toHaveBeenCalled();
       expect(callProvider).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        "[PaidRouteStanding] blocked external work",
+        expect.objectContaining({ reason, providerDispatched: false }),
+      );
     },
   );
 });

--- a/packages/cloud/api/__tests__/credential-broker-lifecycle-standing.test.ts
+++ b/packages/cloud/api/__tests__/credential-broker-lifecycle-standing.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Drives the real credential-broker route through raw compatibility auth and
+ * primary lifecycle authority, proving fenced wallet/mobile callers cannot
+ * dispatch an upstream provider request.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireAuthOrApiKeyWithOrg = mock();
+const findWithOrganizationForWrite = mock();
+const shouldBlockUser = mock();
+const callProvider = mock();
+const warn = mock();
+const error = mock();
+
+mock.module("@/lib/auth", () => ({ requireAuthOrApiKeyWithOrg }));
+mock.module("@/db/repositories/users", () => ({
+  usersRepository: { findWithOrganizationForWrite },
+}));
+mock.module("@/lib/services/admin", () => ({
+  adminService: { shouldBlockUser },
+}));
+mock.module("@/lib/services/oauth", () => ({
+  credentialBroker: { callProvider },
+  internalErrorResponse: (message: string) => ({ error: message }),
+  OAuthError: class OAuthError extends Error {
+    httpStatus = 400;
+    toResponse() {
+      return { error: this.message };
+    }
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn, error },
+}));
+
+const { default: brokerRoute } = await import(
+  "../v1/connections/[id]/broker/route"
+);
+
+const app = new Hono().route("/connections/:id/broker", brokerRoute);
+
+describe("credential broker raw lifecycle standing", () => {
+  beforeEach(() => {
+    requireAuthOrApiKeyWithOrg.mockReset();
+    findWithOrganizationForWrite.mockReset();
+    shouldBlockUser.mockReset();
+    callProvider.mockReset();
+    warn.mockReset();
+    error.mockReset();
+    requireAuthOrApiKeyWithOrg.mockResolvedValue({
+      user: { id: "user-1", organization_id: "org-1", organization: {} },
+      authMethod: "wallet_signature",
+    });
+    shouldBlockUser.mockResolvedValue(false);
+  });
+
+  test.each([
+    [
+      "wallet",
+      {
+        "x-wallet-address": "0x0000000000000000000000000000000000000001",
+        "x-wallet-signature": "signed",
+        "x-timestamp": "1",
+      },
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: false,
+        organization: { id: "org-1", is_active: true },
+      },
+      "account_inactive",
+    ],
+    [
+      "mobile key",
+      { "x-api-key": "eliza_mobile_test" },
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: true,
+        organization: { id: "org-1", is_active: false },
+      },
+      "organization_inactive",
+    ],
+  ])(
+    "fences a lifecycle-inactive %s before provider dispatch",
+    async (_name, authHeaders, current, reason) => {
+      findWithOrganizationForWrite.mockResolvedValueOnce(current);
+
+      const response = await app.request("/connections/connection-1/broker", {
+        method: "POST",
+        headers: { "content-type": "application/json", ...authHeaders },
+        body: JSON.stringify({
+          method: "GET",
+          url: "https://provider.test/me",
+        }),
+      });
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        code: "access_denied",
+        details: { reason },
+      });
+      expect(requireAuthOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
+      expect(findWithOrganizationForWrite).toHaveBeenCalledTimes(1);
+      expect(shouldBlockUser).not.toHaveBeenCalled();
+      expect(callProvider).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
+++ b/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
@@ -263,6 +263,15 @@ mock.module("@/db/schemas/domain-purchase-idempotency", () => ({
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
+const requirePaidRouteStanding = mock(async () => ({
+  user: await requireUserOrApiKeyWithOrg(),
+  apiKeyId: null,
+  authSource: "combined_cache",
+  appScopeId: null,
+}));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding,
+}));
 
 mock.module("@/lib/services/apps", () => ({
   appsService: { getById },
@@ -409,6 +418,7 @@ async function readDomainBuyResponseBody(
 
 beforeEach(() => {
   durableAttempt = null;
+  requirePaidRouteStanding.mockClear();
   getMinimumRegistrationYears.mockReset();
   getMinimumRegistrationYears.mockResolvedValue(1);
 });
@@ -952,6 +962,24 @@ describe("POST /apps/:id/domains/buy — idempotency single-flights the purchase
     );
     dbWriteTerminal.mockClear();
     dbReadLimit.mockReset();
+  });
+
+  test("standing denial stops before app lookup, durable claim, debit, or registrar", async () => {
+    domainPurchaseAttemptsRepository.createOrRead.mockClear();
+    requirePaidRouteStanding.mockRejectedValueOnce(
+      new Error("Organization is inactive"),
+    );
+
+    const res = await buy();
+
+    expect(res.status).toBe(500);
+    expect(requirePaidRouteStanding).toHaveBeenCalledTimes(1);
+    expect(getById).not.toHaveBeenCalled();
+    expect(
+      domainPurchaseAttemptsRepository.createOrRead,
+    ).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(registerDomain).not.toHaveBeenCalled();
   });
 
   test("expired legacy claim with a possible debit fails closed for reconciliation", async () => {

--- a/packages/cloud/api/__tests__/domains-buy-cross-app-replay.integration.test.ts
+++ b/packages/cloud/api/__tests__/domains-buy-cross-app-replay.integration.test.ts
@@ -29,6 +29,7 @@ process.env.MOCK_REDIS = "1";
 
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
+import * as realPaidRouteStanding from "@/api-app/lib/paid-route-standing";
 import { closeDatabaseConnectionsForTests, dbRead, dbWrite } from "@/db/client";
 // Via cloud-shared so `drizzle-kit` (its devDependency) resolves at runtime.
 import { pushSchema } from "@/db/push-schema-for-tests";
@@ -115,6 +116,14 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
   ...realAuth,
   requireUserOrApiKeyWithOrg,
 }));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding: async () => ({
+    user: await requireUserOrApiKeyWithOrg(),
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  }),
+}));
 mock.module("@/lib/services/cloudflare-registrar", () => ({
   ...realRegistrar,
   cloudflareRegistrarService: {
@@ -160,6 +169,7 @@ afterAll(async () => {
   // Restore ALL mocked modules — bun's mock.module is process-global, so a
   // leaked seam mock corrupts sibling suites in a combined run.
   mock.module("@/lib/auth/workers-hono-auth", () => realAuth);
+  mock.module("@/api-app/lib/paid-route-standing", () => realPaidRouteStanding);
   mock.module("@/lib/services/cloudflare-registrar", () => realRegistrar);
   mock.module("@/lib/services/cloudflare-dns", () => realDns);
   mock.module("@/lib/services/email", () => realEmail);

--- a/packages/cloud/api/__tests__/domains-buy-rate-limit.test.ts
+++ b/packages/cloud/api/__tests__/domains-buy-rate-limit.test.ts
@@ -59,6 +59,14 @@ const getById = mock(async () => ({
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding: async () => ({
+    user: await requireUserOrApiKeyWithOrg(),
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  }),
+}));
 mock.module("@/lib/auth/app-key-scope", () => ({ isAppKeyOutOfScope }));
 mock.module("@/lib/services/apps", () => ({
   appsService: { getById },

--- a/packages/cloud/api/__tests__/durable-paid-route-standing.test.ts
+++ b/packages/cloud/api/__tests__/durable-paid-route-standing.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Drives the tunnel and credential-broker Hono routes with deterministic
+ * collaborators, proving standing denial precedes external dispatch and the
+ * tunnel route keeps synchronous debit/refund settlement around Headscale.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+
+const ORG = "00000000-0000-4000-8000-000000030263";
+const USER = "00000000-0000-4000-8000-000000030264";
+const CONNECTION = "00000000-0000-4000-8000-000000030265";
+
+const requirePaidRouteStanding = mock();
+const deductCredits = mock();
+const refundCredits = mock();
+const createPreAuthKey = mock();
+const callProvider = mock();
+const loggerError = mock();
+
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding,
+}));
+mock.module("@/lib/services/credits", () => ({
+  creditsService: { deductCredits, refundCredits },
+}));
+mock.module("@/lib/services/headscale-client", () => ({
+  HeadscaleClient: class {
+    createPreAuthKey = createPreAuthKey;
+  },
+}));
+mock.module("@/lib/services/oauth", () => ({
+  credentialBroker: { callProvider },
+  OAuthError: class extends Error {},
+  internalErrorResponse: (message: string) => ({ error: message }),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: loggerError,
+    warn: mock(),
+    info: mock(),
+  },
+}));
+
+const tunnelRoute = (
+  await import("../v1/apis/tunnels/tailscale/auth-key/route")
+).default;
+const brokerRoute = (await import("../v1/connections/[id]/broker/route"))
+  .default;
+
+const tunnelApp = new Hono();
+tunnelApp.route("/api/v1/apis/tunnels/tailscale/auth-key", tunnelRoute);
+const brokerApp = new Hono();
+brokerApp.route("/api/v1/connections/:id/broker", brokerRoute);
+
+const authorized = {
+  user: { id: USER, organization_id: ORG },
+  apiKeyId: "key-1",
+  authSource: "combined_cache",
+  appScopeId: null,
+};
+
+beforeEach(() => {
+  requirePaidRouteStanding.mockReset();
+  deductCredits.mockReset();
+  refundCredits.mockReset();
+  createPreAuthKey.mockReset();
+  callProvider.mockReset();
+  loggerError.mockReset();
+  requirePaidRouteStanding.mockResolvedValue(authorized);
+  deductCredits.mockResolvedValue({ success: true, newBalance: 9.99 });
+  refundCredits.mockResolvedValue({ success: true, newBalance: 10 });
+  createPreAuthKey.mockResolvedValue({
+    key: "opaque-headscale-key",
+    expiration: "2026-09-01T18:00:00.000Z",
+  });
+  callProvider.mockResolvedValue({
+    connectionId: CONNECTION,
+    platform: "github",
+    status: 200,
+    headers: {},
+    body: "{}",
+    bodyEncoding: "utf8",
+    tokenRefreshed: false,
+  });
+});
+
+function standingDenial(): ApiError {
+  return new ApiError(403, "access_denied", "Organization is inactive", {
+    reason: "organization_inactive",
+  });
+}
+
+describe("durable paid route standing", () => {
+  test("Headscale denial performs one guard decision and no debit or provider call", async () => {
+    requirePaidRouteStanding.mockRejectedValueOnce(standingDenial());
+
+    const response = await tunnelApp.request(
+      "/api/v1/apis/tunnels/tailscale/auth-key",
+      {
+        method: "POST",
+        body: "{}",
+        headers: { "content-type": "application/json" },
+      },
+      {
+        HEADSCALE_API_URL: "https://headscale.internal",
+        HEADSCALE_PUBLIC_URL: "https://headscale.example",
+        HEADSCALE_API_KEY: "test-secret",
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: "Organization is inactive",
+      details: { reason: "organization_inactive" },
+    });
+    expect(requirePaidRouteStanding).toHaveBeenCalledTimes(1);
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(createPreAuthKey).not.toHaveBeenCalled();
+  });
+
+  test("Headscale failure synchronously refunds the completed debit", async () => {
+    createPreAuthKey.mockRejectedValueOnce(new Error("headscale unavailable"));
+
+    const response = await tunnelApp.request(
+      "/api/v1/apis/tunnels/tailscale/auth-key",
+      {
+        method: "POST",
+        body: "{}",
+        headers: { "content-type": "application/json" },
+      },
+      {
+        HEADSCALE_API_URL: "https://headscale.internal",
+        HEADSCALE_PUBLIC_URL: "https://headscale.example",
+        HEADSCALE_API_KEY: "test-secret",
+      },
+    );
+
+    expect(response.status).toBe(500);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(createPreAuthKey).toHaveBeenCalledTimes(1);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("credential-broker denial returns the safe reason without provider dispatch", async () => {
+    requirePaidRouteStanding.mockRejectedValueOnce(standingDenial());
+
+    const response = await brokerApp.request(
+      `/api/v1/connections/${CONNECTION}/broker`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          method: "GET",
+          url: "https://api.github.com/user",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: "Organization is inactive",
+      details: { reason: "organization_inactive" },
+    });
+    expect(requirePaidRouteStanding).toHaveBeenCalledTimes(1);
+    expect(callProvider).not.toHaveBeenCalled();
+  });
+
+  test("credential broker dispatches only after successful standing admission", async () => {
+    const response = await brokerApp.request(
+      `/api/v1/connections/${CONNECTION}/broker`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          method: "GET",
+          url: "https://api.github.com/user",
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(requirePaidRouteStanding).toHaveBeenCalledTimes(1);
+    expect(callProvider).toHaveBeenCalledWith({
+      organizationId: ORG,
+      userId: USER,
+      connectionId: CONNECTION,
+      request: { method: "GET", url: "https://api.github.com/user" },
+    });
+  });
+});

--- a/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
+++ b/packages/cloud/api/__tests__/storage-list-native-authority.test.ts
@@ -46,6 +46,14 @@ mock.module("@/lib/services/storage/native-storage-read", () => ({
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding: async () => ({
+    user: await requireUserOrApiKeyWithOrg(),
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  }),
+}));
 mock.module("@/lib/services/proxy/pricing", () => ({ getServiceMethodCost }));
 mock.module("@/lib/services/credits", () => ({
   creditsService: { deductCredits },

--- a/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
+++ b/packages/cloud/api/__tests__/storage-objects-head-routing.test.ts
@@ -50,6 +50,14 @@ mock.module("@/lib/api/cloud-worker-errors", () => ({
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding: async () => ({
+    user: await requireUserOrApiKeyWithOrg(),
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  }),
+}));
 
 mock.module("@/lib/services/credits", () => ({
   creditsService: { deductCredits },

--- a/packages/cloud/api/__tests__/storage-presign-contract.test.ts
+++ b/packages/cloud/api/__tests__/storage-presign-contract.test.ts
@@ -34,6 +34,15 @@ class TestStorageReadCapabilityConfigurationError extends Error {
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
+const requirePaidRouteStanding = mock(async () => ({
+  user: await requireUserOrApiKeyWithOrg(),
+  apiKeyId: null,
+  authSource: "combined_cache",
+  appScopeId: null,
+}));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding,
+}));
 mock.module("@/lib/services/storage/native-storage-read", () => ({
   executeNativeStoragePresign,
   NativeStorageReadError: TestNativeStorageReadError,
@@ -58,6 +67,7 @@ app.route(ROUTE_PATH, presignRoute);
 
 beforeEach(() => {
   requireUserOrApiKeyWithOrg.mockReset();
+  requirePaidRouteStanding.mockClear();
   executeNativeStoragePresign.mockReset();
   getServiceMethodCost.mockReset();
   mintStorageReadCapabilityUrl.mockReset();
@@ -154,6 +164,39 @@ test("missing signer authority stops before pricing, provider, or settlement", a
     { BLOB: { head: mock() }, R2_PUBLIC_HOST: "https://blob.example" },
   );
   expect(response.status).toBe(503);
+  expect(getServiceMethodCost).not.toHaveBeenCalled();
+  expect(executeNativeStoragePresign).not.toHaveBeenCalled();
+  expect(mintStorageReadCapabilityUrl).not.toHaveBeenCalled();
+});
+
+test("standing denial suppresses pricing, R2 access, settlement, and capability minting", async () => {
+  requirePaidRouteStanding.mockRejectedValueOnce(
+    Object.assign(new Error("Organization is inactive"), {
+      status: 403,
+      details: { reason: "organization_inactive" },
+    }),
+  );
+
+  const response = await app.request(
+    ROUTE_PATH,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "Idempotency-Key": "presign-denied",
+        "X-Storage-Object-Key": "private/voice.ogg",
+      },
+      body: JSON.stringify({ operation: "get" }),
+    },
+    {
+      BLOB: { head: mock() },
+      R2_PUBLIC_HOST: "https://blob.example",
+      STORAGE_READ_SIGNING_SECRETS: "active-secret-that-is-long-enough",
+    },
+  );
+
+  expect(response.status).not.toBe(200);
+  expect(requirePaidRouteStanding).toHaveBeenCalledTimes(1);
   expect(getServiceMethodCost).not.toHaveBeenCalled();
   expect(executeNativeStoragePresign).not.toHaveBeenCalled();
   expect(mintStorageReadCapabilityUrl).not.toHaveBeenCalled();

--- a/packages/cloud/api/__tests__/storage-put-body-budget.test.ts
+++ b/packages/cloud/api/__tests__/storage-put-body-budget.test.ts
@@ -53,6 +53,14 @@ mock.module("@/lib/api/cloud-worker-errors", () => ({
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding: async () => ({
+    user: await requireUserOrApiKeyWithOrg(),
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  }),
+}));
 
 mock.module("@/lib/services/credits", () => ({
   creditsService: { deductCredits },

--- a/packages/cloud/api/src/lib/paid-route-standing.test.ts
+++ b/packages/cloud/api/src/lib/paid-route-standing.test.ts
@@ -53,7 +53,13 @@ beforeEach(() => {
     id: "user-1",
     organization_id: "org-1",
     is_active: true,
-    organization: { id: "org-1", is_active: true },
+    organization: {
+      id: "org-1",
+      is_active: true,
+      account_lifecycle_state: "active",
+      account_lifecycle_revision: 1,
+      account_deletion_request_id: null,
+    },
   });
 });
 
@@ -156,7 +162,13 @@ describe("requirePaidRouteStanding", () => {
         id: "user-1",
         organization_id: "org-1",
         is_active: false,
-        organization: { id: "org-1", is_active: true },
+        organization: {
+          id: "org-1",
+          is_active: true,
+          account_lifecycle_state: "active",
+          account_lifecycle_revision: 1,
+          account_deletion_request_id: null,
+        },
       },
       "account_inactive",
     ],
@@ -166,7 +178,45 @@ describe("requirePaidRouteStanding", () => {
         id: "user-1",
         organization_id: "org-1",
         is_active: true,
-        organization: { id: "org-1", is_active: false },
+        organization: {
+          id: "org-1",
+          is_active: false,
+          account_lifecycle_state: "active",
+          account_lifecycle_revision: 1,
+          account_deletion_request_id: null,
+        },
+      },
+      "organization_inactive",
+    ],
+    [
+      "lifecycle-fenced wallet organization",
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: true,
+        organization: {
+          id: "org-1",
+          is_active: true,
+          account_lifecycle_state: "deletion_recovery",
+          account_lifecycle_revision: 2,
+          account_deletion_request_id: null,
+        },
+      },
+      "organization_inactive",
+    ],
+    [
+      "deletion-requested mobile-key organization",
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: true,
+        organization: {
+          id: "org-1",
+          is_active: true,
+          account_lifecycle_state: "active",
+          account_lifecycle_revision: 2,
+          account_deletion_request_id: "00000000-0000-4000-8000-000000000001",
+        },
       },
       "organization_inactive",
     ],
@@ -191,6 +241,7 @@ describe("requirePaidRouteStanding", () => {
       });
 
       expect(findWithOrganizationForWrite).toHaveBeenCalledTimes(1);
+      expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
       expect(shouldBlockUser).not.toHaveBeenCalled();
       expect(warn).toHaveBeenCalledWith(
         "[PaidRouteStanding] blocked external work",

--- a/packages/cloud/api/src/lib/paid-route-standing.test.ts
+++ b/packages/cloud/api/src/lib/paid-route-standing.test.ts
@@ -9,6 +9,7 @@ import { ApiError } from "@/lib/api/cloud-worker-errors";
 
 const requireGenerativeRouteCaller = mock();
 const shouldBlockUser = mock();
+const findWithOrganizationForWrite = mock();
 const warn = mock();
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
@@ -16,6 +17,9 @@ mock.module("@/api-app/lib/generative-route-auth", () => ({
 }));
 mock.module("@/lib/services/admin", () => ({
   adminService: { shouldBlockUser },
+}));
+mock.module("@/db/repositories/users", () => ({
+  usersRepository: { findWithOrganizationForWrite },
 }));
 mock.module("@/lib/utils/logger", () => ({
   logger: { warn },
@@ -42,8 +46,15 @@ const authorized = {
 beforeEach(() => {
   requireGenerativeRouteCaller.mockReset();
   shouldBlockUser.mockReset();
+  findWithOrganizationForWrite.mockReset();
   warn.mockReset();
   shouldBlockUser.mockResolvedValue(false);
+  findWithOrganizationForWrite.mockResolvedValue({
+    id: "user-1",
+    organization_id: "org-1",
+    is_active: true,
+    organization: { id: "org-1", is_active: true },
+  });
 });
 
 describe("requirePaidRouteStanding", () => {
@@ -137,4 +148,54 @@ describe("requirePaidRouteStanding", () => {
     expect(shouldBlockUser).toHaveBeenCalledWith("user-1");
     expect(warn).toHaveBeenCalledTimes(1);
   });
+
+  test.each([
+    [
+      "inactive wallet user",
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: false,
+        organization: { id: "org-1", is_active: true },
+      },
+      "account_inactive",
+    ],
+    [
+      "inactive mobile-key organization",
+      {
+        id: "user-1",
+        organization_id: "org-1",
+        is_active: true,
+        organization: { id: "org-1", is_active: false },
+      },
+      "organization_inactive",
+    ],
+  ])(
+    "fences a %s through primary lifecycle authority",
+    async (_name, current, reason) => {
+      requireGenerativeRouteCaller.mockResolvedValueOnce({
+        ...authorized,
+        apiKeyId: null,
+        authSource: "compatibility",
+      });
+      findWithOrganizationForWrite.mockResolvedValueOnce(current);
+
+      await expect(
+        requirePaidRouteStanding(context(), {
+          route: "connections.broker",
+          compatibility: "raw",
+        }),
+      ).rejects.toMatchObject({
+        status: 403,
+        details: { reason },
+      });
+
+      expect(findWithOrganizationForWrite).toHaveBeenCalledTimes(1);
+      expect(shouldBlockUser).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        "[PaidRouteStanding] blocked external work",
+        expect.objectContaining({ reason, providerDispatched: false }),
+      );
+    },
+  );
 });

--- a/packages/cloud/api/src/lib/paid-route-standing.test.ts
+++ b/packages/cloud/api/src/lib/paid-route-standing.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Verifies durable paid routes reuse one combined standing resolution, consume
+ * cold continuation in that resolver, and return bounded denials before any
+ * route-owned external side effect.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+
+const requireGenerativeRouteCaller = mock();
+const shouldBlockUser = mock();
+const warn = mock();
+
+mock.module("@/api-app/lib/generative-route-auth", () => ({
+  requireGenerativeRouteCaller,
+}));
+mock.module("@/lib/services/admin", () => ({
+  adminService: { shouldBlockUser },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn },
+}));
+
+const { requirePaidRouteStanding } = await import("./paid-route-standing");
+
+function context() {
+  const values = new Map<string, string>([["traceId", "0".repeat(32)]]);
+  return {
+    get(name: string) {
+      return values.get(name);
+    },
+  } as never;
+}
+
+const authorized = {
+  user: { id: "user-1", organization_id: "org-1" },
+  apiKeyId: "key-1",
+  authSource: "combined_cache" as const,
+  appScopeId: null,
+};
+
+beforeEach(() => {
+  requireGenerativeRouteCaller.mockReset();
+  shouldBlockUser.mockReset();
+  warn.mockReset();
+  shouldBlockUser.mockResolvedValue(false);
+});
+
+describe("requirePaidRouteStanding", () => {
+  test("uses one shared resolution and enables direct cold-continuation consumption", async () => {
+    requireGenerativeRouteCaller.mockResolvedValueOnce(authorized);
+
+    await expect(
+      requirePaidRouteStanding(context(), { route: "storage.put" }),
+    ).resolves.toEqual(authorized);
+
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        compatibility: undefined,
+        awaitWarmingMs: 2_500,
+      },
+    );
+    expect(shouldBlockUser).not.toHaveBeenCalled();
+  });
+
+  test("does not reread after an authoritative cold result", async () => {
+    const coldAuthorized = {
+      ...authorized,
+      authSource: "combined_cache" as const,
+    };
+    requireGenerativeRouteCaller.mockResolvedValueOnce(coldAuthorized);
+
+    await expect(
+      requirePaidRouteStanding(context(), {
+        route: "storage.presign",
+        coldDeadlineMs: 4_000,
+      }),
+    ).resolves.toEqual(coldAuthorized);
+
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        compatibility: undefined,
+        awaitWarmingMs: 4_000,
+      },
+    );
+  });
+
+  test("preserves a cached safe standing reason and emits route-bound diagnostics", async () => {
+    requireGenerativeRouteCaller.mockRejectedValueOnce(
+      new ApiError(403, "access_denied", "Organization is inactive", {
+        reason: "organization_inactive",
+      }),
+    );
+
+    await expect(
+      requirePaidRouteStanding(context(), { route: "apps.domains.buy" }),
+    ).rejects.toMatchObject({
+      status: 403,
+      message: "Organization is inactive",
+      details: { reason: "organization_inactive" },
+    });
+
+    expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "[PaidRouteStanding] blocked external work",
+      expect.objectContaining({
+        route: "apps.domains.buy",
+        status: 403,
+        reason: "organization_inactive",
+        providerDispatched: false,
+      }),
+    );
+  });
+
+  test("checks moderation on the non-cacheable compatibility path", async () => {
+    requireGenerativeRouteCaller.mockResolvedValueOnce({
+      ...authorized,
+      apiKeyId: null,
+      authSource: "compatibility",
+    });
+    shouldBlockUser.mockResolvedValueOnce(true);
+
+    await expect(
+      requirePaidRouteStanding(context(), {
+        route: "connections.broker",
+        compatibility: "raw",
+      }),
+    ).rejects.toMatchObject({
+      status: 403,
+      details: { reason: "moderation_blocked" },
+    });
+
+    expect(shouldBlockUser).toHaveBeenCalledWith("user-1");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/api/src/lib/paid-route-standing.ts
+++ b/packages/cloud/api/src/lib/paid-route-standing.ts
@@ -72,6 +72,9 @@ async function compatibilityStandingReason(
   // that primary authority once here; this path never addresses Redis again.
   if (compatibility === "raw") {
     const { usersRepository } = await import("@/db/repositories/users");
+    const { organizationLifecycleAllowsNewWork } = await import(
+      "@/lib/services/account-lifecycle-authority"
+    );
     const current = await usersRepository.findWithOrganizationForWrite(
       caller.user.id,
     );
@@ -82,7 +85,20 @@ async function compatibilityStandingReason(
     ) {
       return "membership_missing";
     }
-    if (!current.organization.is_active) return "organization_inactive";
+    const lifecycleState = current.organization.account_lifecycle_state;
+    if (
+      (lifecycleState !== "active" &&
+        lifecycleState !== "deletion_recovery" &&
+        lifecycleState !== "deletion_irreversible") ||
+      !organizationLifecycleAllowsNewWork({
+        state: lifecycleState,
+        revision: current.organization.account_lifecycle_revision,
+        active: current.organization.is_active,
+        deletionRequestId: current.organization.account_deletion_request_id,
+      })
+    ) {
+      return "organization_inactive";
+    }
   }
 
   const { adminService } = await import("@/lib/services/admin");

--- a/packages/cloud/api/src/lib/paid-route-standing.ts
+++ b/packages/cloud/api/src/lib/paid-route-standing.ts
@@ -16,6 +16,12 @@ import type { AppContext } from "@/types/cloud-worker-env";
 
 const DEFAULT_COLD_STANDING_DEADLINE_MS = 2_500;
 
+type CompatibilityStandingReason =
+  | "account_inactive"
+  | "membership_missing"
+  | "moderation_blocked"
+  | "organization_inactive";
+
 export interface PaidRouteStandingOptions {
   /** Stable, secret-free route label used in denial diagnostics. */
   route: string;
@@ -42,6 +48,49 @@ function errorStatus(error: unknown): number | undefined {
   return typeof status === "number" ? status : undefined;
 }
 
+function standingMessage(reason: CompatibilityStandingReason): string {
+  switch (reason) {
+    case "moderation_blocked":
+      return "Account access is blocked by policy moderation";
+    case "organization_inactive":
+      return "Organization is inactive";
+    case "membership_missing":
+      return "Account is not associated with an active organization";
+    case "account_inactive":
+      return "Account is inactive";
+  }
+}
+
+async function compatibilityStandingReason(
+  caller: GenerativeRouteCaller,
+  compatibility: "hono" | "raw" | undefined,
+): Promise<CompatibilityStandingReason | null> {
+  if (caller.authSource !== "compatibility") return null;
+
+  // Raw wallet/mobile auth proves possession and organization presence but
+  // does not uniformly prove current user and organization lifecycle. Resolve
+  // that primary authority once here; this path never addresses Redis again.
+  if (compatibility === "raw") {
+    const { usersRepository } = await import("@/db/repositories/users");
+    const current = await usersRepository.findWithOrganizationForWrite(
+      caller.user.id,
+    );
+    if (!current?.is_active) return "account_inactive";
+    if (
+      current.organization_id !== caller.user.organization_id ||
+      !current.organization
+    ) {
+      return "membership_missing";
+    }
+    if (!current.organization.is_active) return "organization_inactive";
+  }
+
+  const { adminService } = await import("@/lib/services/admin");
+  return (await adminService.shouldBlockUser(caller.user.id))
+    ? "moderation_blocked"
+    : null;
+}
+
 /**
  * Resolve one paid-route caller from the combined standing cache. A cold
  * continuation is awaited once and consumed directly, so a miss still has one
@@ -52,6 +101,7 @@ export async function requirePaidRouteStanding(
   options: PaidRouteStandingOptions,
 ): Promise<GenerativeRouteCaller> {
   const traceId = c.get("traceId") ?? c.get("requestId") ?? "unavailable";
+  let denialLogged = false;
   try {
     const caller = await requireGenerativeRouteCaller(c, {
       compatibility: options.compatibility,
@@ -59,29 +109,26 @@ export async function requirePaidRouteStanding(
         options.coldDeadlineMs ?? DEFAULT_COLD_STANDING_DEADLINE_MS,
     });
 
-    // Wallet proofs and non-Worker compatibility callers cannot reuse the
-    // combined cache. Their auth path already proves current user, org, key,
-    // and lifecycle state; moderation is the remaining standing authority.
-    const blockedByModeration =
-      caller.authSource === "compatibility" &&
-      (await import("@/lib/services/admin").then(({ adminService }) =>
-        adminService.shouldBlockUser(caller.user.id),
-      ));
-    if (blockedByModeration) {
+    const compatibilityReason = await compatibilityStandingReason(
+      caller,
+      options.compatibility,
+    );
+    if (compatibilityReason) {
+      denialLogged = true;
       logger.warn("[PaidRouteStanding] blocked external work", {
         route: options.route,
         traceId,
         authSource: caller.authSource,
         decision: "denied",
         status: 403,
-        reason: "moderation_blocked",
+        reason: compatibilityReason,
         providerDispatched: false,
       });
       throw new ApiError(
         403,
         "access_denied",
-        "Account access is blocked by policy moderation",
-        { reason: "moderation_blocked" },
+        standingMessage(compatibilityReason),
+        { reason: compatibilityReason },
       );
     }
 
@@ -92,7 +139,7 @@ export async function requirePaidRouteStanding(
     // The combined resolver already logs its cache/authoritative phase. This
     // route-bound record provides the missing external-side-effect decision
     // without including credentials, provider payloads, or raw cache values.
-    if (errorReason(error) !== "moderation_blocked") {
+    if (!denialLogged) {
       logger.warn("[PaidRouteStanding] blocked external work", {
         route: options.route,
         traceId,

--- a/packages/cloud/api/src/lib/paid-route-standing.ts
+++ b/packages/cloud/api/src/lib/paid-route-standing.ts
@@ -1,0 +1,107 @@
+/**
+ * Admits authenticated non-generative paid routes through the shared combined
+ * standing decision before any debit, provider lease, or external dispatch.
+ * Cold requests consume the resolver's one-shot authoritative continuation;
+ * they never perform a second cache read. Durable workflows retain ownership
+ * of their synchronous receipt, debit, refund, and reconciliation semantics.
+ */
+
+import {
+  type GenerativeRouteCaller,
+  requireGenerativeRouteCaller,
+} from "@/api-app/lib/generative-route-auth";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+import { logger } from "@/lib/utils/logger";
+import type { AppContext } from "@/types/cloud-worker-env";
+
+const DEFAULT_COLD_STANDING_DEADLINE_MS = 2_500;
+
+export interface PaidRouteStandingOptions {
+  /** Stable, secret-free route label used in denial diagnostics. */
+  route: string;
+  compatibility?: "hono" | "raw";
+  coldDeadlineMs?: number;
+}
+
+function errorReason(error: unknown): unknown {
+  if (!error || typeof error !== "object" || !("details" in error)) {
+    return undefined;
+  }
+  const details = (error as { details?: unknown }).details;
+  if (!details || typeof details !== "object" || !("reason" in details)) {
+    return undefined;
+  }
+  return (details as { reason?: unknown }).reason;
+}
+
+function errorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object" || !("status" in error)) {
+    return undefined;
+  }
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" ? status : undefined;
+}
+
+/**
+ * Resolve one paid-route caller from the combined standing cache. A cold
+ * continuation is awaited once and consumed directly, so a miss still has one
+ * cache read and no readback after the authoritative deferred write.
+ */
+export async function requirePaidRouteStanding(
+  c: AppContext,
+  options: PaidRouteStandingOptions,
+): Promise<GenerativeRouteCaller> {
+  const traceId = c.get("traceId") ?? c.get("requestId") ?? "unavailable";
+  try {
+    const caller = await requireGenerativeRouteCaller(c, {
+      compatibility: options.compatibility,
+      awaitWarmingMs:
+        options.coldDeadlineMs ?? DEFAULT_COLD_STANDING_DEADLINE_MS,
+    });
+
+    // Wallet proofs and non-Worker compatibility callers cannot reuse the
+    // combined cache. Their auth path already proves current user, org, key,
+    // and lifecycle state; moderation is the remaining standing authority.
+    const blockedByModeration =
+      caller.authSource === "compatibility" &&
+      (await import("@/lib/services/admin").then(({ adminService }) =>
+        adminService.shouldBlockUser(caller.user.id),
+      ));
+    if (blockedByModeration) {
+      logger.warn("[PaidRouteStanding] blocked external work", {
+        route: options.route,
+        traceId,
+        authSource: caller.authSource,
+        decision: "denied",
+        status: 403,
+        reason: "moderation_blocked",
+        providerDispatched: false,
+      });
+      throw new ApiError(
+        403,
+        "access_denied",
+        "Account access is blocked by policy moderation",
+        { reason: "moderation_blocked" },
+      );
+    }
+
+    return caller;
+  } catch (error) {
+    // error-policy:J2 attach the secret-free route decision to diagnostics,
+    // then preserve the original typed boundary error and its safe response.
+    // The combined resolver already logs its cache/authoritative phase. This
+    // route-bound record provides the missing external-side-effect decision
+    // without including credentials, provider payloads, or raw cache values.
+    if (errorReason(error) !== "moderation_blocked") {
+      logger.warn("[PaidRouteStanding] blocked external work", {
+        route: options.route,
+        traceId,
+        decision: "denied",
+        status: errorStatus(error) ?? "unavailable",
+        reason: errorReason(error) ?? "authorization_failed",
+        providerDispatched: false,
+      });
+    }
+    throw error;
+  }
+}

--- a/packages/cloud/api/src/middleware/auth-paid-standing-path.test.ts
+++ b/packages/cloud/api/src/middleware/auth-paid-standing-path.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Mounts the production global auth boundary around the real paid-standing
+ * helper to prove guarded route shapes do not hydrate Steward sessions before
+ * their one combined identity-and-standing resolution.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const getCurrentUser = mock();
+const resolveInferenceAuthContext = mock();
+const observeInferenceApiKeyUsage = mock();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  getCurrentUser,
+  requireUserOrApiKeyWithOrg: mock(),
+}));
+mock.module("@/lib/services/inference-auth-context", () => ({
+  observeInferenceApiKeyUsage,
+  resolveInferenceAuthContext,
+}));
+
+const { authMiddleware, isRouteAuthenticatedPaidStandingPath } = await import(
+  "./auth"
+);
+const { requirePaidRouteStanding } = await import("../lib/paid-route-standing");
+
+const app = new Hono<AppEnv>();
+app.use("*", authMiddleware);
+app.all("*", async (c) => {
+  const caller = await requirePaidRouteStanding(c, {
+    route: "mounted.paid-standing.probe",
+  });
+  return c.json({ userId: caller.user.id });
+});
+
+const executionContext = {
+  props: {},
+  waitUntil(_promise: Promise<unknown>) {},
+  passThroughOnException() {},
+};
+
+const guardedRoutes = [
+  ["storage", "POST", "/api/v1/apis/storage/presign"],
+  ["domain", "POST", "/api/v1/apps/app-1/domains/buy"],
+  ["tunnel", "POST", "/api/v1/apis/tunnels/tailscale/auth-key"],
+  ["credential broker", "POST", "/api/v1/connections/connection-1/broker"],
+] as const;
+
+describe("production-mounted paid standing auth boundary", () => {
+  beforeEach(() => {
+    getCurrentUser.mockReset();
+    resolveInferenceAuthContext.mockReset();
+    observeInferenceApiKeyUsage.mockReset();
+    getCurrentUser.mockResolvedValue({ id: "unexpected-global-user" });
+    resolveInferenceAuthContext.mockResolvedValue({
+      kind: "authorized",
+      source: "cache",
+      ctx: {
+        userId: "user-1",
+        orgId: "org-1",
+        apiKeyId: null,
+        admission: null,
+      },
+    });
+  });
+
+  test.each(guardedRoutes)(
+    "Steward cookie reaches one combined read without global hydration for %s",
+    async (_name, method, pathname) => {
+      const response = await app.fetch(
+        new Request(`https://api.eliza.app${pathname}`, {
+          method,
+          headers: { cookie: "steward-token=signed-session" },
+        }),
+        {} as never,
+        executionContext,
+      );
+
+      expect(response.status).toBe(200);
+      expect(getCurrentUser).not.toHaveBeenCalled();
+      expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(guardedRoutes)(
+    "API key reaches one combined read without global hydration for %s",
+    async (_name, method, pathname) => {
+      const response = await app.fetch(
+        new Request(`https://api.eliza.app${pathname}`, {
+          method,
+          headers: { "x-api-key": "eliza_test_key" },
+        }),
+        {} as never,
+        executionContext,
+      );
+
+      expect(response.status).toBe(200);
+      expect(getCurrentUser).not.toHaveBeenCalled();
+      expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each([
+    ["GET", "/api/v1/remote/hosts"],
+    ["POST", "/api/v1/connections/connection-1/refresh"],
+    ["GET", "/api/v1/apps/app-1/domains/check"],
+    ["POST", "/api/v1/remote/hosts/host-1/managed-network/activate"],
+    ["GET", "/api/v1/connections/connection-1/broker"],
+    ["GET", "/api/v1/apis/storage/presign"],
+  ])(
+    "keeps recovery/read neighbor globally classified for %s %s",
+    (method, path) => {
+      expect(isRouteAuthenticatedPaidStandingPath(method, path)).toBe(false);
+    },
+  );
+});

--- a/packages/cloud/api/src/middleware/auth.ts
+++ b/packages/cloud/api/src/middleware/auth.ts
@@ -6,6 +6,9 @@
  *   - Public paths pass through with no auth.
  *   - Programmatic auth (X-API-Key, Bearer eliza_*) — pass through; per-route
  *     handlers validate the key against the DB.
+ *   - Durable paid routes with a local combined-standing guard pass through;
+ *     that guard authenticates Steward sessions and keys without a preceding
+ *     session hydration or duplicate database lookup.
  *   - The two remote-host activation routes accept their exact host credential;
  *     their handlers still validate the revocable token against the DB.
  *   - Steward cookie / Steward Bearer JWT — verify via `getCurrentUser` and
@@ -266,6 +269,41 @@ export function isRouteAuthenticatedInferencePath(
 }
 
 /**
+ * Durable paid routes perform their own combined identity-and-standing check.
+ * Keep this allowlist method- and shape-exact: neighboring read, recovery, and
+ * management routes retain the global session boundary unless their own route
+ * handler is explicitly responsible for authentication.
+ */
+export function isRouteAuthenticatedPaidStandingPath(
+  method: string,
+  pathname: string,
+): boolean {
+  if (
+    (method === "GET" || method === "HEAD") &&
+    /^\/api\/v1\/apis\/storage\/list\/?$/.test(pathname)
+  ) {
+    return true;
+  }
+  if (
+    method === "POST" &&
+    (/^\/api\/v1\/apis\/storage\/presign\/?$/.test(pathname) ||
+      /^\/api\/v1\/apis\/tunnels\/tailscale\/auth-key\/?$/.test(pathname) ||
+      /^\/api\/v1\/apps\/[^/]+\/domains\/buy\/?$/.test(pathname) ||
+      /^\/api\/v1\/connections\/[^/]+\/broker\/?$/.test(pathname) ||
+      /^\/api\/v1\/remote\/hosts\/?$/.test(pathname))
+  ) {
+    return true;
+  }
+  return (
+    (method === "GET" ||
+      method === "HEAD" ||
+      method === "PUT" ||
+      method === "DELETE") &&
+    /^\/api\/v1\/apis\/storage\/objects(?:\/.*)?$/.test(pathname)
+  );
+}
+
+/**
  * Remote hosts reach these activation handlers before they have a Cloud
  * session. Keep this pre-auth delegation exact: a syntactically valid,
  * host-bound credential may reach only the two handlers introduced by the
@@ -361,6 +399,11 @@ export const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
   }
 
   if (isRouteAuthenticatedInferencePath(c.req.method, pathname)) {
+    await next();
+    return;
+  }
+
+  if (isRouteAuthenticatedPaidStandingPath(c.req.method, pathname)) {
     await next();
     return;
   }

--- a/packages/cloud/api/v1/apis/storage/list/route.ts
+++ b/packages/cloud/api/v1/apis/storage/list/route.ts
@@ -15,8 +15,8 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { requirePaidRouteStanding } from "@/api-app/lib/paid-route-standing";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
 import {
   executeNativeStorageList,
@@ -39,7 +39,9 @@ const app = new Hono<AppEnv>();
 
 app.get("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "storage.list",
+    });
     const { organization_id } = user;
 
     const bucket = c.env.BLOB;

--- a/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
+++ b/packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts
@@ -23,12 +23,12 @@
  */
 
 import { type Context, Hono } from "hono";
+import { requirePaidRouteStanding } from "@/api-app/lib/paid-route-standing";
 import {
   StoragePutConflictError,
   StorageQuotaExceededError,
 } from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { InsufficientCreditsError } from "@/lib/services/credits";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
 import {
@@ -123,7 +123,9 @@ function rejectPutAndCancelBody(
 
 app.put("/*", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "storage.put",
+    });
     const { organization_id } = user;
 
     if (!c.env.BLOB) {
@@ -234,7 +236,9 @@ async function handleStorageGet(c: Context<AppEnv>) {
   }
 
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "storage.get",
+    });
     const { organization_id } = user;
 
     const validated = validatePrivateObjectKey(c);
@@ -284,7 +288,9 @@ app.get("/*", handleStorageGet);
 
 async function handleStorageHead(c: Context<AppEnv>) {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "storage.head",
+    });
     const { organization_id } = user;
 
     const validated = validatePrivateObjectKey(c);
@@ -355,7 +361,9 @@ function storageReadFailure(
 
 app.delete("/*", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "storage.delete",
+    });
     const { organization_id } = user;
 
     const validated = validatePrivateObjectKey(c);

--- a/packages/cloud/api/v1/apis/storage/presign/route.ts
+++ b/packages/cloud/api/v1/apis/storage/presign/route.ts
@@ -4,13 +4,13 @@
  */
 import { Hono } from "hono";
 import { z } from "zod";
+import { requirePaidRouteStanding } from "@/api-app/lib/paid-route-standing";
 import {
   mintStorageReadCapabilityUrl,
   StorageReadCapabilityConfigurationError,
   validateStorageReadCapabilityConfiguration,
 } from "@/api-app/storage-read-capability";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { getServiceMethodCost } from "@/lib/services/proxy/pricing";
 import {
   executeNativeStoragePresign,
@@ -43,7 +43,9 @@ function validLogicalKey(value: string): string | undefined {
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "storage.presign",
+    });
     const raw = await c.req.json().catch(() => {
       // error-policy:J3 malformed request JSON remains an explicit invalid result.
       return null;

--- a/packages/cloud/api/v1/apis/tunnels/tailscale/auth-key/route.ts
+++ b/packages/cloud/api/v1/apis/tunnels/tailscale/auth-key/route.ts
@@ -9,8 +9,8 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { requirePaidRouteStanding } from "@/api-app/lib/paid-route-standing";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { creditsService } from "@/lib/services/credits";
 import { HeadscaleClient } from "@/lib/services/headscale-client";
 import { logger } from "@/lib/utils/logger";
@@ -40,7 +40,9 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "tunnels.tailscale.auth-key",
+    });
     const rawBody = await c.req.json().catch(() => ({}));
     const parsed = authKeyRequestSchema.safeParse(rawBody);
     if (!parsed.success) {

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.json.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.json.test.ts
@@ -43,6 +43,14 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
   }),
   readSessionCredential: () => undefined,
 }));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: null,
+    authSource: "combined_cache",
+    appScopeId: null,
+  }),
+}));
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: {

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
@@ -9,13 +9,13 @@
  */
 
 import { Hono } from "hono";
+import { requirePaidRouteStanding } from "@/api-app/lib/paid-route-standing";
 import { creditTransactionsRepository } from "@/db/repositories/credit-transactions";
 import { domainPurchaseAttemptsRepository } from "@/db/repositories/domain-purchase-attempts";
 import type { CreditTransaction } from "@/db/schemas/credit-transactions";
 import type { DomainPurchaseIdempotency } from "@/db/schemas/domain-purchase-idempotency";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   moneyRateLimit,
   RateLimitPresets,
@@ -58,7 +58,9 @@ const domainBuyRateLimit = moneyRateLimit(RateLimitPresets.CRITICAL);
 
 app.post("/", domainBuyRateLimit, async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "apps.domains.buy",
+    });
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
 

--- a/packages/cloud/api/v1/connections/[id]/broker/route.ts
+++ b/packages/cloud/api/v1/connections/[id]/broker/route.ts
@@ -10,15 +10,15 @@
 
 import { Hono } from "hono";
 
-import { ApiError } from "@/lib/api/errors";
-import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { requirePaidRouteStanding } from "@/api-app/lib/paid-route-standing";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 import {
   credentialBroker,
   internalErrorResponse,
   OAuthError,
 } from "@/lib/services/oauth";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 interface BrokerRequestBody {
   method: string;
@@ -57,14 +57,18 @@ function parseBrokerBody(raw: unknown): BrokerRequestBody | null {
 }
 
 async function __hono_POST(
-  request: Request,
+  c: AppContext,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const request = c.req.raw;
   const { id: connectionId } = await params;
   let organizationId: string | undefined;
 
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user } = await requirePaidRouteStanding(c, {
+      route: "connections.broker",
+      compatibility: "raw",
+    });
     organizationId = user.organization_id;
 
     let rawBody: unknown;
@@ -121,7 +125,7 @@ async function __hono_POST(
 
 const __hono_app = new Hono<AppEnv>();
 __hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, {
+  __hono_POST(c, {
     params: Promise.resolve({ id: c.req.param("id")! }),
   }),
 );

--- a/packages/cloud/api/v1/connections/[id]/refresh/route.ts
+++ b/packages/cloud/api/v1/connections/[id]/refresh/route.ts
@@ -4,6 +4,9 @@
  * POST /api/v1/connections/:id/refresh revalidates or refreshes the credential
  * behind an opaque connection ID and returns token metadata only (expiry,
  * scopes, whether a refresh happened). Raw token material is never exposed.
+ * This recovery endpoint intentionally stays outside paid standing admission:
+ * restoring or revoking credential validity must remain available to an
+ * authenticated account even when new external work is fenced.
  */
 
 import { Hono } from "hono";

--- a/packages/cloud/api/v1/remote/hosts/[id]/managed-network/activate/route.ts
+++ b/packages/cloud/api/v1/remote/hosts/[id]/managed-network/activate/route.ts
@@ -1,4 +1,8 @@
-/** Activates a pending managed host only after exact Headscale node discovery. */
+/**
+ * Activates a pending managed host only after exact Headscale node discovery.
+ * The host presents its one-use signed delegated enrollment credential, so the
+ * route must not add a second account-cache read after owner-side admission.
+ */
 
 import { Hono } from "hono";
 import { isRemotePairingUuid } from "@/db/crypto/remote-pairing-code";

--- a/packages/cloud/api/v1/remote/hosts/[id]/revoke/route.ts
+++ b/packages/cloud/api/v1/remote/hosts/[id]/revoke/route.ts
@@ -1,4 +1,8 @@
-/** Revokes an owner-scoped host and drains a bounded page of relay authority. */
+/**
+ * Revokes an owner-scoped host and drains a bounded page of relay authority.
+ * Revocation and pending Headscale cleanup are recovery operations and remain
+ * available while new paid/external work is fenced by account standing.
+ */
 
 import { Hono } from "hono";
 import { isRemotePairingUuid } from "@/db/crypto/remote-pairing-code";

--- a/packages/cloud/api/v1/remote/hosts/route.ts
+++ b/packages/cloud/api/v1/remote/hosts/route.ts
@@ -5,6 +5,7 @@ import {
   REMOTE_CONTROL_PROTOCOL_VERSION,
 } from "@elizaos/shared/contracts/remote-control";
 import { Hono } from "hono";
+import { requirePaidRouteStanding } from "@/api-app/lib/paid-route-standing";
 import {
   generateRemoteHostToken,
   hashRemoteHostToken,
@@ -67,7 +68,6 @@ app.get("/", async (c) => {
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
     let value: unknown;
     try {
       value = await c.req.json();
@@ -114,6 +114,17 @@ app.post("/", async (c) => {
         409,
       );
     }
+    // Credential recovery restores access and never provisions Headscale, so
+    // it remains available to an authenticated owner while new work is fenced.
+    // New enrollment uses the one-read standing guard before any host record,
+    // bearer credential, or optional Headscale pre-auth key is created.
+    const user = recoveryHostId
+      ? await requireUserOrApiKeyWithOrg(c)
+      : (
+          await requirePaidRouteStanding(c, {
+            route: "remote.hosts.enroll",
+          })
+        ).user;
     let networkConfig = null;
     if (managedNetworkRequested) {
       try {

--- a/packages/cloud/api/v1/remote/relay-routes.test.ts
+++ b/packages/cloud/api/v1/remote/relay-routes.test.ts
@@ -34,6 +34,12 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: ownerId,
   organization_id: organizationId,
 }));
+const requirePaidRouteStanding = mock(async () => ({
+  user: await requireUserOrApiKeyWithOrg(),
+  apiKeyId: null,
+  authSource: "combined_cache",
+  appScopeId: null,
+}));
 const getCurrentUser = mock(async () => null);
 const createOwned = mock();
 const recoverHostCredential = mock();
@@ -82,6 +88,9 @@ const activationRateLimitConfigs: Array<{
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   getCurrentUser,
   requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/api-app/lib/paid-route-standing", () => ({
+  requirePaidRouteStanding,
 }));
 mock.module("@/db/repositories/remote-hosts", () => ({
   remoteHostsRepository: {
@@ -291,6 +300,7 @@ function productionActivationRequest(
 }
 
 beforeEach(() => {
+  requirePaidRouteStanding.mockClear();
   for (const collaborator of [
     createOwned,
     recoverHostCredential,
@@ -445,6 +455,38 @@ describe("secure remote relay routes", () => {
     expect(createOwned.mock.calls[0]?.[0].host_token_hash).not.toBe(
       body.data.hostToken,
     );
+  });
+
+  test("standing denial creates no host credential or Headscale enrollment", async () => {
+    requirePaidRouteStanding.mockRejectedValueOnce(
+      new Error("Organization is inactive"),
+    );
+
+    const response = await request(
+      "/api/v1/remote/hosts",
+      {
+        deviceId: "mac-denied",
+        displayName: "Denied Mac",
+        platform: "macos",
+        connectionMode: "relay",
+        managedNetwork: true,
+        runtimeKeyId: targetKeyId,
+        signingPublicKeyJwk: publicJwk,
+        encryptionPublicKeyJwk: publicJwk,
+      },
+      {},
+      "POST",
+      {
+        HEADSCALE_API_URL: "https://headscale-staging.example",
+        HEADSCALE_PUBLIC_URL: "https://headscale-staging.example",
+        HEADSCALE_API_KEY: "headscale-api-secret",
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(requirePaidRouteStanding).toHaveBeenCalledTimes(1);
+    expect(createOwned).not.toHaveBeenCalled();
+    expect(createPreAuthKey).not.toHaveBeenCalled();
   });
 
   test("returns a one-use managed-network key without persisting it", async () => {


### PR DESCRIPTION
Closes #30263

## What changed

- Adds one shared standing-only paid-route guard that reuses the combined inference identity decision.
- A warm request performs the existing single combined cache read. A cold request awaits and consumes the authoritative continuation directly without rereading the cache.
- Standing denials preserve bounded safe reasons, emit route-bound structured diagnostics with providerDispatched=false, and stop before durable claims, debits, credentials, or provider dispatch.
- Applies the guard to R2 list/presign/object operations, Tailscale auth-key creation, remote host enrollment with optional Headscale provisioning, domain purchase, and credential-broker user OAuth calls.
- Keeps existing synchronous receipt, lease, debit, refund, and reconciliation behavior intact.

## Deliberate exemptions

- Credential refresh/revalidation remains available as an authentication recovery operation.
- Remote host token recovery and revocation/cleanup remain available while new work is fenced.
- Remote host listing and domain status/check/reconciliation reads remain read-only/recovery paths.
- Signed one-use managed-network activation and blob capability reads retain their delegated proof and do not add a second account-cache read.
- MCP provider proxy already uses the generative standing guard and is not double-admitted.

## Verification

Exact head: 2aa8ba58c8bf6834343c2c1da10b94347d71ea7f
Base: 8623cd08a08f9a48bd39a6f1db3ae5a8cc31c65a

- bun run verify: 376/376 tasks green
- bun run verify:cloud: 84/84 tasks green
- packages/cloud/api typecheck, 708-route router contract, and production Worker dry bundle green
- Biome on all 22 changed TypeScript files and git diff --check green
- shared guard: 4/4
- cold continuation contract: 5/5
- durable Headscale and credential broker: 4/4
- storage presign: 4/4
- domain debit/refund/idempotency: 23/23
- remote relay/provisioning: 33/33
- cross-app registrar replay integration: 4/4
- additional storage list/object/PUT and domain JSON/rate suites green

## Safety properties covered

Tests cover authorized, denied, and cold continuation paths; one shared resolution/no reread; safe denial reason and structured log; provider, pricing, debit, and durable-claim suppression on denial; and retained synchronous Headscale refund and storage/domain settlement behavior.