### PR TITLE
fix(cloud): honor Headscale preauth-key tag authority

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -1171,8 +1171,9 @@ else
     | jq -r '.[] | select(.name == "tunnel") | .id')
   [ -n "$TUNNEL_UID" ] || { echo "required Headscale role is absent (category=cp-router-role-missing)"; exit 1; }
 
-  # Short-lived, single-use, pre-tagged preauth key. Tagged tag:eliza-proxy so
-  # the node lands tagged at join (ownership enforced by acl.hujson tagOwners).
+  # Short-lived, single-use, pre-tagged preauth key. The key is the sole tag
+  # authority for this non-interactive join: Headscale rejects a client-side
+  # --advertise-tags request when a preauth key already supplies the tags.
   PREAUTH_KEY=$(sudo headscale preauthkeys create -u "$TUNNEL_UID" \\
     --tags tag:eliza-proxy --expiration 1h -o json 2>/dev/null | jq -r '.key')
   [ -n "$PREAUTH_KEY" ] || { echo "CP router enrollment credential could not be minted (category=cp-router-key-failed)"; exit 1; }
@@ -1199,7 +1200,6 @@ else
       --login-server="$LOGIN_SERVER" \\
       --authkey="$PREAUTH_KEY" \\
       --hostname="$CP_ROUTER_HOST" \\
-      --advertise-tags=tag:eliza-proxy \\
       --accept-routes >/dev/null 2>&1; then
     echo "CP router forced reauthentication failed (category=cp-router-reauth-failed)"
     exit 1

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -172,6 +172,8 @@ describe("Headscale control-plane self-enrollment", () => {
     expect(retireStaleNode).toBeGreaterThan(mintKey);
     expect(retireStaleNode).toBeLessThan(tailscaleUp);
     expect(remote.match(/--force-reauth/g)).toHaveLength(1);
+    expect(remote).toContain("--tags tag:eliza-proxy");
+    expect(remote).not.toContain("      --advertise-tags=");
     expect(remote).toContain(
       "CP router forced reauthentication failed (category=cp-router-reauth-failed)",
     );


### PR DESCRIPTION
Closes #29341

## What changed
- keep `tag:eliza-proxy` on the short-lived Headscale preauth key
- stop sending the incompatible client-side `--advertise-tags` request during that keyed join
- lock the tag-authority contract in the control-plane renderer test

## Why
Protected staging convergence reaches `tailscale up` and fails immediately. Headscale treats a preauth key as the tag authority and rejects registrations that also request client-side tags.

## Verification
- `bun test packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts`
- `actionlint .github/workflows/arm-headscale-control-plane.yml`
- `git diff --check`