### PR TITLE
fix(cloud): force Dedicated Headscale joins over TLS

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -339,7 +339,11 @@ jobs:
         with:
           ref: ${{ needs.determine-env.outputs.deployment_sha }}
           fetch-depth: 1
-          persist-credentials: false
+          # The runner may need to import the immutable generation currently
+          # installed on the host after that feature ref has been rebased.
+          # The checkout credential remains runner-local; only the verified Git
+          # bundle is transferred to Hetzner and checkout removes it post-job.
+          persist-credentials: true
 
       - name: Verify exact migration source
         if: steps.deploy_config.outputs.configured == 'true'
@@ -530,8 +534,7 @@ jobs:
             exit 1
           fi
           deployed_sha="${BASH_REMATCH[1]}"
-          git fetch --no-tags --depth=2048 \
-            https://github.com/elizaOS/eliza.git \
+          git fetch --no-tags --depth=2048 origin \
             "$DEPLOY_SHA" "$deployed_sha"
           if [ "$deployed_sha" = "$DEPLOY_SHA" ]; then
             # Keep same-SHA retries idempotent: a bundle excluding HEAD itself

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -594,6 +594,11 @@ jobs:
             # commit whose submodule SHA was never pushed to the fork kills the
             # whole deploy with `upload-pack: not our ref`. Skip submodule
             # traversal entirely on this path.
+            # The checkout is service-owned, so repair its remote to the
+            # repository's public canonical URL on every deploy. Bootstrap
+            # credentials and one-off operator URLs must not become a hidden
+            # availability dependency for later immutable-SHA rollouts.
+            git remote set-url origin https://github.com/elizaOS/eliza.git
             git -c fetch.recurseSubmodules=no fetch --no-recurse-submodules origin "$DEPLOY_SHA"
             git -c submodule.recurse=false checkout --no-recurse-submodules \
               -B "$DEPLOY_BRANCH" "$DEPLOY_SHA"

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -599,7 +599,16 @@ jobs:
             # credentials and one-off operator URLs must not become a hidden
             # availability dependency for later immutable-SHA rollouts.
             git remote set-url origin https://github.com/elizaOS/eliza.git
-            git -c fetch.recurseSubmodules=no fetch --no-recurse-submodules origin "$DEPLOY_SHA"
+            GIT_CONFIG_GLOBAL=/dev/null \
+              GIT_CONFIG_SYSTEM=/dev/null \
+              GIT_TERMINAL_PROMPT=0 \
+              git \
+                -c safe.directory=/opt/eliza \
+                -c credential.helper= \
+                -c http.https://github.com/.extraheader= \
+                -c fetch.recurseSubmodules=no \
+                fetch --no-recurse-submodules \
+                https://github.com/elizaOS/eliza.git "$DEPLOY_SHA"
             git -c submodule.recurse=false checkout --no-recurse-submodules \
               -B "$DEPLOY_BRANCH" "$DEPLOY_SHA"
             test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -133,7 +133,7 @@ jobs:
     # wait for an orphaned prior SSH process, 25m identity-locked health) can
     # then each use their ceiling without the enclosing job becoming the first
     # timeout; the remaining fifteen minutes cover action startup and teardown.
-    timeout-minutes: 125
+    timeout-minutes: 140
     env:
       SYSTEMD_UNIT: eliza-provisioning-worker.service
       BACKUP_SYSTEMD_UNIT: eliza-backup-catalog-worker.service
@@ -501,6 +501,74 @@ jobs:
               ln -sf bun /home/deploy/.bun/bin/bunx
             fi
 
