### PR TITLE
fix(plugin-slack): stop caller text from forging the bold sentinel

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -673,3 +673,24 @@ describe("parseSlackMessageLink", () => {
     ).toBeNull();
   });
 });
+
+describe("markdownToSlackMrkdwn — bold-sentinel forgery", () => {
+  const NUL = String.fromCharCode(0);
+  const forged = `${NUL}BOLD${NUL}`;
+
+  it("does not let incoming text forge bold formatting", () => {
+    const out = markdownToSlackMrkdwn(`hello ${forged}world${forged} bye`);
+    expect(out).not.toContain("*world*");
+    expect(out).not.toContain(NUL);
+  });
+
+  it("does not leave a stray asterisk from a lone forged sentinel", () => {
+    const out = markdownToSlackMrkdwn(`a ${forged} b`);
+    expect(out).not.toContain("*");
+    expect(out).not.toContain(NUL);
+  });
+
+  it("still converts real bold alongside a forged sentinel", () => {
+    expect(markdownToSlackMrkdwn(`${forged} and **real**`)).toContain("*real*");
+  });
+});

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -103,7 +103,8 @@ export function escapeSlackMrkdwn(text: string): string {
 }
 
 // Sentinel used during conversion to prevent bold from being matched as italic.
-const BOLD_SENTINEL = "\u0000BOLD\u0000";
+const NUL = "\u0000";
+const BOLD_SENTINEL = `${NUL}BOLD${NUL}`;
 
 /**
  * Converts markdown bold to Slack mrkdwn
@@ -206,8 +207,14 @@ export function markdownToSlackMrkdwn(markdown: string): string {
     return "";
   }
 
+  // The bold pass swaps `**` for a NUL-delimited sentinel and swaps it back
+  // afterwards, so a NUL arriving in the caller's text can forge one: the
+  // sender gets bold they never typed, or a stray `*`. Slack never renders
+  // NUL, so dropping it up front costs nothing and closes that.
+  const source = markdown.split(NUL).join("");
+
   // Process in order: code blocks -> links -> headings -> text styles -> escape
-  let result = convertCodeBlocks(markdown);
+  let result = convertCodeBlocks(source);
   result = convertLinks(result);
   result = convertHeadings(result);
   result = convertBold(result);


### PR DESCRIPTION
# What

`convertBold` swaps `**` for a NUL-delimited sentinel so the italic pass can't match it, and a later pass swaps the sentinel back to a single `*`. `markdownToSlackMrkdwn` never strips NUL from its input, so text arriving with that byte sequence forges the sentinel.

Reproduced against the real exported function on `develop`:

| input | current output |
|---|---|
| `hello \u0000BOLD\u0000world\u0000BOLD\u0000 bye` | `hello *world* bye` |
| `a \u0000BOLD\u0000 b` | `a * b` |
| `# Title \u0000BOLD\u0000x\u0000BOLD\u0000` | `*Title *x**` |

The sender gets bold they never typed, a stray asterisk, or — in the heading case — visibly broken formatting.

# The fix

Drop NUL at entry:

```ts
const source = markdown.split(NUL).join("");
```

`NUL` is hoisted to a module constant that `BOLD_SENTINEL` is now built from, so the strip and the sentinel share one definition instead of repeating the escape. Slack never renders NUL, so nothing is lost, and forged text degrades to the literal characters the sender actually sent:

| input | output |
|---|---|
| `hello \u0000BOLD\u0000world\u0000BOLD\u0000 bye` | `hello BOLDworldBOLD bye` |
| `a \u0000BOLD\u0000 b` | `a BOLD b` |
| `**bold** and _i_` | `*bold* and _i_` — unchanged |

# Evidence

Three regression tests added. They're real detectors — restoring the unfixed function fails exactly the two forgery tests:

| implementation | result |
|---|---|
| before the fix | **2 failed** / 90 passed |
| with the fix | 92 passed |

`bunx @biomejs/biome check` → exit 0 on both changed files.
`bunx tsc --noEmit -p tsconfig.json` → exit 0, zero errors.

# Scope and relationship to #30164

Two notes on where this sits:

- **This is narrower than the Telegram case.** #30371 fixes the same class in `convertMarkdownToTelegram`, where the restore is an *array index* and so also leaks the literal word `undefined` for an out-of-range sentinel. Slack's restore is a plain regex swap to `*`, so there's no `undefined` path here — the damage is confined to forged emphasis.
- **This is independent of #30164.** That PR restructures this same function to add a second (CODE) sentinel; the bold-sentinel forgery predates it and is present on `develop` today. My review on #30164 already recommended this same entry-point strip, so if it lands first this becomes a one-line rebase rather than a competing change. Happy to fold it in there instead if you'd prefer one PR.

I also swept the narrower sub-class mechanically — `String.replace` callbacks that index a collection by a captured group. There's exactly one other site, `packages/ui/src/voice/voice-chat-playback.ts:116`, and it already guards the miss with `urls[Number(i)] ?? _`. Nothing else to fix.

# Risks

Low. The only behaviour change for text without NUL is none at all, which the 89 pre-existing tests confirm.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JAXZZ4WD8YV10VK4YZW3JD","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T00:33:05.508Z","completed_at":"2026-09-03T00:34:09.646Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T00:33:06.178Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4d93c1e726b4e4d1f92eb388f5d91507bd1bfe74758af29f9615f276a13c103b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"131f9cf2-eff8-4c77-9c61-003dfbfa1799","object_id":"sha256:4d93c1e726b4e4d1f92eb388f5d91507bd1bfe74758af29f9615f276a13c103b","sha256":"4d93c1e726b4e4d1f92eb388f5d91507bd1bfe74758af29f9615f276a13c103b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"lEEm9RLnEpf45LhvcOftmpcReWv1H2ZeeKBKMErz7Nvpuuh-EDLFz7Ed0V7GqOMmZpIQdz3WwZ4dXgu4_StIDA"}} -->
