### PR TITLE
fix(plugin-telegram): stop caller text from forging markdown sentinels

### DIFF
--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -182,6 +182,30 @@ describe("convertToTelegramButtons", () => {
   });
 });
 
+describe("convertMarkdownToTelegram — sentinel forgery", () => {
+  const NUL = String.fromCharCode(0);
+  const sentinel = (index: number) => `${NUL}${index}${NUL}`;
+
+  it("does not resolve an out-of-range sentinel to the word undefined", () => {
+    const out = convertMarkdownToTelegram(`hello ${sentinel(9999)} world`);
+    expect(out).not.toContain("undefined");
+    expect(out).not.toContain(NUL);
+  });
+
+  it("does not let incoming text forge a stored replacement", () => {
+    const out = convertMarkdownToTelegram(`\`secret\` then ${sentinel(0)}`);
+    // The code span must appear once — where the author wrote it.
+    expect(out.match(/secret/g)).toHaveLength(1);
+    expect(out).not.toContain(NUL);
+  });
+
+  it("still resolves its own nested sentinels", () => {
+    expect(convertMarkdownToTelegram("**bold** and `code`")).toBe(
+      "*bold* and `code`",
+    );
+  });
+});
+
 describe("cleanText", () => {
   it("strips NULL sentinels and handles nullish input", () => {
     const NUL = String.fromCharCode(0);

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -74,6 +74,8 @@ function escapeUrl(url: string): string {
  * Note: This solution uses a sequence of regex replacements and sentinels.
  * It makes assumptions about non–nested formatting and does not cover every edge case.
  */
+const NUL_CHAR = String.fromCharCode(0);
+
 export function convertMarkdownToTelegram(markdown: string): string {
   // Temporarily replace recognized markdown tokens with sentinel strings.
   // Each sentinel is a string like "\u0000{index}\u0000".
@@ -84,7 +86,12 @@ export function convertMarkdownToTelegram(markdown: string): string {
     return sentinel;
   }
 
-  let converted = markdown;
+  // Sentinels are delimited by NUL, so a NUL arriving in the caller's text can
+  // forge one: an in-range index splices that replacement into a position the
+  // author never wrote, and an out-of-range index resolves to `undefined` and
+  // ships the literal word. `cleanText` already strips NUL on the plain-text
+  // send path; the markdown path needs it more, because here NUL is structural.
+  let converted = cleanText(markdown);
 
   // 1. Fenced code blocks (```...```)
   //    Matches an optional language tag (allowing #, +, - for c#, c++, etc.)
@@ -187,11 +194,9 @@ export function convertMarkdownToTelegram(markdown: string): string {
     },
   );
 
-  // Define the sentinel marker as a string constant.
-  const NULL_CHAR = String.fromCharCode(0);
-  const SENTINEL_PATTERN = new RegExp(`(${NULL_CHAR}\\d+${NULL_CHAR})`, "g");
-  const SENTINEL_TEST = new RegExp(`^${NULL_CHAR}\\d+${NULL_CHAR}$`);
-  const SENTINEL_REPLACE = new RegExp(`${NULL_CHAR}(\\d+)${NULL_CHAR}`, "g");
+  const SENTINEL_PATTERN = new RegExp(`(${NUL_CHAR}\\d+${NUL_CHAR})`, "g");
+  const SENTINEL_TEST = new RegExp(`^${NUL_CHAR}\\d+${NUL_CHAR}$`);
+  const SENTINEL_REPLACE = new RegExp(`${NUL_CHAR}(\\d+)${NUL_CHAR}`, "g");
 
   const finalEscaped = converted
     .split(SENTINEL_PATTERN)
@@ -219,8 +224,9 @@ export function convertMarkdownToTelegram(markdown: string): string {
       break;
     }
     SENTINEL_REPLACE.lastIndex = 0;
-    finalResult = finalResult.replace(SENTINEL_REPLACE, (_, index) => {
-      return replacements[Number.parseInt(index, 10)];
+    finalResult = finalResult.replace(SENTINEL_REPLACE, (match, index) => {
+      const stored = replacements[Number.parseInt(index, 10)];
+      return stored === undefined ? match : stored;
     });
   }
 


### PR DESCRIPTION
# What

`convertMarkdownToTelegram` lifts recognized markdown tokens behind NUL-delimited sentinels (`\u0000<index>\u0000`), escapes the surrounding text, then substitutes the sentinels back. It never strips NUL from its input, so a NUL arriving in the caller's text can forge a sentinel.

Two distinct outcomes, both reproduced against the real exported function:

| input | current output |
|---|---|
| `hello \u00009999\u0000 world` | `hello undefined world` |
| `` `secret` then \u00000\u0000 `` | `` `secret` then `secret` `` |
| `plain \u00000\u0000 text` | `plain undefined text` |

The first is the literal word **undefined** shipped in an outgoing Telegram message: `replacements[9999]` is `undefined`, and `String.replace` stringifies whatever the callback returns. The second is content duplication — a stored replacement spliced into a position the author never wrote.

# Why this one is a bug and not a design choice

The file already exports `cleanText`, which strips NUL and has its own unit test, and `messageManager.ts` applies it on the plain-text send path (`:1216`, `:2467`). The markdown path is the one place it isn't applied — and it's the path where NUL is *structural* rather than incidental.

# The fix

Use the helper that already exists, at entry:

```ts
let converted = cleanText(markdown);
```

plus a defensive change in the resolution loop, so an index with no stored replacement yields the matched text rather than `undefined`:

```ts
finalResult = finalResult.replace(SENTINEL_REPLACE, (match, index) => {
  const stored = replacements[Number.parseInt(index, 10)];
  return stored === undefined ? match : stored;
});
```

The NUL character is hoisted to a module constant so the strip and the three sentinel regexes share one definition.

After the fix:

| input | output |
|---|---|
| `hello \u00009999\u0000 world` | `hello 9999 world` |
| `` `secret` then \u00000\u0000 `` | `` `secret` then 0 `` — code span appears exactly once |
| `**bold** and \`code\`` | `*bold* and \`code\`` — unchanged |

The digits survive as ordinary text, which is the honest rendering of what the author actually typed.

# Not an infinite loop

Worth stating since it's the first thing you'd worry about: the resolution loop is bounded by `for (let pass = 0; pass <= replacements.length; pass++)`, so a forged sentinel can't spin it. The damage is confined to the substituted output.

# Evidence

Three regression tests added next to the existing `cleanText` block. They are real detectors, not decoration — restoring the unfixed implementation fails exactly the two forgery tests:

| implementation | result |
|---|---|
| before the fix | **2 failed** / 22 passed — *does not resolve an out-of-range sentinel to the word undefined*, *does not let incoming text forge a stored replacement* |
| with the fix | 24 passed |

`bunx @biomejs/biome check` → exit 0 on both changed files.
`bunx tsc --noEmit -p tsconfig.json` → exit 0, zero errors.

# How I got here

Reviewing #30164 (the equivalent Slack change), whose description cites this function as the existing correct precedent for the sentinel approach. I checked the cited precedent and found it carries the same input-forgery exposure I'd just flagged there — with the extra `undefined` leak, which the Slack version doesn't have because its restore loop never indexes out of range.

# Risks

Low. `cleanText` is an existing, tested helper already applied to sibling send paths; the only behaviour change for text without NUL is none at all, which the 21 pre-existing tests confirm.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JAD1KE3CJ63D68J251M7F4","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T00:23:50.126Z","completed_at":"2026-09-03T00:24:53.806Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T00:23:50.793Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"65b422bfbb2ae0a2834287da35c94cf64cc00b54f441b7b7edb16f0618bc93cd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"82b8be96-7237-4da7-b4c1-1c13ea3e0e45","object_id":"sha256:65b422bfbb2ae0a2834287da35c94cf64cc00b54f441b7b7edb16f0618bc93cd","sha256":"65b422bfbb2ae0a2834287da35c94cf64cc00b54f441b7b7edb16f0618bc93cd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Mw5eb-kjJxzDLxYf0ZhuOTK7VhkLB4kyoedql6p4n1VavdFdZLS04bXyaQqeycClEfQojfF6Ph70ckNbT1IJBQ"}} -->
