### PR TITLE
test(ci): execute the Infrastructure canonical source-ref pairing

### DIFF
--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -3,6 +3,7 @@
  * host-inventory, and shared-secret drift without inspecting protected values.
  */
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 const repoRoot = new URL("../../../", import.meta.url);
@@ -101,6 +102,30 @@ const requiredAuthWorkerSecretNames = [
   "STEWARD_TENANT_API_KEY",
   "GATEWAY_INTERNAL_SECRET",
 ] as const;
+
+/**
+ * Executes the Infrastructure canonical-source guard so the environment/ref
+ * pairing is covered by behaviour rather than by matching the step's text.
+ * Every Terraform operation in this workflow is gated on `validate-source`,
+ * so which ref may drive which environment is the contract worth running.
+ */
+function runCanonicalInfraSource(options: {
+  environment: string;
+  sourceRef: string;
+}) {
+  return spawnSync(
+    "bash",
+    ["-c", step(infra, "validate-source", "Validate canonical source ref").run],
+    {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH ?? "",
+        SOURCE_REF: options.sourceRef,
+        TARGET_ENVIRONMENT: options.environment,
+      },
+    },
+  );
+}
 
 describe("canonical cloud deployment environment contract", () => {
   test("records the staging certificate with the upload action digest shape", () => {
@@ -334,6 +359,45 @@ describe("canonical cloud deployment environment contract", () => {
     expect(validate.run).toContain('expected_ref="refs/heads/main"');
     expect(validate.run).toContain('expected_ref="refs/heads/develop"');
     expect(validate.run).toContain('if [ "$SOURCE_REF" != "$expected_ref" ]');
+  });
+
+  test("executes the canonical source-ref pairing for both environments", () => {
+    // Admitted: each protected environment driven from its own canonical
+    // branch. `environment` is a two-option choice input, so these are the
+    // only selections that may reach Terraform.
+    for (const admitted of [
+      { environment: "production", sourceRef: "refs/heads/main" },
+      { environment: "staging", sourceRef: "refs/heads/develop" },
+    ]) {
+      const result = runCanonicalInfraSource(admitted);
+      expect(result.status, JSON.stringify(admitted)).toBe(0);
+      // This step annotates with a plain `echo`, so the error would land on
+      // stdout rather than stderr — assert across both streams.
+      expect(
+        `${result.stdout}${result.stderr}`,
+        JSON.stringify(admitted),
+      ).not.toContain("::error::");
+    }
+
+    // Rejected: the crossed pairing in both directions, plus refs that are
+    // neither canonical branch.
+    for (const rejected of [
+      { environment: "production", sourceRef: "refs/heads/develop" },
+      { environment: "staging", sourceRef: "refs/heads/main" },
+      { environment: "production", sourceRef: "refs/heads/feature/infra" },
+      { environment: "staging", sourceRef: "refs/heads/feature/infra" },
+      { environment: "production", sourceRef: "refs/tags/v1.0.0" },
+      { environment: "staging", sourceRef: "refs/pull/1/merge" },
+      { environment: "production", sourceRef: "main" },
+      { environment: "staging", sourceRef: "" },
+    ]) {
+      const result = runCanonicalInfraSource(rejected);
+      expect(result.status, JSON.stringify(rejected)).toBe(1);
+      expect(
+        `${result.stdout}${result.stderr}`,
+        JSON.stringify(rejected),
+      ).toContain("::error::");
+    }
   });
 
   test("validates quoted Terraform state addresses through the executable parser", () => {


### PR DESCRIPTION
`infra.yml` is the sole Terraform operations entry point, and every operation in it is `needs: validate-source`. That job's guard decides which branch may drive which protected environment:

```bash
if [ "$TARGET_ENVIRONMENT" = "production" ]; then
  expected_ref="refs/heads/main"
else
  expected_ref="refs/heads/develop"
fi
if [ "$SOURCE_REF" != "$expected_ref" ]; then
  echo "::error::$TARGET_ENVIRONMENT infrastructure must run from $expected_ref"
  exit 1
fi
```

`cloud-deploy-environment-contract.test.ts` pins it as three substrings:

```ts
expect(validate.run).toContain('expected_ref="refs/heads/main"');
expect(validate.run).toContain('expected_ref="refs/heads/develop"');
expect(validate.run).toContain('if [ "$SOURCE_REF" != "$expected_ref" ]');
```

Substrings can't see behaviour. I ran three mutations against the file; baseline **23 pass / 0 fail / 351 expects**.

| mutation | existing suite |
|---|---|
| swap the branch mapping — `production` demands `refs/heads/develop`, everything else demands `refs/heads/main` | **23 pass — survives** |
| `exit 1` → `exit 0` — the guard reports the mismatch and admits it anyway | **23 pass — survives** |
| invert `!=` to `=` | 22 pass / 1 fail — caught by the third literal |

Both survivors keep all three asserted literals. The first sends production Terraform applies from `develop` and refuses them from `main`; the second removes the gate entirely, so any ref reaches `plan`, `apply`, and `state-rm` against either protected environment.

## What this adds

A `runCanonicalInfraSource` harness that spawns bash on the step's own `run` body, and one matrix test:

- **admitted (2)** — `production` from `refs/heads/main`, `staging` from `refs/heads/develop`. `environment` is a two-option choice input, so these are the only selections that can reach Terraform.
- **rejected (8)** — the crossed pairing in both directions, a feature branch under each environment, a tag, a pull ref, a bare `main` without the `refs/heads/` prefix, and an empty ref.

With the test in place both surviving mutants die:

| mutation | with this test |
|---|---|
| swap the branch mapping | **23 pass / 1 fail** |
| `exit 1` → `exit 0` | **23 pass / 1 fail** |
| invert `!=` to `=` | 22 pass / 2 fail |

The file goes **23 → 24 tests, 351 → 371 expects**, and `bun test packages/scripts/__tests__` is **1501 pass / 3 fail** — the same three failures (`on-demand CodeQL workflow`, two `protected gateway-webhook deployment workflow` cases) that `develop` already has at `51626812ec`, confirmed by stashing this diff and re-running.

`biome check` on the file reports the one pre-existing `noTemplateCurlyInString` warning at line 560 and nothing new.

One note for readers: this step annotates with a plain `echo`, so `::error::` lands on stdout rather than stderr — unlike the Cloud deploy guard, which redirects. The assertion reads both streams and says why.

No workflow behaviour changes; this is test-only.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GSHZ29FAHF0KDG5NCS4XZQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T10:10:11.145Z","completed_at":"2026-09-02T10:11:37.432Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T10:10:11.884Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"681bb4b75968dea42b3646c2d716bbbdb66ca6a281ebeaa3be72530b25990a2b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"defcac8a-fbe9-402b-a725-b0d901a6a852","object_id":"sha256:681bb4b75968dea42b3646c2d716bbbdb66ca6a281ebeaa3be72530b25990a2b","sha256":"681bb4b75968dea42b3646c2d716bbbdb66ca6a281ebeaa3be72530b25990a2b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"BcJlX2nM3EjngHVAPG9lqvMwxWAQ7EjY094Qbz5Qwdp0ODXsOXiqCjY2dpAP_bHivDFISLLYUjOI61lh1wHnBA"}} -->
