### PR TITLE
test(ci): execute the Headscale protected deploy-source matrix

### DIFF
--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -73,6 +73,34 @@ function step(name: string): WorkflowStep {
   return found;
 }
 
+/**
+ * Executes the protected deploy-source guard so the environment/ref pairing and
+ * the operation matrix are covered by behaviour rather than by matching the
+ * step's text. `retire-legacy-vhost-and-converge` is destructive, so its
+ * staging-only and reviewed-SHA constraints are the ones worth running.
+ */
+function runProtectedDeploySource(options: {
+  environment: string;
+  operation: string;
+  githubRef: string;
+  reviewedSha?: string;
+}) {
+  return spawnSync(
+    "bash",
+    ["-c", step("Validate protected deploy source").run],
+    {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH ?? "",
+        GITHUB_REF: options.githubRef,
+        TARGET_ENVIRONMENT: options.environment,
+        TARGET_OPERATION: options.operation,
+        TARGET_REVIEWED_LEGACY_VHOST_SHA256: options.reviewedSha ?? "",
+      },
+    },
+  );
+}
+
 function expectBashSyntax(source: string) {
   const syntax = spawnSync("bash", ["-n"], {
     encoding: "utf8",
@@ -556,6 +584,122 @@ describe("protected Headscale arm workflow", () => {
     expect(controlPlaneRunbookSource).toContain("-f environment=production");
     expect(controlPlaneRunbookSource).not.toContain("-f headscale_api_url=");
     expect(controlPlaneRunbookSource).not.toContain("-f listen_addr=");
+  });
+
+  test("executes the protected deploy-source guard's environment and operation matrix", () => {
+    const reviewed = "a".repeat(64);
+
+    // Admitted: each environment from its canonical ref, plus the two reviewed
+    // staging legacy-vhost operations.
+    for (const admitted of [
+      {
+        environment: "staging",
+        operation: "converge",
+        githubRef: "refs/heads/develop",
+      },
+      {
+        environment: "production",
+        operation: "converge",
+        githubRef: "refs/heads/main",
+      },
+      {
+        environment: "staging",
+        operation: "inspect-legacy-vhost",
+        githubRef: "refs/heads/develop",
+      },
+      {
+        environment: "staging",
+        operation: "retire-legacy-vhost-and-converge",
+        githubRef: "refs/heads/develop",
+        reviewedSha: reviewed,
+      },
+    ]) {
+      const result = runProtectedDeploySource(admitted);
+      expect(result.status, JSON.stringify(admitted)).toBe(0);
+    }
+
+    for (const rejected of [
+      // Cross ref/environment pairings.
+      {
+        environment: "staging",
+        operation: "converge",
+        githubRef: "refs/heads/main",
+      },
+      {
+        environment: "production",
+        operation: "converge",
+        githubRef: "refs/heads/develop",
+      },
+      {
+        environment: "staging",
+        operation: "converge",
+        githubRef: "refs/heads/feature/x",
+      },
+      // Unsupported selections.
+      {
+        environment: "sandbox",
+        operation: "converge",
+        githubRef: "refs/heads/develop",
+      },
+      {
+        environment: "staging",
+        operation: "destroy",
+        githubRef: "refs/heads/develop",
+      },
+      // The destructive retirement is staging-only...
+      {
+        environment: "production",
+        operation: "retire-legacy-vhost-and-converge",
+        githubRef: "refs/heads/main",
+        reviewedSha: reviewed,
+      },
+      // ...and requires the exact reviewed digest.
+      {
+        environment: "staging",
+        operation: "retire-legacy-vhost-and-converge",
+        githubRef: "refs/heads/develop",
+      },
+      {
+        environment: "staging",
+        operation: "retire-legacy-vhost-and-converge",
+        githubRef: "refs/heads/develop",
+        reviewedSha: "A".repeat(64),
+      },
+      {
+        environment: "staging",
+        operation: "retire-legacy-vhost-and-converge",
+        githubRef: "refs/heads/develop",
+        reviewedSha: "a".repeat(63),
+      },
+      // A reviewed digest is meaningful only for retirement.
+      {
+        environment: "staging",
+        operation: "converge",
+        githubRef: "refs/heads/develop",
+        reviewedSha: reviewed,
+      },
+      {
+        environment: "staging",
+        operation: "inspect-legacy-vhost",
+        githubRef: "refs/heads/develop",
+        reviewedSha: reviewed,
+      },
+      // inspect-legacy-vhost is registered for staging only.
+      {
+        environment: "production",
+        operation: "inspect-legacy-vhost",
+        githubRef: "refs/heads/main",
+      },
+    ]) {
+      const result = runProtectedDeploySource(rejected);
+      expect(result.status, JSON.stringify(rejected)).toBe(1);
+      // This workflow annotates on stdout (plain `echo`), unlike the Cloud
+      // deploy guard which redirects to stderr — assert across both streams.
+      expect(
+        `${result.stdout}${result.stderr}`,
+        JSON.stringify(rejected),
+      ).toContain("::error::");
+    }
   });
 
   test("pins staging and production deploys to their canonical branch SHA", () => {


### PR DESCRIPTION
Same class of gap as #30305, in a different workflow — picked deliberately so the two don't touch the same file.

## What's unprotected

`Validate protected deploy source` in `arm-headscale-control-plane.yml` gates three things:

1. which ref may deploy which environment (`develop` → staging, `main` → production);
2. which operations are registered for which environment (`inspect-legacy-vhost` and `retire-legacy-vhost-and-converge` are staging-only);
3. an exact reviewed SHA-256 for the **destructive** `retire-legacy-vhost-and-converge`, and no stray digest on the others.

Only the ref half is pinned, and only as text (`headscale-arm-workflow.test.ts:561-565`):

```ts
expect(sourceGate).toContain('staging) expected_ref="refs/heads/develop"');
expect(sourceGate).toContain('if [ "$GITHUB_REF" != "$expected_ref" ]');
```

## The mutants that survive today

Each keeps the literals those assertions look for:

| mutation | effect | existing suite |
|---|---|---|
| drop the staging-only restriction on `retire-legacy-vhost-and-converge` | **destructive legacy-vhost retirement admitted against production** | **32 pass / 0 fail** |
| drop the `converge` guard rejecting a stray `reviewed_legacy_vhost_sha256` | a retirement digest is silently accepted on a plain converge | **32 pass / 0 fail** |
| `… != … ] && [ "$TARGET_ENVIRONMENT" = "production" ]` | staging deploys admitted from **any** ref | **32 pass / 0 fail** |
| weaken the SHA-256 regex to a non-empty check | — | 31 pass / **1 fail** (already caught) |

I'm only claiming the first three as gaps; the fourth is already covered by a text assertion.

## What's added

A `runProtectedDeploySource` harness — the file already spawns bash for other steps — driving the step with the same env names the job sets (`arm-headscale-control-plane.yml:42-44`), and one matrix test:

- **admitted (4):** `develop`/staging converge, `main`/production converge, staging inspect, staging retirement with a valid digest.
- **rejected (12):** both cross ref/environment pairings, a feature ref, an unsupported environment, an unsupported operation, production retirement, retirement with a missing / uppercase / 63-character digest, a digest passed to each of the two non-retirement operations, and `inspect-legacy-vhost` against production.

All three surviving mutants are now killed (32 pass / 1 fail each, the failure being this test).

## One thing worth knowing for future tests here

My first version asserted `::error::` on **stderr** and failed: this workflow annotates with a plain `echo` to stdout, unlike the Cloud deploy guard which redirects with `>&2`. The assertion now reads both streams, with a comment saying why — widening it silently would have hidden a real difference between the two guards.

## Verification

```
headscale-arm-workflow.test.ts                  33 pass | 0 fail | 440 expect()
  + homepage-deploy + cloud-deploy-environment  73 pass | 0 fail | 1336 expect()
biome check                                     clean
```

Checked and clear: this file isn't in `pr-static-smoke.yml`'s workflow-contract list, but `test:scripts` discovers it (297 files in the inventory, this one included) and runs from `ci.yml:129`, `test.yml:1218` and `scenario-pr.yml:847`.

Test-only change — the workflow itself is untouched.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GR3T89FWXN31WJXCX4EWJH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T09:44:58.889Z","completed_at":"2026-09-02T09:47:24.252Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T09:44:59.803Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9ffac076d57855edc75efe1d46b397933e1ef0d1a0d2f09a922b6aceab9def6f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"cfc6311b-1e37-4af9-98a1-d3acc53a9209","object_id":"sha256:9ffac076d57855edc75efe1d46b397933e1ef0d1a0d2f09a922b6aceab9def6f","sha256":"9ffac076d57855edc75efe1d46b397933e1ef0d1a0d2f09a922b6aceab9def6f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"hiCEJHR9RPQ7LwNAEOoLubtaCKtIbCoxVISuoqwk27vYjpYFhP0K2d1UscrUH4HVpvNTffa1yWgxV1wPnmKbDQ"}} -->
