### PR TITLE
test(ci): execute the canonical deploy-source pairing instead of matching its text

### DIFF
--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -292,6 +292,46 @@ function runTelegramAuthorityCanaryAdmission(
   };
 }
 
+function runCanonicalDeploySourceGuard(
+  overrides: Partial<{ sourceRef: string; targetEnvironment: string }> = {},
+): TelegramExecution {
+  const guard = namedStep(
+    parsedWorkflow.jobs?.["validate-deploy-source"],
+    "Reject feature refs targeting canonical environments",
+  );
+  if (!guard.run)
+    throw new Error("Missing executable canonical deploy source guard");
+
+  const result = Bun.spawnSync(["bash", "-c", guard.run], {
+    cwd: repositoryRoot,
+    env: {
+      ...process.env,
+      CERTIFIED_PRODUCTION_BASE_SHA: "",
+      CERTIFIED_RECOVERY_POLICY_SHA: "",
+      EFFECT_DIGEST: "",
+      EVENT_NAME: "workflow_dispatch",
+      FORCE: "false",
+      GITHUB_SHA: "0123456789012345678901234567890123456789",
+      PRODUCTION_BINDING_ONLY_RECOVERY: "false",
+      RUN_DEPLOYED_RENDERER_STAGING: "false",
+      SOURCE_REF: overrides.sourceRef ?? "refs/heads/develop",
+      SOURCE_SHA: "",
+      TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
+      TELEGRAM_AUTHORITY_CANARY: "false",
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  return {
+    exitCode: result.exitCode,
+    githubOutput: "",
+    stderr: result.stderr.toString(),
+    stdout: result.stdout.toString(),
+    summary: "",
+  };
+}
+
 function assertNoPublicSurfaceLeak(
   execution: TelegramExecution,
   values: string[],
@@ -1002,6 +1042,41 @@ describe("homepage deployment workflow", () => {
       expect(execution.stderr, invalid.label).toContain(
         "Telegram runtime authority was not proven for the selected protected Environment; re-run all jobs",
       );
+    }
+  });
+
+  it("admits only the canonical ref for each environment", () => {
+    // This pairing is the only thing standing between "operator selected
+    // staging" and a production deploy: `release` routes on
+    // `github.ref == 'refs/heads/main'` as well as the environment input, so a
+    // staging dispatch admitted from main would resolve target_environment to
+    // production.
+    for (const valid of [
+      { sourceRef: "refs/heads/develop", targetEnvironment: "staging" },
+      { sourceRef: "refs/heads/main", targetEnvironment: "production" },
+    ]) {
+      const execution = runCanonicalDeploySourceGuard(valid);
+      expect(execution.exitCode, JSON.stringify(valid)).toBe(0);
+    }
+
+    for (const invalid of [
+      { sourceRef: "refs/heads/main", targetEnvironment: "staging" },
+      { sourceRef: "refs/heads/develop", targetEnvironment: "production" },
+      {
+        sourceRef: "refs/heads/feature/anything",
+        targetEnvironment: "staging",
+      },
+      {
+        sourceRef: "refs/heads/feature/anything",
+        targetEnvironment: "production",
+      },
+    ]) {
+      const execution = runCanonicalDeploySourceGuard(invalid);
+      expect(execution.exitCode, JSON.stringify(invalid)).toBe(1);
+      expect(
+        `${execution.stdout}\n${execution.stderr}`,
+        JSON.stringify(invalid),
+      ).toContain("deploys must run from");
     }
   });
 


### PR DESCRIPTION
## What's unprotected

`validate-deploy-source` decides which ref may deploy which environment — staging from `develop`, production from `main`, everything else rejected:

```bash
if [ "$TARGET_ENVIRONMENT" = "production" ]; then
  expected_ref="refs/heads/main"
else
  expected_ref="refs/heads/develop"
fi
if [ "$SOURCE_REF" != "$expected_ref" ]; then … exit 1; fi
```

**That pairing is routing-critical, not hygiene.** The `release` job selects the production path on `github.ref == 'refs/heads/main'` *as well as* on the environment input:

```yaml
((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main')
```

so a **staging** dispatch admitted from `main` resolves `target_environment` to **production**. This guard is the only thing standing between "operator selected staging" and a production deploy.

Today it's pinned only by string containment (`cloud-deploy-environment-contract.test.ts:334-336`):

```ts
expect(validate.run).toContain('expected_ref="refs/heads/main"');
expect(validate.run).toContain('if [ "$SOURCE_REF" != "$expected_ref" ]');
```

That asserts the source text, not the behaviour.

## The mutants that survive today

Each keeps the literals those assertions look for. Run against all three workflow suites:

| mutation | effect | result |
|---|---|---|
| `… != … ] && [ "$TARGET_ENVIRONMENT" = "production" ]` | staging admitted from **any** ref — the routing hazard above | **49 pass / 0 fail** |
| `[ "$SOURCE_REF" = "$expected_ref" ]` | inverted: only the canonical ref is rejected | **49 pass / 0 fail** |
| `if false; then` | check removed entirely | **49 pass / 0 fail** |

The file already executes this exact step, but `runTelegramAuthorityCanaryAdmission` hardwires `TELEGRAM_AUTHORITY_CANARY=true` and the step returns inside the canary block, so it never reaches the pairing logic.

## What's added

A general `runCanonicalDeploySourceGuard` harness (configurable `sourceRef` / `targetEnvironment`, canary off) and one test:

- **admitted:** `develop` → staging, `main` → production
- **rejected:** `main` → staging, `develop` → production, and a feature ref against each environment

Both cross pairings matter: `main` → staging is the one that would silently route to production, and `develop` → production is its mirror.

## Verification

Each mutant is killed by exactly the new test, with the other 17 unaffected:

```
mutant 1 / 2 / 3:   17 pass | 1 fail   ← "admits only the canonical ref for each environment"
with the guard intact:   18 pass | 0 fail   555 expect() calls
```

Sibling workflow contracts are unaffected:

```
homepage-deploy-workflow + cloud-deploy-environment-contract
  + cloud-cf-canonical-source-guard-workflow + cloud-cf-voice-deploy-workflow
  + ci-bun-version-contract
    124 tests | 8 skip | 0 fail | 33679 expect() calls
```

`biome check` clean. Test-only change — the workflow itself is untouched.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GQHDC1HPG7CZ9VQ9X7BP60","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T09:34:55.873Z","completed_at":"2026-09-02T09:36:35.392Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T09:34:56.664Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3ecf20ad231f5cc2b2b8166cfd4eb5d9babead800db3666ceac74396172d5279","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f9b34e17-91fb-443b-bbe3-1685d8baec42","object_id":"sha256:3ecf20ad231f5cc2b2b8166cfd4eb5d9babead800db3666ceac74396172d5279","sha256":"3ecf20ad231f5cc2b2b8166cfd4eb5d9babead800db3666ceac74396172d5279"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"y_i8iN3WAHHVTO_uCarokOdZdv00uPxv8E2YUOL5mQDy-lee5qzy5STChu9QRE8EQiwEZxzJkZdUflI_VixwCw"}} -->
