### PR TITLE
fix: install Bun before Telegram binding check

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -148,6 +148,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
       - name: Validate protected Telegram public identity
         id: telegram
         env:

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -29,6 +29,7 @@ interface WorkflowStep {
   name?: string;
   run?: string;
   uses?: string;
+  with?: Record<string, string>;
 }
 
 interface WorkflowJob {
@@ -585,6 +586,25 @@ describe("homepage deployment workflow", () => {
     expect(telegramAuthorityResolver?.steps?.[0]?.uses).toContain(
       "actions/checkout@",
     );
+    const stagingBunSetupIndex =
+      telegramAuthorityResolver?.steps?.findIndex(
+        (step) =>
+          step.uses ===
+          "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
+      ) ?? -1;
+    const stagingRuntimeBindingIndex =
+      telegramAuthorityResolver?.steps?.findIndex(
+        (step) =>
+          step.name ===
+          "Verify protected staging Telegram Worker binding names",
+      ) ?? -1;
+    expect(stagingBunSetupIndex).toBeGreaterThan(0);
+    expect(stagingBunSetupIndex).toBeLessThan(stagingRuntimeBindingIndex);
+    expect(
+      telegramAuthorityResolver?.steps?.[stagingBunSetupIndex]?.with,
+    ).toEqual({
+      "bun-version": "1.3.14",
+    });
     expect(telegramValidation?.env).toEqual({
       RELEASE_RUN_ATTEMPT: githubExpression("github.run_attempt"),
       TARGET_ENVIRONMENT: "staging",


### PR DESCRIPTION
## Summary

Fixes #30308 and the safe pre-mutation failure in [run 33616648274](https://github.com/elizaOS/eliza/actions/runs/33616648274).

- Installs the repository-pinned Bun 1.3.14 action in the protected staging caller job immediately after checkout and before the `bunx wrangler` names-only Telegram binding check.
- Adds a workflow regression test proving the exact pinned setup action and version precede the runtime binding check.
- Preserves all existing receipt, secret-boundary, names-only verification, and no-mutation behavior.

## Validation

- `bun install --frozen-lockfile`
- focused workflow, binding-verifier, and atomic Worker contract tests (29 passed)
- Biome and actionlint for the affected workflows
- `bun run verify:cloud` (84 successful tasks)
- `bun run verify` (376 successful tasks)

## Evidence

No deployment, environment approval, secret mutation, or Cloudflare mutation was performed. The original hosted run failed before release mutation because `bunx` was unavailable in the caller job; this PR installs pinned Bun before that read-only check.