### PR TITLE
test(ci): execute the apps-worker deploy preflight matrix

### DIFF
--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -3,7 +3,10 @@
  * host-inventory, and shared-secret drift without inspecting protected values.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const repoRoot = new URL("../../../", import.meta.url);
 
@@ -90,6 +93,10 @@ const cloudWorkerSecretNames = [
   "TUNNEL_HOSTNAME_SIGNING_SECRET",
 ] as const;
 
+// A value distinctive enough that finding it in any output stream is proof
+// the guard printed a secret rather than a coincidence.
+const SENTINEL_DEPLOY_SECRET = "sentinel-apps-worker-deploy-secret-value";
+
 const requiredAuthWorkerSecretNames = [
   "OIDC_CLIENTS",
   "OIDC_SIGNING_JWKS",
@@ -101,6 +108,51 @@ const requiredAuthWorkerSecretNames = [
   "STEWARD_TENANT_API_KEY",
   "GATEWAY_INTERNAL_SECRET",
 ] as const;
+
+/**
+ * Executes the apps-worker deploy preflight so its fail-closed behaviour is
+ * covered by running it, rather than by matching the step's text. The guard
+ * decides whether a deploy proceeds without a host or an SSH key, so both the
+ * admission decision and the fact that it never prints a secret are worth
+ * driving directly.
+ */
+function runAppsWorkerPreflight(options: {
+  deployHost: string;
+  deploySshKey: string;
+  environment?: string;
+}) {
+  const scratch = mkdtempSync(join(tmpdir(), "apps-worker-preflight-"));
+  const githubOutput = join(scratch, "output");
+  const stepSummary = join(scratch, "summary");
+  // The Actions runner pre-creates both files; the guard only ever appends.
+  writeFileSync(githubOutput, "");
+  writeFileSync(stepSummary, "");
+  try {
+    const result = spawnSync(
+      "bash",
+      ["-c", step(appsWorker, "deploy", "Check deploy configuration").run],
+      {
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH ?? "",
+          DEPLOY_HOST: options.deployHost,
+          DEPLOY_SSH_KEY: options.deploySshKey,
+          TARGET_ENVIRONMENT: options.environment ?? "production",
+          GITHUB_OUTPUT: githubOutput,
+          GITHUB_STEP_SUMMARY: stepSummary,
+        },
+      },
+    );
+    return {
+      status: result.status,
+      output: readFileSync(githubOutput, "utf8"),
+      summary: readFileSync(stepSummary, "utf8"),
+      streams: `${result.stdout}${result.stderr}`,
+    };
+  } finally {
+    rmSync(scratch, { force: true, recursive: true });
+  }
+}
 
 describe("canonical cloud deployment environment contract", () => {
   test("records the staging certificate with the upload action digest shape", () => {
@@ -667,6 +719,79 @@ describe("canonical cloud deployment environment contract", () => {
     expect(preflight.run).toContain("exit 1");
     expect(preflight.run).not.toContain("skipping apps-worker deploy");
     expect(preflight.run).not.toContain('echo "$value"');
+  });
+
+  test("executes the apps-worker preflight's admission matrix without printing a secret", () => {
+    // A configured environment is admitted, and only then.
+    const configured = runAppsWorkerPreflight({
+      deployHost: "apps-control.internal",
+      deploySshKey: SENTINEL_DEPLOY_SECRET,
+    });
+    expect(configured.status).toBe(0);
+    expect(configured.output).toContain("configured=true");
+    expect(configured.summary).toBe("");
+
+    // Each setting is independently required, and a value that is only
+    // whitespace counts as absent — a trailing newline pasted into a GitHub
+    // secret must not read as configured.
+    for (const blocked of [
+      {
+        deployHost: "",
+        deploySshKey: SENTINEL_DEPLOY_SECRET,
+        names: ["DEPLOY_HOST"],
+      },
+      {
+        deployHost: "apps-control.internal",
+        deploySshKey: "",
+        names: ["DEPLOY_SSH_KEY"],
+      },
+      {
+        deployHost: " ",
+        deploySshKey: SENTINEL_DEPLOY_SECRET,
+        names: ["DEPLOY_HOST"],
+      },
+      {
+        deployHost: "apps-control.internal",
+        deploySshKey: "\n\t ",
+        names: ["DEPLOY_SSH_KEY"],
+      },
+      {
+        deployHost: "",
+        deploySshKey: "",
+        names: ["DEPLOY_HOST", "DEPLOY_SSH_KEY"],
+      },
+    ]) {
+      const label = JSON.stringify(blocked.names);
+      const result = runAppsWorkerPreflight(blocked);
+      expect(result.status, label).toBe(1);
+      expect(result.output, label).toContain("configured=false");
+      expect(result.output, label).not.toContain("configured=true");
+      expect(result.streams, label).toContain("::error::");
+      expect(result.summary, label).toContain("Apps worker deploy blocked");
+      // Every missing name is reported, not just the last one found.
+      for (const name of blocked.names) {
+        expect(result.streams, label).toContain(name);
+        expect(result.summary, label).toContain(name);
+      }
+    }
+
+    // The guard reads secret values but must never emit one, on any stream or
+    // into the job summary. Asserting the absence of a single spelling in the
+    // step text cannot cover this; running it can.
+    for (const probe of [
+      {
+        deployHost: SENTINEL_DEPLOY_SECRET,
+        deploySshKey: SENTINEL_DEPLOY_SECRET,
+      },
+      { deployHost: "", deploySshKey: SENTINEL_DEPLOY_SECRET },
+      { deployHost: SENTINEL_DEPLOY_SECRET, deploySshKey: "" },
+    ]) {
+      const result = runAppsWorkerPreflight(probe);
+      const emitted = `${result.streams}${result.summary}${result.output}`;
+      expect(emitted, JSON.stringify(probe)).not.toContain(
+        SENTINEL_DEPLOY_SECRET,
+      );
+    }
   });
 
   test("validates canonical Worker routes before any cutover mutation", () => {


### PR DESCRIPTION
`deploy-apps-worker.yml`'s `Check deploy configuration` is the gate that decides whether a deploy proceeds without a host or an SSH key — every later step is `if: steps.deploy_config.outputs.configured == 'true'`. `cloud-deploy-environment-contract.test.ts` pins it as five substrings:

```ts
expect(preflight.run).toContain("for name in DEPLOY_HOST DEPLOY_SSH_KEY");
expect(preflight.run).toContain("Apps worker deploy blocked");
expect(preflight.run).toContain("exit 1");
expect(preflight.run).not.toContain("skipping apps-worker deploy");
expect(preflight.run).not.toContain('echo "$value"');
```

Baseline **23 pass / 0 fail / 351 expects**. Four mutations that keep all five literals:

| mutation | existing suite |
|---|---|
| `[ -z "${value//[[:space:]]/}" ]` → `[ -z "$value" ]` | **23 pass — survives** |
| `"${#missing[@]}" -gt 0` → `-gt 1` | **23 pass — survives** |
| `missing+=("$name")` → `missing=("$name")` | **23 pass — survives** |
| add `echo "::debug::$DEPLOY_SSH_KEY"` | **23 pass — survives** |

The first two are the ones that matter. Dropping the whitespace normalisation means a secret containing only a pasted newline reads as configured, and the deploy proceeds to `ssh` with an empty key. Changing `-gt 0` to `-gt 1` admits any environment that is missing exactly one of the two settings — the single-missing case is the likely one in practice.

The fourth is worth separating out. `not.toContain('echo "$value"')` is trying to express "this guard never prints a secret", but a negative substring can only exclude the one spelling it names; `$DEPLOY_SSH_KEY` walks straight past it. That property is testable by running the guard, and not otherwise.

## What this adds

A `runAppsWorkerPreflight` harness that drives the step's own `run` body with a scratch `GITHUB_OUTPUT` and `GITHUB_STEP_SUMMARY` (both pre-created, as the Actions runner does — the guard only appends), and one matrix test:

- **admitted (1)** — host and key present: exit 0, `configured=true`, empty summary.
- **blocked (5)** — each setting absent independently, `" "` for the host, `"\n\t "` for the key, and both absent. Each asserts exit 1, `configured=false`, no `configured=true`, an `::error::` annotation, the `Apps worker deploy blocked` summary banner, and **every** missing name in both the annotation and the summary.
- **secret hygiene (3)** — a sentinel value passed as the host, the key, and both, asserting it never appears in stdout, stderr, the step summary, or the step output.

All four mutants now fail:

| mutation | with this test |
|---|---|
| drop whitespace normalisation | **23 pass / 1 fail** |
| `-gt 1` | **23 pass / 1 fail** |
| last-missing-only | **23 pass / 1 fail** |
| `echo "::debug::$DEPLOY_SSH_KEY"` | **23 pass / 1 fail** |

The file goes **23 → 24 tests, 351 → 394 expects**.

## Validation

- `cloud-deploy-environment-contract.test.ts` — **24 pass / 0 fail / 394 expects**
- `bun test packages/scripts/__tests__` — **1501 pass / 8 skip / 3 fail**; the three (`on-demand CodeQL workflow`, two `protected gateway-webhook deployment workflow`) are the same failures `develop` has at `a3d94c51c3`, confirmed by stashing this diff and re-running
- `biome check` — the one pre-existing `noTemplateCurlyInString` warning at line 530, nothing new

Test-only; no workflow behaviour changes.

*Note on overlap:* I have two other open PRs touching this same file — #30310 and #30312. I test-merged all three pairings rather than assume: they **do** conflict, in two places each — the `node:fs` import line (all three extend it) and the helper block above `describe(`. The test bodies themselves are in separate regions and don't collide. Whichever lands first, I'll rebase the others onto it; the resolution is mechanical in both spots. Flagging it here so a reviewer isn't surprised by a red merge box on the second one.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GVKGKE1AQK3MHK8B1YQPHS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T10:45:59.022Z","completed_at":"2026-09-02T10:47:40.984Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T10:45:59.667Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f6f0059e0c68006ea588d9d3ab3d953718aa6d9a9740e6b35af1a13b41669299","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"87179773-441b-436c-be25-2e23bf1e6058","object_id":"sha256:f6f0059e0c68006ea588d9d3ab3d953718aa6d9a9740e6b35af1a13b41669299","sha256":"f6f0059e0c68006ea588d9d3ab3d953718aa6d9a9740e6b35af1a13b41669299"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"zlsNx5oEW4zBIIdbryLekcomMZ9cwPROAkgjQq10Ie_ZMcFiMjfg8xXYB6qxfxnfUJimixGsVAtDzdAiOtvADw"}} -->
