### PR TITLE
fix(agent): bound the retention sweep cadence to the timer range

### DIFF
--- a/packages/agent/src/runtime/memory-retention-service.test.ts
+++ b/packages/agent/src/runtime/memory-retention-service.test.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveRetentionConfig } from "./memory-retention.ts";
 import {
   MEMORY_RETENTION_SERVICE,
@@ -267,6 +267,39 @@ describe("MemoryRetentionService.start / stop", () => {
     // @ts-expect-error private resolved config
     expect(svc.retentionConfig.retentionDays).toBe(30);
     await svc.stop();
+  });
+});
+
+describe("MemoryRetentionService.start — monthly cadence", () => {
+  const START_DELAY_MS = 30_000; // mirrors the service's boot-settle delay
+
+  it("does not degrade a monthly cadence into a continuous sweep loop", async () => {
+    vi.useFakeTimers();
+    const sweep = vi
+      .spyOn(MemoryRetentionService.prototype, "sweep")
+      .mockResolvedValue([]);
+    try {
+      const svc = await MemoryRetentionService.start(
+        makeRuntime({
+          adapter: new FakeAdapter(),
+          settings: {
+            ELIZA_MEMORY_RETENTION_DAYS: "7",
+            ELIZA_MEMORY_RETENTION_INTERVAL_MINUTES: "43200",
+          },
+        }),
+      );
+      // Past the boot-settle delay: exactly the first sweep has run.
+      await vi.advanceTimersByTimeAsync(START_DELAY_MS + 1);
+      expect(sweep).toHaveBeenCalledTimes(1);
+      // A full fake hour later a monthly cadence must not have fired again.
+      // Unbounded, setInterval overflowed to a 1 ms delay and this was ~3.6M.
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      expect(sweep).toHaveBeenCalledTimes(1);
+      await svc.stop();
+    } finally {
+      sweep.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/agent/src/runtime/memory-retention.test.ts
+++ b/packages/agent/src/runtime/memory-retention.test.ts
@@ -16,6 +16,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  MAX_RETENTION_INTERVAL_MINUTES,
   planRetention,
   policyIsActive,
   type RetainableRow,
@@ -143,6 +144,44 @@ describe("planRetention — pure planner", () => {
     const plan = planRetention(rows, { retentionDays: 7 }, NOW);
     expect(plan.deleteIds).toEqual(["old"]);
     expect(plan.deleteIds).not.toContain("noTs");
+  });
+});
+
+describe("resolveRetentionConfig — sweep cadence bound", () => {
+  const INT32_MAX_MS = 2 ** 31 - 1;
+
+  it("bounds a cadence the timer cannot represent so setInterval never overflows", () => {
+    // "Once a month" is the value an operator reaches for, and it is past the
+    // 32-bit timer range: unbounded, Node/Bun clamp the delay to 1 ms.
+    const cfg = resolveRetentionConfig(
+      (k) => ({ ELIZA_MEMORY_RETENTION_INTERVAL_MINUTES: "43200" })[k],
+    );
+    expect(cfg.intervalMinutes).toBe(MAX_RETENTION_INTERVAL_MINUTES);
+    expect((cfg.intervalMinutes ?? 0) * 60 * 1000).toBeLessThanOrEqual(
+      INT32_MAX_MS,
+    );
+  });
+
+  it("leaves a representable cadence untouched, including the exact bound", () => {
+    const at = resolveRetentionConfig(
+      (k) =>
+        ({
+          ELIZA_MEMORY_RETENTION_INTERVAL_MINUTES: String(
+            MAX_RETENTION_INTERVAL_MINUTES,
+          ),
+        })[k],
+    );
+    expect(at.intervalMinutes).toBe(MAX_RETENTION_INTERVAL_MINUTES);
+    const under = resolveRetentionConfig(
+      (k) => ({ ELIZA_MEMORY_RETENTION_INTERVAL_MINUTES: "1440" })[k],
+    );
+    expect(under.intervalMinutes).toBe(1440);
+    expect(MAX_RETENTION_INTERVAL_MINUTES * 60 * 1000).toBeLessThanOrEqual(
+      INT32_MAX_MS,
+    );
+    expect((MAX_RETENTION_INTERVAL_MINUTES + 1) * 60 * 1000).toBeGreaterThan(
+      INT32_MAX_MS,
+    );
   });
 });
 

--- a/packages/agent/src/runtime/memory-retention.ts
+++ b/packages/agent/src/runtime/memory-retention.ts
@@ -170,9 +170,23 @@ function tsOf(row: RetainableRow, nowMs: number): number {
  * zero-retention-delete-everything.
  */
 export interface ResolvedRetentionConfig extends RetentionPolicy {
-  /** Sweep cadence in minutes. Undefined => service default. */
+  /**
+   * Sweep cadence in minutes. Undefined => service default. Never above
+   * {@link MAX_RETENTION_INTERVAL_MINUTES}.
+   */
   intervalMinutes?: number;
 }
+
+/**
+ * Longest sweep cadence a JS timer can hold. `setInterval` takes a 32-bit
+ * signed millisecond delay; a cadence past it (a "monthly" 43200 minutes is
+ * the common one) overflows and the runtime resets the delay to 1 ms, turning
+ * the sweep into a continuous loop. The services log the effective cadence at
+ * startup, so a bounded value is visible rather than silently different.
+ */
+export const MAX_RETENTION_INTERVAL_MINUTES = Math.floor(
+  (2 ** 31 - 1) / (60 * 1000),
+);
 
 export function resolveRetentionConfig(
   get: (key: string) => string | undefined,
@@ -204,10 +218,17 @@ export function resolveRetentionConfigWithPrefix(
     maxDeletePerSweep: positiveIntegerOrUndefined(
       get(`${prefix}_MAX_DELETE_PER_SWEEP`),
     ),
-    intervalMinutes: positiveNumberOrUndefined(
-      get(`${prefix}_INTERVAL_MINUTES`),
+    intervalMinutes: boundedIntervalMinutes(
+      positiveNumberOrUndefined(get(`${prefix}_INTERVAL_MINUTES`)),
     ),
   };
+}
+
+function boundedIntervalMinutes(
+  minutes: number | undefined,
+): number | undefined {
+  if (minutes === undefined) return undefined;
+  return Math.min(minutes, MAX_RETENTION_INTERVAL_MINUTES);
 }
 
 function positiveNumberOrUndefined(


### PR DESCRIPTION
# Relates to

Closes #30284 — a retention sweep cadence over ~24.85 days overflows `setInterval` and runs the sweep every 1 ms.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5-1`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `ec7ceaa4f9`; zero conflicts. Exact head `255e35ce98d8d17de5afd8a72eb50c7f1376649c`.

# Risks

Low, confined to the shared resolver in `memory-retention.ts`. Every cadence that was representable before resolves identically (the exact bound, `35791`, is pinned unchanged, as is `1440`); only values the timer could never hold are bounded. Both services already log `intervalMinutes=` at startup, so the effective cadence is visible without touching them.

# Background

## What does this PR do?

`resolveRetentionConfigWithPrefix` (`memory-retention.ts`) accepted any positive finite `*_INTERVAL_MINUTES`, and both `logs-retention-service.ts:145` and `memory-retention-service.ts:134` multiply it into `setInterval`. A "monthly" `43200` overflows the 32-bit delay; the runtime emits `TimeoutOverflowWarning` and sets the delay to 1 ms, so the sweep runs continuously. The resolver now bounds the cadence at the exported `MAX_RETENTION_INTERVAL_MINUTES` (the longest representable one).

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`memory-retention-service.test.ts`, `"does not degrade a monthly cadence into a continuous sweep loop"` — it starts the real service with `INTERVAL_MINUTES=43200` under fake timers and asserts exactly one sweep after a full fake hour. On develop that assertion sees millions.

## Detailed testing steps

1. Check out exact head `255e35ce98d8d17de5afd8a72eb50c7f1376649c`.
2. From `packages/agent`: `bun x vitest run src/runtime/memory-retention.test.ts src/runtime/memory-retention-service.test.ts src/runtime/logs-retention-service.test.ts` → all green (see log).
3. RED control — the three new cases against develop's resolver: the resolver cases fail (`43200` resolves unbounded) and the service case fails on the sweep count.
4. Mutation kill — replace `Math.min(minutes, MAX_…)` with `minutes` (export kept): the bound cases fail, the untouched-cadence case still passes.
5. Pinned Biome on all three files: exit 0.

<!-- evidence-head:255e35ce98d8d17de5afd8a72eb50c7f1376649c -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — background sweep with no rendered surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — background sweep with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the reproduction, RED control and mutation kill below are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>Reproduction against develop, RED control, green at head, mutation kill</summary>

```
# reproduction: real resolver + the services' exact multiply (origin/develop)
resolved config: {"retentionDays":30,"intervalMinutes":43200}
delay passed to setInterval: 2592000000 | int32 max: 2147483647
TimeoutOverflowWarning: 2592000000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
sweep callback fired 37 times in 50ms (expected 0 for a monthly cadence)

# RED control: new cases vs develop resolver
 × bounds a cadence the timer cannot represent so setInterval never overflows
   AssertionError: expected 43200 to be undefined
 × does not degrade a monthly cadence into a continuous sweep loop
   (sweep count assertion fails: the 1 ms interval fires continuously)

# head 255e35ce98d8d17de5afd8a72eb50c7f1376649c  (memory-retention, memory-retention-service, logs-retention-service)
      all passed -- see CI

# mutation -- Math.min(minutes, MAX) -> minutes
 × bounds a cadence the timer cannot represent so setInterval never overflows
 × does not degrade a monthly cadence into a continuous sweep loop
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — deterministic config/timer path with no model call.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Code path and static gates at exact head</summary>

```
develop memory-retention.ts:220   if (!Number.isFinite(n) || n <= 0) return undefined;   <- no upper bound
develop logs-retention-service.ts:145 / memory-retention-service.ts:134   intervalMinutes * 60 * 1000 -> setInterval
head    memory-retention.ts   export const MAX_RETENTION_INTERVAL_MINUTES = floor((2^31-1) / 60000)  (= 35791)
head    memory-retention.ts   intervalMinutes: boundedIntervalMinutes(positiveNumberOrUndefined(...))

$ node_modules/.bin/biome check packages/agent/src/runtime/memory-retention.ts \
    packages/agent/src/runtime/memory-retention.test.ts packages/agent/src/runtime/memory-retention-service.test.ts
(exit 0, captured directly)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run verify` was not run in this hand-wired review worktree; the focused suites, RED control and mutation kill above are the evidence.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
