### PR TITLE
fix(cloud): preserve paid media settlements

### DIFF
--- a/packages/cloud/api/fal/proxy/route.standing.test.ts
+++ b/packages/cloud/api/fal/proxy/route.standing.test.ts
@@ -5,9 +5,12 @@ import { Hono } from "hono";
 import { ApiError } from "@/lib/api/cloud-worker-errors";
 import * as aiPricingActual from "@/lib/services/ai-pricing";
 
-const invokeFalProxy = mock(
-  async () => new Response("upstream", { status: 200 }),
-);
+let falResponseStatus = 200;
+let falProxyError: Error | null = null;
+const invokeFalProxy = mock(async () => {
+  if (falProxyError) throw falProxyError;
+  return new Response("upstream", { status: falResponseStatus });
+});
 let routeCallerError: ApiError | null = new ApiError(
   403,
   "access_denied",
@@ -15,8 +18,18 @@ let routeCallerError: ApiError | null = new ApiError(
   { reason: "account_inactive" },
 );
 let admissionError: ApiError | null = null;
+let admissionEnabled = false;
+let dispatchReceiptError: Error | null = null;
+const settle = mock(async (_cost: number) => undefined);
+const settleUnknown = mock(async () => undefined);
+const markProviderDispatched = mock(async () => {
+  if (dispatchReceiptError) throw dispatchReceiptError;
+});
 const admitFlatGenerativeOperation = mock(async () => {
   if (admissionError) throw admissionError;
+  if (admissionEnabled) {
+    return { settle, settleUnknown, markProviderDispatched };
+  }
   throw new Error("unexpected admission success");
 });
 const requireGenerativeRouteCaller = mock(async () => {
@@ -65,6 +78,12 @@ const { default: falRoute } = await import("./route");
 const app = new Hono().route("/fal/proxy", falRoute);
 
 test("standing denial prevents fal pricing, credit admission, and provider dispatch", async () => {
+  routeCallerError = new ApiError(403, "access_denied", "Account is inactive", {
+    reason: "account_inactive",
+  });
+  admissionError = null;
+  admissionEnabled = false;
+  invokeFalProxy.mockClear();
   const response = await app.request("/fal/proxy", {
     method: "POST",
     headers: {
@@ -107,4 +126,87 @@ test("combined credential denial is returned before fal provider dispatch", asyn
     details: { reason: "credential_inactive" },
   });
   expect(invokeFalProxy).not.toHaveBeenCalled();
+});
+
+test("ambiguous fal rejection after dispatch uses conservative settlement", async () => {
+  routeCallerError = null;
+  admissionError = null;
+  admissionEnabled = true;
+  dispatchReceiptError = null;
+  falProxyError = null;
+  falResponseStatus = 503;
+  invokeFalProxy.mockClear();
+  settle.mockClear();
+  settleUnknown.mockClear();
+  markProviderDispatched.mockClear();
+
+  const response = await app.request("/fal/proxy", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fal-target-url": "fal-ai/veo3",
+    },
+    body: "{}",
+  });
+
+  expect(response.status).toBe(503);
+  expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+  expect(invokeFalProxy).toHaveBeenCalledTimes(1);
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
+  expect(settle).not.toHaveBeenCalled();
+});
+
+test("fal transport exception after dispatch uses conservative settlement", async () => {
+  routeCallerError = null;
+  admissionError = null;
+  admissionEnabled = true;
+  dispatchReceiptError = null;
+  falProxyError = new Error("connection closed after submit");
+  falResponseStatus = 200;
+  invokeFalProxy.mockClear();
+  settle.mockClear();
+  settleUnknown.mockClear();
+  markProviderDispatched.mockClear();
+
+  const response = await app.request("/fal/proxy", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fal-target-url": "fal-ai/veo3",
+    },
+    body: "{}",
+  });
+
+  expect(response.status).toBe(500);
+  expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+  expect(invokeFalProxy).toHaveBeenCalledTimes(1);
+  expect(settleUnknown).toHaveBeenCalledTimes(1);
+  expect(settle).not.toHaveBeenCalled();
+});
+
+test("fal dispatch receipt failure releases before provider invocation", async () => {
+  routeCallerError = null;
+  admissionError = null;
+  admissionEnabled = true;
+  dispatchReceiptError = new Error("dispatch receipt unavailable");
+  falProxyError = null;
+  falResponseStatus = 200;
+  invokeFalProxy.mockClear();
+  settle.mockClear();
+  settleUnknown.mockClear();
+  markProviderDispatched.mockClear();
+
+  const response = await app.request("/fal/proxy", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-fal-target-url": "fal-ai/veo3",
+    },
+    body: "{}",
+  });
+
+  expect(response.status).toBe(500);
+  expect(invokeFalProxy).not.toHaveBeenCalled();
+  expect(settle).toHaveBeenCalledWith(0);
+  expect(settleUnknown).not.toHaveBeenCalled();
 });

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -181,11 +181,23 @@ const handle: Handler<AppEnv> = async (c) => {
     null;
   let pendingResponse: Response | undefined;
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
+  let providerDispatchStarted = false;
+  let settlementContext:
+    | {
+        requestId: string;
+        organizationId: string;
+        userId: string;
+        model: string;
+        provider: "fal";
+      }
+    | undefined;
 
   if (willAdmitMutation) {
     try {
       pricedMutation = await priceFalMutation(c);
     } catch (error) {
+      // error-policy:J1 translate pricing input and catalog failures at the
+      // route boundary before any credit admission or provider dispatch.
       if (error instanceof Error && error.message === "missing_target") {
         pendingResponse = c.json({ error: "Invalid request" }, 400);
       } else if (
@@ -219,6 +231,7 @@ const handle: Handler<AppEnv> = async (c) => {
 
     if (pricedMutation) {
       try {
+        const requestId = `fal-proxy:${crypto.randomUUID()}`;
         const billingContext: BillingContext = {
           organizationId: caller.user.organization_id,
           userId: caller.user.id,
@@ -226,8 +239,15 @@ const handle: Handler<AppEnv> = async (c) => {
           model: pricedMutation.model,
           provider: "fal",
           billingSource: "fal",
-          requestId: `fal-proxy:${crypto.randomUUID()}`,
+          requestId,
           description: `fal.ai ${pricedMutation.model}`,
+        };
+        settlementContext = {
+          requestId,
+          organizationId: caller.user.organization_id,
+          userId: caller.user.id,
+          model: pricedMutation.model,
+          provider: "fal",
         };
         admission = await admitFlatGenerativeOperation({
           c,
@@ -256,20 +276,50 @@ const handle: Handler<AppEnv> = async (c) => {
 
     try {
       await admission?.markProviderDispatched?.();
+      providerDispatchStarted = true;
       const response = await invokeFalProxy(c);
 
       if (admission && pricedMutation) {
+        if (!response.ok) {
+          logger.error(
+            "[fal proxy] Provider returned an ambiguous post-dispatch failure",
+            {
+              ...settlementContext,
+              providerStatus: response.status,
+              settlementMode: "unknown",
+            },
+          );
+        }
         await retainFalSettlement(
           c,
-          admission.settle(response.ok ? pricedMutation.cost.totalCost : 0),
-          response.ok ? "settle" : "release",
+          response.ok
+            ? admission.settle(pricedMutation.cost.totalCost)
+            : admission.settleUnknown(),
+          response.ok ? "settle" : "settle_unknown",
+          settlementContext,
         );
       }
 
       return response;
     } catch (error) {
+      // error-policy:J1 translate the provider boundary only after preserving
+      // the admitted mutation's post-dispatch accounting outcome.
       if (admission) {
-        await retainFalSettlement(c, admission.settle(0), "release");
+        const settlementMode = providerDispatchStarted ? "unknown" : "release";
+        logger.error("[fal proxy] Mutation failed after admission", {
+          ...settlementContext,
+          providerDispatchStarted,
+          settlementMode,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await retainFalSettlement(
+          c,
+          providerDispatchStarted
+            ? admission.settleUnknown()
+            : admission.settle(0),
+          providerDispatchStarted ? "settle_unknown" : "release",
+          settlementContext,
+        );
       }
       throw error;
     }
@@ -281,12 +331,21 @@ const handle: Handler<AppEnv> = async (c) => {
 async function retainFalSettlement(
   c: Context<AppEnv>,
   settlement: Promise<unknown>,
-  operation: "settle" | "release",
+  operation: "settle" | "settle_unknown" | "release",
+  context?: {
+    requestId: string;
+    organizationId: string;
+    userId: string;
+    model: string;
+    provider: "fal";
+  },
 ): Promise<void> {
   const observed = settlement.catch((error) => {
     // error-policy:J7 settlement diagnostics must not replace the provider
     // response; the durable reservation sweep remains the recovery boundary.
     logger.error(`[fal proxy] Failed to ${operation} inference admission`, {
+      ...context,
+      settlementMode: operation,
       error: error instanceof Error ? error.message : String(error),
     });
   });

--- a/packages/cloud/api/v1/generate-music/route.json.test.ts
+++ b/packages/cloud/api/v1/generate-music/route.json.test.ts
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const assertSafeForPublicUse = mock(async () => undefined);
 let providerError: Error | null = null;
 let dispatchReceiptError: Error | null = null;
+let generationReceiptError: Error | null = null;
+let billingError: Error | null = null;
+let conservativeSettlementError: Error | null = null;
+let captureBackgroundTasks = false;
+const backgroundTasks: Promise<unknown>[] = [];
+const events: string[] = [];
 const generateAudio = mock(async () => {
   if (providerError) throw providerError;
   return {
@@ -22,6 +28,17 @@ const markProviderDispatched = mock(async () => {
 });
 const settle = mock(async (_cost: number) => undefined);
 const settleUnknown = mock(async () => undefined);
+const createGeneration = mock(async () => {
+  events.push("generation-receipt");
+  if (generationReceiptError) throw generationReceiptError;
+  return { id: "gen-music" };
+});
+const billFlatUsage = mock(async () => {
+  events.push("exact-settlement");
+  if (billingError) throw billingError;
+  return { totalCost: 0.18 };
+});
+const loggerError = mock(() => undefined);
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   requireGenerativeRouteCaller: async () => ({
@@ -36,7 +53,14 @@ mock.module("@/api-app/lib/generative-route-auth", () => ({
     markProviderDispatched,
   }),
   asGenerativeCacheApiError: () => null,
-  getGenerativeExecutionContext: () => undefined,
+  getGenerativeExecutionContext: () =>
+    captureBackgroundTasks
+      ? {
+          waitUntil(task: Promise<unknown>) {
+            backgroundTasks.push(task);
+          },
+        }
+      : undefined,
   getGenerativePricingCacheOptions: () => ({}),
 }));
 
@@ -45,7 +69,7 @@ mock.module("@/lib/services/content-safety", () => ({
 }));
 
 mock.module("@/lib/services/ai-billing", () => ({
-  billFlatUsage: async () => ({ totalCost: 0.18 }),
+  billFlatUsage,
 }));
 
 mock.module("@/lib/services/ai-pricing", () => ({
@@ -61,7 +85,7 @@ mock.module("@/lib/services/credits", () => ({
 }));
 
 mock.module("@/lib/services/generations", () => ({
-  generationsService: { create: async () => ({ id: "gen-music" }) },
+  generationsService: { create: createGeneration },
 }));
 
 mock.module("@/lib/providers/audio/registry", () => ({
@@ -76,7 +100,7 @@ mock.module("@/lib/utils/logger", () => ({
   logger: {
     info: () => undefined,
     warn: () => undefined,
-    error: () => undefined,
+    error: loggerError,
     debug: () => undefined,
   },
 }));
@@ -92,11 +116,23 @@ describe("POST /api/v1/generate-music malformed JSON", () => {
   beforeEach(() => {
     providerError = null;
     dispatchReceiptError = null;
+    generationReceiptError = null;
+    billingError = null;
+    conservativeSettlementError = null;
+    captureBackgroundTasks = false;
+    backgroundTasks.length = 0;
+    events.length = 0;
     assertSafeForPublicUse.mockClear();
     generateAudio.mockClear();
     markProviderDispatched.mockClear();
     settle.mockClear();
     settleUnknown.mockClear();
+    settleUnknown.mockImplementation(async () => {
+      if (conservativeSettlementError) throw conservativeSettlementError;
+    });
+    createGeneration.mockClear();
+    billFlatUsage.mockClear();
+    loggerError.mockClear();
   });
 
   test("returns 400 instead of 500 and never admits generation", async () => {
@@ -163,5 +199,78 @@ describe("POST /api/v1/generate-music malformed JSON", () => {
     expect(generateAudio).not.toHaveBeenCalled();
     expect(settle).toHaveBeenCalledWith(0);
     expect(settleUnknown).not.toHaveBeenCalled();
+  });
+
+  test("persists the completed receipt before exact settlement and returning its id", async () => {
+    captureBackgroundTasks = true;
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { FAL_KEY: "fal-test-key" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      id: expect.any(String),
+    });
+    await Promise.all(backgroundTasks);
+    expect(events).toEqual(["generation-receipt", "exact-settlement"]);
+  });
+
+  test("fails the request and conservatively settles when the completed receipt cannot persist", async () => {
+    generationReceiptError = new Error("generation receipt unavailable");
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { FAL_KEY: "fal-test-key" },
+    );
+
+    expect(response.status).toBe(500);
+    expect(createGeneration).toHaveBeenCalledTimes(1);
+    expect(billFlatUsage).not.toHaveBeenCalled();
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+  });
+
+  test("retains both diagnostics and resolves the task when exact and conservative settlement fail", async () => {
+    captureBackgroundTasks = true;
+    billingError = new Error("exact settlement unavailable");
+    conservativeSettlementError = new Error(
+      "conservative settlement unavailable",
+    );
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { FAL_KEY: "fal-test-key" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(Promise.all(backgroundTasks)).resolves.toBeArray();
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+    expect(loggerError).toHaveBeenCalledWith(
+      "[GenerateMusic] Background exact settlement failed",
+      expect.objectContaining({
+        organizationId: "org-1",
+        settlementMode: "unknown",
+        error: "exact settlement unavailable",
+      }),
+    );
+    expect(loggerError).toHaveBeenCalledWith(
+      "[GenerateMusic] Conservative settlement also failed",
+      expect.objectContaining({
+        organizationId: "org-1",
+        settlementMode: "unknown",
+        error: "conservative settlement unavailable",
+      }),
+    );
   });
 });

--- a/packages/cloud/api/v1/generate-music/route.json.test.ts
+++ b/packages/cloud/api/v1/generate-music/route.json.test.ts
@@ -1,18 +1,27 @@
 /** Verifies the music generation request boundary with deterministic provider mocks. */
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const assertSafeForPublicUse = mock(async () => undefined);
-const generateAudio = mock(async () => ({
-  source: "hosted",
-  url: "https://v3b.fal.media/files/music-output.mp3",
-  fileName: "music-output.mp3",
-  fileSize: 1234,
-  contentType: "audio/mpeg",
-  requestId: "req-music",
-  status: "completed",
-  raw: {},
-}));
-const markProviderDispatched = mock(async () => undefined);
+let providerError: Error | null = null;
+let dispatchReceiptError: Error | null = null;
+const generateAudio = mock(async () => {
+  if (providerError) throw providerError;
+  return {
+    source: "hosted" as const,
+    url: "https://v3b.fal.media/files/music-output.mp3",
+    fileName: "music-output.mp3",
+    fileSize: 1234,
+    contentType: "audio/mpeg",
+    requestId: "req-music",
+    status: "completed",
+    raw: {},
+  };
+});
+const markProviderDispatched = mock(async () => {
+  if (dispatchReceiptError) throw dispatchReceiptError;
+});
+const settle = mock(async (_cost: number) => undefined);
+const settleUnknown = mock(async () => undefined);
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   requireGenerativeRouteCaller: async () => ({
@@ -22,8 +31,8 @@ mock.module("@/api-app/lib/generative-route-auth", () => ({
   }),
   admitFlatGenerativeOperation: async () => ({
     reservation: { reconcile: async () => undefined },
-    settle: async () => undefined,
-    settleUnknown: async () => undefined,
+    settle,
+    settleUnknown,
     markProviderDispatched,
   }),
   asGenerativeCacheApiError: () => null,
@@ -80,6 +89,16 @@ const validBody = {
 };
 
 describe("POST /api/v1/generate-music malformed JSON", () => {
+  beforeEach(() => {
+    providerError = null;
+    dispatchReceiptError = null;
+    assertSafeForPublicUse.mockClear();
+    generateAudio.mockClear();
+    markProviderDispatched.mockClear();
+    settle.mockClear();
+    settleUnknown.mockClear();
+  });
+
   test("returns 400 instead of 500 and never admits generation", async () => {
     const response = await app.request(
       "/",
@@ -109,5 +128,40 @@ describe("POST /api/v1/generate-music malformed JSON", () => {
     );
     expect(response.status).toBe(200);
     expect(generateAudio).toHaveBeenCalled();
+  });
+
+  test("conservatively settles an ambiguous provider failure after dispatch", async () => {
+    providerError = new Error("provider transport closed after submit");
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { FAL_KEY: "fal-test-key" },
+    );
+
+    expect(response.status).toBe(500);
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+    expect(generateAudio).toHaveBeenCalledTimes(1);
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+    expect(settle).not.toHaveBeenCalled();
+  });
+
+  test("releases the reservation when the dispatch receipt fails before provider invocation", async () => {
+    dispatchReceiptError = new Error("dispatch receipt unavailable");
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { FAL_KEY: "fal-test-key" },
+    );
+
+    expect(response.status).toBe(500);
+    expect(generateAudio).not.toHaveBeenCalled();
+    expect(settle).toHaveBeenCalledWith(0);
+    expect(settleUnknown).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -148,6 +148,17 @@ app.post("/", async (c) => {
   // NOT hit the catch's reconcile(0) — which is non-idempotent and would refund
   // the already-correct charge, giving free music. Mirrors generate-image.
   let chargeSettled = false;
+  let providerDispatchStarted = false;
+  let settlementContext:
+    | {
+        requestId: string;
+        organizationId: string;
+        userId: string;
+        model: string;
+        provider: string;
+        billingSource: string;
+      }
+    | undefined;
 
   try {
     const decodedRawBody = await decodeRequestJson(c.req);
@@ -301,6 +312,7 @@ app.post("/", async (c) => {
         cache: getGenerativePricingCacheOptions(c),
       }),
     ]);
+    const billingRequestId = `generate-music:${crypto.randomUUID()}`;
     const billingContext: BillingContext = {
       organizationId: user.organization_id,
       userId: user.id,
@@ -308,9 +320,17 @@ app.post("/", async (c) => {
       model: request.model,
       provider: definition.provider,
       billingSource: definition.billingSource,
-      requestId: `generate-music:${crypto.randomUUID()}`,
+      requestId: billingRequestId,
       affiliateCode: c.req.header("X-Affiliate-Code"),
       description: `Music generation: ${request.model}`,
+    };
+    settlementContext = {
+      requestId: billingRequestId,
+      organizationId: user.organization_id,
+      userId: user.id,
+      model: request.model,
+      provider: definition.provider,
+      billingSource: definition.billingSource,
     };
 
     try {
@@ -336,10 +356,12 @@ app.post("/", async (c) => {
       throw error;
     }
 
+    const audioProvider = getAudioProvider(definition.billingSource);
     await admission.markProviderDispatched?.();
     let generated: GeneratedAudio;
     try {
-      generated = await getAudioProvider(definition.billingSource).generate({
+      providerDispatchStarted = true;
+      generated = await audioProvider.generate({
         kind: "music",
         model: request.model,
         prompt: request.prompt,
@@ -369,7 +391,7 @@ app.post("/", async (c) => {
       });
     } catch (error) {
       // error-policy:J2 breaker accounting for the health gate above, then the
-      // unchanged error proceeds to the route boundary (refund + failureResponse).
+      // unchanged error proceeds to the route boundary for conservative settlement.
       recordGenerativeFailure(
         providerHealthKey,
         classifyGenerativeFailure(error),
@@ -458,11 +480,25 @@ app.post("/", async (c) => {
       cost,
     });
   } catch (error) {
+    // error-policy:J1 translate the route failure after reconciling the durable
+    // reservation according to whether provider dispatch actually began.
     if (admission && !chargeSettled) {
-      const release = admission.settle(0);
+      const settlementMode = providerDispatchStarted ? "unknown" : "release";
+      logger.error("[GenerateMusic] Generation failed after admission", {
+        ...settlementContext,
+        providerDispatchStarted,
+        settlementMode,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      const release = providerDispatchStarted
+        ? admission.settleUnknown()
+        : admission.settle(0);
       const executionCtx = getGenerativeExecutionContext(c);
       const observed = release.catch((reconcileError) => {
-        logger.error("[GenerateMusic] Failed to refund reservation", {
+        logger.error("[GenerateMusic] Failed to reconcile reservation", {
+          ...settlementContext,
+          providerDispatchStarted,
+          settlementMode,
           error:
             reconcileError instanceof Error
               ? reconcileError.message

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -415,61 +415,82 @@ app.post("/", async (c) => {
     const requestId = generated.requestId;
     const status = generated.source === "hosted" ? generated.status : undefined;
     const generationId = crypto.randomUUID();
-    let billingApplied = false;
-    const persistenceTask = (async () => {
-      await billFlatUsage(billingContext, cost, admission?.reservation);
-      billingApplied = true;
-      chargeSettled = true;
-      await generationsService.create({
-        id: generationId,
-        organization_id: user.organization_id,
-        user_id: user.id,
-        type: "music",
-        model: request.model,
-        provider: definition.provider,
-        prompt: request.prompt,
-        result: {
-          requestId,
-          status,
-          billingSource: definition.billingSource,
-          raw: generated.raw,
-        },
-        status: "completed",
-        storage_url: music.url,
-        thumbnail_url: null,
-        file_size: music.file_size ? BigInt(music.file_size) : undefined,
-        mime_type: music.content_type ?? "audio/mpeg",
-        parameters: {
-          ...(request.durationSeconds !== undefined
-            ? { requestedDurationSeconds: request.durationSeconds }
-            : {}),
-          ...(durationSeconds ? { durationSeconds } : {}),
-          durationControl: definition.durationControl,
-          hasLyrics: Boolean(request.lyrics),
-          lyricsOptimizer: request.lyricsOptimizer,
-          instrumental: request.instrumental,
-          referenceUrl: request.referenceUrl,
-          outputFormat: request.outputFormat,
-        },
-        dimensions: {
-          ...(durationSeconds ? { duration: durationSeconds } : {}),
-        },
-        cost: String(cost.totalCost),
-        credits: String(cost.totalCost),
-        job_id: requestId,
-        completed_at: new Date(),
-      });
-    })().catch(async (error) => {
-      if (!billingApplied) await admission?.settleUnknown();
-      // error-policy:J7 billing and generation records persist after the audio
-      // response; conservative settlement remains observable on failure.
-      logger.error("[GenerateMusic] Background persistence failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+    await generationsService.create({
+      id: generationId,
+      organization_id: user.organization_id,
+      user_id: user.id,
+      type: "music",
+      model: request.model,
+      provider: definition.provider,
+      prompt: request.prompt,
+      result: {
+        requestId,
+        status,
+        billingSource: definition.billingSource,
+        raw: generated.raw,
+      },
+      status: "completed",
+      storage_url: music.url,
+      thumbnail_url: null,
+      file_size: music.file_size ? BigInt(music.file_size) : undefined,
+      mime_type: music.content_type ?? "audio/mpeg",
+      parameters: {
+        ...(request.durationSeconds !== undefined
+          ? { requestedDurationSeconds: request.durationSeconds }
+          : {}),
+        ...(durationSeconds ? { durationSeconds } : {}),
+        durationControl: definition.durationControl,
+        hasLyrics: Boolean(request.lyrics),
+        lyricsOptimizer: request.lyricsOptimizer,
+        instrumental: request.instrumental,
+        referenceUrl: request.referenceUrl,
+        outputFormat: request.outputFormat,
+      },
+      dimensions: {
+        ...(durationSeconds ? { duration: durationSeconds } : {}),
+      },
+      cost: String(cost.totalCost),
+      credits: String(cost.totalCost),
+      job_id: requestId,
+      completed_at: new Date(),
     });
+
+    const settlementTask = billFlatUsage(
+      billingContext,
+      cost,
+      admission?.reservation,
+    )
+      .then(() => {
+        chargeSettled = true;
+      })
+      .catch(async (error) => {
+        // error-policy:J7 the durable completed receipt survives accounting
+        // outages; the admission lease remains the conservative backstop.
+        logger.error("[GenerateMusic] Background exact settlement failed", {
+          ...settlementContext,
+          providerDispatchStarted,
+          settlementMode: "unknown",
+          error: error instanceof Error ? error.message : String(error),
+        });
+        try {
+          await admission?.settleUnknown();
+        } catch (settlementError) {
+          // error-policy:J7 reconciliation diagnostics must not reject the
+          // retained background task or hide the primary accounting failure.
+          logger.error("[GenerateMusic] Conservative settlement also failed", {
+            ...settlementContext,
+            providerDispatchStarted,
+            settlementMode: "unknown",
+            error:
+              settlementError instanceof Error
+                ? settlementError.message
+                : String(settlementError),
+          });
+        }
+      });
     const executionCtx = getGenerativeExecutionContext(c);
-    if (executionCtx) executionCtx.waitUntil(persistenceTask);
-    else void persistenceTask;
+    if (executionCtx) executionCtx.waitUntil(settlementTask);
+    else void settlementTask;
 
     return c.json({
       success: true,

--- a/packages/cloud/api/v1/generate-sfx/route.json.test.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.json.test.ts
@@ -1,18 +1,27 @@
 /** Verifies the sound-effect generation request boundary with deterministic provider mocks. */
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const assertSafeForPublicUse = mock(async () => undefined);
-const generateAudio = mock(async () => ({
-  source: "hosted",
-  url: "https://example.test/sfx.mp3",
-  fileName: "sfx.mp3",
-  fileSize: 10,
-  contentType: "audio/mpeg",
-  requestId: "req-sfx",
-  status: "completed",
-  raw: {},
-}));
-const markProviderDispatched = mock(async () => undefined);
+let providerError: Error | null = null;
+let dispatchReceiptError: Error | null = null;
+const generateAudio = mock(async () => {
+  if (providerError) throw providerError;
+  return {
+    source: "hosted" as const,
+    url: "https://example.test/sfx.mp3",
+    fileName: "sfx.mp3",
+    fileSize: 10,
+    contentType: "audio/mpeg",
+    requestId: "req-sfx",
+    status: "completed",
+    raw: {},
+  };
+});
+const markProviderDispatched = mock(async () => {
+  if (dispatchReceiptError) throw dispatchReceiptError;
+});
+const settle = mock(async (_cost: number) => undefined);
+const settleUnknown = mock(async () => undefined);
 const requireGenerativeRouteCaller = mock(async () => ({
   user: { id: "user-1", organization_id: "org-1" },
   apiKeyId: null,
@@ -23,8 +32,8 @@ mock.module("@/api-app/lib/generative-route-auth", () => ({
   requireGenerativeRouteCaller,
   admitFlatGenerativeOperation: async () => ({
     reservation: { reconcile: async () => undefined },
-    settle: async () => undefined,
-    settleUnknown: async () => undefined,
+    settle,
+    settleUnknown,
     markProviderDispatched,
   }),
   asGenerativeCacheApiError: () => null,
@@ -81,6 +90,16 @@ const validBody = {
 };
 
 describe("POST /api/v1/generate-sfx malformed JSON", () => {
+  beforeEach(() => {
+    providerError = null;
+    dispatchReceiptError = null;
+    assertSafeForPublicUse.mockClear();
+    generateAudio.mockClear();
+    markProviderDispatched.mockClear();
+    settle.mockClear();
+    settleUnknown.mockClear();
+  });
+
   test("returns 400 instead of 500 and never admits generation", async () => {
     const response = await app.request(
       "/",
@@ -119,5 +138,40 @@ describe("POST /api/v1/generate-sfx malformed JSON", () => {
       expect.objectContaining({ deferStrongCredentialCheck: true }),
     );
     expect(generateAudio).toHaveBeenCalled();
+  });
+
+  test("conservatively settles an ambiguous provider failure after dispatch", async () => {
+    providerError = new Error("provider transport closed after submit");
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { ELEVENLABS_API_KEY: "el-test-key" },
+    );
+
+    expect(response.status).toBe(500);
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+    expect(generateAudio).toHaveBeenCalledTimes(1);
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+    expect(settle).not.toHaveBeenCalled();
+  });
+
+  test("releases the reservation when the dispatch receipt fails before provider invocation", async () => {
+    dispatchReceiptError = new Error("dispatch receipt unavailable");
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { ELEVENLABS_API_KEY: "el-test-key" },
+    );
+
+    expect(response.status).toBe(500);
+    expect(generateAudio).not.toHaveBeenCalled();
+    expect(settle).toHaveBeenCalledWith(0);
+    expect(settleUnknown).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/generate-sfx/route.json.test.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.json.test.ts
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const assertSafeForPublicUse = mock(async () => undefined);
 let providerError: Error | null = null;
 let dispatchReceiptError: Error | null = null;
+let generationReceiptError: Error | null = null;
+let billingError: Error | null = null;
+let conservativeSettlementError: Error | null = null;
+let captureBackgroundTasks = false;
+const backgroundTasks: Promise<unknown>[] = [];
+const events: string[] = [];
 const generateAudio = mock(async () => {
   if (providerError) throw providerError;
   return {
@@ -22,6 +28,17 @@ const markProviderDispatched = mock(async () => {
 });
 const settle = mock(async (_cost: number) => undefined);
 const settleUnknown = mock(async () => undefined);
+const createGeneration = mock(async () => {
+  events.push("generation-receipt");
+  if (generationReceiptError) throw generationReceiptError;
+  return { id: "gen-sfx" };
+});
+const billFlatUsage = mock(async () => {
+  events.push("exact-settlement");
+  if (billingError) throw billingError;
+  return { totalCost: 0.1 };
+});
+const loggerError = mock(() => undefined);
 const requireGenerativeRouteCaller = mock(async () => ({
   user: { id: "user-1", organization_id: "org-1" },
   apiKeyId: null,
@@ -37,7 +54,14 @@ mock.module("@/api-app/lib/generative-route-auth", () => ({
     markProviderDispatched,
   }),
   asGenerativeCacheApiError: () => null,
-  getGenerativeExecutionContext: () => undefined,
+  getGenerativeExecutionContext: () =>
+    captureBackgroundTasks
+      ? {
+          waitUntil(task: Promise<unknown>) {
+            backgroundTasks.push(task);
+          },
+        }
+      : undefined,
   getGenerativePricingCacheOptions: () => ({}),
 }));
 
@@ -46,7 +70,7 @@ mock.module("@/lib/services/content-safety", () => ({
 }));
 
 mock.module("@/lib/services/ai-billing", () => ({
-  billFlatUsage: async () => ({ totalCost: 0.1 }),
+  billFlatUsage,
 }));
 
 mock.module("@/lib/services/ai-pricing", () => ({
@@ -62,7 +86,7 @@ mock.module("@/lib/services/credits", () => ({
 }));
 
 mock.module("@/lib/services/generations", () => ({
-  generationsService: { create: async () => ({ id: "gen-sfx" }) },
+  generationsService: { create: createGeneration },
 }));
 
 mock.module("@/lib/providers/audio/registry", () => ({
@@ -77,7 +101,7 @@ mock.module("@/lib/utils/logger", () => ({
   logger: {
     info: () => undefined,
     warn: () => undefined,
-    error: () => undefined,
+    error: loggerError,
     debug: () => undefined,
   },
 }));
@@ -93,11 +117,23 @@ describe("POST /api/v1/generate-sfx malformed JSON", () => {
   beforeEach(() => {
     providerError = null;
     dispatchReceiptError = null;
+    generationReceiptError = null;
+    billingError = null;
+    conservativeSettlementError = null;
+    captureBackgroundTasks = false;
+    backgroundTasks.length = 0;
+    events.length = 0;
     assertSafeForPublicUse.mockClear();
     generateAudio.mockClear();
     markProviderDispatched.mockClear();
     settle.mockClear();
     settleUnknown.mockClear();
+    settleUnknown.mockImplementation(async () => {
+      if (conservativeSettlementError) throw conservativeSettlementError;
+    });
+    createGeneration.mockClear();
+    billFlatUsage.mockClear();
+    loggerError.mockClear();
   });
 
   test("returns 400 instead of 500 and never admits generation", async () => {
@@ -173,5 +209,78 @@ describe("POST /api/v1/generate-sfx malformed JSON", () => {
     expect(generateAudio).not.toHaveBeenCalled();
     expect(settle).toHaveBeenCalledWith(0);
     expect(settleUnknown).not.toHaveBeenCalled();
+  });
+
+  test("persists the completed receipt before exact settlement and returning its id", async () => {
+    captureBackgroundTasks = true;
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { ELEVENLABS_API_KEY: "el-test-key" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      id: expect.any(String),
+    });
+    await Promise.all(backgroundTasks);
+    expect(events).toEqual(["generation-receipt", "exact-settlement"]);
+  });
+
+  test("fails the request and conservatively settles when the completed receipt cannot persist", async () => {
+    generationReceiptError = new Error("generation receipt unavailable");
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { ELEVENLABS_API_KEY: "el-test-key" },
+    );
+
+    expect(response.status).toBe(500);
+    expect(createGeneration).toHaveBeenCalledTimes(1);
+    expect(billFlatUsage).not.toHaveBeenCalled();
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+  });
+
+  test("retains both diagnostics and resolves the task when exact and conservative settlement fail", async () => {
+    captureBackgroundTasks = true;
+    billingError = new Error("exact settlement unavailable");
+    conservativeSettlementError = new Error(
+      "conservative settlement unavailable",
+    );
+    const response = await app.fetch(
+      new Request("http://test.local/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validBody),
+      }),
+      { ELEVENLABS_API_KEY: "el-test-key" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(Promise.all(backgroundTasks)).resolves.toBeArray();
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+    expect(loggerError).toHaveBeenCalledWith(
+      "[GenerateSfx] Background exact settlement failed",
+      expect.objectContaining({
+        organizationId: "org-1",
+        settlementMode: "unknown",
+        error: "exact settlement unavailable",
+      }),
+    );
+    expect(loggerError).toHaveBeenCalledWith(
+      "[GenerateSfx] Conservative settlement also failed",
+      expect.objectContaining({
+        organizationId: "org-1",
+        settlementMode: "unknown",
+        error: "conservative settlement unavailable",
+      }),
+    );
   });
 });

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -303,53 +303,74 @@ app.post("/", async (c) => {
 
     const requestId = generated.requestId;
     const generationId = crypto.randomUUID();
-    let billingApplied = false;
-    const persistenceTask = (async () => {
-      await billFlatUsage(billingContext, cost, admission?.reservation);
-      billingApplied = true;
-      chargeSettled = true;
-      await generationsService.create({
-        id: generationId,
-        organization_id: user.organization_id,
-        user_id: user.id,
-        type: "sfx",
-        model: request.model,
-        provider: definition.provider,
-        prompt: request.prompt,
-        result: {
-          requestId,
-          billingSource: definition.billingSource,
-          raw: generated.raw,
-        },
-        status: "completed",
-        storage_url: audio.url,
-        thumbnail_url: null,
-        file_size: audio.file_size ? BigInt(audio.file_size) : undefined,
-        mime_type: audio.content_type ?? "audio/mpeg",
-        parameters: {
-          durationSeconds,
-          promptInfluence: request.promptInfluence,
-          outputFormat: request.outputFormat,
-        },
-        dimensions: {
-          duration: durationSeconds,
-        },
-        cost: String(cost.totalCost),
-        credits: String(cost.totalCost),
-        job_id: requestId,
-        completed_at: new Date(),
-      });
-    })().catch(async (error) => {
-      if (!billingApplied) await admission?.settleUnknown();
-      // error-policy:J7 billing and generation records persist after the audio
-      // response; conservative settlement remains observable on failure.
-      logger.error("[GenerateSfx] Background persistence failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+    await generationsService.create({
+      id: generationId,
+      organization_id: user.organization_id,
+      user_id: user.id,
+      type: "sfx",
+      model: request.model,
+      provider: definition.provider,
+      prompt: request.prompt,
+      result: {
+        requestId,
+        billingSource: definition.billingSource,
+        raw: generated.raw,
+      },
+      status: "completed",
+      storage_url: audio.url,
+      thumbnail_url: null,
+      file_size: audio.file_size ? BigInt(audio.file_size) : undefined,
+      mime_type: audio.content_type ?? "audio/mpeg",
+      parameters: {
+        durationSeconds,
+        promptInfluence: request.promptInfluence,
+        outputFormat: request.outputFormat,
+      },
+      dimensions: {
+        duration: durationSeconds,
+      },
+      cost: String(cost.totalCost),
+      credits: String(cost.totalCost),
+      job_id: requestId,
+      completed_at: new Date(),
     });
+
+    const settlementTask = billFlatUsage(
+      billingContext,
+      cost,
+      admission?.reservation,
+    )
+      .then(() => {
+        chargeSettled = true;
+      })
+      .catch(async (error) => {
+        // error-policy:J7 the durable completed receipt survives accounting
+        // outages; the admission lease remains the conservative backstop.
+        logger.error("[GenerateSfx] Background exact settlement failed", {
+          ...settlementContext,
+          providerDispatchStarted,
+          settlementMode: "unknown",
+          error: error instanceof Error ? error.message : String(error),
+        });
+        try {
+          await admission?.settleUnknown();
+        } catch (settlementError) {
+          // error-policy:J7 reconciliation diagnostics must not reject the
+          // retained background task or hide the primary accounting failure.
+          logger.error("[GenerateSfx] Conservative settlement also failed", {
+            ...settlementContext,
+            providerDispatchStarted,
+            settlementMode: "unknown",
+            error:
+              settlementError instanceof Error
+                ? settlementError.message
+                : String(settlementError),
+          });
+        }
+      });
     const executionCtx = getGenerativeExecutionContext(c);
-    if (executionCtx) executionCtx.waitUntil(persistenceTask);
-    else void persistenceTask;
+    if (executionCtx) executionCtx.waitUntil(settlementTask);
+    else void settlementTask;
 
     return c.json({
       success: true,

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -121,6 +121,17 @@ app.post("/", async (c) => {
   // Post-settle failures must not refund a settled charge (mirrors
   // generate-image / generate-video / generate-music).
   let chargeSettled = false;
+  let providerDispatchStarted = false;
+  let settlementContext:
+    | {
+        requestId: string;
+        organizationId: string;
+        userId: string;
+        model: string;
+        provider: string;
+        billingSource: string;
+      }
+    | undefined;
 
   try {
     const decodedRawBody = await decodeRequestJson(c.req);
@@ -208,6 +219,7 @@ app.post("/", async (c) => {
         cache: getGenerativePricingCacheOptions(c),
       }),
     ]);
+    const billingRequestId = `generate-sfx:${crypto.randomUUID()}`;
     const billingContext: BillingContext = {
       organizationId: user.organization_id,
       userId: user.id,
@@ -215,9 +227,17 @@ app.post("/", async (c) => {
       model: request.model,
       provider: definition.provider,
       billingSource: definition.billingSource,
-      requestId: `generate-sfx:${crypto.randomUUID()}`,
+      requestId: billingRequestId,
       affiliateCode: c.req.header("X-Affiliate-Code"),
       description: `SFX generation: ${request.model}`,
+    };
+    settlementContext = {
+      requestId: billingRequestId,
+      organizationId: user.organization_id,
+      userId: user.id,
+      model: request.model,
+      provider: definition.provider,
+      billingSource: definition.billingSource,
     };
 
     try {
@@ -243,31 +263,31 @@ app.post("/", async (c) => {
       throw error;
     }
 
+    const audioProvider = getAudioProvider(definition.billingSource);
     await admission.markProviderDispatched?.();
-    const generated = await getAudioProvider(definition.billingSource).generate(
-      {
-        kind: "sfx",
-        model: request.model,
-        prompt: request.prompt,
-        durationSeconds: request.durationSeconds,
-        promptInfluence: request.promptInfluence,
-        seed: request.seed,
-        outputFormat: request.outputFormat,
-        extraInput: request.extraInput,
-        apiKeys: {
-          FAL_KEY: envString(c.env, "FAL_KEY"),
-          FAL_API_KEY: envString(c.env, "FAL_API_KEY"),
-          FAL_QUEUE_BASE_URL: envString(c.env, "FAL_QUEUE_BASE_URL"),
-          FAL_QUEUE_POLL_INTERVAL_MS: envString(
-            c.env,
-            "FAL_QUEUE_POLL_INTERVAL_MS",
-          ),
-          FAL_QUEUE_TIMEOUT_MS: envString(c.env, "FAL_QUEUE_TIMEOUT_MS"),
-          ELEVENLABS_API_KEY: envString(c.env, "ELEVENLABS_API_KEY"),
-          ELEVENLABS_BASE_URL: envString(c.env, "ELEVENLABS_BASE_URL"),
-        },
+    providerDispatchStarted = true;
+    const generated = await audioProvider.generate({
+      kind: "sfx",
+      model: request.model,
+      prompt: request.prompt,
+      durationSeconds: request.durationSeconds,
+      promptInfluence: request.promptInfluence,
+      seed: request.seed,
+      outputFormat: request.outputFormat,
+      extraInput: request.extraInput,
+      apiKeys: {
+        FAL_KEY: envString(c.env, "FAL_KEY"),
+        FAL_API_KEY: envString(c.env, "FAL_API_KEY"),
+        FAL_QUEUE_BASE_URL: envString(c.env, "FAL_QUEUE_BASE_URL"),
+        FAL_QUEUE_POLL_INTERVAL_MS: envString(
+          c.env,
+          "FAL_QUEUE_POLL_INTERVAL_MS",
+        ),
+        FAL_QUEUE_TIMEOUT_MS: envString(c.env, "FAL_QUEUE_TIMEOUT_MS"),
+        ELEVENLABS_API_KEY: envString(c.env, "ELEVENLABS_API_KEY"),
+        ELEVENLABS_BASE_URL: envString(c.env, "ELEVENLABS_BASE_URL"),
       },
-    );
+    });
 
     const audio = await storeGeneratedSfx(
       c.env,
@@ -339,11 +359,25 @@ app.post("/", async (c) => {
       cost,
     });
   } catch (error) {
+    // error-policy:J1 translate the route failure after reconciling the durable
+    // reservation according to whether provider dispatch actually began.
     if (admission && !chargeSettled) {
-      const release = admission.settle(0);
+      const settlementMode = providerDispatchStarted ? "unknown" : "release";
+      logger.error("[GenerateSfx] Generation failed after admission", {
+        ...settlementContext,
+        providerDispatchStarted,
+        settlementMode,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      const release = providerDispatchStarted
+        ? admission.settleUnknown()
+        : admission.settle(0);
       const executionCtx = getGenerativeExecutionContext(c);
       const observed = release.catch((reconcileError) => {
-        logger.error("[GenerateSfx] Failed to refund reservation", {
+        logger.error("[GenerateSfx] Failed to reconcile reservation", {
+          ...settlementContext,
+          providerDispatchStarted,
+          settlementMode,
           error:
             reconcileError instanceof Error
               ? reconcileError.message

--- a/packages/cloud/shared/src/lib/services/image-generation.test.ts
+++ b/packages/cloud/shared/src/lib/services/image-generation.test.ts
@@ -188,7 +188,7 @@ describe("executeImageGeneration", () => {
     expect(events.indexOf("history")).toBeLessThan(events.indexOf("bill"));
   });
 
-  test("sanitizes provider failure, refunds admission, and leaves no artifact or history", async () => {
+  test("sanitizes provider failure, settles conservatively, and leaves no artifact or history", async () => {
     const events: string[] = [];
     const bucket = new MemoryR2Bucket();
     const admission = successfulAdmission(events);
@@ -211,7 +211,8 @@ describe("executeImageGeneration", () => {
       status: 503,
       message: "Image generation is temporarily unavailable. Please try again shortly.",
     });
-    expect(events).toContain("direct-settle:0");
+    expect(events).toContain("settle-unknown");
+    expect(events).not.toContain("direct-settle:0");
     expect(events).not.toContain("history");
     expect(bucket.objects.size).toBe(0);
   });
@@ -234,7 +235,8 @@ describe("executeImageGeneration", () => {
     ).rejects.toThrow("database unavailable");
     expect(bucket.objects.size).toBe(0);
     expect(bucket.deleted).toHaveLength(1);
-    expect(events).toContain("direct-settle:0");
+    expect(events).toContain("settle-unknown");
+    expect(events).not.toContain("direct-settle:0");
     expect(events).not.toContain("bill");
   });
 
@@ -302,27 +304,22 @@ describe("executeImageGeneration", () => {
     expect(bucket.objects.size).toBe(1);
   });
 
-  test("preserves the causal transaction error if admission release is offline", async () => {
+  test("releases the admission when the durable dispatch receipt fails before provider invocation", async () => {
     const events: string[] = [];
     const bucket = new MemoryR2Bucket();
     const admission = successfulAdmission(events);
-    admission.settle = async (cost) => {
-      events.push(`direct-settle:${cost}`);
-      throw new Error("reservation release unavailable");
+    admission.markProviderDispatched = async () => {
+      events.push("dispatch");
+      throw new Error("dispatch receipt unavailable");
     };
-    const execute = createImageGenerationExecutor(
-      dependencies(events, {
-        createGeneration: async () => {
-          events.push("history");
-          throw new Error("causal history failure");
-        },
-      }),
-    );
+    const execute = createImageGenerationExecutor(dependencies(events));
 
     await expect(
       execute(requestInput(bucket, async () => ({ kind: "organization", admission }))),
-    ).rejects.toThrow("causal history failure");
+    ).rejects.toThrow("dispatch receipt unavailable");
     expect(events).toContain("direct-settle:0");
+    expect(events).not.toContain("settle-unknown");
+    expect(events).not.toContain("provider");
     expect(bucket.objects.size).toBe(0);
   });
 

--- a/packages/cloud/shared/src/lib/services/image-generation.ts
+++ b/packages/cloud/shared/src/lib/services/image-generation.ts
@@ -317,10 +317,12 @@ export function createImageGenerationExecutor(deps: ImageGenerationDependencies)
     const storedImages: StoredImage[] = [];
     const generationIds: string[] = [];
     let billingUncertain = false;
+    let providerDispatchStarted = false;
     try {
-      await admission?.markProviderDispatched?.();
       const provider = deps.getProvider(definition.billingSource);
+      await admission?.markProviderDispatched?.();
       for (let index = 0; index < request.numImages; index += 1) {
+        providerDispatchStarted = true;
         const generated = await generateProviderImage(request, input.providerKeys, provider);
         const key = `generations/images/${input.actor.organizationId}/${input.actor.userId}/${deps.randomUuid()}.${extensionForMimeType(generated.mimeType)}`;
         const stored = await deps.putObject(input.bindings, {
@@ -444,12 +446,37 @@ export function createImageGenerationExecutor(deps: ImageGenerationDependencies)
       if (!billingUncertain) {
         await cleanupFailedGeneration(deps, input.bindings, storedImages, generationIds);
         try {
-          await admission?.settle(0);
+          if (providerDispatchStarted) {
+            logger.error(
+              "[ImageGeneration] Post-dispatch transaction failed; requesting conservative settlement",
+              {
+                requestId: billingContext.requestId,
+                organizationId: input.actor.organizationId,
+                userId: input.actor.userId,
+                model: request.model,
+                provider: definition.provider,
+                billingSource: definition.billingSource,
+                generatedImageCount: storedImages.length,
+                requestedImageCount: request.numImages,
+                settlementMode: "unknown",
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+            await admission?.settleUnknown();
+          } else {
+            await admission?.settle(0);
+          }
         } catch (settlementError) {
           // error-policy:J7 reservation-release failure is observable but must
           // not replace the causal transaction failure reported to the caller.
-          logger.error("[ImageGeneration] Failed to release rejected image admission", {
+          logger.error("[ImageGeneration] Failed to reconcile rejected image admission", {
             requestId: billingContext.requestId,
+            organizationId: input.actor.organizationId,
+            userId: input.actor.userId,
+            model: request.model,
+            provider: definition.provider,
+            billingSource: definition.billingSource,
+            settlementMode: providerDispatchStarted ? "unknown" : "release",
             error:
               settlementError instanceof Error ? settlementError.message : String(settlementError),
           });


### PR DESCRIPTION
## Summary

- track the actual provider invocation boundary for image generation, music, SFX, and priced FAL mutations
- release reservations only when the durable dispatch receipt or another definitive pre-dispatch step fails
- conservatively settle ambiguous provider, storage, persistence, transport, and non-2xx outcomes after dispatch while retaining durable admission receipts
- persist completed music and SFX receipts before starting exact settlement or returning their success IDs
- separately log primary exact-settlement and conservative-reconciliation failures without rejecting retained background tasks
- add correlated structured settlement diagnostics without exposing provider credentials or request payloads
- cover post-dispatch ambiguity, pre-dispatch receipt failures, receipt-write failures, and double-settlement failures behaviorally

## Safety contract

- successful known-cost work retains exact settlement
- `settle(0)` is limited to failures before provider invocation begins
- after invocation begins, failures use `settleUnknown()` so accepted-but-ambiguous upstream work cannot become free
- music and SFX success IDs always identify a durable completed receipt before asynchronous exact billing begins
- image partial artifacts are still cleaned up; accounting is conservatively retained independently
- voice routes are unchanged

## Verification

- `bun test packages/cloud/shared/src/lib/services/image-generation.test.ts` (9 pass)
- `bun test packages/cloud/api/v1/generate-music/route.json.test.ts` (7 pass)
- `bun test packages/cloud/api/v1/generate-sfx/route.json.test.ts` (7 pass)
- `bun test packages/cloud/api/fal/proxy/route.standing.test.ts` (5 pass)
- `bun run --cwd packages/cloud/shared typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd packages/cloud/api build`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd packages/cloud/api typecheck` (includes router contract and Worker bundle dry-run)
- Biome on all eight changed files
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run verify` (376/376 Turbo tasks plus all root audits)

Closes #30359
