### PR TITLE
fix(cloud): settle ambiguous paid voice calls

### DIFF
--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -1226,7 +1226,7 @@ describe("POST /api/v1/voice/stt — Deepgram prerecorded lane", () => {
     ]);
   });
 
-  test("a malformed 200 fails closed and does not fall back to Whisper", async () => {
+  test("a malformed 200 fails closed and conservatively settles without falling back", async () => {
     upstreamReply = () => Response.json({ text: "whisper fallback" });
     deepgramReply = () =>
       Response.json({
@@ -1244,10 +1244,11 @@ describe("POST /api/v1/voice/stt — Deepgram prerecorded lane", () => {
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
     expect(captured.fileName).toBeNull();
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.0012);
+    expect(allLoggedContent()).toContain('"settlement":"unknown"');
   });
 
-  test("an unparseable Deepgram 200 refunds the reservation", async () => {
+  test("an unparseable Deepgram 200 conservatively settles the reservation", async () => {
     deepgramReply = () =>
       new Response("<html>proxy error</html>", {
         status: 200,
@@ -1257,7 +1258,7 @@ describe("POST /api/v1/voice/stt — Deepgram prerecorded lane", () => {
 
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.0012);
     expect(billFlatUsage).not.toHaveBeenCalled();
   });
 
@@ -1275,7 +1276,7 @@ describe("POST /api/v1/voice/stt — Deepgram prerecorded lane", () => {
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
     expect(captured.fileName).toBeNull();
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.0012);
     const logs = allLoggedContent();
     expect(logs).not.toContain("secret transcript");
     expect(logs).not.toContain("dg-secret");
@@ -1296,7 +1297,7 @@ describe("POST /api/v1/voice/stt — Deepgram prerecorded lane", () => {
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
     expect(captured.fileName).toBeNull();
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.0012);
     const logs = allLoggedContent();
     expect(logs).not.toContain("secret provider socket failure");
     expect(logs).toContain('"errorType":"TypeError"');
@@ -1551,7 +1552,7 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
     expect("words" in body).toBe(false);
   });
 
-  test("a malformed Cartesia 200 fails closed, refunds, and never falls back to Whisper", async () => {
+  test("a malformed Cartesia 200 fails closed, settles unknown, and never falls back", async () => {
     upstreamReply = () => Response.json({ text: "whisper fallback" });
     cartesiaReply = () => Response.json({ type: "transcript" });
     const res = await app.request(
@@ -1563,7 +1564,8 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
     expect(captured.fileName).toBeNull();
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.00003);
+    expect(allLoggedContent()).toContain('"settlement":"unknown"');
     expect(billFlatUsage).not.toHaveBeenCalled();
   });
 
@@ -1581,7 +1583,7 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
 
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.00003);
   });
 
   test("an upstream Cartesia error is a 502 without logging provider body or key", async () => {
@@ -1598,14 +1600,14 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
     expect(captured.fileName).toBeNull();
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.00003);
     const logs = allLoggedContent();
     expect(logs).not.toContain("secret transcript");
     expect(logs).not.toContain("car-secret");
     expect(logs).toContain('"status":503');
   });
 
-  test("a transport failure refunds and is a 502 logged as its type only", async () => {
+  test("a transport failure settles unknown and is logged as its type only", async () => {
     cartesiaReply = () => {
       throw new TypeError("secret provider socket failure");
     };
@@ -1618,7 +1620,7 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
     expect(res.status).toBe(502);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text failed" });
     expect(captured.fileName).toBeNull();
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.00003);
     const logs = allLoggedContent();
     expect(logs).not.toContain("secret provider socket failure");
     expect(logs).toContain('"errorType":"TypeError"');
@@ -1650,7 +1652,7 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
     expect(reserve).not.toHaveBeenCalled();
   });
 
-  test("a Cartesia timeout refunds the reservation and returns a typed 504", async () => {
+  test("a Cartesia timeout settles unknown and returns a typed 504", async () => {
     cartesiaReply = (init) =>
       new Promise<Response>((_resolve, reject) => {
         const signal = init?.signal;
@@ -1666,11 +1668,11 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
 
     expect(res.status).toBe(504);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text timed out" });
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.00003);
     expect(billFlatUsage).not.toHaveBeenCalled();
   });
 
-  test("a stalled Cartesia response body refunds and returns a typed 504", async () => {
+  test("a stalled Cartesia response body settles unknown and returns a typed 504", async () => {
     cartesiaReply = (init) =>
       new Response(
         new ReadableStream<Uint8Array>({
@@ -1695,7 +1697,7 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
 
     expect(res.status).toBe(504);
     expect(await readJson(res)).toEqual({ error: "Speech-to-text timed out" });
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.00003);
     expect(billFlatUsage).not.toHaveBeenCalled();
   });
 
@@ -1705,7 +1707,7 @@ describe("POST /api/v1/voice/stt — Cartesia batch lane (opt-in)", () => {
     const res = await app.request(sttRequest(), undefined, cartesiaEnv);
 
     expect(res.status).toBe(502);
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.00003);
     expect(billFlatUsage).not.toHaveBeenCalled();
   });
 });
@@ -1766,7 +1768,7 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
     expect(speechToText).not.toHaveBeenCalled();
   });
 
-  test("a provider rate-limit failure is a 429 and refunds the reservation", async () => {
+  test("a provider rate-limit failure is a 429 and settles unknown", async () => {
     speechToText.mockRejectedValue(new Error("Rate limit exceeded"));
     const res = await app.request(sttRequest(), undefined, elevenLabsEnv);
 
@@ -1774,7 +1776,7 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
     expect(await readJson(res)).toEqual({
       error: "Rate limit exceeded. Please try again in a moment.",
     });
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.0012);
   });
 
   test("a provider error embedding request content is logged as its type only", async () => {
@@ -1822,7 +1824,7 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
       type: "service_unavailable",
       retryAfter: "5 minutes",
     });
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.0012);
   });
 
   test("a missing provider key maps to a 500 'Service not configured'", async () => {
@@ -1833,7 +1835,7 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
     expect(await readJson(res)).toEqual({ error: "Service not configured" });
   });
 
-  test("an unrecognized provider failure is a generic 500, refunded", async () => {
+  test("an unrecognized provider failure is a generic 500, settled unknown", async () => {
     speechToText.mockRejectedValue(new Error("socket hang up"));
     const res = await app.request(sttRequest(), undefined, elevenLabsEnv);
 
@@ -1841,7 +1843,7 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
     expect(await readJson(res)).toEqual({
       error: "Failed to transcribe audio. Please try again.",
     });
-    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(reconcile).toHaveBeenCalledWith(0.0012);
   });
 });
 

--- a/packages/cloud/api/v1/voice/stt/route.test.ts
+++ b/packages/cloud/api/v1/voice/stt/route.test.ts
@@ -111,8 +111,9 @@ const textToSpeech = mock(
       },
     }),
 );
+const getElevenLabsService = mock(() => ({ speechToText, textToSpeech }));
 mock.module("@/lib/services/elevenlabs", () => ({
-  getElevenLabsService: mock(() => ({ speechToText, textToSpeech })),
+  getElevenLabsService,
 }));
 const usageCreate = mock(async (_record: Record<string, unknown>) => ({}));
 mock.module("@/lib/services/usage", () => ({
@@ -579,6 +580,11 @@ beforeEach(() => {
         },
       }),
   );
+  getElevenLabsService.mockReset();
+  getElevenLabsService.mockImplementation(() => ({
+    speechToText,
+    textToSpeech,
+  }));
   upstreamReply = () => Response.json({ text: "" });
   deepgramReply = () => Response.json(DEEPGRAM_SHAPE);
   cartesiaReply = () => Response.json(CARTESIA_SHAPE);
@@ -1766,6 +1772,18 @@ describe("POST /api/v1/voice/stt — billed ElevenLabs lane", () => {
       required: 42,
     });
     expect(speechToText).not.toHaveBeenCalled();
+  });
+
+  test("releases a reservation when local ElevenLabs service setup fails", async () => {
+    getElevenLabsService.mockImplementationOnce(() => {
+      throw new Error("ELEVENLABS_API_KEY is not set");
+    });
+    const res = await app.request(sttRequest(), undefined, elevenLabsEnv);
+
+    expect(res.status).toBe(500);
+    expect(speechToText).not.toHaveBeenCalled();
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith(0);
   });
 
   test("a provider rate-limit failure is a 429 and settles unknown", async () => {

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -436,6 +436,8 @@ async function readRequestWithMultipartLimit(
 async function __hono_POST(c: AppContext) {
   let reservation: CreditReservation | undefined;
   let settleUnknown: (() => Promise<unknown>) | undefined;
+  let providerWorkMayHaveStarted = false;
+  let settlementProvider: "deepgram" | "cartesia" | "elevenlabs" | undefined;
   let request = c.req.raw;
   const env = c.env;
 
@@ -693,10 +695,23 @@ async function __hono_POST(c: AppContext) {
       reservation = deepgramReservation.reservation;
       settleUnknown = deepgramReservation.settleUnknown;
 
-      const refundDeepgramReservation = async () => {
+      const settleDeepgramFailure = async (reason: string) => {
         if (!reservation) return;
-        await reservation.reconcile(0);
+        await (providerWorkMayHaveStarted && settleUnknown
+          ? settleUnknown()
+          : reservation.reconcile(0));
         reservation = undefined;
+        logger.warn("[Voice STT API] Settled failed paid transcription", {
+          provider: "deepgram",
+          providerDispatchState: providerWorkMayHaveStarted
+            ? "possibly_dispatched"
+            : "not_dispatched",
+          reason,
+          settlement: providerWorkMayHaveStarted ? "unknown" : "released",
+          traceId: c.get("traceId") ?? c.get("requestId") ?? "unavailable",
+          userId: user.id,
+          organizationId: user.organization_id,
+        });
       };
 
       const deepgramStart = Date.now();
@@ -710,6 +725,8 @@ async function __hono_POST(c: AppContext) {
       let deepgramResponse: Response;
       try {
         await deepgramReservation.markProviderDispatched?.();
+        providerWorkMayHaveStarted = true;
+        settlementProvider = "deepgram";
         deepgramResponse = await fetch(deepgramUrl, {
           method: "POST",
           headers: {
@@ -720,7 +737,7 @@ async function __hono_POST(c: AppContext) {
         });
       } catch (error) {
         // error-policy:J1 provider transport failures translate at the route boundary.
-        await refundDeepgramReservation();
+        await settleDeepgramFailure("transport_failure");
         logger.error("[Voice STT API] Deepgram request failed", {
           errorType: error instanceof Error ? error.name : "unknown",
         });
@@ -734,7 +751,7 @@ async function __hono_POST(c: AppContext) {
           // error-policy:J6 response-body drain is best-effort after upstream failure.
           return undefined;
         });
-        await refundDeepgramReservation();
+        await settleDeepgramFailure("upstream_http_error");
         logger.error("[Voice STT API] Deepgram request failed", {
           status: deepgramResponse.status,
         });
@@ -749,7 +766,7 @@ async function __hono_POST(c: AppContext) {
         deepgramPayload = await deepgramResponse.json();
       } catch {
         // error-policy:J3 provider JSON is untrusted input at the HTTP boundary.
-        await refundDeepgramReservation();
+        await settleDeepgramFailure("unparseable_response");
         logger.error("[Voice STT API] Deepgram returned unparseable JSON");
         return Response.json(
           { error: "Speech-to-text failed" },
@@ -759,7 +776,7 @@ async function __hono_POST(c: AppContext) {
 
       const transcription = parseDeepgramTranscription(deepgramPayload);
       if (!transcription) {
-        await refundDeepgramReservation();
+        await settleDeepgramFailure("malformed_response");
         logger.error("[Voice STT API] Deepgram returned a malformed payload");
         return Response.json(
           { error: "Speech-to-text failed" },
@@ -892,10 +909,23 @@ async function __hono_POST(c: AppContext) {
       reservation = cartesiaAdmission.reservation;
       settleUnknown = cartesiaAdmission.settleUnknown;
 
-      const refundCartesiaReservation = async () => {
+      const settleCartesiaFailure = async (reason: string) => {
         if (!reservation) return;
-        await reservation.reconcile(0);
+        await (providerWorkMayHaveStarted && settleUnknown
+          ? settleUnknown()
+          : reservation.reconcile(0));
         reservation = undefined;
+        logger.warn("[Voice STT API] Settled failed paid transcription", {
+          provider: "cartesia",
+          providerDispatchState: providerWorkMayHaveStarted
+            ? "possibly_dispatched"
+            : "not_dispatched",
+          reason,
+          settlement: providerWorkMayHaveStarted ? "unknown" : "released",
+          traceId: c.get("traceId") ?? c.get("requestId") ?? "unavailable",
+          userId: user.id,
+          organizationId: user.organization_id,
+        });
       };
 
       const cartesiaStart = Date.now();
@@ -919,6 +949,8 @@ async function __hono_POST(c: AppContext) {
       let cartesiaResponse: Response;
       try {
         await cartesiaAdmission.markProviderDispatched?.();
+        providerWorkMayHaveStarted = true;
+        settlementProvider = "cartesia";
         cartesiaResponse = await fetch(CARTESIA_BATCH_STT_URL, {
           method: "POST",
           headers: {
@@ -930,7 +962,7 @@ async function __hono_POST(c: AppContext) {
         });
       } catch (error) {
         // error-policy:J1 provider transport failures translate at the route boundary.
-        await refundCartesiaReservation();
+        await settleCartesiaFailure("transport_failure");
         logger.error("[Voice STT API] Cartesia request failed", {
           errorType: error instanceof Error ? error.name : "unknown",
         });
@@ -951,7 +983,7 @@ async function __hono_POST(c: AppContext) {
           // error-policy:J6 response-body drain is best-effort after upstream failure.
           return undefined;
         });
-        await refundCartesiaReservation();
+        await settleCartesiaFailure("upstream_http_error");
         logger.error("[Voice STT API] Cartesia request failed", {
           status: cartesiaResponse.status,
         });
@@ -966,7 +998,7 @@ async function __hono_POST(c: AppContext) {
         cartesiaPayload = await cartesiaResponse.json();
       } catch {
         // error-policy:J3 provider JSON is untrusted input at the HTTP boundary.
-        await refundCartesiaReservation();
+        await settleCartesiaFailure("unparseable_response");
         if (cartesiaTimeoutSignal.aborted) {
           logger.error("[Voice STT API] Cartesia response body timed out");
           return Response.json(
@@ -983,7 +1015,7 @@ async function __hono_POST(c: AppContext) {
 
       const transcription = parseCartesiaTranscription(cartesiaPayload);
       if (!transcription) {
-        await refundCartesiaReservation();
+        await settleCartesiaFailure("malformed_response");
         logger.error("[Voice STT API] Cartesia returned a malformed payload");
         return Response.json(
           { error: "Speech-to-text failed" },
@@ -1206,6 +1238,8 @@ async function __hono_POST(c: AppContext) {
       reservation = admission.reservation;
       settleUnknown = admission.settleUnknown;
       await admission.markProviderDispatched?.();
+      providerWorkMayHaveStarted = true;
+      settlementProvider = "elevenlabs";
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
         return Response.json(
@@ -1302,11 +1336,22 @@ async function __hono_POST(c: AppContext) {
     });
 
     if (reservation) {
-      const release = reservation.reconcile(0);
+      const settlement =
+        providerWorkMayHaveStarted && settleUnknown
+          ? settleUnknown()
+          : reservation.reconcile(0);
       const executionCtx = getGenerativeExecutionContext(c);
-      if (executionCtx) executionCtx.waitUntil(release);
-      else await release;
-      logger.info("[Voice STT API] Released credits after error");
+      if (executionCtx) executionCtx.waitUntil(settlement);
+      else await settlement;
+      logger.warn("[Voice STT API] Settled failed paid transcription", {
+        provider: settlementProvider ?? "unknown",
+        providerDispatchState: providerWorkMayHaveStarted
+          ? "possibly_dispatched"
+          : "not_dispatched",
+        reason: "route_failure",
+        settlement: providerWorkMayHaveStarted ? "unknown" : "released",
+        traceId: c.get("traceId") ?? c.get("requestId") ?? "unavailable",
+      });
     }
 
     const apiError =

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -436,6 +436,7 @@ async function readRequestWithMultipartLimit(
 async function __hono_POST(c: AppContext) {
   let reservation: CreditReservation | undefined;
   let settleUnknown: (() => Promise<unknown>) | undefined;
+  let markProviderDispatched: (() => Promise<void>) | undefined;
   let providerWorkMayHaveStarted = false;
   let settlementProvider: "deepgram" | "cartesia" | "elevenlabs" | undefined;
   let request = c.req.raw;
@@ -1237,9 +1238,7 @@ async function __hono_POST(c: AppContext) {
       });
       reservation = admission.reservation;
       settleUnknown = admission.settleUnknown;
-      await admission.markProviderDispatched?.();
-      providerWorkMayHaveStarted = true;
-      settlementProvider = "elevenlabs";
+      markProviderDispatched = admission.markProviderDispatched;
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
         return Response.json(
@@ -1259,6 +1258,9 @@ async function __hono_POST(c: AppContext) {
     const validatedFile = new File([buffer], audioFile.name, {
       type: finalMimeType,
     });
+    await markProviderDispatched?.();
+    providerWorkMayHaveStarted = true;
+    settlementProvider = "elevenlabs";
     const transcript = await elevenlabs.speechToText({
       audioFile: validatedFile,
       languageCode,

--- a/packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts
@@ -6,12 +6,17 @@
  * honest provider failure.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CartesiaWebSocketFactory } from "../../../../../shared/src/lib/services/cartesia-sonic-tts";
 import {
+  makeWorkersCartesiaWebSocketFactory,
   synthesizeCartesiaBytes,
   synthesizeCartesiaWav,
 } from "../cartesia-synthesis";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 /** In-memory Cartesia socket: on the generation request, replay frames+done. */
 function scriptedFactory(
@@ -243,7 +248,116 @@ describe("synthesizeCartesiaWav", () => {
   });
 });
 
+describe("makeWorkersCartesiaWebSocketFactory", () => {
+  it("completes the dispatch callback exactly once before the upgrade fetch", async () => {
+    const events: string[] = [];
+    const upstreamSocket = {
+      accept() {
+        events.push("accept");
+      },
+      addEventListener() {},
+      close() {},
+      send() {},
+    };
+    const fetchImpl = vi.fn(async () => {
+      events.push("fetch");
+      expect(events).toEqual(["callback:start", "callback:done", "fetch"]);
+      return Object.assign(new Response(null), {
+        webSocket: upstreamSocket,
+      });
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+    const beforeProviderDispatch = vi.fn(async () => {
+      events.push("callback:start");
+      await Promise.resolve();
+      events.push("callback:done");
+    });
+    const factory = makeWorkersCartesiaWebSocketFactory(beforeProviderDispatch);
+    const socket = factory("wss://api.cartesia.test/tts", { headers: {} });
+
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener("open", resolve);
+      socket.addEventListener("error", reject);
+    });
+
+    expect(beforeProviderDispatch).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      "callback:start",
+      "callback:done",
+      "fetch",
+      "accept",
+    ]);
+  });
+
+  it("does not attempt the upgrade when the dispatch callback rejects", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null));
+    vi.stubGlobal("fetch", fetchImpl);
+    const beforeProviderDispatch = vi.fn(async () => {
+      throw new Error("dispatch marker unavailable");
+    });
+    const factory = makeWorkersCartesiaWebSocketFactory(beforeProviderDispatch);
+    const socket = factory("wss://api.cartesia.test/tts", { headers: {} });
+
+    const event = await new Promise<{ readonly message?: string }>(
+      (resolve) => {
+        socket.addEventListener("error", resolve);
+      },
+    );
+
+    expect(event.message).toBe("dispatch marker unavailable");
+    expect(beforeProviderDispatch).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
 describe("synthesizeCartesiaBytes", () => {
+  it("completes the dispatch callback exactly once before REST fetch", async () => {
+    const events: string[] = [];
+    const fetchImpl = vi.fn(async () => {
+      events.push("fetch");
+      expect(events).toEqual(["callback:start", "callback:done", "fetch"]);
+      return new Response(new Uint8Array([1]), { status: 200 });
+    }) as unknown as typeof fetch;
+    const beforeProviderDispatch = vi.fn(async () => {
+      events.push("callback:start");
+      await Promise.resolve();
+      events.push("callback:done");
+    });
+
+    await synthesizeCartesiaBytes({
+      apiKey: "cartesia-key",
+      voiceId: "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+      text: "hello",
+      fetch: fetchImpl,
+      beforeProviderDispatch,
+    });
+
+    expect(beforeProviderDispatch).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call REST fetch when the dispatch callback rejects", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(new Uint8Array([1])),
+    ) as unknown as typeof fetch;
+    const beforeProviderDispatch = vi.fn(async () => {
+      throw new Error("dispatch marker unavailable");
+    });
+
+    await expect(
+      synthesizeCartesiaBytes({
+        apiKey: "cartesia-key",
+        voiceId: "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4",
+        text: "hello",
+        fetch: fetchImpl,
+        beforeProviderDispatch,
+      }),
+    ).rejects.toThrow("dispatch marker unavailable");
+    expect(beforeProviderDispatch).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("posts Sonic 3.5 MP3 requests with server auth and streams the response body", async () => {
     const body = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -53,6 +53,9 @@ let elevenLabsStreamFactory = () => {
   });
 };
 const elevenLabsTextToSpeech = mock(async () => elevenLabsStreamFactory());
+const getElevenLabsService = mock(() => ({
+  textToSpeech: elevenLabsTextToSpeech,
+}));
 let allowKokoroFetch = false;
 let cartesiaStatus = 200;
 let cacheBypass = true;
@@ -217,7 +220,7 @@ mock.module("@/lib/services/credits", () => {
 });
 
 mock.module("@/lib/services/elevenlabs", () => ({
-  getElevenLabsService: () => ({ textToSpeech: elevenLabsTextToSpeech }),
+  getElevenLabsService,
 }));
 
 mock.module("@/lib/services/tts-first-line-cache", () => ({
@@ -282,6 +285,10 @@ beforeEach(() => {
   billUsage.mockClear();
   createUsage.mockClear();
   elevenLabsTextToSpeech.mockClear();
+  getElevenLabsService.mockReset();
+  getElevenLabsService.mockImplementation(() => ({
+    textToSpeech: elevenLabsTextToSpeech,
+  }));
   reconcileReservation.mockClear();
   cacheGet.mockClear();
   cacheHas.mockClear();
@@ -585,6 +592,21 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(billUsage).not.toHaveBeenCalled();
     expect(reconcileReservation).toHaveBeenCalledTimes(1);
     expect(reconcileReservation).toHaveBeenCalledWith(0.0012);
+  });
+
+  test("releases the reservation when ElevenLabs service setup fails locally", async () => {
+    getElevenLabsService.mockImplementationOnce(() => {
+      throw new Error("ELEVENLABS_API_KEY is not set");
+    });
+    const response = await postTts({
+      text: "No provider work starts.",
+      voiceId: "custom-elevenlabs-voice",
+    });
+
+    expect(response.status).toBe(500);
+    expect(elevenLabsTextToSpeech).not.toHaveBeenCalled();
+    expect(reconcileReservation).toHaveBeenCalledTimes(1);
+    expect(reconcileReservation).toHaveBeenCalledWith(0);
   });
 
   test("cancels oversized PCM without billing, caching, or a partial WAV", async () => {

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -125,6 +125,14 @@ mock.module("@elizaos/shared/voice/first-sentence-snip", () => ({
   firstSentenceSnip: (text: string) => {
     const normalized = text.trim();
     if (!normalized) return null;
+    if (normalized === "First sentence. Second sentence.") {
+      return {
+        raw: "First sentence.",
+        normalized: "First sentence.",
+        endOffset: "First sentence.".length,
+        wordCount: 2,
+      };
+    }
     return {
       raw: normalized,
       normalized,
@@ -370,6 +378,7 @@ describe("POST /api/v1/voice/tts provider selection", () => {
       provider: "cartesia",
       code: "rate_limit",
     });
+    expect(reconcileReservation).toHaveBeenCalledWith(0.001);
   });
 
   test("treats the proxy-injected legacy default as unpinned when Cartesia is configured", async () => {
@@ -549,7 +558,7 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(reconcileReservation).not.toHaveBeenCalled();
   });
 
-  test("refunds the reservation and never bills malformed PCM", async () => {
+  test("settles unknown and never bills malformed PCM after dispatch", async () => {
     elevenLabsBytes = new Uint8Array([1, 2, 3]);
     const response = await postTts({
       text: "Do not charge failed audio.",
@@ -560,7 +569,22 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(response.status).toBe(500);
     expect(billUsage).not.toHaveBeenCalled();
     expect(reconcileReservation).toHaveBeenCalledTimes(1);
-    expect(reconcileReservation).toHaveBeenCalledWith(0);
+    expect(reconcileReservation).toHaveBeenCalledWith(0.0012);
+  });
+
+  test("settles unknown when ElevenLabs transport fails after dispatch", async () => {
+    elevenLabsTextToSpeech.mockRejectedValueOnce(
+      new TypeError("private provider transport detail"),
+    );
+    const response = await postTts({
+      text: "Do not refund ambiguous work.",
+      voiceId: "custom-elevenlabs-voice",
+    });
+
+    expect(response.status).toBe(500);
+    expect(billUsage).not.toHaveBeenCalled();
+    expect(reconcileReservation).toHaveBeenCalledTimes(1);
+    expect(reconcileReservation).toHaveBeenCalledWith(0.0012);
   });
 
   test("cancels oversized PCM without billing, caching, or a partial WAV", async () => {
@@ -590,10 +614,10 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(oversized.locked).toBe(false);
     expect(billUsage).not.toHaveBeenCalled();
     expect(cachePut).not.toHaveBeenCalled();
-    expect(reconcileReservation).toHaveBeenCalledWith(0);
+    expect(reconcileReservation).toHaveBeenCalledWith(0.0012);
   });
 
-  test("releases failed PCM reads without billing, caching, or a partial WAV", async () => {
+  test("settles unknown after failed PCM reads without billing or caching", async () => {
     const failing = new ReadableStream<Uint8Array>({
       pull() {
         throw new Error("upstream PCM read failed");
@@ -612,7 +636,63 @@ describe("POST /api/v1/voice/tts provider selection", () => {
     expect(failing.locked).toBe(false);
     expect(billUsage).not.toHaveBeenCalled();
     expect(cachePut).not.toHaveBeenCalled();
-    expect(reconcileReservation).toHaveBeenCalledWith(0);
+    expect(reconcileReservation).toHaveBeenCalledWith(0.0012);
+  });
+
+  test("warms the exact whole-input cache from primary bytes without a second synthesis", async () => {
+    cacheBypass = false;
+    const response = await postTts({
+      text: "Cache this exact response.",
+      voiceId: "custom-elevenlabs-voice",
+    });
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array([73, 68, 51]),
+    );
+    await Bun.sleep(0);
+    expect(elevenLabsTextToSpeech).toHaveBeenCalledTimes(1);
+    expect(cacheHas).not.toHaveBeenCalled();
+    expect(cachePut).toHaveBeenCalledTimes(1);
+    const cachePutCalls = cachePut.mock.calls as unknown as [
+      [{ bytes: Uint8Array; rawText: string }],
+    ];
+    expect(cachePutCalls[0]?.[0]).toMatchObject({
+      bytes: new Uint8Array([73, 68, 51]),
+      rawText: "Cache this exact response.",
+    });
+  });
+
+  test("does not warm a partial first sentence or perform a second synthesis", async () => {
+    cacheBypass = false;
+    const response = await postTts({
+      text: "First sentence. Second sentence.",
+      voiceId: "custom-elevenlabs-voice",
+    });
+
+    expect(response.status).toBe(200);
+    await response.arrayBuffer();
+    await Bun.sleep(0);
+    expect(elevenLabsTextToSpeech).toHaveBeenCalledTimes(1);
+    expect(cacheHas).not.toHaveBeenCalled();
+    expect(cachePut).not.toHaveBeenCalled();
+  });
+
+  test("skips oversized cache capture without truncating primary audio", async () => {
+    cacheBypass = false;
+    elevenLabsBytes = new Uint8Array(256 * 1024 + 1).fill(7);
+    const response = await postTts({
+      text: "Keep every generated audio byte.",
+      voiceId: "custom-elevenlabs-voice",
+    });
+
+    expect(response.status).toBe(200);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect(bytes.byteLength).toBe(256 * 1024 + 1);
+    expect(bytes.every((byte) => byte === 7)).toBe(true);
+    await Bun.sleep(0);
+    expect(elevenLabsTextToSpeech).toHaveBeenCalledTimes(1);
+    expect(cachePut).not.toHaveBeenCalled();
   });
 
   // #16425: the client mints one Idempotency-Key per logical utterance (sent

--- a/packages/cloud/api/v1/voice/tts/cartesia-synthesis.ts
+++ b/packages/cloud/api/v1/voice/tts/cartesia-synthesis.ts
@@ -54,8 +54,10 @@ export async function synthesizeCartesiaBytes(args: {
   voiceId: string;
   text: string;
   fetch?: typeof fetch;
+  beforeProviderDispatch?: () => Promise<void>;
 }): Promise<CartesiaBytesResult> {
   const fetchImpl = args.fetch ?? fetch;
+  await args.beforeProviderDispatch?.();
   const response = await fetchImpl(CARTESIA_BYTES_URL, {
     method: "POST",
     headers: {
@@ -127,7 +129,9 @@ function safeCartesiaRestMessage(status: number): string {
  * replays `open`/`message`/`close`/`error` from the accepted socket. The
  * adapter already queues `sendPhrase` until `open`, so a lazy connect is safe.
  */
-export function makeWorkersCartesiaWebSocketFactory(): CartesiaWebSocketFactory {
+export function makeWorkersCartesiaWebSocketFactory(
+  beforeProviderDispatch?: () => Promise<void>,
+): CartesiaWebSocketFactory {
   return (url, options) => {
     const openListeners: Array<() => void> = [];
     const messageListeners: Array<(event: { readonly data: unknown }) => void> =
@@ -148,6 +152,7 @@ export function makeWorkersCartesiaWebSocketFactory(): CartesiaWebSocketFactory 
 
     (async () => {
       try {
+        await beforeProviderDispatch?.();
         const response = await fetch(httpUrl, {
           headers: { ...options.headers, Upgrade: "websocket" },
         });
@@ -257,12 +262,14 @@ export async function synthesizeCartesiaWav(args: {
   maxPcmBytes: number;
   webSocketFactory?: CartesiaWebSocketFactory;
   timeoutMs?: number;
+  beforeProviderDispatch?: () => Promise<void>;
 }): Promise<CartesiaWavResult> {
   const adapter = new CartesiaSonicTtsAdapter({
     apiKey: args.apiKey,
     voiceId: args.voiceId,
     websocketFactory:
-      args.webSocketFactory ?? makeWorkersCartesiaWebSocketFactory(),
+      args.webSocketFactory ??
+      makeWorkersCartesiaWebSocketFactory(args.beforeProviderDispatch),
     sampleRate: args.sampleRate,
     encoding: "pcm_s16le",
   });

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -698,8 +698,10 @@ async function __hono_POST(c: AppContext) {
     let synthesisEngine: "elevenlabs" | "cartesia" = "elevenlabs";
     let cartesiaMp3ContentType = "audio/mpeg";
     settlementProvider = providerSelection.provider;
-    await markProviderDispatched?.();
-    providerWorkMayHaveStarted = true;
+    const markPaidTtsProviderDispatch = async () => {
+      await markProviderDispatched?.();
+      providerWorkMayHaveStarted = true;
+    };
     if (cartesiaEligible && cartesiaApiKey) {
       if (wantWav) {
         const cartesia = await synthesizeCartesiaWav({
@@ -708,6 +710,7 @@ async function __hono_POST(c: AppContext) {
           text,
           sampleRate: WAV_PCM_SAMPLE_RATE,
           maxPcmBytes: MAX_CARTESIA_PCM_BYTES,
+          beforeProviderDispatch: markPaidTtsProviderDispatch,
         });
         wav = cartesia.wav;
         synthesisEngine = "cartesia";
@@ -745,6 +748,7 @@ async function __hono_POST(c: AppContext) {
           apiKey: cartesiaApiKey,
           voiceId: cartesiaVoiceId,
           text,
+          beforeProviderDispatch: markPaidTtsProviderDispatch,
         });
         audioStream = cartesia.body;
         cartesiaMp3ContentType = cartesia.contentType;
@@ -755,6 +759,7 @@ async function __hono_POST(c: AppContext) {
     if (wav === undefined) {
       if (audioStream === undefined) {
         const elevenlabs = getElevenLabsService(env);
+        await markPaidTtsProviderDispatch();
         audioStream = await elevenlabs.textToSpeech({
           text,
           voiceId,

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -162,6 +162,44 @@ function resolveCartesiaVoiceId(env: AppEnv["Bindings"]): string {
 const MAX_CARTESIA_PCM_BYTES = 16 * 1024 * 1024;
 
 /**
+ * Keep cache capture below the cache service's per-entry ceiling. Exceeding
+ * this limit cancels only the tee used for cache population; the caller's
+ * primary stream remains complete and unmodified.
+ */
+const MAX_FIRST_LINE_CACHE_CAPTURE_BYTES = 256 * 1024;
+
+async function captureExactAudioForCache(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      if (!result.value) continue;
+      total += result.value.byteLength;
+      if (total > MAX_FIRST_LINE_CACHE_CAPTURE_BYTES) {
+        await reader.cancel("TTS cache capture exceeded the per-entry limit");
+        return null;
+      }
+      chunks.push(result.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (total === 0) return null;
+  const merged = new Uint8Array(new ArrayBuffer(total));
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}
+
+/**
  * POST /api/v1/voice/tts
  * Converts text to speech using the voice synthesis service.
  * Supports custom user voices and tracks usage statistics.
@@ -174,6 +212,10 @@ async function __hono_POST(c: AppContext) {
   let reservation: CreditReservation | undefined;
   let settleUnknown: (() => Promise<unknown>) | undefined;
   let markProviderDispatched: (() => Promise<void>) | undefined;
+  let providerWorkMayHaveStarted = false;
+  let settlementOrganizationId = "unavailable";
+  let settlementProvider = "unknown";
+  let settlementUserId = "unavailable";
   const request = c.req.raw;
   const env = c.env;
   const requestStart = Date.now();
@@ -262,6 +304,8 @@ async function __hono_POST(c: AppContext) {
       organizationId: () => user.organization_id,
       credential: () => credential,
     });
+    settlementOrganizationId = user.organization_id;
+    settlementUserId = user.id;
     timings.authMs = Date.now() - requestStart;
     const admissionStart = Date.now();
     if (pendingResponse) return pendingResponse;
@@ -653,7 +697,9 @@ async function __hono_POST(c: AppContext) {
     let audioStream: ReadableStream<Uint8Array> | undefined;
     let synthesisEngine: "elevenlabs" | "cartesia" = "elevenlabs";
     let cartesiaMp3ContentType = "audio/mpeg";
+    settlementProvider = providerSelection.provider;
     await markProviderDispatched?.();
+    providerWorkMayHaveStarted = true;
     if (cartesiaEligible && cartesiaApiKey) {
       if (wantWav) {
         const cartesia = await synthesizeCartesiaWav({
@@ -807,16 +853,20 @@ async function __hono_POST(c: AppContext) {
     if (executionCtx) executionCtx.waitUntil(billingTask);
     else void billingTask;
 
-    // ---------------------------------------------------------------------
-    // First-line cache populate path.
-    //
-    // Re-synthesise JUST the snipped first sentence and store it (the
-    // already-streamed-out bytes can't be sliced reliably at sentence
-    // boundaries — mp3 frames aren't aligned). The fan-out is bounded by
-    // the ≤ 10-word snip cap and skipped entirely on bypass / no-snip.
-    // ---------------------------------------------------------------------
-    if (!wantWav && snipResult && !cacheBypass) {
-      void (async () => {
+    // Populate only when the cache key describes the complete input. Tee the
+    // already-produced provider stream so cache warming never performs a
+    // second, unmetered synthesis. Partial first sentences are deliberately
+    // not warmed because MP3 frames cannot be sliced losslessly.
+    if (
+      !wantWav &&
+      audioStream &&
+      snipResult &&
+      !cacheBypass &&
+      snipResult.endOffset === text.trimEnd().length
+    ) {
+      const [responseStream, cacheStream] = audioStream.tee();
+      audioStream = responseStream;
+      const cacheTask = (async () => {
         try {
           const cacheService = getCloudFirstLineCacheService();
           const cacheKey = {
@@ -830,37 +880,14 @@ async function __hono_POST(c: AppContext) {
             normalizedText: snipResult.normalized,
             scope: cacheScope,
           };
-          if (await cacheService.has(cacheKey)) return;
-          const snipStream =
-            synthesisEngine === "cartesia" && cartesiaApiKey
-              ? (
-                  await synthesizeCartesiaBytes({
-                    apiKey: cartesiaApiKey,
-                    voiceId: cartesiaVoiceId,
-                    text: snipResult.raw,
-                  })
-                ).body
-              : await getElevenLabsService(env).textToSpeech({
-                  text: snipResult.raw,
-                  voiceId,
-                  modelId,
-                });
-          const reader = snipStream.getReader();
-          const chunks: Uint8Array[] = [];
-          let total = 0;
-          while (true) {
-            const r = await reader.read();
-            if (r.done) break;
-            const chunk = r.value as Uint8Array;
-            chunks.push(chunk);
-            total += chunk.byteLength;
-          }
-          if (total === 0) return;
-          const merged = new Uint8Array(total);
-          let off = 0;
-          for (const c of chunks) {
-            merged.set(c, off);
-            off += c.byteLength;
+          const merged = await captureExactAudioForCache(cacheStream);
+          if (!merged) {
+            logger.info("[Voice TTS API] first-line cache capture skipped", {
+              provider: synthesisEngine,
+              reason: "empty_or_over_entry_limit",
+              traceId: c.get("traceId") ?? c.get("requestId") ?? "unavailable",
+            });
+            return;
           }
           await cacheService.put({
             ...cacheKey,
@@ -871,14 +898,20 @@ async function __hono_POST(c: AppContext) {
             wordCount: snipResult.wordCount,
           });
           logger.info(
-            `[Voice TTS API] first-line cache POPULATE ok (${cacheScope}, ${total}B, words=${snipResult.wordCount})`,
+            `[Voice TTS API] first-line cache POPULATE ok (${cacheScope}, ${merged.byteLength}B, words=${snipResult.wordCount})`,
           );
         } catch (err) {
+          // error-policy:J7 cache population is an off-response-path
+          // optimization; failures are observable and never alter audio.
           logger.warn?.("[Voice TTS API] first-line cache populate failed", {
             errorType: err instanceof Error ? err.name : "unknown",
+            provider: synthesisEngine,
+            traceId: c.get("traceId") ?? c.get("requestId") ?? "unavailable",
           });
         }
       })();
+      if (executionCtx) executionCtx.waitUntil(cacheTask);
+      else void cacheTask;
     }
 
     // WAV path: raw PCM (Cartesia frames or the ElevenLabs PCM stream)
@@ -915,11 +948,23 @@ async function __hono_POST(c: AppContext) {
     });
 
     if (reservation) {
-      const release = reservation.reconcile(0);
+      const settlement =
+        providerWorkMayHaveStarted && settleUnknown
+          ? settleUnknown()
+          : reservation.reconcile(0);
       const executionCtx = getGenerativeExecutionContext(c);
-      if (executionCtx) executionCtx.waitUntil(release);
-      else await release;
-      logger.info("[Voice TTS API] Released credits after error");
+      if (executionCtx) executionCtx.waitUntil(settlement);
+      else await settlement;
+      logger.warn("[Voice TTS API] Settled failed paid synthesis", {
+        organizationId: settlementOrganizationId,
+        provider: settlementProvider,
+        providerDispatchState: providerWorkMayHaveStarted
+          ? "possibly_dispatched"
+          : "not_dispatched",
+        settlement: providerWorkMayHaveStarted ? "unknown" : "released",
+        traceId: c.get("traceId") ?? c.get("requestId") ?? "unavailable",
+        userId: settlementUserId,
+      });
     }
 
     const apiError =


### PR DESCRIPTION
Closes #30356

## What changed
- conservatively calls `settleUnknown()` for Deepgram, Cartesia, and ElevenLabs STT failures after provider dispatch is marked, while retaining zero-cost release before dispatch
- applies the same post-dispatch settlement rule to paid TTS failures and emits correlated, redacted settlement logs
- removes the second unmetered TTS synthesis used for cache warming
- populates only exact whole-input MP3 cache entries from a bounded tee of the primary audio stream; partial sentences are not warmed and oversized captures leave primary audio complete

## Verification
- `bun test packages/cloud/api/v1/voice/stt/route.test.ts` (72 pass, 1 live test skipped)
- focused TTS settlement/cache tests (8 pass)
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd packages/cloud/api build`
- `bun run --cwd packages/cloud/api lint`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd packages/cloud/api typecheck` (includes router contract and Worker dry-run bundle)