### PR TITLE
fix(cloud): make character search pagination a total order

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/characters-search-pagination.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/characters-search-pagination.pglite.test.ts
@@ -1,0 +1,116 @@
+/**
+ * PGlite proof that character search pagination is total. Every character
+ * shares the schema-default popularity_score, so a sort on it alone is a tie
+ * across the whole result set; LIMIT/OFFSET over that partial order returns
+ * some rows twice and others never. Real repository, real schema pushed from
+ * the drizzle definitions, the same page walk the my-agents listing performs.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { pushSchema } from "drizzle-kit/api";
+
+const PGLITE_DATABASE_URL = "pglite://memory";
+const ORIGINAL_ENV = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  TEST_DATABASE_URL: process.env.TEST_DATABASE_URL,
+  NODE_ENV: process.env.NODE_ENV,
+  MOCK_REDIS: process.env.MOCK_REDIS,
+  SKIP_AGENT_SANDBOX_ENSURE: process.env.SKIP_AGENT_SANDBOX_ENSURE,
+};
+// Force both selectors before the client is imported so an ambient
+// integration DSN can never receive this suite's DDL.
+process.env.DATABASE_URL = PGLITE_DATABASE_URL;
+process.env.TEST_DATABASE_URL = PGLITE_DATABASE_URL;
+process.env.NODE_ENV = "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { elizaRoomCharactersTable } from "../../schemas/eliza-room-characters";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+
+type ClientModule = typeof import("../../client");
+type CharactersModule = typeof import("../characters");
+type Search = CharactersModule["UserCharactersRepository"]["prototype"]["search"];
+
+const ORGANIZATION_ID = "10000000-0000-4000-8000-000000000001";
+const USER_ID = "20000000-0000-4000-8000-000000000001";
+const TOTAL = 300;
+const PAGE = 30;
+
+let dbWrite: ClientModule["dbWrite"];
+let closeDatabaseConnectionsForTests: ClientModule["closeDatabaseConnectionsForTests"] | undefined;
+let search: Search;
+let schemaFailure = "";
+
+beforeAll(async () => {
+  try {
+    const [clientModule, charactersModule] = await Promise.all([
+      import("../../client"),
+      import("../characters"),
+    ]);
+    dbWrite = clientModule.dbWrite;
+    closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
+    const repository = charactersModule.userCharactersRepository;
+    search = repository.search.bind(repository);
+    const { apply } = await pushSchema(
+      { organizations, users, userCharacters, elizaRoomCharactersTable } as never,
+      dbWrite as never,
+    );
+    await apply();
+    await dbWrite.insert(organizations).values({
+      id: ORGANIZATION_ID,
+      name: "Pagination org",
+      slug: "pagination-org",
+    });
+    await dbWrite.insert(users).values({
+      id: USER_ID,
+      steward_user_id: "pagination-user",
+      organization_id: ORGANIZATION_ID,
+    });
+    for (let i = 0; i < TOTAL; i += 1) {
+      await dbWrite.insert(userCharacters).values({
+        organization_id: ORGANIZATION_ID,
+        user_id: USER_ID,
+        name: `character-${String(i).padStart(3, "0")}`,
+        bio: "tied on the default popularity score",
+        character_data: {},
+      });
+    }
+  } catch (error) {
+    schemaFailure = error instanceof Error ? error.message : String(error);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function walkPages(sort: Parameters<Search>[3]): Promise<Map<string, number>> {
+  const seen = new Map<string, number>();
+  for (let offset = 0; offset < TOTAL; offset += PAGE) {
+    const rows = await search({}, USER_ID, ORGANIZATION_ID, sort, PAGE, offset);
+    for (const row of rows) seen.set(row.id, (seen.get(row.id) ?? 0) + 1);
+  }
+  return seen;
+}
+
+describe("character search pagination is a total order", () => {
+  test("popularity sort without featured pinning returns every character exactly once", async () => {
+    expect(schemaFailure).toBe("");
+    const seen = await walkPages({ sortBy: "popularity", order: "desc", pinFeatured: false });
+    expect(seen.size).toBe(TOTAL);
+    expect([...seen.values()].filter((count) => count > 1)).toHaveLength(0);
+  });
+
+  test("the featured-first branch returns every character exactly once", async () => {
+    expect(schemaFailure).toBe("");
+    const seen = await walkPages({ sortBy: "popularity", order: "desc" });
+    expect(seen.size).toBe(TOTAL);
+    expect([...seen.values()].filter((count) => count > 1)).toHaveLength(0);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/characters.ts
+++ b/packages/cloud/shared/src/db/repositories/characters.ts
@@ -1,5 +1,5 @@
 // Persists characters records for cloud services through the shared DB boundary.
-import { and, desc, eq, inArray, or, SQL, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, or, SQL, sql } from "drizzle-orm";
 import type { SearchFilters, SortOptions } from "../../lib/types/my-agents";
 import { normalizeTokenAddress } from "../../lib/utils/token-address";
 import type { DbTransaction } from "../client";
@@ -544,23 +544,43 @@ export class UserCharactersRepository {
   /**
    * Builds the sort order expression for search queries.
    */
