### PR TITLE
test(cloud): pin the eviction before the fenced app-cache delete

### DIFF
--- a/packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/apps-inference-cache.test.ts
@@ -66,6 +66,35 @@ beforeEach(() => {
 });
 
 describe("AppsService inference cache-only lookup", () => {
+  test("the eviction before shared deletion actually clears this isolate's row", async () => {
+    // The companion test above pins the eviction AFTER the fenced delete. This
+    // one pins the one BEFORE it, which is otherwise removable with every
+    // suite green: without it the local LRU keeps serving the stale row for
+    // the whole time the shared delete is in flight.
+    const stale = app({ review_status: "draft" });
+    const fresh = { ...stale, review_status: "approved" } as App;
+    appRows.set(stale.id, fresh);
+    await cache.set(CacheKeys.app.byId(stale.id), stale, CacheTTL.app.byId);
+    expect((await appsService.getById(stale.id))?.review_status).toBe("draft");
+    expect(appReads).toBe(0);
+
+    let releaseFence = () => {};
+    cacheFenceGate = new Promise<void>((resolve) => {
+      releaseFence = resolve;
+    });
+    const invalidation = appsService.invalidateCache(stale.id);
+
+    // Hold the shared delete and remove the shared row by hand. The local LRU
+    // is now the only place the stale row could still come from, so a read
+    // that still answers "draft" proves the first eviction did not happen.
+    await cache.del(CacheKeys.app.byId(stale.id));
+    expect((await appsService.getById(stale.id))?.review_status).toBe("approved");
+    expect(appReads).toBe(1);
+
+    releaseFence();
+    await invalidation;
+  });
+
   test("async invalidation clears a stale row repopulated while shared deletion waits", async () => {
     const stale = app({ review_status: "draft" });
     const fresh = { ...stale, review_status: "approved" } as App;


### PR DESCRIPTION
Follow-up to #30335, which I reviewed and approved. It made `invalidateCache` evict the isolate-local inference cache on **both** sides of the fenced shared delete, and shipped a test that pins the second one. The first is still deletable with every relevant suite green.

```ts
async invalidateCache(appId, apiKeyId?, slug?) {
  invalidateInferenceAppByIdState(appId);        // ← removable, all green
  try {
    await withAppCacheFences({ appId, apiKeyId, slug }, async () => { … });
  } finally {
    invalidateInferenceAppByIdState(appId);      // ← pinned by #30335
  }
}
```

Without the first call the local LRU keeps answering with the stale row for as long as the shared delete is in flight — which is precisely the window the pair exists to close. The `finally` fixes up the end state; the opening eviction is what stops the isolate serving a superseded approval in the meantime.

## Nothing anywhere catches its removal

Measured on `develop`, per file — these suites use `mock.module` and batching them has produced misleading numbers for me before:

| suite, with the first eviction deleted | on `develop` |
|---|---|
| `apps-inference-cache` | 6 pass / 0 fail |
| `service-cache.invalidate` | 9 pass / 0 fail |
| `__tests__/app-review-rejection-cuts-monetization` | 3 pass / 0 fail |
| `app-credits-monetization-write-through` | 3 pass / 0 fail |

## The case

It reuses the fence gate #30335 already built, so this adds no new machinery. Hold the shared delete, then remove the shared row by hand — now the isolate LRU is the only place the stale row could still come from — and read:

```ts
const invalidation = appsService.invalidateCache(stale.id);

await cache.del(CacheKeys.app.byId(stale.id));
expect((await appsService.getById(stale.id))?.review_status).toBe("approved");
expect(appReads).toBe(1);

releaseFence();
await invalidation;
```

Evicted means the read falls through to the authoritative row and returns `approved`. Not evicted means the LRU still answers `draft`. The `appReads` assertions on both sides of the invalidation pin *where* each read was served from, which is the whole property.

## Both directions

Clean tree **7 pass / 0 fail / 23 expects**:

| mutation | result |
|---|---|
| the pre-fence eviction removed — the case this adds | **6 pass / 1 fail** |
| the post-fence eviction removed — regression check on #30335's own test | **6 pass / 1 fail** |

The second row is there to show this doesn't disturb what #30335 already pinned.

## Verification

| check | result |
|---|---|
| `apps-inference-cache` | 7 pass / 0 fail |
| `service-cache.invalidate` | 9 pass / 0 fail |
| `app-review-rejection-cuts-monetization` | 3 pass / 0 fail |
| `app-credits-monetization-write-through` | 3 pass / 0 fail |
| `biome check` (package-level, `lineWidth: 100`) | clean after a follow-up commit |

**Correction.** The row above originally read "clean". It was not: this branch's first
commit failed `@elizaos/cloud-shared:lint:check` on formatting, and CI caught it. I had
piped the local check's output into `tail -2` inside a larger command and never actually
read it. Worth recording the trap as well as the slip: `packages/cloud/shared/biome.json`
sets `lineWidth: 100`, while the repository root uses the default, so a `biome` invocation
from the repo root formats this package's files differently from the `lint:check` CI runs
inside the package. The fix is pushed and verified with the package's own script.

One added test case in one file. No source file is touched, so this cannot change runtime behaviour — it only removes the ability to delete a line of it unnoticed.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1H6YENZ4WNG25ZKK48TBTTW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T14:04:11.839Z","completed_at":"2026-09-02T14:05:16.172Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T14:04:12.161Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"62fc9ed6a469a79580c2cc709123b312d163728057487d533cbf83e8e395f1cb","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"751743d1-c6ad-47af-a515-79db8f53ab23","object_id":"sha256:62fc9ed6a469a79580c2cc709123b312d163728057487d533cbf83e8e395f1cb","sha256":"62fc9ed6a469a79580c2cc709123b312d163728057487d533cbf83e8e395f1cb"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"72J-wto2jKSAjwpH1Qcho51SJrv9Uy_7jCe9KWNOhVKNEgShiq0RiWl8z_fnkcTJcyVm68HLRN5WnumnDjmGAw"}} -->

