### PR TITLE
fix(cloud): reset stale CP router profile

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -1194,6 +1194,7 @@ else
   # server must not prevent the forced local reauthentication below.
   sudo tailscale logout >/dev/null 2>&1 || true
   if ! sudo tailscale up \\
+      --reset \\
       --force-reauth \\
       --login-server="$LOGIN_SERVER" \\
       --authkey="$PREAUTH_KEY" \\

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -158,6 +158,7 @@ describe("Headscale control-plane self-enrollment", () => {
       'sudo headscale nodes delete --identifier "$STALE_NODE_ID" --force',
     );
     const tailscaleUp = remote.indexOf("sudo tailscale up \\");
+    const resetProfile = remote.indexOf("      --reset \\");
     const loginServer = remote.indexOf('    --login-server="$LOGIN_SERVER" \\');
 
     expect(inspectPrefs).toBeGreaterThan(0);
@@ -165,6 +166,8 @@ describe("Headscale control-plane self-enrollment", () => {
     expect(remote).toContain("CONTROL_URL_MATCH=true");
     expect(forceReauth).toBeGreaterThan(mintKey);
     expect(forceReauth).toBeGreaterThan(tailscaleUp);
+    expect(resetProfile).toBeGreaterThan(tailscaleUp);
+    expect(resetProfile).toBeLessThan(forceReauth);
     expect(forceReauth).toBeLessThan(loginServer);
     expect(retireStaleNode).toBeGreaterThan(mintKey);
     expect(retireStaleNode).toBeLessThan(tailscaleUp);


### PR DESCRIPTION
Closes #29341

Protected staging arm run 33624576929 isolated the post-merge failure to `cp-router-reauth-failed`. Tailscale requires `--reset` when `tailscale up` changes a profile that retains non-default preferences. This makes the forced re-enrollment authoritative before applying the reviewed CP-router settings.

Verification:
- `bun test packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts`
- `actionlint .github/workflows/arm-headscale-control-plane.yml`
- `git diff --check`