+      - name: Resolve deployed host source
+        id: deployed_source
+        if: steps.deploy_config.outputs.configured == 'true'
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+          username: deploy
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+          command_timeout: 1m
+          capture_stdout: true
+          script: |
+            set -euo pipefail
+            cd /opt/eliza
+            deployed_sha="$(git rev-parse HEAD)"
+            [[ "$deployed_sha" =~ ^[0-9a-f]{40}$ ]] || exit 1
+            echo "ELIZA_DEPLOYED_SHA=$deployed_sha"
+
+      - name: Prepare exact incremental source bundle
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 5
+        env:
+          DEPLOYED_SOURCE_OUTPUT: ${{ steps.deployed_source.outputs.stdout }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$DEPLOYED_SOURCE_OUTPUT" =~ ELIZA_DEPLOYED_SHA=([0-9a-f]{40}) ]]; then
+            echo "::error::Could not resolve the immutable source currently installed on the provisioning host"
+            exit 1
+          fi
+          deployed_sha="${BASH_REMATCH[1]}"
+          git fetch --no-tags --depth=2048 \
+            https://github.com/elizaOS/eliza.git \
+            "$DEPLOY_SHA" "$deployed_sha"
+          if [ "$deployed_sha" = "$DEPLOY_SHA" ]; then
+            # Keep same-SHA retries idempotent: a bundle excluding HEAD itself
+            # is empty and Git refuses to create it, while the installed
+            # generation necessarily already contains its parent.
+            merge_base="$(git rev-parse "$DEPLOY_SHA^")"
+          else
+            merge_base="$(git merge-base "$DEPLOY_SHA" "$deployed_sha")"
+          fi
+          [[ "$merge_base" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::The deployed source has no bounded common history with the requested source"
+            exit 1
+          }
+          git merge-base --is-ancestor "$merge_base" "$deployed_sha"
+          git bundle create .eliza-provisioning-source.bundle \
+            HEAD "^$merge_base"
+          git bundle verify .eliza-provisioning-source.bundle
+          source_bundle_sha256="$(sha256sum \
+            .eliza-provisioning-source.bundle | awk '{print $1}')"
+          [[ "$source_bundle_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "::error::Could not hash the exact incremental source bundle"
+            exit 1
+          }
+          echo "SOURCE_BUNDLE_SHA256=$source_bundle_sha256" >> "$GITHUB_ENV"
+
+      - name: Transfer exact incremental source bundle
+        if: steps.deploy_config.outputs.configured == 'true'
+        timeout-minutes: 5
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345
+        with:
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+          username: deploy
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+          source: .eliza-provisioning-source.bundle
+          target: /tmp/eliza-provisioning-transfer-${{ needs.determine-env.outputs.deployment_sha }}
+          overwrite: true
+
       - name: Deploy and restart worker
         if: steps.deploy_config.outputs.configured == 'true'
         env:
@@ -525,7 +593,7 @@ jobs:
           # wait without weakening the preflight's own eight-minute fail-closed
           # fence near the end of this remote script.
           command_timeout: 40m
-          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,SYSTEMD_ENVIRONMENT_HELPER_SHA256,BACKUP_SYSTEMD_UNIT_SHA256,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,VPN_REGISTRATION_TIMEOUT_MS,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,STEWARD_API_URL,STEWARD_PLATFORM_KEYS,AGENT_TOKEN_PRIVATE_KEY_PEM_BASE64,DATABASE_SSL_NO_VERIFY,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,WARM_POOL_ENABLED,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST,AGENT_BACKUP_CATALOG_WORKER_ID,AGENT_BACKUP_R2_ENDPOINT_ALIAS,AGENT_BACKUP_R2_ACCOUNT_ID,AGENT_BACKUP_R2_ENDPOINT,AGENT_BACKUP_R2_BUCKET,AGENT_BACKUP_R2_REGION,AGENT_BACKUP_R2_ACCESS_KEY_ID,AGENT_BACKUP_R2_SECRET_ACCESS_KEY,AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS,AGENT_BACKUP_HETZNER_ACCOUNT_ID,AGENT_BACKUP_HETZNER_ENDPOINT,AGENT_BACKUP_HETZNER_BUCKET,AGENT_BACKUP_HETZNER_REGION,AGENT_BACKUP_HETZNER_ACCESS_KEY_ID,AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY,AGENT_BACKUP_STEWARD_KMS_BASE_URL,AGENT_BACKUP_AGENT_SCHEMA_VERSION,AGENT_BACKUP_RUNTIME_PLUGINS_JSON,AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID,AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT,AGENT_BACKUP_STORAGE_SCOPE,AGENT_BACKUP_SPOOL_MAX_BYTES,AGENT_BACKUP_SPOOL_MIN_FREE_BYTES,AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE,AGENT_BACKUP_CAPTURE_DEADLINE_MS,AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS,AGENT_BACKUP_SCHEDULE_BATCH_SIZE,AGENT_BACKUP_SCHEDULE_LEASE_MS,AGENT_BACKUP_SCHEDULE_RETRY_MS,AGENT_BACKUP_OPERATION_BATCH_SIZE,AGENT_BACKUP_OPERATION_LEASE_MS,AGENT_BACKUP_OPERATION_RETRY_BASE_MS,AGENT_BACKUP_OPERATION_RETRY_MAX_MS,AGENT_BACKUP_GC_BATCH_SIZE,AGENT_BACKUP_GC_LEASE_MS,AGENT_BACKUP_GC_RETRY_BASE_MS,AGENT_BACKUP_GC_RETRY_MAX_MS,AGENT_BACKUP_DELETION_BATCH_SIZE,AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS,AGENT_BACKUP_CATALOG_WORKER_RETRY_MS,AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SOURCE_BUNDLE_SHA256,SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,SYSTEMD_ENVIRONMENT_HELPER_SHA256,BACKUP_SYSTEMD_UNIT_SHA256,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,VPN_REGISTRATION_TIMEOUT_MS,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,STEWARD_API_URL,STEWARD_PLATFORM_KEYS,AGENT_TOKEN_PRIVATE_KEY_PEM_BASE64,DATABASE_SSL_NO_VERIFY,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,WARM_POOL_ENABLED,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST,AGENT_BACKUP_CATALOG_WORKER_ID,AGENT_BACKUP_R2_ENDPOINT_ALIAS,AGENT_BACKUP_R2_ACCOUNT_ID,AGENT_BACKUP_R2_ENDPOINT,AGENT_BACKUP_R2_BUCKET,AGENT_BACKUP_R2_REGION,AGENT_BACKUP_R2_ACCESS_KEY_ID,AGENT_BACKUP_R2_SECRET_ACCESS_KEY,AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS,AGENT_BACKUP_HETZNER_ACCOUNT_ID,AGENT_BACKUP_HETZNER_ENDPOINT,AGENT_BACKUP_HETZNER_BUCKET,AGENT_BACKUP_HETZNER_REGION,AGENT_BACKUP_HETZNER_ACCESS_KEY_ID,AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY,AGENT_BACKUP_STEWARD_KMS_BASE_URL,AGENT_BACKUP_AGENT_SCHEMA_VERSION,AGENT_BACKUP_RUNTIME_PLUGINS_JSON,AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID,AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT,AGENT_BACKUP_STORAGE_SCOPE,AGENT_BACKUP_SPOOL_MAX_BYTES,AGENT_BACKUP_SPOOL_MIN_FREE_BYTES,AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE,AGENT_BACKUP_CAPTURE_DEADLINE_MS,AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS,AGENT_BACKUP_SCHEDULE_BATCH_SIZE,AGENT_BACKUP_SCHEDULE_LEASE_MS,AGENT_BACKUP_SCHEDULE_RETRY_MS,AGENT_BACKUP_OPERATION_BATCH_SIZE,AGENT_BACKUP_OPERATION_LEASE_MS,AGENT_BACKUP_OPERATION_RETRY_BASE_MS,AGENT_BACKUP_OPERATION_RETRY_MAX_MS,AGENT_BACKUP_GC_BATCH_SIZE,AGENT_BACKUP_GC_LEASE_MS,AGENT_BACKUP_GC_RETRY_BASE_MS,AGENT_BACKUP_GC_RETRY_MAX_MS,AGENT_BACKUP_DELETION_BATCH_SIZE,AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS,AGENT_BACKUP_CATALOG_WORKER_RETRY_MS,AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS
           script: |
             set -euo pipefail
 
@@ -594,24 +662,31 @@ jobs:
             # commit whose submodule SHA was never pushed to the fork kills the
             # whole deploy with `upload-pack: not our ref`. Skip submodule
             # traversal entirely on this path.
-            # The checkout is service-owned, so repair its remote to the
-            # repository's public canonical URL on every deploy. Bootstrap
-            # credentials and one-off operator URLs must not become a hidden
-            # availability dependency for later immutable-SHA rollouts.
+            # The trusted runner transfers only the objects between the
+            # deployed generation's common ancestor and the exact admitted
+            # target. The host verifies the bundle before importing it, so
+            # stale Git credentials or GitHub egress policy are not deployment
+            # dependencies and no repository token crosses the SSH boundary.
             git remote set-url origin https://github.com/elizaOS/eliza.git
-            GIT_CONFIG_GLOBAL=/dev/null \
-              GIT_CONFIG_SYSTEM=/dev/null \
-              GIT_TERMINAL_PROMPT=0 \
-              git \
-                -c safe.directory=/opt/eliza \
-                -c credential.helper= \
-                -c http.https://github.com/.extraheader= \
-                -c fetch.recurseSubmodules=no \
-                fetch --no-recurse-submodules \
-                https://github.com/elizaOS/eliza.git "$DEPLOY_SHA"
+            SOURCE_BUNDLE_DIRECTORY="/tmp/eliza-provisioning-transfer-$DEPLOY_SHA"
+            SOURCE_BUNDLE="$SOURCE_BUNDLE_DIRECTORY/.eliza-provisioning-source.bundle"
+            [[ "$SOURCE_BUNDLE_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+              echo "::error::Refusing an incremental source bundle without its runner-side digest"
+              exit 1
+            }
+            actual_source_bundle_sha256="$(sha256sum "$SOURCE_BUNDLE" | awk '{print $1}')"
+            [ "$actual_source_bundle_sha256" = "$SOURCE_BUNDLE_SHA256" ] || {
+              echo "::error::Incremental source bundle differs from the exact runner artifact"
+              exit 1
+            }
+            git bundle verify "$SOURCE_BUNDLE"
+            git -c fetch.recurseSubmodules=no fetch \
+              --no-recurse-submodules "$SOURCE_BUNDLE" HEAD
             git -c submodule.recurse=false checkout --no-recurse-submodules \
               -B "$DEPLOY_BRANCH" "$DEPLOY_SHA"
             test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"
+            rm -f "$SOURCE_BUNDLE"
+            rmdir "$SOURCE_BUNDLE_DIRECTORY"
 
             # The `rm -f bun.lock` above deletes a TRACKED file; when bun.lock
             # is identical between the previous HEAD and the new tip, checkout

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1300,6 +1300,65 @@ jobs:
             echo "headscale_registration_timeout_seen=$timed_out"
             echo "headscale_tag_rejection_seen=$tag_rejected"
 
+      - name: Summarize Headscale ingress protocol
+        if: steps.cleanup_reconciliation.outputs.agent_id != ''
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+          username: deploy
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+          command_timeout: 2m
+          script: |
+            set -euo pipefail
+            version_raw="$(sudo headscale version 2>/dev/null || true)"
+            version="$(printf '%s' "$version_raw" | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 || true)"
+            if [[ ! "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              version='unknown'
+            fi
+            unset version_raw
+
+            # Default nginx access logs contain remote addresses and user
+            # agents. Reduce the bounded tail on-host to exact method/path/status
+            # counters and emit only those closed aggregate fields.
+            summary="$({
+              sudo tail -n 20000 /var/log/nginx/access.log 2>/dev/null || true
+              sudo zcat -f /var/log/nginx/access.log.1 2>/dev/null || true
+            } | awk '
+              function count_path(method, path, status) {
+                if (method == "GET" && path ~ /^\/key([?]|$)/) key[status] += 1
+                if (path == "/ts2021") {
+                  ts2021[status] += 1
+                  if (method == "POST") ts2021_post += 1
+                  if (method == "GET") ts2021_get += 1
+                }
+                if (method == "POST" && path == "/machine/register") machine_register[status] += 1
+              }
+              {
+                split($0, quoted, "\"")
+                split(quoted[2], request, " ")
+                split(quoted[3], response, " ")
+                if (length(request) >= 2 && response[1] ~ /^[0-9][0-9][0-9]$/) {
+                  count_path(request[1], request[2], response[1])
+                }
+              }
+              END {
+                key_total = ts_total = machine_total = 0
+                for (status in key) key_total += key[status]
+                for (status in ts2021) ts_total += ts2021[status]
+                for (status in machine_register) machine_total += machine_register[status]
+                printf "key_total=%d\n", key_total
+                printf "ts2021_total=%d\n", ts_total
+                printf "ts2021_post=%d\n", ts2021_post + 0
+                printf "ts2021_get=%d\n", ts2021_get + 0
+                printf "machine_register_total=%d\n", machine_total
+                for (status in ts2021) printf "ts2021_status_%s=%d\n", status, ts2021[status]
+                for (status in machine_register) printf "machine_register_status_%s=%d\n", status, machine_register[status]
+              }
+            ')"
+            echo "headscale_version=$version"
+            printf '%s\n' "$summary"
+            unset version summary
+
       - name: Summarize recent agent pre-auth key state
         if: steps.cleanup_reconciliation.outputs.agent_id != ''
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -857,6 +857,14 @@ jobs:
             ORDER BY jobs.created_at DESC, jobs.id DESC
             LIMIT 1
           ),
+          latest_delete AS (
+            SELECT jobs.id
+            FROM jobs
+            INNER JOIN target ON target.id::text = jobs.agent_id
+            WHERE jobs.type = 'agent_delete'
+            ORDER BY jobs.created_at DESC, jobs.id DESC
+            LIMIT 1
+          ),
           eligible AS (
             SELECT candidate.replacement_cleanup_created_at
             FROM agent_sandboxes AS candidate
@@ -928,6 +936,7 @@ jobs:
           SELECT json_build_object(
             'targetCount', (SELECT count(*) FROM target),
             'agentId', (SELECT id FROM target),
+            'deleteJobId', (SELECT id FROM latest_delete),
             'headscaleIp', (SELECT headscale_ip FROM facts),
             'cleanupFencePresent', COALESCE((SELECT cleanup_fence_present FROM facts), false),
             'deletionAttemptPresent', COALESCE((SELECT deletion_attempt_present FROM facts), false),
@@ -947,9 +956,10 @@ jobs:
           SQL
           } | sed '/^[[:space:]]*$/d' | head -n 1)"
           jq -e '
-            keys == ["activeExclusiveJobs", "agentId", "cleanupCreatedAt", "cleanupFencePresent", "deletionAttemptPresent", "graceElapsed", "headscaleIp", "inspectableCandidatePresent", "lifecycleGenerationPresent", "lifecycleJobPresent", "olderEligibleFences", "provisionExecutionGenerationPresent", "provisionExecutionQuiescedPresent", "provisionLiveExecutionLeasePresent", "targetCount", "totalEligibleFences"] and
+            keys == ["activeExclusiveJobs", "agentId", "cleanupCreatedAt", "cleanupFencePresent", "deleteJobId", "deletionAttemptPresent", "graceElapsed", "headscaleIp", "inspectableCandidatePresent", "lifecycleGenerationPresent", "lifecycleJobPresent", "olderEligibleFences", "provisionExecutionGenerationPresent", "provisionExecutionQuiescedPresent", "provisionLiveExecutionLeasePresent", "targetCount", "totalEligibleFences"] and
             .targetCount == 1 and
             (.agentId | test("^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")) and
+            (.deleteJobId == null or (.deleteJobId | test("^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"))) and
             (.cleanupFencePresent | type == "boolean") and
             (
               (
@@ -976,6 +986,12 @@ jobs:
           echo "::add-mask::$agent_id"
           echo "agent_id=$agent_id" >> "$GITHUB_OUTPUT"
           unset agent_id
+          delete_job_id="$(jq -r '.deleteJobId // ""' <<<"$summary")"
+          if [ -n "$delete_job_id" ]; then
+            echo "::add-mask::$delete_job_id"
+          fi
+          echo "delete_job_id=$delete_job_id" >> "$GITHUB_OUTPUT"
+          unset delete_job_id
           headscale_ip="$(jq -r '.headscaleIp // ""' <<<"$summary")"
           if [ -n "$headscale_ip" ]; then
             echo "::add-mask::$headscale_ip"
@@ -1531,24 +1547,27 @@ jobs:
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
         env:
           CANARY_AGENT_ID: ${{ steps.cleanup_reconciliation.outputs.agent_id }}
+          CANARY_DELETE_JOB_ID: ${{ steps.cleanup_reconciliation.outputs.delete_job_id }}
         with:
           host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
           username: deploy
           key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
           command_timeout: 2m
-          envs: CANARY_AGENT_ID
+          envs: CANARY_AGENT_ID,CANARY_DELETE_JOB_ID
           script: |
             set -euo pipefail
             [[ "$CANARY_AGENT_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] || exit 1
+            if [ -n "$CANARY_DELETE_JOB_ID" ]; then
+              [[ "$CANARY_DELETE_JOB_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] || exit 1
+            fi
             block="$(
               sudo journalctl \
                 -u eliza-provisioning-worker.service \
                 --since '4 hours ago' \
                 -o cat \
                 --no-pager 2>/dev/null \
-                | grep -F -B 12 -A 12 "$CANARY_AGENT_ID" \
+                | { grep -F -B 12 -A 12 -e "$CANARY_AGENT_ID" ${CANARY_DELETE_JOB_ID:+-e "$CANARY_DELETE_JOB_ID"} || true; } \
                 | tail -n 1200 \
-                || true
             )"
             lower="$(printf '%s' "$block" | tr '[:upper:]' '[:lower:]')"
             signals=''
@@ -1617,7 +1636,7 @@ jobs:
               *'marked sandbox as deletion_failed'*) delete_category='permanent_failure_unclassified' ;;
               *) delete_category='none' ;;
             esac
-            unset block lower CANARY_AGENT_ID
+            unset block lower CANARY_AGENT_ID CANARY_DELETE_JOB_ID
             echo "dedicated_lifecycle_signals=${signals:-none}"
             echo "dedicated_heartbeat_failure_category=$heartbeat_category"
             echo "dedicated_delete_failure_category=$delete_category"

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1605,6 +1605,14 @@ jobs:
               *'inference revocation durable object binding is missing'*) delete_category='inference_revocation_binding_missing' ;;
               *'refusing to delete without a current backup'*) delete_category='pre_delete_capture_refused' ;;
               *'failed to delete sandbox'*) delete_category='sandbox_stop_failed' ;;
+              *'value.toisostring is not a function'*) delete_category='timestamp_shape_invalid' ;;
+              *'still owns backup catalog v2 authority'*) delete_category='backup_catalog_authority_retained' ;;
+              *'reviewed restore authority is fenced for agent'*) delete_category='reviewed_restore_authority_fenced' ;;
+              *'failed query: delete from "agent_sandboxes"'*) delete_category='sandbox_row_delete_query_failed' ;;
+              *'failed query: update "api_keys"'*) delete_category='credential_revocation_query_failed' ;;
+              *'deadlock detected'*) delete_category='database_deadlock' ;;
+              *'could not serialize access'*) delete_category='database_serialization' ;;
+              *'connection terminated'*|*'connection closed'*) delete_category='database_connection_lost' ;;
               *'agent deletion ownership changed'*|*'agent row delete lost its lifecycle ownership'*) delete_category='database_ownership_lost' ;;
               *'marked sandbox as deletion_failed'*) delete_category='permanent_failure_unclassified' ;;
               *) delete_category='none' ;;

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -537,6 +537,116 @@ jobs:
       - name: Validate provision diagnostic contract
         run: bun test packages/cloud/scripts/admin/managed-dedicated-provision-diagnostic.test.ts
 
