### PR TITLE
fix(ci): classify Headscale failures by failure category

### DIFF
--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -207,17 +207,20 @@ jobs:
             # The remote script's category tokens are a closed diagnostic
             # channel. Never print its free-form stdout/stderr: those streams
             # may contain host configuration or command diagnostics.
+            # Match only the categories the remote script emits immediately
+            # before exiting. The progress tokens it also prints — notably
+            # `cp-router-visible` and `headscale-unit-state`, the latter
+            # printed after the health-failure line — are the newest match on
+            # most failing runs, so accepting any category reports the step
+            # that succeeded rather than the one that failed.
             safe_category=$(
-              grep -hEo 'category=(headscale|cp-router)-[a-z0-9-]+' \
+              grep -hEo 'category=(headscale-local-health-failed|cp-router-(key|reauth|live-proof|durable-proof)-failed|cp-router-role-missing|cp-router-node-id-invalid|cp-router-identity-ambiguous|cp-router-control-url-mismatch)' \
                 "$arm_stdout" "$arm_stderr" \
                 | tail -n 1 \
                 | cut -d= -f2 \
                 || true
             )
-            case "$safe_category" in
-              headscale-*|cp-router-*) ;;
-              *) safe_category="headscale-remote-failed" ;;
-            esac
+            [ -n "$safe_category" ] || safe_category="headscale-remote-failed"
             echo "::error::Headscale remote operation failed (category=$safe_category; exit=$arm_status; raw-output=suppressed)."
             exit "$arm_status"
           fi

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -313,15 +313,159 @@ describe("Headscale protected workflow contract", () => {
   });
 
   test("emits only closed remote failure categories", () => {
-    const step = namedStep(workflow, "Inspect or converge Headscale control plane");
+    const step = namedStep(
+      workflow,
+      "Inspect or converge Headscale control plane",
+    );
     const run = String(step.run ?? "");
 
-    expect(run).toContain(
-      "grep -hEo 'category=(headscale|cp-router)-[a-z0-9-]+'",
-    );
+    expect(run).toContain("grep -hEo 'category=(");
     expect(run).toContain('safe_category="headscale-remote-failed"');
     expect(run).toContain("raw-output=suppressed");
     expect(run).not.toContain('cat "$arm_stdout"');
     expect(run).not.toContain('cat "$arm_stderr"');
   });
