### PR TITLE
fix(elizacloud): keep container polling alive through transient API failures

### DIFF
--- a/plugins/plugin-elizacloud/src/services/cloud-container.poll-resilience.test.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-container.poll-resilience.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Deployment-polling resilience for CloudContainerService. A transient cloud
+ * API failure inside one poll must count as an attempt and re-arm the chain
+ * with backoff, not kill it and escape as an unhandled rejection that freezes
+ * the tracked container at its last observed status. Deterministic harness —
+ * real service, fake timers, a stub auth client, core and shared mocked out.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  Service: class {
+    protected runtime: unknown;
+    constructor(runtime?: unknown) {
+      this.runtime = runtime;
+    }
+  },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@elizaos/shared", () => ({ CLOUD_CONTAINER_SERVICE_TYPE: "CLOUD_CONTAINER" }));
+
+import { CloudContainerService } from "./cloud-container.ts";
+
+type Tracked = {
+  container: { id: string; status: string };
+  pollingTimer: ReturnType<typeof setTimeout> | null;
+  healthTimer: ReturnType<typeof setInterval> | null;
+};
+type Harness = {
+  authService: unknown;
+  tracked: Map<string, Tracked>;
+  startPolling(id: string): void;
+};
+
+const ID = "container-1";
+const BASE_INTERVAL_MS = 5_000;
+
+function makeService(get: (path: string) => Promise<unknown>) {
+  const service = new CloudContainerService({} as never) as unknown as Harness;
+  service.authService = {
+    isAuthenticated: () => true,
+    getClient: () => ({ get }),
+  };
+  service.tracked.set(ID, {
+    container: { id: ID, status: "deploying" },
+    pollingTimer: null,
+    healthTimer: null,
+  });
+  return service;
+}
+
+function sequence(outcomes: Array<"reject" | string>) {
+  let calls = 0;
+  const get = vi.fn(async () => {
+    const outcome = outcomes[Math.min(calls, outcomes.length - 1)];
+    calls += 1;
+    if (outcome === "reject") throw new Error("transient 503 from cloud API");
+    return { data: { id: ID, status: outcome } };
+  });
+  return get;
+}
+
+describe("CloudContainerService deployment polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps polling while the container is deploying (harness control)", async () => {
+    const get = sequence(["deploying"]);
+    const service = makeService(get);
+    service.startPolling(ID);
+
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL_MS); // poll #1
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL_MS * 2); // poll #2 after 10s backoff
+
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-arms the chain after a transient failure and still reaches running", async () => {
+    const get = sequence(["reject", "running"]);
+    const service = makeService(get);
+    service.startPolling(ID);
+
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL_MS); // poll #1 rejects
+    await vi.advanceTimersByTimeAsync(BASE_INTERVAL_MS * 2); // poll #2 must still happen
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(service.tracked.get(ID)?.container.status).toBe("running");
+    expect(service.tracked.get(ID)?.healthTimer).not.toBeNull();
+  });
+
+  it("counts failed polls against the attempt budget and stops at the limit", async () => {
+    const get = sequence(["reject"]);
+    const service = makeService(get);
+    service.startPolling(ID);
+
+    // 120 attempts at ≤30s each is well under two fake hours.
+    await vi.advanceTimersByTimeAsync(2 * 60 * 60_000);
+
+    expect(get).toHaveBeenCalledTimes(120);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/plugins/plugin-elizacloud/src/services/cloud-container.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-container.ts
@@ -202,7 +202,27 @@ export class CloudContainerService
         return;
       }
 
-      const container = await this.getContainer(containerId);
+      // Backoff for the next poll; computed once so the failure branch below
+      // re-arms on exactly the schedule a successful poll would have used.
+      const delay = Math.min(baseInterval * 2 ** Math.min(attempt - 1, 3), maxInterval);
+
+      let container: CloudContainer;
+      try {
+        container = await this.getContainer(containerId);
+      } catch (error) {
+        // error-policy:J7 diagnostics must not kill the loop — a transient API
+        // failure counts as one attempt and the chain re-arms; the maxAttempts
+        // budget above still terminates it. Unhandled, this rejection escaped
+        // the setTimeout callback and froze the container at its last observed
+        // status for the life of the process.
+        logger.warn(
+          `[CloudContainer] Poll #${attempt} for ${containerId} failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        tracked.pollingTimer = setTimeout(poll, delay);
+        return;
+      }
       const status = container.status;
 
       logger.debug(`[CloudContainer] Poll #${attempt} for ${containerId}: status=${status}`);
@@ -224,7 +244,6 @@ export class CloudContainerService
       }
 
       // Schedule next poll with exponential backoff
-      const delay = Math.min(baseInterval * 2 ** Math.min(attempt - 1, 3), maxInterval);
       tracked.pollingTimer = setTimeout(poll, delay);
     };
 


### PR DESCRIPTION
# Relates to

Closes #30271 — one transient cloud API failure permanently kills container deployment polling and escapes as an unhandled rejection.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5-1`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `9c6fc21cce`; zero conflicts. Exact head `c92f9c86c9b2e864af9d6fd9d0d65fc8af30e46a`.

# Risks

Low and contained to the `poll` callback in `startPolling`. Successful polls are unchanged; the backoff delay is now computed once at the top of the callback so the failure branch re-arms on exactly the schedule a successful poll would have used. Failures still count against `maxAttempts`, so the chain cannot run forever — the third test pins that it stops at 120 with no timer left.

# Background

## What does this PR do?

`cloud-container.ts:205` awaited `this.getContainer(containerId)` inside a `setTimeout`-driven callback with no error handling. A rejection threw out before the reschedule at `:228`, so the chain died, and because nothing awaits a `setTimeout` callback the rejection was unhandled. The container then stayed at its last observed status until process restart; `startPolling` has only two callers (`createContainer`, `initialize`) and nothing re-arms a dead chain.

The catch is annotated `error-policy:J7` — a background job's transient dependency failure is warned and the loop continues; the existing `maxAttempts` timeout is the terminal condition.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-elizacloud/src/services/cloud-container.poll-resilience.test.ts` — three cases over the real service with fake timers and a stub auth client.

## Detailed testing steps

1. Check out exact head `c92f9c86c9b2e864af9d6fd9d0d65fc8af30e46a`.
2. From `plugins/plugin-elizacloud`: `bun x vitest run src/services/cloud-container.poll-resilience.test.ts` → **3/3**.
3. RED control — same tests against `origin/develop`'s `cloud-container.ts`: **2 failed | 1 passed**, plus vitest reporting the escaped `Unhandled Rejection: transient 503 from cloud API`.
4. Mutation kill — remove only the re-arm inside the catch: **2 failed | 1 passed** (both resilience cases).
5. Pinned Biome on both files: exit 0.

<!-- evidence-head:c92f9c86c9b2e864af9d6fd9d0d65fc8af30e46a -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — background service state with no rendered surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — background service state with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the RED control and mutation kill below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Reproduction against develop, RED control, green at head, mutation kill</summary>

```
# reproduction: real CloudContainerService, stub auth client, identical scenario twice (origin/develop)
HAPPY  (no failure):       getContainer calls in 12s = 2; tracked status = deploying
UNHANDLED REJECTION: transient 503 from cloud API
FAILED (1st poll rejects): getContainer calls in 12s = 1; tracked status = deploying

# RED control: this PR's tests vs origin/develop cloud-container.ts
 × re-arms the chain after a transient failure and still reaches running
   AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
 × counts failed polls against the attempt budget and stops at the limit
   AssertionError: expected "vi.fn()" to be called 120 times, but got 1 times
 Unhandled Rejection: Error: transient 503 from cloud API
      Tests  2 failed | 1 passed (3)

# head c92f9c86c9b2e864af9d6fd9d0d65fc8af30e46a
      Tests  3 passed (3)

# mutation -- catch no longer re-arms the chain
      Tests  2 failed | 1 passed (3)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic timer path with no model call.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Code path and static gates at exact head</summary>

```
develop cloud-container.ts:205  const container = await this.getContainer(containerId);   (no try/catch)
develop cloud-container.ts:228  reschedule -- unreachable once :205 throws
develop cloud-container.ts:231  setTimeout(poll, ...)  -- nothing awaits poll, so the rejection is unhandled
head    poll(): delay computed once; try { getContainer } catch { warn; re-arm with the same delay; return }

$ node_modules/.bin/biome check \
    plugins/plugin-elizacloud/src/services/cloud-container.ts \
    plugins/plugin-elizacloud/src/services/cloud-container.poll-resilience.test.ts
(exit 0, captured directly)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` was not run in this hand-wired review worktree; the focused suite, RED control, and mutation kill above are the evidence.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
