### PR TITLE
fix(cloud): recover transient fresh Steward binding activation

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -200,6 +200,11 @@ mock.module("../cache/client", () => ({
     del: async (key: string) => {
       deletedCacheKeys.push(key);
     },
+    delConfirmed: async (key: string) => {
+      deletedCacheKeys.push(key);
+      return true;
+    },
+    delPatternConfirmed: async () => true,
   },
 }));
 

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 
 // ── Captured side effects + per-test repository state ───────────────────────
 const invalidatedHashBatches: string[][] = [];
@@ -30,7 +31,7 @@ let orgApiKeys: Array<{ key_hash: string }> = [];
 let userRecord: Record<string, unknown> | undefined;
 let readUserRecordOverride: Record<string, unknown> | undefined;
 let useReadUserRecordOverride = false;
-let failNextBindingActivation = false;
+let bindingActivationFailuresRemaining = 0;
 let failProjectionFenceKey: string | null = null;
 let listByOrganizationUsers: unknown[] = [];
 let listByUserError: Error | null = null;
@@ -60,9 +61,12 @@ mock.module("./inference-credential-revocation", () => ({
     active: boolean,
   ) => {
     lifecycleEvents.push(`session-binding:${orgId}:${userId}:${stewardUserId}:${active}`);
-    if (active && failNextBindingActivation) {
-      failNextBindingActivation = false;
-      throw new Error("binding activation unavailable");
+    if (active && bindingActivationFailuresRemaining > 0) {
+      bindingActivationFailuresRemaining -= 1;
+      throw new ElizaError("binding activation unavailable", {
+        code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+        severity: "ephemeral",
+      });
     }
   },
   revokeInferenceSessionsThrough: async (orgId: string, userId: string) => {
@@ -213,7 +217,7 @@ beforeEach(() => {
   userRecord = undefined;
   readUserRecordOverride = undefined;
   useReadUserRecordOverride = false;
-  failNextBindingActivation = false;
+  bindingActivationFailuresRemaining = 0;
   failProjectionFenceKey = null;
   listByOrganizationUsers = [];
   listByUserError = null;
@@ -365,14 +369,41 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     expect(invalidatedSessionBatches).toEqual([]);
   });
 
-  test("fresh Steward identity initialization rejects active-binding failure", async () => {
+  test("fresh Steward identity initialization retries a transient active-binding failure", async () => {
     const { usersService } = await import("./users");
     const user = await usersService.createFreshStewardSignupUser({
       email: "fresh@example.com",
       organization_id: "o1",
       steward_user_id: "steward-new",
     });
-    failNextBindingActivation = true;
+    bindingActivationFailuresRemaining = 1;
+
+    await expect(
+      usersService.initializeFreshStewardIdentity({
+        user,
+        stewardUserId: "steward-new",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(lifecycleEvents).toEqual([
+      "user-create:u-fresh",
+      "identity-upsert:u-fresh:steward-new",
+      "session-binding:o1:u-fresh:steward-new:true",
+      "session-binding:o1:u-fresh:steward-new:true",
+    ]);
+    expect(repositoryReads).toEqual([]);
+    expect(deletedCacheKeys).toEqual([]);
+    expect(invalidatedSessionBatches).toEqual([]);
+  });
+
+  test("fresh Steward identity initialization rejects a persistent active-binding failure", async () => {
+    const { usersService } = await import("./users");
+    const user = await usersService.createFreshStewardSignupUser({
+      email: "fresh@example.com",
+      organization_id: "o1",
+      steward_user_id: "steward-new",
+    });
+    bindingActivationFailuresRemaining = 2;
 
     await expect(
       usersService.initializeFreshStewardIdentity({
@@ -385,10 +416,8 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
       "user-create:u-fresh",
       "identity-upsert:u-fresh:steward-new",
       "session-binding:o1:u-fresh:steward-new:true",
+      "session-binding:o1:u-fresh:steward-new:true",
     ]);
-    expect(repositoryReads).toEqual([]);
-    expect(deletedCacheKeys).toEqual([]);
-    expect(invalidatedSessionBatches).toEqual([]);
   });
 
   test("fresh Steward identity initialization rejects a missing organization", async () => {
@@ -565,7 +594,7 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
       email: null,
       steward_user_id: "steward-old",
     };
-    failNextBindingActivation = true;
+    bindingActivationFailuresRemaining = 1;
 
     const { usersService } = await import("./users");
     await expect(usersService.upsertStewardIdentity("u1", "steward-new")).rejects.toThrow(

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -2,7 +2,7 @@
  * Users service for managing user accounts and organization relationships.
  */
 
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, isElizaError } from "@elizaos/core";
 import {
   apiKeysRepository,
   type NewUser,
@@ -53,6 +53,33 @@ type FreshStewardIdentityInput = {
   user: Pick<User, "id" | "organization_id" | "steward_user_id">;
   stewardUserId: string;
 };
+
+const FRESH_STEWARD_BINDING_ACTIVATION_ATTEMPTS = 2;
+
+async function activateFreshStewardBinding(input: {
+  organizationId: string;
+  userId: string;
+  stewardUserId: string;
+}): Promise<void> {
+  const { organizationId, userId, stewardUserId } = input;
+  for (let attempt = 1; attempt <= FRESH_STEWARD_BINDING_ACTIVATION_ATTEMPTS; attempt += 1) {
+    try {
+      await setInferenceSessionBindingActive(organizationId, userId, stewardUserId, true);
+      return;
+    } catch (error) {
+      const isTransientBoundaryFailure =
+        isElizaError(error) && error.code === "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE";
+      if (!isTransientBoundaryFailure || attempt === FRESH_STEWARD_BINDING_ACTIVATION_ATTEMPTS) {
+        throw error;
+      }
+      logger.warn("[UsersService] Retrying fresh Steward binding activation", {
+        organizationId,
+        userId,
+        attempt,
+      });
+    }
+  }
+}
 
 function personalDeliveryRoutingIdentities(
   ...sources: Array<PersonalDeliveryIdentitySource | undefined>
@@ -542,7 +569,7 @@ export class UsersService {
     }
 
     await usersRepository.upsertStewardIdentity(user.id, stewardUserId);
-    await setInferenceSessionBindingActive(organizationId, user.id, stewardUserId, true);
+    await activateFreshStewardBinding({ organizationId, userId: user.id, stewardUserId });
   }
 
   async linkStewardId(userId: string, stewardUserId: string): Promise<void> {

--- a/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError, isElizaError } from "@elizaos/core";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -37,11 +38,15 @@ let welcomeEmailStarted = false;
 let discordLogStarted = false;
 let freshUserCreateCompleted = false;
 let freshIdentityInitializeCompleted = false;
+let freshIdentityProjectionCommitted = false;
 let genericCreateAttempted = false;
 let genericIdentityUpsertAttempted = false;
 let finalIdentityReadAttempted = false;
 let organizationCreateAttempts = 0;
 let organizationSlugPreflightAttempts = 0;
+let organizationDeleteAttempts = 0;
+let userDeleteAttempts = 0;
+let identityInitializeError: Error | undefined;
 const organizationCreateErrors: unknown[] = [];
 const loggerErrors: Array<{ message: string; context?: unknown }> = [];
 const loggerInfos: Array<{ message: string; context?: unknown }> = [];
@@ -86,7 +91,9 @@ mock.module("./services/organizations", () => ({
       return createdOrg;
     },
     update: async () => createdOrg,
-    delete: async () => undefined,
+    delete: async () => {
+      organizationDeleteAttempts += 1;
+    },
   },
 }));
 mock.module("./services/users", () => ({
@@ -109,6 +116,8 @@ mock.module("./services/users", () => ({
       expect(user).toBe(createdUser);
       expect(stewardUserId).toBe("steward-123");
       freshIdentityInitializeCompleted = true;
+      freshIdentityProjectionCommitted = true;
+      if (identityInitializeError) throw identityInitializeError;
     },
     create: async () => {
       genericCreateAttempted = true;
@@ -123,7 +132,9 @@ mock.module("./services/users", () => ({
 }));
 mock.module("../db/repositories/users", () => ({
   usersRepository: {
-    delete: async () => undefined,
+    delete: async () => {
+      userDeleteAttempts += 1;
+    },
     findPendingPhoneTelegramPersonalAccountConvergence: async () => ({
       status: "not_found" as const,
     }),
@@ -222,11 +233,15 @@ describe("syncUserFromSteward direct-signup provisioning", () => {
     discordLogStarted = false;
     freshUserCreateCompleted = false;
     freshIdentityInitializeCompleted = false;
+    freshIdentityProjectionCommitted = false;
     genericCreateAttempted = false;
     genericIdentityUpsertAttempted = false;
     finalIdentityReadAttempted = false;
     organizationCreateAttempts = 0;
     organizationSlugPreflightAttempts = 0;
+    organizationDeleteAttempts = 0;
+    userDeleteAttempts = 0;
+    identityInitializeError = undefined;
     organizationCreateErrors.length = 0;
     loggerErrors.length = 0;
     loggerInfos.length = 0;
@@ -297,6 +312,41 @@ describe("syncUserFromSteward direct-signup provisioning", () => {
         ],
       }),
     });
+  });
+
+  test("preserves a committed fresh identity when its revocation boundary remains unavailable", async () => {
+    const boundaryFailure = new ElizaError("Inference revocation boundary is unavailable", {
+      code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+      severity: "ephemeral",
+    });
+    identityInitializeError = boundaryFailure;
+
+    const failure = await syncUserFromSteward(baseParams).catch((error: unknown) => error);
+
+    expect(failure).toMatchObject({ code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE" });
+    expect(failure).toBeInstanceOf(ElizaError);
+    if (!isElizaError(failure)) throw new Error("Expected a typed ElizaError");
+    expect(failure.cause).toBe(boundaryFailure);
+    expect(freshIdentityInitializeCompleted).toBe(true);
+    expect(freshIdentityProjectionCommitted).toBe(true);
+    expect(freshUserCreateCompleted).toBe(true);
+    expect(organizationCreateAttempts).toBe(1);
+    expect(userDeleteAttempts).toBe(0);
+    expect(organizationDeleteAttempts).toBe(0);
+    expect(
+      loggerWarnings.some(({ message }) =>
+        message.includes("binding activation unavailable; preserving recoverable identity"),
+      ),
+    ).toBe(true);
+  });
+
+  test("rolls back a non-recoverable fresh identity initialization failure", async () => {
+    identityInitializeError = new Error("identity projection rejected");
+
+    await expect(syncUserFromSteward(baseParams)).rejects.toThrow("identity projection rejected");
+
+    expect(userDeleteAttempts).toBe(1);
+    expect(organizationDeleteAttempts).toBe(1);
   });
 
   test("Worker tail contains only safe resources and isolates both failures", async () => {

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -149,6 +149,10 @@ function isRecoverableStewardProjectionConflict(error: unknown): boolean {
   return isUniqueViolation && hasExactStewardConstraint;
 }
 
+function isInferenceRevocationBoundaryUnavailable(error: unknown): boolean {
+  return isElizaError(error) && error.code === "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE";
+}
+
 function isOrganizationSlugConflict(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
@@ -1231,11 +1235,29 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     );
 
     if (!recovered) {
-      await rollbackCreatedUserSafely(createdUser.id, "signup", error);
-      await organizationsService.delete(organization.id);
-      logger.error(
-        `[StewardSync] Identity projection upsert failed for new user ${createdUser.id}: ${describeSyncError(error)}`,
-      );
+      if (isInferenceRevocationBoundaryUnavailable(error)) {
+        // error-policy:J2 The user and Steward projection committed before the
+        // idempotent revocation-boundary activation failed. Preserve that
+        // canonical state so the existing-user path can repair activation on the
+        // next session instead of attempting a retention-blocked destructive
+        // rollback, then rethrow the original typed availability failure.
+        logger.warn(
+          `[StewardSync] Fresh Steward binding activation unavailable; preserving recoverable identity for user ${createdUser.id}: ${describeSyncError(error)}`,
+          { organizationId: organization.id },
+        );
+        throw new ElizaError("Fresh Steward binding activation is temporarily unavailable", {
+          code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+          context: { userId: createdUser.id, organizationId: organization.id },
+          cause: error,
+          severity: "ephemeral",
+        });
+      } else {
+        await rollbackCreatedUserSafely(createdUser.id, "signup", error);
+        await organizationsService.delete(organization.id);
+        logger.error(
+          `[StewardSync] Identity projection upsert failed for new user ${createdUser.id}: ${describeSyncError(error)}`,
+        );
+      }
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

- retry fresh Steward binding activation once when the strong-revocation boundary reports its typed transient-unavailable error
- remain fail-closed if the second attempt fails or if any other error occurs
- preserve the already-committed canonical user, organization, and Steward identity so the existing-user path can repair activation on the next request
- retain the existing rollback behavior for non-target initialization failures

This is a bounded repair for #18627. It addresses the freshly correlated intermittent Steward binding-activation failure during new-account sync. It does not close the issue's remaining WebKit magic-link, Google OAuth, stale-asset, or Agents-table acceptance criteria.

## Evidence

### Before

A fresh AgentMail identity was tested against staging in headless Chromium while the staging Worker was tailed. Email verification succeeded, but the Steward session endpoint returned 500 and the UI showed `Could not sync Steward user`. The correlated Worker failure was `INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE` after the identity projection had committed; the subsequent destructive cleanup was rejected by retention/FK policy.

### After (local exact revision)

- transient typed boundary failure: activation is attempted twice and succeeds
- persistent typed boundary failure: the request still rejects after two attempts
- committed identity state is preserved only for that exact failure, with the original error retained as the cause
- non-target initialization failure still rolls back the user and organization
- two independent adversarial reviews found no correctness, security, regression, or scope issues

### Verification

- `bun --config=/dev/null test packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts` — 27 passed
- `bun --config=/dev/null test packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts` — 8 passed
- `bun run --cwd packages/cloud/shared typecheck` — passed
- `bun run --cwd packages/cloud/shared lint` — passed
- `bun run verify` — passed (376/376 Turbo tasks plus repository audit gates)

Exact-revision staging validation remains pending deployment. No deployment was performed as part of this PR.

## UI evidence

N/A — server-side authentication lifecycle repair; no UI files or rendered states changed.
