### PR TITLE
fix: preserve protected staging Telegram bindings

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -363,18 +363,24 @@ pair only when it matches the protected `staging` GitHub Environment secret
 `TELEGRAM_IDENTITY_AUTHORITY_SHA256`, and requires both components to differ
 from production. The receipt is the lowercase SHA-256 of the framed bytes
 `elizaOS/eliza\0staging\0telegram-public-identity\0v1\0<ID>\0<lowercase-username>\n`.
-The entry workflow's protected Environment job reads the receipt directly; the
-reusable release uses an exact caller-secret allowlist that deliberately does
-not forward or declare it, and receives only the already-admitted public pair.
-That keeps a repository or organization secret from substituting for the
-Environment authority. A repository/organization variable may resolve the same
-committed public pair, but cannot select a different pair.
+The protected staging entry job reads the receipt directly and verifies that the
+existing Worker has both Telegram binding names before any release mutation. It
+emits only a safe staging preserve-authority result; the reusable release
+receives that result and the already-admitted public pair, never the receipt,
+bot token, or webhook secret. This keeps a repository or organization secret
+from substituting for Environment authority or crossing the reusable-workflow
+boundary. The `deploy-api` job preserves a staging binding whose GitHub source
+is blank, then verifies its name again after the atomic Worker deploy. For
+production, the already-approved `production` authorization job verifies the
+live bot token against the canonical public identity and the deploy hard-fails
+if either protected credential is blank. A repository/organization variable may
+resolve the same committed public pair, but cannot select a different pair.
 For a hosted, read-only authority proof on a ref allowed by the protected
 `staging` Environment policy, dispatch `cloud-cf-deploy.yml` with
 `environment=staging` and `telegram_authority_canary=true`. The canary rejects
 production, force, and deployed-renderer options, runs only the protected
-staging receipt preflight, and skips admission, the reusable release, every
-mutation, and certification.
+staging identity and runtime-binding preflight, and skips admission, the
+reusable release, every mutation, and certification.
 Because GitHub preserves successful job outputs during failed-job reruns, the
 migration, API deploy, Pages build, and Pages deploy jobs each repeat the bound
 attempt check as their first step; a partial rerun must be replaced with a full
@@ -382,11 +388,13 @@ rerun before stale admitted values can reach a release mutation. Cancel and
 fully rerun any in-flight release when rotating the pair or receipt. Missing,
 partial, malformed, out-of-range, receipt-mismatched, or cross-environment
 staging configuration stops the release without printing either value or the
-receipt. Production continues to ignore every GitHub Telegram input and
-derives its exact canonical identity from the checked out
+receipt. Production continues to ignore every GitHub Telegram input, derives
+its exact canonical identity from the checked out
 `packages/homepage/src/lib/contact.ts`. Implicit Vite fallback use remains
