### PR TITLE
test(ui): cover the shared-tier handoff guard

### DIFF
--- a/packages/ui/src/api/client-cloud-handoff-target.test.ts
+++ b/packages/ui/src/api/client-cloud-handoff-target.test.ts
@@ -242,6 +242,46 @@ describe("startCloudAgentHandoff — dedicated migration target", () => {
     );
   });
 
+  it("does not switch onto a PUBLIC dedicated-looking row whose tier is shared", async () => {
+    // The sibling shared-row tests are decided by URL classification: a
+    // loopback proxy or a control-plane UUID path is rejected before the tier
+    // is read. This row advertises a public dedicated web UI and reports
+    // `running`, so every URL-shaped guard passes and only `execution_tier`
+    // can stop the switch. Without that check the client migrates the
+    // conversation onto a shared adapter, which has no migration target.
+    const { client } = fakeClient({});
+    const onSwitch = vi.fn();
+    const fetchMock = vi.fn(async () => ({
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: {
+          id: "dedicated-1",
+          status: "running",
+          executionTier: "shared",
+          webUiUrl: "https://dedicated-1.elizacloud.ai",
+        },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await client.startCloudAgentHandoff({
+      agentId: "shared-1",
+      sharedApiBase: SHARED_BASE,
+      conversationId: "shared-1",
+      dedicatedAgentId: "dedicated-1",
+      cloudApiBase: "https://www.elizacloud.ai",
+      authToken: "tok",
+      onSwitch,
+      intervalMs: 1,
+      timeoutMs: 20,
+      log: () => {},
+    });
+
+    expect(onSwitch).not.toHaveBeenCalled();
+    expect(result.status).toBe("timed-out");
+  });
+
   it("does not treat a production control-plane UUID path as a dedicated handoff target", async () => {
     const dedicatedId = "00000000-0000-4000-8000-000000000001";
     const cloudApiBase = DEFAULT_DIRECT_CLOUD_API_BASE_URL;


### PR DESCRIPTION
# What

`readiness.resolveReadyBase` in `client-cloud.ts` refuses to switch onto a control-plane row whose `execution_tier` is `"shared"` — a shared adapter is never a migration target. Nothing exercised that branch.

Replacing the check with `if (false)` leaves **91/91 passing** across all five suites that touch handoff readiness:

```
client-cloud-handoff-target.test.ts
client-cloud-direct-auth.test.ts
client-cloud-select-or-provision.test.ts
client-cloud-wake-typed-errors.test.ts
cloud/handoff/cloud-handoff-supervisor.test.ts
```

# Why the existing shared-row tests don't reach it

There are already two tests about shared rows, and I assumed one of them covered this. Neither does — both are decided by **URL classification** and return `null` before the tier is ever read:

- *does not treat a shared row on the local UUID proxy as dedicated* — rejected as a loopback proxy.
- *does not treat a production control-plane UUID path as a dedicated handoff target* — rejected as a control-plane UUID path.

My first attempt at a covering test passed with the guard both enabled and disabled, which is worse than no test. Rather than guess again, I instrumented every `return null` in `resolveReadyBase` with a distinct marker (`shared-adapter`, `no-agent`, `tier-shared`, `no-dedicated-url`, `not-running`, `shared-base`, `probe-retryable`, `probe-threw`, `OK`) and printed which one fired.

# The input that isolates the guard

A row advertising a **public dedicated web UI** and `status: "running"`, so every URL-shaped check passes:

```ts
data: {
  id: "dedicated-1",
  status: "running",
  executionTier: "shared",
  webUiUrl: "https://dedicated-1.elizacloud.ai",
}
```

| implementation | marker | `onSwitch` |
|---|---|---|
| guard intact | `tier-shared` | not called |
| guard disabled | `OK` | **called** |

With the guard removed the client migrates the conversation onto the shared row. That's the defect the check exists to prevent, demonstrated rather than asserted.

# Evidence

Instrumentation removed and `client-cloud.ts` restored from a pristine copy before writing the final test, so the diff is test-only: one file, **+40/-0**.

| implementation | result |
|---|---|
| guard mutated to `if (false)` | **1 failed** / 9 passed — the failing test is exactly the new one |
| guard intact | 92 passed across the 5 suites (up from 91) |

`bunx @biomejs/biome check` → exit 0.
`bunx tsc --noEmit -p tsconfig.json` → exit 0, zero errors.

# Context

Found while reviewing #30330; carried as an unfiled note until I could produce a test that actually fails without the guard. No production behaviour changes here — the guard already works, it just wasn't pinned.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JC34VSXTXYK84KQ1WBN899","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T00:53:22.937Z","completed_at":"2026-09-03T00:54:24.195Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T00:53:23.546Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"91074e45451c50c3645cc98ab2b75fd3dafc22c37c2b85045c90fa4afb236cd3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a22a73ad-9272-45df-a73f-dd58d1335467","object_id":"sha256:91074e45451c50c3645cc98ab2b75fd3dafc22c37c2b85045c90fa4afb236cd3","sha256":"91074e45451c50c3645cc98ab2b75fd3dafc22c37c2b85045c90fa4afb236cd3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"g5nrhG0ptYKGwd_WQtZCipiU6sIEUhmPn7Byl3v53c4X7oIuGNLmWPRuzFi6vA0urTY22K-IIAfYCOfq0HyzBQ"}} -->
