### PR TITLE
fix(ci): source Telegram authority receipt from protected environment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -355,18 +355,25 @@ Terraform domain workflow additionally requires zone-scoped DNS write and
 certificate packs. Prefer separate environment-scoped deploy and DNS/TLS
 tokens so staging automation cannot mutate production zones.
 
-The Cloud release resolves the public Telegram bot ID and username before
-database migration or API deployment. Staging consumes the complete
+The Cloud deploy entry workflow resolves the public Telegram bot ID and
+username before it invokes the reusable release, database migration, or API
+deployment. Staging consumes the complete
 `VITE_TELEGRAM_BOT_ID` / `VITE_TELEGRAM_BOT_USERNAME` configuration-variable
 pair only when it matches the protected `staging` GitHub Environment secret
 `TELEGRAM_IDENTITY_AUTHORITY_SHA256`, and requires both components to differ
 from production. The receipt is the lowercase SHA-256 of the framed bytes
 `elizaOS/eliza\0staging\0telegram-public-identity\0v1\0<ID>\0<lowercase-username>\n`.
-The reusable release uses an exact caller-secret allowlist that deliberately
-does not forward or declare that receipt: it is resolved only from the protected
-job Environment, so a repository or organization secret cannot substitute for
-the Environment authority. A repository/organization variable may resolve the
-same committed public pair, but cannot select a different pair.
+The entry workflow's protected Environment job reads the receipt directly; the
+reusable release uses an exact caller-secret allowlist that deliberately does
+not forward or declare it, and receives only the already-admitted public pair.
+That keeps a repository or organization secret from substituting for the
+Environment authority. A repository/organization variable may resolve the same
+committed public pair, but cannot select a different pair.
+For a hosted, read-only authority proof on a pull-request branch, dispatch
+`cloud-cf-deploy.yml` with `environment=staging` and
+`telegram_authority_canary=true`. The canary rejects production, force, and
+deployed-renderer options, runs only the protected staging receipt preflight,
+and skips admission, the reusable release, every mutation, and certification.
 Because GitHub preserves successful job outputs during failed-job reruns, the
 migration, API deploy, Pages build, and Pages deploy jobs each repeat the bound
 attempt check as their first step; a partial rerun must be replaced with a full

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -363,9 +363,10 @@ pair only when it matches the protected `staging` GitHub Environment secret
 from production. The receipt is the lowercase SHA-256 of the framed bytes
 `elizaOS/eliza\0staging\0telegram-public-identity\0v1\0<ID>\0<lowercase-username>\n`.
 The reusable release uses an exact caller-secret allowlist that deliberately
-does not forward that receipt, so a repository or organization secret cannot
-substitute for the Environment authority. A repository/organization variable
-may resolve the same committed public pair, but cannot select a different pair.
+does not forward or declare that receipt: it is resolved only from the protected
+job Environment, so a repository or organization secret cannot substitute for
+the Environment authority. A repository/organization variable may resolve the
+same committed public pair, but cannot select a different pair.
 Because GitHub preserves successful job outputs during failed-job reruns, the
 migration, API deploy, Pages build, and Pages deploy jobs each repeat the bound
 attempt check as their first step; a partial rerun must be replaced with a full

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -369,11 +369,12 @@ not forward or declare it, and receives only the already-admitted public pair.
 That keeps a repository or organization secret from substituting for the
 Environment authority. A repository/organization variable may resolve the same
 committed public pair, but cannot select a different pair.
-For a hosted, read-only authority proof on a pull-request branch, dispatch
-`cloud-cf-deploy.yml` with `environment=staging` and
-`telegram_authority_canary=true`. The canary rejects production, force, and
-deployed-renderer options, runs only the protected staging receipt preflight,
-and skips admission, the reusable release, every mutation, and certification.
+For a hosted, read-only authority proof on a ref allowed by the protected
+`staging` Environment policy, dispatch `cloud-cf-deploy.yml` with
+`environment=staging` and `telegram_authority_canary=true`. The canary rejects
+production, force, and deployed-renderer options, runs only the protected
+staging receipt preflight, and skips admission, the reusable release, every
+mutation, and certification.
 Because GitHub preserves successful job outputs during failed-job reruns, the
 migration, API deploy, Pages build, and Pages deploy jobs each repeat the bound
 attempt check as their first step; a partial rerun must be replaced with a full

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -87,6 +87,11 @@ on:
         required: false
         default: false
         type: boolean
+      telegram_authority_canary:
+        description: Run only the protected staging Telegram authority preflight; no release mutation or certification
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   # #18092: admission is unique per run so two dispatches/reruns of the same
@@ -122,6 +127,110 @@ jobs:
           }
           printf 'run_attempt=%s\n' "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 
