### PR TITLE
fix(cloud): omit local PGlite from Worker bundle

### DIFF
--- a/packages/cloud/api/src/stubs/pglite.test.ts
+++ b/packages/cloud/api/src/stubs/pglite.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Deterministic coverage for the Worker-only PGlite replacement.
+ * The real embedded database remains available to local tests; any accidental
+ * Worker execution fails before opening a database.
+ */
+
+import { describe, expect, test } from "vitest";
+import { btree_gist, PGlite, types, vector } from "./pglite";
+
+const NOT_AVAILABLE =
+  "PGlite is local-only and unavailable in the Cloudflare Worker runtime.";
+
+describe("PGlite Worker stub", () => {
+  test("rejects embedded database construction", () => {
+    expect(() => new PGlite()).toThrowError(NOT_AVAILABLE);
+  });
+
+  test.each([vector, btree_gist])(
+    "rejects local extension access",
+    (extension) => {
+      expect(extension).toThrowError(NOT_AVAILABLE);
+    },
+  );
+
+  test("keeps the parser OIDs expected by drizzle-orm/pglite", () => {
+    expect(types).toEqual({
+      TIMESTAMP: 1114,
+      TIMESTAMPTZ: 1184,
+      INTERVAL: 1186,
+      DATE: 1082,
+    });
+  });
+});

--- a/packages/cloud/api/src/stubs/pglite.ts
+++ b/packages/cloud/api/src/stubs/pglite.ts
@@ -1,0 +1,29 @@
+/**
+ * Worker-only replacement for the local PGlite runtime.
+ *
+ * Cloud deployments connect through Hyperdrive and reject `pglite://` URLs,
+ * so bundling the embedded Postgres engine only consumes startup CPU and can
+ * never serve a production request.
+ */
+
+function unavailable(): never {
+  throw new Error(
+    "PGlite is local-only and unavailable in the Cloudflare Worker runtime.",
+  );
+}
+
+export class PGlite {
+  constructor() {
+    unavailable();
+  }
+}
+
+export const vector = unavailable;
+export const btree_gist = unavailable;
+
+export const types = {
+  TIMESTAMP: 1114,
+  TIMESTAMPTZ: 1184,
+  INTERVAL: 1186,
+  DATE: 1082,
+} as const;

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -54,6 +54,11 @@ __filename = '"/worker.js"'
 # Worker-side call throws instead of returning empty text (#21327).
 "unpdf" = "./src/stubs/unpdf.ts"
 "mammoth" = "./src/stubs/mammoth.ts"
+# PGlite is the local test database. The deployed Worker always uses
+# Hyperdrive; db/client.ts explicitly rejects pglite:// in workerd.
+"@electric-sql/pglite" = "./src/stubs/pglite.ts"
+"@electric-sql/pglite/vector" = "./src/stubs/pglite.ts"
+"@electric-sql/pglite/contrib/btree_gist" = "./src/stubs/pglite.ts"
 
 [observability]
 enabled = true


### PR DESCRIPTION
Refs #22550

## Problem

The exact staging deploy at `367c65f22db39996b42da8f07425c841228fdd01` failed Cloudflare validation with error 10021 (`Script startup exceeded CPU time limit`). The immediately preceding effectively identical bundle had validated at 444 ms, showing that the 28.5 MiB Worker was operating without safe startup margin.

Wrangler profiling and its bundle metafile showed that the deployed Worker included both ESM and CommonJS copies of PGlite even though cloud database access is Hyperdrive-only and `pglite://` is already rejected in workerd.

## Change

Alias `@electric-sql/pglite` and its two extensions to a Worker-only fail-fast stub. Local tests continue using the real package because the aliases apply only to Wrangler bundling. Any accidental Worker-side attempt to construct PGlite or use its extensions now throws explicitly.

## Evidence

- Exact head: `f4459081aa2a1e2bc3fe54cef10f012ae2dfee35`
- Base: `367c65f22db39996b42da8f07425c841228fdd01`
- Unpatched Worker: 28,507.91 KiB raw / 6,858.70 KiB gzip; live validation 624 ms in a temporary probe.
- Patched Worker: 27,243.02 KiB raw / 6,560.75 KiB gzip; live validation 456 ms in a temporary probe.
- Reduction: 1,264.89 KiB raw / 297.95 KiB gzip. Temporary probe Workers were deleted.
- `bunx vitest run packages/cloud/api/src/stubs/pglite.test.ts`: 4/4 passed.
- `bun run --cwd packages/cloud/api typecheck`: passed, including router contract and production Worker dry-run.
- `bunx biome check packages/cloud/api/src/stubs/pglite.ts packages/cloud/api/src/stubs/pglite.test.ts`: passed.
- `bunx wrangler check startup --env staging`: passed; bundle 27,243.02 KiB / 6,560.75 KiB gzip; local active CPU 208.8 ms.
- `bun run verify`: passed; 376/376 workspace tasks plus repository audits.
- A broad cloud-api unit sweep was started but not used as acceptance evidence because unrelated pre-existing admin-canary and trace-ID assertions failed before completion; the affected stub contract and Worker boundary checks above are green.

## Reviewer-visible behavior

A real Cloudflare upload of the patched bundle passed startup validation at 456 ms. After merge, the canonical staging workflow will deploy the exact merge SHA and verify `/api/health` plus the deployed renderer before latency certification.

## Evidence matrix

- UI screenshots: N/A - no UI or rendered output changes.
- Video: N/A - no interactive flow changes.
- Frontend console/network logs: N/A - Worker bundle configuration only.
- Backend logs: Cloudflare startup measurements and bundle sizes are recorded above.
- Live model trajectory: N/A - no prompt, provider, or model behavior changes.

<!-- evidence-head:f4459081aa2a1e2bc3fe54cef10f012ae2dfee35 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive flow changes

<!-- evidence-row:backend-logs -->
- [ ] N/A - failure occurs during Cloudflare upload validation before a Worker version can execute or emit backend request logs

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser request path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, or provider behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Worker bundle configuration only; exact bundle and Cloudflare startup measurements are documented above

