### PR TITLE
test(ci): tie the workflow Wrangler CLI to the root override pin

### DIFF
--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -3,7 +3,7 @@
  * host-inventory, and shared-secret drift without inspecting protected values.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 
 const repoRoot = new URL("../../../", import.meta.url);
 
@@ -89,6 +89,40 @@ const cloudWorkerSecretNames = [
   ...workerSecretNames,
   "TUNNEL_HOSTNAME_SIGNING_SECRET",
 ] as const;
+
+// The repository pins the Wrangler CLI in the root `overrides` block, and every
+// protected Worker-secret path runs that exact version through `bunx`. Those
+// call sites — and the assertions covering them — spell the version as a
+// constant, so bumping the pin alone would silently leave CI on the old CLI.
+// Tie the two together rather than repeating a literal.
+const rootPackageJson = JSON.parse(read("package.json")) as {
+  overrides?: Record<string, string>;
+};
+const pinnedWranglerVersion = rootPackageJson.overrides?.wrangler;
+
+// The Pages and AASA edge paths sit on 4.100.0, re-introduced after
+// `02e44bb10c` removed that pin for crashing under `bunx`. Whether that still
+// reproduces is a maintainer call and not something this contract should
+// decide, so record the exception instead of changing it — frozen by file and
+// count, so the set can only shrink deliberately.
+const legacyWranglerCallSites: Record<string, number> = {
+  ".github/workflows/cloud-cf-release.yml": 4,
+  ".github/workflows/deploy-aasa.yml": 3,
+};
+
+function wranglerCallSites(): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+  const dir = ".github/workflows";
+  for (const entry of readdirSync(new URL(dir, repoRoot)).sort()) {
+    if (!entry.endsWith(".yml") && !entry.endsWith(".yaml")) continue;
+    const path = `${dir}/${entry}`;
+    const versions = [
+      ...read(path).matchAll(/bunx wrangler@(\d+\.\d+\.\d+)/g),
+    ].map((match) => match[1]);
+    if (versions.length > 0) found.set(path, versions);
+  }
+  return found;
+}
 
 const requiredAuthWorkerSecretNames = [
   "OIDC_CLIENTS",
@@ -892,5 +926,37 @@ describe("canonical cloud deployment environment contract", () => {
       '--environment "${' + '{ steps.env.outputs.environment }}"',
     );
     expect(verify.run).toContain("--require-beacon");
+  });
+
+  test("runs the Wrangler CLI at the root-pinned version everywhere but the recorded legacy paths", () => {
+    expect(pinnedWranglerVersion).toMatch(/^\d+\.\d+\.\d+$/);
+
+    const legacyCounts: Record<string, number> = {};
+    for (const [path, versions] of wranglerCallSites()) {
+      for (const version of versions) {
+        if (version === pinnedWranglerVersion) continue;
+        legacyCounts[path] = (legacyCounts[path] ?? 0) + 1;
+      }
+    }
+
+    // Every non-pinned call site is one of the recorded legacy ones, and there
+    // are exactly as many as recorded — a new stray version, or one more
+    // legacy invocation, fails here rather than reaching a protected deploy.
+    expect(legacyCounts).toEqual(legacyWranglerCallSites);
+
+    // The protected Worker-secret paths still invoke Wrangler, and every one of
+    // those invocations is the pinned version — an empty list would satisfy a
+    // "no legacy versions here" check vacuously, so assert the count too.
+    const sites = wranglerCallSites();
+    for (const [path, count] of [
+      [".github/workflows/cloud-cf-deploy.yml", 1],
+      [".github/workflows/activate-personal-shared-telegram-edge.yml", 1],
+      [".github/workflows/cloud-cf-release.yml", 6],
+    ] as const) {
+      const pinned = (sites.get(path) ?? []).filter(
+        (version) => version === pinnedWranglerVersion,
+      );
+      expect(pinned.length, path).toBe(count);
+    }
   });
 });


### PR DESCRIPTION
The root `package.json` pins the Wrangler CLI:

```json
"overrides": { "wrangler": "4.116.0" }
```

and six places assert that version — but as a literal, not as a reference to the pin:

```
packages/cloud/scripts/cloud-latency-certification.mjs
packages/cloud/scripts/ensure-worker-secret-absent.mjs
packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
packages/scripts/__tests__/homepage-deploy-workflow.test.ts
```