+  resolve-telegram-environment-authority:
+    name: Resolve protected Telegram configuration authority
+    needs: [bind-telegram-release-attempt, validate-deploy-source]
+    if: ${{ always() && needs.bind-telegram-release-attempt.result == 'success' && needs.validate-deploy-source.result == 'success' && github.event_name == 'workflow_dispatch' && inputs.environment == 'staging' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # A reusable workflow cannot reference an Environment-only secret unless
+    # its caller declares that same secret in workflow_call.secrets. Resolve
+    # this receipt in the entry workflow's protected Environment instead, so
+    # no repository or organization secret can substitute for it.
+    environment: staging
+    outputs:
+      telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
+      telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
+      telegram_authority_run_attempt: ${{ steps.telegram.outputs.run_attempt }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Validate protected Telegram public identity
+        id: telegram
+        env:
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TARGET_ENVIRONMENT: staging
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ needs.bind-telegram-release-attempt.outputs.run_attempt }}
+          ENVIRONMENT_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
+          ENVIRONMENT_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
+          TELEGRAM_IDENTITY_AUTHORITY_SHA256: ${{ secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256 }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            printf '%s\n' "::error::$1" >&2
+            exit 1
+          }
+
+          valid_bot_id() {
+            local candidate="$1"
+            [[ "$candidate" =~ ^[1-9][0-9]{0,15}$ ]] || return 1
+            (( 10#$candidate <= 4503599627370495 ))
+          }
+
+          [[ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || \
+            fail "Telegram configuration authority run attempt is missing or invalid"
+          [[ "$RELEASE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || \
+            fail "Cloud release run attempt is missing or invalid"
+          [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || \
+            fail "Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs"
+
+          case "$TARGET_ENVIRONMENT" in
+            staging|production) ;;
+            *) fail "target_environment must be exactly staging or production" ;;
+          esac
+
+          canonical_source="packages/homepage/src/lib/contact.ts"
+          canonical_bot_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
+          canonical_bot_username="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_USERNAME = "([^"]+)";$/\1/p' "$canonical_source")"
+          valid_bot_id "$canonical_bot_id" || \
+            fail "The homepage canonical Telegram bot ID is missing or invalid"
+          [[ "$canonical_bot_username" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+            fail "The homepage canonical Telegram username is missing or invalid"
+          canonical_bot_username_key="$(printf '%s' "$canonical_bot_username" | tr '[:upper:]' '[:lower:]')"
+          [[ "$canonical_bot_username_key" == *bot ]] || \
+            fail "The homepage canonical Telegram username must use the managed bot suffix"
+
+          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
+            resolved_bot_id="$canonical_bot_id"
+            resolved_bot_username="$canonical_bot_username"
+          else
+            if [ -z "$ENVIRONMENT_TELEGRAM_BOT_ID" ] || \
+              [ -z "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" ]; then
+              fail "The protected staging Telegram identity must configure the complete VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME pair"
+            fi
+            valid_bot_id "$ENVIRONMENT_TELEGRAM_BOT_ID" || \
+              fail "The protected staging VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
+            [[ "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
+            staging_bot_username_key="$(printf '%s' "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
+            [[ "$staging_bot_username_key" == *bot ]] || \
+              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
+            if [ "$ENVIRONMENT_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
+              [ "$staging_bot_username_key" = "$canonical_bot_username_key" ]; then
+              fail "Staging Telegram configuration must use an identity fully distinct from production"
+            fi
+            [[ "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" =~ ^[0-9a-f]{64}$ ]] || \
+              fail "The staging GitHub Environment must provide a valid TELEGRAM_IDENTITY_AUTHORITY_SHA256 receipt"
+            computed_identity_sha256="$(
+              printf 'elizaOS/eliza\0staging\0telegram-public-identity\0v1\0%s\0%s\n' \
+                "$ENVIRONMENT_TELEGRAM_BOT_ID" "$staging_bot_username_key" \
+                | sha256sum | cut -d ' ' -f 1
+            )"
+            [ "$computed_identity_sha256" = "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" ] || \
+              fail "The staging Telegram identity does not match its protected Environment authority receipt"
+            resolved_bot_id="$ENVIRONMENT_TELEGRAM_BOT_ID"
+            resolved_bot_username="$ENVIRONMENT_TELEGRAM_BOT_USERNAME"
+          fi
+
+          printf 'bot_id=%s\n' "$resolved_bot_id" >> "$GITHUB_OUTPUT"
+          printf 'bot_username=%s\n' "$resolved_bot_username" >> "$GITHUB_OUTPUT"
+          printf 'run_attempt=%s\n' "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+          printf 'Validated protected Telegram public identity policy for %s.\n' \
+            "$TARGET_ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
+
   validate-deploy-source:
     name: Validate Canonical Deploy Source
     # A manual dispatch can select an invalid ref, so reject it before any
@@ -139,6 +248,7 @@ jobs:
           SOURCE_REF: ${{ github.ref }}
           FORCE: ${{ inputs.force == true }}
           RUN_DEPLOYED_RENDERER_STAGING: ${{ inputs.run_deployed_renderer_staging == true }}
+          TELEGRAM_AUTHORITY_CANARY: ${{ inputs.telegram_authority_canary == true }}
           PRODUCTION_BINDING_ONLY_RECOVERY: ${{ inputs.production_binding_only_recovery == true }}
           CERTIFIED_PRODUCTION_BASE_SHA: ${{ inputs.certified_production_base_sha }}
           CERTIFIED_RECOVERY_POLICY_SHA: ${{ inputs.certified_recovery_policy_sha }}
@@ -146,6 +256,27 @@ jobs:
           set -euo pipefail
 
           if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            exit 0
+          fi
+
+          if [ "$TELEGRAM_AUTHORITY_CANARY" = "true" ]; then
+            [ "$TARGET_ENVIRONMENT" = "staging" ] || {
+              echo "::error::Telegram authority canary may target only staging."
+              exit 1
+            }
+            [ "$FORCE" = "false" ] || {
+              echo "::error::Telegram authority canary forbids force."
+              exit 1
+            }
+            [ "$RUN_DEPLOYED_RENDERER_STAGING" = "false" ] || {
+              echo "::error::Telegram authority canary forbids the deployed-renderer proof."
+              exit 1
+            }
+            [ "$PRODUCTION_BINDING_ONLY_RECOVERY" = "false" ] || {
+              echo "::error::Telegram authority canary forbids production recovery."
+              exit 1
+            }
+            echo "Telegram authority canary admitted for protected staging preflight only."
             exit 0
           fi
 
@@ -205,7 +336,7 @@ jobs:
   admit-staging:
     name: Authorize and admit staging release
     needs: validate-deploy-source
-    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && github.event_name != 'pull_request' && !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && github.event_name != 'pull_request' && inputs.telegram_authority_canary != true && !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -263,7 +394,7 @@ jobs:
   validate-staging-certification:
     name: Validate staging certification for production tree
     needs: validate-deploy-source
-    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && github.event_name != 'pull_request' && ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && github.event_name != 'pull_request' && inputs.telegram_authority_canary != true && ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -610,7 +741,7 @@ jobs:
   authorize-production:
     name: Authorize production environment
     needs: [validate-deploy-source, validate-staging-certification]
-    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && github.event_name != 'pull_request' && ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && github.event_name != 'pull_request' && inputs.telegram_authority_canary != true && ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Approval only. This job must not share a mutation concurrency group, or
@@ -847,8 +978,8 @@ jobs:
 
   release:
     name: Mutate and verify Cloud CF release
-    needs: [bind-telegram-release-attempt, validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
-    if: ${{ always() && github.event_name != 'pull_request' && needs.bind-telegram-release-attempt.result == 'success' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
+    needs: [bind-telegram-release-attempt, resolve-telegram-environment-authority, validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
+    if: ${{ always() && github.event_name != 'pull_request' && inputs.telegram_authority_canary != true && needs.bind-telegram-release-attempt.result == 'success' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.resolve-telegram-environment-authority.result == 'skipped' && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.resolve-telegram-environment-authority.result == 'success' && needs.admit-staging.outputs.should_deploy == 'true') }}
     # One critical section for migrate + API + Pages + routing proof.
     # `queue: max` is GitHub's production-deploy contract: up to 100 approved
     # releases wait instead of the default one-pending eviction. FIFO is by
@@ -860,9 +991,10 @@ jobs:
       queue: max
     uses: ./.github/workflows/cloud-cf-release.yml
     # Explicitly forward every caller-scope secret consumed by the reusable
-    # release except TELEGRAM_IDENTITY_AUTHORITY_SHA256. That receipt must come
-    # only from the protected job Environment in the called workflow; `inherit`
-    # would also admit a repository/organization secret with the same name.
+    # release except TELEGRAM_IDENTITY_AUTHORITY_SHA256. The entry workflow
+    # validates that receipt in its protected Environment job and passes only
+    # the admitted public bot identity; `inherit` could admit a repository or
+    # organization secret with the same name.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CARTESIA_API_KEY: ${{ secrets.CARTESIA_API_KEY }}
@@ -918,7 +1050,9 @@ jobs:
       VOICE_REALTIME_ELIZA_AUTHORIZATION: ${{ secrets.VOICE_REALTIME_ELIZA_AUTHORIZATION }}
     with:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
-      telegram_authority_run_attempt: ${{ needs.bind-telegram-release-attempt.outputs.run_attempt }}
+      telegram_authority_run_attempt: ${{ needs.resolve-telegram-environment-authority.result == 'success' && needs.resolve-telegram-environment-authority.outputs.telegram_authority_run_attempt || needs.bind-telegram-release-attempt.outputs.run_attempt }}
+      admitted_telegram_bot_id: ${{ needs.resolve-telegram-environment-authority.outputs.telegram_bot_id }}
+      admitted_telegram_bot_username: ${{ needs.resolve-telegram-environment-authority.outputs.telegram_bot_username }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
       # Resolve the proof request at the entry workflow boundary. A live-ready
       # automatic release is a Develop effect reconciliation with a bound
@@ -936,7 +1070,7 @@ jobs:
     # A canonical manual staging dispatch is equally authoritative after the
     # same release and routing checks; supporting it makes intentional pinned
     # releases certifiable when develop is moving faster than hosted runners.
-    if: ${{ always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/develop' && needs.release.result == 'success' && needs.release.outputs.superseded != 'true' }}
+    if: ${{ always() && inputs.telegram_authority_canary != true && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/develop' && needs.release.result == 'success' && needs.release.outputs.superseded != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -88,7 +88,7 @@ on:
         default: false
         type: boolean
       telegram_authority_canary:
-        description: Run only the protected staging Telegram authority preflight; no release mutation or certification
+        description: Run only the protected staging Telegram authority preflight on an Environment-allowed ref; no release mutation or certification
         required: false
         default: false
         type: boolean

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -15,6 +15,14 @@ on:
         description: Workflow attempt bound before the protected Telegram configuration is resolved
         required: true
         type: string
+      admitted_telegram_bot_id:
+        description: Public Telegram bot ID admitted by the protected entry-workflow Environment job
+        required: true
+        type: string
+      admitted_telegram_bot_username:
+        description: Public Telegram bot username admitted by the protected entry-workflow Environment job
+        required: true
+        type: string
       force:
         description: Bypass the deploy freshness guard
         required: false
@@ -42,8 +50,8 @@ on:
         default: ""
     # Keep caller-scope secrets explicit. The Telegram authority receipt is
     # intentionally absent from both this callable schema and the caller map:
-    # GitHub must resolve it from the protected job Environment below, rather
-    # than materializing an empty caller-scope secret with the same name.
+    # the entry workflow resolves it in its protected Environment job before
+    # passing only the admitted public identity to this reusable workflow.
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -180,19 +188,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate Telegram public identity preflight
+      - name: Validate caller-admitted Telegram public identity
         id: telegram
         env:
           RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
           TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
-          # Configuration variables carry only public values. A protected
-          # Environment secret binds the accepted pair; that secret is
-          # deliberately absent from the caller's forwarding map, so a
-          # repository/organization secret cannot substitute for it.
-          ENVIRONMENT_TELEGRAM_BOT_ID: ${{ vars.VITE_TELEGRAM_BOT_ID }}
-          ENVIRONMENT_TELEGRAM_BOT_USERNAME: ${{ vars.VITE_TELEGRAM_BOT_USERNAME }}
-          TELEGRAM_IDENTITY_AUTHORITY_SHA256: ${{ secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256 }}
+          ADMITTED_TELEGRAM_BOT_ID: ${{ inputs.admitted_telegram_bot_id }}
+          ADMITTED_TELEGRAM_BOT_USERNAME: ${{ inputs.admitted_telegram_bot_username }}
         run: |
           set -euo pipefail
 
@@ -219,52 +222,32 @@ jobs:
             *) fail "target_environment must be exactly staging or production" ;;
           esac
 
-          canonical_source="packages/homepage/src/lib/contact.ts"
-          canonical_bot_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
-          canonical_bot_username="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_USERNAME = "([^"]+)";$/\1/p' "$canonical_source")"
-          valid_bot_id "$canonical_bot_id" || \
-            fail "The homepage canonical Telegram bot ID is missing or invalid"
-          [[ "$canonical_bot_username" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
-            fail "The homepage canonical Telegram username is missing or invalid"
-          canonical_bot_username_key="$(printf '%s' "$canonical_bot_username" | tr '[:upper:]' '[:lower:]')"
-          [[ "$canonical_bot_username_key" == *bot ]] || \
-            fail "The homepage canonical Telegram username must use the managed bot suffix"
-
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
-            resolved_bot_id="$canonical_bot_id"
-            resolved_bot_username="$canonical_bot_username"
+            canonical_source="packages/homepage/src/lib/contact.ts"
+            resolved_bot_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
+            resolved_bot_username="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_USERNAME = "([^"]+)";$/\1/p' "$canonical_source")"
+            valid_bot_id "$resolved_bot_id" || \
+              fail "The homepage canonical Telegram bot ID is missing or invalid"
+            [[ "$resolved_bot_username" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+              fail "The homepage canonical Telegram username is missing or invalid"
+            resolved_bot_username_key="$(printf '%s' "$resolved_bot_username" | tr '[:upper:]' '[:lower:]')"
+            [[ "$resolved_bot_username_key" == *bot ]] || \
+              fail "The homepage canonical Telegram username must use the managed bot suffix"
           else
-            if [ -z "$ENVIRONMENT_TELEGRAM_BOT_ID" ] || \
-              [ -z "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" ]; then
-              fail "The protected staging Telegram identity must configure the complete VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME pair"
-            fi
-            valid_bot_id "$ENVIRONMENT_TELEGRAM_BOT_ID" || \
-              fail "The protected staging VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
-            [[ "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
-              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
-            staging_bot_username_key="$(printf '%s' "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
-            [[ "$staging_bot_username_key" == *bot ]] || \
-              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
-            if [ "$ENVIRONMENT_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
-              [ "$staging_bot_username_key" = "$canonical_bot_username_key" ]; then
-              fail "Staging Telegram configuration must use an identity fully distinct from production"
-            fi
-            [[ "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" =~ ^[0-9a-f]{64}$ ]] || \
-              fail "The staging GitHub Environment must provide a valid TELEGRAM_IDENTITY_AUTHORITY_SHA256 receipt"
-            computed_identity_sha256="$(
-              printf 'elizaOS/eliza\0staging\0telegram-public-identity\0v1\0%s\0%s\n' \
-                "$ENVIRONMENT_TELEGRAM_BOT_ID" "$staging_bot_username_key" \
-                | sha256sum | cut -d ' ' -f 1
-            )"
-            [ "$computed_identity_sha256" = "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" ] || \
-              fail "The staging Telegram identity does not match its protected Environment authority receipt"
-            resolved_bot_id="$ENVIRONMENT_TELEGRAM_BOT_ID"
-            resolved_bot_username="$ENVIRONMENT_TELEGRAM_BOT_USERNAME"
+            valid_bot_id "$ADMITTED_TELEGRAM_BOT_ID" || \
+              fail "The caller-admitted Telegram bot ID is missing or invalid; re-run all jobs"
+            [[ "$ADMITTED_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+              fail "The caller-admitted Telegram username is missing or invalid; re-run all jobs"
+            admitted_bot_username_key="$(printf '%s' "$ADMITTED_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
+            [[ "$admitted_bot_username_key" == *bot ]] || \
+              fail "The caller-admitted Telegram username must use the managed bot suffix; re-run all jobs"
+            resolved_bot_id="$ADMITTED_TELEGRAM_BOT_ID"
+            resolved_bot_username="$ADMITTED_TELEGRAM_BOT_USERNAME"
           fi
 
           printf 'bot_id=%s\n' "$resolved_bot_id" >> "$GITHUB_OUTPUT"
           printf 'bot_username=%s\n' "$resolved_bot_username" >> "$GITHUB_OUTPUT"
-          printf 'Validated Telegram public identity policy for %s.\n' \
+          printf 'Accepted caller-admitted Telegram public identity for %s.\n' \
             "$TARGET_ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Attest protected Telegram runtime identity

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -41,9 +41,9 @@ on:
         type: string
         default: ""
     # Keep caller-scope secrets explicit. The Telegram authority receipt is
-    # declared for the reusable-workflow type contract but intentionally not
-    # forwarded by the caller, so jobs below may resolve it only from their
-    # protected GitHub Environment.
+    # intentionally absent from both this callable schema and the caller map:
+    # GitHub must resolve it from the protected job Environment below, rather
+    # than materializing an empty caller-scope secret with the same name.
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -140,8 +140,6 @@ on:
       STEWARD_SESSION_SECRET:
         required: false
       STEWARD_TENANT_API_KEY:
-        required: false
-      TELEGRAM_IDENTITY_AUTHORITY_SHA256:
         required: false
       TUNNEL_HOSTNAME_SIGNING_SECRET:
         required: false

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -81,11 +81,17 @@ const guardedReleaseJobNames = [
   "deploy-app",
 ] as const;
 
+const telegramAuthorityResolver =
+  parsedWorkflow.jobs?.["resolve-telegram-environment-authority"];
 const resolver =
   parsedReleaseWorkflow.jobs?.["resolve-pages-environment-config"];
-const telegramValidation = resolver?.steps?.find(
+const telegramValidation = telegramAuthorityResolver?.steps?.find(
   (candidate) =>
-    candidate.name === "Validate Telegram public identity preflight",
+    candidate.name === "Validate protected Telegram public identity",
+);
+const admittedTelegramValidation = resolver?.steps?.find(
+  (candidate) =>
+    candidate.name === "Validate caller-admitted Telegram public identity",
 );
 
 function requiredTelegramConstant(
@@ -182,6 +188,101 @@ function runTelegramPreflight(
   } finally {
     rmSync(fixtureRoot, { force: true, recursive: true });
   }
+}
+
+function runReusableTelegramPreflight(
+  overrides: Partial<{
+    botId: string;
+    botUsername: string;
+    authorityRunAttempt: string;
+    releaseRunAttempt: string;
+    targetEnvironment: string;
+  }> = {},
+): TelegramExecution {
+  if (!admittedTelegramValidation?.run) {
+    throw new Error("Missing executable caller-admitted Telegram preflight");
+  }
+
+  const fixtureRoot = mkdtempSync(
+    path.join(tmpdir(), "homepage-telegram-reusable-preflight-"),
+  );
+  const githubOutputPath = path.join(fixtureRoot, "github-output.txt");
+  const summaryPath = path.join(fixtureRoot, "step-summary.md");
+
+  try {
+    const result = Bun.spawnSync(
+      ["bash", "-c", admittedTelegramValidation.run],
+      {
+        cwd: repositoryRoot,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: githubOutputPath,
+          GITHUB_STEP_SUMMARY: summaryPath,
+          ADMITTED_TELEGRAM_BOT_ID: overrides.botId ?? stagingTelegram.botId,
+          ADMITTED_TELEGRAM_BOT_USERNAME:
+            overrides.botUsername ?? stagingTelegram.botUsername,
+          RELEASE_RUN_ATTEMPT: overrides.releaseRunAttempt ?? "1",
+          TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
+          TELEGRAM_AUTHORITY_RUN_ATTEMPT: overrides.authorityRunAttempt ?? "1",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+
+    return {
+      exitCode: result.exitCode,
+      githubOutput: readOptionalFile(githubOutputPath),
+      stderr: result.stderr.toString(),
+      stdout: result.stdout.toString(),
+      summary: readOptionalFile(summaryPath),
+    };
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+}
+
+function runTelegramAuthorityCanaryAdmission(
+  overrides: Partial<{
+    force: string;
+    renderer: string;
+    targetEnvironment: string;
+  }> = {},
+): TelegramExecution {
+  const guard = namedStep(
+    parsedWorkflow.jobs?.["validate-deploy-source"],
+    "Reject feature refs targeting canonical environments",
+  );
+  if (!guard.run) throw new Error("Missing executable canary admission guard");
+
+  const result = Bun.spawnSync(["bash", "-c", guard.run], {
+    cwd: repositoryRoot,
+    env: {
+      ...process.env,
+      CERTIFIED_PRODUCTION_BASE_SHA: "",
+      CERTIFIED_RECOVERY_POLICY_SHA: "",
+      EFFECT_DIGEST: "",
+      EVENT_NAME: "workflow_dispatch",
+      FORCE: overrides.force ?? "false",
+      GITHUB_SHA: "0123456789012345678901234567890123456789",
+      PRODUCTION_BINDING_ONLY_RECOVERY: "false",
+      RUN_DEPLOYED_RENDERER_STAGING: overrides.renderer ?? "false",
+      SOURCE_REF: "refs/heads/feature/telegram-canary",
+      SOURCE_SHA: "",
+      TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
+      TELEGRAM_AUTHORITY_CANARY: "true",
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  return {
+    exitCode: result.exitCode,
+    githubOutput: "",
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+    summary: "",
+  };
 }
 
 function assertNoPublicSurfaceLeak(
@@ -336,9 +437,20 @@ describe("homepage deployment workflow", () => {
     expect(release?.if).toContain(
       "needs.bind-telegram-release-attempt.result == 'success'",
     );
-    expect(release?.with?.telegram_authority_run_attempt).toBe(
+    expect(release?.with?.telegram_authority_run_attempt).toContain(
+      "needs.resolve-telegram-environment-authority.outputs.telegram_authority_run_attempt",
+    );
+    expect(release?.with?.telegram_authority_run_attempt).toContain(
+      "needs.bind-telegram-release-attempt.outputs.run_attempt",
+    );
+    expect(release?.with?.admitted_telegram_bot_id).toBe(
       githubExpression(
-        "needs.bind-telegram-release-attempt.outputs.run_attempt",
+        "needs.resolve-telegram-environment-authority.outputs.telegram_bot_id",
+      ),
+    );
+    expect(release?.with?.admitted_telegram_bot_username).toBe(
+      githubExpression(
+        "needs.resolve-telegram-environment-authority.outputs.telegram_bot_username",
       ),
     );
     expect(
@@ -349,6 +461,13 @@ describe("homepage deployment workflow", () => {
       required: true,
       type: "string",
     });
+    expect(
+      parsedReleaseWorkflow.on?.workflow_call?.inputs?.admitted_telegram_bot_id,
+    ).toMatchObject({ required: true, type: "string" });
+    expect(
+      parsedReleaseWorkflow.on?.workflow_call?.inputs
+        ?.admitted_telegram_bot_username,
+    ).toMatchObject({ required: true, type: "string" });
   });
 
   it("reserves the Telegram authority receipt exclusively for the protected Environment", () => {
@@ -397,14 +516,63 @@ describe("homepage deployment workflow", () => {
         parsedReleaseWorkflow.on?.workflow_call?.secrets,
       ).not.toHaveProperty(name);
     }
+    expect(releaseWorkflow).not.toContain(
+      "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+    );
   });
 
-  it("runs the Telegram resolver before every release mutation", () => {
+  it("admits Telegram identity in the entry workflow before every release mutation", () => {
     const jobs = parsedReleaseWorkflow.jobs ?? {};
     const jobNames = Object.keys(jobs);
     const migration = jobs["migrate-db"];
     const apiDeploy = jobs["deploy-api"];
     const pagesBuild = jobs["build-pages"];
+
+    expect(telegramAuthorityResolver?.environment).toBe("staging");
+    expect(jobNeeds(telegramAuthorityResolver)).toEqual([
+      "bind-telegram-release-attempt",
+      "validate-deploy-source",
+    ]);
+    expect(telegramAuthorityResolver?.if).toContain(
+      "inputs.environment == 'staging'",
+    );
+    expect(telegramAuthorityResolver?.outputs).toEqual({
+      telegram_bot_id: githubExpression("steps.telegram.outputs.bot_id"),
+      telegram_bot_username: githubExpression(
+        "steps.telegram.outputs.bot_username",
+      ),
+      telegram_authority_run_attempt: githubExpression(
+        "steps.telegram.outputs.run_attempt",
+      ),
+    });
+    expect(telegramAuthorityResolver?.steps?.[0]?.uses).toContain(
+      "actions/checkout@",
+    );
+    expect(telegramValidation?.env).toEqual({
+      RELEASE_RUN_ATTEMPT: githubExpression("github.run_attempt"),
+      TARGET_ENVIRONMENT: "staging",
+      TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression(
+        "needs.bind-telegram-release-attempt.outputs.run_attempt",
+      ),
+      ENVIRONMENT_TELEGRAM_BOT_ID: githubExpression(
+        "vars.VITE_TELEGRAM_BOT_ID",
+      ),
+      ENVIRONMENT_TELEGRAM_BOT_USERNAME: githubExpression(
+        "vars.VITE_TELEGRAM_BOT_USERNAME",
+      ),
+      TELEGRAM_IDENTITY_AUTHORITY_SHA256: githubExpression(
+        "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+      ),
+    });
+    expect(jobNeeds(parsedWorkflow.jobs?.release)).toContain(
+      "resolve-telegram-environment-authority",
+    );
+    expect(parsedWorkflow.jobs?.release?.if).toContain(
+      "needs.resolve-telegram-environment-authority.result == 'success'",
+    );
+    expect(parsedWorkflow.jobs?.release?.if).toContain(
+      "needs.resolve-telegram-environment-authority.result == 'skipped'",
+    );
 
     expect(jobNames.indexOf("resolve-pages-environment-config")).toBeLessThan(
       jobNames.indexOf("migrate-db"),
@@ -416,20 +584,17 @@ describe("homepage deployment workflow", () => {
       ),
     );
     expect(resolver?.steps?.[0]?.uses).toContain("actions/checkout@");
-    expect(telegramValidation?.env).toEqual({
+    expect(admittedTelegramValidation?.env).toEqual({
       RELEASE_RUN_ATTEMPT: githubExpression("github.run_attempt"),
       TARGET_ENVIRONMENT: githubExpression("inputs.target_environment"),
       TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression(
         "inputs.telegram_authority_run_attempt",
       ),
-      ENVIRONMENT_TELEGRAM_BOT_ID: githubExpression(
-        "vars.VITE_TELEGRAM_BOT_ID",
+      ADMITTED_TELEGRAM_BOT_ID: githubExpression(
+        "inputs.admitted_telegram_bot_id",
       ),
-      ENVIRONMENT_TELEGRAM_BOT_USERNAME: githubExpression(
-        "vars.VITE_TELEGRAM_BOT_USERNAME",
-      ),
-      TELEGRAM_IDENTITY_AUTHORITY_SHA256: githubExpression(
-        "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+      ADMITTED_TELEGRAM_BOT_USERNAME: githubExpression(
+        "inputs.admitted_telegram_bot_username",
       ),
     });
     expect(releaseWorkflow).not.toContain("secrets.VITE_TELEGRAM_BOT_ID");
@@ -453,6 +618,64 @@ describe("homepage deployment workflow", () => {
     expect(pagesBuild?.if).toContain(
       "needs.resolve-pages-environment-config.result == 'success'",
     );
+  });
+
+  it("limits the feature-ref Telegram authority canary to protected staging preflight", () => {
+    const dispatchInputs = (
+      (parsedWorkflow.on?.workflow_dispatch ?? {}) as {
+        inputs?: Record<string, WorkflowCallInput>;
+      }
+    ).inputs;
+    const sourceValidation = namedStep(
+      parsedWorkflow.jobs?.["validate-deploy-source"],
+      "Reject feature refs targeting canonical environments",
+    );
+    const canaryInput = dispatchInputs?.telegram_authority_canary;
+
+    expect(canaryInput).toMatchObject({ required: false, type: "boolean" });
+    expect(telegramAuthorityResolver?.environment).toBe("staging");
+    expect(telegramAuthorityResolver?.if).toContain(
+      "inputs.environment == 'staging'",
+    );
+    expect(telegramValidation?.run).not.toContain(
+      "TELEGRAM_IDENTITY_AUTHORITY_SHA256=",
+    );
+    expect(telegramValidation?.run).not.toContain(
+      'TELEGRAM_IDENTITY_AUTHORITY_SHA256" >>',
+    );
+    for (const jobName of [
+      "admit-staging",
+      "validate-staging-certification",
+      "authorize-production",
+      "release",
+      "certify-staging-release",
+    ]) {
+      expect(parsedWorkflow.jobs?.[jobName]?.if, jobName).toContain(
+        "inputs.telegram_authority_canary != true",
+      );
+    }
+    expect(sourceValidation.env?.TELEGRAM_AUTHORITY_CANARY).toBe(
+      githubExpression("inputs.telegram_authority_canary == true"),
+    );
+
+    const accepted = runTelegramAuthorityCanaryAdmission();
+    expect(accepted.exitCode).toBe(0);
+    expect(accepted.stdout).toContain(
+      "Telegram authority canary admitted for protected staging preflight only.",
+    );
+
+    for (const invalid of [
+      { label: "production", targetEnvironment: "production" },
+      { label: "force", force: "true" },
+      { label: "renderer", renderer: "true" },
+    ]) {
+      const execution = runTelegramAuthorityCanaryAdmission(invalid);
+      expect(execution.exitCode, invalid.label).toBe(1);
+      expect(
+        `${execution.stdout}\n${execution.stderr}`,
+        invalid.label,
+      ).toContain("Telegram authority canary");
+    }
   });
 
   it("guards the first selected job for every partial-rerun mutation path", () => {
@@ -538,10 +761,10 @@ describe("homepage deployment workflow", () => {
       });
       expect(execution.exitCode).toBe(0);
       expect(execution.githubOutput).toBe(
-        `bot_id=${valid.botId}\nbot_username=${valid.botUsername}\n`,
+        `bot_id=${valid.botId}\nbot_username=${valid.botUsername}\nrun_attempt=1\n`,
       );
       expect(execution.summary).toContain(
-        `Validated Telegram public identity policy for ${valid.target}.`,
+        `Validated protected Telegram public identity policy for ${valid.target}.`,
       );
       assertNoPublicSurfaceLeak(execution, [valid.botId, valid.botUsername]);
     }
@@ -634,7 +857,7 @@ describe("homepage deployment workflow", () => {
     ]);
   });
 
-  it("derives production Telegram identity from source and ignores all staging inputs", () => {
+  it("derives production Telegram identity in the reusable release and ignores caller inputs", () => {
     for (const configuredStagingPair of [
       { botId: "", botUsername: "" },
       stagingTelegram,
@@ -643,7 +866,7 @@ describe("homepage deployment workflow", () => {
         botUsername: "not-a-valid-name!",
       },
     ]) {
-      const execution = runTelegramPreflight({
+      const execution = runReusableTelegramPreflight({
         ...configuredStagingPair,
         targetEnvironment: "production",
       });
@@ -652,7 +875,7 @@ describe("homepage deployment workflow", () => {
         `bot_id=${canonicalTelegram.botId}\nbot_username=${canonicalTelegram.botUsername}\n`,
       );
       expect(execution.summary).toContain(
-        "Validated Telegram public identity policy for production.",
+        "Accepted caller-admitted Telegram public identity for production.",
       );
       assertNoPublicSurfaceLeak(execution, [
         configuredStagingPair.botId,

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -351,7 +351,7 @@ describe("homepage deployment workflow", () => {
     });
   });
 
-  it("forwards an exact caller-secret allowlist without the Environment authority receipt", () => {
+  it("reserves the Telegram authority receipt exclusively for the protected Environment", () => {
     const release = parsedWorkflow.jobs?.release;
     const callerSecrets = release?.secrets;
     const environmentOnlySecrets = [
@@ -381,7 +381,7 @@ describe("homepage deployment workflow", () => {
       Object.keys(
         parsedReleaseWorkflow.on?.workflow_call?.secrets ?? {},
       ).sort(),
-    ).toEqual([...expectedCallerSecrets, ...environmentOnlySecrets].sort());
+    ).toEqual(expectedCallerSecrets);
     for (const name of expectedCallerSecrets) {
       expect(callerSecretMap[name], name).toBe(
         githubExpression(`secrets.${name}`),
@@ -393,9 +393,9 @@ describe("homepage deployment workflow", () => {
     }
     for (const name of environmentOnlySecrets) {
       expect(callerSecretMap).not.toHaveProperty(name);
-      expect(parsedReleaseWorkflow.on?.workflow_call?.secrets?.[name]).toEqual({
-        required: false,
-      });
+      expect(
+        parsedReleaseWorkflow.on?.workflow_call?.secrets,
+      ).not.toHaveProperty(name);
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes #30300. Hosted staging runs 33607968604 and 33608714838 resolved protected public Telegram variables but saw an empty receipt before all mutations skipped. GitHub/actionlint requires a reusable workflow to declare caller-passed secrets, so an Environment-only receipt cannot safely be read inside that reusable boundary without a same-named caller secret contract.

The entry workflow now has a staging-only protected Environment preflight. It validates the staging public pair, its framed SHA-256 receipt, distinctness from production, and the bound run attempt; it emits only the accepted public ID, username, and run attempt. The reusable release receives typed public inputs only, rechecks their format and attempt binding, and never declares, receives, outputs, or logs the receipt. Production continues to derive the canonical identity from checked-out source, without a second caller Environment approval.

A telegram_authority_canary dispatch mode is read-only: it runs only on a ref permitted by the protected staging Environment policy, requires staging with force and renderer disabled, performs the caller preflight, and skips all admission, reusable-release, mutation, and certification jobs.

## Evidence

- Focused workflow contracts: 72 passing tests / 1,105 assertions; the Telegram contract has 17 tests / 545 assertions, including missing, malformed, mismatch, replay, production-source, and canary-negative paths.
- actionlint passed for both modified workflows; Biome, guide parity, diff check, verify:cloud (84 successful tasks), and root verify passed locally.
- Canary attempted on preceding exact PR SHA 709a267414ed74dd07dede9a531f88c4ad4289df: run 33611381085. Canonical-source validation and attempt bind passed; GitHub Environment policy rejected the unpermitted feature branch before the protected preflight could access secrets; all admission, release, mutation, and certification jobs were skipped. No environment setting, secret, or deployment was changed.

No deployment or GitHub secret was changed by this PR.