### PR TITLE
fix(ci): fail closed in the staging Telegram authority job

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -178,10 +178,12 @@ jobs:
           [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || \
             fail "Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs"
 
-          case "$TARGET_ENVIRONMENT" in
-            staging|production) ;;
-            *) fail "target_environment must be exactly staging or production" ;;
-          esac
+          # This job resolves the staging authority only: it is gated on
+          # `inputs.environment == 'staging'` and holds the protected `staging`
+          # Environment. Fail closed rather than trusting that wiring, so no
+          # later edit can reach an identity path that skips the receipt.
+          [ "$TARGET_ENVIRONMENT" = "staging" ] || \
+            fail "This job resolves the protected staging Telegram authority only"
 
           canonical_source="packages/homepage/src/lib/contact.ts"
           canonical_bot_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
@@ -194,37 +196,32 @@ jobs:
           [[ "$canonical_bot_username_key" == *bot ]] || \
             fail "The homepage canonical Telegram username must use the managed bot suffix"
 
-          if [ "$TARGET_ENVIRONMENT" = "production" ]; then
-            resolved_bot_id="$canonical_bot_id"
-            resolved_bot_username="$canonical_bot_username"
-          else
-            if [ -z "$ENVIRONMENT_TELEGRAM_BOT_ID" ] || \
-              [ -z "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" ]; then
-              fail "The protected staging Telegram identity must configure the complete VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME pair"
-            fi
-            valid_bot_id "$ENVIRONMENT_TELEGRAM_BOT_ID" || \
-              fail "The protected staging VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
-            [[ "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
-              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
-            staging_bot_username_key="$(printf '%s' "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
-            [[ "$staging_bot_username_key" == *bot ]] || \
-              fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
-            if [ "$ENVIRONMENT_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
-              [ "$staging_bot_username_key" = "$canonical_bot_username_key" ]; then
-              fail "Staging Telegram configuration must use an identity fully distinct from production"
-            fi
-            [[ "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" =~ ^[0-9a-f]{64}$ ]] || \
-              fail "The staging GitHub Environment must provide a valid TELEGRAM_IDENTITY_AUTHORITY_SHA256 receipt"
-            computed_identity_sha256="$(
-              printf 'elizaOS/eliza\0staging\0telegram-public-identity\0v1\0%s\0%s\n' \
-                "$ENVIRONMENT_TELEGRAM_BOT_ID" "$staging_bot_username_key" \
-                | sha256sum | cut -d ' ' -f 1
-            )"
-            [ "$computed_identity_sha256" = "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" ] || \
-              fail "The staging Telegram identity does not match its protected Environment authority receipt"
-            resolved_bot_id="$ENVIRONMENT_TELEGRAM_BOT_ID"
-            resolved_bot_username="$ENVIRONMENT_TELEGRAM_BOT_USERNAME"
+          if [ -z "$ENVIRONMENT_TELEGRAM_BOT_ID" ] || \
+            [ -z "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" ]; then
+            fail "The protected staging Telegram identity must configure the complete VITE_TELEGRAM_BOT_ID and VITE_TELEGRAM_BOT_USERNAME pair"
           fi
+          valid_bot_id "$ENVIRONMENT_TELEGRAM_BOT_ID" || \
+            fail "The protected staging VITE_TELEGRAM_BOT_ID must match the Telegram bot ID contract"
+          [[ "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" =~ ^[A-Za-z0-9_]{5,32}$ ]] || \
+            fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must match the Telegram username contract"
+          staging_bot_username_key="$(printf '%s' "$ENVIRONMENT_TELEGRAM_BOT_USERNAME" | tr '[:upper:]' '[:lower:]')"
+          [[ "$staging_bot_username_key" == *bot ]] || \
+            fail "The protected staging VITE_TELEGRAM_BOT_USERNAME must use the managed bot suffix"
+          if [ "$ENVIRONMENT_TELEGRAM_BOT_ID" = "$canonical_bot_id" ] || \
+            [ "$staging_bot_username_key" = "$canonical_bot_username_key" ]; then
+            fail "Staging Telegram configuration must use an identity fully distinct from production"
+          fi
+          [[ "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" =~ ^[0-9a-f]{64}$ ]] || \
+            fail "The staging GitHub Environment must provide a valid TELEGRAM_IDENTITY_AUTHORITY_SHA256 receipt"
+          computed_identity_sha256="$(
+            printf 'elizaOS/eliza\0staging\0telegram-public-identity\0v1\0%s\0%s\n' \
+              "$ENVIRONMENT_TELEGRAM_BOT_ID" "$staging_bot_username_key" \
+              | sha256sum | cut -d ' ' -f 1
+          )"
+          [ "$computed_identity_sha256" = "$TELEGRAM_IDENTITY_AUTHORITY_SHA256" ] || \
+            fail "The staging Telegram identity does not match its protected Environment authority receipt"
+          resolved_bot_id="$ENVIRONMENT_TELEGRAM_BOT_ID"
+          resolved_bot_username="$ENVIRONMENT_TELEGRAM_BOT_USERNAME"
 
           printf 'bot_id=%s\n' "$resolved_bot_id" >> "$GITHUB_OUTPUT"
           printf 'bot_username=%s\n' "$resolved_bot_username" >> "$GITHUB_OUTPUT"

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -1005,6 +1005,22 @@ describe("homepage deployment workflow", () => {
     }
   });
 
