### PR TITLE
test(core): pin the action-tiering rank tiebreaker

### DIFF
--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -102,6 +102,31 @@ describe("complete action surface", () => {
 		).toEqual(["EMAIL", "MUSIC"]);
 	});
 
+	it("orders saturated parents by retrieval rank against alphabetical order", () => {
+		const catalog = buildActionCatalog(actions);
+		const music = catalog.parentByName.get("MUSIC");
+		const email = catalog.parentByName.get("EMAIL");
+		if (!music || !email) throw new Error("missing catalog parent");
+		// The sibling saturated-score case ranks EMAIL first, which is also its
+		// position under the normalizedName fallback -- so it holds whether or
+		// not rank is consulted. Invert it: rank puts MUSIC first while
+		// localeCompare puts EMAIL first, so only the rank tiebreaker can
+		// produce this order.
+		const musicResult = resultFor(music, 1);
+		const emailResult = resultFor(email, 1);
+		musicResult.rank = 1;
+		emailResult.rank = 2;
+
+		const surface = tierActionResults({
+			catalog,
+			results: [emailResult, musicResult],
+		});
+
+		expect(
+			surface.tierAParents.slice(0, 2).map((parent) => parent.name),
+		).toEqual(["MUSIC", "EMAIL"]);
+	});
+
 	it("ignores legacy parent, child, threshold, and candidate caps", () => {
 		const manyChildren = Array.from({ length: 24 }, (_, index) => ({
 			name: `CHILD_${String(index).padStart(2, "0")}`,


### PR DESCRIPTION
## What this pins

`compareTieredParents` breaks equal-score ties on retrieval rank before falling back to name order:

```ts
// action-tiering.ts:155
return (
  right.score - left.score ||
  left.result.rank - right.result.rank ||     // ← this term
  left.normalizedName.localeCompare(right.normalizedName)
);
```

Deleting that middle term leaves the entire `packages/core` runtime suite green — **138 files / 1983 tests passed**, identical to the pristine baseline. The ordering it establishes is unprotected.

## Why the existing coverage misses it

This is the part worth reading, because the suite *looks* like it already covers this. There's a case named `"preserves retrieval rank when relevance scores are saturated"`:

```ts
musicResult.rank = 2;
emailResult.rank = 1;
…
expect(…).toEqual(["EMAIL", "MUSIC"]);
```

`EMAIL` also precedes `MUSIC` under `normalizedName.localeCompare`. So that assertion holds whether or not rank is consulted — it passes for the wrong reason, and deleting the rank term doesn't disturb it.

## The change

One test, in the file's existing idiom: the same saturated-score setup with the ranks inverted, so **rank order and alphabetical order disagree**.

```ts
musicResult.rank = 1;
emailResult.rank = 2;
// results passed in as [emailResult, musicResult] so input order
// can't account for the outcome either
expect(…).toEqual(["MUSIC", "EMAIL"]);
```

Only the rank tiebreaker can produce that order.

## The guard earns its place

Two mutants, scored against `develop`'s suite alone and against `develop`'s suite plus this test:

| mutation | develop's suite | with this test |
|---|---|---|
| **delete the rank term** | **6 / 0 — survives** | **1 failed / 6** |
| reverse the tiebreaker direction | 1 failed / 5 | 2 failed / 5 |

Exactly one newly-killed mutant, and it's the one this PR is about. The reversal was already caught — I'm not claiming it as coverage this adds.

I left the existing saturated-score case alone: it's insufficient, not wrong. The new test carries a comment explaining that its sibling is satisfied by the alphabetical fallback, so nobody later deletes one as a duplicate of the other.

## Verification

Run with the commands CI runs, from `packages/core`:

```
bunx @biomejs/biome check <touched file>   Checked 1 file. No fixes applied.
bun run typecheck                          exit 0, zero `error TS` lines
run-vitest.mjs run src/runtime             138 files, 1984 tests passed  (baseline 1983)
```

Test-only, one file, no source change.

*Context: this was finding 2 of four in my review of #30330, which merged with them unaddressed. Filing the guard rather than leaving it in a review comment. Finding 1 — the `execution_tier` guard in `client-cloud.ts` that executes zero times across its own suite — is still open; I haven't been able to construct a fixture that reaches it, so I'd rather report that honestly than guess at one.*

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1HF12SG1207CS573X7NTBKG","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T16:25:26.576Z","completed_at":"2026-09-02T16:25:59.261Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T16:25:27.280Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5d6a2cd3233370d2cc5bc2f5f40a7fd3fa7f65bce78ff54e182ba9d995aebebb","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f9d50208-5e8c-42b5-83ed-887e10791db8","object_id":"sha256:5d6a2cd3233370d2cc5bc2f5f40a7fd3fa7f65bce78ff54e182ba9d995aebebb","sha256":"5d6a2cd3233370d2cc5bc2f5f40a7fd3fa7f65bce78ff54e182ba9d995aebebb"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"6_LOasAolbSbCjZTWxmlxYwGtFm8a5oaMJBAy7yXAsSBsrSFjytCGrtlj5H-AWbwstHYeOyqhXAsNzXkl50BDA"}} -->