+      - name: Classify exact canary journal by suffix
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        env:
+          CANARY_DIAGNOSTIC_SUFFIX: ${{ inputs.diagnose_canary_suffix }}
+        with:
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+          username: deploy
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+          command_timeout: 2m
+          envs: CANARY_DIAGNOSTIC_SUFFIX
+          script: |
+            set -euo pipefail
+            [[ "$CANARY_DIAGNOSTIC_SUFFIX" =~ ^r[1-9][0-9]{7,19}a[1-9][0-9]{0,3}$ ]] || exit 1
+            expected_name="managed-dedicated-canary-$CANARY_DIAGNOSTIC_SUFFIX"
+            journal="$(
+              sudo journalctl \
+                -u eliza-provisioning-worker.service \
+                --since '4 hours ago' \
+                -o cat \
+                --no-pager 2>/dev/null \
+                | tail -n 20000 \
+                || true
+            )"
+            ids="$(
+              printf '%s\n' "$journal" \
+                | grep -F "$expected_name" \
+                | grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}' \
+                | sort -u \
+                || true
+            )"
+            id_count="$(printf '%s\n' "$ids" | sed '/^$/d' | wc -l | tr -d ' ')"
+            if [ "$id_count" = 1 ]; then
+              agent_id="$(printf '%s\n' "$ids" | sed '/^$/d')"
+              echo "::add-mask::$agent_id"
+              block="$(printf '%s\n' "$journal" | grep -F -B 16 -A 24 "$agent_id" | tail -n 1600 || true)"
+              target='resolved'
+            elif [ "$id_count" = 0 ]; then
+              block="$(printf '%s\n' "$journal" | grep -F -B 16 -A 160 "$expected_name" | tail -n 800 || true)"
+              target='missing_id'
+            else
+              block=''
+              target='ambiguous_id'
+            fi
+            lower="$(printf '%s' "$block" | tr '[:upper:]' '[:lower:]')"
+            observation="$(
+              printf '%s\n' "$lower" \
+                | sed -n 's/^.*docker candidate mesh observation before cleanup: //p' \
+                | tail -n 1
+            )"
+            case "$observation" in
+              *'authkey_rejected=true'*|*'interactive=true'*) category='mesh_auth_required' ;;
+              *'container=exited'*|*'container=dead'*) category='candidate_container_exited' ;;
+              *'socket=false'*'daemon=false'*) category='tailscale_daemon_unavailable' ;;
+              *'control=false'*) category='headscale_control_unreachable' ;;
+              *'dns_failed=true'*) category='headscale_dns_failure' ;;
+              *'tls_failed=true'*) category='headscale_tls_failure' ;;
+              *'control_transport_failed=true'*) category='headscale_control_transport_failure' ;;
+              *'control_key=false'*) category='headscale_control_key_not_fetched' ;;
+              *'login_started=false'*) category='tailscale_login_not_started' ;;
+              *'register_request=false'*) category='tailscale_register_request_not_sent' ;;
+              *'status=error'*) category='tailscale_status_unavailable' ;;
+              *'backend=needslogin'*) category='tailscale_needs_login' ;;
+              *'backend=needsmachineauth'*) category='tailscale_needs_machine_auth' ;;
+              *'backend=starting'*) category='tailscale_starting_without_ip' ;;
+              *'backend=stopped'*) category='tailscale_stopped' ;;
+              *'backend=running'*'ip=false'*) category='tailscale_running_without_ip' ;;
+              *'ip=true'*) category='candidate_ip_observed' ;;
+              '')
+                case "$lower" in
+                  *'required headscale registration: auth_required'*) category='mesh_auth_required' ;;
+                  *'required headscale registration: container_exited'*) category='candidate_container_exited' ;;
+                  *'headscale registration did not reach an exact observable completion'*) category='registration_unresolved' ;;
+                  *'vpn registration timeout'*) category='registration_timeout' ;;
+                  *' registered on vpn:'*) category='registration_observed' ;;
+                  '') category='missing' ;;
+                  *) category='unclassified' ;;
+                esac
+                ;;
+              *) category='observation_unclassified' ;;
+            esac
+            observation_present=false
+            [ -n "$observation" ] && observation_present=true
+            provision_failed=false
+            provision_completed=false
+            case "$lower" in *'agent_provision failed'*) provision_failed=true ;; esac
+            case "$lower" in *'agent_provision completed'*) provision_completed=true ;; esac
+            echo "suffix_journal_target=$target"
+            echo "suffix_journal_mesh_category=$category"
+            echo "suffix_journal_observation_present=$observation_present"
+            echo "suffix_journal_provision_failed=$provision_failed"
+            echo "suffix_journal_provision_completed=$provision_completed"
+            if [ "$observation_present" = true ]; then
+              for field in container socket daemon status backend authorized authurl ip route tun control \
+                control_key login_started register_request control_transport_failed tls_failed dns_failed \
+                authkey_rejected interactive up_failed agent_started; do
+                value="$(printf '%s' "$observation" | tr ',' '\n' | sed -n "s/^${field}=//p" | tail -n 1)"
+                case "$field:$value" in
+                  container:running|container:paused|container:restarting|container:removing|container:exited|container:dead|container:created|container:unknown) ;;
+                  status:success|status:error) ;;
+                  backend:running|backend:starting|backend:stopped|backend:needslogin|backend:needsmachineauth|backend:nostate|backend:unknown) ;;
+                  authorized:true|authorized:false|authorized:unknown) ;;
+                  socket:true|socket:false|daemon:true|daemon:false|authurl:true|authurl:false|ip:true|ip:false|route:true|route:false|tun:true|tun:false|control:true|control:false|control_key:true|control_key:false|login_started:true|login_started:false|register_request:true|register_request:false|control_transport_failed:true|control_transport_failed:false|tls_failed:true|tls_failed:false|dns_failed:true|dns_failed:false|authkey_rejected:true|authkey_rejected:false|interactive:true|interactive:false|up_failed:true|up_failed:false|agent_started:true|agent_started:false) ;;
+                  *) value='unknown' ;;
+                esac
+                echo "suffix_journal_observation_${field}=$value"
+              done
+            fi
+            unset expected_name journal ids id_count agent_id block lower observation target category \
+              observation_present provision_failed provision_completed CANARY_DIAGNOSTIC_SUFFIX
+
       - name: Query exact failed canary read-only
         shell: bash
         env:

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.contract.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.contract.test.ts
@@ -149,6 +149,7 @@ describe("owned agent detail private-address contract", () => {
       data: {
         id: AGENT_ID,
         webUiUrl: `https://${AGENT_ID}.staging.elizacloud.ai`,
+        meshAddressPresent: true,
         adminDetails: null,
       },
     });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -272,6 +272,7 @@ app.get("/", async (c) => {
       walletAddress,
       walletProvider,
       walletStatus,
+      meshAddressPresent: agent.headscale_ip !== null,
       adminDetails,
     };
 

--- a/packages/cloud/infra/AGENT-RUNTIME-ARCHITECTURE.md
+++ b/packages/cloud/infra/AGENT-RUNTIME-ARCHITECTURE.md
@@ -747,3 +747,152 @@ compute the API cannot claim; enabling only the API would find no replenished
 capacity. Do not use the pool to mask the cold-path failure. Activation requires
 recorded billing, capacity, starvation, digest, health, claim, and rollback
 evidence for both halves in one controlled change.
+
+## 2026-09-02 closure: signed-in Dedicated path restored
+
+This section supersedes the intermediate acceptance language above. The full
+investigation crossed several independent faults that presented as one long
+"Dedicated agents do not start" symptom. The failures were repaired in causal
+order and re-tested at their real boundaries instead of treating a public
+health beacon, a Docker `running` state, or a database row as readiness.
+
+The product routing invariant is now explicit:
+
+- authenticated Eliza application and Cloud sessions select
+  `dedicated-always`; they do not fall back to Shared on provisioning failure;
+- anonymous/public `eliza.app` chat and explicitly Shared channel ingress may
+  select Shared;
+- Telegram, Discord, iMessage, and similar external ingress is Shared only
+  when it is the public Eliza service, while a connector installed for a
+  user's personal agent delivers to that user's Dedicated runtime;
+- handoff transfers an explicitly delimited conversation state into the
+  Dedicated owner and records provenance; it is not an implicit Shared
+  continuation or a reason to route a signed-in turn through Shared.
+
+The resulting end-to-end flow is:
+
+```text
+signed-in client
+  -> authenticated Cloud route
+  -> dedicated-always resolver
+  -> agent_sandboxes durable lifecycle row
+  -> provision_jobs leased by the Hetzner provisioning worker
+  -> capacity selection / Docker node allocation
+  -> tenant database creation and migration
+  -> immutable agent image start
+  -> Tailscale join through Headscale over TLS
+  -> headscale_ip persisted only after observed mesh identity
+  -> agent health + fresh heartbeat
+  -> Cloud agent-router forwards the original per-agent host over the mesh
+  -> Dedicated agent chat/SSE
+```
+
+Shared remains a separate edge-owned execution path:
+
+```text
+public or explicitly Shared ingress
+  -> Shared admission and conversation Durable Object
+  -> Shared runtime execution
+  -> Shared response/channel delivery
+```
+
+The two paths may exchange a deliberate handoff envelope, but they do not
+share runtime identity, storage ownership, health, or fallback semantics.
+
+### Root causes and repairs
+
+1. **Signed-in routing admitted Shared fallback.** The authenticated routes,
+   SDK contracts, and regression suites now require `dedicated-always` and
+   preserve a visible failure when Dedicated is unavailable. Merge
+   `696922e0c0861348f3330b41378ef1b15630f12f` and exact hosted run
+   `33596412886` established this boundary.
+2. **The active agent image was initially misidentified.** The protected
+   `ELIZA_AGENT_IMAGE` is built by `build-agent-image.yml` from
+   `packages/app-core/deploy/Dockerfile.ci`, not the similarly named dormant
+   Dockerfile. Build `33630300533` produced and pull-tested
+   `ghcr.io/elizaos/eliza-demo@sha256:b4077a84eaa372f0b8b2d640f966869ae8d614009a6191bb8ed3df238cfa7897`.
+3. **Headscale error reporting collapsed distinct causes.** Merge
+   `4526287d7c9a90e7a0775a8dcd072d8938cff410` introduced closed safe
+   categories; later diagnostics distinguish ingress, registration, peer,
+   routing, application-start, and deletion failures without exposing keys or
+   mesh addresses.
+4. **The Headscale control-plane re-arm trusted a stale durable row.** Merge
+   `408b4647d4880a751cffdce7912fbd7385da2932` requires the durable node, local
+   Running state and IP, and canonical ControlURL together. Arm run
+   `33630162925` converged successfully. Earlier arm failures `33621556735`,
+   `33624576929`, and `33627254594` were retained as negative evidence rather
+   than called success.
+5. **Provisioning containers attempted the TS2021 exchange through plaintext
+   port 80.** Headscale was healthy on the proxied TLS path, but Tailscale
+   remained `NeedsLogin`. The image now sets `TS_FORCE_NOISE_443=1`, matching
+   the upstream client and Headscale reverse-proxy contracts. Exact worker
+   deployment `33650901840` installed the repair; cleanup `33651439541`
+   removed the prior failed target.
+6. **The canary could not safely observe mesh readiness through the owner
+   API.** The raw Headscale address remains admin-only, while the owner DTO now
+   exposes required boolean `meshAddressPresent`. This prevents a healthy mesh
+   from being misreported as absent without widening private network data.
+7. **Deletion retries could become permanently stranded after bridge loss.**
+   The first delete attempt could remove or clear the bridge, and the next
+   attempt returned before honoring its explicit `stateLossAcknowledged`
+   authority. The repaired service binds the waiver to the exact lifecycle
+   generation under lock, proceeds without fabricating or persisting a bridge
+   URL, and still fails closed for ordinary unacknowledged deletion. Diagnostic
+   `33658113000` isolated `pre_delete_capture_refused`; exact worker deployment
+   `33661686020` installed the repair, and cleanup-only run `33662307557`
+   confirmed deletion of `r33654221184a1` with no orphan.
+8. **The Hetzner worker host depended on ambient Git credentials.** The public
+   remote still returned an authentication challenge because host-level Git
+   state contaminated the fetch. The deployment now resolves the installed
+   host generation, constructs a bounded incremental Git bundle from the
+   trusted exact-SHA runner checkout, hashes and transfers it over the existing
+   protected SSH boundary, verifies it on-host, and imports it locally. No
+   GitHub token crosses into Hetzner. Run `33661686020` proved bundle transfer,
+   exact checkout, migration, build, systemd restart, router health, and worker
+   health. Same-SHA retries include the target commit relative to its parent,
+   avoiding an empty-bundle failure.
+
+### Database findings
+
+The tenant and control databases were not the startup root cause in the final
+failed provisions. Canaries `33651867586` and `33654221184` reached a ready
+tenant database and fresh worker heartbeat. Diagnostic `33656460024` showed a
+terminal `deletion_failed` row with durable Docker and Headscale locators,
+completed provisioning, and lifecycle events through `delete_failed`. The
+initial generic "database" label was a diagnostic classifier bug: it matched
+database-looking stack paths instead of the exact delete job's closed failure
+category. Job-correlated diagnostics corrected that false attribution. The
+deployment workflow nevertheless continues to run canonical migrations against
+the protected environment DSN and to fence activation on the job-interruption
+schema preflight.
+
+### Hetzner, queue, and warm-pool weaknesses
+
+- Cold provisioning remains sensitive to queue delay. Canary `33654221184`
+  spent 619,598 ms queued and 37,890 ms executing before the later readiness
+  and cleanup work. Queue age, execution time, and terminal category must stay
+  separate in alerts.
+- The self-hosted GitHub runner fleet repeatedly reported runners online while
+  jobs terminated within four to five seconds at checkout. These attempts made
+  no host or database mutation, but "online" is insufficient fleet health.
+  Deployment receipts must therefore distinguish runner startup failure from
+  host deployment failure, and operators should alert on repeated no-log job
+  terminations.
+- The provisioning host no longer needs outbound Git authentication, removing
+  a mutable credential/configuration dependency from disaster recovery and
+  ordinary rollout.
+- The warm pool remains protected-off. It was not used to conceal cold-path
+  faults, and it should not be enabled until both the API claim half and daemon
+  replenish half pass the billing, starvation, generation, and rollback
+  evidence enumerated above.
+
+### Acceptance state
+
+At the feature-source boundary, the repaired worker has terminal proof for
+canonical migrations, exact incremental-source admission, systemd identity,
+worker/router health, and recovery of the known deletion orphan. A final fresh
+signed-in create/chat/SSE/delete canary must run from the merged `develop`
+revision after the owner-safe mesh DTO is deployed to Cloudflare; running it
+against the older API would produce a known false negative. That post-merge run
+is the final release receipt for the complete path, not a substitute for the
+causal evidence above.

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -207,6 +207,20 @@ describe("managed dedicated live-smoke workflow contract", () => {
     );
     expect(headscaleExchange?.with?.script).not.toContain('echo "$block"');
 
+    const headscaleIngress = diagnostic.steps.find(
+      (step) => step.name === "Summarize Headscale ingress protocol",
+    );
+    expect(headscaleIngress?.if).toBe(
+      "steps.cleanup_reconciliation.outputs.agent_id != ''",
+    );
+    expect(headscaleIngress?.with?.script).toContain("headscale version");
+    expect(headscaleIngress?.with?.script).toContain("/var/log/nginx/access.log");
+    expect(headscaleIngress?.with?.script).toContain("ts2021_total=");
+    expect(headscaleIngress?.with?.script).toContain("machine_register_total=");
+    expect(headscaleIngress?.with?.script).toContain("response[1]");
+    expect(headscaleIngress?.with?.script).not.toContain("response[2]");
+    expect(headscaleIngress?.with?.script).not.toContain('echo "$version_raw"');
+
     const headscaleKeys = diagnostic.steps.find(
       (step) => step.name === "Summarize recent agent pre-auth key state",
     );

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -289,6 +289,9 @@ describe("managed dedicated live-smoke workflow contract", () => {
     expect(lifecycleJournal?.env?.CANARY_AGENT_ID).toBe(
       githubExpression("steps.cleanup_reconciliation.outputs.agent_id"),
     );
+    expect(lifecycleJournal?.env?.CANARY_DELETE_JOB_ID).toBe(
+      githubExpression("steps.cleanup_reconciliation.outputs.delete_job_id"),
+    );
     expect(lifecycleJournal?.run ?? lifecycleJournal?.with?.script).toContain(
       "dedicated_lifecycle_signals=",
     );

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -310,6 +310,12 @@ describe("managed dedicated live-smoke workflow contract", () => {
     expect(lifecycleJournal?.run ?? lifecycleJournal?.with?.script).toContain(
       "dedicated_delete_failure_category=",
     );
+    expect(lifecycleJournal?.run ?? lifecycleJournal?.with?.script).toContain(
+      "timestamp_shape_invalid",
+    );
+    expect(lifecycleJournal?.run ?? lifecycleJournal?.with?.script).toContain(
+      "sandbox_row_delete_query_failed",
+    );
 
     const cleanupFailure = diagnostic.steps.find(
       (step) =>

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -214,7 +214,9 @@ describe("managed dedicated live-smoke workflow contract", () => {
       "steps.cleanup_reconciliation.outputs.agent_id != ''",
     );
     expect(headscaleIngress?.with?.script).toContain("headscale version");
-    expect(headscaleIngress?.with?.script).toContain("/var/log/nginx/access.log");
+    expect(headscaleIngress?.with?.script).toContain(
+      "/var/log/nginx/access.log",
+    );
     expect(headscaleIngress?.with?.script).toContain("ts2021_total=");
     expect(headscaleIngress?.with?.script).toContain("machine_register_total=");
     expect(headscaleIngress?.with?.script).toContain("response[1]");
@@ -232,8 +234,12 @@ describe("managed dedicated live-smoke workflow contract", () => {
       "managed-dedicated-canary-$CANARY_DIAGNOSTIC_SUFFIX",
     );
     expect(suffixJournal?.with?.script).toContain("::add-mask::$agent_id");
-    expect(suffixJournal?.with?.script).toContain("suffix_journal_mesh_category=");
-    expect(suffixJournal?.with?.script).toContain("suffix_journal_observation_present=");
+    expect(suffixJournal?.with?.script).toContain(
+      "suffix_journal_mesh_category=",
+    );
+    expect(suffixJournal?.with?.script).toContain(
+      "suffix_journal_observation_present=",
+    );
     expect(suffixJournal?.with?.script).not.toContain('echo "$journal"');
     expect(suffixJournal?.with?.script).not.toContain('echo "$block"');
 

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -221,6 +221,22 @@ describe("managed dedicated live-smoke workflow contract", () => {
     expect(headscaleIngress?.with?.script).not.toContain("response[2]");
     expect(headscaleIngress?.with?.script).not.toContain('echo "$version_raw"');
 
+    const suffixJournal = diagnostic.steps.find(
+      (step) => step.name === "Classify exact canary journal by suffix",
+    );
+    expect(suffixJournal).toBeDefined();
+    expect(suffixJournal?.env?.CANARY_DIAGNOSTIC_SUFFIX).toBe(
+      githubExpression("inputs.diagnose_canary_suffix"),
+    );
+    expect(suffixJournal?.with?.script).toContain(
+      "managed-dedicated-canary-$CANARY_DIAGNOSTIC_SUFFIX",
+    );
+    expect(suffixJournal?.with?.script).toContain("::add-mask::$agent_id");
+    expect(suffixJournal?.with?.script).toContain("suffix_journal_mesh_category=");
+    expect(suffixJournal?.with?.script).toContain("suffix_journal_observation_present=");
+    expect(suffixJournal?.with?.script).not.toContain('echo "$journal"');
+    expect(suffixJournal?.with?.script).not.toContain('echo "$block"');
+
     const headscaleKeys = diagnostic.steps.find(
       (step) => step.name === "Summarize recent agent pre-auth key state",
     );

--- a/packages/cloud/scripts/admin/managed-dedicated-canary.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary.test.ts
@@ -36,6 +36,8 @@ interface FixtureOptions {
   createStatus?: number;
   createdTier?: string;
   readyTier?: string;
+  terminalStatus?: string;
+  terminalErrorMessage?: string | null;
   mesh?: boolean;
   bridgeUrl?: string;
   heartbeatAt?: string | null;
@@ -251,7 +253,10 @@ function createFixture(options: FixtureOptions = {}) {
         data: {
           id: AGENT_ID,
           agentName,
-          status: provisionCompleted ? "running" : "provisioning",
+          status: provisionCompleted
+            ? (options.terminalStatus ?? "running")
+            : "provisioning",
+          errorMessage: options.terminalErrorMessage ?? null,
           databaseStatus: "ready",
           executionTier:
             options.readyTier ?? options.createdTier ?? "dedicated-always",
@@ -1003,6 +1008,23 @@ describe("managed dedicated canary", () => {
     expect(evidence.path.heartbeatFresh).toBe(false);
     expect(evidence.path.meshAddressPresent).toBe(false);
     expect(evidence.timingsMs.ready).toBe(30);
+    expect(evidence.cleanup.status).toBe("passed");
+    expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
+  });
+
+  test("terminal readiness classifies the agent error without retaining private diagnostics", async () => {
+    const privateDiagnostic =
+      "Headscale route failed for private-agent-id on private-node-id";
+    const { evidence } = await runFixture({
+      terminalStatus: "error",
+      terminalErrorMessage: privateDiagnostic,
+    });
+
+    expect(evidence.failure).toEqual({
+      phase: "ready",
+      code: "provisioning_ingress_failed",
+    });
+    expect(JSON.stringify(evidence)).not.toContain(privateDiagnostic);
     expect(evidence.cleanup.status).toBe("passed");
     expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
   });

--- a/packages/cloud/scripts/admin/managed-dedicated-canary.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary.test.ts
@@ -39,6 +39,7 @@ interface FixtureOptions {
   terminalStatus?: string;
   terminalErrorMessage?: string | null;
   mesh?: boolean;
+  meshAddressPresent?: boolean;
   bridgeUrl?: string;
   heartbeatAt?: string | null;
   bridgeReply?: "real" | "canned";
@@ -270,6 +271,7 @@ function createFixture(options: FixtureOptions = {}) {
             (options.mesh === false
               ? "http://192.0.2.10:3000"
               : "http://100.64.0.21:3000"),
+          meshAddressPresent: options.meshAddressPresent,
           adminDetails: null,
         },
       });
@@ -1010,6 +1012,17 @@ describe("managed dedicated canary", () => {
     expect(evidence.timingsMs.ready).toBe(30);
     expect(evidence.cleanup.status).toBe("passed");
     expect(validateManagedDedicatedCanaryArtifact(evidence)).toEqual([]);
+  });
+
+  test("accepts the owner-safe mesh-presence bit without exposing a private address", async () => {
+    const { evidence } = await runFixture({
+      bridgeUrl: "https://agent.example.test",
+      meshAddressPresent: true,
+    });
+
+    expect(evidence.verdict).toBe("pass");
+    expect(evidence.path.meshAddressPresent).toBe(true);
+    expect(validateManagedDedicatedCanaryEvidence(evidence)).toEqual([]);
   });
 
   test("terminal readiness classifies the agent error without retaining private diagnostics", async () => {

--- a/packages/cloud/scripts/admin/managed-dedicated-canary.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary.ts
@@ -398,6 +398,7 @@ function hasExactHeadscaleIpv4Url(value: string): boolean {
 }
 
 function hasMeshAddress(agent: JsonObject): boolean {
+  if (agent.meshAddressPresent === true) return true;
   const adminDetails = isRecord(agent.adminDetails) ? agent.adminDetails : null;
   const explicit = stringField(adminDetails, "headscaleIp");
   if (explicit && isHeadscaleIpv4(explicit)) return true;

--- a/packages/cloud/scripts/admin/managed-dedicated-canary.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary.ts
@@ -1313,7 +1313,13 @@ export async function runManagedDedicatedCanary(
         throw new CanaryFailure("ready", "wrong_execution_tier");
       }
       if (status && TERMINAL_AGENT_FAILURE_STATUSES.has(status)) {
-        throw new CanaryFailure("ready", "terminal_agent_state");
+        const errorMessage = stringField(data, "errorMessage");
+        throw new CanaryFailure(
+          "ready",
+          errorMessage
+            ? classifyProvisioningJobFailure({ error: errorMessage })
+            : "terminal_agent_state",
+        );
       }
       if (
         evidence.path.running &&

--- a/packages/cloud/sdk/src/types.cloud-api.ts
+++ b/packages/cloud/sdk/src/types.cloud-api.ts
@@ -233,6 +233,8 @@ export type AgentWalletStatus = "active" | "pending" | "none" | "error";
 
 export interface AgentDetailDto extends AgentListItemDto {
   errorCount: number;
+  /** True when the control plane has persisted private mesh routing authority. */
+  meshAddressPresent: boolean;
   walletAddress: string | null;
   walletProvider: string | null;
   walletStatus: AgentWalletStatus;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -5387,6 +5387,51 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
     }
   });
 
+  test("an acknowledged retry with no reachable bridge is fenced to that exact generation", async () => {
+    const { svc, spyTarget } = await makeCaptureSvc();
+    const rec = {
+      ...customSandbox(),
+      status: "deletion_failed" as const,
+      bridge_url: null,
+      deletion_attempt_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      deletion_started_at: new Date("2026-08-13T00:00:00.000Z"),
+    };
+    const getForWrite = spyOn(spyTarget, "getAgentForWrite").mockResolvedValue(rec);
+    const priorBackup = spyOn(agentSandboxesRepository, "getLatestBackupByType").mockResolvedValue(
+      undefined,
+    );
+    const fetchSnap = spyOn(spyTarget, "fetchSnapshotState");
+    const prepare = spyOn(spyTarget, "prepareAgentDelete").mockResolvedValue({
+      ok: false,
+      error: "halted by test after capture phase",
+    });
+    try {
+      await expect(
+        svc.deleteAgent(rec.id, rec.organization_id, {
+          authorization: "user_request",
+          stateLossAcknowledged: true,
+        }),
+      ).resolves.toEqual({ success: false, error: "halted by test after capture phase" });
+      expect(fetchSnap).not.toHaveBeenCalled();
+      expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, "user_request", {
+        snapshot: null,
+        captureAuthority: rec,
+        captureWaiverGeneration: {
+          bridgeUrl: null,
+          environmentRevision: rec.environment_revision,
+          sandboxId: rec.sandbox_id,
+        },
+        captureWaiverAlreadyPersisted: false,
+        existingBackup: null,
+      });
+    } finally {
+      getForWrite.mockRestore();
+      priorBackup.mockRestore();
+      fetchSnap.mockRestore();
+      prepare.mockRestore();
+    }
+  });
+
   test("a stopped-origin deletion continuation does not recapture a dead container", async () => {
     const { svc, spyTarget } = await makeCaptureSvc();
     const rec = {
@@ -5861,6 +5906,66 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
           pre_delete_capture_waiver_bridge_url: live.bridge_url,
         }),
       );
+    } finally {
+      upgradeTransactionImpl = null;
+      lockLifecycle.mockRestore();
+      getForMutation.mockRestore();
+      activeProvision.mockRestore();
+      activeReplacement.mockRestore();
+      persist.mockRestore();
+    }
+  });
+
+  test("prepareAgentDelete accepts an acknowledged absent-bridge generation without fabricating a persisted URL", async () => {
+    const { svc, spyTarget } = await makeCaptureSvc();
+    const live = {
+      ...customSandbox(),
+      status: "deletion_failed" as const,
+      bridge_url: null,
+      deletion_attempt_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      deletion_started_at: new Date("2026-08-13T00:00:00.000Z"),
+    };
+    const lockLifecycle = spyOn(spyTarget, "lockLifecycle").mockResolvedValue(undefined);
+    const getForMutation = spyOn(spyTarget, "getAgentForLifecycleMutation").mockResolvedValue(live);
+    const activeProvision = spyOn(spyTarget, "hasActiveProvisionJobTx").mockResolvedValue(false);
+    const activeReplacement = spyOn(spyTarget, "hasActiveReplacementJobTx").mockResolvedValue(
+      false,
+    );
+    const persist = spyOn(spyTarget, "persistSnapshotWithinTransaction");
+    const set = mock((values: Record<string, unknown>) => ({
+      where: mock(() => ({
+        returning: mock(async () => [
+          {
+            id: live.id,
+            deletionAttemptId: live.deletion_attempt_id,
+            deletionStartedAt: live.deletion_started_at,
+            lifecycleRevision: 7,
+          },
+        ]),
+      })),
+    }));
+    const update = mock(() => ({ set }));
+    upgradeTransactionImpl = async (fn) => fn({ execute: async () => ({ rows: [] }), update });
+    try {
+      const result = (await (
+        svc as unknown as {
+          prepareAgentDelete: (...args: unknown[]) => Promise<{ ok: boolean }>;
+        }
+      ).prepareAgentDelete(live.id, live.organization_id, "user_request", {
+        snapshot: null,
+        captureAuthority: live,
+        captureWaiverGeneration: {
+          bridgeUrl: null,
+          environmentRevision: live.environment_revision,
+          sandboxId: live.sandbox_id,
+        },
+        captureWaiverAlreadyPersisted: false,
+        existingBackup: null,
+      })) as { ok: boolean };
+      expect(result.ok).toBe(true);
+      expect(persist).not.toHaveBeenCalled();
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set.mock.calls[0]?.[0]).not.toHaveProperty("pre_delete_capture_waiver_bridge_url");
     } finally {
       upgradeTransactionImpl = null;
       lockLifecycle.mockRestore();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -2676,7 +2676,7 @@ export class ElizaSandboxService {
     // refusal leaves a recoverable tombstone the next attempt retries.
     let captureWaiverAlreadyPersisted = false;
     let captureWaiverGeneration: {
-      bridgeUrl: string;
+      bridgeUrl: string | null;
       environmentRevision: number;
       sandboxId: string | null;
     } | null = null;
@@ -2734,15 +2734,36 @@ export class ElizaSandboxService {
       } else if (this.hasCurrentPreDeleteCaptureWaiver(snapshotSource)) {
         captureWaiverAlreadyPersisted = true;
       } else if (!snapshotSource.bridge_url) {
-        logger.error("[agent-sandbox] Delete refused: data-bearing container has no bridge", {
-          agentId,
-          status: snapshotSource.status,
-        });
-        return {
-          success: false,
-          error:
-            "Refusing to delete without a current backup: the agent's container has no reachable bridge to capture from",
-        };
+        if (options.stateLossAcknowledged) {
+          // A prior attempt can remove the workload before a later boundary
+          // (credential revocation or row-delete settlement) fails. The
+          // acknowledged job is the durable authority for the retry; bind its
+          // in-memory waiver to the exact absent-bridge generation under the
+          // lifecycle lock below. There is no URL to persist in the legacy
+          // row-level waiver shape, and every later attempt must re-present the
+          // acknowledged job authority.
+          preDeleteCaptureAuthority = snapshotSource;
+          captureWaiverGeneration = {
+            bridgeUrl: null,
+            environmentRevision: snapshotSource.environment_revision,
+            sandboxId: snapshotSource.sandbox_id,
+          };
+          logger.error(
+            "[agent-sandbox] Delete proceeding without pre-deletion capture: " +
+              "state loss acknowledged for an absent bridge",
+            { agentId, status: snapshotSource.status },
+          );
+        } else {
+          logger.error("[agent-sandbox] Delete refused: data-bearing container has no bridge", {
+            agentId,
+            status: snapshotSource.status,
+          });
+          return {
+            success: false,
+            error:
+              "Refusing to delete without a current backup: the agent's container has no reachable bridge to capture from",
+          };
+        }
       } else {
         preDeleteCaptureAuthority = snapshotSource;
         try {
@@ -3091,7 +3112,7 @@ export class ElizaSandboxService {
       } | null;
       captureAuthority: SnapshotAuthorityCapture | null;
       captureWaiverGeneration: {
-        bridgeUrl: string;
+        bridgeUrl: string | null;
         environmentRevision: number;
         sandboxId: string | null;
       } | null;
@@ -3191,7 +3212,17 @@ export class ElizaSandboxService {
                   "Refusing to delete: the agent's lifecycle generation moved after the pre-deletion capture; retry the delete.",
               };
             }
-            captureWaiverToPersist = waiver;
+            // The database waiver shape intentionally records a concrete
+            // bridge URL. An acknowledged retry whose bridge is already absent
+            // is authorized by the durable job tuple and revalidated here, but
+            // has no URL to persist.
+            if (waiver.bridgeUrl !== null) {
+              captureWaiverToPersist = {
+                bridgeUrl: waiver.bridgeUrl,
+                environmentRevision: waiver.environmentRevision,
+                sandboxId: waiver.sandboxId,
+              };
+            }
           } else {
             const snapshot = preDeleteCapture?.snapshot ?? null;
             // The capture must be OF THIS exact generation (shutdown's rule).

--- a/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.test.ts
@@ -110,6 +110,7 @@ describe("Headscale container credentials", () => {
     expect(request).not.toHaveProperty("user");
     expect(request).not.toHaveProperty("ensureUser");
     expect(prepared.preAuthKey).toBe("test-preauth-key");
+    expect(prepared.envVars.TS_FORCE_NOISE_443).toBe("1");
   });
 
   test("removes a stale persistent registration before issuing a replacement key", async () => {

--- a/packages/cloud/shared/src/lib/services/headscale-integration.ts
+++ b/packages/cloud/shared/src/lib/services/headscale-integration.ts
@@ -265,6 +265,13 @@ export class HeadscaleIntegration {
       const envVars: Record<string, string> = {
         HEADSCALE_URL: headscalePublicUrl(),
         TS_AUTHKEY: preAuthKeyObj.key,
+        // Tailscale otherwise races a plaintext port-80 Noise attempt against
+        // the configured HTTPS control origin. The Headscale edge redirects
+        // port 80, and container networking can leave that first upgraded
+        // connection hanging without reaching the 443 fallback. Keep every
+        // managed agent on the authenticated endpoint whose TS2021 upgrade is
+        // part of the control-plane convergence contract.
+        TS_FORCE_NOISE_443: "1",
         TS_HOSTNAME: tsHostname,
         TS_STATE_DIR: "/var/lib/tailscale",
         TS_EXTRA_ARGS: "--accept-routes",

--- a/packages/cloud/shared/src/lib/types/cloud-api.ts
+++ b/packages/cloud/shared/src/lib/types/cloud-api.ts
@@ -550,6 +550,8 @@ export type AgentWalletStatus = "active" | "pending" | "none" | "error";
 
 export interface AgentDetailDto extends AgentListItemDto {
   errorCount: number;
+  /** True when the control plane has persisted private mesh routing authority. */
+  meshAddressPresent: boolean;
   walletAddress: string | null;
   walletProvider: string | null;
   walletStatus: AgentWalletStatus;

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -375,6 +375,21 @@ describe("provisioning worker deployment contract", () => {
     expect(parsedWorkflow.jobs?.deploy?.["timeout-minutes"]).toBe(125);
   });
 
+  it("repairs the service-owned checkout to the canonical public remote before fetching", () => {
+    const script = deployStep("Deploy and restart worker").with?.script ?? "";
+    const setCanonicalRemote = script.indexOf(
+      "git remote set-url origin https://github.com/elizaOS/eliza.git",
+    );
+    const fetchExactSha = script.indexOf(
+      'git -c fetch.recurseSubmodules=no fetch --no-recurse-submodules origin "$DEPLOY_SHA"',
+    );
+
+    expect(setCanonicalRemote).toBeGreaterThan(-1);
+    expect(fetchExactSha).toBeGreaterThan(setCanonicalRemote);
+    expect(script).not.toContain("x-access-token");
+    expect(script).not.toContain("github.token");
+  });
+
   it("regenerates before deploy and self-heals every service", () => {
     expect(workflow).toContain(
       "bash packages/cloud/scripts/admin/ensure-generated-keywords.sh",

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -87,7 +87,7 @@ describe("provisioning worker deployment contract", () => {
       'git ls-remote "https://github.com/$' + '{GITHUB_REPOSITORY}.git"',
     );
     expect(workflow).toContain(
-      'fetch --no-recurse-submodules origin "$DEPLOY_SHA"',
+      'git fetch --no-tags --depth=2048 origin \\\n            "$DEPLOY_SHA" "$deployed_sha"',
     );
     expect(workflow).toContain('-B "$DEPLOY_BRANCH" "$DEPLOY_SHA"');
     expect(workflow).toContain('test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"');
@@ -186,7 +186,7 @@ describe("provisioning worker deployment contract", () => {
     expect(migrationGate).toContain(
       "bun install --frozen-lockfile --no-save --ignore-scripts",
     );
-    expect(parsedWorkflow.jobs?.deploy?.["timeout-minutes"]).toBe(125);
+    expect(parsedWorkflow.jobs?.deploy?.["timeout-minutes"]).toBe(140);
   });
 
   it("scopes protected values away from checkout, setup, and install actions", () => {
@@ -318,7 +318,7 @@ describe("provisioning worker deployment contract", () => {
       totalPreSshMinutes += bound ?? 0;
     }
 
-    expect(totalPreSshMinutes).toBe(40);
+    expect(totalPreSshMinutes).toBe(50);
     const remoteSteps = parsedWorkflow.jobs?.deploy?.steps?.filter((step) =>
       step.uses?.startsWith("appleboy/ssh-action@"),
     );
@@ -368,10 +368,12 @@ describe("provisioning worker deployment contract", () => {
         "{{ format('run-{0}', github.run_id) }}",
     );
     const lock = "exec 9>/tmp/eliza-provisioning-worker-deploy.lock";
-    expect(workflow).toContain(lock);
-    expect(workflow).toContain("flock -w 1200 9");
-    expect(workflow.indexOf(lock)).toBeLessThan(
-      workflow.indexOf("cd /opt/eliza"),
+    const deployScript =
+      deployStep("Deploy and restart worker").with?.script ?? "";
+    expect(deployScript).toContain(lock);
+    expect(deployScript).toContain("flock -w 1200 9");
+    expect(deployScript.indexOf(lock)).toBeLessThan(
+      deployScript.indexOf("cd /opt/eliza"),
     );
     expect(workflow).toContain("command_timeout: 40m");
     expect(parsedWorkflow.jobs?.deploy?.["timeout-minutes"]).toBe(140);
@@ -394,6 +396,10 @@ describe("provisioning worker deployment contract", () => {
     expect(script).toContain("actual_source_bundle_sha256");
     expect(script).not.toContain(
       'fetch --no-recurse-submodules origin "$DEPLOY_SHA"',
+    );
+    expect(workflow).toContain("persist-credentials: true");
+    expect(workflow).toContain(
+      'git fetch --no-tags --depth=2048 origin \\\n            "$DEPLOY_SHA" "$deployed_sha"',
     );
     expect(script).not.toContain("x-access-token");
     expect(script).not.toContain("github.token");

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -380,12 +380,18 @@ describe("provisioning worker deployment contract", () => {
     const setCanonicalRemote = script.indexOf(
       "git remote set-url origin https://github.com/elizaOS/eliza.git",
     );
-    const fetchExactSha = script.indexOf(
-      'git -c fetch.recurseSubmodules=no fetch --no-recurse-submodules origin "$DEPLOY_SHA"',
-    );
+    const fetchExactSha = script.indexOf('fetch --no-recurse-submodules');
 
     expect(setCanonicalRemote).toBeGreaterThan(-1);
     expect(fetchExactSha).toBeGreaterThan(setCanonicalRemote);
+    expect(script).toContain("GIT_CONFIG_GLOBAL=/dev/null");
+    expect(script).toContain("GIT_CONFIG_SYSTEM=/dev/null");
+    expect(script).toContain("GIT_TERMINAL_PROMPT=0");
+    expect(script).toContain("-c credential.helper=");
+    expect(script).toContain("-c http.https://github.com/.extraheader=");
+    expect(script).toContain(
+      'https://github.com/elizaOS/eliza.git "$DEPLOY_SHA"',
+    );
     expect(script).not.toContain("x-access-token");
     expect(script).not.toContain("github.token");
   });

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -308,6 +308,8 @@ describe("provisioning worker deployment contract", () => {
       ["Fence current develop SHA before database mutation", 1],
       ["Run exact-SHA canonical database migrations", 10],
       ["Recheck current develop SHA before host deployment", 1],
+      ["Prepare exact incremental source bundle", 5],
+      ["Transfer exact incremental source bundle", 5],
     ]);
     let totalPreSshMinutes = 0;
     for (const [name, expectedMinutes] of expectedBounds) {
@@ -325,10 +327,10 @@ describe("provisioning worker deployment contract", () => {
       expect(timeout).toMatch(/^\d+m$/);
       return Number.parseInt(timeout ?? "", 10);
     });
-    expect(remoteBounds).toEqual([5, 40, 25]);
+    expect(remoteBounds).toEqual([5, 1, 40, 25]);
 
     const jobBound = parsedWorkflow.jobs?.deploy?.["timeout-minutes"];
-    expect(jobBound).toBe(125);
+    expect(jobBound).toBe(140);
     expect(
       totalPreSshMinutes + remoteBounds.reduce((sum, n) => sum + n, 0),
     ).toBeLessThan(jobBound ?? 0);
@@ -372,28 +374,32 @@ describe("provisioning worker deployment contract", () => {
       workflow.indexOf("cd /opt/eliza"),
     );
     expect(workflow).toContain("command_timeout: 40m");
-    expect(parsedWorkflow.jobs?.deploy?.["timeout-minutes"]).toBe(125);
+    expect(parsedWorkflow.jobs?.deploy?.["timeout-minutes"]).toBe(140);
   });
 
-  it("repairs the service-owned checkout to the canonical public remote before fetching", () => {
+  it("imports an exact runner-verified source bundle without host GitHub credentials", () => {
     const script = deployStep("Deploy and restart worker").with?.script ?? "";
     const setCanonicalRemote = script.indexOf(
       "git remote set-url origin https://github.com/elizaOS/eliza.git",
     );
-    const fetchExactSha = script.indexOf('fetch --no-recurse-submodules');
+    const verifyBundle = script.indexOf('git bundle verify "$SOURCE_BUNDLE"');
+    const fetchExactSha = script.indexOf(
+      '--no-recurse-submodules "$SOURCE_BUNDLE" HEAD',
+    );
 
     expect(setCanonicalRemote).toBeGreaterThan(-1);
-    expect(fetchExactSha).toBeGreaterThan(setCanonicalRemote);
-    expect(script).toContain("GIT_CONFIG_GLOBAL=/dev/null");
-    expect(script).toContain("GIT_CONFIG_SYSTEM=/dev/null");
-    expect(script).toContain("GIT_TERMINAL_PROMPT=0");
-    expect(script).toContain("-c credential.helper=");
-    expect(script).toContain("-c http.https://github.com/.extraheader=");
-    expect(script).toContain(
-      'https://github.com/elizaOS/eliza.git "$DEPLOY_SHA"',
+    expect(verifyBundle).toBeGreaterThan(setCanonicalRemote);
+    expect(fetchExactSha).toBeGreaterThan(verifyBundle);
+    expect(script).toContain("SOURCE_BUNDLE_SHA256");
+    expect(script).toContain("actual_source_bundle_sha256");
+    expect(script).not.toContain(
+      'fetch --no-recurse-submodules origin "$DEPLOY_SHA"',
     );
     expect(script).not.toContain("x-access-token");
     expect(script).not.toContain("github.token");
+    expect(workflow).toContain(
+      'if [ "$deployed_sha" = "$DEPLOY_SHA" ]; then',
+    );
   });
 
   it("regenerates before deploy and self-heals every service", () => {

--- a/packages/ui/src/cloud-ui/types/cloud-api.ts
+++ b/packages/ui/src/cloud-ui/types/cloud-api.ts
@@ -416,6 +416,8 @@ export type AgentWalletStatus = "active" | "pending" | "none" | "error";
 
 export interface AgentDetailDto extends AgentListItemDto {
   errorCount: number;
+  /** True when the control plane has persisted private mesh routing authority. */
+  meshAddressPresent: boolean;
   walletAddress: string | null;
   walletProvider: string | null;
   walletStatus: AgentWalletStatus;

--- a/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
+++ b/packages/ui/src/cloud/instances/AgentDetailPage.test.tsx
@@ -68,6 +68,7 @@ const baseAgent: NormalizedAgentDetailDto = {
   webUiUrl: null,
   activeJob: null,
   errorCount: 0,
+  meshAddressPresent: true,
   walletAddress: null,
   walletProvider: null,
   walletStatus: "none",


### PR DESCRIPTION
Closes the remaining startup boundary from #29341.

Fresh signed-in Dedicated canary `33635711462` proved database readiness and a running container, but no mesh address. Privacy-safe diagnosis `33641832485` narrowed that to a Tailscale registration request that never consumed the Headscale preauth key. Follow-up diagnostic `33644286183` proved the staging authority is Headscale v0.28.0 and that the public edge receives plaintext-port TS2021 attempts returning `301`, alongside HTTPS upgrade successes returning `101`.

Tailscale 1.98.3 intentionally tries port 80 first even for an HTTPS control origin and documents `TS_FORCE_NOISE_443` for container/middlebox paths where the initial connection can interfere with fallback. Managed Dedicated containers now receive `TS_FORCE_NOISE_443=1`, keeping registration on the already-converged TLS/443 TS2021 endpoint. The change also retains a privacy-safe diagnostic that emits only the Headscale version and aggregate method/path/status counts; it never emits IPs, keys, headers, user agents, or raw logs.

Validation:
- `bun test packages/cloud/shared/src/lib/services/headscale-integration.test.ts packages/cloud/shared/src/lib/services/docker-sandbox-mesh-join-probe.test.ts packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`
- `actionlint .github/workflows/live-smoke.yml`
- `git diff --check`
