### PR TITLE
test(ci): record the subscription-authority lane in the ruleset contract

### DIFF
--- a/packages/scripts/__tests__/repository-ruleset-contract.test.ts
+++ b/packages/scripts/__tests__/repository-ruleset-contract.test.ts
@@ -31,6 +31,7 @@ describe("repository ruleset contract", () => {
     expect(Object.keys(admission.jobs)).toEqual([
       "source-smoke",
       "billing-payment-replay-e2e",
+      "subscription-authority-postgres",
       "browser-bridge-windows-security",
       "static-smoke",
     ]);
@@ -38,6 +39,7 @@ describe("repository ruleset contract", () => {
       "source-smoke",
       "browser-bridge-windows-security",
       "billing-payment-replay-e2e",
+      "subscription-authority-postgres",
     ]);
     expect(admission.jobs["billing-payment-replay-e2e"].needs).toBeUndefined();
     expect(admission.jobs["browser-bridge-windows-security"].uses).toBe(


### PR DESCRIPTION
`repository ruleset contract > publishes one stable fail-closed aggregate for PR and merge candidates` has been red on `develop`. #30154 added a `subscription-authority-postgres` job to `pr-static-smoke.yml`, and the contract that pins the admission workflow's shape was not updated with it.

## Which side is wrong

This contract exists to catch a lane that runs but does not gate the aggregate, so the first thing to establish is whether the workflow or the test is at fault. **The workflow is correct:**

```yaml
# .github/workflows/pr-static-smoke.yml:407
  static-smoke:
    needs:
      - source-smoke
      - browser-bridge-windows-security
      - billing-payment-replay-e2e
      - subscription-authority-postgres     # ← already wired
```

`All Tests Passed` does depend on the new job, so nothing is admitted ungated and there is no fail-open hole. Only the two expected lists in the test are stale, and this updates them — the job's position in each list matches the workflow's own order.

## A stronger version I wrote and then dropped

My first draft also added the property the literal lists exist to protect:

```ts
const lanes = Object.keys(admission.jobs).filter((job) => job !== "static-smoke");
expect([...admission.jobs["static-smoke"].needs].sort()).toEqual(lanes.sort());
```

It passes, and two mutants kill it:

| mutation to `pr-static-smoke.yml` | with the property assertion |
|---|---|
| `subscription-authority-postgres` removed from `needs`, job still runs | 3 pass / 1 fail |
| a new lane added without wiring it to the aggregate | 3 pass / 1 fail |

But that isn't the question. The question is whether it catches anything the **existing** assertions miss, so I ran the same two mutants against the literal-only fix in this PR:

| same mutation | literal-only (what this PR ships) |
|---|---|
| dropped from `needs` | **3 pass / 1 fail** |
| new lane not wired | **3 pass / 1 fail** |

Identical. The ordered lists already pin the job set and the `needs` set exactly, so the extra assertion kills nothing and only adds a second thing to keep in sync. Dropped it and shipped the two-line repair. Recording the measurement because "add a stronger invariant" is the obvious review suggestion here, and it does not pay for itself.

## Verification

Run from the **repository root**, which is the cwd `test:scripts` uses:

| | `packages/scripts/__tests__` |
|---|---|
| `develop` | 1500 pass / **4 fail** |
| this branch | 1501 pass / **3 fail** |

Exactly one test moves. `biome check` clean. Two-line, test-only diff — no workflow or source file is touched.

### On the three that remain

Worth writing down, because two of them are not real and I lost time to it:

- `mission workflow diagnostic redaction` — genuine; #30328 fixes it.
- both `protected gateway-webhook deployment workflow` cases — **local only.** They spawn the workflow step under `bash` and die on `declare: -A: invalid option`, which is bash 3.2 (the macOS system shell). Ubuntu runners have bash 4+, so these are green in CI.

Separately, running this lane as `cd packages/scripts && bun test __tests__` reports **12** failures rather than 4: eight tests resolve paths relative to `process.cwd()` and only pass from the repository root. That's not in scope here, but it makes the real failures hard to see, and it's why the numbers above specify the cwd.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1H6R5R2MYWBSXMXQTVNHDH6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T14:00:46.082Z","completed_at":"2026-09-02T14:02:00.846Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T14:00:46.776Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"db9da86bc3fdf13d983acda59d226c3a543f7787dc7dc246f7431ba172ca68aa","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"64d2c34c-9cf0-4f65-82b1-f308b0850a5e","object_id":"sha256:db9da86bc3fdf13d983acda59d226c3a543f7787dc7dc246f7431ba172ca68aa","sha256":"db9da86bc3fdf13d983acda59d226c3a543f7787dc7dc246f7431ba172ca68aa"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"wa-bMvMELe-1Uiwivd1KU398Fvkwze6AkGlL5pluWegLqxdFVtQt22fXEbaCfQ53F4Xq0179FVJO9qDv7q8rAA"}} -->