+
+  /**
+   * Runs the workflow's own failure-classification block against synthetic
+   * captures. The block reads only the two capture files, so it executes
+   * faithfully without a host, credentials, or the surrounding step.
+   */
+  function classify(stdout: string, stderr: string): string {
+    const run = String(
+      namedStep(workflow, "Inspect or converge Headscale control plane").run ??
+        "",
+    );
+    const start = run.indexOf('if [ "$arm_status" -ne 0 ]; then');
+    const end = run.indexOf('exit "$arm_status"', start);
+    expect(start, "classification block not found").toBeGreaterThan(-1);
+    expect(end, "classification block not terminated").toBeGreaterThan(start);
+    const block = `${run.slice(start, end)}fi\n`;
+
+    const root = mkdtempSync(join(tmpdir(), "headscale-classify-"));
+    tempRoots.push(root);
+    const outPath = join(root, "stdout");
+    const errPath = join(root, "stderr");
+    writeFileSync(outPath, stdout);
+    writeFileSync(errPath, stderr);
+    const result = spawnSync("bash", ["-c", `set -euo pipefail\n${block}`], {
+      encoding: "utf8",
+      env: {
+        PATH: process.env.PATH ?? "",
+        arm_status: "1",
+        arm_stdout: outPath,
+        arm_stderr: errPath,
+      },
+    });
+    return `${result.stdout}${result.stderr}`;
+  }
+
+  test("classifies a failing run by its failure category, not its last progress token", () => {
+    // `report_headscale_unit_state` prints immediately before the health
+    // failure exits, so the newest category on a health failure is the state
+    // reporter rather than the failure itself.
+    expect(
+      classify(
+        [
+          "headscale local health failed (category=headscale-local-health-failed; attempts=30)",
+          "headscale-unit-state category=headscale-unit-state active=failed",
+        ].join("\n"),
+        "",
+      ),
+    ).toContain("category=headscale-local-health-failed;");
+
+    // The cp-router block ends by announcing success; anything failing after
+    // it must not be reported as that success.
+    expect(
+      classify(
+        [
+          "CP router live identity and canonical control URL verified (category=cp-router-visible)",
+          "env file /etc/eliza.env not found on host",
+        ].join("\n"),
+        "",
+      ),
+    ).toContain("category=headscale-remote-failed;");
+
+    // A self-classifying failure is still reported exactly.
+    expect(
+      classify(
+        "CP router forced reauthentication failed (category=cp-router-reauth-failed)",
+        "",
+      ),
+    ).toContain("category=cp-router-reauth-failed;");
+
+    // No category anywhere falls back rather than inventing one.
+    expect(classify("ssh: connection reset by peer", "")).toContain(
+      "category=headscale-remote-failed;",
+    );
+  });
+
+  test("never emits captured remote output, whatever it contains", () => {
+    const secret = "sentinel-headscale-preauth-key-value";
+    for (const [stdout, stderr] of [
+      [`tailscale up --authkey=${secret} failed`, ""],
+      [`authkey=${secret} (category=cp-router-reauth-failed) aborted`, ""],
+      ["", `${secret} refused (category=cp-router-key-failed)`],
+    ]) {
+      expect(classify(stdout, stderr), stdout || stderr).not.toContain(secret);
+    }
+  });
+
+  test("accepts exactly the categories the remote script exits on", () => {
+    const remote = renderRemoteScript();
+    const lines = remote.split("\n");
+    const exiting = new Set<string>();
+    for (let index = 0; index < lines.length; index += 1) {
+      // A category is a failure category when the statement printing it also
+      // terminates the script; `headscale-local-health-failed` reports unit
+      // state first, so look a couple of lines ahead.
+      const window = lines.slice(index, index + 3).join(" ");
+      for (const match of lines[index].matchAll(/category=([a-z0-9-]+)/g)) {
+        if (/\bexit 1\b/.test(window)) exiting.add(match[1]);
+      }
+    }
+    expect(exiting.size).toBeGreaterThan(0);
+
+    const run = String(
+      namedStep(workflow, "Inspect or converge Headscale control plane").run ??
+        "",
+    );
+    const pattern = run.match(/grep -hEo 'category=\((.+)\)'/)?.[1] ?? "";
+    expect(pattern, "classifier alternation not found").not.toBe("");
+    const accepted = new Set(
+      splitTopLevel(pattern).flatMap((alternative) =>
+        expandAlternation(alternative),
+      ),
+    );
+    // Every category the script exits on is classifiable, and the workflow
+    // accepts nothing the script never exits on.
+    expect([...accepted].sort()).toEqual([...exiting].sort());
+  });
 });