-  private buildSortOrder(sortOptions: SortOptions) {
+  /**
+   * The requested sort followed by the primary key, so the order is total.
+   * Every sort key here admits ties -- popularity_score defaults to 0 for all
+   * characters -- and LIMIT/OFFSET over a partial order drops or duplicates
+   * rows across pages as soon as a tied row's tuple moves (a counter update
+   * between two page loads is enough).
+   */
+  private buildSortOrder(sortOptions: SortOptions): SQL[] {
     const { sortBy, order } = sortOptions;
     const direction = order === "asc" ? "asc" : "desc";
+    const tieBreak = asc(userCharacters.id);
 
     switch (sortBy) {
       case "popularity":
-        return direction === "asc"
-          ? userCharacters.popularity_score
-          : desc(userCharacters.popularity_score);
+        return [
+          direction === "asc"
+            ? asc(userCharacters.popularity_score)
+            : desc(userCharacters.popularity_score),
+          tieBreak,
+        ];
       case "newest":
-        return direction === "asc" ? userCharacters.created_at : desc(userCharacters.created_at);
+        return [
+          direction === "asc" ? asc(userCharacters.created_at) : desc(userCharacters.created_at),
+          tieBreak,
+        ];
       case "name":
-        return direction === "asc" ? userCharacters.name : desc(userCharacters.name);
+        return [
+          direction === "asc" ? asc(userCharacters.name) : desc(userCharacters.name),
+          tieBreak,
+        ];
       case "updated":
-        return direction === "asc" ? userCharacters.updated_at : desc(userCharacters.updated_at);
+        return [
+          direction === "asc" ? asc(userCharacters.updated_at) : desc(userCharacters.updated_at),
+          tieBreak,
+        ];
       default:
-        return desc(userCharacters.popularity_score);
+        return [desc(userCharacters.popularity_score), tieBreak];
     }
   }
 
@@ -586,11 +606,14 @@ export class UserCharactersRepository {
       .where(conditions.length > 0 ? and(...conditions) : undefined);
 
     if (sortOptions.pinFeatured === false) {
-      return await baseQuery.orderBy(secondaryOrderBy).limit(limit).offset(offset);
+      return await baseQuery
+        .orderBy(...secondaryOrderBy)
+        .limit(limit)
+        .offset(offset);
     }
 
     return await baseQuery
-      .orderBy(desc(userCharacters.featured), secondaryOrderBy)
+      .orderBy(desc(userCharacters.featured), ...secondaryOrderBy)
       .limit(limit)
       .offset(offset);
   }
@@ -690,7 +713,7 @@ export class UserCharactersRepository {
       .select()
       .from(userCharacters)
       .where(and(...conditions))
-      .orderBy(desc(userCharacters.featured), secondaryOrderBy)
+      .orderBy(desc(userCharacters.featured), ...secondaryOrderBy)
       .limit(limit)
       .offset(offset);
   }


### PR DESCRIPTION
# Relates to

Closes #30296 — character search pagination drops and duplicates rows across pages.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5-1`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `80205522e0`; zero conflicts. Exact head `cb0f6e1f45fbe3d6b338347b4ee1ebb0c0cea0b2`.

# Risks

Low. `buildSortOrder` now returns the requested sort followed by `id ASC`, and the three call sites spread it. The primary sort for every `sortBy` is unchanged, so any page that was already deterministic is identical; only tied rows gain a stable order. This is the tie-break the same file already applies in `listPublic` (`characters.ts:438-445`) for exactly this reason, and the primary key is index-backed.

# Background

## What does this PR do?

`search()` (`:589`, `:592-595`) and `searchPublic()` (`:693`) ordered by a single column from `buildSortOrder`. Under the default popularity sort every row ties at the schema default 0, and `LIMIT/OFFSET` over a partial order does not return each row exactly once across pages. The fix appends the primary key so the order is total.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`characters-search-pagination.pglite.test.ts` — real repository, real PGlite, schema pushed from the drizzle definitions, 300 characters, the listing's own 10-page walk, for both `search()` branches.

## Detailed testing steps

1. Check out exact head `cb0f6e1f45fbe3d6b338347b4ee1ebb0c0cea0b2`.
2. From `packages/cloud/shared`: `bun test --conditions=eliza-source src/db/repositories/__tests__/characters-search-pagination.pglite.test.ts` → **2 pass**.
3. RED control — the same test against develop's `characters.ts`: **2 fail**, `Expected: 300 / Received: 297` on both branches.
4. Mutation kill — replace the `id` tie-break with `featured` (a boolean, not a tie-break): **2 fail** with the same 297.
5. Pinned Biome on both files: exit 0.

<!-- evidence-head:cb0f6e1f45fbe3d6b338347b4ee1ebb0c0cea0b2 -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — repository pagination with no rendered surface; the missing/duplicated rows are counted by the test.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — repository pagination with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A — the PGlite RED control and mutation kill are the proof.
<!-- evidence-row:backend-logs -->
- Backend logs:

<details><summary>RED control on develop, green at head, mutation kill (real PGlite, 300 rows, 10 pages)</summary>

```
# RED control: new test vs origin/develop characters.ts
 (fail) popularity sort without featured pinning returns every character exactly once
   Expected: 300   Received: 297
 (fail) the featured-first branch returns every character exactly once
   Expected: 300   Received: 297

# head cb0f6e1f45fbe3d6b338347b4ee1ebb0c0cea0b2
 2 pass
 0 fail

# mutation -- tie-break replaced with desc(featured)
 (fail) popularity sort without featured pinning returns every character exactly once
   Expected: 300   Received: 297
 (fail) the featured-first branch returns every character exactly once
   Expected: 300   Received: 297
```

</details>

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A — no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- Live-model trajectory: N/A — no model call.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts:

<details><summary>Emitted SQL before and after, precedent in the same file, and static gates at exact head</summary>

```
develop  ... order by "user_characters"."popularity_score" desc limit $1 offset $2
head     ... order by "user_characters"."popularity_score" desc, "user_characters"."id" asc limit $1 offset $2
precedent characters.ts:438-445 (listPublic): documented total-order requirement, `id asc` appended
schema   user-characters.ts:70  popularity_score integer NOT NULL DEFAULT 0

$ node_modules/.bin/biome check \
    packages/cloud/shared/src/db/repositories/characters.ts \
    packages/cloud/shared/src/db/repositories/__tests__/characters-search-pagination.pglite.test.ts
(exit 0, captured directly)
```

</details>

<!-- evidence-row:ocr-review -->
- OCR review: N/A — no captured imagery.

# Known gaps / failures

- The test needs `--conditions=eliza-source` (the package's own `run-bun-tests.mjs` composes `--conditions`) because the repository import reaches `@elizaos/plugin-sql` → `@elizaos/core` source; it runs in the package's existing `*.pglite.test.ts` lane.
- `bun run verify` was not run in this hand-wired review worktree; the PGlite RED control, green run, and mutation kill above are the evidence.

— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
