### PR TITLE
test(cloud): pin adopted wallet-signup balance equality

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-orphan-org.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/wallet-signup-orphan-org.test.ts
@@ -212,6 +212,36 @@ describe("wallet signup atomic opening-balance creation", () => {
   );
 
   test(
+    "an adopted organization richer than the grant is not reported as credited",
+    async () => {
+      if (!pgliteReady) throw pgliteError;
+
+      // A slug collision can adopt an organization that already carries a
+      // balance above the opening grant. This signup granted nothing, so the
+      // reported figures must stay false/0 -- reporting the adopted balance as
+      // an initial grant is the same false statement as the zero-dollar orphan
+      // case, approached from above rather than below.
+      const normalized = EVM_ADDRESS_2.toLowerCase();
+      const slug = `wallet-${normalized}`;
+      const adoptedBalanceUsd = SIGNUP_CREDIT_POLICY.automaticGrantUsd + 37.5;
+      await dbWrite.execute(
+        `INSERT INTO organizations (name, slug, credit_balance) VALUES ('Accrued', '${slug}', '${adoptedBalanceUsd.toFixed(2)}');`,
+      );
+
+      const result = await walletSignup.findOrCreateUserByWalletAddress(EVM_ADDRESS_2);
+
+      expect(result.isNewAccount).toBe(true);
+      expect(result.user.organization?.slug).toBe(slug);
+      expect(result.initialCreditsGranted).toBe(false);
+      expect(result.initialFreeCreditsUsd).toBe(0);
+      expect(await countRows("organizations")).toBe(1);
+      expect(await countRows("credit_transactions")).toBe(0);
+      expect(await orgBalanceBySlug(slug)).toBe(adoptedBalanceUsd);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "a second sign-in returns the existing owner without creating rows",
     async () => {
       if (!pgliteReady) throw pgliteError;


### PR DESCRIPTION
## What this pins

`createOrFindWalletOrg` reports whether a signup actually granted credits by comparing the adopted organization's balance to the grant:

```ts
// wallet-signup.ts:105
initialCreditsGranted: Number(org.credit_balance) === SIGNUP_CREDIT_POLICY.automaticGrantUsd,
```

That `===` is an equality, not a floor, and the distinction is load-bearing. The suite proves the **below**-grant direction — the zero-dollar orphan case asserts `false`/`0` for a legacy row. Nothing held the **above**-grant direction.

Measured on `develop` at `bc5ced13a2`, loosening `===` to `>=`:

```
wallet-signup-orphan-org.test.ts    5 pass / 0 fail    ← mutant survives
```

## Why it matters

`createOrFindWalletOrg` adopts an existing organization on slug conflict. If the adopted org carries *more* than the grant — a slug collision with an org that has accrued balance — a `>=` predicate reports `initialCreditsGranted: true` and `initialFreeCreditsUsd: 5` for a signup that granted nothing.

That is the same class of false statement the zero-dollar orphan guard already prevents, approached from above rather than below. The comment on that line says *"legacy zero-dollar orphan rows must not be presented as credited"*; the equality is what makes the richer-than-grant row equally safe, and it was unprotected.

## The change

One test added to the existing PGlite suite, in the file's established idiom: seed an adopted organization at grant + 37.50, sign up, and assert `false`/`0` with the balance untouched and no credit write.

## The guard earns its place

Scored five mutants against `develop`'s suite alone and against `develop`'s suite plus this test, so the claim is a delta rather than an absolute:

| mutation of the predicate | develop's suite | with this test |
|---|---|---|
| **`===` → `>=`** | **5 / 0 — survives** | **5 / 1 — killed** |
| `===` → `!==` | 2 / 3 | 2 / 4 |
| always `true` | 4 / 1 | 4 / 2 |
| always `false` | 3 / 2 | 4 / 2 |
| `===` → `>` | 3 / 2 | 3 / 3 |

Exactly one newly-killed mutant, and it's the one this PR is about. The extra failures on the other four rows are incidental — those were already caught, and I'm not claiming them as coverage this adds.

## Verification

Run with the commands CI runs, from the package directory CI runs them in (`packages/cloud/shared` carries its own `biome.json` with `lineWidth: 100`):

```
bunx @biomejs/biome check <touched file>   Checked 1 file. No fixes applied.
bun run typecheck                          exit 0, zero `error TS` lines
wallet-signup-orphan-org.test.ts           6 pass / 0 fail
wallet-signup.error-policy.test.ts         5 pass / 0 fail
signup-grant-amount.test.ts                3 pass / 0 fail
```

Test-only, one file, no source change.

*Context: this was the one open non-blocking finding from my review of #30342, which merged at the head I approved. Filing the guard rather than leaving it in a review comment.*

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1HAXZKST4RB6N2EJMSVN96C","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T15:13:50.713Z","completed_at":"2026-09-02T15:14:24.813Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T15:13:51.458Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1eb4721286e0e30a7d3f4aae51cea3f0afec6bfcc4a4bd8a1a39c7096bbfaaf4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7ff263eb-c9a7-4873-b687-433c3d15f18f","object_id":"sha256:1eb4721286e0e30a7d3f4aae51cea3f0afec6bfcc4a4bd8a1a39c7096bbfaaf4","sha256":"1eb4721286e0e30a7d3f4aae51cea3f0afec6bfcc4a4bd8a1a39c7096bbfaaf4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"YRFMf1pKegAfEmIRkWdMJUp108s-6Gb7WV-te5qussAKxdKuZsLgHhsnbeFDfr8z9yaEIVvqTRrR-VbTF6q1Dg"}} -->
