### PR TITLE
fix(cloud): classify Headscale convergence failures

### DIFF
--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -204,7 +204,21 @@ jobs:
           arm_status=$?
           set -e
           if [ "$arm_status" -ne 0 ]; then
-            echo "::error::Headscale remote operation failed (category=headscale-remote-failed; exit=$arm_status; raw-output=suppressed)."
+            # The remote script's category tokens are a closed diagnostic
+            # channel. Never print its free-form stdout/stderr: those streams
+            # may contain host configuration or command diagnostics.
+            safe_category=$(
+              grep -hEo 'category=(headscale|cp-router)-[a-z0-9-]+' \
+                "$arm_stdout" "$arm_stderr" \
+                | tail -n 1 \
+                | cut -d= -f2 \
+                || true
+            )
+            case "$safe_category" in
+              headscale-*|cp-router-*) ;;
+              *) safe_category="headscale-remote-failed" ;;
+            esac
+            echo "::error::Headscale remote operation failed (category=$safe_category; exit=$arm_status; raw-output=suppressed)."
             exit "$arm_status"
           fi
 

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -1193,13 +1193,16 @@ else
   # credential. Logout is best-effort because an unreachable retired control
   # server must not prevent the forced local reauthentication below.
   sudo tailscale logout >/dev/null 2>&1 || true
-  sudo tailscale up \\
-    --force-reauth \\
-    --login-server="$LOGIN_SERVER" \\
-    --authkey="$PREAUTH_KEY" \\
-    --hostname="$CP_ROUTER_HOST" \\
-    --advertise-tags=tag:eliza-proxy \\
-    --accept-routes >/dev/null 2>&1
+  if ! sudo tailscale up \\
+      --force-reauth \\
+      --login-server="$LOGIN_SERVER" \\
+      --authkey="$PREAUTH_KEY" \\
+      --hostname="$CP_ROUTER_HOST" \\
+      --advertise-tags=tag:eliza-proxy \\
+      --accept-routes >/dev/null 2>&1; then
+    echo "CP router forced reauthentication failed (category=cp-router-reauth-failed)"
+    exit 1
+  fi
   echo "CP router enrollment completed (category=cp-router-enrolled)"
 fi
 

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -170,6 +170,9 @@ describe("Headscale control-plane self-enrollment", () => {
     expect(retireStaleNode).toBeLessThan(tailscaleUp);
     expect(remote.match(/--force-reauth/g)).toHaveLength(1);
     expect(remote).toContain(
+      "CP router forced reauthentication failed (category=cp-router-reauth-failed)",
+    );
+    expect(remote).toContain(
       "CP router live identity and canonical control URL verified (category=cp-router-visible)",
     );
     expect(remote).toContain('.BackendState == "Running"');
@@ -307,5 +310,18 @@ describe("Headscale protected workflow contract", () => {
       "node packages/cloud/scripts/admin/arm-headscale-control-plane.mjs",
     );
     expect(converge).not.toContain("force-reauth");
+  });
+
+  test("emits only closed remote failure categories", () => {
+    const step = namedStep(workflow, "Inspect or converge Headscale control plane");
+    const run = String(step.run ?? "");
+
+    expect(run).toContain(
+      "grep -hEo 'category=(headscale|cp-router)-[a-z0-9-]+'",
+    );
+    expect(run).toContain('safe_category="headscale-remote-failed"');
+    expect(run).toContain("raw-output=suppressed");
+    expect(run).not.toContain('cat "$arm_stdout"');
+    expect(run).not.toContain('cat "$arm_stderr"');
   });
 });


### PR DESCRIPTION
Closes #29341

Follow-up to #29973 after the first protected staging converge exposed only a generic failure. This preserves secret suppression while surfacing the last closed Headscale/CP-router category and explicitly classifies forced Tailscale reauthentication failures.

Verification:
- `bun test packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts`
- `actionlint .github/workflows/arm-headscale-control-plane.yml`
- `git diff --check`

Live evidence: staging arm run 33621556735 failed with raw output suppressed, motivating this closed diagnostic channel.