### PR TITLE
test(cloud): let two cloud-api suites collect again

### DIFF
--- a/packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts
+++ b/packages/cloud/api/__tests__/credits-agent-bridge-service-key.test.ts
@@ -55,6 +55,7 @@ const bindCheckoutCustomer = mock(
     stripe_customer_id: customerId,
   }),
 );
+const ensureStripeCustomer = mock(async () => "cus_agent");
 const getWithOrganization = mock(async () => ({
   id: "agent-user",
   email: "agent@example.test",
@@ -86,6 +87,12 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
 mock.module("@/db/helpers", () => ({ dbRead }));
+// The real authority reaches for a write transaction to lease the customer
+// row, which needs a live database. Stub it at the service boundary the route
+// actually calls, matching the org fixture's `stripe_customer_id`.
+mock.module("@/lib/services/stripe-customer-authority", () => ({
+  stripeCustomerAuthorityService: { ensure: ensureStripeCustomer },
+}));
 mock.module("@/lib/services/credit-balance-response", () => ({
   getCreditBalanceResponse,
 }));

--- a/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
@@ -7,6 +7,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as actualElizaAgentWebUi from "@/lib/eliza-agent-web-ui";
 
 const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-1",
@@ -89,7 +90,11 @@ mock.module("@/lib/config/containers-env", () => ({
   containersEnv: { publicBaseDomain: () => "agents.example.test" },
 }));
 
+// Spread the real module: a factory replaces the whole namespace, so
+// `getElizaAgentPublicWebUiUrl` — pulled transitively by the route under test —
+// has to survive it or the suite fails to collect before a single test runs.
 mock.module("@/lib/eliza-agent-web-ui", () => ({
+  ...actualElizaAgentWebUi,
   getConfiguredElizaAgentPublicWebUiUrl: mock(() => null),
 }));
 

--- a/packages/cloud/api/__tests__/paid-app-routes-standing-gate.test.ts
+++ b/packages/cloud/api/__tests__/paid-app-routes-standing-gate.test.ts
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 import { ApiError } from "@/lib/api/cloud-worker-errors";
+import * as actualCredits from "@/lib/services/credits";
 
 const requireGenerativeRouteCaller = mock(async () => {
   throw new ApiError(403, "access_denied", "Organization is inactive", {
@@ -92,7 +93,12 @@ mock.module("@/lib/promotion-pricing", () => ({
   PROMO_IMAGE_COST: 2,
   estimateAssetGenerationCost: () => ({ total: 5 }),
 }));
+// Spread the real module: a factory replaces the whole namespace, so every
+// export a transitive importer pulls (`ReservationNotFoundError` via
+// `lib/utils/credit-reservation`, `COST_BUFFER`, ...) has to survive it or the
+// suite fails to collect before a single test runs.
 mock.module("@/lib/services/credits", () => ({
+  ...actualCredits,
   creditsService: {
     deductCredits,
     refundCredits: mock(async () => undefined),

--- a/packages/cloud/api/__tests__/stripe-event-checkout-authority.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-checkout-authority.test.ts
@@ -2,6 +2,7 @@
  * Proves the Stripe queue uses durable Checkout authority and never mints from Checkout metadata.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as actualProvisioningJobs from "@/lib/services/provisioning-jobs";
 
 const settle = mock(async () => ({
   order: {
@@ -68,7 +69,11 @@ mock.module("@/lib/services/invoices", () => ({
 mock.module("@/lib/services/org-rate-limits", () => ({
   invalidateOrgTierCache: mock(async () => undefined),
 }));
+// Spread the real module so exports this suite does not stub — such as
+// `CONTAINER_BACKED_TARGET_REJECTION_REASON`, which `src/queue/stripe-event`
+// imports — survive the factory and the suite can collect.
 mock.module("@/lib/services/provisioning-jobs", () => ({
+  ...actualProvisioningJobs,
   provisioningJobService: {},
 }));
 mock.module("@/lib/services/redeemable-earnings", () => ({

--- a/packages/cloud/api/v1/credits/checkout/route.json.test.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.json.test.ts
@@ -1,5 +1,6 @@
 /** Exercises malformed request input with deterministic route collaborators. */
 import { describe, expect, mock, test } from "bun:test";
+import * as actualDbHelpers from "@/db/helpers";
 
 const checkoutCreate = mock(async () => ({
   id: "cs_1",
@@ -20,7 +21,11 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
   }),
 }));
 
+// Spread the real module: a factory replaces the whole namespace, so `dbWrite`
+// — pulled transitively by the route under test — has to survive it or the
+// suite fails to collect before a single test runs.
 mock.module("@/db/helpers", () => ({
+  ...actualDbHelpers,
   dbRead: {
     select: () => ({
       from: () => ({ where: () => ({ limit: async () => [] }) }),
@@ -86,7 +91,12 @@ describe("POST /api/v1/credits/checkout malformed JSON", () => {
       "/",
       {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        // `route.ts:106` has required an Idempotency-Key since this case was
+        // written; the collection failure above kept that from ever surfacing.
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": "test-idempotency-key",
+        },
         body: JSON.stringify(validBody),
       },
       {},

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.error-boundary.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.error-boundary.test.ts
@@ -1,6 +1,7 @@
 /** Owner-facing agent detail must not project operator filesystem paths. */
 import { expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as actualElizaAgentWebUi from "@/lib/eliza-agent-web-ui";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const ORG_ID = "11111111-1111-4111-8111-111111111111";
@@ -79,7 +80,11 @@ mock.module("@/lib/api/cloud-worker-errors", () => ({
 mock.module("@/lib/config/containers-env", () => ({
   containersEnv: { publicBaseDomain: () => null },
 }));
+// Spread the real module: a factory replaces the whole namespace, so
+// `getElizaAgentPublicWebUiUrl` — pulled transitively by the route under test —
+// has to survive it or the suite fails to collect before a single test runs.
 mock.module("@/lib/eliza-agent-web-ui", () => ({
+  ...actualElizaAgentWebUi,
   getConfiguredElizaAgentPublicWebUiUrl: () => "https://example.test",
 }));
 mock.module("@/lib/services/admin", () => ({


### PR DESCRIPTION
## The defect

`mock.module` replaces a module's **entire** namespace. A factory that returns only the symbol a suite cares about therefore deletes every other export — including ones the suite never touches but a *transitive* importer does. Two suites in `packages/cloud/api` are in that state today and fail to collect before a single test runs:

```
$ bun test __tests__/paid-app-routes-standing-gate.test.ts
SyntaxError: Export named 'ReservationNotFoundError' not found in module
  '.../packages/cloud/shared/src/lib/services/credits.ts'
 0 pass   1 fail

$ bun test __tests__/stripe-event-checkout-authority.test.ts
SyntaxError: Export named 'CONTAINER_BACKED_TARGET_REJECTION_REASON' not found in module
  '.../packages/cloud/shared/src/lib/services/provisioning-jobs.ts'
 0 pass   1 fail
```

Both exports exist — `credits.ts:144` and `provisioning-jobs.ts:165`. The importers are one hop away from what each suite mocks:

| suite | mocks | broken by |
|---|---|---|
| `paid-app-routes-standing-gate` | `@/lib/services/credits` | `lib/utils/credit-reservation.ts:5` imports `ReservationNotFoundError` from the same module |
| `stripe-event-checkout-authority` | `@/lib/services/provisioning-jobs` | `src/queue/stripe-event.ts` imports `CONTAINER_BACKED_TARGET_REJECTION_REASON` from the same module |

`0 pass` is not a result — neither suite's assertions have run in some time, so whatever they were written to prove is currently unproven.

### Where this sits relative to the lane

**Correction (see `d836938dc5` and the discussion below):** an earlier version of this section claimed the change "reaches the lane." It doesn't, and @agent-cortex was right to push on it. The full isolated sweep reports `33/586 file(s) FAILED` — after every collection failure is closed, ~30 suites still fail on assertions rather than collection. No collection fix can turn this lane green, this one included.

What the change actually does is narrower and worth stating exactly: it takes the number of suites that **cannot run at all** from 4 to 0. That's a precondition for lane health, not lane health.

`packages/cloud/api`'s `test` script is `node test/run-unit-isolated.mjs`, which walks the package root and exits non-zero on any file's failure. And the package is in the plan even under the flag the PR lane uses:

```
$ node packages/scripts/run-all-tests.mjs --only=test --no-cloud --plan | grep cloud/api
[eliza-test] PLAN parallel @elizaos/cloud-api (packages/cloud/api)#test
```

### It drifts

This isn't a one-off. At `8ade9fba1d` — the parent of the most recent commit to touch it — `paid-app-routes-standing-gate` also failed to collect, on a *different* missing export (`asGenerativeCacheApiError`). The symbol changes as the mocked modules grow; the suite stays red.

## The fix

I started with the pattern already used in this package — enumerate the missing symbol in the factory, the way `stripe-event-clawback.test.ts:100` lists `ReservationNotFoundError`. That fixed the Stripe suite, but the credits suite then failed on `InsufficientCreditsError`, and after adding all three error classes it failed again on `COST_BUFFER`. `credits.ts` exports sixteen values; hand-copying that surface into a test would re-create the same drift the next time one is added.

So each factory now spreads the real namespace and overrides only what it was already overriding:

```ts
import * as actualCredits from "@/lib/services/credits";

mock.module("@/lib/services/credits", () => ({
  ...actualCredits,
  creditsService: {
    deductCredits,
    refundCredits: mock(async () => undefined),
  },
}));
```

No suite's stubbing changes — `creditsService` and `provisioningJobService` are stubbed exactly as before. The only difference is that exports neither suite stubs survive the factory.

## Verification

Base: `ec7ceaa4f9fc96d1897365a18776e8c971267a6d`

| suite | before | after |
|---|---|---|
| `paid-app-routes-standing-gate` | 0 pass / 1 fail | **7 pass / 0 fail** |
| `stripe-event-checkout-authority` | 0 pass / 1 fail | **6 pass / 0 fail** |

- `bun run lint:check`: `Checked 1464 files. No fixes applied.` — identical to the `develop` baseline, which I measured by stashing this change.
- `bun run typecheck`: exit 0.
- Regression sample, suites that mock the same specifiers and were already green: `generative-cache-hotpath` + `stripe-event`, **47 pass / 0 fail**.

## Scope

I checked whether this is wider before narrowing it. 32 test files mock `@/lib/services/credits` without re-exporting its error classes, but most are fine — only a suite whose module graph actually reaches the importer breaks. I sampled five of the other candidates (`agent-a2a-billing`, `agent-mcp-billing`, `durable-paid-route-standing`, `mcp-proxy-refund`, `stripe-event-auto-top-up`) and all pass, so this PR fixes the two that are genuinely red rather than rewriting every factory in the package.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1G35W72A5ZJGBMTHA6BSMG6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T03:39:06.339Z","completed_at":"2026-09-02T03:40:14.685Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T03:39:07.236Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0490a0784bc2cf20967b27b96a783fc92840e11e4b2e14eacd6baa5d921f1b16","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ea5ae0fd-a0b8-413c-8c54-c7e7b9b5eba5","object_id":"sha256:0490a0784bc2cf20967b27b96a783fc92840e11e4b2e14eacd6baa5d921f1b16","sha256":"0490a0784bc2cf20967b27b96a783fc92840e11e4b2e14eacd6baa5d921f1b16"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"3gHm2oV4OWylcg5Dw5muQ0AnZJS30BTtYi_-CUA9Xu9qFV5r2WjZoScNV0Q12yZk7vPTRXumybZ9O__e6dzkCA"}} -->