+
+/** Splits a grep alternation on the `|`s that sit outside any group. */
+function splitTopLevel(pattern: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const character of pattern) {
+    if (character === "(") depth += 1;
+    if (character === ")") depth -= 1;
+    if (character === "|" && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Expands a single `a-(b|c)-d` grep alternative into concrete tokens. */
+function expandAlternation(pattern: string): string[] {
+  const group = pattern.match(/^(.*)\(([^)]*)\)(.*)$/);
+  if (!group) return [pattern];
+  const [, prefix, choices, suffix] = group;
+  return choices.split("|").map((choice) => `${prefix}${choice}${suffix}`);
+}


### PR DESCRIPTION
Follow-up to #30315, which I reviewed. The suppression mechanism it added is sound — I verified that separately and have no objection to it. The classification on top of it takes the newest category token of *any* kind, and on the two most common failing shapes that token is a success marker.

I raised this as a blocking review; the PR merged at the head I reviewed, so here it is as a change instead of a comment.

## The remote script's namespace mixes failures with progress

`arm-headscale-control-plane.mjs` emits fourteen category tokens. Nine are printed by a statement that then exits; five are progress announcements (`cp-router-enrolled`, `cp-router-already-enrolled`, `cp-router-stale-node-retired`, `cp-router-visible`, `headscale-unit-state`). `tail -n 1` cannot tell them apart.

Two reproductions, both from lines the script emits verbatim:

**1. The health-check path defeats itself.** `report_headscale_unit_state` is called immediately before `exit 1` on the health failure, so stdout ends:

```
headscale local health failed (category=headscale-local-health-failed; attempts=30)
headscale-unit-state category=headscale-unit-state active=failed
```

| | reported |
|---|---|
| `develop` today | `category=headscale-unit-state` |
| this PR | `category=headscale-local-health-failed` |

**2. Anything failing after the cp-router block reports success.** That block ends with `echo "… (category=cp-router-visible)"`, and the env-file work that follows carries no category:

```
CP router live identity and canonical control URL verified (category=cp-router-visible)
env file /etc/eliza.env not found on host
```

| | reported |
|---|---|
| `develop` today | `category=cp-router-visible` |
| this PR | `category=headscale-remote-failed` |

An operator reading `cp-router-visible` on a failed run is pointed at the component that worked — worse than the generic marker this replaced, which claimed nothing.

The self-classifying paths were always fine, because each `echo` is followed immediately by `exit 1`; `cp-router-reauth-failed`, the category #30315 added, still reports exactly. It's every other failure that regressed.

## The change

Match only the categories the script exits on, and let the pattern be the allowlist:

```bash
grep -hEo 'category=(headscale-local-health-failed|cp-router-(key|reauth|live-proof|durable-proof)-failed|cp-router-role-missing|cp-router-node-id-invalid|cp-router-identity-ambiguous|cp-router-control-url-mismatch)' …
[ -n "$safe_category" ] || safe_category="headscale-remote-failed"
```

A literal alternation is **stricter** than the previous `[a-z0-9-]+` charset, so the closed-channel property is unchanged — nothing free-form can reach the annotation. The `case` re-validation collapses into an emptiness check because the pattern now *is* the validation.

## Three tests, replacing text assertions with execution

- **executes the classification block** against synthetic captures — both reproductions above, a self-classifying failure, and a run with no category at all. The block reads only the two capture files, so it runs faithfully with no host or credentials.
- **drives a sentinel secret** through the same block on three shapes and asserts it never reaches stdout or stderr. The existing pair

  ```ts
  expect(run).not.toContain('cat "$arm_stdout"');
  expect(run).not.toContain('cat "$arm_stderr"');
  ```

  can only exclude the spelling it names: adding `tail -n 5 "$arm_stderr" >&2` before the `::error::` line leaves that assertion untouched. A "never emits X" property needs a value and an execution.
- **derives the failure set from the rendered remote script** — the categories whose printing statement also exits — and asserts the workflow accepts exactly that set. Adding a new failure category to the script without teaching the workflow now fails here, which is the drift that produced this bug.

Measured against this file (baseline **13 pass / 0 fail / 109 expects**):

| mutation | result |
|---|---|
| the classifier as merged on `develop` | **11 pass / 2 fail** |
| accept a progress token (`\|cp-router-visible`) | **11 pass / 2 fail** |
| drop one real failure category | **12 pass / 1 fail** |
| leak via `tail -n 5 "$arm_stderr" >&2` | **12 pass / 1 fail** |

I also relaxed #30315's `toContain("grep -hEo 'category=(headscale|cp-router)-[a-z0-9-]+'")` to `toContain("grep -hEo 'category=(")`. That literal pinned the pattern's exact text; the derivation test above pins its *content* against the script, which is the property that assertion was reaching for.

## Validation

- `packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts` — **13 pass / 0 fail / 109 expects** (was 10 / 3 tests fewer)
- `packages/scripts/__tests__/headscale-arm-workflow.test.ts` + `mission-workflow-diagnostics-redaction.test.ts` — 40 pass / 1 fail; the failure is the pre-existing `Headscale projects remote output to fixed receipts…` case, which `develop` has had since #29973 removed a `tailscale status … grep -F` line from the script. Untouched here, and I flagged it on #30315.
- `actionlint .github/workflows/arm-headscale-control-plane.yml` — clean
- `biome check` on the test file — clean **after** this PR; `develop` currently fails it on a long `namedStep(...)` call that landed with #30315, so this also unbreaks that lane for the file.

Not verified: I have no way to exercise a real arm run, so the reproductions are the classification block driven over the script's literal output lines rather than captures from a hosted run.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1GYBDJAEA173BNWFY40VRE4","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T11:33:59.499Z","completed_at":"2026-09-02T11:35:29.890Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T11:34:00.267Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fd067d6d8f7f769e88fc0626b76096f084103211807588a18b8e52cfdd3d04ee","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b8948b4c-e0dd-4b0e-9917-f7fcfb2a4742","object_id":"sha256:fd067d6d8f7f769e88fc0626b76096f084103211807588a18b8e52cfdd3d04ee","sha256":"fd067d6d8f7f769e88fc0626b76096f084103211807588a18b8e52cfdd3d04ee"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Fw0Z817TSec5_lZfEZVoVIIvU1y4ooQOBky0bOHQA_xHKoVP9JsvFGzQZQi2DtXd8WF1F7KyiG7rOwo9t1brAA"}} -->
