### PR TITLE
test(agent): bound the linear-time suffix trim assertion

### DIFF
--- a/packages/agent/src/utils/string-boundaries.test.ts
+++ b/packages/agent/src/utils/string-boundaries.test.ts
@@ -11,7 +11,14 @@ describe("agent string boundary scanner", () => {
   });
 
   it("handles a 100k-character suffix in linear time", () => {
-    expect(trimEndCharacters(`base${"/".repeat(100_000)}`, "/")).toBe("base");
+    // The `toBe` below only proves correctness. Without an elapsed-time bound
+    // a quadratic rewrite passes too: it finishes this input in ~33s, well
+    // inside this package's 120s `testTimeout`. The linear scan takes under
+    // 2ms, so a 1s budget fails on complexity rather than on a slow machine.
+    const value = `base${"/".repeat(100_000)}`;
+    const startedAt = performance.now();
+    expect(trimEndCharacters(value, "/")).toBe("base");
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
   it("does not split an unmatched Unicode code point", () => {


### PR DESCRIPTION
# What

`packages/agent/src/utils/string-boundaries.test.ts` has a test called *handles a 100k-character suffix in linear time* that asserts only the returned value. It doesn't measure anything, so it doesn't test what its name promises.

# Why it matters

I substituted a genuinely quadratic `trimEndCharacters` — one that rebuilds the string through `Array.from(...).slice(0, -1).join("")` each iteration, so it can't hide behind V8's O(1) `SlicedString` — and ran the suite:

```
Tests  3 passed (3)      33.5s
```

All three tests pass. `packages/agent/vitest.config.ts` sets `testTimeout: 120_000`, so a quadratic implementation clears the bar with 87 seconds to spare. The one guard standing between this hot-path scanner and an accidental O(n²) rewrite doesn't fire.

# The fix

Bound the elapsed time, so the assertion enforces the claim in its own name:

```ts
const value = `base${"/".repeat(100_000)}`;
const startedAt = performance.now();
expect(trimEndCharacters(value, "/")).toBe("base");
expect(performance.now() - startedAt).toBeLessThan(1_000);
```

**Threshold, measured rather than guessed.** Five runs of the real linear scan over the same input: `1.8, 0.8, 0.8, 0.8, 0.8` ms. A 1s budget is over 500x that, so it fails on complexity, not on a slow or loaded runner.

This is the pattern the repository already uses for the same kind of claim, in three places:

| file | bound |
|---|---|
| `packages/core/src/security/entity-recognizer.test.ts` | `Date.now() - start` under `2000` |
| `packages/cloud/shared/src/lib/utils/email-validation.test.ts` | `performance.now()` elapsed under `1000` |
| `packages/agent/src/services/vfs-search-pattern.test.ts` | `Date.now() - startedAt` under `1_500` |

# Evidence

Both directions verified against this branch:

| implementation | result |
|---|---|
| quadratic substitution | **1 failed** / 2 passed — `× handles a 100k-character suffix in linear time 33425ms` |
| unmodified `trimEndCharacters` | 3 passed |

`bunx @biomejs/biome check src/utils/string-boundaries.test.ts` → exit 0.
`bunx tsc --noEmit -p tsconfig.json` → exit 0, zero errors.

The implementation was restored from a pristine copy afterwards, so the diff is test-only: one file, +8/-1.

# Scope

Deliberately limited to the `packages/agent` copy. `packages/core/src/utils/string-boundaries.test.ts` carries the same untimed claim over a byte-identical implementation, but that file is being rewritten by #30083, so touching it here would conflict; I raised it in that PR's review instead.

# Risks

None to runtime behaviour — no production file changes. The only failure mode is a false positive on a runner over 500x slower than the measured baseline, which the same threshold in `email-validation.test.ts` has not produced.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1J8PJ4PD251D663GFAQ2BGS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-02T23:54:04.822Z","completed_at":"2026-09-02T23:55:06.969Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-02T23:54:05.360Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"10627ae7929dc33ddff11f045e0e5b18a6d5d6617a203152012b752dbbd45b85","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5eeedef5-1c7e-455a-9700-08af0bf396a0","object_id":"sha256:10627ae7929dc33ddff11f045e0e5b18a6d5d6617a203152012b752dbbd45b85","sha256":"10627ae7929dc33ddff11f045e0e5b18a6d5d6617a203152012b752dbbd45b85"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"1ueVkSIk0nDa8X79Z3e0frsFKfy6d1_6vM-AQiJquShjyup_Wdt7PxunSJoxPZMRcy1MjTKD_J-xNTuK8OdbDQ"}} -->