Nothing joins the two ends, so the drift is only defended in one direction. Baseline across the five suites that mention wrangler: **63 pass / 0 fail**.

| mutation | existing suites |
|---|---|
| `overrides.wrangler` → `"4.117.0"`, workflows untouched | **63 pass — survives** |
| a protected secret-path call site → `bunx wrangler@4.90.0` | **63 pass — survives** |
| one extra `bunx wrangler@4.100.0` invocation added | **63 pass — survives** |
| a protected call site → `bunx wrangler@4.100.0` | 62 pass / 1 fail — already caught |

The first is the one that matters: bump the override and every workflow keeps fetching the old CLI through `bunx`, with the whole suite green and nothing to notice it. `ci-bun-version-contract.mjs` does exactly this job for Bun — 304 sites, 68 workflow pins in lockstep — and Wrangler has no equivalent.

## What this adds

A `wranglerCallSites()` scan of `.github/workflows`, and one test that:

- derives the expected version from `overrides.wrangler` instead of repeating the literal;
- freezes the recorded legacy call sites **by file and count**, so the set can only shrink;
- asserts the protected Worker-secret paths carry the pinned version, with an explicit count so an empty list can't satisfy it vacuously.

All three surviving mutants now fail:

| mutation | with this test |
|---|---|
| `overrides.wrangler` → `"4.117.0"` | **23 pass / 1 fail** |
| stray `wrangler@4.90.0` in a protected path | **23 pass / 1 fail** |
| one more `wrangler@4.100.0` site | **23 pass / 1 fail** |

The file goes **23 → 24 tests, 351 → 356 expects**.

## The legacy set is recorded, not changed

Seven call sites are on `wrangler@4.100.0` — four in `cloud-cf-release.yml` (Pages Functions build, Pages project create, two Pages deploys) and three in `deploy-aasa.yml` (AASA edge Worker bundle, rollback, delete).

That version has history in this repo. Commit `02e44bb10c` (2026-06-28) removed exactly that pin:

> `ci(deploy): unpin wrangler in cloud-cf-deploy (bunx wrangler@4.100.0 crashes under Bun)`
> #9869 pinned the deploy wrangler invocations to @4.100.0, which fails under bunx with "Cannot find module './sender'" (undici websocket lazy-require bug under Bun) …

`git blame` puts the current occurrences at `b07633a657` (2026-07-17) and `074bf300d4` (2026-08-14) — both **after** that removal.

I did not try to settle whether the crash still reproduces. `bunx wrangler@4.100.0 --version` and `@4.116.0 --version` both load fine under Bun 1.4.0 locally, but `--version` never reaches undici's lazy websocket require, so that is not a probe — and CI runs Bun 1.3.14 on Linux, not 1.4.0 on macOS. Reproducing it properly means a real Cloudflare API call, which I have no business making.

So this PR does not touch those seven sites. It records them as an explicit exception with the reasoning above, and freezes the count so a new one fails the contract. Whether to bump them is a maintainer call with information I don't have; if the answer is "yes", deleting two lines from `legacyWranglerCallSites` is the whole follow-up.

## Validation

- `packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts` — **24 pass / 0 fail / 356 expects**
- `bun test packages/scripts/__tests__` — **1501 pass / 8 skip / 3 fail**; the three (`on-demand CodeQL workflow`, two `protected gateway-webhook deployment workflow`) are the same failures `develop` has at `a3d94c51c3`, confirmed by stashing this diff and re-running
- `biome check` on the file — the one pre-existing `noTemplateCurlyInString` warning at line 530, nothing new

Test-only; no workflow behaviour changes.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GTHEAYBZKPKDADGNXNYVVH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T10:27:22.590Z","completed_at":"2026-09-02T10:28:52.775Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T10:27:23.330Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2fda4593985cf80fcedb87b88444c955254d88e03c6e6988b1876e0c48f74ea7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0959c1f8-720c-4087-b76d-135246979a1c","object_id":"sha256:2fda4593985cf80fcedb87b88444c955254d88e03c6e6988b1876e0c48f74ea7","sha256":"2fda4593985cf80fcedb87b88444c955254d88e03c6e6988b1876e0c48f74ea7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"pjiir0OuqHMx9aUZVdCZ5wehqTOh5KPaS7aFg-CkKUxCWEsiEwRGtdEfJp41p86FtxKZINZMQot_Dke-F66dAA"}} -->
