### PR TITLE
test(agent): bound the redactor's linear-time scans

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -78,15 +78,23 @@ describe("defaultPrivacyRedactor", () => {
 
   it("scans adversarial coordinate-like text in linear time", () => {
     const input = `{"coords":{"latitude":0,"longitude":0${',"A":+\t'.repeat(50_000)}}}`;
+    const startedAt = performance.now();
     expect(defaultPrivacyRedactor(input)).toBe("{[REDACTED_GEO]}");
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
   it("scans many overlapping malformed coordinate candidates in linear time", () => {
     // Every "coords" marker starts a candidate whose scan runs to the end of
     // the unterminated input; a non-monotonic cursor would rescan each
     // remaining suffix and go quadratic.
+    // The result assertions below hold for a quadratic scan too, so the
+    // elapsed-time bound is what actually detects a non-monotonic cursor:
+    // this input takes ~15ms linear and ~117s quadratic, and the package's
+    // 120s `testTimeout` is too loose to catch the difference on its own.
     const input = '"coords":{"latitude":0,"longitude":0,'.repeat(50_000);
+    const startedAt = performance.now();
     const out = defaultPrivacyRedactor(input) as string;
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
     expect(out).toContain("[REDACTED_GEO]");
     expect(out).not.toContain('"latitude":0');
   });


### PR DESCRIPTION
# What

`redact.test.ts` has two tests named *…in linear time*. Both assert only the redacted output, so neither measures the property they're named for.

# Why it matters

This is the case where the guard is documented in the source and still untested. `redactCoordsBlocks` advances the outer cursor like this:

```ts
if (!scan.matched) {
  // Monotonic cursor: never re-walk a failed candidate span, so total
  // work stays linear even with many overlapping malformed candidates.
  searchFrom = Math.max(start + COORDS_MARKER.length, scan.resumeAt);
  continue;
}
```

and the test carries its own comment saying *"a non-monotonic cursor would rescan each remaining suffix and go quadratic"*. I introduced exactly that regression — `searchFrom = start + 1` — and ran the suite:

```
Tests  21 passed (21)      117.6s
```

Every test passes. `packages/agent/vitest.config.ts` sets `testTimeout: 120_000`, so the quadratic scan cleared the bar by 2.4 seconds.

**Then I ran the same mutant again and it took 120442ms — a timeout.** That variance is the real problem: as things stand, whether a quadratic regression in a redaction hot path is caught depends on a ~2% difference in machine speed. The suite isn't just silent about the property, it's flaky about it.

# The fix

Bound the elapsed time on both tests:

```ts
const startedAt = performance.now();
const out = defaultPrivacyRedactor(input) as string;
expect(performance.now() - startedAt).toBeLessThan(1_000);
```

**Threshold, measured.** Under the verbose reporter the two tests cost **5ms** and **15ms** against the real implementation, and the overlapping-candidates input costs ~117s quadratic. A 1s budget sits ~65x above the linear cost and two orders of magnitude below the quadratic one.

This matches the pattern the repo already uses for the same kind of claim:

| file | bound |
|---|---|
| `packages/core/src/security/entity-recognizer.test.ts` | `Date.now()` elapsed under `2000` |
| `packages/cloud/shared/src/lib/utils/email-validation.test.ts` | `performance.now()` elapsed under `1000` |
| `packages/agent/src/services/vfs-search-pattern.test.ts` | `Date.now()` elapsed under `1_500` |

# Evidence

| implementation | result |
|---|---|
| `searchFrom = start + 1` (non-monotonic) | **1 failed** / 20 passed — `× scans many overlapping malformed coordinate candidates in linear time 120442ms` |
| unmodified `redactCoordsBlocks` | 21 passed, 0.5s |

`bunx @biomejs/biome check src/runtime/tool-call-cache/redact.test.ts` → exit 0.
`bunx tsc --noEmit -p packages/agent/tsconfig.json` → exit 0, zero errors.

One honest caveat: the first test's input (`,"A":+\t` repeated) stays at 5ms even under the mutant — it doesn't drive the quadratic path. Its bound is precautionary and matches its name; the overlapping-candidates test is the one that actually detects the regression.

The implementation was restored from a pristine copy, so the diff is test-only: one file, +8/-0.

# Scope

Same reasoning as #30369, which covered `packages/agent/src/utils/string-boundaries.test.ts` and named the `packages/core` copy it deliberately skipped.

**Update — the third candidate doesn't need this.** I originally named `packages/cloud/routing/src/resolve.test.ts:138` (*normalizes 100k boundary slashes in linear time*) as the remaining instance, since it has no timing call either. I've since checked it and it holds up, so there's no follow-up to file:

- The realistic naive rewrite — `while (result.endsWith("/")) result = result.slice(0, -1)` in `stripTrailingSlashes` — isn't a regression at all. V8 backs `String.prototype.slice` with an O(1) `SlicedString`, so the suite still runs in **0.38s / 56 passed**. Nothing to catch.
- Forcing a genuine quadratic (rebuilding through `Array.from(...).join("")` in `normalizeServiceName`) **already fails**: `Error: Test timed out in 120000ms`, at 133808ms.

So that file's assertion is adequate for the regressions that can actually reach it. Recording the negative result here rather than leaving a follow-up implied that isn't warranted.

# Risks

None to runtime behaviour — no production file changes. The only failure mode is a runner ~65x slower than the measured baseline, which the identical threshold in `email-validation.test.ts` has not produced.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1J9FWX7JN9083WZS0RAB1DM","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T00:07:55.047Z","completed_at":"2026-09-03T00:09:00.446Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T00:07:55.999Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ff230a8a8f4d74f650645ded4460a1799cc6c5b342301ac4abbe55341d9435fb","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"19d09d06-3abf-4a91-a2c6-651f6d94b0ad","object_id":"sha256:ff230a8a8f4d74f650645ded4460a1799cc6c5b342301ac4abbe55341d9435fb","sha256":"ff230a8a8f4d74f650645ded4460a1799cc6c5b342301ac4abbe55341d9435fb"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"OwDgOskPpq95MzfDYJkDzwGKGekevM6Z33JGCRr6t6WW8GHeE9KK4_qYHKzf7SgrRb8_WxusFjHZr4dDK3ByDw"}} -->

