### PR TITLE
fix(ui): page the memories feed from the raw server tail under a multi-type filter

### DIFF
--- a/packages/ui/src/components/pages/MemoryViewerView.feed-cursor.test.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.feed-cursor.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Keyset-cursor coverage for the Memories feed under a multi-type filter. With
+ * two or more types selected the server filter is dropped and the page is
+ * filtered on the client, so the "Load older" cursor must come from the raw
+ * server page tail — deriving it from the filtered list stalls paging on any
+ * page that holds none of the selected types. Real MemoryViewerView in jsdom
+ * against an in-memory keyset server; only the API client and store are mocked.
+ */
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetResourceCache } from "../../hooks/resource-cache";
+
+const clientMock = vi.hoisted(() => ({
+  getMemoryStats: vi.fn(),
+  getRelationshipsPeople: vi.fn(),
+  getMemoryFeed: vi.fn(),
+  browseMemories: vi.fn(),
+  getMemoriesByEntity: vi.fn(),
+}));
+vi.mock("../../api/client", () => ({ client: clientMock }));
+vi.mock("../../state", () => ({
+  useAppSelector: (
+    selector: (state: {
+      t: (key: string, options?: { defaultValue?: string }) => string;
+      setTab: () => void;
+    }) => unknown,
+  ) =>
+    selector({
+      t: (_key, options) => options?.defaultValue ?? _key,
+      setTab: vi.fn(),
+    }),
+}));
+
+import { MemoryViewerView } from "./MemoryViewerView";
+
+const SELECTED_A = "messages";
+const SELECTED_B = "documents";
+const OTHER = "facts";
+
+type Item = {
+  id: string;
+  type: string;
+  text: string;
+  createdAt: number;
+  entityId: null;
+  roomId: null;
+  agentId: null;
+  metadata: null;
+  source: null;
+};
+
+function item(index: number, type: string): Item {
+  return {
+    id: `mem-${index}`,
+    type,
+    text: `memory ${index}`,
+    createdAt: 10_000 - index,
+    entityId: null,
+    roomId: null,
+    agentId: null,
+    metadata: null,
+    source: null,
+  };
+}
+
+// Newest first. The first server page (50 items) holds none of the selected
+// types; the selected items only exist on the second page.
+const DATASET: Item[] = [
+  ...Array.from({ length: 50 }, (_, i) => item(i, OTHER)),
+  ...Array.from({ length: 10 }, (_, i) => item(50 + i, SELECTED_A)),
+];
+
+function keysetServer(params: { limit?: number; before?: number }) {
+  const before = params.before;
+  const older =
+    before === undefined
+      ? DATASET
+      : DATASET.filter((m) => m.createdAt < before);
+  const limit = params.limit ?? 50;
+  const page = older.slice(0, limit);
+  return Promise.resolve({
+    memories: page,
+    count: page.length,
+    limit,
+    hasMore: older.length > limit,
+  });
+}
+
+function mockDesktopViewport() {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+beforeEach(() => {
+  mockDesktopViewport();
+  __resetResourceCache();
+  clientMock.getMemoryStats.mockResolvedValue({
+    total: 61,
+    byType: { [SELECTED_A]: 10, [SELECTED_B]: 1, [OTHER]: 50 },
+  });
+  clientMock.getRelationshipsPeople.mockResolvedValue({ people: [] });
+  clientMock.getMemoryFeed.mockImplementation(keysetServer);
+  clientMock.browseMemories.mockResolvedValue({
+    memories: [],
+    total: 0,
+    totalIsExact: true,
+    hasMore: false,
+    limit: 50,
+    offset: 0,
+  });
+  clientMock.getMemoriesByEntity.mockResolvedValue({
+    memories: [],
+    total: 0,
+    totalIsExact: true,
+    hasMore: false,
+    limit: 50,
+    offset: 0,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  for (const mock of Object.values(clientMock)) mock.mockReset();
+});
+
+describe("Memories feed keyset cursor under a multi-type filter", () => {
+  it("pages past a server page that holds none of the selected types", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<MemoryViewerView />);
+
+    const trigger = await screen.findByTestId("memory-type-filter-trigger");
+    await user.click(trigger);
+    await user.click(
+      await screen.findByTestId(`memory-type-filter-${SELECTED_A}`),
+    );
+    // Checkbox items prevent the default select, so the menu stays open.
+    await user.click(
+      await screen.findByTestId(`memory-type-filter-${SELECTED_B}`),
+    );
+
+    // Two types selected: the server-side type param is dropped and the first
+    // page (all OTHER) filters to nothing on the client while hasMore stays true.
+    await waitFor(() => {
+      expect(
+        clientMock.getMemoryFeed.mock.calls.some(
+          ([params]) => params.type === undefined,
+        ),
+      ).toBe(true);
+    });
+    // Close the filter menu: while it is open Radix marks the rest of the page
+    // aria-hidden, which hides the feed's controls from role queries.
+    await user.keyboard("{Escape}");
+    await user.click(await screen.findByRole("button", { name: "Load older" }));
+
+    // The next request must advance from the raw server tail (mem-49,
+    // createdAt 9951), not from the empty filtered list.
+    await waitFor(() => {
+      expect(
+        clientMock.getMemoryFeed.mock.calls.some(
+          ([params]) => params.before === 10_000 - 49,
+        ),
+      ).toBe(true);
+    });
+    expect(await screen.findByTestId("memory-card-mem-50")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/pages/MemoryViewerView.tsx
+++ b/packages/ui/src/components/pages/MemoryViewerView.tsx
@@ -440,6 +440,11 @@ function MemoryFeedPanel({
   const [error, setError] = useState<MemoryIssue | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const loadingMore = useRef(false);
+  // Raw server-page tail for keyset paging. With two or more types selected the
+  // server filter is dropped and the page is filtered here, so the cursor must
+  // come from the unfiltered page: a page holding none of the selected types
+  // would otherwise leave the cursor where it was and stall "Load older".
+  const feedCursor = useRef<{ createdAt: number; id: string } | null>(null);
 
   const toggleExpanded = useCallback((id: string) => {
     setExpandedId((prev) => (prev === id ? null : id));
@@ -466,6 +471,12 @@ function MemoryFeedPanel({
           }),
         );
         const memories = filterMemoriesByTypes(result.memories, typeFilter);
+        const rawTail = result.memories[result.memories.length - 1];
+        if (rawTail) {
+          feedCursor.current = { createdAt: rawTail.createdAt, id: rawTail.id };
+        } else if (!before) {
+          feedCursor.current = null;
+        }
         if (before) {
           // Cap retained items so a long pagination session can't grow the
           // feed unboundedly. 500 covers many pages of scrollback while
@@ -510,8 +521,8 @@ function MemoryFeedPanel({
   }, FEED_POLL_MS);
 
   const loadMore = () => {
-    const last = feed[feed.length - 1];
-    if (last) void loadFeed({ createdAt: last.createdAt, id: last.id });
+    const cursor = feedCursor.current;
+    if (cursor) void loadFeed(cursor);
   };
 
   if (loading && feed.length === 0) {
@@ -552,6 +563,10 @@ function MemoryFeedPanel({
   }
 
   if (feed.length === 0) {
+    // With two or more types selected the newest server page can filter to
+    // nothing while older pages still hold matches; that is "nothing here yet",
+    // not "no memories", so keep paging reachable instead of dead-ending.
+    const olderPagesRemain = hasMore;
     return (
       <MemoryStateSurface plain>
         <PagePanel.ContentState
@@ -559,21 +574,49 @@ function MemoryFeedPanel({
           placement="workspace"
           className="min-h-[20rem]"
           icon={<Brain className="size-5" />}
-          title={t("memoryviewer.noMemoriesYet", {
-            defaultValue: "No memories yet",
-          })}
-          description={t("memoryviewer.empty.description", {
-            defaultValue: "Chat with Eliza and memories will appear here.",
-          })}
+          title={
+            olderPagesRemain
+              ? t("memoryviewer.noMatchesInLatest", {
+                  defaultValue: "No matching memories in the latest page",
+                })
+              : t("memoryviewer.noMemoriesYet", {
+                  defaultValue: "No memories yet",
+                })
+          }
+          description={
+            olderPagesRemain
+              ? t("memoryviewer.noMatchesInLatest.description", {
+                  defaultValue:
+                    "None of the selected types are in the newest memories. Older pages may still have some.",
+                })
+              : t("memoryviewer.empty.description", {
+                  defaultValue:
+                    "Chat with Eliza and memories will appear here.",
+                })
+          }
           action={
-            <Button
-              type="button"
-              className={MEMORY_FOCUS_CLASS}
-              data-chat-open="true"
-              onClick={dispatchChatOpen}
-            >
-              {t("memoryviewer.empty.askEliza", { defaultValue: "Ask Eliza" })}
-            </Button>
+            olderPagesRemain ? (
+              <Button
+                type="button"
+                size="touch"
+                variant="outline"
+                className={MEMORY_FOCUS_CLASS}
+                onClick={loadMore}
+              >
+                {t("memoryviewer.loadOlder", { defaultValue: "Load older" })}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                className={MEMORY_FOCUS_CLASS}
+                data-chat-open="true"
+                onClick={dispatchChatOpen}
+              >
+                {t("memoryviewer.empty.askEliza", {
+                  defaultValue: "Ask Eliza",
+                })}
+              </Button>
+            )
           }
         />
       </MemoryStateSurface>


### PR DESCRIPTION
# Relates to

Closes #30294 — the Memories feed cannot page past a server page that holds none of the selected types.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5-1`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `80205522e0`; zero conflicts. Exact head `b282073def408a97e75d5cf927c2b544a2b29097`.

# Risks

Low and confined to the feed panel. Single-type and unfiltered paging are unchanged: the raw tail and the filtered tail coincide there, and the four existing `MemoryViewerView` suites pass unchanged. The empty state is unchanged when `hasMore` is false ("No memories yet / Ask Eliza"); only the empty-with-more case gets a distinct title and a "Load older" action. The two new copy strings use `t()` with default values like the rest of the view.

# Background

## What does this PR do?

`loadMore` derived the keyset cursor from the client-filtered list (`MemoryViewerView.tsx:512`), and the empty state rendered on `feed.length === 0` regardless of `hasMore` (`:565`). Under a multi-type filter — where the server filter is dropped and pages are narrowed on the client — an all-filtered page dead-ended the feed. The fix records the raw server-page tail in a ref and pages from it, and lets the empty filtered state offer "Load older" while more pages remain.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`MemoryViewerView.feed-cursor.test.tsx` — the real view in jsdom against an in-memory keyset server (60 memories, first page all `facts`, matches only on page two), two types selected through the real dropdown.

## Detailed testing steps

1. Check out exact head `b282073def408a97e75d5cf927c2b544a2b29097`.
2. From `packages/ui`: `bun x vitest run src/components/pages/MemoryViewerView.feed-cursor.test.tsx` plus the four existing `MemoryViewerView.*.test.tsx` suites → **23/23**.
3. RED control — the new test against develop's view: **1 failed**, `Unable to find role="button" and name "Load older"` — the empty panel with no paging control.
4. Mutation kills, each alone and reverted: cursor back to the filtered tail (button kept) → fails on the `before` assertion, no request advances; empty state never offers "Load older" (cursor kept) → fails on the missing button.
5. Pinned Biome on both files: exit 0.

<!-- evidence-head:b282073def408a97e75d5cf927c2b544a2b29097 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — reproduced deterministically in jsdom; the rendered before-state is the "No memories yet" panel with no paging control, asserted by the RED control.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — the after-state ("No matching memories in the latest page" with a working "Load older") is asserted by the passing test.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the RED control and the two mutation kills are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A — no backend surface changed; the in-memory keyset server's request log is asserted by the test.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs:

<details><summary>RED control on develop, green at head with the existing suites, two mutation kills</summary>

```
# RED control: new test vs origin/develop MemoryViewerView.tsx
 × pages past a server page that holds none of the selected types
   TestingLibraryElementError: Unable to find role="button" and name "Load older"
      Tests  1 failed (1)

# head b282073def408a97e75d5cf927c2b544a2b29097: new test + availability + interface + mobile-sidebar + people-error suites
 Test Files  5 passed (5)
      Tests  23 passed (23)

# mutation A -- loadMore back to feed[feed.length - 1] (empty-state button kept)
   AssertionError: expected false to be true      (no request advanced to before=9951)
      Tests  1 failed (1)
# mutation B -- empty state never offers Load older (cursor kept)
   TestingLibraryElementError: Unable to find role="button" and name "Load older"
      Tests  1 failed (1)
```

</details>

<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — no model call.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Code path and static gates at exact head</summary>

```
develop :214  serverTypeParam -> undefined for 2+ types; :218 filterMemoriesByTypes on the client
develop :512  loadMore: const last = feed[feed.length - 1]        (filtered tail)
develop :565  if (feed.length === 0) -> "No memories yet", hasMore ignored
head          feedCursor ref set from result.memories tail in loadFeed; loadMore pages from it
head          empty state: hasMore ? "No matching memories in the latest page" + Load older : unchanged

$ node_modules/.bin/biome check \
    packages/ui/src/components/pages/MemoryViewerView.tsx \
    packages/ui/src/components/pages/MemoryViewerView.feed-cursor.test.tsx
(exit 0, captured directly)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- `bun run --cwd packages/app audit:app` was not run: this is a `packages/ui` panel-state change with no new layout, and the review worktree is hand-wired; the jsdom RED/GREEN and mutation kills above are the evidence. Happy to attach captures if a maintainer wants them before merge.
- `bun run verify` was not run for the same reason.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
