### PR TITLE
test(cloud): let four more cloud-api suites collect

### DIFF
--- a/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as actualOrganizationInferenceAdmission from "@/lib/services/organization-inference-admission";
 
 const aiActual = require("ai") as Record<string, unknown>;
 const languageModelActual = await import("@/lib/providers/language-model");
@@ -153,6 +154,7 @@ const admitOrganizationInference = mock(
   },
 );
 mock.module("@/lib/services/organization-inference-admission", () => ({
+  ...actualOrganizationInferenceAdmission,
   admitOrganizationInference,
 }));
 

--- a/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
@@ -10,6 +10,8 @@
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { APICallError } from "ai";
+import * as actualCredits from "@/lib/services/credits";
+import * as actualOrganizationInferenceAdmission from "@/lib/services/organization-inference-admission";
 
 const aiActual = require("ai") as Record<string, unknown>;
 const languageModelActual = await import("@/lib/providers/language-model");
@@ -119,6 +121,7 @@ let ledger = makeLedgerReservation(100, 0.015);
 const admissionCalls: Array<Record<string, unknown>> = [];
 
 mock.module("@/lib/services/credits", () => ({
+  ...actualCredits,
   assertCreditRefundWithinReservation: () => {
     throw new Error("credit refund assertion is outside this test path");
   },
@@ -136,6 +139,7 @@ mock.module("@/lib/services/credits", () => ({
 }));
 
 mock.module("@/lib/services/organization-inference-admission", () => ({
+  ...actualOrganizationInferenceAdmission,
   admitOrganizationInference: mock(async (params: Record<string, unknown>) => {
     admissionCalls.push(params);
     let settlement: Promise<unknown> | undefined;

--- a/packages/cloud/api/__tests__/shared-agent-turn-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-turn-idempotency.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { beforeEach, expect, mock, test } from "bun:test";
+import * as actualOrganizationInferenceAdmission from "@/lib/services/organization-inference-admission";
 import * as realResolveSharedAgent from "@/lib/services/shared-runtime/resolve-shared-agent";
 
 // ---------------------------------------------------------------------------
@@ -89,6 +90,7 @@ mock.module("@/lib/services/inference-admission-snapshot", () => ({
   inferenceRateLimitConfig: () => ({ windowMs: 60_000, maxRequests: 120 }),
 }));
 mock.module("@/lib/services/organization-inference-admission", () => ({
+  ...actualOrganizationInferenceAdmission,
   admitOrganizationInference: async (params: {
     context: { requestId: string; metadata?: Record<string, unknown> };
   }) => {

--- a/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
+++ b/packages/cloud/api/src/paid-proxy-mounted-admission.test.ts
@@ -6,6 +6,7 @@
 
 import { beforeEach, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as actualOrganizationInferenceAdmission from "@/lib/services/organization-inference-admission";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const globalSessionReads = mock();
@@ -113,6 +114,7 @@ mock.module("@/lib/services/inference-admission-snapshot", () => ({
   inferenceRateLimitConfig: () => ({ windowMs: 60_000, maxRequests: 100 }),
 }));
 mock.module("@/lib/services/organization-inference-admission", () => ({
+  ...actualOrganizationInferenceAdmission,
   admitOrganizationInference: mock(async (params: Record<string, unknown>) => {
     admissionCalls.push(params);
     return {


### PR DESCRIPTION
## The defect

`mock.module` replaces a module's **entire** namespace. A factory that returns only the symbol a suite cares about therefore deletes every other export — including ones the suite never touches but a *transitive* importer does. That surfaces as a `SyntaxError` at collection time, so the suite reports `0 pass / 1 fail` without running a single assertion.

Four suites are in that state on `develop` (`cb721535b6`):

| suite | mocks | missing export |
|---|---|---|
| `__tests__/chat-cache-hotpath.test.ts` | `@/lib/services/organization-inference-admission` | `InferenceAdmissionUnavailableError` |
| `__tests__/shared-agent-turn-idempotency.test.ts` | same | `InferenceAdmissionUnavailableError` |
| `src/paid-proxy-mounted-admission.test.ts` | same | `InferenceAdmissionUnavailableError` |
| `__tests__/chat-stream-credit-leak.test.ts` | `@/lib/services/credits` | `COST_BUFFER` |

## The fix

Import the real namespace and spread it into the factory, so the exports the suite doesn't override survive:

```ts
import * as actualOrganizationInferenceAdmission from "@/lib/services/organization-inference-admission";

mock.module("@/lib/services/organization-inference-admission", () => ({
  ...actualOrganizationInferenceAdmission,
  admitOrganizationInference,
}));
```

10 added lines across 4 files, no test logic touched.

**`chat-stream-credit-leak` needed it twice.** Closing the `credits` failure exposed a *second* broken factory in the same file, for `organization-inference-admission` — the first collection error had been aborting the module graph before the second could be reached. Worth knowing if you fix more of these: one `SyntaxError` can hide the next.

## Result

Four suites go from cannot-run to green:

| suite | before | after |
|---|---|---|
| `chat-cache-hotpath` | `SyntaxError`, 0 pass | **12 pass** 0 fail |
| `shared-agent-turn-idempotency` | `SyntaxError`, 0 pass | **2 pass** 0 fail |
| `paid-proxy-mounted-admission` | `SyntaxError`, 0 pass | **8 pass** 0 fail |
| `chat-stream-credit-leak` | `SyntaxError`, 0 pass | **7 pass** 0 fail |

29 assertions that hadn't been running now run and pass.

## Scope, stated exactly

This does **not** make the lane green. A full isolated sweep of `develop` (`node test/run-unit-isolated.mjs`, 591 files) reports **21 FAILED**; the rest fail on assertions, not collection, and no collection fix touches those.

There is a **fifth** suite in the same state — `__tests__/messages-iac-fast-path.test.ts`, which loses `isSubscriptionFundedOrganization` from `@/lib/services/ai-billing`. I deliberately left it out: applying the same one-line fix makes it collect (14 pass) and reveals **3 genuine assertion failures**:

```
(fail) authorized resolver result skips serial auth, api-key lookup, and sync moderation
(fail) returns Anthropic 402 when organization credits are insufficient before provider dispatch
(fail) refunds the reservation when post-reserve payload conversion throws
```

Those are real findings about the IAC fast path that have been invisible for as long as the suite hasn't collected, and they deserve their own change with someone who knows that route — not to be buried inside a collection fix. Happy to open it separately.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1J0B1G16VKC6NAQ1X7ES5F2","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T21:27:58.721Z","completed_at":"2026-09-02T21:28:38.981Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T21:27:59.406Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d274aa70302625e460300bc237b5561e4255a239f6a96823a49dc02dc09127eb","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"45933dfa-86cd-443c-88b0-f0e0b095755d","object_id":"sha256:d274aa70302625e460300bc237b5561e4255a239f6a96823a49dc02dc09127eb","sha256":"d274aa70302625e460300bc237b5561e4255a239f6a96823a49dc02dc09127eb"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"ay0_65QdQ_YD5S7Km46gminRjltkQw2gbsFmax9m5DEHXlvzY5qlODE6xlXq_0vYBSdPR5WOmSVu9Jp8tgrjBw"}} -->