+  it("fails closed when the protected authority job is pointed at anything but staging", () => {
+    // This job holds the `staging` Environment and is gated on
+    // `inputs.environment == 'staging'`, so only staging can reach it today.
+    // The check exists so a later edit that parameterises TARGET_ENVIRONMENT
+    // cannot reach an identity path that skips the receipt entirely.
+    for (const target of ["production", "", "Staging", "staging "]) {
+      const execution = runTelegramPreflight({ targetEnvironment: target });
+      expect(execution.exitCode, target).toBe(1);
+      expect(execution.githubOutput, target).toBe("");
+      expect(execution.summary, target).toBe("");
+      expect(execution.stderr, target).toContain(
+        "This job resolves the protected staging Telegram authority only",
+      );
+    }
+  });
+
   it("derives production Telegram identity in the reusable release and ignores caller inputs", () => {
     for (const configuredStagingPair of [
       { botId: "", botUsername: "" },


### PR DESCRIPTION
Follow-up to #30301 (merged as `b03c7fd239`), which moved the Telegram receipt check into the entry workflow's protected `staging` Environment. I approved that PR and raised this in review; recording it here with the fix rather than leaving it as a comment.

## The problem

The job #30301 added carries a `production` arm that resolves an identity **without evaluating the receipt at all**:

```bash
if [ "$TARGET_ENVIRONMENT" = "production" ]; then
  resolved_bot_id="$canonical_bot_id"
  resolved_bot_username="$canonical_bot_username"
else
  … the entire receipt verification …
fi
```

That arm is unreachable today. `TARGET_ENVIRONMENT` is the literal `staging` (`cloud-cf-deploy.yml:154`) and the job is gated on `inputs.environment == 'staging'`, so **nothing is wrong in the current wiring** and this is not a live vulnerability.

The concern is what the code invites. The surrounding `case "$TARGET_ENVIRONMENT" in staging|production)` only makes sense if the variable is expected to become a parameter — and parameterising it is the obvious next edit. At that moment this becomes a receipt-free identity path inside a job that already holds `staging` Environment approval, and nothing in the file flags it.

Extracting the step and running it directly shows what the arm does:

```
$ TARGET_ENVIRONMENT=production bash authority.sh
rc=0
bot_id=8931353359
bot_username=ElizaIsNotABot        ← production identity, no receipt evaluated
```

## The change

This job resolves the staging authority only, so it now asserts that instead of trusting the two external guards:

- the permissive `case` becomes an exact `[ "$TARGET_ENVIRONMENT" = "staging" ]` check that fails closed;
- the dead `production` arm is removed, so receipt verification is the function's **only** path to an identity.

Production is unaffected: the reusable release already derives it from `packages/homepage/src/lib/contact.ts` and ignores caller inputs, which `derives production Telegram identity in the reusable release and ignores caller inputs` already pins.

## Verification

Re-ran the extracted step through the same harness:

| case | before | after |
|---|---|---|
| valid staging pair + matching receipt | rc=0 | **rc=0**, byte-identical outputs |
| `TARGET_ENVIRONMENT=production` | **rc=0, emits production identity** | **rc=1** — `This job resolves the protected staging Telegram authority only` |
| `TARGET_ENVIRONMENT=""` | rc=1 (`case` catch-all) | rc=1 — same explicit error |
| forged receipt | rc=1 | **rc=1** — unchanged |

The added test drives the existing `runTelegramPreflight` helper with `production`, `""`, `"Staging"` and `"staging "`; the last two pin that the check is exact rather than case-insensitive or a prefix match.

**The test is load-bearing** — against `develop`'s copy of the workflow it fails, and only it:

```
develop's workflow + new test:   17 pass | 1 fail   ← the new test
with this fix:                   18 pass |  0 fail   561 expect() calls
```

Sibling workflow contracts named in `pr-static-smoke.yml:137-140` are unaffected:

```
homepage-deploy-workflow + canonical-source-guard + voice-deploy + bun-version-contract
  93 pass | 8 skip | 0 fail | 33334 expect() calls
```

`biome check` clean on the touched test file; the workflow still parses (8 jobs, authority job intact).
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GPVZFDJ03057JDRD10A8Q8","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T09:23:13.517Z","completed_at":"2026-09-02T09:24:36.163Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T09:23:14.545Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1df2a7959c8120fe1dd4ed9988f6239d7ad53c9ed910e33fa3a88f4c7159879d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"92a1ec06-c364-4a37-bc1d-8b80d0d384d1","object_id":"sha256:1df2a7959c8120fe1dd4ed9988f6239d7ad53c9ed910e33fa3a88f4c7159879d","sha256":"1df2a7959c8120fe1dd4ed9988f6239d7ad53c9ed910e33fa3a88f4c7159879d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"cH7k9oTxady0fIV1QBkG2a4Aqr0tiey1yDOm3HVNKpVR9Y-d1sQ3s5Y0tpDL-ZfO0GwXBM6jrbxGGUyQ0GWzDA"}} -->
