### PR TITLE
test(core): pin the single-code-unit budget edge in the well-formed helpers

### DIFF
--- a/packages/core/src/utils/well-formed.test.ts
+++ b/packages/core/src/utils/well-formed.test.ts
@@ -68,6 +68,22 @@ describe("truncateWellFormed", () => {
 		const malformed = `x\uD83D`;
 		expect(truncateWellFormed(`${malformed}yz`, 2)).toBe(malformed);
 	});
+
+	it("yields empty rather than a lone high half when a 1-unit budget meets an astral first character", () => {
+		// The back-off has nowhere to go: cutting at 1 would split the pair, and
+		// the only boundary below it is 0. Every other boundary can retreat one
+		// code unit, so this is the single case where a caller loses the
+		// character outright instead of shortening it — callers that render the
+		// result (an avatar initial, a badge) must handle "" themselves.
+		expect(truncateWellFormed("\u{1F680}x", 1)).toBe("");
+		expect(truncateWellFormed("\u{1F680}", 1)).toBe("");
+		expect(isWellFormed(truncateWellFormed("\u{1F680}x", 1))).toBe(true);
+	});
+
+	it("still backs off at a 1-unit budget when the text is ASCII-led", () => {
+		// Guards the boundary above: a 1-unit budget is not itself special.
+		expect(truncateWellFormed("a\u{1F680}", 1)).toBe("a");
+	});
 });
 
 describe("tailWellFormed", () => {
@@ -94,6 +110,19 @@ describe("tailWellFormed", () => {
 		expect(tailWellFormed("abc", Number.NaN)).toBe("");
 		expect(tailWellFormed("abc", Number.POSITIVE_INFINITY)).toBe("");
 		expect(tailWellFormed("abc", Number.NEGATIVE_INFINITY)).toBe("");
+	});
+
+	it("yields empty rather than a lone low half when a 1-unit budget meets an astral last character", () => {
+		// The tail-side dual: advancing past the split pair runs off the end of
+		// the string, so the whole character is dropped rather than the orphaned
+		// low half being emitted.
+		expect(tailWellFormed("x\u{1F680}", 1)).toBe("");
+		expect(tailWellFormed("\u{1F680}", 1)).toBe("");
+		expect(isWellFormed(tailWellFormed("x\u{1F680}", 1))).toBe(true);
+	});
+
+	it("still advances at a 1-unit budget when the text is ASCII-tailed", () => {
+		expect(tailWellFormed("\u{1F680}a", 1)).toBe("a");
 	});
 });
 


### PR DESCRIPTION
## What this pins

`truncateWellFormed` and `tailWellFormed` guarantee well-formed output at every boundary. A budget of **one code unit** is the only boundary where the back-off has nowhere to retreat to: cutting an astral character at 1 would split the pair, and the only lower boundary is the empty string. Both helpers already do the right thing — they drop the character rather than emit the orphaned half:

```ts
truncateWellFormed("🚀x", 1)  // ""   (not "\uD83D")
tailWellFormed("x🚀", 1)      // ""   (not "\uDE80")
```

Nothing pinned that.

## Why it matters — the mutants that survive today

I restricted each helper's back-off to `maxLength > 1`, so a 1-unit budget emits the lone surrogate:

| mutant | existing suite |
|---|---|
| `truncateWellFormed` back-off restricted to `maxLength > 1` | **71/71 green — missed** |
| `tailWellFormed` advance restricted to `maxLength > 1` | **71/71 green — missed** |

Both produce exactly the ill-formed shape this module exists to prevent (#18025 — a mid-emoji slice whose `\uD8xx` escape a strict JSON parser rejects), and the whole suite lets them through.

The blind spot is in the fixtures, not the sweeps: `"produces well-formed output at every possible boundary"` iterates every `n`, but its text starts with `"hi "` and ends with `"end"`, so `n = 1` never meets an astral character at either edge.

## What's added

Four cases, and I checked each one earns its place rather than padding the count:

| new test | kills |
|---|---|
| astral first character, budget 1 → `""` | back-off restricted to `maxLength > 1` |
| astral last character, budget 1 → `""` | tail advance restricted to `maxLength > 1` |
| ASCII-led text, budget 1 → `"a"` | an over-correcting `if (maxLength === 1) return ""` |
| ASCII-tailed text, budget 1 → `"a"` | the tail-side dual of the same over-correction |

Each of the three mutants is killed by exactly one new test, with the other 74 staying green. The two guards are not decoration — without the ASCII-led case, "always drop at a 1-unit budget" passes.

## For callers

The tests also document the consequence, which is easy to meet by accident: a renderer that displays `truncateWellFormed(label, 1)` — an avatar initial, a single-character badge — receives `""` for an emoji-led label and must handle it. `truncateWellFormed` is a *truncation* helper; taking a first **code point** is a different operation (`Array.from(text)[0]`).

## Verification

```
packages/core  well-formed.test.ts     75 passed  (was 71)
packages/core  src/utils/ (full)       60 files / 865 passed
biome check    well-formed.test.ts     clean
tsc --noEmit   -p packages/core        clean
```

Test-only change; no source is touched.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GP9Z5X9Y0M9HATZVJ1W8DQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T09:13:23.389Z","completed_at":"2026-09-02T09:14:39.987Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T09:13:24.085Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1141a2b7175e3ac7f080456f0dafe1ab59047914fabf4071bfcde46a84fcac87","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"98c1459c-9dd1-4d42-984f-b346392ff05d","object_id":"sha256:1141a2b7175e3ac7f080456f0dafe1ab59047914fabf4071bfcde46a84fcac87","sha256":"1141a2b7175e3ac7f080456f0dafe1ab59047914fabf4071bfcde46a84fcac87"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"3TA14cbZGPbySYGxO0pX7weK9xWm5ciZPKeENHsK8fxCwyPVbJtDgL0geQOOzt6EysA8BNNOfrSW2F4vQTUOCg"}} -->
