### PR TITLE
fix(cloud): complete the inference-revocation mocks that leak across files

### DIFF
--- a/packages/cloud/shared/src/lib/services/admin-moderation-iac.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-moderation-iac.test.ts
@@ -56,7 +56,14 @@ mock.module("./inference-auth-cache", () => ({
   invalidateInferenceAuthContextsByKeyHashes: invalidateSpy,
   invalidateInferenceSessionAuthContexts: invalidateSessionSpy,
 }));
+// `mock.module` is process-global: this replaces the module for every other
+// file in the same Bun process too. Only `setInferenceSubjectActive` needs
+// stubbing here, so spread the real module rather than enumerate the rest —
+// an omitted export becomes a SyntaxError in whichever co-batched suite
+// imports it, and the list would go stale as the module grows.
+const actualInferenceCredentialRevocation = await import("./inference-credential-revocation");
 mock.module("./inference-credential-revocation", () => ({
+  ...actualInferenceCredentialRevocation,
   setInferenceSubjectActive: subjectFenceSpy,
 }));
 

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -53,6 +53,15 @@ mock.module("./api-keys", () => ({
 }));
 
 mock.module("./inference-credential-revocation", () => ({
+  // `mock.module` is process-global: a partial mock of this module also
+  // replaces it for every other file in the same Bun process, so an export
+  // omitted here becomes a SyntaxError in whichever co-batched suite needs it.
+  // `inference-auth-context.ts` and `proxy/engine.ts` both import this one.
+  inferenceCredentialRevocationReason: (reason: string) => {
+    if (reason === "credential_revoked") return "credential_inactive";
+    if (reason === "organization_disabled") return "organization_inactive";
+    return "credential_invalid";
+  },
   setInferenceSessionBindingActive: async (
     orgId: string,
     userId: string,

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
@@ -51,6 +51,15 @@ mock.module("./inference-app-key-scope", () => ({
   },
 }));
 mock.module("./inference-credential-revocation", () => ({
+  // `mock.module` is process-global: a partial mock of this module also
+  // replaces it for every other file in the same Bun process, so an export
+  // omitted here becomes a SyntaxError in whichever co-batched suite needs it.
+  // `inference-auth-context.ts` and `proxy/engine.ts` both import this one.
+  inferenceCredentialRevocationReason: (reason: string) => {
+    if (reason === "credential_revoked") return "credential_inactive";
+    if (reason === "organization_disabled") return "organization_inactive";
+    return "credential_invalid";
+  },
   isInferenceStrongRevocationEnabled: () =>
     process.env.INFERENCE_STRONG_REVOCATION_ENABLED === "true",
   InferenceCredentialRevokedError: class InferenceCredentialRevokedError extends Error {},

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -69,6 +69,15 @@ mock.module("./inference-admission-snapshot", () => ({
   loadInferenceAdmissionSnapshot: async () => ADMISSION,
 }));
 mock.module("./inference-credential-revocation", () => ({
+  // `mock.module` is process-global: a partial mock of this module also
+  // replaces it for every other file in the same Bun process, so an export
+  // omitted here becomes a SyntaxError in whichever co-batched suite needs it.
+  // `inference-auth-context.ts` and `proxy/engine.ts` both import this one.
+  inferenceCredentialRevocationReason: (reason: string) => {
+    if (reason === "credential_revoked") return "credential_inactive";
+    if (reason === "organization_disabled") return "organization_inactive";
+    return "credential_invalid";
+  },
   isInferenceStrongRevocationEnabled: () =>
     process.env.INFERENCE_STRONG_REVOCATION_ENABLED === "true",
   InferenceCredentialRevokedError: class InferenceCredentialRevokedError extends Error {


### PR DESCRIPTION
`packages/cloud/shared` runs its suites through `scripts/run-bun-tests.mjs`, which batches **16 ordinary files per Bun process** (`DEFAULT_TEST_BATCH_SIZE`). `mock.module` is process-global, so a partial mock replaces the module for every co-batched file as well — and an export omitted from the mock becomes a `SyntaxError` in whichever suite needs it.

On `develop` today:

```
$ bun test src/lib/services/inference-auth-context.test.ts \
           src/lib/services/inference-session-auth-context.test.ts

# Unhandled error between tests
SyntaxError: Export named 'inferenceCredentialRevocationReason' not found
in module .../services/inference-credential-revocation.ts

 12 pass  1 fail  1 error
```

Both files pass alone (52 and 12). Together, one of them aborts.

## Why

Five suites mock `./inference-credential-revocation`, and only `inference-auth-context.test.ts` supplies `inferenceCredentialRevocationReason` — which `inference-auth-context.ts` and `proxy/engine.ts` both import from the real module.

I measured which pairings actually break rather than assuming all four incomplete mocks do:

| co-run with `inference-auth-context.test.ts` | on `develop` |
|---|---|
| `inference-session-auth-context` | **12 pass / 1 fail / 1 error** |
| `admin-moderation-iac` | **4 pass / 1 fail / 1 error** |
| `inference-hot-path-benchmark` | 56 pass / 0 fail |
| `inference-auth-lifecycle` | 78 pass / 0 fail |

The last two are clean today, but their mocks have the same omission — whether a pairing breaks depends on batch composition, which is a function of file count and sort order, not of anything a test author controls. So all four are completed here.

## The fix, and one deliberate difference

Three of the mocks deliberately stub many functions to keep real database calls out of the suite. Those gain the one missing export.

`admin-moderation-iac` stubs only `setInferenceSubjectActive`, so enumerating the rest of the module there would recreate the defect the moment the module grows another export. That one spreads the real module instead:

```ts
const actualInferenceCredentialRevocation = await import(
  "./inference-credential-revocation"
);
mock.module("./inference-credential-revocation", () => ({
  ...actualInferenceCredentialRevocation,
  setInferenceSubjectActive: subjectFenceSpy,
}));
```

## Result

| | `develop` | this branch |
|---|---|---|
| `inference-auth-context` + `inference-session-auth-context` | 12 pass / 1 fail / **1 error** | **64 pass / 0 fail** |

64 is the exact sum of the two files run alone, so nothing is being skipped — the second file now runs to completion instead of aborting.

Every file still passes individually and identically to `develop`:

| file | alone, `develop` | alone, this branch |
|---|---|---|
| `inference-auth-context` | 52 / 0 | 52 / 0 |
| `inference-session-auth-context` | 12 / 0 | 12 / 0 |
| `admin-moderation-iac` | 4 / 0 | 4 / 0 |
| `inference-hot-path-benchmark` | 4 / 0 | 4 / 0 |
| `inference-auth-lifecycle` | 26 / 0 | 26 / 0 |

`biome check` clean on all four changed files.

## What this does not fix

`admin-moderation-iac` **still** fails when co-batched with `inference-auth-context`, on a different and unrelated leak:

```
SyntaxError: export 'db' not found in './client'
```

That is a second partial mock, of the database client rather than the revocation module, and it needs its own change. I'm leaving it out rather than widening this diff, but recording it here because "one leak fixed" should not read as "that pairing is green".

Test-only; no source file is touched.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1H7M5BH20B181Y126863ZGJ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T14:16:03.185Z","completed_at":"2026-09-02T14:17:35.445Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T14:16:03.882Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7971f13989ee28b55343e8bc882c72b2905b9251108ccc5e463d2ca71d04bd49","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d680382d-e9e3-4eb6-bb5e-6b9e60eceb83","object_id":"sha256:7971f13989ee28b55343e8bc882c72b2905b9251108ccc5e463d2ca71d04bd49","sha256":"7971f13989ee28b55343e8bc882c72b2905b9251108ccc5e463d2ca71d04bd49"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"nU2EurzIOJ_N6_mNxJeTAZThr7D2pSMTRXyqBpzD66DHu0I7WvPYioLAdm3U_5NMuPqfVjTgE43EGjRtxsZ-AA"}} -->
