### PR TITLE
test(ci): resolve every literal workflow script reference

### DIFF
--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -34,6 +34,7 @@ interface WorkflowStep {
 }
 
 interface WorkflowJob {
+  env?: Record<string, string>;
   environment?: string;
   if?: string;
   needs?: string | string[];
@@ -66,6 +67,58 @@ interface TelegramExecution {
   stderr: string;
   stdout: string;
   summary: string;
+}
+
+// Jobs that deploy from a pristine tree materialise it at `CHECKOUT_DIR`, a
+// checkout of this repository, so a path under it resolves the same way a
+// repository-relative one does. Any other expression-valued or absolute
+// working directory is not something this test can resolve, and is skipped.
+const CHECKOUT_DIR_PREFIX = "${{ env.CHECKOUT_DIR }}";
+
+/**
+ * Collects every checked-in script a workflow step hands to `node` or `bun`,
+ * paired with the directory the step runs in, discarding the references this
+ * repository cannot resolve on its own.
+ */
+function literalScriptReferences(parsed: WorkflowFile): Array<{
+  job: string;
+  step: string;
+  workingDirectory: string;
+  script: string;
+}> {
+  const references: Array<{
+    job: string;
+    step: string;
+    workingDirectory: string;
+    script: string;
+  }> = [];
+  for (const [job, definition] of Object.entries(parsed.jobs ?? {})) {
+    for (const step of definition.steps ?? []) {
+      if (!step.run) continue;
+      const declared = step["working-directory"] ?? ".";
+      let workingDirectory = declared;
+      if (declared === CHECKOUT_DIR_PREFIX) {
+        workingDirectory = ".";
+      } else if (declared.startsWith(`${CHECKOUT_DIR_PREFIX}/`)) {
+        workingDirectory = declared.slice(CHECKOUT_DIR_PREFIX.length + 1);
+      } else if (declared.includes("${{") || declared.startsWith("/")) {
+        continue;
+      }
+      for (const match of step.run.matchAll(
+        /(?:^|\s)(?:node|bun)\s+(?:\\\s*)?([^\s'"]+\.(?:mjs|cjs|js|ts))/g,
+      )) {
+        const script = match[1];
+        if (script.includes("$")) continue;
+        references.push({
+          job,
+          step: step.name ?? "(unnamed)",
+          workingDirectory,
+          script,
+        });
+      }
+    }
+  }
+  return references;
 }
 
 const workflow = readFileSync(workflowPath, "utf8");
@@ -1301,5 +1354,38 @@ describe("homepage deployment workflow", () => {
     expect(homepageValidationIndex).toBeGreaterThan(uiBuildIndex);
     expect(coreBuildIndex).toBeGreaterThan(-1);
     expect(webBuildIndex).toBeGreaterThan(homepageValidationIndex);
+  });
+
+  it("resolves every literal workflow script reference from its own working directory", () => {
+    // #30311 was a path that resolved somewhere unintended. The assertions
+    // covering these invocations are string matches, so they cannot tell a
+    // working path from one that points at nothing — resolve them instead.
+    for (const [label, parsed] of [
+      ["cloud-cf-deploy.yml", parsedWorkflow],
+      ["cloud-cf-release.yml", parsedReleaseWorkflow],
+    ] as const) {
+      // The CHECKOUT_DIR rewrite above is only sound while that directory is a
+      // checkout of this repository; pin the premise rather than assume it.
+      for (const [job, definition] of Object.entries(parsed.jobs ?? {})) {
+        const checkoutDir = definition.env?.CHECKOUT_DIR;
+        if (checkoutDir === undefined) continue;
+        expect(checkoutDir, `${label} ${job}`).toContain("/eliza-checkout-");
+      }
+
+      const references = literalScriptReferences(parsed);
+      // A regex that stopped matching would make this vacuous.
+      expect(references.length, label).toBeGreaterThan(0);
+      for (const reference of references) {
+        const resolved = path.resolve(
+          repositoryRoot,
+          reference.workingDirectory,
+          reference.script,
+        );
+        expect(
+          existsSync(resolved),
+          `${label} ${reference.job} / ${reference.step}: ${reference.script}`,
+        ).toBe(true);
+      }
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #30313, which I reviewed. That PR fixed a real bug — the caller Telegram preflight ran from the repository root, where its `--env staging` config does not exist — and pinned the new spelling as a string:

```ts
expect(stagingRuntimeBinding.run).toContain(
  "../scripts/verify-worker-secret-binding-names.mjs",
);
```

I raised this there as a non-blocking note and it merged without it, so here it is as a change rather than a comment — and generalised, because the gap turned out not to be specific to that one step.

## A string match can't tell a path that resolves from one that doesn't

I renamed each checked-in script that `cloud-cf-deploy.yml` and `cloud-cf-release.yml` hand to `node` or `bun`, and ran the **ten** suites that reference those two workflows. Baseline **102 pass / 0 fail**:

| renamed script | existing suites |
|---|---|
| `release-admission-cli.mjs` | **102 pass — survives** |
| `staging-release-certification.mjs` | **102 pass — survives** |
| `canonical-deploy-source-guard.mjs` | **102 pass — survives** |
| `resolve-production-railway-postgres-service.ts` | **102 pass — survives** |
| `audit-production-railway-database-authority.ts` | **102 pass — survives** |
| `deploy-freshness-guard-cli.mjs` | **102 pass — survives** |
| `verify-worker-secret-binding-names.mjs` | 101 / 1 — caught (by #30313's literal) |
| `verify-telegram-bot-identity.mjs` | 101 / 1 — caught |

Six of eight point the release path at a file that isn't there, with every guard green. These are `release-admission-cli`, the staging certification authority, the canonical deploy-source guard, the production Railway audits, and the deploy freshness guard — the protected steps, in other words.

## What this adds

A `literalScriptReferences` collector and one test that resolves **all 32** literal `node`/`bun` script references across the two workflows — 10 in `cloud-cf-deploy.yml`, 22 in `cloud-cf-release.yml` — against the directory each step actually runs in, and asserts the file exists. All six survivors now fail:

| renamed script | with this test |
|---|---|
| each of the six above | **102 pass / 1 fail** |
| the two already covered | 101 pass / 2 fail |

## Two things I was careful about

**The `CHECKOUT_DIR` rewrite is a premise, so it's asserted.** Deploy jobs materialise a pristine tree at `CHECKOUT_DIR` and run from it, so `${{ env.CHECKOUT_DIR }}/packages/cloud/api` resolves the same way `packages/cloud/api` does. That's only true while `CHECKOUT_DIR` is a checkout of this repository, so the test asserts every job-level `CHECKOUT_DIR` is an `/eliza-checkout-` path rather than taking it on faith. Any other expression-valued working directory, and any absolute one (`/tmp`), is skipped as unresolvable.

**Vacuity.** A regex that quietly stopped matching would turn this into a no-op, so the reference count is asserted non-zero per workflow. I also found the bug in my own first draft this way: it resolved `${{ env.CHECKOUT_DIR }}` literally and reported `deploy-freshness-guard-cli.mjs` as missing when the file is present — which is what prompted the explicit prefix handling above.

## Validation

- `homepage-deploy-workflow.test.ts` — **20 pass / 0 fail / 621 expects** (was 19 / 604)
- the `Test required workflow contracts` lane from `pr-static-smoke.yml:132-141` — **131 pass / 8 skip / 0 fail**
- `bun test packages/scripts/__tests__` — **5 fail**, the same five `develop` has at `696922e0c0` (`mission workflow diagnostic redaction`, `on-demand CodeQL workflow`, two `protected gateway-webhook deployment workflow`, `repository ruleset contract`), confirmed by stashing this diff and re-running
- `biome check` — one pre-existing warning, nothing new

Test-only; no workflow behaviour changes. `WorkflowJob` gains an `env?` field, which the `CHECKOUT_DIR` assertion reads.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GWBTT0X1ZJ62HAYWH87CT0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T10:59:15.904Z","completed_at":"2026-09-02T11:00:52.136Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T10:59:16.536Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"82ed35e0bdf835628a6ce11d1323d2a86027804d21409897ac3f648acd0140d3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1a3b9b78-fd23-459d-88e5-b82c80c12906","object_id":"sha256:82ed35e0bdf835628a6ce11d1323d2a86027804d21409897ac3f648acd0140d3","sha256":"82ed35e0bdf835628a6ce11d1323d2a86027804d21409897ac3f648acd0140d3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"ui9vRpwdJQSnjnBDxB7HLNv7wAav_uHbDgCWXC04uo8L_50GKRfmN94PQmMCD-yecI5_DnERpmYa1_D4dM-MBQ"}} -->
