### PR TITLE
fix(cloud): retry transient admission limiter 503

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts
@@ -1,11 +1,12 @@
 /**
  * Offline unit coverage for the cold-gateway warming retry: a 503 whose body
- * carries a structural `*_cache_warming` code (or the retryable
- * service_unavailable envelope) is retried in place with bounded backoff so a
+ * carries a structural `*_cache_warming` code, the inference admission
+ * boundary's exact `rate_limit_unavailable` shape, or the retryable
+ * service_unavailable envelope is retried in place with bounded backoff so a
  * gateway that recovers in ~3s stays within one registration. Persistent
- * warming preserves a typed exhaustion signal for provider-aware fallback,
- * while every other failure still throws immediately. The fetch is mocked;
- * timers are faked to drive the backoff deterministically.
+ * unavailability preserves a typed exhaustion signal for provider-aware
+ * fallback, while every other failure still throws immediately. The fetch is
+ * mocked; timers are faked to drive the backoff deterministically.
  */
 import { ELIZA_CLOUD_GATEWAY_WARMING_EXHAUSTED, type IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -54,6 +55,13 @@ const REAL_FAILURE_BODY = {
   },
 };
 
+const RATE_LIMIT_UNAVAILABLE_BODY = {
+  success: false,
+  error: "Rate limit unavailable",
+  code: "rate_limit_unavailable",
+  message: "The inference rate limiter is temporarily unavailable.",
+};
+
 function warmingResponse(headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(WARMING_BODY), {
     status: 503,
@@ -65,6 +73,13 @@ function realFailureResponse(): Response {
   return new Response(JSON.stringify(REAL_FAILURE_BODY), {
     status: 503,
     headers: { "Content-Type": "application/json" },
+  });
+}
+
+function rateLimitUnavailableResponse(): Response {
+  return new Response(JSON.stringify(RATE_LIMIT_UNAVAILABLE_BODY), {
+    status: 503,
+    headers: { "Content-Type": "application/json", "Retry-After": "1" },
   });
 }
 
@@ -110,7 +125,7 @@ const NATIVE_PARAMS = {
 } as Parameters<typeof generateNativeChatCompletion>[2];
 
 describe("warming 503 classification", () => {
-  it("recognizes every *_cache_warming code and the retryable envelope", () => {
+  it("recognizes every explicit transient gateway shape", () => {
     expect(isWarmingUnavailableResponse(503, JSON.stringify(WARMING_BODY))).toBe(true);
     expect(
       isWarmingUnavailableResponse(
@@ -135,6 +150,9 @@ describe("warming 503 classification", () => {
         })
       )
     ).toBe(true);
+    expect(isWarmingUnavailableResponse(503, JSON.stringify(RATE_LIMIT_UNAVAILABLE_BODY))).toBe(
+      true
+    );
   });
 
   it("rejects real failures, non-503 statuses, and unparseable bodies", () => {
@@ -146,6 +164,9 @@ describe("warming 503 classification", () => {
         503,
         JSON.stringify({ success: false, code: "service_unavailable" })
       )
+    ).toBe(false);
+    expect(
+      isWarmingUnavailableResponse(503, JSON.stringify({ code: "rate_limit_unavailable" }))
     ).toBe(false);
     expect(isWarmingUnavailableResponse(503, "<html>bad gateway</html>")).toBe(false);
     expect(isWarmingUnavailableResponse(503, "")).toBe(false);
@@ -249,6 +270,17 @@ describe("buffered native chat completion", () => {
     const result = await pending;
     expect(result.text).toBe("ok");
   });
+
+  it("retries a cold inference-admission limiter and stays on Cloud", async () => {
+    const fetchMock = mockFetchSequence([rateLimitUnavailableResponse, successResponse]);
+    const pending = generateNativeChatCompletion(runtime(), "TEXT_SMALL", NATIVE_PARAMS, CONTEXT);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await pending;
+    expect(result.text).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("streaming native chat completion", () => {
@@ -276,6 +308,17 @@ describe("streaming native chat completion", () => {
     }
     expect(chunks.join("")).toBe("hi");
     await expect(result.text).resolves.toBe("hi");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries an unavailable admission limiter then streams the recovered response", async () => {
+    const fetchMock = mockFetchSequence([rateLimitUnavailableResponse, sseResponse]);
+    const pending = streamNativeChatCompletion(runtime(), "TEXT_SMALL", NATIVE_PARAMS, CONTEXT);
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    const chunks: string[] = [];
+    for await (const chunk of result.textStream) chunks.push(chunk);
+    expect(chunks.join("")).toBe("hi");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -474,9 +474,10 @@ function firstNumber(...values: unknown[]): number | undefined {
 /**
  * Bounded retry for the cold-gateway "warming" 503 (first turn after idle).
  *
- * A cold Cloudflare Worker answers with 503 and a machine-readable warming
- * code (`*_cache_warming`, or the generative ApiError retryable envelope)
- * while it hydrates auth/billing caches under waitUntil — recovery is ~3s.
+ * A cold Cloudflare Worker answers with 503 and a machine-readable transient
+ * code (`*_cache_warming`, `rate_limit_unavailable`, or the generative ApiError
+ * retryable envelope) while it hydrates auth/billing/admission state under
+ * waitUntil or starts the inference-admission Durable Object — recovery is ~3s.
  * That 503 is a retry-shortly signal, NOT a dead provider, but the runtime's
  * useModel failover ladder classifies any thrown 503 as fallback-class and
  * advances instantly, so one cold gateway spent the whole
@@ -520,12 +521,13 @@ function parseJsonRecord(text: string): Record<string, unknown> | undefined {
 }
 
 /**
- * True only for the gateway's explicit cache-warming 503 shape:
+ * True only for the gateway's explicit transient 503 shapes:
  * `{ error: { code: "*_cache_warming" } }` (chat/completions, embeddings) or
  * the generative ApiError envelope `{ code: "service_unavailable",
- * details: { retryable: true } }`. Everything else — including provider-5xx
- * mapped 503s (`api_error`, upstream codes) and `ai_not_configured` — is a
- * real failure and must keep failing over promptly.
+ * details: { retryable: true } }`, plus the inference-admission boundary's
+ * `{ success: false, code: "rate_limit_unavailable" }`. Everything else —
+ * including provider-5xx mapped 503s (`api_error`, upstream codes) and
+ * `ai_not_configured` — is a real failure and must keep failing over promptly.
  */
 export function isWarmingUnavailableResponse(status: number, bodyText: string): boolean {
   if (status !== 503) return false;
@@ -533,6 +535,9 @@ export function isWarmingUnavailableResponse(status: number, bodyText: string): 
   if (!body) return false;
   const errorCode = asRecord(body.error).code;
   if (typeof errorCode === "string" && errorCode.endsWith("_cache_warming")) {
+    return true;
+  }
+  if (body.success === false && body.code === "rate_limit_unavailable") {
     return true;
   }
   return body.code === "service_unavailable" && asRecord(body.details).retryable === true;


### PR DESCRIPTION
Closes #30348

## Problem

A cold inference-admission Durable Object can return the exact machine-readable `rate_limit_unavailable` 503 with `Retry-After: 1`. The identical authenticated request succeeds immediately afterward, but plugin-elizacloud classified this as a terminal provider failure and fell back to `eliza-router`.

## Change

Include only `{ success: false, code: "rate_limit_unavailable" }` in the existing bounded same-provider retry classifier. Arbitrary, upstream, non-JSON, and incomplete 503 bodies continue to fail over immediately. Buffered and streaming Cloud paths already share this classifier; both now have explicit regression coverage.

## Evidence

- Live authenticated production reproduction: first `chat/completions` request returned `503 rate_limit_unavailable`; identical second request returned 200.
- `bunx vitest run plugins/plugin-elizacloud/__tests__/unit/text-warming-retry.test.ts`: 15/15 passed.
- `bun run --cwd plugins/plugin-elizacloud test`: 631 passed, 5 skipped; dist packaging 5/5 passed.
- `bun run --cwd plugins/plugin-elizacloud typecheck`: passed.
- `bun run --cwd plugins/plugin-elizacloud build`: passed.
- `bunx biome check` on both touched files: passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bun run verify`: passed, 376/376 workspace tasks plus repository audits.

## Reviewer-visible behavior

On the first Cloud request after admission-gate idling, Eliza waits the server-declared bounded retry and remains on `elizaOSCloud` when the gate recovers, rather than immediately answering through the local router.

No UI surfaces changed; screenshots/video are N/A.