### PR TITLE
test(ci): pin both authenticated deploy-SHA resolutions

### DIFF
--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -80,12 +80,25 @@ describe("provisioning worker deployment contract", () => {
 
   it("resolves one immutable SHA and deploys exactly that snapshot", () => {
     expect(workflow).toContain('deployment_sha="$PUSH_SHA"');
-    expect(workflow).toContain(
-      '"repos/$' + '{GITHUB_REPOSITORY}/git/ref/heads/$' + '{BRANCH}"',
-    );
-    expect(workflow).not.toContain(
-      'git ls-remote "https://github.com/$' + '{GITHUB_REPOSITORY}.git"',
-    );
+    // #30329 moved every repository read behind the authenticated API. Two
+    // properties carry that, and neither survives a substring assertion:
+    //
+    // 1. No anonymous fetch of this repository is left ANYWHERE. Naming one
+    //    spelling of the URL is not enough — dropping the braces from
+    //    ${GITHUB_REPOSITORY} walks straight past it. Matching `git ls-remote`
+    //    instead would fail on the clean tree, because the deploy job
+    //    legitimately reads `git ls-remote origin` from its checkout; the
+    //    anonymous https://github.com/ URL is what distinguishes the two.
+    // 2. BOTH branch-head resolutions go through that API — the `else` branch
+    //    that picks the snapshot, and the reconciled freshness read that
+    //    compares the branch against it. A `toContain` is satisfied by
+    //    whichever of the two sites was left alone, so count them.
+    expect(workflow).not.toMatch(/https:\/\/github\.com\//);
+    expect(
+      workflow.match(
+        /"repos\/\$\{GITHUB_REPOSITORY\}\/git\/ref\/heads\/\$\{BRANCH\}"/g,
+      ),
+    ).toHaveLength(2);
     expect(workflow).toContain(
       'fetch --no-recurse-submodules origin "$DEPLOY_SHA"',
     );
@@ -109,7 +122,7 @@ describe("provisioning worker deployment contract", () => {
     expect(workflow).toContain('[ "$TARGET_ENVIRONMENT" = "staging" ] || {');
     expect(workflow).toContain('[[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]] || {');
     expect(workflow).toContain(
-      '"repos/$' + '{GITHUB_REPOSITORY}/commits/$' + '{REQUESTED_SHA}"',
+      '"repos/$' + "{GITHUB_REPOSITORY}/commits/$" + '{REQUESTED_SHA}"',
     );
     expect(workflow).toContain("GH_TOKEN: $" + "{{ github.token }}");
     expect(workflow).toContain('[ "$deployment_sha" = "$REQUESTED_SHA" ] || {');


### PR DESCRIPTION
Follow-up to #30329, which I reviewed and approved. Its body lists four things it does; this is the fourth:

> update the workflow contract tests to prohibit the unauthenticated private-repository fetch

The workflow half of that PR is right — every repository read now goes through `gh api` with `GH_TOKEN`. The test half doesn't hold it. Both new assertions can be satisfied while the unauthenticated fetch comes back at the site that decides what gets deployed.

## Why neither assertion holds

```ts
expect(workflow).toContain(
  '"repos/$' + '{GITHUB_REPOSITORY}/git/ref/heads/$' + '{BRANCH}"',
);
expect(workflow).not.toContain(
  'git ls-remote "https://github.com/$' + '{GITHUB_REPOSITORY}.git"',
);
```

**The negative one names one spelling.** Drop the braces — `"https://github.com/$GITHUB_REPOSITORY.git"` — and it matches nothing.

**The positive one is a `toContain` over a string that occurs twice.** That endpoint appears at both the `else` branch that resolves the branch head and the reconciled-deploy freshness read, so whichever site is left alone satisfies it.

Measured on `develop`, with a pristine copy of the workflow restored between runs. Baseline **25 pass / 0 fail / 433 expects**:

| mutation applied to `deploy-eliza-provisioning-worker.yml` | on `develop` |
|---|---|
| `else` branch → `git ls-remote "https://github.com/$GITHUB_REPOSITORY.git" …` | **25 pass / 0 fail — survives** |
| reconciled `current_sha` → the same unbraced `git ls-remote` | **25 pass / 0 fail — survives** |
| `current_sha="$deployment_sha"` — freshness read made tautological | **25 pass / 0 fail — survives** |

The first two put the anonymous fetch back on the protected staging deploy path. The third is quieter and worse: comparing the reconciled source against itself turns

```
::error::$BRANCH is $current_sha, not reconciled source $deployment_sha
```

into a guard that can never fire.

## What this replaces them with

Two properties instead of two spellings:

```ts
expect(workflow).not.toMatch(/https:\/\/github\.com\//);
expect(
  workflow.match(
    /"repos\/\$\{GITHUB_REPOSITORY\}\/git\/ref\/heads\/\$\{BRANCH\}"/g,
  ),
).toHaveLength(2);
```

The clean head has **zero** anonymous `https://github.com/` URLs and **two** ref-endpoint sites, so both are exact rather than approximate.

**The obvious alternative is wrong, and I ran it before ruling it out.** `not.toMatch(/git ls-remote/)` fails on the clean tree: the deploy job legitimately reads

```yaml
current_sha="$(git ls-remote origin refs/heads/develop | awk 'NR == 1 { print $1 }')"
```

at `:422` and `:455`. Those go through `origin` inside a checkout and are authenticated by it. The anonymous URL is what separates them from the pattern being removed, which is why the assertion targets the URL and not the command. That reasoning is in a comment in the test so the next person doesn't retry it.

## Both directions

| mutant | `develop` | this branch |
|---|---|---|
| `else` branch → unbraced anonymous `ls-remote` | 25 / 0 | **24 / 1** |
| reconciled site → unbraced anonymous `ls-remote` | 25 / 0 | **24 / 1** |
| reconciled read → `current_sha="$deployment_sha"` | 25 / 0 | **24 / 1** |
| `REQUESTED_SHA` check → anonymous `git fetch` | 24 / 1 | **23 / 2** |

Three mutants that `develop` misses now fail, and the one it already caught is caught by both new assertions rather than one.

## Verification

| check | result |
|---|---|
| this file, this branch | 25 pass / 0 fail / 433 expects |
| this file, `develop` | 25 pass / 0 fail / 433 expects |
| whole `packages/scripts/__tests__` lane | 13 fail — **identical to `develop`** |
| `biome check` | clean |

The expectation count is unchanged because this swaps two assertions for two, rather than adding cases. No test is added or removed; the existing one is made exact. Test-only — no workflow or source file is touched, so it cannot affect a deploy.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1H41PTBZP1QB6N1N5JGG64A","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T13:13:32.747Z","completed_at":"2026-09-02T13:14:46.695Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T13:13:33.519Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6356de91ad1d45e83ba77e62954c91afa9f1268cb0f1d9bb72f277b4b60bbf48","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3aa63c21-af7a-469e-8398-a29c8b412193","object_id":"sha256:6356de91ad1d45e83ba77e62954c91afa9f1268cb0f1d9bb72f277b4b60bbf48","sha256":"6356de91ad1d45e83ba77e62954c91afa9f1268cb0f1d9bb72f277b4b60bbf48"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"nhxyrf72vUnZCJvFlj2qiXPNPkiH9-P--feVuqljYjfx94QU_M8STpJ8zf1qWtfdCTw01ApjQPQWIabAXc77AQ"}} -->
