### PR TITLE
fix(cloud): point cloud-e2e at the real test-mocks source path

### DIFF
--- a/packages/cloud/e2e/tsconfig.json
+++ b/packages/cloud/e2e/tsconfig.json
@@ -14,7 +14,8 @@
     "ignoreDeprecations": "5.0",
     "paths": {
       "@elizaos/cloud-shared/*": ["../../cloud/shared/src/*"],
-      "@elizaos/cloud-test-mocks/*": ["../cloud-mocks/src/*"],
+      "@elizaos/cloud-test-mocks": ["../test-mocks/src/index.ts"],
+      "@elizaos/cloud-test-mocks/*": ["../test-mocks/src/*"],
       "@elizaos/core": ["../../../packages/core/src/index.node.ts"],
       "@elizaos/core/*": ["../../../packages/core/src/*"],
       "@elizaos/core/edge": ["../../../packages/core/src/index.edge.ts"],


### PR DESCRIPTION
## What

`packages/cloud/e2e/tsconfig.json` mapped `@elizaos/cloud-test-mocks/*` to
`../cloud-mocks/src/*`. Resolved from `packages/cloud/e2e/`, that is
`packages/cloud/cloud-mocks/src/*` — a directory that has never existed in this
repository (`git log --diff-filter=D -- 'packages/cloud/cloud-mocks/*'` is
empty). The package lives at `packages/cloud/test-mocks`.

TypeScript does not fail on an unresolvable `paths` target; it skips it and
continues down the normal resolution chain. So the alias was inert and every
`@elizaos/cloud-test-mocks/…` import in `src/fixtures/stack.ts` resolved through
`node_modules` + the workspace `exports` map instead. That is why the package
typechecked green while the mapping did nothing.

```diff
-      "@elizaos/cloud-test-mocks/*": ["../cloud-mocks/src/*"],
+      "@elizaos/cloud-test-mocks": ["../test-mocks/src/index.ts"],
+      "@elizaos/cloud-test-mocks/*": ["../test-mocks/src/*"],
```

The bare key matches the two consumers that already get this right —
`plugins/plugin-linear/tsconfig.json` and `plugins/plugin-maps/tsconfig.json`,
which map both keys to `packages/cloud/test-mocks/src/index.ts` and
`.../src/*` — and matches the package's own `"."` export
(`packages/cloud/test-mocks/package.json`). The root `tsconfig.json` does not
map this scope at all, so the package-local mapping is the only source alias.

No behaviour changes. `paths` is type-checking only; Bun's runtime resolution
goes through `exports` and is untouched (proved below).

## Why it survived

`bun run audit:tsconfig-workspace-resolution` passes both before and after —
it proves an import resolves *somewhere* acceptable, not that it resolves
through the declared source alias. A dead `paths` target is invisible to it.

## Evidence

`tsc --traceResolution` for `@elizaos/cloud-test-mocks/hetzner` from
`src/fixtures/stack.ts`.

Before — the substitution is attempted, missed, and abandoned:

```
Module name '@elizaos/cloud-test-mocks/hetzner', matched pattern '@elizaos/cloud-test-mocks/*'.
Trying substitution '../cloud-mocks/src/*', candidate module location: '../cloud-mocks/src/hetzner'.
Directory '…/packages/cloud/cloud-mocks/src' does not exist, skipping all lookups in it.
Loading module '@elizaos/cloud-test-mocks/hetzner' from 'node_modules' folder, …
======== Module name '@elizaos/cloud-test-mocks/hetzner' was successfully resolved to
'…/packages/cloud/test-mocks/src/hetzner/index.ts' with Package ID
'@elizaos/cloud-test-mocks/src/hetzner/index.ts@0.0.0'. ========
```

After — resolved through the mapping, no `node_modules` hop, no Package ID:

```
Trying substitution '../test-mocks/src/*', candidate module location: '../test-mocks/src/hetzner'.
======== Module name '@elizaos/cloud-test-mocks/control-plane' was successfully resolved to '…/packages/cloud/test-mocks/src/control-plane/index.ts'. ========
======== Module name '@elizaos/cloud-test-mocks/hetzner'      was successfully resolved to '…/packages/cloud/test-mocks/src/hetzner/index.ts'. ========
======== Module name '@elizaos/cloud-test-mocks/steward'      was successfully resolved to '…/packages/cloud/test-mocks/src/steward/index.ts'. ========
======== Module name '@elizaos/cloud-test-mocks/stripe'       was successfully resolved to '…/packages/cloud/test-mocks/src/stripe/index.ts'. ========
```

Runtime resolution is unchanged — all four subpaths plus the bare specifier
still load under `bun --conditions=eliza-source` from `packages/cloud/e2e`:

```
@elizaos/cloud-test-mocks/control-plane -> packages/cloud/test-mocks/src/control-plane/index.ts | exports: 3
@elizaos/cloud-test-mocks/hetzner       -> packages/cloud/test-mocks/src/hetzner/index.ts       | exports: 3
@elizaos/cloud-test-mocks/steward       -> packages/cloud/test-mocks/src/steward/index.ts       | exports: 1
@elizaos/cloud-test-mocks/stripe        -> packages/cloud/test-mocks/src/stripe/index.ts        | exports: 1
@elizaos/cloud-test-mocks               -> packages/cloud/test-mocks/src/index.ts               | exports: 8
```

## Checks

| Command | Result |
| --- | --- |
| `bun run --cwd packages/cloud/e2e typecheck` | pass (exit 0) |
| `bun run verify:cloud` | pass — 84/84 tasks |
| `bun run verify` pre-turbo gates (`check:agents-claude`, `check:biome-version`, `check:i18n`, `ci-bun-version-contract`, `ci-turbo-cache-contract`, `fix-deps:check`, `ensure-plugin-test-conventions:check`, `audit:alias-read-guard`, `audit:tsconfig-workspace-resolution`, `audit:publish-graph`) | all pass |
| `run-turbo run typecheck lint:check --continue` | 368/376 pass; **0 typecheck failures**, 8 pre-existing `lint:check` failures |
| `bun run verify` post-turbo audits (`audit:build-model`, `audit:turbo-build-deps`, `audit:tee-secret-leak`, `audit:hetzner-fleet-routing`, `audit:workflow-triggers`, `audit:scripts`, `audit:scripts:inventory`, `audit:test-lane-membership`, `audit:view-bundle-inventory`, `audit:plugin-view-inventory`, `audit:focused-tests`) | all pass |

The 8 `lint:check` failures (`app`, `app-core`, `electrobun`, `homepage-source`,
`plugin-notes`, `plugin-wallet`, `shared`, `ui`) are unrelated to this change and
reproduce on unmodified `origin/develop`: they are Biome `format` errors on CSS
files that check out CRLF on Windows. `.gitattributes` pins `text eol=lf` for
js/jsx/ts/tsx/mjs/cjs/mts/cts/json/java/yml/yaml but not `*.css`, e.g.
`git ls-files --eol packages/ui/src/styles/styles.css` → `i/lf w/crlf attr/`.
Every failing file is byte-identical to `origin/develop`; the two non-CSS entries
are untracked build output. That gap makes `bun run verify` unpassable on any
Windows checkout with `core.autocrlf=true` and is worth a separate fix.

**Screenshots / MP4 / model trajectories:** N/A — compile-time module-resolution
config only; no runtime, UI, or agent-behaviour surface is touched.
