### PR TITLE
fix(cloud): unwrap a revocation the disposal error displaced

### DIFF
--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -240,6 +240,67 @@ describe("deferredCredentialAdmissionGuard", () => {
     expect(assertInferenceCredentialActive).toHaveBeenCalledTimes(1);
   });
 
+  test("unwraps a revocation the disposal failure displaced into `suppressed`", async () => {
+    const credential = {
+      kind: "api_key" as const,
+      credentialId: "key-1",
+      userId: "user-1",
+    };
+
+    let caught: unknown;
+    try {
+      // The route body fails with the revocation first; disposal then throws
+      // its own error because no organization was resolved. `SuppressedError`
+      // keeps the NEWER disposal failure in `.error`, so the revocation is the
+      // one that got displaced.
+      await using _guard = deferredCredentialAdmissionGuard({
+        organizationId: () => undefined,
+        credential: () => credential,
+      });
+      throw new InferenceCredentialRevokedError("session_revoked");
+    } catch (error) {
+      // error-policy:J1 the test captures the route-boundary translation input.
+      caught = error;
+    }
+
+    const suppressedError = caught as Error & {
+      error?: unknown;
+      suppressed?: unknown;
+    };
+    expect(suppressedError.name).toBe("SuppressedError");
+    expect(suppressedError.error).not.toBeInstanceOf(
+      InferenceCredentialRevokedError,
+    );
+    expect(suppressedError.suppressed).toBeInstanceOf(
+      InferenceCredentialRevokedError,
+    );
+
+    // Without reading `.suppressed` this is null, and the route answers 500
+    // instead of the credential contract.
+    const denial = resolveInferenceCredentialAdmissionDenial(caught, {
+      route: "displaced-revocation-test",
+      traceId: "trace-displaced",
+    });
+    expect(denial?.status).toBe(401);
+    expect(denial?.reason).toBe("credential_inactive");
+
+    const mapped = asGenerativeCacheApiError(caught, {
+      route: "displaced-revocation-test",
+      traceId: "trace-displaced",
+    });
+    expect(mapped?.status).toBe(401);
+    expect(mapped?.details).toEqual({ reason: "credential_inactive" });
+    expect(loggerError).toHaveBeenCalledWith(
+      "[InferenceAuth] deferred revocation suppressed an earlier route failure",
+      {
+        route: "displaced-revocation-test",
+        traceId: "trace-displaced",
+        credentialReason: "session_revoked",
+        suppressedError: { name: "Error" },
+      },
+    );
+  });
+
   test("unwraps disposal revocation when it suppresses a body failure without logging secrets", async () => {
     const credential = {
       kind: "api_key" as const,

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -148,32 +148,43 @@ export function resolveInferenceCredentialAdmissionDenial(
   logContext?: { route: string; traceId?: string },
 ): InferenceAuthStandingDenial | null {
   let credentialError = error;
-  if (
-    error instanceof Error &&
-    error.name === "SuppressedError" &&
-    "error" in error &&
-    error.error instanceof InferenceCredentialRevokedError
-  ) {
-    credentialError = error.error;
-    const suppressed = "suppressed" in error ? error.suppressed : undefined;
-    const suppressedError =
-      suppressed instanceof Error
-        ? {
-            name: suppressed.name,
-            ...(suppressed instanceof ApiError
-              ? { code: suppressed.code, status: suppressed.status }
-              : {}),
-          }
-        : { name: typeof suppressed };
-    logger.error(
-      "[InferenceAuth] deferred revocation suppressed an earlier route failure",
-      {
-        route: logContext?.route ?? "unavailable",
-        traceId: logContext?.traceId ?? "unavailable",
-        credentialReason: error.error.reason,
-        suppressedError,
-      },
-    );
+  if (error instanceof Error && error.name === "SuppressedError") {
+    // `SuppressedError.error` is the *newer* disposal failure and `.suppressed`
+    // the one it displaced, so the revocation can land in either slot: disposal
+    // rejecting while the route body succeeded puts it in `.error`, and a route
+    // body that already failed with a revocation puts it in `.suppressed` when
+    // disposal then throws something of its own. Checking only `.error` drops
+    // the second case on the floor and turns a 401/403 into a 500.
+    const raised = "error" in error ? error.error : undefined;
+    const displaced = "suppressed" in error ? error.suppressed : undefined;
+    const revocation =
+      raised instanceof InferenceCredentialRevokedError
+        ? raised
+        : displaced instanceof InferenceCredentialRevokedError
+          ? displaced
+          : undefined;
+    if (revocation) {
+      credentialError = revocation;
+      const companion = revocation === raised ? displaced : raised;
+      const suppressedError =
+        companion instanceof Error
+          ? {
+              name: companion.name,
+              ...(companion instanceof ApiError
+                ? { code: companion.code, status: companion.status }
+                : {}),
+            }
+          : { name: typeof companion };
+      logger.error(
+        "[InferenceAuth] deferred revocation suppressed an earlier route failure",
+        {
+          route: logContext?.route ?? "unavailable",
+          traceId: logContext?.traceId ?? "unavailable",
+          credentialReason: revocation.reason,
+          suppressedError,
+        },
+      );
+    }
   }
   if (!(credentialError instanceof InferenceCredentialRevokedError)) {
     return null;


### PR DESCRIPTION
Follow-up to #30264 (merged as `bc84c05273`). I reviewed that PR at head `8ceb43c0a2` and raised this as a non-blocking note; it merged without it. The blocking finding from that review — an `./engine` mock leaking from `birdeye-handler.error-policy.test.ts` into `birdeye-handler.timeout.test.ts` — **is** resolved: the merged version rewrote that suite onto reserve/reconcile, and the whole proxy directory now runs clean in one shared process (`102 pass / 0 fail across 19 files`). This PR is only the remaining half.

## The defect

`resolveInferenceCredentialAdmissionDenial` (`generative-route-auth.ts:150`) unwraps `SuppressedError` by inspecting `.error` alone:

```ts
error.name === "SuppressedError" &&
"error" in error &&
error.error instanceof InferenceCredentialRevokedError
```

`SuppressedError.error` is the **newer** failure — the one disposal raised — and `.suppressed` is the one it displaced. So that condition matches only one of the two orderings this code can produce:

| ordering | `.error` | `.suppressed` | handled |
|---|---|---|---|
| body succeeds, disposal rejects with the revocation | revocation | route failure | ✅ today |
| **body fails with the revocation, disposal then throws its own error** | **disposal failure** | **revocation** | ❌ dropped |

## It is reachable with only existing code

`deferredCredentialAdmissionGuard`'s disposal throws when a credential is present but no organization resolved:

```ts
if (!organizationId) {
  throw new Error("Deferred inference credential is missing its organization");
}
```

Drive that under `await using` while the body raises the revocation and you get the second row. Executed on `develop`:

```
name         SuppressedError
.error       Error                            ← "missing its organization"
.suppressed  InferenceCredentialRevokedError
denialStatus null
mappedStatus null
```

`resolveInferenceCredentialAdmissionDenial` returns `null`, `asGenerativeCacheApiError` returns `null` with it, and **the route answers 500 instead of 401** — a revoked credential is reported to the caller as a server fault. The forward ordering, on the same head, correctly maps to 401.

## The change

Take the revocation from whichever slot holds it, and log the *other* one as the displaced failure so the existing log line keeps its meaning in both orderings:

```ts
const raised = "error" in error ? error.error : undefined;
const displaced = "suppressed" in error ? error.suppressed : undefined;
const revocation =
  raised instanceof InferenceCredentialRevokedError ? raised
  : displaced instanceof InferenceCredentialRevokedError ? displaced
  : undefined;
...
const companion = revocation === raised ? displaced : raised;
```

The `ApiError` shaping of the logged companion and the redaction behaviour are unchanged — the existing test that asserts no secrets reach the log still passes untouched.

## Verification

The regression test builds the ordering through a real `await using` rather than constructing a `SuppressedError` directly, because the `SuppressedError` global is not defined in this package's vitest environment — a direct construction throws `ReferenceError` and would have looked like a passing test only if written carelessly.

| | result |
|---|---|
| `generative-route-auth.test.ts` at head | **68 passed** (67 existing + 1 new) |
| restrict the search back to `.error` | **1 failed / 67 passed** |
| log the wrong companion (`companion = displaced`) | **1 failed / 67 passed** |
| `guarded-paid-proxy.test.ts`, `paid-route-standing.test.ts` (bun) | 4 pass / 0 fail, 8 pass / 0 fail |
| `biome check` on both files | clean |
| `tsc --noEmit` `packages/cloud/api` | exit 0 |

Branched off `origin/develop` at `bc84c05273`.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GD6NGZNZC1D324G10SYRY7","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T06:34:18.015Z","completed_at":"2026-09-02T06:35:31.895Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T06:34:18.782Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ecc58d4d2b96247850b8f5e3831fe24c557bfcf91791fd91d54d45020fa9a143","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7c72824e-a811-49df-85ed-5aab520450f9","object_id":"sha256:ecc58d4d2b96247850b8f5e3831fe24c557bfcf91791fd91d54d45020fa9a143","sha256":"ecc58d4d2b96247850b8f5e3831fe24c557bfcf91791fd91d54d45020fa9a143"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"D0McLWBFVfKQdX9iNcMcEQaC6d1DN8nsg9-9m4gb2Zr-xr3W0uBVK1QWOexEk8FAiQ9MLh6C97K-VGCIUxx9AQ"}} -->
