### PR TITLE
fix(ci): restore develop cloud contracts

### DIFF
--- a/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
@@ -40,12 +40,14 @@ describe("Personal Shared Telegram edge deploy contract", () => {
   const prepare = namedStep("Prepare Worker secrets for atomic deploy");
 
   test("sources both Telegram credentials from the protected environment", () => {
-    expect(prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toContain(
-      "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
-    );
-    expect(prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toContain(
-      "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
-    );
+    const token = prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN ?? "";
+    const webhookSecret = prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET ?? "";
+    expect(token).toContain("secrets[format(");
+    expect(token).toContain("'ELIZA_APP_TELEGRAM_'");
+    expect(token).toContain("'BOT_TOKEN'");
+    expect(webhookSecret).toContain("secrets[format(");
+    expect(webhookSecret).toContain("'ELIZA_APP_TELEGRAM_'");
+    expect(webhookSecret).toContain("'WEBHOOK_SECRET'");
   });
 
   test("includes both credentials in the atomic Worker version", () => {

--- a/packages/cloud/scripts/__tests__/telegram-identity-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/telegram-identity-deploy-contract.test.ts
@@ -46,7 +46,7 @@ function expectBashSyntax(step: WorkflowStep): void {
 }
 
 describe("protected Telegram identity workflow contract", () => {
-  test("Cloudflare preflight attests the selected identity before migration or deploy", () => {
+  test("Cloudflare preflight admits the selected identity before migration or deploy", () => {
     const release = workflow("cloud-cf-release.yml");
     const resolver = release.jobs["resolve-pages-environment-config"];
     const migrate = release.jobs["migrate-db"];
@@ -56,34 +56,30 @@ describe("protected Telegram identity workflow contract", () => {
 
     const select = namedStep(
       resolver,
-      "Validate Telegram public identity preflight",
-    );
-    const attest = namedStep(
-      resolver,
-      "Attest protected Telegram runtime identity",
-    );
-    expect(resolver.steps.indexOf(attest)).toBeGreaterThan(
-      resolver.steps.indexOf(select),
+      "Validate caller-admitted Telegram public identity",
     );
     expect(migrate.needs).toBe("resolve-pages-environment-config");
-    expect(attest.env).toMatchObject({
-      TELEGRAM_BOT_TOKEN: expect.stringContaining(
-        "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
+    expect(select.env).toMatchObject({
+      RELEASE_RUN_ATTEMPT: expect.stringContaining("github.run_attempt"),
+      TARGET_ENVIRONMENT: expect.stringContaining("inputs.target_environment"),
+      TELEGRAM_AUTHORITY_RUN_ATTEMPT: expect.stringContaining(
+        "inputs.telegram_authority_run_attempt",
       ),
-      TELEGRAM_WEBHOOK_SECRET: expect.stringContaining(
-        "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+      ADMITTED_TELEGRAM_BOT_ID: expect.stringContaining(
+        "inputs.admitted_telegram_bot_id",
       ),
-      TELEGRAM_EXPECTED_BOT_ID: expect.stringContaining(
-        "steps.telegram.outputs.bot_id",
+      ADMITTED_TELEGRAM_BOT_USERNAME: expect.stringContaining(
+        "inputs.admitted_telegram_bot_username",
       ),
-      TELEGRAM_EXPECTED_BOT_USERNAME: expect.stringContaining(
-        "steps.telegram.outputs.bot_username",
+      TELEGRAM_RUNTIME_AUTHORITY: expect.stringContaining(
+        "inputs.telegram_runtime_authority",
       ),
     });
-    expect(attest.run).toContain("verify-telegram-bot-identity.mjs");
     expect(select.run).toContain("packages/homepage/src/lib/contact.ts");
-    expect(select.run).toContain("ENVIRONMENT_TELEGRAM_BOT_ID");
-    expect(select.run).toContain("TELEGRAM_IDENTITY_AUTHORITY_SHA256");
+    expect(select.run).toContain("TELEGRAM_AUTHORITY_RUN_ATTEMPT");
+    expect(select.run).toContain("TELEGRAM_RUNTIME_AUTHORITY");
+    expect(select.run).toContain("ADMITTED_TELEGRAM_BOT_ID");
+    expect(select.run).toContain("ADMITTED_TELEGRAM_BOT_USERNAME");
 
     const prepare = namedStep(
       deploy,
@@ -95,7 +91,10 @@ describe("protected Telegram identity workflow contract", () => {
       "Verify deployed Telegram identity readiness",
     );
     expect(prepare.run).toContain(
-      "Required protected $DEPLOY_ENVIRONMENT Telegram secret is absent or blank",
+      "Required protected production Telegram secret is absent or blank",
+    );
+    expect(prepare.run).toContain(
+      "Staging can preserve the existing Telegram credentials",
     );
     expect(prepare.run).toContain('queue_secret "$name"');
     expect(publish.run).toContain("ELIZA_APP_TELEGRAM_BOT_ID");

--- a/packages/cloud/scripts/admin/sync-api-dev-vars.ts
+++ b/packages/cloud/scripts/admin/sync-api-dev-vars.ts
@@ -258,7 +258,12 @@ if (process.env.PLAYWRIGHT_TEST_AUTH === "true") {
 
   env.TEST_DATABASE_URL = testDatabaseUrl;
   env.DATABASE_URL = testDatabaseUrl;
-  env.CACHE_ENABLED = "false";
+  // Wallet-header authentication consumes an atomic replay nonce before it
+  // can reach route authorization. The local Worker therefore needs the
+  // explicit test-only memory backend; disabling cache makes every valid
+  // signed request fail closed as a misleading 401.
+  env.CACHE_ENABLED = "true";
+  env.CACHE_BACKEND = "memory";
   env.RATE_LIMIT_DISABLED = "true";
 }
 

--- a/packages/scripts/__tests__/repository-ruleset-contract.test.ts
+++ b/packages/scripts/__tests__/repository-ruleset-contract.test.ts
@@ -31,6 +31,7 @@ describe("repository ruleset contract", () => {
     expect(Object.keys(admission.jobs)).toEqual([
       "source-smoke",
       "billing-payment-replay-e2e",
+      "subscription-authority-postgres",
       "browser-bridge-windows-security",
       "static-smoke",
     ]);
@@ -38,6 +39,7 @@ describe("repository ruleset contract", () => {
       "source-smoke",
       "browser-bridge-windows-security",
       "billing-payment-replay-e2e",
+      "subscription-authority-postgres",
     ]);
     expect(admission.jobs["billing-payment-replay-e2e"].needs).toBeUndefined();
     expect(admission.jobs["browser-bridge-windows-security"].uses).toBe(


### PR DESCRIPTION
Closes #30361. Aligns the protected Telegram and PR-admission contract tests with the already-landed workflow definitions. It also restores a test-only in-memory cache for PLAYWRIGHT_TEST_AUTH so valid wallet signatures can atomically claim replay nonces and reach the intended authorization branch instead of deterministically failing closed as 401. Focused workflow contracts pass 9/9; generated dev vars prove CACHE_BACKEND=memory and CACHE_ENABLED=true. The broader local script lane was stopped after unrelated generated i18n artifacts were absent because this isolated install intentionally skipped lifecycle scripts; hosted exact-head lanes remain authoritative.