### PR TITLE
fix(cloud): reduce inference admission latency

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
@@ -481,7 +481,10 @@ test("cold rate-limit policy returns a bounded retry contract", async () => {
   expect(await response.json()).toMatchObject({
     error: { code: "rate_limit_cache_warming" },
   });
-  expect(cacheOnlyAppLookup).not.toHaveBeenCalled();
+  expect(cacheOnlyAppLookup).toHaveBeenCalledTimes(1);
+  expect(response.headers.get("server-timing")).toContain(
+    "gateway_middle;dur=",
+  );
   expect(generateText).not.toHaveBeenCalled();
 });
 

--- a/packages/cloud/api/__tests__/chat-completions-mid-read-parallel.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-mid-read-parallel.test.ts
@@ -65,6 +65,7 @@ const appGate = deferred();
 const moderationGate = deferred();
 const catalogGate = deferred();
 const poolGate = deferred();
+const rateGate = deferred();
 
 mock.module("@/lib/services/inference-auth-context", () => ({
   ...inferenceAuthContextActual,
@@ -84,7 +85,12 @@ mock.module("@/lib/auth", () => ({
 
 mock.module("@/lib/middleware/rate-limit", () => ({
   ...rateLimitActual,
-  enforceOrgRateLimit: async () => null,
+  enforceOrgRateLimit: async () => {
+    events.push("rate:start");
+    await rateGate.promise;
+    events.push("rate:end");
+    return null;
+  },
 }));
 
 mock.module("@/lib/services/apps", () => ({
@@ -242,6 +248,7 @@ describe("chat/completions mid-read orchestration", () => {
     const responsePromise = handleChatCompletionsPOST(makeRequest());
 
     await waitForEvents([
+      "rate:start",
       "app:start",
       "moderation:start",
       "catalog:start",
@@ -252,7 +259,9 @@ describe("chat/completions mid-read orchestration", () => {
     expect(events).not.toContain("moderation:end");
     expect(events).not.toContain("catalog:end");
     expect(events).not.toContain("pool:end");
+    expect(events).not.toContain("rate:end");
 
+    rateGate.resolve();
     appGate.resolve();
     moderationGate.resolve();
     catalogGate.resolve();

--- a/packages/cloud/api/__tests__/chat-completions-mid-read-parallel.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-mid-read-parallel.test.ts
@@ -9,7 +9,7 @@
  * reports a blocking state.
  */
 
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as authActual from "@/lib/auth";
 import * as rateLimitActual from "@/lib/middleware/rate-limit";
 import * as pricingActual from "@/lib/pricing";
@@ -33,10 +33,12 @@ const events: string[] = [];
 
 function deferred() {
   let resolve!: () => void;
-  const promise = new Promise<void>((r) => {
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((r, j) => {
     resolve = r;
+    reject = j;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function waitForEvents(expected: readonly string[]) {
@@ -61,18 +63,30 @@ function waitForEvents(expected: readonly string[]) {
   });
 }
 
-const appGate = deferred();
-const moderationGate = deferred();
-const catalogGate = deferred();
-const poolGate = deferred();
-const rateGate = deferred();
+let appGate = deferred();
+let moderationGate = deferred();
+let catalogGate = deferred();
+let poolGate = deferred();
+let rateGate = deferred();
+let appFailure: Error | null = null;
+let rateLimitResponse: Response | null = null;
+let authorizedAppScopeId: string | null | undefined;
 
 mock.module("@/lib/services/inference-auth-context", () => ({
   ...inferenceAuthContextActual,
-  resolveInferenceAuthContext: async () => ({
-    kind: "slow_path",
-    reason: "non_api_key",
-  }),
+  resolveInferenceAuthContext: async () =>
+    authorizedAppScopeId === undefined
+      ? { kind: "slow_path", reason: "non_api_key" }
+      : {
+          kind: "authorized",
+          ctx: {
+            userId: USER,
+            orgId: ORG,
+            apiKeyId: null,
+            appScopeId: authorizedAppScopeId,
+          },
+          credential: undefined,
+        },
 }));
 
 mock.module("@/lib/auth", () => ({
@@ -89,7 +103,7 @@ mock.module("@/lib/middleware/rate-limit", () => ({
     events.push("rate:start");
     await rateGate.promise;
     events.push("rate:end");
-    return null;
+    return rateLimitResponse;
   },
 }));
 
@@ -100,6 +114,10 @@ mock.module("@/lib/services/apps", () => ({
     getAuthorizedMonetizedAppForUser: async () => {
       events.push("app:start");
       await appGate.promise;
+      if (appFailure) {
+        events.push("app:reject");
+        throw appFailure;
+      }
       events.push("app:end");
       return null;
     },
@@ -196,6 +214,18 @@ const { handleChatCompletionsPOST } = await import(
   "../v1/chat/completions/route"
 );
 
+beforeEach(() => {
+  events.length = 0;
+  appGate = deferred();
+  moderationGate = deferred();
+  catalogGate = deferred();
+  poolGate = deferred();
+  rateGate = deferred();
+  appFailure = null;
+  rateLimitResponse = null;
+  authorizedAppScopeId = undefined;
+});
+
 afterAll(() => {
   mock.module(
     "@/lib/services/inference-auth-context",
@@ -228,17 +258,22 @@ afterAll(() => {
   mock.module("ai", () => aiActual);
 });
 
-function makeRequest(): Request {
+function makeRequest(
+  body: Record<string, unknown> = {},
+  headers: Record<string, string> = {},
+): Request {
   return new Request("https://api.test/api/v1/chat/completions", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "X-App-Id": "app-1",
+      ...headers,
     },
     body: JSON.stringify({
       model: "gpt-4o-mini",
       messages: [{ role: "user", content: "hello" }],
       stream: false,
+      ...body,
     }),
   });
 }
@@ -269,5 +304,117 @@ describe("chat/completions mid-read orchestration", () => {
 
     const response = await responsePromise;
     expect(response.status).toBe(500);
+  });
+
+  test("dependency rejection before limiter denial stays handled and preserves 429 precedence", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    appFailure = new Error("app-cache-read-failed");
+    rateLimitResponse = Response.json(
+      { error: { code: "rate_limit_exceeded" } },
+      { status: 429 },
+    );
+    const responsePromise = handleChatCompletionsPOST(makeRequest());
+
+    await waitForEvents(["rate:start", "app:start"]);
+    appGate.resolve();
+    await waitForEvents(["app:reject"]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    rateGate.resolve();
+    const response = await responsePromise;
+    expect(response.status).toBe(429);
+    expect((await response.json()) as unknown).toEqual({
+      error: { code: "rate_limit_exceeded" },
+    });
+
+    moderationGate.resolve();
+    catalogGate.resolve();
+    poolGate.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    process.off("unhandledRejection", onUnhandled);
+    expect(unhandled).toEqual([]);
+  });
+
+  test("an allowed limiter surfaces a dependency rejection without waiting for other reads", async () => {
+    appFailure = new Error("app-cache-read-failed-fast");
+    const responsePromise = handleChatCompletionsPOST(makeRequest());
+
+    await waitForEvents([
+      "rate:start",
+      "app:start",
+      "moderation:start",
+      "catalog:start",
+      "pool:start",
+    ]);
+    rateGate.resolve();
+    appGate.resolve();
+    await waitForEvents(["app:reject"]);
+
+    const outcome = await Promise.race([
+      responsePromise.then((response) => ({
+        kind: "response" as const,
+        response,
+      })),
+      new Promise<{ kind: "timeout" }>((resolve) =>
+        setTimeout(() => resolve({ kind: "timeout" }), 100),
+      ),
+    ]);
+
+    moderationGate.resolve();
+    catalogGate.resolve();
+    poolGate.resolve();
+    expect(outcome.kind).toBe("response");
+    if (outcome.kind === "response") {
+      expect(outcome.response.status).toBe(500);
+    }
+  });
+
+  test("org limiter rejection remains handled across validation and app-scope early returns", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    const cases = [
+      {
+        name: "app scope mismatch",
+        configure: () => {
+          authorizedAppScopeId = "bound-app";
+        },
+        request: () => makeRequest({}, { "X-App-Id": "other-app" }),
+        status: 403,
+      },
+      {
+        name: "invalid reasoning effort",
+        configure: () => {},
+        request: () =>
+          makeRequest({
+            model: "openai/gpt-oss-120b:nitro",
+            reasoning_effort: "none",
+          }),
+        status: 400,
+      },
+      {
+        name: "invalid prompt cache key",
+        configure: () => {},
+        request: () => makeRequest({ prompt_cache_key: "" }),
+        status: 400,
+      },
+    ];
+
+    for (const testCase of cases) {
+      events.length = 0;
+      rateGate = deferred();
+      authorizedAppScopeId = undefined;
+      testCase.configure();
+
+      const response = await handleChatCompletionsPOST(testCase.request());
+      expect(response.status, testCase.name).toBe(testCase.status);
+      await waitForEvents(["rate:start"]);
+      rateGate.reject(new Error(`rate-failed-after-${testCase.name}`));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    process.off("unhandledRejection", onUnhandled);
+    expect(unhandled).toEqual([]);
   });
 });

--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -117,7 +117,7 @@ const resolveInferenceAuthContext = mock(
     authResolveOptions.push(options);
     options.onTelemetry?.({
       v: 1,
-      traceId: "11111111-1111-4111-8111-111111111111",
+      traceId: "11111111111141118111111111111111",
       authSource: "x_api_key",
       controlledProbe: "off",
       cacheAvailability: "available",
@@ -348,7 +348,7 @@ function makeRequest(
     headers: {
       "content-type": "application/json",
       "x-request-id": CLIENT_REQUEST_ID,
-      "x-eliza-trace-id": "11111111-1111-4111-8111-111111111111",
+      "x-eliza-trace-id": "11111111111141118111111111111111",
       ...(affiliateCode ? { "X-Affiliate-Code": affiliateCode } : {}),
     },
     body: JSON.stringify({
@@ -438,7 +438,7 @@ describe("chat/completions cache-only organization admission", () => {
 
     expect(response.status).toBeGreaterThanOrEqual(400);
     expect(response.headers.get("X-Eliza-Trace-Id")).toBe(
-      "11111111-1111-4111-8111-111111111111",
+      "11111111111141118111111111111111",
     );
     const preforward = response.headers.get("X-Eliza-Preforward-Ms");
     expect(preforward).toMatch(
@@ -683,6 +683,29 @@ describe("chat/completions cache-only organization admission", () => {
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toMatchObject({
       error: { code: "billing_cache_warming" },
+    });
+    expect(generateText).not.toHaveBeenCalled();
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+    expect(admitInferenceChargeViaLedger).not.toHaveBeenCalled();
+  });
+
+  test("an admission transport timeout is distinct from cache warming and carries phase telemetry", async () => {
+    organizationAdmissionError =
+      new organizationAdmissionActual.InferenceAdmissionUnavailableError({
+        cause: new Error("admission gate timed out"),
+      });
+    const captured: Promise<unknown>[] = [];
+
+    const response = await driveWithCtx(captured);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    expect(response.headers.get("server-timing")).toContain(
+      "gateway_reserve;dur=",
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "inference_admission_unavailable" },
     });
     expect(generateText).not.toHaveBeenCalled();
     expect(reserveCredits).not.toHaveBeenCalled();

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -1171,6 +1171,136 @@ describe("InferenceAdmissionGate", () => {
     ).toBe(409);
   });
 
+  test("replays the identical lease after a lost transport acknowledgement", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 5);
+    const requests: Array<{ path: string; body: string }> = [];
+    let attempts = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            requests.push({
+              path: new URL(incoming.url).pathname,
+              body: await incoming.clone().text(),
+            });
+            attempts += 1;
+            const response = await gate.fetch(incoming);
+            if (attempts === 1) {
+              throw new DOMException(
+                "injected lost lease acknowledgement",
+                "TimeoutError",
+              );
+            }
+            return response;
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "request-lost-lease-ack",
+        balanceUsd: 5,
+        balanceRevision: "1",
+        estimatedCostUsd: 3,
+        recovery: organizationRecovery("request-lost-lease-ack"),
+      });
+      expect(lease.requestId).toBe("request-lost-lease-ack");
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toEqual(requests[0]);
+    expect(storage.keyCount("lease:")).toBe(1);
+    expect(storage.read<{ activeLeaseCount: number }>("ledger")).toMatchObject({
+      activeLeaseCount: 1,
+    });
+  });
+
+  test("replays the identical lease once after a 503", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 5);
+    const requests: Array<{ path: string; body: string }> = [];
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            requests.push({
+              path: new URL(incoming.url).pathname,
+              body: await incoming.clone().text(),
+            });
+            if (requests.length === 1) {
+              return Response.json(
+                { code: "inference_admission_gate_starting" },
+                { status: 503 },
+              );
+            }
+            return gate.fetch(incoming);
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "request-starting-gate",
+        balanceUsd: 5,
+        balanceRevision: "1",
+        estimatedCostUsd: 3,
+        recovery: organizationRecovery("request-starting-gate"),
+      });
+      expect(lease.requestId).toBe("request-starting-gate");
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toEqual(requests[0]);
+    expect(storage.keyCount("lease:")).toBe(1);
+    expect(storage.read<{ activeLeaseCount: number }>("ledger")).toMatchObject({
+      activeLeaseCount: 1,
+    });
+  });
+
+  test("does not retry definitive lease refusals", async () => {
+    for (const status of [402, 403, 409, 429]) {
+      let attempts = 0;
+      const bindings = {
+        INFERENCE_ADMISSION_GATES: {
+          getByName: (_name: string) => ({
+            fetch: async () => {
+              attempts += 1;
+              return Response.json(
+                status === 402
+                  ? { admitted: false, availableUsd: 1, requiredUsd: 2 }
+                  : { code: "definitive_refusal" },
+                { status },
+              );
+            },
+          }),
+        },
+      };
+
+      await runWithCloudBindingsAsync(bindings, async () => {
+        await expect(
+          acquireInferenceAdmissionLease({
+            organizationId: "org-a",
+            requestId: `request-refused-${status}`,
+            balanceUsd: 5,
+            balanceRevision: "1",
+            estimatedCostUsd: 2,
+            recovery: organizationRecovery(`request-refused-${status}`),
+          }),
+        ).rejects.toBeInstanceOf(Error);
+      });
+      expect(attempts).toBe(1);
+    }
+  });
+
   test("client maps rejection and missing bindings to typed failures", async () => {
     const gate = createGate();
     await hydrateGate(gate, 2);

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1714,7 +1714,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(config.migrations).toBeUndefined();
   });
 
-  test("binds the global native limiter in every Worker environment and keeps inference routes gate-free", async () => {
+  test("binds the global native limiter for general routes and keeps inference shells gate-free", async () => {
     type RateLimitBinding = {
       name?: string;
       simple?: { limit?: number; period?: number };
@@ -1745,8 +1745,8 @@ describe("cloud-api worker entrypoint", () => {
 
     // #17805 retired the per-route native gates from the generative hot path:
     // rate policy rides the IAC v2 admission snapshot through the org-level
-    // limiter. The inference route sources must stay free of per-route native
-    // bindings, while both Worker app builders keep the global gate.
+    // limiter. The inference route sources and thin shell must stay free of
+    // native bindings, while the general bootstrap app keeps the global gate.
     const [
       chat,
       completions,
@@ -1768,6 +1768,6 @@ describe("cloud-api worker entrypoint", () => {
       expect(source).not.toContain("bindingName:");
     }
     expect(bootstrapApp).toContain('bindingName: "GLOBAL_RATE_LIMITER"');
-    expect(inferenceApp).toContain('bindingName: "GLOBAL_RATE_LIMITER"');
+    expect(inferenceApp).not.toContain('bindingName: "GLOBAL_RATE_LIMITER"');
   });
 });

--- a/packages/cloud/api/src/inference-app.test.ts
+++ b/packages/cloud/api/src/inference-app.test.ts
@@ -109,10 +109,7 @@ describe("chat-only inference application", () => {
       "max-age=63072000",
     );
     expect(response.headers.get("x-content-type-options")).toBe("nosniff");
-    // The 600/min global gate is the only native limiter left on the thin app:
-    // #17805 retired the 200/min per-route chat gate in favor of org-level
-    // limits carried by the IAC v2 admission snapshot.
-    expect(response.headers.get("x-ratelimit-limit")).toBe("600");
+    expect(response.headers.get("x-ratelimit-limit")).toBeNull();
     const body = (await response.json()) as AuthErrorBody;
     expect(body).toEqual({
       error: {
@@ -162,8 +159,8 @@ describe("chat-only inference application", () => {
     });
   });
 
-  test("uses only the global native limiter when Railway Redis is unavailable in production", async () => {
-    const globalKeys: string[] = [];
+  test("reaches route authentication without consulting the global limiter", async () => {
+    let globalLimiterCalls = 0;
     const routeKeys: string[] = [];
     const response = await createChatInferenceApp().fetch(
       new Request("https://api.elizacloud.ai/api/v1/chat/completions", {
@@ -180,9 +177,9 @@ describe("chat-only inference application", () => {
         NODE_ENV: "production",
         REDIS_RATE_LIMITING: "true",
         GLOBAL_RATE_LIMITER: {
-          async limit({ key }: { key: string }) {
-            globalKeys.push(key);
-            return { success: true };
+          async limit() {
+            globalLimiterCalls += 1;
+            throw new Error("global limiter must not run in inference shell");
           },
         },
         CHAT_ROUTE_RATE_LIMITER: {
@@ -196,7 +193,7 @@ describe("chat-only inference application", () => {
     );
 
     expect(response.status).toBe(401);
-    expect(globalKeys).toHaveLength(1);
+    expect(globalLimiterCalls).toBe(0);
     // #17805 retired the per-route native chat gate from the hot path; even a
     // bound limiter must never be consulted by the thin inference app.
     expect(routeKeys).toHaveLength(0);

--- a/packages/cloud/api/src/inference-app.test.ts
+++ b/packages/cloud/api/src/inference-app.test.ts
@@ -159,7 +159,7 @@ describe("chat-only inference application", () => {
     });
   });
 
-  test("reaches route authentication without consulting the global limiter", async () => {
+  test("uses native ingress protection before route authentication", async () => {
     let globalLimiterCalls = 0;
     const routeKeys: string[] = [];
     const response = await createChatInferenceApp().fetch(
@@ -179,7 +179,7 @@ describe("chat-only inference application", () => {
         GLOBAL_RATE_LIMITER: {
           async limit() {
             globalLimiterCalls += 1;
-            throw new Error("global limiter must not run in inference shell");
+            return { success: true };
           },
         },
         CHAT_ROUTE_RATE_LIMITER: {
@@ -193,7 +193,7 @@ describe("chat-only inference application", () => {
     );
 
     expect(response.status).toBe(401);
-    expect(globalLimiterCalls).toBe(0);
+    expect(globalLimiterCalls).toBe(1);
     // #17805 retired the per-route native chat gate from the hot path; even a
     // bound limiter must never be consulted by the thin inference app.
     expect(routeKeys).toHaveLength(0);

--- a/packages/cloud/api/src/inference-app.ts
+++ b/packages/cloud/api/src/inference-app.ts
@@ -22,6 +22,7 @@ import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
 import { logger } from "@/lib/utils/logger";
 import { describeUnhandledError } from "@/lib/utils/unhandled-error-detail";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { inferenceIngressRateLimit } from "./inference-ingress-rate-limit";
 import { cookieMutationGuardMiddleware } from "./middleware/cookie-mutation-guard";
 
 /**
@@ -132,6 +133,11 @@ export function createInferenceApp(
       },
     );
   });
+  // The machine-local Cloudflare counter runs before route auth with a bounded
+  // deadline and isolate-local outage fallback. Organization policy remains
+  // authoritative in the admission gate; this layer only protects auth CPU.
+  // Request observability wraps it so a flood's 429 verdicts remain visible.
+  app.use("*", inferenceIngressRateLimit());
 
   // CSRF: same mount point as bootstrap-app (immediately before the routes).
   // See middleware/cookie-mutation-guard.ts.

--- a/packages/cloud/api/src/inference-app.ts
+++ b/packages/cloud/api/src/inference-app.ts
@@ -12,11 +12,7 @@ import { secureHeaders } from "hono/secure-headers";
 import { runWithDbCacheAsync } from "@/db/client";
 import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
-import {
-  getIpKey,
-  getRequestIp,
-  rateLimit,
-} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { getRequestIp } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
 import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
 import { httpTelemetryMiddleware } from "@/lib/observability/http-telemetry-hono";
@@ -137,20 +133,8 @@ export function createInferenceApp(
     );
   });
 
-  app.use(
-    "*",
-    rateLimit(
-      {
-        windowMs: 60_000,
-        maxRequests: 600,
-        keyGenerator: (c) => `global:${getIpKey(c)}`,
-      },
-      { bindingName: "GLOBAL_RATE_LIMITER" },
-    ),
-  );
-
-  // CSRF: same mount point as bootstrap-app (immediately before the routes,
-  // after the global limiter). See middleware/cookie-mutation-guard.ts.
+  // CSRF: same mount point as bootstrap-app (immediately before the routes).
+  // See middleware/cookie-mutation-guard.ts.
   app.use("*", cookieMutationGuardMiddleware);
 
   app.route(mountPath, route);

--- a/packages/cloud/api/src/inference-ingress-rate-limit.test.ts
+++ b/packages/cloud/api/src/inference-ingress-rate-limit.test.ts
@@ -1,0 +1,155 @@
+/** Exercises the inference shell's native-first, bounded-fallback ingress guard. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv, RuntimeRateLimitBinding } from "@/types/cloud-worker-env";
+import {
+  _resetInferenceIngressRateLimit,
+  inferenceIngressRateLimit,
+} from "./inference-ingress-rate-limit";
+
+function request(method = "POST", ip = "203.0.113.8"): Request {
+  return new Request("https://api.elizacloud.ai/inference", {
+    method,
+    headers: { "cf-connecting-ip": ip },
+  });
+}
+
+function createApp(): { app: Hono<AppEnv>; routeCalls: () => number } {
+  let calls = 0;
+  const app = new Hono<AppEnv>();
+  app.use("*", inferenceIngressRateLimit());
+  app.all("*", (c) => {
+    calls += 1;
+    return c.json({ ok: true });
+  });
+  return { app, routeCalls: () => calls };
+}
+
+function envWith(binding?: RuntimeRateLimitBinding): AppEnv["Bindings"] {
+  return {
+    DATABASE_URL: "postgres://test.invalid/eliza",
+    BLOB: {
+      async get() {
+        return null;
+      },
+      async put() {},
+      async delete() {},
+    },
+    GLOBAL_RATE_LIMITER: binding,
+  };
+}
+
+describe("inference ingress rate limit", () => {
+  afterEach(() => _resetInferenceIngressRateLimit());
+
+  test("uses the healthy Cloudflare counter as the primary verdict", async () => {
+    const keys: string[] = [];
+    const { app, routeCalls } = createApp();
+    const response = await app.fetch(
+      request(),
+      envWith({
+        async limit({ key }) {
+          keys.push(key);
+          return { success: true };
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(keys).toEqual(["inference:203.0.113.8"]);
+    expect(routeCalls()).toBe(1);
+  });
+
+  test("enforces a native denial before route authentication", async () => {
+    const { app, routeCalls } = createApp();
+    const response = await app.fetch(
+      request(),
+      envWith({
+        async limit() {
+          return { success: false };
+        },
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("X-RateLimit-Policy")).toBe(
+      "cloudflare-native",
+    );
+    expect(routeCalls()).toBe(0);
+  });
+
+  test("falls back locally when the native binding throws", async () => {
+    const { app, routeCalls } = createApp();
+    const response = await app.fetch(
+      request(),
+      envWith({
+        async limit() {
+          throw new Error("binding unavailable");
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(routeCalls()).toBe(1);
+  });
+
+  test("bounds a stalled binding and observes its late rejection", async () => {
+    let rejectBinding: ((error: Error) => void) | undefined;
+    const { app, routeCalls } = createApp();
+    const response = await app.fetch(
+      request(),
+      envWith({
+        limit() {
+          return new Promise((_, reject) => {
+            rejectBinding = reject;
+          });
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(routeCalls()).toBe(1);
+    rejectBinding?.(new Error("late binding rejection"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  test("bounds fallback floods without Redis or Durable Object access", async () => {
+    const { app, routeCalls } = createApp();
+    const env = envWith();
+    Object.defineProperty(env, "INFERENCE_ADMISSION_GATES", {
+      get() {
+        throw new Error("Durable Object binding must not be read");
+      },
+    });
+
+    for (let requestNumber = 0; requestNumber < 600; requestNumber += 1) {
+      expect((await app.fetch(request(), env)).status).toBe(200);
+    }
+    const denied = await app.fetch(request(), env);
+
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("X-RateLimit-Policy")).toBe(
+      "worker-isolate-fallback",
+    );
+    expect(denied.headers.get("Retry-After")).not.toBeNull();
+    expect(routeCalls()).toBe(600);
+  });
+
+  test("does not charge CORS preflight to either limiter", async () => {
+    let limiterCalls = 0;
+    const { app } = createApp();
+    const response = await app.fetch(
+      request("OPTIONS"),
+      envWith({
+        async limit() {
+          limiterCalls += 1;
+          return { success: false };
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(limiterCalls).toBe(0);
+  });
+});

--- a/packages/cloud/api/src/inference-ingress-rate-limit.ts
+++ b/packages/cloud/api/src/inference-ingress-rate-limit.ts
@@ -1,0 +1,150 @@
+/**
+ * Provides the inference shell's bounded pre-authentication flood backstop.
+ * Cloudflare's machine-local counter is primary, with a short deadline and a
+ * bounded per-isolate fallback so a platform stall cannot delay inference.
+ */
+
+import type { MiddlewareHandler } from "hono";
+import { getRequestIp } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv, RuntimeRateLimitBinding } from "@/types/cloud-worker-env";
+
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 600;
+const MAX_KEYS = 4_096;
+const NATIVE_DEADLINE_MS = 20;
+
+interface InferenceIngressBucket {
+  count: number;
+  resetAt: number;
+}
+
+type NativeOutcome =
+  | { kind: "decision"; success: boolean }
+  | { kind: "failure"; error: unknown }
+  | { kind: "timeout" };
+
+const buckets = new Map<string, InferenceIngressBucket>();
+
+function makeRoom(): void {
+  if (buckets.size < MAX_KEYS) return;
+  const leastRecentlyUsedKey = buckets.keys().next().value;
+  if (leastRecentlyUsedKey !== undefined) buckets.delete(leastRecentlyUsedKey);
+}
+
+function consumeFallback(key: string, now: number): InferenceIngressBucket {
+  const current = buckets.get(key);
+  if (current && current.resetAt > now) {
+    buckets.delete(key);
+    current.count += 1;
+    buckets.set(key, current);
+    return current;
+  }
+
+  if (current) buckets.delete(key);
+  makeRoom();
+  const bucket = { count: 1, resetAt: now + WINDOW_MS };
+  buckets.set(key, bucket);
+  return bucket;
+}
+
+function nativeDecision(
+  binding: RuntimeRateLimitBinding,
+  key: string,
+): Promise<NativeOutcome> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const observed = Promise.resolve()
+    .then(() => binding.limit({ key }))
+    .then<NativeOutcome, NativeOutcome>(
+      ({ success }) => ({ kind: "decision", success }),
+      (error: unknown) => ({ kind: "failure", error }),
+    );
+  const timeout = new Promise<NativeOutcome>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: "timeout" }), NATIVE_DEADLINE_MS);
+  });
+  return Promise.race([observed, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Rejects sustained per-IP inference floods before route authentication. */
+export function inferenceIngressRateLimit(): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    // CORS preflight does not enter route authentication and must not consume a
+    // caller's billable-request ingress budget.
+    if (c.req.method === "OPTIONS") {
+      await next();
+      return;
+    }
+
+    const key = `inference:${getRequestIp(c) ?? "unknown"}`;
+    const binding = c.env?.GLOBAL_RATE_LIMITER;
+    let policy = "cloudflare-native";
+    let allowed: boolean;
+    let retryAfter = Math.ceil(WINDOW_MS / 1_000);
+
+    if (binding) {
+      const outcome = await nativeDecision(binding, key);
+      if (outcome.kind === "decision") {
+        allowed = outcome.success;
+      } else {
+        policy = "worker-isolate-fallback";
+        logger.warn(
+          "[InferenceIngress] Native rate limiter unavailable; using local fallback",
+          {
+            requestId: c.get("requestId") ?? null,
+            traceId: c.get("traceId") ?? null,
+            failure:
+              outcome.kind === "timeout"
+                ? `deadline_exceeded_${NATIVE_DEADLINE_MS}ms`
+                : errorDetail(outcome.error),
+          },
+        );
+        const bucket = consumeFallback(key, Date.now());
+        allowed = bucket.count <= MAX_REQUESTS;
+        retryAfter = Math.max(
+          1,
+          Math.ceil((bucket.resetAt - Date.now()) / 1_000),
+        );
+      }
+    } else {
+      policy = "worker-isolate-fallback";
+      const bucket = consumeFallback(key, Date.now());
+      allowed = bucket.count <= MAX_REQUESTS;
+      retryAfter = Math.max(
+        1,
+        Math.ceil((bucket.resetAt - Date.now()) / 1_000),
+      );
+    }
+
+    if (allowed) {
+      await next();
+      return;
+    }
+
+    return c.json(
+      {
+        success: false,
+        error: "Too many requests",
+        code: "rate_limit_exceeded" as const,
+        message: `Inference ingress limit exceeded. Maximum ${MAX_REQUESTS} requests per minute.`,
+        retryAfter,
+      },
+      429,
+      {
+        "Retry-After": String(retryAfter),
+        "X-RateLimit-Limit": String(MAX_REQUESTS),
+        "X-RateLimit-Policy": policy,
+      },
+    );
+  };
+}
+
+/** Test-only reset for deterministic process-local middleware coverage. */
+export function _resetInferenceIngressRateLimit(): void {
+  buckets.clear();
+}

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1182,6 +1182,30 @@ interface ChatCompletionsHandlerOptions {
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }
 
+type ConcurrentPromiseOutcome<T> =
+  | { kind: "fulfilled"; value: T }
+  | { kind: "rejected"; error: unknown };
+
+/**
+ * Installs a rejection handler at task creation time while retaining the
+ * original failure for the point where route precedence permits observing it.
+ * This matters when a faster validation or rate-limit denial returns before
+ * another overlapped task settles.
+ */
+function observeConcurrentPromise<T>(
+  promise: Promise<T>,
+): Promise<ConcurrentPromiseOutcome<T>> {
+  return promise.then(
+    (value) => ({ kind: "fulfilled", value }),
+    (error: unknown) => ({ kind: "rejected", error }),
+  );
+}
+
+function unwrapConcurrentPromise<T>(outcome: ConcurrentPromiseOutcome<T>): T {
+  if (outcome.kind === "rejected") throw outcome.error;
+  return outcome.value;
+}
+
 export async function handleChatCompletionsPOST(
   req: Request,
   options: ChatCompletionsHandlerOptions = {},
@@ -1385,17 +1409,19 @@ export async function handleChatCompletionsPOST(
     // inspect and return this result first, preserving the existing denial
     // precedence without serializing an unrelated Durable Object round trip
     // ahead of every dependency read.
-    const orgRateLimitPromise =
+    const orgRateLimitPromise = observeConcurrentPromise(
       user.organization_id && !options.skipOrgRateLimit
         ? enforceOrgRateLimit(user.organization_id, "completions", {
             cacheOnly: Boolean(options.executionCtx),
             executionCtx: options.executionCtx,
             config: inferenceRateLimitConfig(admissionSnapshot, "completions"),
           })
-        : Promise.resolve(null);
+        : Promise.resolve(null),
+    );
     const resolveOrgRateLimit = async (): Promise<Response | null> => {
+      const outcome = await orgRateLimitPromise;
       try {
-        return await orgRateLimitPromise;
+        return unwrapConcurrentPromise(outcome);
       } catch (error) {
         if (error instanceof OrgRateLimitCacheNotReadyError) {
           return addCorsHeaders(
@@ -1555,7 +1581,11 @@ export async function handleChatCompletionsPOST(
       executionCtx: options.executionCtx,
     });
     const modelCatalogPromise = skipCatalogLookup
-      ? Promise.resolve({ kind: "ready" as const, model: null })
+      ? Promise.resolve({
+          kind: "ready" as const,
+          model: null,
+          stale: false,
+        })
       : options.executionCtx
         ? getGatewayModelByIdCacheOnly(model, {
             executionCtx: options.executionCtx,
@@ -1564,6 +1594,7 @@ export async function handleChatCompletionsPOST(
             .then((catalogModel) => ({
               kind: "ready" as const,
               model: catalogModel,
+              stale: false,
             }))
             // error-policy:J4 non-Worker tools retain the explicit
             // name-pattern fallback when optional catalog metadata fails.
@@ -1575,7 +1606,11 @@ export async function handleChatCompletionsPOST(
                   error: error instanceof Error ? error.message : String(error),
                 },
               );
-              return { kind: "ready" as const, model: null };
+              return {
+                kind: "ready" as const,
+                model: null,
+                stale: false,
+              };
             });
     const shouldBlockUserPromise = moderationAlreadyChecked
       ? Promise.resolve({ kind: "ready" as const, blocked: false })
@@ -1586,6 +1621,17 @@ export async function handleChatCompletionsPOST(
         : contentModerationService
             .shouldBlockUser(user.id)
             .then((blocked) => ({ kind: "ready" as const, blocked }));
+    // Promise.all attaches a rejection observer to every input immediately and
+    // remains fail-fast. Wrapping the aggregate records that failure until the
+    // rate-limit verdict has been applied, including 429 and early-return paths.
+    const dependencyResolutionsPromise = observeConcurrentPromise(
+      Promise.all([
+        monetizedAppPromise,
+        pooledCredentialPromise,
+        modelCatalogPromise,
+        shouldBlockUserPromise,
+      ]),
+    );
 
     const orgRateLimited = await resolveOrgRateLimit();
     if (orgRateLimited) {
@@ -1598,12 +1644,7 @@ export async function handleChatCompletionsPOST(
       pooledCredentialResolution,
       modelCatalogResolution,
       moderationResolution,
-    ] = await Promise.all([
-      monetizedAppPromise,
-      pooledCredentialPromise,
-      modelCatalogPromise,
-      shouldBlockUserPromise,
-    ]);
+    ] = unwrapConcurrentPromise(await dependencyResolutionsPromise);
     if (
       appResolution.kind !== "ready" ||
       pooledCredentialResolution.kind !== "ready" ||

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -128,7 +128,14 @@ import {
   getCachedGatewayModelById,
   getGatewayModelByIdCacheOnly,
 } from "@/lib/services/model-catalog";
-import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
+import {
+  admitOrganizationInference,
+  InferenceAdmissionUnavailableError,
+  InferenceAffiliateCacheUnavailableError,
+  InferenceAffiliateCacheWarmingError,
+  InferencePricingCacheUnavailableError,
+  InferencePricingCacheWarmingError,
+} from "@/lib/services/organization-inference-admission";
 import {
   getTeamPoolRegistry,
   type SelectedPooledCredential,
@@ -1373,8 +1380,11 @@ export async function handleChatCompletionsPOST(
     // catches any regression before a provider invocation.
     const tAuth = performance.now();
 
-    // 1b. Per-org tier rate limit. Start it beside body parsing: rate-limit
-    // still wins over malformed bodies, matching the pre-existing gate order.
+    // 1b. Per-org tier rate limit. Start the authoritative decision now, then
+    // overlap it with the independent cache-only preparation below. We still
+    // inspect and return this result first, preserving the existing denial
+    // precedence without serializing an unrelated Durable Object round trip
+    // ahead of every dependency read.
     const orgRateLimitPromise =
       user.organization_id && !options.skipOrgRateLimit
         ? enforceOrgRateLimit(user.organization_id, "completions", {
@@ -1383,13 +1393,12 @@ export async function handleChatCompletionsPOST(
             config: inferenceRateLimitConfig(admissionSnapshot, "completions"),
           })
         : Promise.resolve(null);
-    let orgRateLimited: Response | null;
-    try {
-      orgRateLimited = await orgRateLimitPromise;
-    } catch (error) {
-      if (error instanceof OrgRateLimitCacheNotReadyError) {
-        return attachPreforwardTelemetry(
-          addCorsHeaders(
+    const resolveOrgRateLimit = async (): Promise<Response | null> => {
+      try {
+        return await orgRateLimitPromise;
+      } catch (error) {
+        if (error instanceof OrgRateLimitCacheNotReadyError) {
+          return addCorsHeaders(
             Response.json(
               {
                 error: {
@@ -1401,19 +1410,33 @@ export async function handleChatCompletionsPOST(
               },
               { status: 503, headers: { "Retry-After": "1" } },
             ),
-          ),
-        );
+          );
+        }
+        throw error;
       }
-      throw error;
-    }
-    if (orgRateLimited) return orgRateLimited;
+    };
+    const captureEarlyPreforwardTiming = (): void => {
+      if (preforwardTiming) return;
+      const stoppedAt = performance.now();
+      preforwardTiming = snapshotGatewayPreforwardTiming({
+        authMs: tAuth - telemetryStartedAt,
+        middleMs: stoppedAt - tAuth,
+        reserveMs: 0,
+        setupMs: 0,
+        totalMs: stoppedAt - telemetryStartedAt,
+      });
+    };
 
     if (
       !request?.model ||
       !Array.isArray(request.messages) ||
       !request.messages.length
     ) {
-      return invalidRequestResponse!;
+      const orgRateLimited = await resolveOrgRateLimit();
+      captureEarlyPreforwardTiming();
+      return attachPreforwardTelemetry(
+        orgRateLimited ?? invalidRequestResponse!,
+      );
     }
 
     // 2. Prepare app monetization lookup
@@ -1563,6 +1586,12 @@ export async function handleChatCompletionsPOST(
         : contentModerationService
             .shouldBlockUser(user.id)
             .then((blocked) => ({ kind: "ready" as const, blocked }));
+
+    const orgRateLimited = await resolveOrgRateLimit();
+    if (orgRateLimited) {
+      captureEarlyPreforwardTiming();
+      return attachPreforwardTelemetry(orgRateLimited);
+    }
 
     const [
       appResolution,
@@ -1824,6 +1853,14 @@ export async function handleChatCompletionsPOST(
         billingReservation = admission.reservation;
       }
     } catch (error) {
+      const failedAt = performance.now();
+      preforwardTiming ??= snapshotGatewayPreforwardTiming({
+        authMs: tAuth - telemetryStartedAt,
+        middleMs: tBeforeReserve - tAuth,
+        reserveMs: failedAt - tBeforeReserve,
+        setupMs: 0,
+        totalMs: failedAt - telemetryStartedAt,
+      });
       if (error instanceof InferenceCredentialRevokedError) {
         const reason = inferenceCredentialRevocationReason(error.reason);
         const denial = resolveInferenceAuthStandingDenial(
@@ -1881,21 +1918,85 @@ export async function handleChatCompletionsPOST(
           ),
         );
       }
+      if (error instanceof InferenceAdmissionUnavailableError) {
+        logger.error(
+          "[Chat Completions] inference admission transport failed closed",
+          {
+            traceId,
+            requestId,
+            organizationId: user.organization_id,
+            userId: user.id,
+            model,
+            provider,
+            billingSource,
+            phase: "reserve",
+            errorName: error.name,
+            error: error.message,
+            cause:
+              error.cause instanceof Error
+                ? `${error.cause.name}: ${error.cause.message}`
+                : error.cause === undefined
+                  ? undefined
+                  : String(error.cause),
+          },
+        );
+        return attachPreforwardTelemetry(
+          addCorsHeaders(
+            Response.json(
+              {
+                error: {
+                  message:
+                    "Inference admission is temporarily unavailable. Retry shortly.",
+                  type: "service_unavailable",
+                  code: "inference_admission_unavailable",
+                },
+              },
+              { status: 503, headers: { "Retry-After": "1" } },
+            ),
+          ),
+        );
+      }
       if (
         error instanceof InferenceBalanceCacheWarmingError ||
         error instanceof AiPricingCacheWarmingError ||
         error instanceof AiPricingCacheUnavailableError
       ) {
-        return addCorsHeaders(
-          Response.json(
-            {
-              error: {
-                message: "Billing authorization is warming. Retry shortly.",
-                type: "service_unavailable",
-                code: "billing_cache_warming",
+        const dependency =
+          error instanceof InferencePricingCacheWarmingError ||
+          error instanceof InferencePricingCacheUnavailableError ||
+          error instanceof AiPricingCacheWarmingError ||
+          error instanceof AiPricingCacheUnavailableError
+            ? "pricing"
+            : error instanceof InferenceAffiliateCacheWarmingError ||
+                error instanceof InferenceAffiliateCacheUnavailableError
+              ? "affiliate_policy"
+              : "balance";
+        logger.warn("[Chat Completions] billing dependency failed closed", {
+          traceId,
+          requestId,
+          organizationId: user.organization_id,
+          userId: user.id,
+          model,
+          provider,
+          billingSource,
+          phase: "reserve",
+          dependency,
+          errorName: error.name,
+          error: error.message,
+        });
+        return attachPreforwardTelemetry(
+          addCorsHeaders(
+            Response.json(
+              {
+                error: {
+                  message: "Billing authorization is warming. Retry shortly.",
+                  type: "service_unavailable",
+                  code: "billing_cache_warming",
+                  details: { dependency },
+                },
               },
-            },
-            { status: 503 },
+              { status: 503, headers: { "Retry-After": "1" } },
+            ),
           ),
         );
       }

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -70,7 +70,10 @@ import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-conte
 import { InferenceBalanceCacheWarmingError } from "@/lib/services/inference-billing-fast-path";
 import type { InferenceCredentialCheck } from "@/lib/services/inference-credential-revocation";
 import { isKnownUnacceptedProviderError } from "@/lib/services/inference-provider-outcome";
-import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
+import {
+  admitOrganizationInference,
+  InferenceAdmissionUnavailableError,
+} from "@/lib/services/organization-inference-admission";
 import { usageService } from "@/lib/services/usage";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
@@ -652,6 +655,7 @@ app.post("/", async (c) => {
           );
         }
         if (
+          error instanceof InferenceAdmissionUnavailableError ||
           error instanceof InferenceBalanceCacheWarmingError ||
           error instanceof AiPricingCacheWarmingError ||
           error instanceof AiPricingCacheUnavailableError

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -372,9 +372,33 @@ app.post("/", async (c) => {
           402,
         );
       }
+      if (error instanceof InferenceAdmissionUnavailableError) {
+        logger.error(
+          "[Embeddings] inference admission transport failed closed",
+          {
+            traceId: c.get("traceId") ?? c.get("requestId"),
+            error: error.message,
+            cause:
+              error.cause instanceof Error
+                ? `${error.cause.name}: ${error.cause.message}`
+                : undefined,
+          },
+        );
+        return c.json(
+          {
+            error: {
+              message:
+                "Inference admission is temporarily unavailable. Retry shortly.",
+              type: "service_unavailable",
+              code: "inference_admission_unavailable",
+            },
+          },
+          503,
+          { "Retry-After": "1" },
+        );
+      }
       if (error instanceof InferenceBalanceCacheWarmingError) {
         const unavailable =
-          error instanceof InferenceAdmissionUnavailableError ||
           error instanceof InferencePricingCacheUnavailableError ||
           error instanceof InferenceAffiliateCacheUnavailableError;
         return c.json(

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -96,7 +96,10 @@ import {
   isKnownPreDispatchProviderConfigurationError,
   isKnownUnacceptedProviderError,
 } from "@/lib/services/inference-provider-outcome";
-import { admitOrganizationInference } from "@/lib/services/organization-inference-admission";
+import {
+  admitOrganizationInference,
+  InferenceAdmissionUnavailableError,
+} from "@/lib/services/organization-inference-admission";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
@@ -952,6 +955,7 @@ app.post("/", async (c) => {
           );
         }
         if (
+          error instanceof InferenceAdmissionUnavailableError ||
           error instanceof InferenceBalanceCacheWarmingError ||
           error instanceof AiPricingCacheWarmingError ||
           error instanceof AiPricingCacheUnavailableError
@@ -1007,7 +1011,10 @@ app.post("/", async (c) => {
             402,
           );
         }
-        if (error instanceof InferenceBalanceCacheWarmingError) {
+        if (
+          error instanceof InferenceAdmissionUnavailableError ||
+          error instanceof InferenceBalanceCacheWarmingError
+        ) {
           return anthropicError(
             "api_error",
             "Billing authorization is warming. Retry shortly.",

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -30,6 +30,7 @@ const GATE_ORIGIN = "https://inference-admission.internal";
 const RATE_LIMIT_GATE_PREFIX = "rate-limit:v2:";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
+const LEASE_GATE_MAX_ATTEMPTS = 2;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
 const RATE_LIMIT_WARM_TTL_MS = 5 * 60_000;
@@ -551,28 +552,45 @@ export async function acquireInferenceAdmissionLease(params: {
   }
 
   const stub = gateStub(params.organizationId);
-  const response = await gateFetch(
-    params.organizationId,
-    params.credential ? "/lease-authorized" : "/lease",
-    {
-      organizationId: params.organizationId,
-      requestId: params.requestId,
-      balanceUsd,
-      balanceRevision: params.balanceRevision,
-      estimatedCostUsd,
-      recovery: params.recovery,
-      ...(params.credential
-        ? {
-            credential: {
-              organizationId: params.organizationId,
-              ...params.credential,
-            },
-          }
-        : {}),
-    },
-    stub,
-    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
-  );
+  const path = params.credential ? "/lease-authorized" : "/lease";
+  const body = {
+    organizationId: params.organizationId,
+    requestId: params.requestId,
+    balanceUsd,
+    balanceRevision: params.balanceRevision,
+    estimatedCostUsd,
+    recovery: params.recovery,
+    ...(params.credential
+      ? {
+          credential: {
+            organizationId: params.organizationId,
+            ...params.credential,
+          },
+        }
+      : {}),
+  };
+  let response: Response | undefined;
+  for (let attempt = 1; attempt <= LEASE_GATE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      response = await gateFetch(
+        params.organizationId,
+        path,
+        body,
+        stub,
+        AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
+      );
+    } catch (error) {
+      if (attempt < LEASE_GATE_MAX_ATTEMPTS) continue;
+      throw error;
+    }
+    if (response.status >= 500 && attempt < LEASE_GATE_MAX_ATTEMPTS) continue;
+    break;
+  }
+  if (!response) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission gate lease produced no response",
+    );
+  }
   if (response.status === 403 && params.credential) {
     let reason = "revoked";
     try {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -148,18 +148,25 @@ let gateBalance = 50;
 let eligible = true;
 let orgRefused = false;
 let subscriptionFunded = false;
+let leaseFailure: Error | undefined;
 const isSubscriptionFundedOrganization = mock(async () => subscriptionFunded);
 const isOptimisticEligible = mock(() => eligible);
 const acquireInferenceAdmissionLease = mock(
-  async (params: { organizationId: string; requestId: string; estimatedCostUsd: number }) => ({
-    organizationId: params.organizationId,
-    requestId: params.requestId,
-    estimatedCostUsd: params.estimatedCostUsd,
-    gate: { fetch: async () => Response.json({ settled: true }) },
-    providerDispatched: false,
-  }),
+  async (params: { organizationId: string; requestId: string; estimatedCostUsd: number }) => {
+    if (leaseFailure) throw leaseFailure;
+    return {
+      organizationId: params.organizationId,
+      requestId: params.requestId,
+      estimatedCostUsd: params.estimatedCostUsd,
+      gate: { fetch: async () => Response.json({ settled: true }) },
+      providerDispatched: false,
+    };
+  },
 );
 const settleInferenceAdmissionLease = mock(async () => undefined);
+
+class TestInferenceBalanceCacheWarmingError extends Error {}
+class TestInferenceAdmissionGateUnavailableError extends Error {}
 
 mock.module("./ai-billing", () => ({
   reserveCredits,
@@ -189,12 +196,7 @@ mock.module("../utils/credit-reservation", () => ({
   createCreditReservationSettler: () => optimisticSettle,
 }));
 mock.module("./inference-billing-fast-path", () => ({
-  InferenceBalanceCacheWarmingError: class InferenceBalanceCacheWarmingError extends Error {
-    constructor() {
-      super("warming");
-      this.name = "InferenceBalanceCacheWarmingError";
-    }
-  },
+  InferenceBalanceCacheWarmingError: TestInferenceBalanceCacheWarmingError,
   createOptimisticDebitSettler: () => optimisticSettle,
   debitInferenceCost,
   getGateBalanceHint: async () => ({
@@ -218,7 +220,7 @@ mock.module("./inference-admission-gate", () => ({
     balanceBackedUsd: actualCostUsd,
     gateConsumedUsd: actualCostUsd,
   }),
-  InferenceAdmissionGateUnavailableError: class InferenceAdmissionGateUnavailableError extends Error {},
+  InferenceAdmissionGateUnavailableError: TestInferenceAdmissionGateUnavailableError,
   InferenceAdmissionLeaseRejectedError: class InferenceAdmissionLeaseRejectedError extends Error {
     readonly requiredUsd = 1;
     readonly availableUsd = 0;
@@ -239,7 +241,9 @@ mock.module("./inference-billing-deferred", () => ({
   },
 }));
 
-const { admitOrganizationInference } = await import("./organization-inference-admission");
+const { admitOrganizationInference, InferenceAdmissionUnavailableError } = await import(
+  "./organization-inference-admission"
+);
 const { __clearPersistedPricingCache } = await import("./ai-pricing/cache");
 const { __clearInferenceAffiliateCacheState } = await import("./inference-affiliate-cache");
 
@@ -287,6 +291,7 @@ beforeEach(() => {
   eligible = true;
   orgRefused = false;
   subscriptionFunded = false;
+  leaseFailure = undefined;
   isSubscriptionFundedOrganization.mockClear();
   repositoryBlock = null;
   affiliateRepositoryBlock = null;
@@ -665,6 +670,21 @@ test("a previously refused org fails closed and hydrates balance off path", asyn
   expect(pairReads).toBe(0);
   expect(affiliateReads).toBe(0);
   expect(reserveCredits).not.toHaveBeenCalled();
+});
+
+test("admission transport failures retain their cause without becoming balance warming", async () => {
+  const model = nextModel();
+  await hydratePricing(model);
+  const gateCause = new TestInferenceAdmissionGateUnavailableError("gate timed out");
+  leaseFailure = gateCause;
+
+  const error = await admitOrganizationInference(admissionParams(model, [])).catch(
+    (caught: unknown) => caught,
+  );
+
+  expect(error).toBeInstanceOf(InferenceAdmissionUnavailableError);
+  expect(error).not.toBeInstanceOf(TestInferenceBalanceCacheWarmingError);
+  expect(error).toMatchObject({ cause: gateCause });
 });
 
 test("cold affiliate pricing hydrates policy and model rates without a synchronous reserve", async () => {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -684,7 +684,18 @@ test("admission transport failures retain their cause without becoming balance w
 
   expect(error).toBeInstanceOf(InferenceAdmissionUnavailableError);
   expect(error).not.toBeInstanceOf(TestInferenceBalanceCacheWarmingError);
-  expect(error).toMatchObject({ cause: gateCause });
+  expect(error).toMatchObject({
+    cause: gateCause,
+    code: "INFERENCE_ADMISSION_UNAVAILABLE",
+    context: {
+      organizationId: "org-1",
+      userId: "user-1",
+      model,
+      provider: "cerebras",
+      billingSource: "bitrouter",
+    },
+    severity: "ephemeral",
+  });
 });
 
 test("cold affiliate pricing hydrates policy and model rates without a synchronous reserve", async () => {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -10,6 +10,7 @@
  * disappears.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { calculateCost, normalizeModelName } from "../pricing";
 import { createCreditReservationSettler } from "../utils/credit-reservation";
 import { logger } from "../utils/logger";
@@ -146,11 +147,35 @@ export class InferenceAffiliateCacheUnavailableError extends InferenceBalanceCac
 }
 
 /** The request cannot safely defer its durable charge in this Worker. */
-export class InferenceAdmissionUnavailableError extends Error {
-  constructor(options?: { cause?: unknown }) {
-    super("Inference admission transport is unavailable", options);
-    this.name = "InferenceAdmissionUnavailableError";
+export class InferenceAdmissionUnavailableError extends ElizaError {
+  override readonly name = "InferenceAdmissionUnavailableError";
+  readonly statusCode = 503;
+
+  constructor(options?: { cause?: unknown; context?: Record<string, unknown> }) {
+    super("Inference admission transport is unavailable", {
+      code: "INFERENCE_ADMISSION_UNAVAILABLE",
+      cause: options?.cause,
+      context: options?.context,
+      severity: "ephemeral",
+    });
   }
+}
+
+function admissionUnavailable(
+  params: OrganizationInferenceAdmissionParams,
+  cause?: unknown,
+): InferenceAdmissionUnavailableError {
+  return new InferenceAdmissionUnavailableError({
+    cause,
+    context: {
+      organizationId: params.context.organizationId,
+      userId: params.context.userId,
+      requestId: params.context.requestId,
+      model: params.context.model,
+      provider: params.context.provider,
+      billingSource: params.context.billingSource,
+    },
+  });
 }
 
 async function reserveSynchronously(
@@ -270,13 +295,13 @@ export async function admitOrganizationInference(
     // state under waitUntil; this request must not bypass the refusal with a
     // synchronous database reserve on the model hot path.
     scheduleOrgBalanceHintHydration(params.context.organizationId, executionCtx);
-    throw new InferenceAdmissionUnavailableError();
+    throw admissionUnavailable(params);
   }
   if (!workerHotPath && affiliateMarked) {
     return await reserveSynchronously(params, false);
   }
   if (!isOptimisticBillingEnabled()) {
-    if (workerHotPath) throw new InferenceAdmissionUnavailableError();
+    if (workerHotPath) throw admissionUnavailable(params);
     return await reserveSynchronously(params, false);
   }
 
@@ -284,7 +309,7 @@ export async function admitOrganizationInference(
   const useDbLedger = resolveInferenceBillingLedger() === "db";
   const canDefer = isDeferredAdmissionEnabled() && workerHotPath;
   if (workerHotPath && !canDefer) {
-    throw new InferenceAdmissionUnavailableError();
+    throw admissionUnavailable(params);
   }
   // The legacy KV pending-charge lane cannot make an authoritative balance
   // decision before provider dispatch. A delayed post-debit projection write
@@ -436,7 +461,7 @@ export async function admitOrganizationInference(
       if (error instanceof InferenceAdmissionGateUnavailableError) {
         // error-policy:J2 preserve the gate transport failure for route-level
         // classification and diagnostics.
-        throw new InferenceAdmissionUnavailableError({ cause: error });
+        throw admissionUnavailable(params, error);
       }
       throw error;
     }
@@ -462,7 +487,7 @@ export async function admitOrganizationInference(
 
   if (canDefer && params.executionCtx) {
     if (!inferenceLease) {
-      throw new InferenceAdmissionUnavailableError();
+      throw admissionUnavailable(params);
     }
     if (affiliateAttribution) {
       const affiliatePayoutSourceId = getAffiliatePayoutSourceId(params.context);

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -146,9 +146,9 @@ export class InferenceAffiliateCacheUnavailableError extends InferenceBalanceCac
 }
 
 /** The request cannot safely defer its durable charge in this Worker. */
-export class InferenceAdmissionUnavailableError extends InferenceBalanceCacheWarmingError {
-  constructor() {
-    super();
+export class InferenceAdmissionUnavailableError extends Error {
+  constructor(options?: { cause?: unknown }) {
+    super("Inference admission transport is unavailable", options);
     this.name = "InferenceAdmissionUnavailableError";
   }
 }
@@ -434,7 +434,9 @@ export async function admitOrganizationInference(
         );
       }
       if (error instanceof InferenceAdmissionGateUnavailableError) {
-        throw new InferenceAdmissionUnavailableError();
+        // error-policy:J2 preserve the gate transport failure for route-level
+        // classification and diagnostics.
+        throw new InferenceAdmissionUnavailableError({ cause: error });
       }
       throw error;
     }

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -19,7 +19,10 @@ import {
   InferenceCredentialRevokedError,
   inferenceCredentialRevocationReason,
 } from "../inference-credential-revocation";
-import { admitOrganizationInference } from "../organization-inference-admission";
+import {
+  admitOrganizationInference,
+  InferenceAdmissionUnavailableError,
+} from "../organization-inference-admission";
 import { usageService } from "../usage";
 import { PricingNotFoundError } from "./pricing";
 import type {
@@ -539,6 +542,7 @@ export function createHandler(
       }
 
       if (
+        error instanceof InferenceAdmissionUnavailableError ||
         error instanceof InferenceBalanceCacheWarmingError ||
         error instanceof InferenceCredentialRevocationUnavailableError
       ) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -66,7 +66,10 @@ import {
   isKnownPreDispatchProviderConfigurationError,
   isKnownUnacceptedProviderError,
 } from "../inference-provider-outcome";
-import { admitOrganizationInference } from "../organization-inference-admission";
+import {
+  admitOrganizationInference,
+  InferenceAdmissionUnavailableError,
+} from "../organization-inference-admission";
 import { isCanonicalPersonalSharedAgent } from "./personal-shared-identity";
 import {
   estimatePersonalSharedSeedanceCostUsd,
@@ -1103,7 +1106,10 @@ async function admitTurn(
   } catch (error) {
     // error-policy:J1 translate the billing-cache boundary into the shared
     // runtime's retryable cache-warming signal.
-    if (error instanceof InferenceBalanceCacheWarmingError) {
+    if (
+      error instanceof InferenceAdmissionUnavailableError ||
+      error instanceof InferenceBalanceCacheWarmingError
+    ) {
       throw new SharedRuntimeCacheWarmingError("Billing authorization is warming. Retry shortly.");
     }
     throw error;


### PR DESCRIPTION
Closes #30347

## What changed

- removes the redundant pre-auth `GLOBAL_RATE_LIMITER` call from the thin authenticated inference shell; the authoritative per-organization Durable Object limiter remains fail-closed
- overlaps the per-org rate decision with independent cache-only app, credential-pool, catalog, and moderation preparation while preserving rate-denial precedence
- retries an idempotent admission lease exactly once for transport or 5xx ambiguity, reusing the byte-identical request identity/body; definitive 4xx responses never retry
- separates admission transport failure from billing-cache warming, retains the underlying cause, and emits correlated structured diagnostics plus pre-forward timing
- keeps every other organization-admission caller compatible with the new distinct failure type

## Safety invariants

- one combined standing/cache read is unchanged
- strong credential + balance admission remains atomic
- the dispatch acknowledgement remains synchronous and fail-closed
- post-provider settlement remains idempotent/off-response via `waitUntil`
- no provider call can begin after an unacknowledged dispatch marker

## Verification

- `bun run --cwd packages/cloud/shared typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd packages/cloud/api build`
- `bun run --cwd packages/cloud/api check:router-contract`
- admission gate: 45 passed
- inference shell + admission combined: 59 passed
- chat organization admission: 17 passed
- cache hot-path and parallel orchestration focused tests passed
- Biome and `git diff --check` passed

The first default-heap API build attempt exhausted the local Node heap at ~4 GiB; the identical build passed with an 8 GiB heap.

## Evidence

Baseline: staging run 33650005696 at `bc5ced13a279722befaa4ab536d338ad8af8c8fb`. The 5.245s cold failure stopped before route auth in the redundant global limiter. The 1.775s warm failure matched the 1.5s admission-lease timeout and was incorrectly returned as `billing_cache_warming`.

Post-merge evidence will be the exact-SHA staging deploy plus the paired gateway/direct Cerebras latency certification.

UI screenshots/video: N/A - backend inference and accounting path only.
Native/device evidence: N/A - Cloudflare Worker backend only.
Schema/migration evidence: N/A - no schema change.