### PR TITLE
fix(plugin-blocker): reset the full policy on stopSelfControlBlock

### DIFF
--- a/plugins/plugin-blocker/src/services/website-blocker/engine-stop.test.ts
+++ b/plugins/plugin-blocker/src/services/website-blocker/engine-stop.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isWebsiteBlockedByPolicy,
+  resetSelfControlStatusCache,
+  startSelfControlBlock,
+  stopSelfControlBlock,
+} from "./engine.ts";
+
+/**
+ * Tests for the website-blocker UNBLOCK path (#8801 / #9943). The status
+ * returned by `stopSelfControlBlock` is what clients render and what
+ * `isWebsiteBlockedByPolicy` is asked about, so the policy fields have to be
+ * reset along with `active`. A temp hosts file keeps this off the real
+ * `/etc/hosts` — no elevation is needed because the temp file is writable.
+ */
+describe("stopSelfControlBlock", () => {
+  let tmpDir: string;
+  let hostsFilePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-blocker-stop-"));
+    hostsFilePath = path.join(tmpDir, "hosts");
+    fs.writeFileSync(hostsFilePath, "127.0.0.1 localhost\n", "utf8");
+    resetSelfControlStatusCache();
+  });
+
+  afterEach(() => {
+    resetSelfControlStatusCache();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty policy so the removed block no longer matches", async () => {
+    const config = { hostsFilePath, validateSystemResolution: false };
+    const started = await startSelfControlBlock(
+      { websites: ["example.com"], durationMinutes: null },
+      config,
+    );
+    expect(started.success).toBe(true);
+
+    const stopped = await stopSelfControlBlock(config);
+    if (stopped.success !== true) {
+      throw new Error(stopped.error);
+    }
+
+    expect(stopped.removed).toBe(true);
+    expect(stopped.status.active).toBe(false);
+    expect(stopped.status.websites).toEqual([]);
+    expect(stopped.status.blockedWebsites).toEqual([]);
+    expect(stopped.status.allowedWebsites).toEqual([]);
+    expect(stopped.status.requestedWebsites).toEqual([]);
+    expect(isWebsiteBlockedByPolicy(stopped.status, "example.com")).toBe(false);
+    expect(isWebsiteBlockedByPolicy(stopped.status, "www.example.com")).toBe(
+      false,
+    );
+  });
+
+  it("keeps the capability fields from the reconciled status", async () => {
+    const config = { hostsFilePath, validateSystemResolution: false };
+    await startSelfControlBlock(
+      { websites: ["example.com"], durationMinutes: null },
+      config,
+    );
+
+    const stopped = await stopSelfControlBlock(config);
+    if (stopped.success !== true) {
+      throw new Error(stopped.error);
+    }
+
+    expect(stopped.status.available).toBe(true);
+    expect(stopped.status.hostsFilePath).toBe(hostsFilePath);
+    expect(stopped.status.canUnblockEarly).toBe(true);
+    expect(stopped.status.engine).toBe("hosts-file");
+  });
+});

