### PR TITLE
fix: resolve Telegram preflight from API config

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -238,6 +238,7 @@ jobs:
 
       - name: Verify protected staging Telegram Worker binding names
         id: runtime_binding
+        working-directory: packages/cloud/api
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -245,7 +246,7 @@ jobs:
           set -euo pipefail
           secret_inventory="$(bunx wrangler@4.116.0 secret list --env staging --format json)"
           printf '%s' "$secret_inventory" | node \
-            packages/cloud/scripts/verify-worker-secret-binding-names.mjs \
+            ../scripts/verify-worker-secret-binding-names.mjs \
             ELIZA_APP_TELEGRAM_BOT_TOKEN \
             ELIZA_APP_TELEGRAM_WEBHOOK_SECRET
           printf 'runtime_authority=staging-protected-receipt-and-existing-bindings\n' >> "$GITHUB_OUTPUT"

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -30,6 +30,7 @@ interface WorkflowStep {
   run?: string;
   uses?: string;
   with?: Record<string, string>;
+  "working-directory"?: string;
 }
 
 interface WorkflowJob {
@@ -629,11 +630,14 @@ describe("homepage deployment workflow", () => {
       CLOUDFLARE_API_TOKEN: githubExpression("secrets.CLOUDFLARE_API_TOKEN"),
       CLOUDFLARE_ACCOUNT_ID: githubExpression("secrets.CLOUDFLARE_ACCOUNT_ID"),
     });
+    expect(stagingRuntimeBinding["working-directory"]).toBe(
+      "packages/cloud/api",
+    );
     expect(stagingRuntimeBinding.run).toContain(
       "wrangler@4.116.0 secret list --env staging --format json",
     );
     expect(stagingRuntimeBinding.run).toContain(
-      "verify-worker-secret-binding-names.mjs",
+      "../scripts/verify-worker-secret-binding-names.mjs",
     );
     expect(stagingRuntimeBinding.run).toContain(
       "runtime_authority=staging-protected-receipt-and-existing-bindings",


### PR DESCRIPTION
## Summary

Fixes #30311 and the safe pre-mutation failure in run 33618804490.

- Run the protected staging Telegram Worker binding check from `packages/cloud/api`, matching the Cloud API Wrangler configuration convention.
- Resolve the checked-in verifier relative to that directory, so `--env staging` uses `packages/cloud/api/wrangler.toml`.
- Cover the exact working directory and verifier resolution in the deployment-workflow contract test.

## Validation

- `bun install --frozen-lockfile`
- Focused workflow and Worker-binding tests: 29 passed
- Biome and actionlint
- `bun run verify:cloud` — 84 successful
- `bun run verify` — 376 successful

## Safety

No deploy, environment-secret change, or live Worker mutation was performed.