### PR TITLE
test(cloud): pin the deferred credential admission guard's disposal branches

### DIFF
--- a/packages/cloud/shared/src/lib/services/deferred-credential-admission-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/deferred-credential-admission-guard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Pins the two branches of the deferred guard's async disposal that decide
+ * whether a strong credential proof is checked, skipped, or reported missing.
+ * Both are reachable only through `Symbol.asyncDispose`, so no route test
+ * exercises them directly.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { deferredCredentialAdmissionGuard } from "./deferred-credential-admission-guard";
+import type { InferenceCredentialCheck } from "./inference-credential-revocation";
+
+const CREDENTIAL: InferenceCredentialCheck = {
+  kind: "api_key",
+  credentialId: "cred_1",
+  userId: "user_1",
+};
+
+async function disposeOf(guard: AsyncDisposable): Promise<void> {
+  await guard[Symbol.asyncDispose]();
+}
+
+describe("deferredCredentialAdmissionGuard disposal", () => {
+  test("a credential with no organization is reported, not silently dropped", async () => {
+    const guard = deferredCredentialAdmissionGuard({
+      organizationId: () => undefined,
+      credential: () => CREDENTIAL,
+    });
+
+    await expect(disposeOf(guard)).rejects.toThrow(
+      "Deferred inference credential is missing its organization",
+    );
+  });
+
+  test("no credential means nothing to check, so no organization is required", async () => {
+    const guard = deferredCredentialAdmissionGuard({
+      organizationId: () => undefined,
+      credential: () => undefined,
+    });
+
+    await expect(disposeOf(guard)).resolves.toBeUndefined();
+  });
+
+  test("taking the credential for admission suppresses the standalone check", async () => {
+    const guard = deferredCredentialAdmissionGuard({
+      organizationId: () => undefined,
+      credential: () => CREDENTIAL,
+    });
+
+    expect(guard.credentialForAdmission()).toEqual(CREDENTIAL);
+    await expect(disposeOf(guard)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #30265, which landed the guard. This adds tests only — no behaviour change.

## What isn't covered

`deferredCredentialAdmissionGuard` decides, during async disposal, whether a deferred strong credential proof is **checked**, **skipped**, or **reported as missing its organization**:

```ts
async [Symbol.asyncDispose](): Promise<void> {
  const credential = params.credential();
  if (admissionStarted || !credential) return;
  const organizationId = params.organizationId();
  if (!organizationId) {
    throw new Error("Deferred inference credential is missing its organization");
  }
  const { assertInferenceCredentialActive } = await import("./inference-credential-revocation");
  await assertInferenceCredentialActive(organizationId, credential);
}
```

All three outcomes live behind `Symbol.asyncDispose`. The routes that use the guard reach it only through `credentialForAdmission()`, so nothing exercises the disposal path directly.

I measured that rather than assuming it. Against the suites that do cover the guard — `generative-cache-hotpath` and `generative-route-auth`, **81 pass / 0 fail** — these three mutations all survive:

| mutation | existing suites |
|---|---|
| `if (admissionStarted \|\| !credential) return;` → `if (admissionStarted) return;` | **81 pass — survives** |
| `if (!organizationId) { throw ... }` → `if (!organizationId) { return; }` | **81 pass — survives** |
| `admissionStarted = true;` → `admissionStarted = false;` | **81 pass — survives** |

The middle one is the reason I bothered. It converts a fail-closed report — a credential that reached disposal without ever reaching an admission boundary — into a silent drop, and the whole point of the guard is that "every deferred strong credential proof reaches exactly one admission boundary" (its own file header). Nothing today would notice that regression.

## What this adds

One colocated suite, `deferred-credential-admission-guard.test.ts`, next to the existing `inference-credential-revocation.test.ts` and following its style. Three tests, one per branch:

- a credential with no organization is reported, not silently dropped
- no credential means nothing to check, so no organization is required
- taking the credential for admission suppresses the standalone check

Each mutation above fails **exactly one** of them and no others:

```
drop the !credential short-circuit        2 pass / 1 fail
missing organization returns              2 pass / 1 fail
credentialForAdmission clears the flag    2 pass / 1 fail
baseline                                  3 pass / 0 fail
```

The tests need no bindings, env, or network — every case passes an `undefined` organization id, so disposal decides before it would reach `assertInferenceCredentialActive`. That keeps them fast (6 ms) and keeps the revocation Durable Object out of the picture, which `inference-credential-revocation.test.ts` already covers separately.

## Verification

Base: `ec7ceaa4f9fc96d1897365a18776e8c971267a6d`

- `bun test src/lib/services/deferred-credential-admission-guard.test.ts` — **3 pass / 0 fail**
- `bun run lint:check` — `Checked 2564 files. No fixes applied.`
- `bun run typecheck` — exit 0
- `scripts/run-bun-tests.mjs` discovers tests by walking the package directory, so the colocated file is collected by `@elizaos/cloud-shared#test` without any manifest change.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1G3E83Q401AY5NW2RZYS013","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T03:43:40.663Z","completed_at":"2026-09-02T03:44:35.939Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T03:43:40.979Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a7a72342bd42e3b711cee0040ebd157db5bb1dce4551f55ba6bd6ffc2a501b67","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"be0f7445-8cd4-4dbc-ab00-8e9cb207993d","object_id":"sha256:a7a72342bd42e3b711cee0040ebd157db5bb1dce4551f55ba6bd6ffc2a501b67","sha256":"a7a72342bd42e3b711cee0040ebd157db5bb1dce4551f55ba6bd6ffc2a501b67"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"CxmnfDRQ7NzmcoLU0NIHfz7RjEZFKiAqsUDXf9l5N6uzQ2y9nMFY_OIFWAWfrnWagoZxp4knxn7hl2tp77ahCw"}} -->