--- a/plugins/plugin-blocker/src/services/website-blocker/engine.ts
+++ b/plugins/plugin-blocker/src/services/website-blocker/engine.ts
@@ -907,6 +907,7 @@ export async function stopSelfControlBlock(
       startedAt: null,
       endsAt: null,
       websites: [],
+      ...EMPTY_SELF_CONTROL_BLOCK_POLICY,
       managedBy: null,
       metadata: null,
       scheduledByAgentId: null,


### PR DESCRIPTION
Closes #30278

## The defect

`stopSelfControlBlock` builds its success status by spreading the pre-unblock status and nulling fields one at a time. It nulls `active`, `startedAt`, `endsAt`, `websites`, `managedBy`, `metadata` and `scheduledByAgentId` — but not the four *policy* fields. `blockedWebsites`, `allowedWebsites`, `requestedWebsites` and `matchMode` survive the spread, so the status handed back for a block that was just removed still describes that block as blocking.

Start a block on `example.com` against a temp hosts file, then stop it:

| Field of the returned `status` | Expected | Actual on `develop` |
|---|---|---|
| `active` | `false` | `false` |
| `websites` | `[]` | `[]` |
| `blockedWebsites` | `[]` | `["example.com", "www.example.com"]` |
| `requestedWebsites` | `[]` | `["example.com"]` |
| `isWebsiteBlockedByPolicy(status, "example.com")` | `false` | `true` |

`plugins/plugin-blocker/src/services/website-blocker/engine.ts:901-914`:

```ts
return {
  success: true,
  removed: true,
  status: {
    ...status,
    active: false,
    startedAt: null,
    endsAt: null,
    websites: [],
    managedBy: null,
    metadata: null,
    scheduledByAgentId: null,
  },
};
```

`isWebsiteBlockedByPolicy` (`engine.ts:279`) reads exactly `blockedWebsites` / `allowedWebsites` / `matchMode`, so it answers `true` for a site whose block was just removed. This is the only "no block active" status construction in the file that does not reset the policy: the other six (`engine.ts:340`, `:365`, `:397`, `:428`, `:451`, `:482`) all spread `EMPTY_SELF_CONTROL_BLOCK_POLICY`, defined at `engine.ts:220` precisely to zero these four fields together.

## What changed

One line: the success return now spreads `...EMPTY_SELF_CONTROL_BLOCK_POLICY` alongside the other nulled fields, the way every other no-block construction in the file does. Nothing else in the handler moves.

The spread is placed after `websites: []` and before `managedBy`, matching the position it occupies in the six existing sites. The capability fields carried over from the reconciled status — `available`, `hostsFilePath`, `canUnblockEarly`, `requiresElevation`, `supportsElevationPrompt`, `elevationPromptMethod`, `engine`, `platform` — are untouched; only the policy is reset.

## Test

New file `plugins/plugin-blocker/src/services/website-blocker/engine-stop.test.ts`, following the existing `engine-hosts.test.ts` naming. It drives the real `startSelfControlBlock` / `stopSelfControlBlock` pair against a temp hosts file through the injectable `SelfControlPluginConfig.hostsFilePath`, so nothing touches `/etc/hosts` and no elevation is involved (the temp file is writable, so `canUnblockEarly` is `true` and the write goes through plain `fs.writeFileSync`). `validateSystemResolution: false` keeps the reconcile pass off DNS.

```ts
const stopped = await stopSelfControlBlock(config);
if (stopped.success !== true) {
  throw new Error(stopped.error);
}

expect(stopped.removed).toBe(true);
expect(stopped.status.active).toBe(false);
expect(stopped.status.websites).toEqual([]);
expect(stopped.status.blockedWebsites).toEqual([]);
expect(stopped.status.allowedWebsites).toEqual([]);
expect(stopped.status.requestedWebsites).toEqual([]);
expect(isWebsiteBlockedByPolicy(stopped.status, "example.com")).toBe(false);
```

On `develop` this fails at the `blockedWebsites` assertion — the assertions above it (`active`, `websites`) already pass, which pins the defect to the un-nulled policy fields rather than to the unblock itself:

```
AssertionError: expected [ 'example.com', 'www.example.com' ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "example.com",
+   "www.example.com",
+ ]
```

A second case asserts the capability fields (`available`, `hostsFilePath`, `canUnblockEarly`, `engine`) still come through, so the fix cannot be "reset everything". It passes both before and after.

The existing `engine.test.ts` covers `buildSelfControlBlockPolicy` and `isWebsiteBlockedByPolicy` as pure functions only; no test previously exercised the stop path's return shape.

## Verification

Base: `8ade9fba1d55ccb840cdd57bd72958644a42d7be`

- `vitest run --config ./vitest.config.ts src/services/website-blocker/engine-stop.test.ts` from `plugins/plugin-blocker`: 2 passed (1 failed before the fix)
- full package suite, `vitest run --config ./vitest.config.ts` from `plugins/plugin-blocker`: 5 files / 33 tests passed, 2 suites fail to collect. Both are pre-existing and unrelated to this change — `test/blocker.real-db.test.ts` (`Cannot find package '@elizaos/core/testing'`) and `src/components/focus/FocusView.test.tsx` (`Failed to resolve import "@capacitor/preferences"`). Both fail identically on a clean checkout of this base with the patch stashed.
- Biome on both changed files: clean.

## Risk

Low. The only way to regress is a consumer that reads `blockedWebsites` off a `removed: true` response to render "you just unblocked these sites". Both known consumers were checked and neither does:

- `plugin-personal-assistant/src/routes/website-blocker-routes.ts:164-180` gates on `status.active` before reading the policy (`status.active && isWebsiteBlockedByPolicy(...)`, and `websites: status.active ? status.blockedWebsites : []`), so the stale policy could only have produced a wrong answer here through the separately-cached `getSelfControlStatus` path; after the fix the stop response is consistent with it either way.
- `plugin-blocker/src/components/focus/FocusView.tsx:97-108` only puts `blockedWebsites` into the snapshot on the `status.active` branch; the inactive branch returns `{ phase: "empty" }`. `FocusSpatialView.tsx:146` reads that snapshot field and is therefore only reached while active.

The `removed` boolean and the already-emptied `websites` array carry the outcome of the stop, so nothing loses information. `status.active === false` is unchanged, so any consumer already gating on it sees no difference.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-operator-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@ffc07b0ca4888df20faee5b490181dbcaae5cc91:skills/contribute-to-eliza"} -->
