### PR TITLE
fix(elizacloud): fence the reconnect ladder against stop()

### DIFF
--- a/plugins/plugin-elizacloud/src/cloud/reconnect.test.ts
+++ b/plugins/plugin-elizacloud/src/cloud/reconnect.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Lifecycle tests for ConnectionMonitor's reconnect ladder. A monitor the host
+ * has stopped must abandon an in-flight ladder: no further provision calls, no
+ * status or reconnect callbacks, and no timer left behind to keep the process
+ * alive. Deterministic harness — real ConnectionMonitor, fake timers, a stub
+ * client, and the core logger mocked out.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { ConnectionMonitor } from "./reconnect.ts";
+
+type Outcome = "ok" | "fail";
+
+function makeClient(outcomes: Outcome[]) {
+  let calls = 0;
+  const provision = vi.fn(async () => {
+    const outcome = outcomes[Math.min(calls, outcomes.length - 1)];
+    calls += 1;
+    if (outcome === "fail") throw new Error("cloud unreachable");
+    return {};
+  });
+  return {
+    heartbeat: vi.fn(async () => false),
+    provision,
+  };
+}
+
+function makeCallbacks() {
+  return {
+    onDisconnect: vi.fn(),
+    onReconnect: vi.fn(),
+    onStatusChange: vi.fn(),
+    onReconnectExhausted: vi.fn(),
+  };
+}
+
+const HEARTBEAT_MS = 10;
+const FIRST_BACKOFF_MS = 3_000;
+
+describe("ConnectionMonitor stop() fences the reconnect ladder", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("completes the ladder and reconnects when never stopped (harness control)", async () => {
+    const client = makeClient(["fail", "ok"]);
+    const callbacks = makeCallbacks();
+    const monitor = new ConnectionMonitor(client as never, "agent-1", callbacks, HEARTBEAT_MS, 1);
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MS);
+    await vi.advanceTimersByTimeAsync(FIRST_BACKOFF_MS);
+
+    expect(client.provision).toHaveBeenCalledTimes(2);
+    expect(callbacks.onReconnect).toHaveBeenCalledTimes(1);
+    expect(callbacks.onStatusChange).toHaveBeenLastCalledWith("connected");
+    monitor.stop();
+  });
+
+  it("abandons an in-flight ladder after stop(): no more provisioning, no callbacks", async () => {
+    const client = makeClient(["fail", "ok"]);
+    const callbacks = makeCallbacks();
+    const monitor = new ConnectionMonitor(client as never, "agent-1", callbacks, HEARTBEAT_MS, 1);
+
+    monitor.start();
+    // First tick: heartbeat fails, ladder starts, attempt 1 rejects, backoff sleep armed.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MS);
+    expect(client.provision).toHaveBeenCalledTimes(1);
+    expect(callbacks.onStatusChange).toHaveBeenLastCalledWith("reconnecting");
+
+    monitor.stop();
+    expect(monitor.isMonitoring()).toBe(false);
+    callbacks.onStatusChange.mockClear();
+
+    // Everything the ladder could still do must not happen once stopped.
+    await vi.advanceTimersByTimeAsync(FIRST_BACKOFF_MS * 4);
+
+    expect(client.provision).toHaveBeenCalledTimes(1);
+    expect(callbacks.onReconnect).not.toHaveBeenCalled();
+    expect(callbacks.onStatusChange).not.toHaveBeenCalled();
+  });
+
+  it("leaves no backoff timer pending after stop()", async () => {
+    const client = makeClient(["fail"]);
+    const callbacks = makeCallbacks();
+    const monitor = new ConnectionMonitor(client as never, "agent-1", callbacks, HEARTBEAT_MS, 1);
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MS);
+    monitor.stop();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("ignores a provision call that resolves after stop() was called mid-flight", async () => {
+    let resolveProvision: (() => void) | undefined;
+    const client = {
+      heartbeat: vi.fn(async () => false),
+      provision: vi.fn(
+        () =>
+          new Promise<unknown>((resolve) => {
+            resolveProvision = () => resolve({});
+          }),
+      ),
+    };
+    const callbacks = makeCallbacks();
+    const monitor = new ConnectionMonitor(client as never, "agent-1", callbacks, HEARTBEAT_MS, 1);
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MS);
+    expect(client.provision).toHaveBeenCalledTimes(1);
+
+    // The host tears the monitor down while the network call is still out.
+    monitor.stop();
+    callbacks.onStatusChange.mockClear();
+    resolveProvision?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.onReconnect).not.toHaveBeenCalled();
+    expect(callbacks.onStatusChange).not.toHaveBeenCalledWith("connected");
+  });
+
+  it("does not report exhaustion for a ladder that was stopped mid-backoff", async () => {
+    const client = makeClient(["fail"]);
+    const callbacks = makeCallbacks();
+    const monitor = new ConnectionMonitor(client as never, "agent-1", callbacks, HEARTBEAT_MS, 1);
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MS);
+    monitor.stop();
+    callbacks.onStatusChange.mockClear();
+
+    // Longer than the whole 10-attempt backoff schedule (3s doubling, capped at 60s).
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(client.provision).toHaveBeenCalledTimes(1);
+    expect(callbacks.onReconnectExhausted).not.toHaveBeenCalled();
+    expect(callbacks.onStatusChange).not.toHaveBeenCalledWith("disconnected");
+  });
+});

