### PR TITLE
fix(cloud): use canonical trace ID in Responses E2E

### DIFF
--- a/packages/cloud/api/test/e2e/group-d-ai-media.test.ts
+++ b/packages/cloud/api/test/e2e/group-d-ai-media.test.ts
@@ -380,7 +380,7 @@ describeLocalWorker("Group D — /api/v1/voice/session/ws", () => {
 });
 
 describeE2E("Group D — /api/v1/responses", () => {
-  const traceId = "16098110-0000-4000-8000-000000000110";
+  const traceId = "16098110000040008000000000000110";
 
   test("auth gate: missing credentials → 401", async () => {
     const res = await api.post(


### PR DESCRIPTION
Closes #30321

## What changed
- replace the stale UUID-shaped Responses E2E trace fixture with the canonical lowercase 32-hex inference trace form
- preserve the exact echo assertions for both unauthenticated and validation-error responses

## Verification
- `E2E_ONLY=group-d-ai-media bun run --cwd packages/cloud/api test:e2e` — 26 passed, 1 skipped, 0 failed
- trace telemetry unit suites — 25 passed, 0 failed
- changed-file Biome and `git diff --check` passed

## Deploy failure addressed
Run 33625149052 passed the corrected Group C suite, then stopped before Cloudflare publication because these two stale tests expected an invalid UUID trace ID to be adopted instead of safely replaced.