### PR TITLE
test(cloud,ui): pin the dedicated trace-id contract on both sides

### DIFF
--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -1,6 +1,10 @@
 /** Exercises Worker-safe core stub behavior with deterministic fixtures. */
 import { describe, expect, test } from "bun:test";
 import {
+  INFERENCE_TRACE_ID_PATTERN as canonicalInferenceTraceIdPattern,
+  isInferenceTraceId as canonicalIsInferenceTraceId,
+} from "@elizaos/core";
+import {
   groupResponsePrecedencePolicy as canonicalGroupResponsePrecedencePolicy,
   registerResponsePolicy as canonicalRegisterResponsePolicy,
 } from "@elizaos/prompts";
@@ -14,6 +18,9 @@ import {
   getInferenceTimer,
   groupResponsePrecedencePolicy,
   hasDocumentAugmentationEnvelope,
+  INFERENCE_TRACE_ID_PATTERN,
+  isInferenceTraceId,
+  mintInferenceTraceId,
   registerResponsePolicy,
   runWithTrajectoryPurpose,
   SsrfBlockedError,
@@ -28,6 +35,47 @@ describe("elizaos-core Worker stub", () => {
       canonicalGroupResponsePrecedencePolicy,
     );
     expect(registerResponsePolicy).toBe(canonicalRegisterResponsePolicy);
+  });
+
+  test("mirrors core's inference trace-id contract exactly", () => {
+    // The Worker bundle aliases @elizaos/core to this stub, so the gateway,
+    // the dedicated proxy, and plugin-elizacloud all validate ingress trace
+    // ids against the copy below rather than core's. A stub that widened the
+    // schema (accepting upper-case hex, say) would echo an id core rejects,
+    // and no lane compares the two — so compare them here, against the real
+    // module rather than a literal transcribed from it.
+    expect(INFERENCE_TRACE_ID_PATTERN.source).toBe(
+      canonicalInferenceTraceIdPattern.source,
+    );
+    expect(INFERENCE_TRACE_ID_PATTERN.flags).toBe(
+      canonicalInferenceTraceIdPattern.flags,
+    );
+
+    for (const value of [
+      "0123456789abcdef0123456789abcdef",
+      "0123456789ABCDEF0123456789ABCDEF",
+      "0123456789abcdef0123456789abcde",
+      "0123456789abcdef0123456789abcdef0",
+      "82e92cc6-6fab-4c4a-a1dc-7c1605aebfeb",
+      "",
+      null,
+      undefined,
+      12345,
+      // A boxed string stringifies into a valid id, so a guard that tests the
+      // coerced value instead of checking `typeof` first would adopt it.
+      new String("0123456789abcdef0123456789abcdef"),
+    ]) {
+      expect(isInferenceTraceId(value)).toBe(
+        canonicalIsInferenceTraceId(value),
+      );
+    }
+
+    // Minting has to land inside the shape both sides agree on: a stub that
+    // emitted a hyphenated UUID would be stripped at the gateway boundary.
+    const minted = mintInferenceTraceId();
+    expect(minted).toMatch(canonicalInferenceTraceIdPattern);
+    expect(canonicalIsInferenceTraceId(minted)).toBe(true);
+    expect(mintInferenceTraceId()).not.toBe(minted);
   });
 
   test("exports the Eliza Cloud default text model aliases used by plugin-elizacloud", () => {

--- a/packages/ui/src/api/client-agent-stream.test.ts
+++ b/packages/ui/src/api/client-agent-stream.test.ts
@@ -67,6 +67,30 @@ describe("ElizaClient agent streaming transport", () => {
     );
   });
 
+  it("mints no trace for a self-hosted base, so the header is dedicated-only", async () => {
+    const request = vi.fn<AgentRequestTransport["request"]>(async () => {
+      return new Response(
+        'data: {"type":"done","fullText":"ok","agentName":"Eliza"}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    });
+    // Same call as the test above, differing only in the base URL. The trace id
+    // is minted client-side and echoed back by the gateway as a correlation
+    // key, so a base outside the dedicated cloud must not receive one.
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+
+    await client.streamChatEndpoint(
+      "/api/conversations/conversation-id/messages/stream",
+      "private model input",
+      vi.fn(),
+    );
+
+    const headers = new Headers(request.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("Accept")).toBe("text/event-stream");
+    expect(headers.has("X-Eliza-Trace-Id")).toBe(false);
+  });
+
   it("resolves chat streams immediately after a terminal done event", async () => {
     const encoder = new TextEncoder();
     const read = vi


### PR DESCRIPTION
Follow-up to #30274 (merged as `80205522e0`). That PR added two things nothing pins, and I confirmed both gaps by mutation rather than by reading — each mutant below survives on `develop` today.

Tests only; no source is touched.

## 1. The Worker stub's copy of core's trace-id contract is unpinned

`wrangler.toml:34` aliases `@elizaos/core` to `packages/cloud/api/src/stubs/elizaos-core.ts`, and #30274 hand-copied core's `INFERENCE_TRACE_ID_PATTERN`, `isInferenceTraceId`, and `mintInferenceTraceId` into it. The gateway, the dedicated proxy (`dedicated-agent-proxy.ts:343`), and plugin-elizacloud validate ingress trace ids against that copy, not against core's.

`__tests__/elizaos-core-stub.test.ts` enumerates literals, so it cannot see the copy drift:

```
stub regex widened to /^[0-9a-fA-F]{32}$/
  → cloud-api suites: 223 pass / 0 fail
```

A widened stub echoes an id that core itself rejects, and no lane compares the two.

The added test compares against the **real module** rather than a transcribed literal — a transcribed literal drifts the same way the stub does. It checks the pattern's `source` and `flags`, agreement of `isInferenceTraceId` across a table of inputs, and that a minted id satisfies the canonical predicate.

Mutation-scored against the stub (baseline 15 pass / 0 fail):

| stub mutation | result |
|---|---|
| regex widened to `[0-9a-fA-F]` | **14 pass / 1 fail** |
| length loosened to `{32,}` | **14 pass / 1 fail** |
| `mintInferenceTraceId` returns a hyphenated UUID | **14 pass / 1 fail** |
| `typeof` guard dropped for `PATTERN.test(value as string)` | **14 pass / 1 fail** |

The fourth is worth a note, because it initially **survived**. `null`, `undefined`, and `12345` all stringify to text that fails the pattern, so a coercing guard happens to agree with the real one on every obvious input. It only diverges on a value whose *string form* is a valid id — so the table carries a boxed `new String("0123…")`, which a coercing guard adopts and the real one rejects on `typeof`. Without that entry the assertion would have looked thorough and pinned nothing.

## 2. The dedicated-trace gate has no negative case

`client-base.ts:2900` mints `X-Eliza-Trace-Id` only for a dedicated cloud base:

```ts
const dedicatedTraceId = isDedicatedCloudAgentBase(this.baseUrl)
  ? generateDedicatedTraceId()
  : null;
```

`client-agent-stream.test.ts` covers the positive case only, so the gate is free:

```
gate forced true (every base mints)  → 20 passed (20)
```

The added test is the existing positive test differing only in the base URL, asserting the header is absent for `http://agent.example:31337`. Both gate mutants fail exactly one test:

| gate mutation | result |
|---|---|
| gate forced `true` | **1 failed / 20 passed** |
| `isElizaDedicatedAgentHostname(host)` → `host.length > 0` | **1 failed / 20 passed** |

## Verification

| check | result |
|---|---|
| `packages/ui` `src/api` | **1212 passed** (102 files) |
| `packages/cloud/api` stub + `dedicated-agent-proxy` | **67 pass / 0 fail** |
| `biome check` both files | clean |
| `tsc --noEmit` `packages/cloud/api`, `packages/ui` | exit 0 |

Branched off `origin/develop` at `80205522e0`.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1G7N115KFYG2R0D7XXFCM7N","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T04:57:17.093Z","completed_at":"2026-09-02T04:58:34.357Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T04:57:17.775Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d3e269e574c8511198bd78129629799772816f62268da87cd044213d32aa9b1e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d779099a-2a48-4760-b738-63c6230996ff","object_id":"sha256:d3e269e574c8511198bd78129629799772816f62268da87cd044213d32aa9b1e","sha256":"d3e269e574c8511198bd78129629799772816f62268da87cd044213d32aa9b1e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"ErdbTBD1Wj2GNjzyfliLY5ZTxi-dm3QbxVbPuUA9zfOLojxOK6NqI2Lp0-fMs-OaGycpbX_QhT6xdBak2xNACg"}} -->
