### PR TITLE
test(cloud): match the absent --advertise-tags flag in argument position

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -173,7 +173,13 @@ describe("Headscale control-plane self-enrollment", () => {
     expect(retireStaleNode).toBeLessThan(tailscaleUp);
     expect(remote.match(/--force-reauth/g)).toHaveLength(1);
     expect(remote).toContain("--tags tag:eliza-proxy");
-    expect(remote).not.toContain("      --advertise-tags=");
+    // #30324 made the preauth key the sole tag authority, and this pins that
+    // no client-side request comes back. It has to match the flag in ARGUMENT
+    // position rather than by its indentation: re-adding the line at a
+    // different indent walks past a fixed-width substring. Matching the bare
+    // flag name would fail on the clean tree, because the comment above the
+    // key mint names `--advertise-tags` while explaining why it is absent.
+    expect(remote).not.toMatch(/^\s*--advertise-tags/m);
     expect(remote).toContain(
       "CP router forced reauthentication failed (category=cp-router-reauth-failed)",
     );
@@ -318,7 +324,10 @@ describe("Headscale protected workflow contract", () => {
   });
 
   test("emits only closed remote failure categories", () => {
-    const step = namedStep(workflow, "Inspect or converge Headscale control plane");
+    const step = namedStep(
+      workflow,
+      "Inspect or converge Headscale control plane",
+    );
     const run = String(step.run ?? "");
 
     expect(run).toContain(


### PR DESCRIPTION
Follow-up to #30324, which I reviewed and approved. It made the preauth key the sole tag authority for the CP-router join, and added this to hold that no client-side request comes back:

```ts
expect(remote).not.toContain("      --advertise-tags=");
```

That pins the flag's **indentation**, not its absence.

## The regression it is supposed to prevent walks past it

Re-adding a tag request after the key mint:

```bash
  sudo tailscale set \
    --advertise-tags=tag:eliza-proxy
```

| indent of the re-added flag | on `develop` |
|---|---|
| four spaces | **10 pass / 0 fail — survives** |
| six spaces | 9 pass / 1 fail |
| eight spaces | 9 pass / 1 fail |

Six and eight are caught only because the literal contains a six-space run, and eight spaces contains one. Four does not, so the node once again advertises tags the key already supplies — the exact thing #30324 removed — with the suite green.

That matters here because the flag's absence is now load-bearing rather than cosmetic: since #30319 added `--reset` and #30324 removed the client-side request, the node's tag comes **entirely** from the preauth key, and a re-added `--advertise-tags` is what #30324's own comment says Headscale rejects.

## The fix, and why the obvious one doesn't work

```ts
expect(remote).not.toMatch(/^\s*--advertise-tags/m);
```

| mutant | `develop` | this branch |
|---|---|---|
| flag re-added at four spaces | 10 / 0 | **9 / 1** |
| at six spaces | 9 / 1 | **9 / 1** |
| at eight spaces | 9 / 1 | **9 / 1** |

I also ran the tightening I *didn't* ship, so this isn't an assertion about it:

```ts
expect(remote).not.toContain("--advertise-tags");   // 9 pass / 1 fail on the CLEAN tree
```

It fails on unmodified `develop`, because the comment above the key mint names the flag while explaining why it's absent:

```bash
  # Short-lived, single-use, pre-tagged preauth key. The key is the sole tag
  # authority for this non-interactive join: Headscale rejects a client-side
  # --advertise-tags request when a preauth key already supplies the tags.
```

A negative assertion can only exclude the spelling it names, and here the excluded string legitimately appears in the prose explaining the exclusion. Anchoring to argument position (`^\s*`) is what separates the two. That reasoning is now a comment beside the assertion so the next person doesn't retry the bare-name version.

## One unrelated line, and why it's here

`biome check` fails on this file on `develop`, at a call #30315 merged unformatted:

```
-  const step = namedStep(workflow, "Inspect or converge Headscale control plane");
+  const step = namedStep(
+    workflow,
+    "Inspect or converge Headscale control plane",
+  );
```

I confirmed it is present on unmodified `develop` before touching it. Since `lint:check --affected` fails for any PR that touches this file, the reflow is folded in here rather than left to red this one. It is the only change outside the assertion.

## Verification

| check | result |
|---|---|
| `arm-headscale-control-plane.test.ts`, this branch | 10 pass / 0 fail / 87 expects |
| same file, `develop` | 10 pass / 0 fail / 87 expects |
| `biome check` | clean (fails on `develop`) |
| test-merge into my open #30320, which touches this file | `git merge --no-commit --no-ff` → **clean** |

The expectation count is unchanged: this swaps one assertion for one, rather than adding a case. Test-only — the remote script and the workflow are untouched.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1H55EMWZBYYN5GVABA91YBH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T13:33:04.028Z","completed_at":"2026-09-02T13:34:01.714Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T13:33:04.783Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"14ff0265be93a047141ff6f2b6fc384bbe451cc187fe75033fd3d99994a00116","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a3b53948-7f37-4a76-a898-aa122fef8986","object_id":"sha256:14ff0265be93a047141ff6f2b6fc384bbe451cc187fe75033fd3d99994a00116","sha256":"14ff0265be93a047141ff6f2b6fc384bbe451cc187fe75033fd3d99994a00116"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"zskpheUoGTa0O4kC88uO84i9zdo1JI7ufkRazCh37L-6b2vRNkomllfRK1NG0KReJ-rQkboAtffLtsK5HGQyBw"}} -->