-local/direct-only; protected production explicitly selects and validates the
-canonical source constants. Pull requests are validated by
+local/direct-only; its already-approved `production` authorization job verifies
+the live runtime identity before the reusable release begins, so no second
+Environment approval is introduced. Protected production explicitly selects and
+validates the canonical source constants. Pull requests are validated by
 `pr-static-smoke.yml`; there is no credentialed or artifact-only Pages preview
 path in `cloud-cf-deploy.yml`.
 

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -133,15 +133,16 @@ jobs:
     if: ${{ always() && needs.bind-telegram-release-attempt.result == 'success' && needs.validate-deploy-source.result == 'success' && github.event_name == 'workflow_dispatch' && inputs.environment == 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    # A reusable workflow cannot reference an Environment-only secret unless
-    # its caller declares that same secret in workflow_call.secrets. Resolve
-    # this receipt in the entry workflow's protected Environment instead, so
-    # no repository or organization secret can substitute for it.
+    # Keep Environment-only receipt authority and staging binding verification
+    # in this ordinary caller job. The reusable workflow receives only public
+    # identity and a safe environment-bound authority result, so no repository
+    # or organization secret can substitute across the workflow-call boundary.
     environment: staging
     outputs:
       telegram_bot_id: ${{ steps.telegram.outputs.bot_id }}
       telegram_bot_username: ${{ steps.telegram.outputs.bot_username }}
       telegram_authority_run_attempt: ${{ steps.telegram.outputs.run_attempt }}
+      telegram_runtime_authority: ${{ steps.runtime_binding.outputs.runtime_authority }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -230,6 +231,20 @@ jobs:
           printf 'run_attempt=%s\n' "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
           printf 'Validated protected Telegram public identity policy for %s.\n' \
             "$TARGET_ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify protected staging Telegram Worker binding names
+        id: runtime_binding
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          secret_inventory="$(bunx wrangler@4.116.0 secret list --env staging --format json)"
+          printf '%s' "$secret_inventory" | node \
+            packages/cloud/scripts/verify-worker-secret-binding-names.mjs \
+            ELIZA_APP_TELEGRAM_BOT_TOKEN \
+            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET
+          printf 'runtime_authority=staging-protected-receipt-and-existing-bindings\n' >> "$GITHUB_OUTPUT"
 
   validate-deploy-source:
     name: Validate Canonical Deploy Source
@@ -747,14 +762,31 @@ jobs:
     # Approval only. This job must not share a mutation concurrency group, or
     # a waiting reviewer holds the release lock (#18092).
     environment: production
+    outputs:
+      telegram_runtime_authority: ${{ steps.runtime_attestation.outputs.runtime_authority }}
     steps:
       - name: Checkout exact production candidate for bounded recovery audit
-        if: ${{ inputs.production_binding_only_recovery == true }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Attest protected production Telegram runtime identity
+        id: runtime_attestation
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          TELEGRAM_ATTESTATION_CONTEXT: production
+        run: |
+          set -euo pipefail
+          canonical_source="packages/homepage/src/lib/contact.ts"
+          expected_bot_id="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_ID = "([^"]+)";$/\1/p' "$canonical_source")"
+          expected_bot_username="$(sed -nE 's/^export const ELIZA_TELEGRAM_BOT_USERNAME = "([^"]+)";$/\1/p' "$canonical_source")"
+          TELEGRAM_EXPECTED_BOT_ID="$expected_bot_id" \
+            TELEGRAM_EXPECTED_BOT_USERNAME="$expected_bot_username" \
+            node packages/cloud/scripts/verify-telegram-bot-identity.mjs
+          printf 'runtime_authority=production-live-attested\n' >> "$GITHUB_OUTPUT"
 
       - if: ${{ inputs.production_binding_only_recovery == true }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -991,10 +1023,10 @@ jobs:
       queue: max
     uses: ./.github/workflows/cloud-cf-release.yml
     # Explicitly forward every caller-scope secret consumed by the reusable
-    # release except TELEGRAM_IDENTITY_AUTHORITY_SHA256. The entry workflow
-    # validates that receipt in its protected Environment job and passes only
-    # the admitted public bot identity; `inherit` could admit a repository or
-    # organization secret with the same name.
+    # release except Telegram authority and runtime credentials. The entry
+    # workflow validates the protected receipt and passes only public identity
+    # plus a safe runtime-authority result; `inherit` could admit a repository
+    # or organization secret with the same name.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CARTESIA_API_KEY: ${{ secrets.CARTESIA_API_KEY }}
@@ -1013,8 +1045,6 @@ jobs:
       ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
       ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
       ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
-      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
       ELIZA_MOBILE_APP_AUTH_APP_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_APP_ID }}
       ELIZA_SERVICE_JWT_SECRET: ${{ secrets.ELIZA_SERVICE_JWT_SECRET }}
@@ -1053,6 +1083,7 @@ jobs:
       telegram_authority_run_attempt: ${{ needs.resolve-telegram-environment-authority.result == 'success' && needs.resolve-telegram-environment-authority.outputs.telegram_authority_run_attempt || needs.bind-telegram-release-attempt.outputs.run_attempt }}
       admitted_telegram_bot_id: ${{ needs.resolve-telegram-environment-authority.outputs.telegram_bot_id }}
       admitted_telegram_bot_username: ${{ needs.resolve-telegram-environment-authority.outputs.telegram_bot_username }}
+      telegram_runtime_authority: ${{ needs.resolve-telegram-environment-authority.result == 'success' && needs.resolve-telegram-environment-authority.outputs.telegram_runtime_authority || needs.authorize-production.outputs.telegram_runtime_authority }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
       # Resolve the proof request at the entry workflow boundary. A live-ready
       # automatic release is a Develop effect reconciliation with a bound

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -23,6 +23,10 @@ on:
         description: Public Telegram bot username admitted by the protected entry-workflow Environment job
         required: true
         type: string
+      telegram_runtime_authority:
+        description: Safe caller-proven Telegram runtime authority mode for the selected protected Environment
+        required: true
+        type: string
       force:
         description: Bypass the deploy freshness guard
         required: false
@@ -48,10 +52,11 @@ on:
         required: false
         type: string
         default: ""
-    # Keep caller-scope secrets explicit. The Telegram authority receipt is
-    # intentionally absent from both this callable schema and the caller map:
-    # the entry workflow resolves it in its protected Environment job before
-    # passing only the admitted public identity to this reusable workflow.
+    # Keep caller-scope secrets explicit. Telegram's authority receipt and
+    # live credentials are intentionally absent from both this callable schema
+    # and the caller map. The entry workflow proves the environment-specific
+    # runtime authority; deploy-api resolves fixed credential names only from
+    # its own protected Environment context for atomic Worker publication.
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -86,10 +91,6 @@ on:
       ELIZA_APP_BLOOIO_PHONE_NUMBER:
         required: false
       ELIZA_APP_BLOOIO_WEBHOOK_SECRET:
-        required: false
-      ELIZA_APP_TELEGRAM_BOT_TOKEN:
-        required: false
-      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:
         required: false
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET:
         required: false
@@ -196,6 +197,7 @@ jobs:
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: ${{ inputs.telegram_authority_run_attempt }}
           ADMITTED_TELEGRAM_BOT_ID: ${{ inputs.admitted_telegram_bot_id }}
           ADMITTED_TELEGRAM_BOT_USERNAME: ${{ inputs.admitted_telegram_bot_username }}
+          TELEGRAM_RUNTIME_AUTHORITY: ${{ inputs.telegram_runtime_authority }}
         run: |
           set -euo pipefail
 
@@ -216,10 +218,14 @@ jobs:
             fail "Cloud release run attempt is missing or invalid"
           [ "$TELEGRAM_AUTHORITY_RUN_ATTEMPT" = "$RELEASE_RUN_ATTEMPT" ] || \
             fail "Telegram configuration authority was not resolved for the current workflow attempt; re-run all jobs"
-
           case "$TARGET_ENVIRONMENT" in
             staging|production) ;;
             *) fail "target_environment must be exactly staging or production" ;;
+          esac
+
+          case "$TARGET_ENVIRONMENT:$TELEGRAM_RUNTIME_AUTHORITY" in
+            staging:staging-protected-receipt-and-existing-bindings|production:production-live-attested) ;;
+            *) fail "Telegram runtime authority was not proven for the selected protected Environment; re-run all jobs" ;;
           esac
 
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
@@ -249,15 +255,6 @@ jobs:
           printf 'bot_username=%s\n' "$resolved_bot_username" >> "$GITHUB_OUTPUT"
           printf 'Accepted caller-admitted Telegram public identity for %s.\n' \
             "$TARGET_ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Attest protected Telegram runtime identity
-        env:
-          TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
-          TELEGRAM_EXPECTED_BOT_ID: ${{ steps.telegram.outputs.bot_id }}
-          TELEGRAM_EXPECTED_BOT_USERNAME: ${{ steps.telegram.outputs.bot_username }}
-          TELEGRAM_ATTESTATION_CONTEXT: ${{ inputs.target_environment }}
-        run: node packages/cloud/scripts/verify-telegram-bot-identity.mjs
 
       - name: Resolve public WhatsApp configuration
         id: whatsapp
@@ -1403,8 +1400,11 @@ jobs:
           # The edge Telegram route needs both values in the Worker. They are
           # required and replaced atomically with the exact attested source;
           # activation is still a separate protected, live-proven rollout.
-          ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
-          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          # These fixed names are resolved in this job's protected Environment,
+          # never forwarded through workflow_call. The format expression keeps
+          # actionlint from treating them as caller-provided reusable secrets.
+          ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')] }}
+          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')] }}
           # Personal Shared Blooio is the public-number messaging surface in
           # both protected environments. Commit the environment-specific
           # values atomically with the exact Worker source below.
@@ -1680,6 +1680,17 @@ jobs:
             ' "${worker_secret_names[@]}"
           }
 
+          verify_telegram_binding_candidates() {
+            local secret_inventory
+            secret_inventory="$(bunx wrangler@4.116.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            printf '%s' "$secret_inventory" | node \
+              "$CHECKOUT_DIR/packages/cloud/scripts/verify-worker-secret-binding-names.mjs" \
+              --queued "${worker_secret_names[@]}" \
+              --required \
+              ELIZA_APP_TELEGRAM_BOT_TOKEN \
+              ELIZA_APP_TELEGRAM_WEBHOOK_SECRET
+          }
+
           verify_webhook_gateway_binding_candidates() {
             if ! has_nonblank_value "$ELIZA_APP_WEBHOOK_GATEWAY_URL"; then
               return 0
@@ -1799,12 +1810,14 @@ jobs:
             queue_secret INFERENCE_AUTH_PROBE_TOKEN || exit 1
           fi
 
-          for name in \
-            ELIZA_APP_TELEGRAM_BOT_TOKEN \
+          telegram_runtime_secret_names=(
+            ELIZA_APP_TELEGRAM_BOT_TOKEN
             ELIZA_APP_TELEGRAM_WEBHOOK_SECRET
-          do
-            if ! has_nonblank_value "${!name:-}"; then
-              echo "::error::Required protected $DEPLOY_ENVIRONMENT Telegram secret is absent or blank: $name"
+          )
+          for name in "${telegram_runtime_secret_names[@]}"; do
+            if [ "$DEPLOY_ENVIRONMENT" = "production" ] && \
+               ! has_nonblank_value "${!name:-}"; then
+              echo "::error::Required protected production Telegram secret is absent or blank: $name"
               exit 1
             fi
             queue_secret "$name" || exit 1
@@ -1897,6 +1910,11 @@ jobs:
           # same Worker version. A missing value may never deploy as a healthy
           # but permanently unauthorized embeddings path.
           verify_staging_embeddings_secret_candidate || exit 1
+          # Staging can preserve the existing Telegram credentials when the
+          # protected Environment intentionally has no recoverable value.
+          # Production has already required both values above. In both cases,
+          # names-only inventory proves the atomic version can keep the route.
+          verify_telegram_binding_candidates || exit 1
           # The messaging webhook gateway URL is a routing toggle: unset stays
           # on the honest WEBHOOK_GATEWAY_NOT_CONFIGURED 503 (#18235), but a
           # configured URL must point at THIS environment's canonical gateway

--- a/packages/cloud/scripts/__tests__/verify-worker-secret-binding-names.test.ts
+++ b/packages/cloud/scripts/__tests__/verify-worker-secret-binding-names.test.ts
@@ -1,0 +1,65 @@
+/** Exercises the names-only Worker binding verifier without live Cloudflare access. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  parseWorkerSecretBindingNames,
+  verifyWorkerSecretBindingNames,
+} from "../verify-worker-secret-binding-names.mjs";
+
+const telegramNames = [
+  "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+  "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+];
+
+describe("verifyWorkerSecretBindingNames", () => {
+  test("accepts a complete names-only inventory", () => {
+    expect(() =>
+      verifyWorkerSecretBindingNames({
+        inventory: JSON.stringify(telegramNames.map((name) => ({ name }))),
+        requiredNames: telegramNames,
+      }),
+    ).not.toThrow();
+  });
+
+  test("fails closed when either Telegram binding is absent", () => {
+    for (const absentName of telegramNames) {
+      const inventory = telegramNames
+        .filter((name) => name !== absentName)
+        .map((name) => ({ name }));
+      expect(() =>
+        verifyWorkerSecretBindingNames({
+          inventory: JSON.stringify(inventory),
+          requiredNames: telegramNames,
+        }),
+      ).toThrow(
+        `Required Worker secret binding name(s) are absent: ${absentName}`,
+      );
+    }
+  });
+
+  test("accepts an atomic candidate without exposing any value", () => {
+    const value = "private-worker-secret-value";
+    expect(() =>
+      verifyWorkerSecretBindingNames({
+        inventory: "[]",
+        queuedNames: telegramNames,
+        requiredNames: telegramNames,
+      }),
+    ).not.toThrow();
+    try {
+      verifyWorkerSecretBindingNames({
+        inventory: JSON.stringify([
+          { name: "ELIZA_APP_TELEGRAM_BOT_TOKEN", value },
+        ]),
+        requiredNames: telegramNames,
+      });
+      throw new Error("Expected an absent binding to fail");
+    } catch (error) {
+      expect(String(error)).toContain("ELIZA_APP_TELEGRAM_WEBHOOK_SECRET");
+      expect(String(error)).not.toContain(value);
+    }
+    expect(() => parseWorkerSecretBindingNames("not-json")).toThrow(
+      "Worker secret inventory is not valid JSON",
+    );
+  });
+});

--- a/packages/cloud/scripts/verify-worker-secret-binding-names.mjs
+++ b/packages/cloud/scripts/verify-worker-secret-binding-names.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+/**
+ * Validates a names-only Wrangler secret inventory before or after a protected
+ * Worker deploy without accepting provider values, diagnostics, or ambiguity.
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const BINDING_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function fail(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  throw error;
+}
+
+/** Parses a Wrangler secret-list response into valid binding names only. */
+export function parseWorkerSecretBindingNames(output) {
+  let parsed;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    fail("inventory_invalid", "Worker secret inventory is not valid JSON");
+  }
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.result)
+      ? parsed.result
+      : undefined;
+  if (!entries)
+    fail("inventory_invalid", "Worker secret inventory is not an array");
+
+  const names = new Set();
+  for (const entry of entries) {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof entry.name !== "string" ||
+      !BINDING_NAME.test(entry.name)
+    ) {
+      fail(
+        "inventory_invalid",
+        "Worker secret inventory contains an invalid name",
+      );
+    }
+    names.add(entry.name);
+  }
+  return names;
+}
+
+/** Fails closed unless every required name appears in an existing or queued inventory. */
+export function verifyWorkerSecretBindingNames({
+  inventory,
+  requiredNames,
+  queuedNames = [],
+}) {
+  if (!Array.isArray(requiredNames) || !Array.isArray(queuedNames)) {
+    fail(
+      "request_invalid",
+      "Worker secret binding verification requires name arrays",
+    );
+  }
+  const available = parseWorkerSecretBindingNames(inventory);
+  for (const name of [...requiredNames, ...queuedNames]) {
+    if (typeof name !== "string" || !BINDING_NAME.test(name)) {
+      fail(
+        "request_invalid",
+        "Worker secret binding verification received an invalid name",
+      );
+    }
+  }
+  for (const name of queuedNames) available.add(name);
+
+  const missing = requiredNames.filter((name) => !available.has(name));
+  if (missing.length > 0) {
+    fail(
+      "binding_absent",
+      `Required Worker secret binding name(s) are absent: ${missing.join(" ")}`,
+    );
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const requiredNames = [];
+  const queuedNames = [];
+  let destination = requiredNames;
+  for (const arg of args) {
+    if (arg === "--required") {
+      destination = requiredNames;
+      continue;
+    }
+    if (arg === "--queued") {
+      destination = queuedNames;
+      continue;
+    }
+    destination.push(arg);
+  }
+  if (requiredNames.length === 0) {
+    fail(
+      "request_invalid",
+      "Worker secret binding verification requires required names",
+    );
+  }
+  verifyWorkerSecretBindingNames({
+    inventory: readFileSync(0, "utf8"),
+    requiredNames,
+    queuedNames,
+  });
+  process.stdout.write(
+    `Verified ${requiredNames.length} required Worker secret binding names; values were not read.\n`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    // error-policy:J1 The CLI boundary reports only safe binding names and no provider payload.
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Worker secret binding verification failed";
+    process.stderr.write(`::error::${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -102,6 +102,35 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
     expect(verify.run).toContain('"VOICE_REALTIME_ELIZA_AUTHORIZATION"');
   });
 
+  test("preserves staging Telegram bindings but requires production sources", () => {
+    const prepare = step("Prepare Worker secrets for atomic deploy");
+    const verify = step("Verify required Worker secret binding names");
+
+    expect(prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toBe(
+      "$" +
+        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')] }}",
+    );
+    expect(prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toBe(
+      "$" +
+        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')] }}",
+    );
+    expect(prepare.run).toContain("telegram_runtime_secret_names=(");
+    expect(prepare.run).toContain('[ "$DEPLOY_ENVIRONMENT" = "production" ]');
+    expect(prepare.run).toContain(
+      "Required protected production Telegram secret is absent or blank",
+    );
+    expect(prepare.run).toContain("verify_telegram_binding_candidates() {");
+    expect(prepare.run).toContain("verify-worker-secret-binding-names.mjs");
+    expect(prepare.run).toContain(`--queued "\${worker_secret_names[@]}"`);
+    expect(prepare.run).toContain("--required");
+    expect(prepare.run).toContain(
+      "verify_telegram_binding_candidates || exit 1",
+    );
+    expect(verify.run).toContain('"ELIZA_APP_TELEGRAM_BOT_TOKEN"');
+    expect(verify.run).toContain('"ELIZA_APP_TELEGRAM_WEBHOOK_SECRET"');
+    expect(verify.run).toContain("values were not read");
+  });
+
   test("publishes the controlled inference-auth probe token only in staging", () => {
     const prepare = step("Prepare Worker secrets for atomic deploy");
     expect(prepare.env?.INFERENCE_AUTH_PROBE_TOKEN).toBe(

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -196,6 +196,7 @@ function runReusableTelegramPreflight(
     botUsername: string;
     authorityRunAttempt: string;
     releaseRunAttempt: string;
+    runtimeAuthority: string;
     targetEnvironment: string;
   }> = {},
 ): TelegramExecution {
@@ -210,6 +211,7 @@ function runReusableTelegramPreflight(
   const summaryPath = path.join(fixtureRoot, "step-summary.md");
 
   try {
+    const targetEnvironment = overrides.targetEnvironment ?? "staging";
     const result = Bun.spawnSync(
       ["bash", "-c", admittedTelegramValidation.run],
       {
@@ -222,8 +224,13 @@ function runReusableTelegramPreflight(
           ADMITTED_TELEGRAM_BOT_USERNAME:
             overrides.botUsername ?? stagingTelegram.botUsername,
           RELEASE_RUN_ATTEMPT: overrides.releaseRunAttempt ?? "1",
-          TARGET_ENVIRONMENT: overrides.targetEnvironment ?? "staging",
+          TARGET_ENVIRONMENT: targetEnvironment,
           TELEGRAM_AUTHORITY_RUN_ATTEMPT: overrides.authorityRunAttempt ?? "1",
+          TELEGRAM_RUNTIME_AUTHORITY:
+            overrides.runtimeAuthority ??
+            (targetEnvironment === "production"
+              ? "production-live-attested"
+              : "staging-protected-receipt-and-existing-bindings"),
         },
         stderr: "pipe",
         stdout: "pipe",
@@ -470,11 +477,13 @@ describe("homepage deployment workflow", () => {
     ).toMatchObject({ required: true, type: "string" });
   });
 
-  it("reserves the Telegram authority receipt exclusively for the protected Environment", () => {
+  it("keeps Telegram authority and runtime credentials in protected Environment jobs", () => {
     const release = parsedWorkflow.jobs?.release;
     const callerSecrets = release?.secrets;
     const environmentOnlySecrets = [
       "TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+      "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
     ] as const;
     const referencedSecrets = [
       ...releaseWorkflow.matchAll(/\bsecrets\.([A-Z0-9_]+)/g),
@@ -519,6 +528,31 @@ describe("homepage deployment workflow", () => {
     expect(releaseWorkflow).not.toContain(
       "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
     );
+    expect(releaseWorkflow).not.toContain(
+      "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
+    );
+    expect(releaseWorkflow).not.toContain(
+      "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+    );
+
+    const apiDeploy = parsedReleaseWorkflow.jobs?.["deploy-api"];
+    const secretPreparation = namedStep(
+      apiDeploy,
+      "Prepare Worker secrets for atomic deploy",
+    );
+    expect(apiDeploy?.environment).toBe(
+      githubExpression("inputs.target_environment"),
+    );
+    expect(secretPreparation.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toBe(
+      githubExpression(
+        "secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')]",
+      ),
+    );
+    expect(secretPreparation.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toBe(
+      githubExpression(
+        "secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')]",
+      ),
+    );
   });
 
   it("admits Telegram identity in the entry workflow before every release mutation", () => {
@@ -544,6 +578,9 @@ describe("homepage deployment workflow", () => {
       telegram_authority_run_attempt: githubExpression(
         "steps.telegram.outputs.run_attempt",
       ),
+      telegram_runtime_authority: githubExpression(
+        "steps.runtime_binding.outputs.runtime_authority",
+      ),
     });
     expect(telegramAuthorityResolver?.steps?.[0]?.uses).toContain(
       "actions/checkout@",
@@ -564,6 +601,25 @@ describe("homepage deployment workflow", () => {
         "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
       ),
     });
+    const stagingRuntimeBinding = namedStep(
+      telegramAuthorityResolver,
+      "Verify protected staging Telegram Worker binding names",
+    );
+    expect(stagingRuntimeBinding.env).toEqual({
+      CLOUDFLARE_API_TOKEN: githubExpression("secrets.CLOUDFLARE_API_TOKEN"),
+      CLOUDFLARE_ACCOUNT_ID: githubExpression("secrets.CLOUDFLARE_ACCOUNT_ID"),
+    });
+    expect(stagingRuntimeBinding.run).toContain(
+      "wrangler@4.116.0 secret list --env staging --format json",
+    );
+    expect(stagingRuntimeBinding.run).toContain(
+      "verify-worker-secret-binding-names.mjs",
+    );
+    expect(stagingRuntimeBinding.run).toContain(
+      "runtime_authority=staging-protected-receipt-and-existing-bindings",
+    );
+    expect(stagingRuntimeBinding.run).not.toContain("TELEGRAM_BOT_TOKEN=");
+    expect(stagingRuntimeBinding.run).not.toContain("TELEGRAM_WEBHOOK_SECRET=");
     expect(jobNeeds(parsedWorkflow.jobs?.release)).toContain(
       "resolve-telegram-environment-authority",
     );
@@ -572,6 +628,54 @@ describe("homepage deployment workflow", () => {
     );
     expect(parsedWorkflow.jobs?.release?.if).toContain(
       "needs.resolve-telegram-environment-authority.result == 'skipped'",
+    );
+    expect(
+      parsedWorkflow.jobs?.release?.with?.telegram_runtime_authority,
+    ).toContain(
+      "needs.resolve-telegram-environment-authority.outputs.telegram_runtime_authority",
+    );
+    expect(
+      parsedWorkflow.jobs?.release?.with?.telegram_runtime_authority,
+    ).toContain(
+      "needs.authorize-production.outputs.telegram_runtime_authority",
+    );
+    expect(
+      parsedReleaseWorkflow.on?.workflow_call?.inputs
+        ?.telegram_runtime_authority,
+    ).toMatchObject({ required: true, type: "string" });
+
+    const productionAuthorization =
+      parsedWorkflow.jobs?.["authorize-production"];
+    const productionRuntimeAttestation = namedStep(
+      productionAuthorization,
+      "Attest protected production Telegram runtime identity",
+    );
+    expect(productionAuthorization?.environment).toBe("production");
+    expect(productionAuthorization?.outputs).toEqual({
+      telegram_runtime_authority: githubExpression(
+        "steps.runtime_attestation.outputs.runtime_authority",
+      ),
+    });
+    expect(productionRuntimeAttestation.env).toEqual({
+      TELEGRAM_BOT_TOKEN: githubExpression(
+        "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      ),
+      TELEGRAM_WEBHOOK_SECRET: githubExpression(
+        "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+      ),
+      TELEGRAM_ATTESTATION_CONTEXT: "production",
+    });
+    expect(productionRuntimeAttestation.run).toContain(
+      "packages/homepage/src/lib/contact.ts",
+    );
+    expect(productionRuntimeAttestation.run).toContain(
+      "packages/cloud/scripts/verify-telegram-bot-identity.mjs",
+    );
+    expect(productionRuntimeAttestation.run).toContain(
+      "runtime_authority=production-live-attested",
+    );
+    expect(jobNeeds(parsedWorkflow.jobs?.release)).toContain(
+      "authorize-production",
     );
 
     expect(jobNames.indexOf("resolve-pages-environment-config")).toBeLessThan(
@@ -590,6 +694,9 @@ describe("homepage deployment workflow", () => {
       TELEGRAM_AUTHORITY_RUN_ATTEMPT: githubExpression(
         "inputs.telegram_authority_run_attempt",
       ),
+      TELEGRAM_RUNTIME_AUTHORITY: githubExpression(
+        "inputs.telegram_runtime_authority",
+      ),
       ADMITTED_TELEGRAM_BOT_ID: githubExpression(
         "inputs.admitted_telegram_bot_id",
       ),
@@ -601,6 +708,9 @@ describe("homepage deployment workflow", () => {
     expect(releaseWorkflow).not.toContain("secrets.VITE_TELEGRAM_BOT_USERNAME");
 
     expect(jobNeeds(migration)).toEqual(["resolve-pages-environment-config"]);
+    expect(jobNeeds(parsedWorkflow.jobs?.release)).toContain(
+      "resolve-telegram-environment-authority",
+    );
     expect(migration?.if).toContain(
       "needs.resolve-pages-environment-config.result == 'success'",
     );
@@ -855,6 +965,44 @@ describe("homepage deployment workflow", () => {
       environmentTelegram.botId,
       environmentTelegram.botUsername,
     ]);
+  });
+
+  it("fails closed before release mutations when caller runtime authority is absent", () => {
+    const execution = runReusableTelegramPreflight({ runtimeAuthority: "" });
+
+    expect(execution.exitCode).toBe(1);
+    expect(execution.githubOutput).toBe("");
+    expect(execution.summary).toBe("");
+    expect(execution.stderr).toContain(
+      "Telegram runtime authority was not proven for the selected protected Environment; re-run all jobs",
+    );
+    assertNoPublicSurfaceLeak(execution, [
+      stagingTelegram.botId,
+      stagingTelegram.botUsername,
+    ]);
+  });
+
+  it("rejects a runtime-authority result for the wrong protected Environment", () => {
+    for (const invalid of [
+      {
+        label: "production live attestation passed to staging",
+        targetEnvironment: "staging",
+        runtimeAuthority: "production-live-attested",
+      },
+      {
+        label: "staging preserve authority passed to production",
+        targetEnvironment: "production",
+        runtimeAuthority: "staging-protected-receipt-and-existing-bindings",
+      },
+    ]) {
+      const execution = runReusableTelegramPreflight(invalid);
+      expect(execution.exitCode, invalid.label).toBe(1);
+      expect(execution.githubOutput, invalid.label).toBe("");
+      expect(execution.summary, invalid.label).toBe("");
+      expect(execution.stderr, invalid.label).toContain(
+        "Telegram runtime authority was not proven for the selected protected Environment; re-run all jobs",
+      );
+    }
   });
 
   it("derives production Telegram identity in the reusable release and ignores caller inputs", () => {


### PR DESCRIPTION
## Summary

Fixes #30303 and the staging failure in [run 33612944092](https://github.com/elizaOS/eliza/actions/runs/33612944092) without forwarding Telegram credentials through the reusable workflow.

- Moves runtime authority to ordinary caller jobs scoped to the selected protected Environment. Staging validates the protected identity receipt and reads only the existing Worker binding names before the reusable release; production derives the canonical public identity and performs the live token attestation in its existing approved `production` job.
- Removes Telegram token/webhook secret declarations and forwarding from `workflow_call`. The reusable workflow accepts a safe, environment-bound authority mode only; it rejects a missing or cross-environment mode before any release job can begin.
- Keeps staging source blanks preserve-only, verifies the two Worker binding names before atomic deploy and again after deploy, and preserves production hard-fail behavior for either blank credential. No credential is emitted as a job output or logged.
- Adds a tested names-only Wrangler-inventory verifier and workflow contract coverage for absent bindings, safe output boundaries, pre-mutation order, production semantics, and atomic-preservation behavior.

## Validation

- `bun install --frozen-lockfile`
- `bun test packages/cloud/scripts/__tests__/verify-worker-secret-binding-names.test.ts packages/cloud/scripts/__tests__/verify-telegram-bot-identity.test.ts packages/scripts/__tests__/homepage-deploy-workflow.test.ts packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts` (33 passed)
- `bunx @biomejs/biome check` on the changed scripts/tests
- `actionlint` for `.github/workflows/cloud-cf-deploy.yml` and `.github/workflows/cloud-cf-release.yml`
- `bun run check:agents-claude`
- `bun run verify:cloud` (84 successful tasks; existing unrelated cloud-test-mocks warnings remain warnings)
- `bun run verify` (376 successful tasks; repository audit gates passed)

## Evidence

- Real hosted deployment/mutation: N/A by design. This PR does not dispatch a deployment, alter an Environment secret, or change Cloudflare state.
- Live staging inventory: names-only evidence supplied during diagnosis showed both required Telegram Worker binding names present while GitHub did not expose their values; this change preserves and re-verifies that condition.