### PR TITLE
test(scripts): pin the Headscale identity-proof and classifier properties

### DIFF
--- a/packages/scripts/__tests__/mission-workflow-diagnostics-redaction.test.ts
+++ b/packages/scripts/__tests__/mission-workflow-diagnostics-redaction.test.ts
@@ -205,6 +205,28 @@ exit 17
     expect(script).toContain("sudo tailscale debug prefs");
     expect(script).toContain('((.Self.HostName // "") == $h');
     expect(script).toContain('.ControlURL // ""');
+    // Both identity proofs — the pre-enrollment check and the post-enrollment
+    // one — pass the hostname as a jq argument rather than interpolating it
+    // into the program, so a single remaining site cannot satisfy this.
+    expect(script.match(/jq -e --arg h "\$CP_ROUTER_HOST"/g)).toHaveLength(2);
+    // This file's contract is redaction: a captured daemon blob may be fed to
+    // jq, never echoed, printed or cat-ed into the log.
+    for (const captured of [
+      "STATUS_JSON",
+      "PREFS_JSON",
+      "FINAL_STATUS_JSON",
+      "FINAL_PREFS_JSON",
+    ]) {
+      expect(script, captured).not.toMatch(
+        new RegExp(`(?:echo|printf|cat)[^\\n]*\\$(?:\\{)?${captured}`),
+      );
+    }
+    // Every jq read of a captured status discards its stdout.
+    for (const match of script.matchAll(
+      /<<<"\$(?:FINAL_)?STATUS_JSON"[^\n]*/g,
+    )) {
+      expect(match[0], match[0]).toContain(">/dev/null");
+    }
     expect(script).toContain('headscale users create "$user" >/dev/null');
   });
 


### PR DESCRIPTION
> **Rebased 2026-09-02.** `develop` has since adopted the `safe_category` assertions this branch originally carried (`3c04ef2d35`, `978fdb06ac`), so the lane is **green on `develop` today** — 9 pass / 179 expects — and the original "this makes the red lane green" framing no longer applies. This branch is rebased onto `cb721535b6` and reduced to the residual property those upstream commits did not pin. The history below is kept for context.

## What this branch adds now

`develop` pins the identity proof by naming strings that appear in the script:

```ts
expect(script).toContain("sudo tailscale status --json");
expect(script).toContain('((.Self.HostName // "") == $h');
```

`toContain` is satisfied by *one* occurrence, and there are two identity proofs — the pre-enrollment check and the post-enrollment one. Nothing currently stops the second from interpolating `$CP_ROUTER_HOST` into the jq program, and nothing at all pins the property this file is named for: that a captured daemon blob never reaches the log.

This adds 22 lines covering exactly that:

```ts
expect(script.match(/jq -e --arg h "\$CP_ROUTER_HOST"/g)).toHaveLength(2);
```

plus an assertion that none of `STATUS_JSON`, `PREFS_JSON`, `FINAL_STATUS_JSON`, `FINAL_PREFS_JSON` is echoed, printed or `cat`-ed, and that every `jq` read of a captured status discards its stdout.

**Both halves are mutation-scored** against `packages/cloud/scripts/admin/arm-headscale-control-plane.mjs`, pristine restored between runs:

| mutant | result |
|---|---|
| `echo "$STATUS_JSON"` added after the capture | 8 pass / **1 fail** |
| the first `jq -e` loses `--arg h` and interpolates the hostname | 8 pass / **1 fail** |

Baseline on this branch: **9 pass / 0 fail / 186 expects** (`develop`: 9 pass / 179 expects). No source file is changed; this is test-only.

<details>
<summary>Original description (the lane was red when this was opened)</summary>

`packages/scripts/__tests__/mission-workflow-diagnostics-redaction.test.ts` was red on `develop`. It is in the bun-owned `packages/scripts` lane, so `test:scripts` — run from `ci.yml:129`, `test.yml:1218` and `scenario-pr.yml:847` — carried the failure on every PR.

One test, `"Headscale projects remote output to fixed receipts and never prints node or journal lines"`, spelled out two implementation strings that two later merges legitimately changed. **#29973** replaced the grep-based idempotence probe with a JSON capture read through `jq`, orphaning `expect(script).toContain('tailscale status 2>/dev/null | grep -F "$CP_ROUTER_HOST" >/dev/null')`. **#30315** moved the failure category behind a validated variable, orphaning `expect(converge).toContain("category=headscale-remote-failed")`.

Both assertions named a spelling; neither named the property the test exists to protect, which is why a correct refactor turned the lane red. `develop` has since fixed the classifier half the same way.

</details>
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1H1NJWRBY7MB3AW7JYB54KQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T12:31:58.361Z","completed_at":"2026-09-02T12:32:55.432Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T12:31:59.204Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b2edcbcf5dc05a30540470f797e99cb6b97d5a59032d002c355d2b0452eaecdf","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f2fce583-60d1-40a0-822a-48d83c27b812","object_id":"sha256:b2edcbcf5dc05a30540470f797e99cb6b97d5a59032d002c355d2b0452eaecdf","sha256":"b2edcbcf5dc05a30540470f797e99cb6b97d5a59032d002c355d2b0452eaecdf"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"LtA7xRueOH0Q3LPviiBRD27nSLnZ4E79YrnmIX_w2OavXhjO1hX3-hYIxNP3KpM6jRwud0LIpZx3ITIUZk9cDA"}} -->
