### PR TITLE
fix(cli-inference): decode CLI child stdio as a UTF-8 stream

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/default-spawn-utf8.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/default-spawn-utf8.test.ts
@@ -5,6 +5,7 @@
  * own turns it into two U+FFFD in the text generate() returns. Real child
  * process (node -e), no mocks: the split is produced by two separate writes.
  */
+import { devNull } from "node:os";
 import { describe, expect, it } from "vitest";
 import { defaultSpawn } from "../src/claude-cli";
 
@@ -12,7 +13,7 @@ const OPTS = {
   cwd: process.cwd(),
   env: { PATH: process.env.PATH ?? "" } as Record<string, string>,
   timeoutMs: 5_000,
-  stdinPath: "/dev/null",
+  stdinPath: devNull,
 };
 
 function splitWriter(stream: "stdout" | "stderr", first: number[], rest: number[]): string {

--- a/plugins/plugin-cli-inference/__tests__/default-spawn-utf8.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/default-spawn-utf8.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Byte-boundary coverage for the shared CLI spawner. The model's reply comes
+ * back through the child's stdout pipe in chunks, so a multi-byte code point
+ * split across two reads must be reassembled — decoding each chunk on its
+ * own turns it into two U+FFFD in the text generate() returns. Real child
+ * process (node -e), no mocks: the split is produced by two separate writes.
+ */
+import { describe, expect, it } from "vitest";
+import { defaultSpawn } from "../src/claude-cli";
+
+const OPTS = {
+  cwd: process.cwd(),
+  env: { PATH: process.env.PATH ?? "" } as Record<string, string>,
+  timeoutMs: 5_000,
+  stdinPath: "/dev/null",
+};
+
+function splitWriter(stream: "stdout" | "stderr", first: number[], rest: number[]): string {
+  return (
+    `process.${stream}.write(Buffer.from([${first.join(",")}]));` +
+    `setTimeout(()=>{process.${stream}.write(Buffer.from([${rest.join(",")}]));},80);`
+  );
+}
+
+describe("defaultSpawn decodes child stdio as a UTF-8 stream", () => {
+  it("reassembles a two-byte code point split across stdout reads", async () => {
+    // "é" is 0xC3 0xA9; the 80ms gap forces two separate pipe reads.
+    const result = await defaultSpawn(
+      [process.execPath, "-e", splitWriter("stdout", [0xc3], [0xa9])],
+      OPTS
+    );
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("é");
+  });
+
+  it("reassembles a three-byte code point split across stderr reads", async () => {
+    // "世" is 0xE4 0xB8 0x96.
+    const result = await defaultSpawn(
+      [process.execPath, "-e", splitWriter("stderr", [0xe4], [0xb8, 0x96])],
+      OPTS
+    );
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe("世");
+  });
+
+  it("leaves whole-chunk ASCII output untouched", async () => {
+    const result = await defaultSpawn(
+      [process.execPath, "-e", "process.stdout.write('plain text')"],
+      OPTS
+    );
+    expect(result.stdout).toBe("plain text");
+  });
+});

--- a/plugins/plugin-cli-inference/src/claude-cli.ts
+++ b/plugins/plugin-cli-inference/src/claude-cli.ts
@@ -176,11 +176,16 @@ export const defaultSpawn: SpawnFn = (argv, opts) =>
       closeStdinFd();
     };
 
-    child.stdout?.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString("utf8");
+    // Preserve code points split across OS pipe reads before accumulating:
+    // stdout is the model's reply, so a per-chunk decode would hand the user
+    // U+FFFD wherever a multi-byte character straddled a 64 KiB boundary.
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
     });
-    child.stderr?.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
     });
     child.on("error", (err) => {
       clearTimers();


### PR DESCRIPTION
# Relates to

Closes #30288 — the CLI inference spawner mangles non-ASCII model replies that straddle a stdout pipe read.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5-1`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `ec7ceaa4f9`; zero conflicts. Exact head `371671377903cdd6cccbe9b57f22a9e1c55e98a6`.

# Risks

Low. Two `setEncoding("utf8")` calls before the existing handlers; ASCII and whole-chunk output decode byte-identically (pinned by the control case) and the existing `cli-inference.test.ts` suite passes unchanged. `defaultSpawn` only ever receives a real `ChildProcess` — the test seam `__setSpawnForTests` replaces the entire spawner rather than injecting a fake stream — so `setEncoding` cannot meet a stream-less double here, unlike the transport fixed in #30287 where a `StringDecoder` was needed.

# Background

## What does this PR do?

`claude-cli.ts:179-183` accumulated the child's stdout/stderr with a per-chunk `Buffer.toString("utf8")`; a code point split across two reads became U+FFFD on both sides, and `stdout` is what `generate()` returns as the model's answer. The fix lets Node's stream decoder carry the partial code point across chunks.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`__tests__/default-spawn-utf8.test.ts` — a real `node -e` child writes the bytes of one character in two writes 80 ms apart, so they arrive as two pipe reads. No mocks.

## Detailed testing steps

1. Check out exact head `371671377903cdd6cccbe9b57f22a9e1c55e98a6`.
2. From `plugins/plugin-cli-inference`: run `__tests__/default-spawn-utf8.test.ts` and `__tests__/cli-inference.test.ts` → all green (see log).
3. RED control — the new test against develop's `claude-cli.ts`: **2 failed | 1 passed** (`'��'` / `'���'`), ASCII control passing.
4. Mutation kill — remove only the stdout `setEncoding`: the stdout case fails, the stderr case passes.
5. Pinned Biome on both files: exit 0.

<!-- evidence-head:371671377903cdd6cccbe9b57f22a9e1c55e98a6 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — corruption inside the returned text, no rendered surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — corruption inside the returned text, no rendered surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the RED control against a real child process and the mutation kill are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>RED control on develop, green at head, mutation kill</summary>

```
# RED control: new test vs origin/develop claude-cli.ts (real node child, two writes 80ms apart)
 × reassembles a two-byte code point split across stdout reads
   AssertionError: expected '��' to be 'é'
 × reassembles a three-byte code point split across stderr reads
   AssertionError: expected '���' to be '世'
 ✓ leaves whole-chunk ASCII output untouched
      Tests  2 failed | 1 passed (3)

# head 371671377903cdd6cccbe9b57f22a9e1c55e98a6: default-spawn-utf8 + cli-inference suites
      all passed -- see CI

# mutation -- remove child.stdout?.setEncoding("utf8") only
 × reassembles a two-byte code point split across stdout reads
      Tests  1 failed | 2 passed (3)
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — byte decoding below the model boundary; the child in the test is `node -e`, not a model.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Code path and static gates at exact head</summary>

```
develop claude-cli.ts:179-183   stdout += chunk.toString("utf8") / stderr += chunk.toString("utf8")   (per chunk)
head    claude-cli.ts           child.stdout?.setEncoding("utf8"); child.stderr?.setEncoding("utf8"); handlers take string
siblings: shell-execution-router.ts:242-244, #29884 (sandbox-engine), #30287 (ACP transport)

$ node_modules/.bin/biome check \
    plugins/plugin-cli-inference/src/claude-cli.ts \
    plugins/plugin-cli-inference/__tests__/default-spawn-utf8.test.ts
(exit 0, captured directly)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- This package's vitest config aliases `@elizaos/core` to its built dist, which is absent in my review worktree; I ran the suites with a local probe config aliasing core and its workspace siblings to source (not part of this PR). `bun run verify` was not run for the same reason.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