--- a/plugins/plugin-elizacloud/src/cloud/reconnect.ts
+++ b/plugins/plugin-elizacloud/src/cloud/reconnect.ts
@@ -26,6 +26,12 @@ export class ConnectionMonitor {
   private timer: ReturnType<typeof setInterval> | null = null;
   private consecutiveFailures = 0;
   private reconnecting = false;
+  // stop() advances this. A reconnect ladder captures it on entry and abandons
+  // itself after every await once it has moved, so a monitor the host tore
+  // down never provisions again or reports "connected" on a stale client.
+  private epoch = 0;
+  private backoffTimer: ReturnType<typeof setTimeout> | null = null;
+  private wakeBackoff: (() => void) | null = null;
 
   constructor(
     private client: ElizaCloudClient,
@@ -47,10 +53,12 @@ export class ConnectionMonitor {
   }
 
   stop(): void {
+    this.epoch += 1;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
     }
+    this.cancelBackoff();
     this.consecutiveFailures = 0;
     this.reconnecting = false;
     logger.info("[cloud-monitor] Connection monitor stopped");
@@ -88,7 +96,30 @@ export class ConnectionMonitor {
     }
   }
 
+  /** Wake a pending backoff sleep so the ladder can observe stop() at once. */
+  private cancelBackoff(): void {
+    if (this.backoffTimer) {
+      clearTimeout(this.backoffTimer);
+      this.backoffTimer = null;
+    }
+    const wake = this.wakeBackoff;
+    this.wakeBackoff = null;
+    wake?.();
+  }
+
+  private sleepBackoff(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.wakeBackoff = resolve;
+      this.backoffTimer = setTimeout(() => {
+        this.backoffTimer = null;
+        this.wakeBackoff = null;
+        resolve();
+      }, delayMs);
+    });
+  }
+
   private async attemptReconnect(): Promise<void> {
+    const epoch = this.epoch;
     this.reconnecting = true;
     this.callbacks.onStatusChange?.("reconnecting");
 
@@ -99,6 +130,7 @@ export class ConnectionMonitor {
         .provision(this.agentId)
         .then(() => true)
         .catch(() => false);
+      if (epoch !== this.epoch) return;
 
       if (ok) {
         logger.info("[cloud-monitor] Reconnection successful");
@@ -109,7 +141,8 @@ export class ConnectionMonitor {
         return;
       }
 
-      await new Promise((r) => setTimeout(r, delay));
+      await this.sleepBackoff(delay);
+      if (epoch !== this.epoch) return;
       delay = Math.min(delay * 2, 60_000);
     }
 


### PR DESCRIPTION
# Relates to

Closes #30269 — `ConnectionMonitor.stop()` cannot cancel an in-flight reconnect ladder, which then provisions on a stale client and reports `connected` on a manager the host tore down.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5-1`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `9c6fc21cce`; zero conflicts. Exact head `d84cdedbde84da9d8e2aaac636d3de87b410dacd`.

# Risks

Low and contained to `reconnect.ts`. The ladder's success, failure, and exhaustion behaviour is unchanged when the monitor is not stopped — the harness control case pins that (attempt 1 fails, attempt 2 succeeds, `onReconnect` fires once). The only new behaviour is that a stopped monitor abandons its ladder: no further `provision` calls, no callbacks, no pending timer. `start()` after `stop()` gets a fresh epoch, so a restarted monitor is unaffected by the abandoned ladder.

# Background

## What does this PR do?

`stop()` (`reconnect.ts:49-57`) cleared the heartbeat interval and reset `reconnecting`, but a running `attemptReconnect()` (`:91-131`) held no reference to either. It kept calling `client.provision()` on the client captured at construction — so a swapped API key was never seen — and slept on a bare `setTimeout` (`:112`) that nothing could clear, for up to ten attempts with backoff capped at 60s. On success it fired `onStatusChange("connected")` and `onReconnect()` regardless; on exhaustion it fired `onStatusChange("disconnected")` minutes after a clean stop. Through `CloudManager.disconnect()` / `replaceApiKey()` that flips a deliberate disconnect back to `connected` with a `null` proxy.

The fix: `stop()` advances an `epoch` and wakes any pending backoff sleep; the ladder captures the epoch on entry and returns after every `await` once it has moved; the backoff timer is stored and cleared instead of left dangling.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-elizacloud/src/cloud/reconnect.test.ts` — five cases over the real `ConnectionMonitor` with fake timers and a stub client. Each of the three fence points is killed by its own case.

## Detailed testing steps

1. Check out exact head `d84cdedbde84da9d8e2aaac636d3de87b410dacd`.
2. From `plugins/plugin-elizacloud`: `bun x vitest run src/cloud/reconnect.test.ts` → **5/5**.
3. RED control — the same five tests against `origin/develop`'s `reconnect.ts`: **4 failed | 1 passed** (only the harness control passes). Failures: `provision` called 2× after `stop()`; 1 timer still pending; a provision resolving after `stop()` still emits `connected`; all 10 attempts run and exhaustion is reported after `stop()`.
4. Mutation kills, each applied alone and reverted:
   - drop the post-provision epoch check → the mid-flight case fails (1/5);
   - drop the post-sleep epoch check → the abandon and exhaustion cases fail (2/5);
   - remove `cancelBackoff()` from `stop()` → the no-pending-timer case fails (1/5).
5. Pinned Biome on both files: exit 0.

<!-- evidence-head:d84cdedbde84da9d8e2aaac636d3de87b410dacd -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — connector lifecycle state with no rendered surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — connector lifecycle state with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the RED control and three independent mutation kills below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Reproduction against develop, RED control, green at head, and the three mutation kills</summary>

```
# reproduction: real ConnectionMonitor + CloudManager, stop() between provision attempts (origin/develop)
 Info  [cloud-monitor] Reconnect attempt 1/10...
 Info  [cloud-monitor] Connection monitor stopped
 Info  [cloud-monitor] Reconnect attempt 2/10...
 Info  [cloud-monitor] Reconnection successful
["onDisconnect","status:reconnecting","provision#1","--- after stop(); isMonitoring=false ---",
 "provision#2","status:connected","onReconnect","--- 4s after stop(); provisionCalls=2 ---"]
AFTER disconnect; status=disconnected proxy=null agentId=null
4s LATER; status=connected proxy=null agentId=null provisionCalls=3

# RED control: this PR's tests vs origin/develop reconnect.ts
      Tests  4 failed | 1 passed (5)

# head d84cdedbde
      Tests  5 passed (5)

# mutation A -- drop post-provision epoch check
 × ignores a provision call that resolves after stop() was called mid-flight
      Tests  1 failed | 4 passed (5)
# mutation B -- drop post-sleep epoch check
 × abandons an in-flight ladder after stop(): no more provisioning, no callbacks
 × does not report exhaustion for a ladder that was stopped mid-backoff
      Tests  2 failed | 3 passed (5)
# mutation C -- stop() no longer cancels the backoff
 × leaves no backoff timer pending after stop()
      Tests  1 failed | 4 passed (5)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic timer/state path with no model call.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Fence points and static gates at exact head</summary>

```
reconnect.ts  stop(): this.epoch += 1; this.cancelBackoff()
reconnect.ts  attemptReconnect(): const epoch = this.epoch  (entry)
              after await provision  -> if (epoch !== this.epoch) return
              after await sleepBackoff -> if (epoch !== this.epoch) return
reconnect.ts  sleepBackoff(): timer handle stored; cancelBackoff() clears it and resolves the sleep

$ node_modules/.bin/biome check \
    plugins/plugin-elizacloud/src/cloud/reconnect.ts \
    plugins/plugin-elizacloud/src/cloud/reconnect.test.ts
(exit 0, captured directly)

$ git diff --stat origin/develop..HEAD
 .../plugin-elizacloud/src/cloud/reconnect.test.ts  | 154 +++++++++++++++++++++
 plugins/plugin-elizacloud/src/cloud/reconnect.ts   |  35 ++++-
 2 files changed, 188 insertions(+), 1 deletion(-)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- Three sibling suites in `src/cloud/` (`auth.session-id`, `cloud-api-key.authority`, `managed-payment-clients.routes`) fail in this review worktree with `Cannot find package '@elizaos/core/client-public'` — identically with `reconnect.ts` restored to develop, and none of them import `reconnect`. That is this worktree's package linking, not this change; the focused suite, RED control, and mutation kills above are the evidence.
- `bun run verify` was not run for the same reason.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
