### PR TITLE
fix(cloud): preserve paid proxy rollback admission

### DIFF
--- a/packages/cloud/api/src/lib/guarded-paid-proxy.test.ts
+++ b/packages/cloud/api/src/lib/guarded-paid-proxy.test.ts
@@ -175,6 +175,81 @@ test("preflight sees the caller after one standing read and can reject without p
   expect(executeWithBody).not.toHaveBeenCalled();
 });
 
+test("Worker flag-off mode forwards pre-resolved auth through compatibility admission", async () => {
+  combinedStandingRead.mockReset();
+  executionContextRead.mockReset();
+  executeWithBody.mockReset();
+  combinedStandingRead.mockResolvedValue({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    authSource: "combined_cache",
+    appScopeId: null,
+  });
+  executionContextRead.mockReturnValue({ waitUntil: () => undefined });
+  executeWithBody.mockResolvedValue(Response.json({ ok: true }));
+
+  const response = await executeGuardedPaidProxyWithBody(
+    makeContext(),
+    {
+      id: "market-data",
+      name: "Market data",
+      auth: "apiKeyWithOrg",
+      getCost: async () => 0.01,
+    },
+    mock(),
+    { method: "getPrice" },
+  );
+
+  expect(response.status).toBe(200);
+  expect(combinedStandingRead).toHaveBeenCalledTimes(1);
+  expect(executeWithBody).toHaveBeenCalledTimes(1);
+  expect(executeWithBody.mock.calls[0]?.[4]).toEqual({
+    mode: "compatibility",
+    auth: {
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKey: { id: "key-1" },
+    },
+    requestId: "paid-proxy-request-1",
+  });
+});
+
+test("enabled auth cache fails closed when its combined snapshot is missing", async () => {
+  combinedStandingRead.mockReset();
+  executionContextRead.mockReset();
+  executeWithBody.mockReset();
+  combinedStandingRead.mockResolvedValue({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    authSource: "combined_cache",
+    appScopeId: null,
+  });
+  executionContextRead.mockReturnValue({ waitUntil: () => undefined });
+  const context = makeContext();
+  Object.assign(context, {
+    env: {
+      INFERENCE_AUTH_CACHE_ENABLED: "true",
+      INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+    },
+  });
+
+  const response = await executeGuardedPaidProxyWithBody(
+    context,
+    {
+      id: "market-data",
+      name: "Market data",
+      auth: "apiKeyWithOrg",
+      getCost: async () => 0.01,
+    },
+    mock(),
+    { method: "getPrice" },
+  );
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get("Retry-After")).toBe("1");
+  expect(combinedStandingRead).toHaveBeenCalledTimes(1);
+  expect(executeWithBody).not.toHaveBeenCalled();
+});
+
 test("production without a Worker lifetime fails closed before reserve or dispatch", async () => {
   combinedStandingRead.mockReset();
   executionContextRead.mockReset();

--- a/packages/cloud/api/src/lib/guarded-paid-proxy.ts
+++ b/packages/cloud/api/src/lib/guarded-paid-proxy.ts
@@ -5,6 +5,7 @@
 
 import { ApiError } from "@/lib/api/cloud-worker-errors";
 import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
+import { isInferenceAuthCacheEnabled } from "@/lib/services/inference-hot-path-caches";
 import type { EndpointType } from "@/lib/services/org-rate-limits";
 import type { ProxyCombinedAdmission } from "@/lib/services/proxy/engine";
 import { createHandler, executeWithBody } from "@/lib/services/proxy/engine";
@@ -88,24 +89,27 @@ export async function withGuardedPaidProxyAdmission(
       ...(caller.apiKeyId ? { apiKey: { id: caller.apiKeyId } } : {}),
     };
 
-    if (!executionCtx) {
+    if (!executionCtx || !caller.admissionSnapshot) {
+      if (executionCtx && isInferenceAuthCacheEnabled(c.env)) {
+        logger.error(
+          "[PaidProxyAdmission] Combined admission snapshot missing",
+          {
+            requestId,
+            route: new URL(c.req.url).pathname,
+            organizationId: caller.user.organization_id,
+            authSource: caller.authSource,
+          },
+        );
+        return paidProxyApiErrorResponse(
+          new ApiError(
+            503,
+            "service_unavailable",
+            "Provider admission is unavailable; retry shortly",
+            { retryable: true, retryAfterSeconds: 1 },
+          ),
+        );
+      }
       return dispatch({ mode: "compatibility", auth, requestId });
-    }
-    if (!caller.admissionSnapshot) {
-      logger.error("[PaidProxyAdmission] Combined admission snapshot missing", {
-        requestId,
-        route: new URL(c.req.url).pathname,
-        organizationId: caller.user.organization_id,
-        authSource: caller.authSource,
-      });
-      return paidProxyApiErrorResponse(
-        new ApiError(
-          503,
-          "service_unavailable",
-          "Provider admission is unavailable; retry shortly",
-          { retryable: true, retryAfterSeconds: 1 },
-        ),
-      );
     }
 
     return dispatch({


### PR DESCRIPTION
Closes #30323

## What changed

- use the already-resolved caller identity through the proxy engine compatibility admission when effective inference auth caching is disabled and no hot admission snapshot is expected
- retain fail-closed 503 behavior when effective auth caching is enabled but its required snapshot is unexpectedly absent
- add regression coverage for both modes

The compatibility admission receives pre-resolved auth, so the proxy engine does not perform a second identity/standing read. Standing still resolves before route-local validation or provider dispatch.

## Verification

- `bun install`
- `bun test src/lib/guarded-paid-proxy.test.ts src/paid-proxy-mounted-admission.test.ts --timeout 120000` — 14 pass
- `E2E_ONLY=group-h-misc bun run --cwd packages/cloud/api test:e2e` — 78 pass, 4 skip, 0 fail
- `bun run --cwd packages/cloud/api typecheck` — pass, including Worker bundle dry-run
- Biome on both touched files — pass
- `git diff --check` — pass
- `bun run verify` — 376/376 tasks plus repository audits pass