### PR TITLE
fix(cloud): retain voice clone provider receipts

### DIFF
--- a/packages/cloud/api/elevenlabs/voices/jobs/route.reconciliation.test.ts
+++ b/packages/cloud/api/elevenlabs/voices/jobs/route.reconciliation.test.ts
@@ -10,7 +10,7 @@ const getUserJobs = mock(async () => [
     jobType: "professional",
     status: "reconciliation_required",
     progress: 0,
-    errorMessage: "ElevenLabs samples submission outcome is unknown",
+    errorMessage: "account acct_private_456 samples submission failed",
     elevenlabsVoiceId: "pvc-accepted-1",
     metadata: {
       providerSubmissionState: "submission_unknown",
@@ -52,13 +52,15 @@ test("returns reconciliation state and provider locator while excluding terminal
   const response = await app.request("/");
 
   expect(response.status).toBe(200);
-  await expect(response.json()).resolves.toMatchObject({
+  const body = await response.json();
+  expect(body).toMatchObject({
     success: true,
     total: 1,
     jobs: [
       {
         id: "job-reconcile-1",
         status: "reconciliation_required",
+        errorMessage: "provider_work_reconciliation_required",
         reconciliationRequired: true,
         providerState: "submission_unknown",
         providerStep: "samples",
@@ -66,5 +68,6 @@ test("returns reconciliation state and provider locator while excluding terminal
       },
     ],
   });
+  expect(JSON.stringify(body)).not.toContain("acct_private_456");
   expect(getUserJobs).toHaveBeenCalledWith("org-1", "user-1");
 });

--- a/packages/cloud/api/elevenlabs/voices/jobs/route.reconciliation.test.ts
+++ b/packages/cloud/api/elevenlabs/voices/jobs/route.reconciliation.test.ts
@@ -1,0 +1,70 @@
+/** Proves ambiguous voice clones remain visible in the authenticated manual reconciliation queue. */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getUserJobs = mock(async () => [
+  {
+    id: "job-reconcile-1",
+    voiceName: "Accepted Maybe",
+    jobType: "professional",
+    status: "reconciliation_required",
+    progress: 0,
+    errorMessage: "ElevenLabs samples submission outcome is unknown",
+    elevenlabsVoiceId: "pvc-accepted-1",
+    metadata: {
+      providerSubmissionState: "submission_unknown",
+      providerLastStep: "samples",
+    },
+    createdAt: new Date("2026-09-02T12:00:00.000Z"),
+    startedAt: new Date("2026-09-02T12:00:01.000Z"),
+  },
+  {
+    id: "job-failed-1",
+    voiceName: "Rejected",
+    jobType: "instant",
+    status: "failed",
+    progress: 0,
+    errorMessage: "Provider rejected the request",
+    elevenlabsVoiceId: null,
+    metadata: {},
+    createdAt: new Date("2026-09-02T12:00:00.000Z"),
+    startedAt: new Date("2026-09-02T12:00:01.000Z"),
+  },
+]);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+  }),
+}));
+mock.module("@/lib/services/voice-cloning", () => ({
+  voiceCloningService: { getUserJobs },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+test("returns reconciliation state and provider locator while excluding terminal failures", async () => {
+  const response = await app.request("/");
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toMatchObject({
+    success: true,
+    total: 1,
+    jobs: [
+      {
+        id: "job-reconcile-1",
+        status: "reconciliation_required",
+        reconciliationRequired: true,
+        providerState: "submission_unknown",
+        providerStep: "samples",
+        providerVoiceId: "pvc-accepted-1",
+      },
+    ],
+  });
+  expect(getUserJobs).toHaveBeenCalledWith("org-1", "user-1");
+});

--- a/packages/cloud/api/elevenlabs/voices/jobs/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/jobs/route.ts
@@ -8,8 +8,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 /**
  * GET /api/elevenlabs/voices/jobs
- * Gets all active (processing or pending) voice cloning jobs for the authenticated user.
- * Only returns jobs that are still in progress.
+ * Gets active and reconciliation-required voice cloning jobs for the authenticated user.
  *
  * @param request - The Next.js request object.
  * @returns Array of active voice cloning jobs with status and progress information.
@@ -26,23 +25,42 @@ async function __hono_GET(request: Request) {
       user.id,
     );
 
-    // Filter for only processing/pending jobs
+    // Reconciliation-required jobs stay visible as an explicit manual queue;
+    // they must never disappear as ordinary failures after ambiguous provider work.
     const activeJobs = allJobs.filter(
-      (job) => job.status === "processing" || job.status === "pending",
+      (job) =>
+        job.status === "processing" ||
+        job.status === "pending" ||
+        job.status === "reconciliation_required",
     );
 
     return Response.json({
       success: true,
-      jobs: activeJobs.map((job) => ({
-        id: job.id,
-        voiceName: job.voiceName,
-        jobType: job.jobType,
-        status: job.status,
-        progress: job.progress,
-        errorMessage: job.errorMessage,
-        createdAt: job.createdAt,
-        startedAt: job.startedAt,
-      })),
+      jobs: activeJobs.map((job) => {
+        const metadata = job.metadata as Record<string, unknown>;
+        const providerState =
+          typeof metadata.providerSubmissionState === "string"
+            ? metadata.providerSubmissionState
+            : null;
+        const providerStep =
+          typeof metadata.providerLastStep === "string"
+            ? metadata.providerLastStep
+            : null;
+        return {
+          id: job.id,
+          voiceName: job.voiceName,
+          jobType: job.jobType,
+          status: job.status,
+          progress: job.progress,
+          errorMessage: job.errorMessage,
+          reconciliationRequired: job.status === "reconciliation_required",
+          providerState,
+          providerStep,
+          providerVoiceId: job.elevenlabsVoiceId,
+          createdAt: job.createdAt,
+          startedAt: job.startedAt,
+        };
+      }),
       total: activeJobs.length,
     });
   } catch (error) {

--- a/packages/cloud/api/elevenlabs/voices/jobs/route.ts
+++ b/packages/cloud/api/elevenlabs/voices/jobs/route.ts
@@ -2,6 +2,7 @@
 import { Hono } from "hono";
 import { getErrorStatusCode, nextJsonFromCaughtError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { exposedVoiceCloneFailureReason } from "@/lib/services/voice-clone-failure";
 import { voiceCloningService } from "@/lib/services/voice-cloning";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -52,7 +53,10 @@ async function __hono_GET(request: Request) {
           jobType: job.jobType,
           status: job.status,
           progress: job.progress,
-          errorMessage: job.errorMessage,
+          errorMessage: exposedVoiceCloneFailureReason(
+            job.errorMessage,
+            job.status === "reconciliation_required",
+          ),
           reconciliationRequired: job.status === "reconciliation_required",
           providerState,
           providerStep,

--- a/packages/cloud/api/v1/voice/clone/route.standing.test.ts
+++ b/packages/cloud/api/v1/voice/clone/route.standing.test.ts
@@ -267,7 +267,7 @@ test("combined credential denial is sanitized before ElevenLabs dispatch", async
     expect(createOrReadCloningJob).toHaveBeenCalledTimes(1);
     expect(markCloningJobFailed).toHaveBeenCalledWith(
       "job-credential-denial",
-      "Authentication required",
+      "voice_clone_request_failed",
     );
     expect(providerFetch).not.toHaveBeenCalled();
   } finally {
@@ -572,7 +572,10 @@ test("timeout after provider submission retains evidence and settles unknown", a
     await expect(response.json()).resolves.toMatchObject({
       error:
         "Voice clone provider work could not be completed. It is retained for reconciliation.",
-      details: { outcome: "submission_unknown", jobId: "job-timeout" },
+      details: {
+        outcome: "provider_submission_unknown",
+        jobId: "job-timeout",
+      },
     });
     expect(recordCloningJobProviderReceipt.mock.calls).toEqual([
       [
@@ -587,7 +590,7 @@ test("timeout after provider submission retains evidence and settles unknown", a
           jobId: "job-timeout",
           step: "create",
           state: "submission_unknown",
-          errorMessage: "The operation timed out",
+          errorMessage: "provider_transport_uncertain",
         },
       ],
     ]);
@@ -596,7 +599,7 @@ test("timeout after provider submission retains evidence and settles unknown", a
     expect(markCloningJobFailed).not.toHaveBeenCalled();
     expect(markCloningJobReconciliationRequired).toHaveBeenCalledWith(
       "job-timeout",
-      "ElevenLabs create submission outcome is unknown",
+      "provider_submission_unknown",
     );
     expect(settleUnknown).toHaveBeenCalledTimes(1);
     expect(settle).not.toHaveBeenCalled();
@@ -708,7 +711,7 @@ test("professional later-step failure retains the voice id and evidence", async 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({
       details: {
-        outcome: "provider_work_retained",
+        outcome: "provider_work_reconciliation_required",
         jobId: "job-professional",
       },
     });
@@ -730,7 +733,7 @@ test("professional later-step failure retains the voice id and evidence", async 
     expect(markCloningJobFailed).not.toHaveBeenCalled();
     expect(markCloningJobReconciliationRequired).toHaveBeenCalledWith(
       "job-professional",
-      "ElevenLabs PVC sample upload failed: sample rejected",
+      "provider_work_reconciliation_required",
     );
     expect(settleUnknown).toHaveBeenCalledTimes(1);
     expect(settle).not.toHaveBeenCalled();
@@ -741,6 +744,97 @@ test("professional later-step failure retains the voice id and evidence", async 
         providerState: "rejected",
         providerStep: "samples",
         providerVoiceId: "pvc-accepted-1",
+      }),
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("definitive provider rejection exposes and persists only a typed safe reason", async () => {
+  settle.mockClear();
+  settleUnknown.mockClear();
+  loggerError.mockClear();
+  recordCloningJobProviderReceipt.mockClear();
+  markCloningJobFailed.mockClear();
+  createUsage.mockClear();
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: { balanceUsd: 10, revision: "5" },
+  }));
+  calculateVoiceCloneCostFromCatalog.mockImplementationOnce(async () => ({
+    totalCost: 1,
+    baseTotalCost: 0.8,
+    platformMarkup: 0.2,
+    pricingSource: "catalog",
+  }));
+  admitFlatGenerativeOperation.mockImplementationOnce(async () => ({
+    mode: "synchronous_db_ledger",
+    markProviderDispatched,
+    settle,
+    settleUnknown,
+  }));
+  createOrReadCloningJob.mockImplementationOnce(async () => ({
+    created: true,
+    job: { id: "job-provider-rejected", startedAt: new Date() },
+  }));
+  const privateProviderError =
+    "subscription account acct_private_123 rejected the request";
+  const providerFetch = mock(
+    async () => new Response(privateProviderError, { status: 422 }),
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+  const form = new FormData();
+  form.set("name", "Rejected Voice");
+  form.set("cloneType", "instant");
+  form.set(
+    "file0",
+    new File([new Uint8Array([1])], "sample.wav", { type: "audio/wav" }),
+  );
+
+  try {
+    const response = await app.request(
+      "/v1/voice/clone",
+      {
+        method: "POST",
+        body: form,
+        headers: { "Idempotency-Key": "voice-provider-rejected-1" },
+      },
+      {
+        ELEVENLABS_API_KEY: "configured",
+        BLOB: {
+          put: mock(async () => undefined),
+          delete: mock(async () => undefined),
+        },
+      },
+    );
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: "Failed to create voice clone. Credits have been refunded.",
+      details: {
+        outcome: "provider_request_rejected",
+        jobId: "job-provider-rejected",
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain(privateProviderError);
+    expect(markCloningJobFailed).toHaveBeenCalledWith(
+      "job-provider-rejected",
+      "provider_request_rejected",
+    );
+    expect(createUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ error_message: "provider_request_rejected" }),
+    );
+    expect(settle).toHaveBeenCalledWith(0);
+    expect(settleUnknown).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith(
+      "[Voice Clone API] Unhandled error",
+      expect.objectContaining({
+        error: expect.stringContaining(privateProviderError),
+        safeFailureReason: "provider_request_rejected",
       }),
     );
   } finally {

--- a/packages/cloud/api/v1/voice/clone/route.standing.test.ts
+++ b/packages/cloud/api/v1/voice/clone/route.standing.test.ts
@@ -14,6 +14,12 @@ class ApiError extends Error {
   }
 }
 
+class InsufficientCreditsError extends Error {
+  constructor(readonly required: number) {
+    super("Insufficient balance");
+  }
+}
+
 const requireGenerativeRouteCaller = mock<
   (
     context?: unknown,
@@ -32,9 +38,11 @@ const calculateVoiceCloneCostFromCatalog = mock<() => Promise<unknown>>(
     throw new Error("pricing must not run after standing denial");
   },
 );
-const createCloningJob = mock<() => Promise<unknown>>(async () => {
-  throw new Error("storage must not run after standing denial");
-});
+const createOrReadCloningJob = mock<(input: unknown) => Promise<unknown>>(
+  async () => {
+    throw new Error("storage must not run after standing denial");
+  },
+);
 const createSamples = mock(async () => undefined);
 const createVoice = mock(async () => ({
   id: "voice-row-1",
@@ -51,6 +59,18 @@ const completeCloningJob = mock(async () => ({
   status: "completed",
   progress: 100,
 }));
+const recordCloningJobProviderReceipt = mock<
+  (input: {
+    jobId: string;
+    step: "create" | "samples" | "train";
+    state: "submitted" | "accepted" | "rejected" | "submission_unknown";
+    elevenlabsVoiceId?: string;
+    errorMessage?: string;
+  }) => Promise<void>
+>(async () => undefined);
+const deleteSamplesByJobId = mock(async () => undefined);
+const markCloningJobFailed = mock(async () => undefined);
+const markCloningJobReconciliationRequired = mock(async () => undefined);
 const markProviderDispatched = mock(async () => undefined);
 const settle = mock(async () => null);
 const settleUnknown = mock(async () => null);
@@ -60,6 +80,7 @@ const billFlatUsage = mock(async () => ({
   platformMarkup: 0.2,
 }));
 const createUsage = mock(async () => undefined);
+const loggerError = mock(() => undefined);
 
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   admitFlatGenerativeOperation,
@@ -98,17 +119,19 @@ mock.module("@/lib/services/ai-billing", () => ({
   billFlatUsage,
 }));
 mock.module("@/lib/services/credits", () => ({
-  InsufficientCreditsError: class InsufficientCreditsError extends Error {},
+  InsufficientCreditsError,
 }));
 mock.module("@/db/repositories/user-voices", () => ({
   userVoicesRepository: {
-    createCloningJob,
+    createOrReadCloningJob,
     createSamples,
     createVoice,
     attachSamplesToVoice,
     completeCloningJob,
-    deleteSamplesByJobId: mock(async () => undefined),
-    markCloningJobFailed: mock(async () => undefined),
+    recordCloningJobProviderReceipt,
+    deleteSamplesByJobId,
+    markCloningJobFailed,
+    markCloningJobReconciliationRequired,
   },
 }));
 mock.module("@/lib/services/usage", () => ({
@@ -116,7 +139,7 @@ mock.module("@/lib/services/usage", () => ({
 }));
 mock.module("@/lib/utils/logger", () => ({
   logger: {
-    error: mock(() => undefined),
+    error: loggerError,
     info: mock(() => undefined),
   },
 }));
@@ -178,7 +201,7 @@ test("cached bad standing denies before pricing, admission, provider, or storage
     expect(requireGenerativeRouteCaller).toHaveBeenCalledTimes(1);
     expect(calculateVoiceCloneCostFromCatalog).not.toHaveBeenCalled();
     expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
-    expect(createCloningJob).not.toHaveBeenCalled();
+    expect(createOrReadCloningJob).not.toHaveBeenCalled();
     expect(blobPut).not.toHaveBeenCalled();
     expect(providerFetch).not.toHaveBeenCalled();
   } finally {
@@ -187,6 +210,10 @@ test("cached bad standing denies before pricing, admission, provider, or storage
 });
 
 test("combined credential denial is sanitized before ElevenLabs dispatch", async () => {
+  createOrReadCloningJob.mockImplementationOnce(async () => ({
+    created: true,
+    job: { id: "job-credential-denial", startedAt: new Date() },
+  }));
   requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
     user: { id: "user-1", organization_id: "org-1" },
     apiKeyId: "key-1",
@@ -224,7 +251,11 @@ test("combined credential denial is sanitized before ElevenLabs dispatch", async
   try {
     const response = await app.request(
       "/v1/voice/clone",
-      { method: "POST", body: form },
+      {
+        method: "POST",
+        body: form,
+        headers: { "Idempotency-Key": "voice-credential-denial-1" },
+      },
       { ELEVENLABS_API_KEY: "configured", BLOB: { put: mock() } },
     );
     expect(response.status).toBe(401);
@@ -233,7 +264,11 @@ test("combined credential denial is sanitized before ElevenLabs dispatch", async
       error: "Authentication required",
       details: { reason: "credential_inactive" },
     });
-    expect(createCloningJob).not.toHaveBeenCalled();
+    expect(createOrReadCloningJob).toHaveBeenCalledTimes(1);
+    expect(markCloningJobFailed).toHaveBeenCalledWith(
+      "job-credential-denial",
+      "Authentication required",
+    );
     expect(providerFetch).not.toHaveBeenCalled();
   } finally {
     globalThis.fetch = originalFetch;
@@ -260,9 +295,9 @@ test("admits before ElevenLabs and settles the flat charge without a readback", 
     settle,
     settleUnknown,
   }));
-  createCloningJob.mockImplementationOnce(async () => ({
-    id: "job-1",
-    startedAt: new Date(),
+  createOrReadCloningJob.mockImplementationOnce(async () => ({
+    created: true,
+    job: { id: "job-1", startedAt: new Date() },
   }));
   const providerFetch = mock(async () =>
     Response.json({ voice_id: "eleven-voice-1" }),
@@ -283,7 +318,11 @@ test("admits before ElevenLabs and settles the flat charge without a readback", 
   try {
     const response = await app.request(
       "/v1/voice/clone",
-      { method: "POST", body: form },
+      {
+        method: "POST",
+        body: form,
+        headers: { "Idempotency-Key": "voice-success-1" },
+      },
       {
         ELEVENLABS_API_KEY: "configured",
         R2_PUBLIC_HOST: "blob.example.test",
@@ -299,6 +338,411 @@ test("admits before ElevenLabs and settles the flat charge without a readback", 
     expect(settle).toHaveBeenCalledWith(1);
     expect(settleUnknown).not.toHaveBeenCalled();
     expect(createUsage).toHaveBeenCalledTimes(1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("rejects a reused key with a different payload before billing or provider work", async () => {
+  admitFlatGenerativeOperation.mockClear();
+  calculateVoiceCloneCostFromCatalog.mockClear();
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: { balanceUsd: 10, revision: "2" },
+  }));
+  createOrReadCloningJob.mockImplementationOnce(async () => ({
+    created: false,
+    job: {
+      id: "job-conflict",
+      requestDigest: "digest-for-a-different-payload",
+      status: "processing",
+      progress: 0,
+      responsePayload: null,
+    },
+  }));
+  const providerFetch = mock(async () =>
+    Response.json({ voice_id: "duplicate" }),
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+  const form = new FormData();
+  form.set("name", "Different Voice");
+  form.set("cloneType", "instant");
+  form.set(
+    "file0",
+    new File([new Uint8Array([9])], "different.wav", { type: "audio/wav" }),
+  );
+
+  try {
+    const response = await app.request(
+      "/v1/voice/clone",
+      {
+        method: "POST",
+        body: form,
+        headers: { "Idempotency-Key": "voice-success-1" },
+      },
+      { ELEVENLABS_API_KEY: "configured", BLOB: { put: mock() } },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "idempotency_conflict",
+    });
+    expect(calculateVoiceCloneCostFromCatalog).not.toHaveBeenCalled();
+    expect(admitFlatGenerativeOperation).not.toHaveBeenCalled();
+    expect(providerFetch).not.toHaveBeenCalled();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("durably replays insufficient-credit denial without a stranded processing job", async () => {
+  admitFlatGenerativeOperation.mockClear();
+  markCloningJobFailed.mockClear();
+  requireGenerativeRouteCaller
+    .mockImplementationOnce(async () => ({
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKeyId: "key-1",
+      admissionSnapshot: { balanceUsd: 0, revision: "3" },
+    }))
+    .mockImplementationOnce(async () => ({
+      user: { id: "user-1", organization_id: "org-1" },
+      apiKeyId: "key-1",
+      admissionSnapshot: { balanceUsd: 0, revision: "3" },
+    }));
+  calculateVoiceCloneCostFromCatalog.mockImplementationOnce(async () => ({
+    totalCost: 1,
+    baseTotalCost: 0.8,
+    platformMarkup: 0.2,
+    pricingSource: "catalog",
+  }));
+  admitFlatGenerativeOperation.mockImplementationOnce(async () => {
+    throw new InsufficientCreditsError(1);
+  });
+  let requestDigest = "";
+  createOrReadCloningJob
+    .mockImplementationOnce(async (input: unknown) => {
+      requestDigest = (input as { requestDigest: string }).requestDigest;
+      return {
+        created: true,
+        job: { id: "job-insufficient", startedAt: new Date() },
+      };
+    })
+    .mockImplementationOnce(async () => ({
+      created: false,
+      job: {
+        id: "job-insufficient",
+        status: "failed",
+        progress: 0,
+        requestDigest,
+        responsePayload: {
+          status: 402,
+          body: {
+            success: false,
+            error: "Insufficient balance",
+            code: "insufficient_credits",
+            details: { required: 1, cloneType: "instant" },
+          },
+        },
+      },
+    }));
+  const providerFetch = mock(async () =>
+    Response.json({ voice_id: "duplicate" }),
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+
+  try {
+    const request = () => {
+      const form = new FormData();
+      form.set("name", "No Credits Voice");
+      form.set("cloneType", "instant");
+      form.set(
+        "file0",
+        new File([new Uint8Array([4])], "sample.wav", { type: "audio/wav" }),
+      );
+      return app.request(
+        "/v1/voice/clone",
+        {
+          method: "POST",
+          body: form,
+          headers: { "Idempotency-Key": "voice-insufficient-1" },
+        },
+        { ELEVENLABS_API_KEY: "configured", BLOB: { put: mock() } },
+      );
+    };
+
+    const first = await request();
+    const retry = await request();
+    expect(first.status).toBe(402);
+    expect(retry.status).toBe(402);
+    await expect(retry.json()).resolves.toMatchObject({
+      code: "insufficient_credits",
+      details: { required: 1 },
+    });
+    expect(markCloningJobFailed).toHaveBeenCalledWith(
+      "job-insufficient",
+      "Insufficient balance",
+      expect.any(Date),
+      expect.objectContaining({ status: 402 }),
+    );
+    expect(admitFlatGenerativeOperation).toHaveBeenCalledTimes(1);
+    expect(providerFetch).not.toHaveBeenCalled();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("timeout after provider submission retains evidence and settles unknown", async () => {
+  admitFlatGenerativeOperation.mockClear();
+  settle.mockClear();
+  settleUnknown.mockClear();
+  loggerError.mockClear();
+  recordCloningJobProviderReceipt.mockClear();
+  deleteSamplesByJobId.mockClear();
+  markCloningJobFailed.mockClear();
+  markCloningJobReconciliationRequired.mockClear();
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: { balanceUsd: 10, revision: "3" },
+  }));
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: { balanceUsd: 10, revision: "3" },
+  }));
+  calculateVoiceCloneCostFromCatalog.mockImplementationOnce(async () => ({
+    totalCost: 1,
+    baseTotalCost: 0.8,
+    platformMarkup: 0.2,
+    pricingSource: "catalog",
+  }));
+  admitFlatGenerativeOperation.mockImplementationOnce(async () => ({
+    mode: "synchronous_db_ledger",
+    markProviderDispatched,
+    settle,
+    settleUnknown,
+  }));
+  createOrReadCloningJob
+    .mockImplementationOnce(async () => ({
+      created: true,
+      job: { id: "job-timeout", startedAt: new Date() },
+    }))
+    .mockImplementationOnce(async (input: unknown) => ({
+      created: false,
+      job: {
+        id: "job-timeout",
+        status: "reconciliation_required",
+        progress: 0,
+        requestDigest: (input as { requestDigest: string }).requestDigest,
+        responsePayload: null,
+      },
+    }));
+  const providerFetch = mock(async () => {
+    throw new DOMException("The operation timed out", "TimeoutError");
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+  const blobDelete = mock(async () => undefined);
+  const form = new FormData();
+  form.set("name", "Ambiguous Voice");
+  form.set("cloneType", "instant");
+  form.set(
+    "file0",
+    new File([new Uint8Array([1])], "sample.wav", { type: "audio/wav" }),
+  );
+
+  try {
+    const response = await app.request(
+      "/v1/voice/clone",
+      {
+        method: "POST",
+        body: form,
+        headers: { "Idempotency-Key": "voice-timeout-1" },
+      },
+      {
+        ELEVENLABS_API_KEY: "configured",
+        BLOB: { put: mock(async () => undefined), delete: blobDelete },
+      },
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error:
+        "Voice clone provider work could not be completed. It is retained for reconciliation.",
+      details: { outcome: "submission_unknown", jobId: "job-timeout" },
+    });
+    expect(recordCloningJobProviderReceipt.mock.calls).toEqual([
+      [
+        {
+          jobId: "job-timeout",
+          step: "create",
+          state: "submitted",
+        },
+      ],
+      [
+        {
+          jobId: "job-timeout",
+          step: "create",
+          state: "submission_unknown",
+          errorMessage: "The operation timed out",
+        },
+      ],
+    ]);
+    expect(deleteSamplesByJobId).not.toHaveBeenCalled();
+    expect(blobDelete).not.toHaveBeenCalled();
+    expect(markCloningJobFailed).not.toHaveBeenCalled();
+    expect(markCloningJobReconciliationRequired).toHaveBeenCalledWith(
+      "job-timeout",
+      "ElevenLabs create submission outcome is unknown",
+    );
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+    expect(settle).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith(
+      "[Voice Clone API] Provider work requires reconciliation",
+      expect.objectContaining({
+        jobId: "job-timeout",
+        organizationId: "org-1",
+        provider: "elevenlabs",
+        providerState: "submission_unknown",
+        providerStep: "create",
+      }),
+    );
+
+    const retryForm = new FormData();
+    retryForm.set("name", "Ambiguous Voice");
+    retryForm.set("cloneType", "instant");
+    retryForm.set(
+      "file0",
+      new File([new Uint8Array([1])], "sample.wav", { type: "audio/wav" }),
+    );
+    const retry = await app.request(
+      "/v1/voice/clone",
+      {
+        method: "POST",
+        body: retryForm,
+        headers: { "Idempotency-Key": "voice-timeout-1" },
+      },
+      {
+        ELEVENLABS_API_KEY: "configured",
+        BLOB: { put: mock(async () => undefined), delete: blobDelete },
+      },
+    );
+    expect(retry.status).toBe(202);
+    await expect(retry.json()).resolves.toMatchObject({
+      code: "idempotency_replay",
+      reconciliationRequired: true,
+      job: { id: "job-timeout", status: "reconciliation_required" },
+    });
+    expect(providerFetch).toHaveBeenCalledTimes(1);
+    expect(admitFlatGenerativeOperation).toHaveBeenCalledTimes(1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("professional later-step failure retains the voice id and evidence", async () => {
+  settle.mockClear();
+  settleUnknown.mockClear();
+  loggerError.mockClear();
+  recordCloningJobProviderReceipt.mockClear();
+  deleteSamplesByJobId.mockClear();
+  markCloningJobFailed.mockClear();
+  markCloningJobReconciliationRequired.mockClear();
+  createVoice.mockClear();
+  requireGenerativeRouteCaller.mockImplementationOnce(async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKeyId: "key-1",
+    admissionSnapshot: { balanceUsd: 10, revision: "4" },
+  }));
+  calculateVoiceCloneCostFromCatalog.mockImplementationOnce(async () => ({
+    totalCost: 5,
+    baseTotalCost: 4,
+    platformMarkup: 1,
+    pricingSource: "catalog",
+  }));
+  admitFlatGenerativeOperation.mockImplementationOnce(async () => ({
+    mode: "synchronous_db_ledger",
+    markProviderDispatched,
+    settle,
+    settleUnknown,
+  }));
+  createOrReadCloningJob.mockImplementationOnce(async () => ({
+    created: true,
+    job: { id: "job-professional", startedAt: new Date() },
+  }));
+  const providerFetch = mock(async (request: RequestInfo | URL) => {
+    const url = String(request);
+    if (url.endsWith("/v1/voices/pvc")) {
+      return Response.json({ voice_id: "pvc-accepted-1" });
+    }
+    return new Response("sample rejected", { status: 422 });
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch as unknown as typeof fetch;
+  const blobDelete = mock(async () => undefined);
+  const form = new FormData();
+  form.set("name", "Professional Voice");
+  form.set("cloneType", "professional");
+  form.set(
+    "file0",
+    new File([new Uint8Array([1])], "sample.wav", { type: "audio/wav" }),
+  );
+
+  try {
+    const response = await app.request(
+      "/v1/voice/clone",
+      {
+        method: "POST",
+        body: form,
+        headers: { "Idempotency-Key": "test-key-0001" },
+      },
+      {
+        ELEVENLABS_API_KEY: "configured",
+        BLOB: { put: mock(async () => undefined), delete: blobDelete },
+      },
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      details: {
+        outcome: "provider_work_retained",
+        jobId: "job-professional",
+      },
+    });
+    expect(recordCloningJobProviderReceipt).toHaveBeenCalledWith({
+      jobId: "job-professional",
+      step: "create",
+      state: "accepted",
+      elevenlabsVoiceId: "pvc-accepted-1",
+    });
+    expect(recordCloningJobProviderReceipt).toHaveBeenLastCalledWith({
+      jobId: "job-professional",
+      step: "samples",
+      state: "rejected",
+      elevenlabsVoiceId: "pvc-accepted-1",
+    });
+    expect(createVoice).not.toHaveBeenCalled();
+    expect(deleteSamplesByJobId).not.toHaveBeenCalled();
+    expect(blobDelete).not.toHaveBeenCalled();
+    expect(markCloningJobFailed).not.toHaveBeenCalled();
+    expect(markCloningJobReconciliationRequired).toHaveBeenCalledWith(
+      "job-professional",
+      "ElevenLabs PVC sample upload failed: sample rejected",
+    );
+    expect(settleUnknown).toHaveBeenCalledTimes(1);
+    expect(settle).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith(
+      "[Voice Clone API] Provider work requires reconciliation",
+      expect.objectContaining({
+        jobId: "job-professional",
+        providerState: "rejected",
+        providerStep: "samples",
+        providerVoiceId: "pvc-accepted-1",
+      }),
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -48,6 +48,7 @@ import { calculateVoiceCloneCostFromCatalog } from "@/lib/services/ai-pricing";
 import { InsufficientCreditsError } from "@/lib/services/credits";
 import { deferredCredentialAdmissionGuard } from "@/lib/services/deferred-credential-admission-guard";
 import { usageService } from "@/lib/services/usage";
+import type { VoiceCloneFailureReason } from "@/lib/services/voice-clone-failure";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -58,11 +59,6 @@ const ELEVENLABS_API = "https://api.elevenlabs.io";
 const DEFAULT_R2_PUBLIC_HOST = "blob.eliza.app";
 
 type CloneType = "instant" | "professional";
-type VoiceCloneFailureReason =
-  | "provider_submission_unknown"
-  | "provider_work_reconciliation_required"
-  | "provider_request_rejected"
-  | "voice_clone_request_failed";
 type DurableCloneResponse = {
   status: 201 | 402;
   body: Record<string, unknown>;

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -58,6 +58,11 @@ const ELEVENLABS_API = "https://api.elevenlabs.io";
 const DEFAULT_R2_PUBLIC_HOST = "blob.eliza.app";
 
 type CloneType = "instant" | "professional";
+type VoiceCloneFailureReason =
+  | "provider_submission_unknown"
+  | "provider_work_reconciliation_required"
+  | "provider_request_rejected"
+  | "voice_clone_request_failed";
 type DurableCloneResponse = {
   status: 201 | 402;
   body: Record<string, unknown>;
@@ -153,6 +158,22 @@ function providerSubmissionIsAmbiguous(
   state: VoiceCloneProviderState | "not_dispatched",
 ): boolean {
   return state === "submitted" || state === "submission_unknown";
+}
+
+function safeVoiceCloneFailureReason(
+  state: VoiceCloneProviderState | "not_dispatched",
+  providerMayHaveAccepted: boolean,
+): VoiceCloneFailureReason {
+  if (providerSubmissionIsAmbiguous(state)) {
+    return "provider_submission_unknown";
+  }
+  if (providerMayHaveAccepted) {
+    return "provider_work_reconciliation_required";
+  }
+  if (state === "rejected") {
+    return "provider_request_rejected";
+  }
+  return "voice_clone_request_failed";
 }
 
 function isUploadedFile(value: FormDataEntryValue): value is File {
@@ -645,6 +666,10 @@ app.post("/", async (c) => {
       providerState,
       providerVoiceId,
     );
+    const safeFailureReason = safeVoiceCloneFailureReason(
+      providerState,
+      providerMayHaveAccepted,
+    );
 
     // Once provider submission may have been accepted, samples and R2 objects
     // are reconciliation evidence. They survive even when the local voice
@@ -690,7 +715,10 @@ app.post("/", async (c) => {
 
       if (!providerMayHaveAccepted) {
         try {
-          await userVoicesRepository.markCloningJobFailed(jobId, errorMessage);
+          await userVoicesRepository.markCloningJobFailed(
+            jobId,
+            safeFailureReason,
+          );
         } catch (dbError) {
           logger.error("[Voice Clone API] Failed to mark job failed", {
             jobId,
@@ -701,7 +729,7 @@ app.post("/", async (c) => {
         try {
           await userVoicesRepository.markCloningJobReconciliationRequired(
             jobId,
-            errorMessage,
+            safeFailureReason,
           );
         } catch (dbError) {
           // error-policy:J7 failure to enrich reconciliation diagnostics must
@@ -753,7 +781,7 @@ app.post("/", async (c) => {
             input_cost: String(0),
             output_cost: String(0),
             is_successful: false,
-            error_message: errorMessage,
+            error_message: safeFailureReason,
           })
           .catch((usageError) => {
             logger.error("[Voice Clone API] Failed to record failed usage", {
@@ -832,6 +860,7 @@ app.post("/", async (c) => {
       providerStep,
       providerVoiceId,
       providerMayHaveAccepted,
+      safeFailureReason,
     });
     return c.json(
       {
@@ -840,14 +869,10 @@ app.post("/", async (c) => {
           ? "Voice clone provider work could not be completed. It is retained for reconciliation."
           : "Failed to create voice clone. Credits have been refunded.",
         code: "internal_error" as const,
-        details: providerMayHaveAccepted
-          ? {
-              outcome: providerSubmissionIsAmbiguous(providerState)
-                ? "submission_unknown"
-                : "provider_work_retained",
-              jobId,
-            }
-          : errorMessage,
+        details: {
+          outcome: safeFailureReason,
+          ...(jobId ? { jobId } : {}),
+        },
       },
       500,
     );
@@ -946,7 +971,7 @@ async function createElevenLabsVoice(params: {
       await recordProviderReceipt({
         step: "create",
         state: "submission_unknown",
-        errorMessage: error instanceof Error ? error.message : String(error),
+        errorMessage: "provider_transport_uncertain",
       });
       throw new VoiceCloneSubmissionUnknownError("create", error);
     }
@@ -982,7 +1007,7 @@ async function createElevenLabsVoice(params: {
     await recordProviderReceipt({
       step: "create",
       state: "submission_unknown",
-      errorMessage: error instanceof Error ? error.message : String(error),
+      errorMessage: "provider_transport_uncertain",
     });
     throw new VoiceCloneSubmissionUnknownError("create", error);
   }
@@ -1023,7 +1048,7 @@ async function createElevenLabsVoice(params: {
       step: "samples",
       state: "submission_unknown",
       elevenlabsVoiceId: voiceId,
-      errorMessage: error instanceof Error ? error.message : String(error),
+      errorMessage: "provider_transport_uncertain",
     });
     throw new VoiceCloneSubmissionUnknownError("samples", error);
   }
@@ -1068,7 +1093,7 @@ async function createElevenLabsVoice(params: {
       step: "train",
       state: "submission_unknown",
       elevenlabsVoiceId: voiceId,
-      errorMessage: error instanceof Error ? error.message : String(error),
+      errorMessage: "provider_transport_uncertain",
     });
     throw new VoiceCloneSubmissionUnknownError("train", error);
   }

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -18,6 +18,7 @@
  *   - file0,file1... File (1..10, total <= 100MB)
  */
 
+import { ElizaError } from "@elizaos/core";
 import { Hono } from "hono";
 import {
   admitFlatGenerativeOperation,
@@ -30,6 +31,8 @@ import {
   type NewVoiceCloningJob,
   type NewVoiceSample,
   userVoicesRepository,
+  type VoiceCloneProviderState,
+  type VoiceCloneProviderStep,
 } from "@/db/repositories/user-voices";
 import {
   failureResponse,
@@ -55,6 +58,102 @@ const ELEVENLABS_API = "https://api.elevenlabs.io";
 const DEFAULT_R2_PUBLIC_HOST = "blob.eliza.app";
 
 type CloneType = "instant" | "professional";
+type DurableCloneResponse = {
+  status: 201 | 402;
+  body: Record<string, unknown>;
+};
+
+function durableCloneResponse(value: unknown): DurableCloneResponse | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { status?: unknown; body?: unknown };
+  if (candidate.status !== 201 && candidate.status !== 402) return null;
+  if (!candidate.body || typeof candidate.body !== "object") return null;
+  return {
+    status: candidate.status,
+    body: candidate.body as Record<string, unknown>,
+  };
+}
+
+class VoiceCloneSubmissionUnknownError extends ElizaError {
+  override readonly name = "VoiceCloneSubmissionUnknownError";
+  readonly step: VoiceCloneProviderStep;
+
+  constructor(step: VoiceCloneProviderStep, cause: unknown) {
+    super(`ElevenLabs ${step} submission outcome is unknown`, {
+      code: "VOICE_CLONE_SUBMISSION_UNKNOWN",
+      context: { provider: "elevenlabs", step },
+      cause,
+      severity: "ephemeral",
+    });
+    this.step = step;
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(
+      ([a], [b]) => a.localeCompare(b),
+    );
+    return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+async function sha256Hex(bytes: ArrayBuffer | Uint8Array): Promise<string> {
+  const stableBytes =
+    bytes instanceof ArrayBuffer ? bytes : Uint8Array.from(bytes).buffer;
+  const digest = await crypto.subtle.digest("SHA-256", stableBytes);
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+async function voiceCloneRequestDigest(input: {
+  cloneType: CloneType;
+  name: string;
+  description: string | undefined;
+  settings: Record<string, unknown>;
+  files: File[];
+}): Promise<string> {
+  const files = await Promise.all(
+    input.files.map(async (file) => ({
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      sha256: await sha256Hex(await file.arrayBuffer()),
+    })),
+  );
+  return sha256Hex(
+    new TextEncoder().encode(
+      canonicalJson({
+        cloneType: input.cloneType,
+        name: input.name,
+        description: input.description ?? null,
+        settings: input.settings,
+        files,
+      }),
+    ),
+  );
+}
+
+function providerAcceptanceIsPossible(
+  state: VoiceCloneProviderState | "not_dispatched",
+  voiceId: string | undefined,
+): boolean {
+  return (
+    state === "submitted" ||
+    state === "submission_unknown" ||
+    state === "accepted" ||
+    voiceId !== undefined
+  );
+}
+
+function providerSubmissionIsAmbiguous(
+  state: VoiceCloneProviderState | "not_dispatched",
+): boolean {
+  return state === "submitted" || state === "submission_unknown";
+}
 
 function isUploadedFile(value: FormDataEntryValue): value is File {
   return (
@@ -104,13 +203,16 @@ app.post("/", async (c) => {
   let description: string | undefined;
   let settings: Record<string, unknown> = {};
   let files: File[] = [];
+  let idempotencyKey = "";
 
-  // Track partial state so the catch branch can delete R2 and DB orphans
-  // when the clone fails before we've successfully persisted a `user_voices`
-  // row. Once `userVoicePersisted` flips, the voice clone is committed and
-  // the deletion branch must NOT delete those samples or R2 objects.
+  // Provider submission is the irreversible boundary. A local `user_voices`
+  // insert is only a projection of that external outcome and must never be
+  // used to decide whether evidence can be deleted or credits released.
   const uploadedR2Keys: string[] = [];
-  let userVoicePersisted = false;
+  let providerState: VoiceCloneProviderState | "not_dispatched" =
+    "not_dispatched";
+  let providerStep: VoiceCloneProviderStep | undefined;
+  let providerVoiceId: string | undefined;
 
   let caller: Awaited<ReturnType<typeof requireGenerativeRouteCaller>>;
   try {
@@ -227,6 +329,10 @@ app.post("/", async (c) => {
     if (!cloneType || !voiceName || files.length === 0) {
       throw new Error("Validated voice-clone request was not retained");
     }
+    idempotencyKey = c.req.header("Idempotency-Key")?.trim() ?? "";
+    if (idempotencyKey.length === 0 || idempotencyKey.length > 128) {
+      throw ValidationError("A valid Idempotency-Key header is required");
+    }
 
     logger.info(
       `[Voice Clone API] Creating ${cloneType} voice clone: ${voiceName}`,
@@ -237,6 +343,72 @@ app.post("/", async (c) => {
         totalSize,
       },
     );
+
+    const requestDigest = await voiceCloneRequestDigest({
+      cloneType,
+      name: voiceName,
+      description,
+      settings,
+      files,
+    });
+    const newJob = {
+      organizationId: user.organization_id,
+      userId: user.id,
+      jobType: cloneType,
+      voiceName,
+      voiceDescription: description,
+      status: "processing",
+      metadata: { fileCount, totalSize },
+      startedAt: new Date(),
+      idempotencyKey,
+      requestDigest,
+    } satisfies NewVoiceCloningJob & {
+      idempotencyKey: string;
+      requestDigest: string;
+    };
+    const preparedJob =
+      await userVoicesRepository.createOrReadCloningJob(newJob);
+    const createdJob = preparedJob.job;
+    jobId = createdJob.id;
+    if (!preparedJob.created) {
+      if (createdJob.requestDigest !== requestDigest) {
+        return c.json(
+          {
+            success: false,
+            error:
+              "Idempotency-Key was already used with a different voice-clone payload",
+            code: "idempotency_conflict" as const,
+          },
+          409,
+        );
+      }
+      if (createdJob.responsePayload) {
+        const replay = durableCloneResponse(createdJob.responsePayload);
+        if (!replay) {
+          throw new ElizaError("Stored voice-clone response is malformed", {
+            code: "VOICE_CLONE_IDEMPOTENCY_RESPONSE_INVALID",
+            context: { jobId: createdJob.id },
+            severity: "fatal",
+          });
+        }
+        return c.json(replay.body, replay.status);
+      }
+      return c.json(
+        {
+          success: false,
+          error: "Voice clone request is already recorded",
+          code: "idempotency_replay" as const,
+          job: {
+            id: createdJob.id,
+            status: createdJob.status,
+            progress: createdJob.progress,
+          },
+          reconciliationRequired:
+            createdJob.status === "reconciliation_required",
+        },
+        202,
+      );
+    }
 
     cloneCost = await calculateVoiceCloneCostFromCatalog({ cloneType });
     billingContext = {
@@ -262,31 +434,23 @@ app.post("/", async (c) => {
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {
-        return c.json(
-          {
-            success: false,
-            error: "Insufficient balance",
-            code: "insufficient_credits" as const,
-            details: { required: error.required, cloneType },
-          },
-          402,
+        const responseBody = {
+          success: false,
+          error: "Insufficient balance",
+          code: "insufficient_credits" as const,
+          details: { required: error.required, cloneType },
+        };
+        await userVoicesRepository.markCloningJobFailed(
+          createdJob.id,
+          "Insufficient balance",
+          new Date(),
+          { status: 402, body: responseBody },
         );
+        return c.json(responseBody, 402);
       }
       throw error;
     }
 
-    const newJob: NewVoiceCloningJob = {
-      organizationId: user.organization_id,
-      userId: user.id,
-      jobType: cloneType,
-      voiceName,
-      voiceDescription: description,
-      status: "processing",
-      metadata: { fileCount, totalSize },
-      startedAt: new Date(),
-    };
-    const createdJob = await userVoicesRepository.createCloningJob(newJob);
-    jobId = createdJob.id;
     const userId = user.id;
     const organizationId = user.organization_id;
 
@@ -345,6 +509,24 @@ app.post("/", async (c) => {
       language,
       files,
       markProviderDispatched: admission.markProviderDispatched,
+      recordProviderReceipt: async (receipt) => {
+        const persistReceipt =
+          userVoicesRepository.recordCloningJobProviderReceipt({
+            jobId: createdJob.id,
+            ...receipt,
+          });
+        if (receipt.state === "submitted") {
+          await persistReceipt;
+        }
+        providerState = receipt.state;
+        providerStep = receipt.step;
+        if (receipt.elevenlabsVoiceId) {
+          providerVoiceId = receipt.elevenlabsVoiceId;
+        }
+        if (receipt.state !== "submitted") {
+          await persistReceipt;
+        }
+      },
     });
 
     // 3) Persist user_voices row.
@@ -360,7 +542,6 @@ app.post("/", async (c) => {
       creationCost: String(cloneCost.totalCost),
     };
     const insertedVoice = await userVoicesRepository.createVoice(newUserVoice);
-    userVoicePersisted = true;
 
     // Backfill the sample rows with the new userVoiceId.
     await userVoicesRepository.attachSamplesToVoice(
@@ -371,10 +552,28 @@ app.post("/", async (c) => {
     const startTime = createdJob.startedAt?.getTime() ?? Date.now();
     const duration = Date.now() - startTime;
 
+    const successPayload = {
+      success: true as const,
+      voice: {
+        id: insertedVoice.id,
+        elevenlabsVoiceId: insertedVoice.elevenlabsVoiceId,
+        name: insertedVoice.name,
+        description: insertedVoice.description,
+        cloneType: insertedVoice.cloneType,
+        status: "completed",
+        sampleCount: insertedVoice.sampleCount,
+        createdAt: insertedVoice.createdAt.toISOString(),
+      },
+      job: { id: createdJob.id, status: "completed", progress: 100 },
+      creditsDeducted: cloneCost.totalCost,
+      estimatedCompletionTime:
+        cloneType === "professional" ? "30-60 minutes" : "30 seconds",
+    };
     const updatedJob = await userVoicesRepository.completeCloningJob({
       jobId: createdJob.id,
       userVoiceId: insertedVoice.id,
       elevenlabsVoiceId,
+      responsePayload: { status: 201, body: successPayload },
     });
 
     const completedAdmission = admission;
@@ -437,42 +636,23 @@ app.post("/", async (c) => {
       duration,
     });
 
-    return c.json(
-      {
-        success: true as const,
-        voice: {
-          id: insertedVoice.id,
-          elevenlabsVoiceId: insertedVoice.elevenlabsVoiceId,
-          name: insertedVoice.name,
-          description: insertedVoice.description,
-          cloneType: insertedVoice.cloneType,
-          status: updatedJob.status,
-          sampleCount: insertedVoice.sampleCount,
-          createdAt: insertedVoice.createdAt.toISOString(),
-        },
-        job: {
-          id: updatedJob.id,
-          status: updatedJob.status,
-          progress: updatedJob.progress,
-        },
-        creditsDeducted: cloneCost.totalCost,
-        estimatedCompletionTime:
-          cloneType === "professional" ? "30-60 minutes" : "30 seconds",
-      },
-      201,
-    );
+    return c.json(successPayload, 201);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const admissionError = asGenerativeCacheApiError(error);
 
-    // Deletion pass runs only when we have partial state to undo (i.e.
-    // the user_voices row was never written). Once that row is committed,
-    // the voice clone is real and we must not delete its samples or R2
-    // objects, even if a later step (billing, usage tracking) throws.
+    const providerMayHaveAccepted = providerAcceptanceIsPossible(
+      providerState,
+      providerVoiceId,
+    );
+
+    // Once provider submission may have been accepted, samples and R2 objects
+    // are reconciliation evidence. They survive even when the local voice
+    // projection or a later professional-clone step fails.
     // Each deletion operation is wrapped in its own try/catch so a deletion
     // failure does not mask the original error from the client.
     if (jobId) {
-      if (!userVoicePersisted) {
+      if (!providerMayHaveAccepted) {
         // 1) Drop the voice_samples rows we wrote for this job (orphaned
         //    rows referencing R2 keys we're about to delete).
         try {
@@ -508,53 +688,47 @@ app.post("/", async (c) => {
         }
       }
 
-      // 3) Mark the job failed last so it carries the canonical error
-      //    message even if step 1 or 2 emitted their own log lines.
-      try {
-        await userVoicesRepository.markCloningJobFailed(jobId, errorMessage);
-      } catch (dbError) {
-        logger.error("[Voice Clone API] Failed to mark job failed", {
-          jobId,
-          error: dbError instanceof Error ? dbError.message : String(dbError),
-        });
+      if (!providerMayHaveAccepted) {
+        try {
+          await userVoicesRepository.markCloningJobFailed(jobId, errorMessage);
+        } catch (dbError) {
+          logger.error("[Voice Clone API] Failed to mark job failed", {
+            jobId,
+            error: dbError instanceof Error ? dbError.message : String(dbError),
+          });
+        }
+      } else {
+        try {
+          await userVoicesRepository.markCloningJobReconciliationRequired(
+            jobId,
+            errorMessage,
+          );
+        } catch (dbError) {
+          // error-policy:J7 failure to enrich reconciliation diagnostics must
+          // not release the conservative settlement or erase prior receipts.
+          logger.error(
+            "[Voice Clone API] Failed to mark reconciliation required",
+            {
+              jobId,
+              providerState,
+              providerStep,
+              providerVoiceId,
+              error:
+                dbError instanceof Error ? dbError.message : String(dbError),
+            },
+          );
+        }
       }
     }
 
-    // A delivered ElevenLabs voice remains billable even if a later local DB
-    // update fails. Before that commit point, release the full admission.
-    if (admission && userVoicePersisted && cloneCost && billingContext) {
-      const failedAdmission = admission;
-      const failedCost = cloneCost;
-      const failedBillingContext = billingContext;
-      await retainVoiceCloneTask(
-        c,
-        billFlatUsage(
-          failedBillingContext,
-          failedCost,
-          failedAdmission.reservation,
-        )
-          .then(async (billing) => {
-            if (!failedAdmission.reservation) {
-              await failedAdmission.settle(billing.totalCost);
-            }
-          })
-          .catch(async (settlementError) => {
-            await failedAdmission.settleUnknown();
-            logger.error(
-              "[Voice Clone API] Failed to settle committed voice clone",
-              {
-                error:
-                  settlementError instanceof Error
-                    ? settlementError.message
-                    : String(settlementError),
-              },
-            );
-          }),
-      );
+    // Ambiguous or accepted submissions remain conservatively billable. Only
+    // a definitive pre-dispatch/provider rejection releases the reservation.
+    if (admission && providerMayHaveAccepted) {
+      await retainVoiceCloneSettlement(c, admission.settleUnknown(), "settle");
     } else if (admission) {
       await retainVoiceCloneSettlement(c, admission.settle(0), "release");
     }
-    if (admission && !userVoicePersisted) {
+    if (admission && !providerMayHaveAccepted) {
       logger.info("[Voice Clone API] Credits refunded", {
         organizationId: user?.organization_id,
         amount: cloneCost?.totalCost,
@@ -594,7 +768,25 @@ app.post("/", async (c) => {
 
     if (admissionError) return failureResponse(c, admissionError);
 
-    if (error instanceof Error) {
+    if (providerMayHaveAccepted) {
+      logger.error("[Voice Clone API] Provider work requires reconciliation", {
+        error: errorMessage,
+        cause:
+          error instanceof Error && error.cause instanceof Error
+            ? error.cause.message
+            : undefined,
+        jobId,
+        organizationId: user?.organization_id,
+        userId: user?.id,
+        cloneType,
+        provider: "elevenlabs",
+        providerState,
+        providerStep,
+        providerVoiceId,
+      });
+    }
+
+    if (error instanceof Error && !providerMayHaveAccepted) {
       const lower = errorMessage.toLowerCase();
       if (lower.includes("rate limit")) {
         return jsonError(
@@ -632,13 +824,30 @@ app.post("/", async (c) => {
     logger.error("[Voice Clone API] Unhandled error", {
       error: errorMessage,
       jobId,
+      organizationId: user?.organization_id,
+      userId: user?.id,
+      cloneType,
+      provider: "elevenlabs",
+      providerState,
+      providerStep,
+      providerVoiceId,
+      providerMayHaveAccepted,
     });
     return c.json(
       {
         success: false,
-        error: "Failed to create voice clone. Credits have been refunded.",
+        error: providerMayHaveAccepted
+          ? "Voice clone provider work could not be completed. It is retained for reconciliation."
+          : "Failed to create voice clone. Credits have been refunded.",
         code: "internal_error" as const,
-        details: errorMessage,
+        details: providerMayHaveAccepted
+          ? {
+              outcome: providerSubmissionIsAmbiguous(providerState)
+                ? "submission_unknown"
+                : "provider_work_retained",
+              jobId,
+            }
+          : errorMessage,
       },
       500,
     );
@@ -696,6 +905,12 @@ async function createElevenLabsVoice(params: {
   language: string;
   files: File[];
   markProviderDispatched: (() => Promise<void>) | undefined;
+  recordProviderReceipt: (receipt: {
+    step: VoiceCloneProviderStep;
+    state: VoiceCloneProviderState;
+    elevenlabsVoiceId?: string;
+    errorMessage?: string;
+  }) => Promise<void>;
 }): Promise<string> {
   const {
     apiKey,
@@ -705,6 +920,7 @@ async function createElevenLabsVoice(params: {
     language,
     files,
     markProviderDispatched,
+    recordProviderReceipt,
   } = params;
 
   if (cloneType === "instant") {
@@ -715,62 +931,161 @@ async function createElevenLabsVoice(params: {
       fd.append("files", file, file.name);
     }
     await markProviderDispatched?.();
-    const res = await fetch(`${ELEVENLABS_API}/v1/voices/add`, {
-      method: "POST",
-      headers: { "xi-api-key": apiKey },
-      body: fd,
-      signal: AbortSignal.timeout(30_000),
+    await recordProviderReceipt({ step: "create", state: "submitted" });
+    let res: Response;
+    try {
+      res = await fetch(`${ELEVENLABS_API}/v1/voices/add`, {
+        method: "POST",
+        headers: { "xi-api-key": apiKey },
+        body: fd,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch (error) {
+      // error-policy:J2 preserve the transport failure as the cause after
+      // durably recording that provider acceptance is unknown.
+      await recordProviderReceipt({
+        step: "create",
+        state: "submission_unknown",
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+      throw new VoiceCloneSubmissionUnknownError("create", error);
+    }
+    if (!res.ok) {
+      await recordProviderReceipt({ step: "create", state: "rejected" });
+    }
+    const voiceId = await parseElevenLabsResponse(res, "instant");
+    await recordProviderReceipt({
+      step: "create",
+      state: "accepted",
+      elevenlabsVoiceId: voiceId,
     });
-    return parseElevenLabsResponse(res, "instant");
+    return voiceId;
   }
 
   // Professional voice cloning is a 3-step operation in ElevenLabs.
   await markProviderDispatched?.();
-  const createRes = await fetch(`${ELEVENLABS_API}/v1/voices/pvc`, {
-    method: "POST",
-    headers: {
-      "xi-api-key": apiKey,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ name, description, language }),
-    signal: AbortSignal.timeout(30_000),
-  });
-  const voiceId = await parseElevenLabsResponse(createRes, "professional");
-
-  const uploadFd = new FormData();
-  for (const file of files) {
-    uploadFd.append("files", file, file.name);
-  }
-  const uploadRes = await fetch(
-    `${ELEVENLABS_API}/v1/voices/pvc/${encodeURIComponent(voiceId)}/samples`,
-    {
-      method: "POST",
-      headers: { "xi-api-key": apiKey },
-      body: uploadFd,
-      signal: AbortSignal.timeout(30_000),
-    },
-  );
-  if (!uploadRes.ok) {
-    const message = await readElevenLabsError(uploadRes);
-    throw new Error(`ElevenLabs PVC sample upload failed: ${message}`);
-  }
-
-  const trainRes = await fetch(
-    `${ELEVENLABS_API}/v1/voices/pvc/${encodeURIComponent(voiceId)}/train`,
-    {
+  await recordProviderReceipt({ step: "create", state: "submitted" });
+  let createRes: Response;
+  try {
+    createRes = await fetch(`${ELEVENLABS_API}/v1/voices/pvc`, {
       method: "POST",
       headers: {
         "xi-api-key": apiKey,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ language }),
+      body: JSON.stringify({ name, description, language }),
       signal: AbortSignal.timeout(30_000),
-    },
-  );
+    });
+  } catch (error) {
+    // error-policy:J2 preserve the transport failure as the cause after
+    // durably recording that provider acceptance is unknown.
+    await recordProviderReceipt({
+      step: "create",
+      state: "submission_unknown",
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    throw new VoiceCloneSubmissionUnknownError("create", error);
+  }
+  if (!createRes.ok) {
+    await recordProviderReceipt({ step: "create", state: "rejected" });
+  }
+  const voiceId = await parseElevenLabsResponse(createRes, "professional");
+  await recordProviderReceipt({
+    step: "create",
+    state: "accepted",
+    elevenlabsVoiceId: voiceId,
+  });
+
+  const uploadFd = new FormData();
+  for (const file of files) {
+    uploadFd.append("files", file, file.name);
+  }
+  await recordProviderReceipt({
+    step: "samples",
+    state: "submitted",
+    elevenlabsVoiceId: voiceId,
+  });
+  let uploadRes: Response;
+  try {
+    uploadRes = await fetch(
+      `${ELEVENLABS_API}/v1/voices/pvc/${encodeURIComponent(voiceId)}/samples`,
+      {
+        method: "POST",
+        headers: { "xi-api-key": apiKey },
+        body: uploadFd,
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+  } catch (error) {
+    // error-policy:J2 preserve the transport failure as the cause after
+    // durably recording that provider acceptance is unknown.
+    await recordProviderReceipt({
+      step: "samples",
+      state: "submission_unknown",
+      elevenlabsVoiceId: voiceId,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    throw new VoiceCloneSubmissionUnknownError("samples", error);
+  }
+  if (!uploadRes.ok) {
+    await recordProviderReceipt({
+      step: "samples",
+      state: "rejected",
+      elevenlabsVoiceId: voiceId,
+    });
+    const message = await readElevenLabsError(uploadRes);
+    throw new Error(`ElevenLabs PVC sample upload failed: ${message}`);
+  }
+  await recordProviderReceipt({
+    step: "samples",
+    state: "accepted",
+    elevenlabsVoiceId: voiceId,
+  });
+
+  await recordProviderReceipt({
+    step: "train",
+    state: "submitted",
+    elevenlabsVoiceId: voiceId,
+  });
+  let trainRes: Response;
+  try {
+    trainRes = await fetch(
+      `${ELEVENLABS_API}/v1/voices/pvc/${encodeURIComponent(voiceId)}/train`,
+      {
+        method: "POST",
+        headers: {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ language }),
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+  } catch (error) {
+    // error-policy:J2 preserve the transport failure as the cause after
+    // durably recording that provider acceptance is unknown.
+    await recordProviderReceipt({
+      step: "train",
+      state: "submission_unknown",
+      elevenlabsVoiceId: voiceId,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    throw new VoiceCloneSubmissionUnknownError("train", error);
+  }
   if (!trainRes.ok) {
+    await recordProviderReceipt({
+      step: "train",
+      state: "rejected",
+      elevenlabsVoiceId: voiceId,
+    });
     const message = await readElevenLabsError(trainRes);
     throw new Error(`ElevenLabs PVC train failed: ${message}`);
   }
+  await recordProviderReceipt({
+    step: "train",
+    state: "accepted",
+    elevenlabsVoiceId: voiceId,
+  });
 
   return voiceId;
 }

--- a/packages/cloud/api/v1/voice/jobs/route.reconciliation.test.ts
+++ b/packages/cloud/api/v1/voice/jobs/route.reconciliation.test.ts
@@ -10,7 +10,7 @@ const getUserJobs = mock(async () => [
     jobType: "professional",
     status: "reconciliation_required",
     progress: 0,
-    errorMessage: "Provider submission outcome is unknown",
+    errorMessage: "account acct_private_123 provider submission failed",
     elevenlabsVoiceId: "pvc-accepted-1",
     metadata: {
       providerSubmissionState: "submission_unknown",
@@ -40,13 +40,15 @@ test("returns explicit reconciliation state and the provider locator", async () 
   const response = await app.request("/");
 
   expect(response.status).toBe(200);
-  await expect(response.json()).resolves.toMatchObject({
+  const body = await response.json();
+  expect(body).toMatchObject({
     success: true,
     total: 1,
     jobs: [
       {
         id: "job-reconcile-1",
         status: "reconciliation_required",
+        errorMessage: "provider_work_reconciliation_required",
         reconciliationRequired: true,
         providerState: "submission_unknown",
         providerStep: "samples",
@@ -54,4 +56,5 @@ test("returns explicit reconciliation state and the provider locator", async () 
       },
     ],
   });
+  expect(JSON.stringify(body)).not.toContain("acct_private_123");
 });

--- a/packages/cloud/api/v1/voice/jobs/route.reconciliation.test.ts
+++ b/packages/cloud/api/v1/voice/jobs/route.reconciliation.test.ts
@@ -1,0 +1,57 @@
+/** Proves the canonical voice-jobs API exposes ambiguous provider work for reconciliation. */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getUserJobs = mock(async () => [
+  {
+    id: "job-reconcile-1",
+    voiceName: "Accepted Maybe",
+    jobType: "professional",
+    status: "reconciliation_required",
+    progress: 0,
+    errorMessage: "Provider submission outcome is unknown",
+    elevenlabsVoiceId: "pvc-accepted-1",
+    metadata: {
+      providerSubmissionState: "submission_unknown",
+      providerLastStep: "samples",
+    },
+    createdAt: new Date("2026-09-02T12:00:00.000Z"),
+    startedAt: new Date("2026-09-02T12:00:01.000Z"),
+  },
+]);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+  }),
+}));
+mock.module("@/lib/services/voice-cloning", () => ({
+  voiceCloningService: { getUserJobs },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: () => undefined, error: () => undefined },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/", route);
+
+test("returns explicit reconciliation state and the provider locator", async () => {
+  const response = await app.request("/");
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toMatchObject({
+    success: true,
+    total: 1,
+    jobs: [
+      {
+        id: "job-reconcile-1",
+        status: "reconciliation_required",
+        reconciliationRequired: true,
+        providerState: "submission_unknown",
+        providerStep: "samples",
+        providerVoiceId: "pvc-accepted-1",
+      },
+    ],
+  });
+});

--- a/packages/cloud/api/v1/voice/jobs/route.ts
+++ b/packages/cloud/api/v1/voice/jobs/route.ts
@@ -25,6 +25,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { getErrorStatusCode, nextJsonFromCaughtError } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { exposedVoiceCloneFailureReason } from "@/lib/services/voice-clone-failure";
 import { voiceCloningService } from "@/lib/services/voice-cloning";
 import { logger } from "@/lib/utils/logger";
 
@@ -63,7 +64,10 @@ async function __hono_GET(request: Request) {
           jobType: job.jobType,
           status: job.status,
           progress: job.progress,
-          errorMessage: job.errorMessage,
+          errorMessage: exposedVoiceCloneFailureReason(
+            job.errorMessage,
+            job.status === "reconciliation_required",
+          ),
           reconciliationRequired: job.status === "reconciliation_required",
           providerState:
             typeof metadata.providerSubmissionState === "string"

--- a/packages/cloud/api/v1/voice/jobs/route.ts
+++ b/packages/cloud/api/v1/voice/jobs/route.ts
@@ -30,8 +30,7 @@ import { logger } from "@/lib/utils/logger";
 
 /**
  * GET /api/v1/voice/jobs
- * Gets all active (processing or pending) voice cloning jobs for the authenticated user.
- * Only returns jobs that are still in progress.
+ * Gets active and reconciliation-required voice cloning jobs for the authenticated user.
  *
  * @param request - The Next.js request object.
  * @returns Array of active voice cloning jobs with status and progress information.
@@ -48,21 +47,37 @@ async function __hono_GET(request: Request) {
     );
 
     const activeJobs = allJobs.filter(
-      (job) => job.status === "processing" || job.status === "pending",
+      (job) =>
+        job.status === "processing" ||
+        job.status === "pending" ||
+        job.status === "reconciliation_required",
     );
 
     return Response.json({
       success: true,
-      jobs: activeJobs.map((job) => ({
-        id: job.id,
-        voiceName: job.voiceName,
-        jobType: job.jobType,
-        status: job.status,
-        progress: job.progress,
-        errorMessage: job.errorMessage,
-        createdAt: job.createdAt,
-        startedAt: job.startedAt,
-      })),
+      jobs: activeJobs.map((job) => {
+        const metadata = job.metadata as Record<string, unknown>;
+        return {
+          id: job.id,
+          voiceName: job.voiceName,
+          jobType: job.jobType,
+          status: job.status,
+          progress: job.progress,
+          errorMessage: job.errorMessage,
+          reconciliationRequired: job.status === "reconciliation_required",
+          providerState:
+            typeof metadata.providerSubmissionState === "string"
+              ? metadata.providerSubmissionState
+              : null,
+          providerStep:
+            typeof metadata.providerLastStep === "string"
+              ? metadata.providerLastStep
+              : null,
+          providerVoiceId: job.elevenlabsVoiceId,
+          createdAt: job.createdAt,
+          startedAt: job.startedAt,
+        };
+      }),
       total: activeJobs.length,
     });
   } catch (error) {

--- a/packages/cloud/shared/src/db/migrations/0375_voice_clone_idempotency.sql
+++ b/packages/cloud/shared/src/db/migrations/0375_voice_clone_idempotency.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "voice_cloning_jobs" ADD COLUMN IF NOT EXISTS "idempotency_key" text;
+--> statement-breakpoint
+ALTER TABLE "voice_cloning_jobs" ADD COLUMN IF NOT EXISTS "request_digest" text;
+--> statement-breakpoint
+ALTER TABLE "voice_cloning_jobs" ADD COLUMN IF NOT EXISTS "response_payload" jsonb;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "voice_cloning_jobs_tenant_idempotency_uidx"
+  ON "voice_cloning_jobs" ("organization_id", "user_id", "idempotency_key");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2507,6 +2507,13 @@
       "when": 1796083200001,
       "tag": "0374_subscription_funding_transaction_uniqueness",
       "breakpoints": true
+    },
+    {
+      "idx": 358,
+      "version": "7",
+      "when": 1796083200002,
+      "tag": "0375_voice_clone_idempotency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/user-voices-provider-receipts.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/user-voices-provider-receipts.pglite.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Proves voice-clone provider receipts are append-only and immediately durable
+ * against a real in-process PGlite database.
+ */
+
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+
+const JOB_ID = "10000000-0000-4000-8000-000000000001";
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests;
+let repository: typeof import("../user-voices").userVoicesRepository;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = "pglite://memory";
+  process.env.DISABLE_LOCAL_PGLITE_FALLBACK = "1";
+  const client = await import("../../client");
+  dbWrite = client.dbWrite;
+  closeDb = client.closeDatabaseConnectionsForTests;
+  ({ userVoicesRepository: repository } = await import("../user-voices"));
+
+  const pglite = client.getPgliteClientForTests();
+  if (!pglite) throw new Error("PGlite test client was not initialized");
+  await pglite.exec(`
+    CREATE TABLE voice_cloning_jobs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      user_id uuid NOT NULL,
+      job_type text NOT NULL,
+      voice_name text NOT NULL,
+      voice_description text,
+      status text NOT NULL DEFAULT 'pending',
+      progress integer NOT NULL DEFAULT 0,
+      user_voice_id uuid,
+      elevenlabs_voice_id text,
+      error_message text,
+      retry_count integer NOT NULL DEFAULT 0,
+      idempotency_key text,
+      request_digest text,
+      response_payload jsonb,
+      metadata jsonb NOT NULL DEFAULT '{}',
+      started_at timestamp,
+      completed_at timestamp,
+      created_at timestamp NOT NULL DEFAULT now(),
+      updated_at timestamp NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX voice_cloning_jobs_tenant_idempotency_uidx
+      ON voice_cloning_jobs (organization_id, user_id, idempotency_key);
+  `);
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+beforeEach(async () => {
+  await dbWrite.execute(sql`DELETE FROM voice_cloning_jobs`);
+  await dbWrite.execute(sql`
+    INSERT INTO voice_cloning_jobs (
+      id, organization_id, user_id, job_type, voice_name, status, metadata
+    ) VALUES (
+      ${JOB_ID},
+      '20000000-0000-4000-8000-000000000001',
+      '30000000-0000-4000-8000-000000000001',
+      'professional',
+      'Receipt Test',
+      'processing',
+      '{"fileCount":1}'::jsonb
+    )
+  `);
+});
+
+test("appends step receipts and retains the provider voice locator", async () => {
+  await repository.recordCloningJobProviderReceipt({
+    jobId: JOB_ID,
+    step: "create",
+    state: "submitted",
+    now: new Date("2026-09-02T12:00:00.000Z"),
+  });
+  await repository.recordCloningJobProviderReceipt({
+    jobId: JOB_ID,
+    step: "create",
+    state: "accepted",
+    elevenlabsVoiceId: "pvc-receipt-1",
+    now: new Date("2026-09-02T12:00:01.000Z"),
+  });
+  await repository.recordCloningJobProviderReceipt({
+    jobId: JOB_ID,
+    step: "samples",
+    state: "submission_unknown",
+    elevenlabsVoiceId: "pvc-receipt-1",
+    errorMessage: "upstream connection closed",
+    now: new Date("2026-09-02T12:00:02.000Z"),
+  });
+  await repository.markCloningJobReconciliationRequired(
+    JOB_ID,
+    "ElevenLabs samples submission outcome is unknown",
+    new Date("2026-09-02T12:00:03.000Z"),
+  );
+
+  const result = await dbWrite.execute(sql`
+    SELECT elevenlabs_voice_id, error_message, metadata
+    FROM voice_cloning_jobs
+    WHERE id = ${JOB_ID}
+  `);
+  const row = result.rows[0] as {
+    elevenlabs_voice_id: string;
+    error_message: string;
+    metadata: {
+      fileCount: number;
+      providerSubmissionState: string;
+      providerLastStep: string;
+      providerReceipts: Array<Record<string, unknown>>;
+    };
+  };
+
+  expect(row.elevenlabs_voice_id).toBe("pvc-receipt-1");
+  expect(row.error_message).toBe("ElevenLabs samples submission outcome is unknown");
+  expect(row.metadata).toMatchObject({
+    fileCount: 1,
+    providerSubmissionState: "submission_unknown",
+    providerLastStep: "samples",
+    reconciliationRequired: true,
+    reconciliationRequestedAt: "2026-09-02T12:00:03.000Z",
+  });
+  expect(row.metadata.providerReceipts).toEqual([
+    {
+      provider: "elevenlabs",
+      step: "create",
+      state: "submitted",
+      recordedAt: "2026-09-02T12:00:00.000Z",
+    },
+    {
+      provider: "elevenlabs",
+      step: "create",
+      state: "accepted",
+      recordedAt: "2026-09-02T12:00:01.000Z",
+      elevenlabsVoiceId: "pvc-receipt-1",
+    },
+    {
+      provider: "elevenlabs",
+      step: "samples",
+      state: "submission_unknown",
+      recordedAt: "2026-09-02T12:00:02.000Z",
+      elevenlabsVoiceId: "pvc-receipt-1",
+      errorMessage: "upstream connection closed",
+    },
+  ]);
+});
+
+test("atomically fences tenant-scoped idempotency keys", async () => {
+  await dbWrite.execute(sql`DELETE FROM voice_cloning_jobs`);
+  const organizationId = "20000000-0000-4000-8000-000000000001";
+  const userId = "30000000-0000-4000-8000-000000000001";
+  const base = {
+    organizationId,
+    userId,
+    jobType: "instant" as const,
+    voiceName: "Fence Test",
+    status: "processing" as const,
+    idempotencyKey: "voice-fence-1",
+    requestDigest: "digest-a",
+  };
+
+  const first = await repository.createOrReadCloningJob(base);
+  const replay = await repository.createOrReadCloningJob(base);
+  const conflict = await repository.createOrReadCloningJob({
+    ...base,
+    requestDigest: "digest-b",
+  });
+  const otherUser = await repository.createOrReadCloningJob({
+    ...base,
+    userId: "30000000-0000-4000-8000-000000000002",
+  });
+
+  expect(first.created).toBe(true);
+  expect(replay).toMatchObject({
+    created: false,
+    job: { id: first.job.id, requestDigest: "digest-a" },
+  });
+  expect(conflict).toMatchObject({
+    created: false,
+    job: { id: first.job.id, requestDigest: "digest-a" },
+  });
+  expect(otherUser.created).toBe(true);
+  expect(otherUser.job.id).not.toBe(first.job.id);
+});
+
+test("elects exactly one winner under concurrent same-key inserts", async () => {
+  await dbWrite.execute(sql`DELETE FROM voice_cloning_jobs`);
+  const input = {
+    organizationId: "20000000-0000-4000-8000-000000000001",
+    userId: "30000000-0000-4000-8000-000000000001",
+    jobType: "instant" as const,
+    voiceName: "Concurrent Fence Test",
+    status: "processing" as const,
+    idempotencyKey: "voice-concurrent-1",
+    requestDigest: "digest-concurrent",
+  };
+
+  const results = await Promise.all(
+    Array.from({ length: 8 }, () => repository.createOrReadCloningJob(input)),
+  );
+
+  expect(results.filter((result) => result.created)).toHaveLength(1);
+  expect(new Set(results.map((result) => result.job.id))).toEqual(new Set([results[0]?.job.id]));
+});

--- a/packages/cloud/shared/src/db/repositories/user-voices.ts
+++ b/packages/cloud/shared/src/db/repositories/user-voices.ts
@@ -37,6 +37,14 @@ export interface UserVoiceListResult {
   hasMore: boolean;
 }
 
+export type VoiceCloneProviderStep = "create" | "samples" | "train";
+export type VoiceCloneProviderState = "submitted" | "accepted" | "rejected" | "submission_unknown";
+
+export interface PreparedVoiceCloningJob {
+  job: VoiceCloningJob;
+  created: boolean;
+}
+
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
@@ -95,6 +103,39 @@ export class UserVoicesRepository {
     return job;
   }
 
+  async createOrReadCloningJob(
+    data: NewVoiceCloningJob & { idempotencyKey: string; requestDigest: string },
+  ): Promise<PreparedVoiceCloningJob> {
+    const [created] = await dbWrite
+      .insert(voiceCloningJobs)
+      .values(data)
+      .onConflictDoNothing({
+        target: [
+          voiceCloningJobs.organizationId,
+          voiceCloningJobs.userId,
+          voiceCloningJobs.idempotencyKey,
+        ],
+      })
+      .returning();
+    if (created) return { job: created, created: true };
+
+    // Read the conflict winner from the primary. A replica may lag the unique
+    // insert and falsely make an accepted idempotency key look absent.
+    const [existing] = await dbWrite
+      .select()
+      .from(voiceCloningJobs)
+      .where(
+        and(
+          eq(voiceCloningJobs.organizationId, data.organizationId),
+          eq(voiceCloningJobs.userId, data.userId),
+          eq(voiceCloningJobs.idempotencyKey, data.idempotencyKey),
+        ),
+      )
+      .limit(1);
+    if (!existing) throw new Error("Voice-clone idempotency winner was not readable");
+    return { job: existing, created: false };
+  }
+
   async createSamples(data: NewVoiceSample[]): Promise<void> {
     if (data.length === 0) return;
     await dbWrite.insert(voiceSamples).values(data);
@@ -106,6 +147,72 @@ export class UserVoicesRepository {
     return voice;
   }
 
+  async recordCloningJobProviderReceipt(input: {
+    jobId: string;
+    step: VoiceCloneProviderStep;
+    state: VoiceCloneProviderState;
+    elevenlabsVoiceId?: string;
+    errorMessage?: string;
+    now?: Date;
+  }): Promise<void> {
+    const now = input.now ?? new Date();
+    const receipt = {
+      provider: "elevenlabs",
+      step: input.step,
+      state: input.state,
+      recordedAt: now.toISOString(),
+      ...(input.elevenlabsVoiceId ? { elevenlabsVoiceId: input.elevenlabsVoiceId } : {}),
+      ...(input.errorMessage ? { errorMessage: input.errorMessage } : {}),
+    };
+    const metadataPatch = JSON.stringify({
+      providerSubmissionState: input.state,
+      providerLastStep: input.step,
+    });
+    const receiptArray = JSON.stringify([receipt]);
+    const [job] = await dbWrite
+      .update(voiceCloningJobs)
+      .set({
+        ...(input.elevenlabsVoiceId ? { elevenlabsVoiceId: input.elevenlabsVoiceId } : {}),
+        metadata: sql`jsonb_set(
+          ${voiceCloningJobs.metadata} || ${metadataPatch}::jsonb,
+          '{providerReceipts}',
+          COALESCE(${voiceCloningJobs.metadata}->'providerReceipts', '[]'::jsonb) || ${receiptArray}::jsonb,
+          true
+        )`,
+        errorMessage:
+          input.state === "submission_unknown"
+            ? (input.errorMessage ?? "Provider submission outcome is unknown")
+            : undefined,
+        updatedAt: now,
+      })
+      .where(eq(voiceCloningJobs.id, input.jobId))
+      .returning({ id: voiceCloningJobs.id });
+    if (!job) throw new Error("Failed to persist voice-clone provider receipt");
+  }
+
+  async markCloningJobReconciliationRequired(
+    jobId: string,
+    errorMessage: string,
+    now = new Date(),
+  ): Promise<void> {
+    const [job] = await dbWrite
+      .update(voiceCloningJobs)
+      .set({
+        status: "reconciliation_required",
+        metadata: sql`${voiceCloningJobs.metadata} || ${JSON.stringify({
+          reconciliationRequired: true,
+          reconciliationRequestedAt: now.toISOString(),
+        })}::jsonb`,
+        errorMessage,
+        updatedAt: now,
+      })
+      .where(eq(voiceCloningJobs.id, jobId))
+      .returning({ id: voiceCloningJobs.id });
+    if (!job) {
+      throw new Error("Failed to mark voice-clone reconciliation required");
+    }
+  }
+
   async attachSamplesToVoice(jobId: string, userVoiceId: string): Promise<void> {
     await dbWrite.update(voiceSamples).set({ userVoiceId }).where(eq(voiceSamples.jobId, jobId));
   }
@@ -114,6 +221,7 @@ export class UserVoicesRepository {
     jobId: string;
     userVoiceId: string;
     elevenlabsVoiceId: string;
+    responsePayload?: Record<string, unknown>;
     now?: Date;
   }): Promise<VoiceCloningJob> {
     const now = input.now ?? new Date();
@@ -123,6 +231,7 @@ export class UserVoicesRepository {
         status: "completed",
         userVoiceId: input.userVoiceId,
         elevenlabsVoiceId: input.elevenlabsVoiceId,
+        responsePayload: input.responsePayload,
         progress: 100,
         completedAt: now,
         updatedAt: now,
@@ -137,10 +246,15 @@ export class UserVoicesRepository {
     await dbWrite.delete(voiceSamples).where(eq(voiceSamples.jobId, jobId));
   }
 
-  async markCloningJobFailed(jobId: string, errorMessage: string, now = new Date()): Promise<void> {
+  async markCloningJobFailed(
+    jobId: string,
+    errorMessage: string,
+    now = new Date(),
+    responsePayload?: Record<string, unknown>,
+  ): Promise<void> {
     await dbWrite
       .update(voiceCloningJobs)
-      .set({ status: "failed", errorMessage, updatedAt: now })
+      .set({ status: "failed", errorMessage, responsePayload, updatedAt: now })
       .where(eq(voiceCloningJobs.id, jobId));
   }
 

--- a/packages/cloud/shared/src/db/schemas/user-voices.ts
+++ b/packages/cloud/shared/src/db/schemas/user-voices.ts
@@ -10,6 +10,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 import { organizations } from "./organizations";
@@ -93,49 +94,62 @@ export const userVoices = pgTable(
  *
  * Tracks voice cloning job status and progress for instant and professional clones.
  */
-export const voiceCloningJobs = pgTable("voice_cloning_jobs", {
-  id: uuid("id").primaryKey().defaultRandom(),
+export const voiceCloningJobs = pgTable(
+  "voice_cloning_jobs",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
 
-  // Ownership
-  organizationId: uuid("organization_id")
-    .notNull()
-    .references(() => organizations.id, { onDelete: "cascade" }),
-  userId: uuid("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
+    // Ownership
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
 
-  // Job Details
-  jobType: text("job_type", { enum: ["instant", "professional"] }).notNull(),
-  voiceName: text("voice_name").notNull(),
-  voiceDescription: text("voice_description"),
+    // Job Details
+    jobType: text("job_type", { enum: ["instant", "professional"] }).notNull(),
+    voiceName: text("voice_name").notNull(),
+    voiceDescription: text("voice_description"),
 
-  // Status
-  status: text("status", {
-    enum: ["pending", "processing", "completed", "failed"],
-  })
-    .notNull()
-    .default("pending"),
-  progress: integer("progress").notNull().default(0),
+    // Status
+    status: text("status", {
+      enum: ["pending", "processing", "completed", "failed", "reconciliation_required"],
+    })
+      .notNull()
+      .default("pending"),
+    progress: integer("progress").notNull().default(0),
 
-  // Results
-  userVoiceId: uuid("user_voice_id").references(() => userVoices.id, {
-    onDelete: "set null",
+    // Results
+    userVoiceId: uuid("user_voice_id").references(() => userVoices.id, {
+      onDelete: "set null",
+    }),
+    elevenlabsVoiceId: text("elevenlabs_voice_id"),
+
+    // Error Handling
+    errorMessage: text("error_message"),
+    retryCount: integer("retry_count").notNull().default(0),
+    idempotencyKey: text("idempotency_key"),
+    requestDigest: text("request_digest"),
+    responsePayload: jsonb("response_payload").$type<Record<string, unknown>>(),
+
+    // Metadata
+    metadata: jsonb("metadata").notNull().default({}),
+
+    // Timestamps
+    startedAt: timestamp("started_at"),
+    completedAt: timestamp("completed_at"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    tenantIdempotencyIdx: uniqueIndex("voice_cloning_jobs_tenant_idempotency_uidx").on(
+      table.organizationId,
+      table.userId,
+      table.idempotencyKey,
+    ),
   }),
-  elevenlabsVoiceId: text("elevenlabs_voice_id"),
-
-  // Error Handling
-  errorMessage: text("error_message"),
-  retryCount: integer("retry_count").notNull().default(0),
-
-  // Metadata
-  metadata: jsonb("metadata").notNull().default({}),
-
-  // Timestamps
-  startedAt: timestamp("started_at"),
-  completedAt: timestamp("completed_at"),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at").notNull().defaultNow(),
-});
+);
 
 /**
  * Voice samples table schema.

--- a/packages/cloud/shared/src/lib/services/voice-clone-failure.ts
+++ b/packages/cloud/shared/src/lib/services/voice-clone-failure.ts
@@ -1,0 +1,28 @@
+/** Defines the bounded failure vocabulary exposed by voice-clone API surfaces. */
+
+export type VoiceCloneFailureReason =
+  | "provider_submission_unknown"
+  | "provider_work_reconciliation_required"
+  | "provider_request_rejected"
+  | "voice_clone_request_failed";
+
+const failureReasons = new Set<VoiceCloneFailureReason>([
+  "provider_submission_unknown",
+  "provider_work_reconciliation_required",
+  "provider_request_rejected",
+  "voice_clone_request_failed",
+]);
+
+export function isVoiceCloneFailureReason(value: unknown): value is VoiceCloneFailureReason {
+  return typeof value === "string" && failureReasons.has(value as VoiceCloneFailureReason);
+}
+
+export function exposedVoiceCloneFailureReason(
+  value: unknown,
+  reconciliationRequired: boolean,
+): VoiceCloneFailureReason {
+  if (isVoiceCloneFailureReason(value)) return value;
+  return reconciliationRequired
+    ? "provider_work_reconciliation_required"
+    : "voice_clone_request_failed";
+}


### PR DESCRIPTION
Closes #30357

## What changed
- adds an organization/user-scoped durable `Idempotency-Key` fence before pricing, billing admission, uploads, or provider dispatch
- hashes the complete canonical request (including each audio file) so same-payload retries replay safely and different-payload key reuse returns `409 idempotency_conflict`
- stores the completed response for exact successful replay and returns the existing job on in-flight or reconciliation retries without duplicate billing/provider work
- synchronously persists append-only ElevenLabs step receipts and the provider voice ID at each irreversible boundary
- classifies ambiguous post-dispatch transport failures with `VoiceCloneSubmissionUnknownError extends ElizaError` (`VOICE_CLONE_SUBMISSION_UNKNOWN`, provider/step context, cause, severity)
- preserves R2/sample/job evidence and conservatively calls `settleUnknown()` whenever provider acceptance is possible
- exposes `reconciliation_required` jobs through the authenticated voice-jobs endpoint as an explicit manual recovery queue, including provider state, step, and voice locator
- emits tenant/job/provider/step/state/voice-locator structured error context without request audio or API keys

## Verification
- `bun test packages/cloud/api/v1/voice/clone/route.standing.test.ts` — 7 pass, including different-payload conflict, timeout-after-acceptance same-key retry, and later-step failure
- `bun test packages/cloud/api/elevenlabs/voices/jobs/route.reconciliation.test.ts` — 1 pass; proves reconciliation-required jobs remain public to the authenticated manual queue
- `bun test packages/cloud/shared/src/db/repositories/__tests__/user-voices-provider-receipts.pglite.test.ts --coverage-reporter=lcov` — 2 pass against real PGlite; proves receipts and tenant-scoped atomic idempotency fencing
- `bun run --cwd packages/cloud/shared typecheck` — pass
- `bun run --cwd packages/cloud/api typecheck` — pass, including router contract and Worker dry-run bundle
- `bun run --cwd packages/cloud/api build` — pass
- package Biome checks, migration check, and `git diff --check` — pass
- `bun run verify` — pass (376/376 Turbo tasks plus repository audits)

## Evidence
- Database artifact: real PGlite rows retain provider receipts, `elevenlabs_voice_id`, explicit reconciliation state, and one tenant-scoped job per idempotency key.
- Live ElevenLabs mutation: N/A — intentionally not invoked from a PR test because clone creation is paid and irreversible; adversarial provider transport behavior is deterministic at the route boundary.
- UI screenshots/video: N/A — no UI changes.