### PR TITLE
fix(coding-tools): reject a past-EOF offset before writing the line checkpoint

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/read.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.test.ts
@@ -171,6 +171,26 @@ describe("READ", () => {
     ).toEqual({ unit: "line", start: 2, end: 2, total: 2 });
   });
 
+  it("rejects a past-EOF line offset on the repeat call too", async () => {
+    const file = path.join(env.tmpDir, "past-eof.txt");
+    await fs.writeFile(file, "alpha\nbeta\n", "utf8");
+    await readFileHandler(env.runtime, env.message, undefined, {
+      parameters: { file_path: file, limit: 10 },
+    });
+
+    const first = await readFileHandler(env.runtime, env.message, undefined, {
+      parameters: { file_path: file, offset: 5, limit: 1 },
+    });
+    const second = await readFileHandler(env.runtime, env.message, undefined, {
+      parameters: { file_path: file, offset: 5, limit: 1 },
+    });
+
+    expect(first.success).toBe(false);
+    expect(first.text).toContain("line offset 5 exceeds total 2");
+    expect(second.success).toBe(false);
+    expect(second.text).toContain("line offset 5 exceeds total 2");
+  });
+
   it("accepts exact EOF from a cold line checkpoint after a byte-mode revision read", async () => {
     const file = path.join(env.tmpDir, "cold-eof.txt");
     await fs.writeFile(file, "alpha\nbeta\n", "utf8");

--- a/plugins/plugin-coding-tools/src/actions/read.ts
+++ b/plugins/plugin-coding-tools/src/actions/read.ts
@@ -356,9 +356,6 @@ export async function readFileHandler(
             checkpointByte,
             checkpointLine,
           );
-    if (unit === "line" && window.nextByte !== undefined) {
-      checkpoints.set(window.end, window.nextByte);
-    }
     if (
       unit === "line" &&
       window.total !== undefined &&
@@ -368,6 +365,9 @@ export async function readFileHandler(
         reason: "invalid_param",
         message: `line offset ${offset} exceeds total ${window.total}`,
       });
+    }
+    if (unit === "line" && window.nextByte !== undefined) {
+      checkpoints.set(window.end, window.nextByte);
     }
     const afterRevision = fileRevision(await handle.stat());
     if (afterRevision !== currentRevision)


### PR DESCRIPTION
Closes #30276

## The defect

`readFileHandler` caches the line checkpoint before it validates the offset, so a rejected past-EOF read still mutates `lineCheckpoints` and the identical retry then succeeds with a fabricated line total.

On a two-line file `alpha\nbeta\n`, after the required offset-0 read:

| Call | Input | Output on `develop` |
|---|---|---|
| 1 | `{ offset: 5, limit: 1 }` | `success: false` — `line offset 5 exceeds total 2` (correct) |
| 2 | `{ offset: 5, limit: 1 }` (identical) | `success: true`, `text: ""`, `range: { start: 5, end: 5, total: 5 }`, `completeness: "complete"` |

`plugins/plugin-coding-tools/src/actions/read.ts:358-370`: the write

```ts
if (unit === "line" && window.nextByte !== undefined) {
  checkpoints.set(window.end, window.nextByte);
}
```

runs ahead of the `offset > window.total` guard. For a past-EOF offset, `lineWindow` returns `end = offset` with `nextByte = size`, so the module-level checkpoint map (`read.ts:51`) is seeded with `5 -> <EOF byte>` and only then is the request rejected. On the retry the checkpoint selector (`read.ts:333-341`) picks that poisoned entry, `lineWindow` takes its `startByte >= size` branch and reports `total: startLine` — the bogus offset itself — so the guard no longer fires. A rejected read becomes an accepted empty read, and the file's line count is reported as the caller's bad offset.

## What changed

- Move the `offset > window.total` validation above the `checkpoints.set(...)` call so a rejected read never mutates the checkpoint map. Two adjacent blocks are swapped; nothing else in the handler changes.
- Every accepted read still writes its checkpoint, including the `offset === total` exact-EOF case already pinned by `read.test.ts`.

## Test

`plugins/plugin-coding-tools/src/actions/read.test.ts` gains the repeat-call assertion. Existing coverage has `offset == total`, the cold-checkpoint EOF case and the offset-0 gate — nothing called a past-EOF offset, and nothing repeated the same offset.

```ts
it("rejects a past-EOF line offset on the repeat call too", async () => {
  const file = path.join(env.tmpDir, "past-eof.txt");
  await fs.writeFile(file, "alpha\nbeta\n", "utf8");
  await readFileHandler(env.runtime, env.message, undefined, {
    parameters: { file_path: file, limit: 10 },
  });

  const first = await readFileHandler(env.runtime, env.message, undefined, {
    parameters: { file_path: file, offset: 5, limit: 1 },
  });
  const second = await readFileHandler(env.runtime, env.message, undefined, {
    parameters: { file_path: file, offset: 5, limit: 1 },
  });

  expect(first.success).toBe(false);
  expect(first.text).toContain("line offset 5 exceeds total 2");
  expect(second.success).toBe(false);
  expect(second.text).toContain("line offset 5 exceeds total 2");
});
```

Fails on `develop` at the `second.success` assertion (`expected true to be false`); passes with the reorder.

## Verification

Base: `8ade9fba1d55ccb840cdd57bd72958644a42d7be`

- `vitest run src/actions/read.test.ts` from `plugins/plugin-coding-tools`: 29 passed
- full package suite, `vitest run` from `plugins/plugin-coding-tools`: 42 files, 1026 passed, 1 skipped
- Biome on both changed files: clean

## Risk

Low. The reorder makes the handler idempotent, which is what the resumable-read contract requires. The only way to regress is a caller that depends on a past-EOF read being *eventually* accepted as an empty page — nothing in-repo does, and the first call already rejects it, so today's behaviour is already inconsistent between the first and second call. The exact-EOF acceptance path (`offset === total`) is untouched and still covered.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-operator-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza"} -->
