### PR TITLE
feat(cloud): report the CP router's ACL tag after enrollment

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -1222,10 +1222,29 @@ FINAL_NODE_COUNT=$(sudo headscale nodes list -o json 2>/dev/null \\
   | jq -r --arg h "$CP_ROUTER_HOST" '[.[] | select(.name == $h)] | length')
 [ "$FINAL_NODE_COUNT" -eq 1 ] \\
   || { echo "CP router durable identity proof failed (category=cp-router-durable-proof-failed)"; exit 1; }
+# The node's tag has a single unverified path: the preauth key is minted with
+# --tags tag:eliza-proxy and the client no longer sends --advertise-tags. An
+# untagged join still enrolls and still counts as 1 above, but every ACL rule
+# with src: ["tag:eliza-proxy"] stops matching and the router silently cannot
+# reach agents. Report the observed tags so that failure is visible in the log
+# instead of hiding behind cp-router-visible. Advisory rather than fatal: the
+# field names below are not confirmed against this deployment's headscale
+# build, and a wrong guess must not fail a deploy that is actually healthy.
+FINAL_NODE_TAGS=$(sudo headscale nodes list -o json 2>/dev/null \\
+  | jq -r --arg h "$CP_ROUTER_HOST" '
+      [ .[] | select(.name == $h)
+        | (.validTags // .valid_tags // []) + (.forcedTags // .forced_tags // [])
+      ] | flatten | unique | join(",")' 2>/dev/null || true)
+case ",$FINAL_NODE_TAGS," in
+  *,tag:eliza-proxy,*)
+    echo "CP router ACL tag verified (category=cp-router-tag-verified)" ;;
+  *)
+    echo "CP router ACL tag not observed on the enrolled node (category=cp-router-tag-unverified): tags=[$FINAL_NODE_TAGS]" ;;
+esac
 echo "CP router live identity and canonical control URL verified (category=cp-router-visible)"
 unset NODE_ROWS NODE_COUNT STATUS_JSON PREFS_JSON LOCAL_IDENTITY_READY CONTROL_URL_MATCH \\
   CONTROL_URL TUNNEL_UID PREAUTH_KEY STALE_NODE_ID FINAL_STATUS_JSON FINAL_PREFS_JSON \\
-  FINAL_CONTROL_URL FINAL_NODE_COUNT
+  FINAL_CONTROL_URL FINAL_NODE_COUNT FINAL_NODE_TAGS
 `;
 
 const legacyVhostInspectionRemote = `

--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.test.ts
@@ -184,6 +184,23 @@ describe("Headscale control-plane self-enrollment", () => {
     expect(remote).toContain("(.Self.TailscaleIPs // []) | length > 0");
   });
 
+  test("reports the enrolled node's ACL tags after the durable identity proof", () => {
+    const remote = renderRemoteScript();
+
+    // The preauth key is the sole tag authority (the client no longer sends
+    // --advertise-tags), so an untagged join still enrolls and still counts as
+    // one node. Assert the observation exists and lands after the count check.
+    const durableProof = remote.indexOf("cp-router-durable-proof-failed");
+    const tagProbe = remote.indexOf("FINAL_NODE_TAGS=");
+    const visible = remote.indexOf("category=cp-router-visible");
+    expect(durableProof).toBeGreaterThan(-1);
+    expect(tagProbe).toBeGreaterThan(durableProof);
+    expect(visible).toBeGreaterThan(tagProbe);
+    expect(remote).toContain("category=cp-router-tag-verified");
+    expect(remote).toContain("category=cp-router-tag-unverified");
+    expect(remote).toContain("FINAL_NODE_TAGS");
+  });
+
   test("does not emit forced reauthentication when router enrollment is skipped", () => {
     const remote = renderRemoteScript(["--skip-cp-router"]);
 


### PR DESCRIPTION
# What

The CP router's `tag:eliza-proxy` now has a **single unverified path**, and nothing checks it.

Since #30319 added `--reset` and #30324 removed the client-side `--advertise-tags`, the only thing that tags the node is the preauth key minted with `--tags tag:eliza-proxy`. If that ever stops carrying the tag, the join still succeeds, `FINAL_NODE_COUNT -eq 1` still passes, and the script still prints `category=cp-router-visible` — while every ACL rule with `src: ["tag:eliza-proxy"]` stops matching and the router silently cannot reach `100.64.x` agents.

`arm-headscale-control-plane.mjs` already runs `headscale nodes list -o json` and selects the node by name for the durable identity proof. It just never looks at the tags.

# The change

Report the enrolled node's observed tags, reusing that same call:

```sh
FINAL_NODE_TAGS=$(sudo headscale nodes list -o json 2>/dev/null \
  | jq -r --arg h "$CP_ROUTER_HOST" '
      [ .[] | select(.name == $h)
        | (.validTags // .valid_tags // []) + (.forcedTags // .forced_tags // [])
      ] | flatten | unique | join(",")' 2>/dev/null || true)
case ",$FINAL_NODE_TAGS," in
  *,tag:eliza-proxy,*)
    echo "CP router ACL tag verified (category=cp-router-tag-verified)" ;;
  *)
    echo "CP router ACL tag not observed on the enrolled node (category=cp-router-tag-unverified): tags=[$FINAL_NODE_TAGS]" ;;
esac
```

# Why advisory and not fail-closed

I wanted this to be a hard gate and decided it shouldn't be, at least not yet. I can't confirm the node-tag field names against your headscale build from here:

- `HeadscaleNode` in `packages/cloud/shared/src/lib/services/headscale-client.ts` is a partial camelCase interface that doesn't model tags at all.
- The one existing `acl_tags` filter, `deploy-tunnel-proxy.yml:409`, is over **preauth keys**, not nodes.

A wrong field name in a fail-closed gate would break a deploy that is actually healthy. So this prints what it observes and names both outcomes; the next operator run reveals the real field names, after which promoting it to `exit 1` is a one-line follow-up. That's a deliberate first step, not an oversight.

# Ordering is load-bearing, and asserted

`arm-headscale-control-plane.yml` extracts categories **only inside the `arm_status != 0` branch**, via `grep -hEo 'category=...' | tail -n 1`. The new lines are emitted *before* the `cp-router-visible` echo, so the last matched category for an unrelated later failure is unchanged. The new test pins that with index comparisons (`durableProof < tagProbe < visible`) rather than leaving it to chance.

Both new categories match the workflow's closed alphabet, `category=(headscale|cp-router)-[a-z0-9-]+`.

# Evidence

Rendered the remote script through the same `--dry-run` path the tests use, extracted the 273-line block, and ran `bash -n` on it → **syntax OK**.

Exercised the jq expression and `case` against seven shapes:

| fixture | result |
|---|---|
| camelCase `validTags: ["tag:eliza-proxy"]` | verified |
| snake_case `forced_tags: ["tag:eliza-proxy"]` | verified |
| node present, tags empty | unverified, `tags=[]` |
| node present, no tag fields at all | unverified |
| tag present on a **different** node | unverified |
| empty node list | unverified |
| malformed non-JSON output | unverified |

No shape errors or exits non-zero, which is what the advisory framing requires.

`bun test admin/arm-headscale-control-plane.test.ts` → **11 pass / 0 fail** (up from 10).
`node --check admin/arm-headscale-control-plane.mjs` → clean.
`bunx @biomejs/biome check` → exit 0 on the `.mjs`.

One note: biome also reformatted an unrelated pre-existing line in the test file, which I reverted to keep the diff scoped — that file is pre-existing-unformatted (biome exits 1 on develop's copy too).

# Context

Raised while reviewing #30319 and sharpened while reviewing #30324, then carried unfiled until I could make the remedy concrete without guessing at a schema I can't see.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JCRQSRPV2X9XC80HASKW4V","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T01:05:10.457Z","completed_at":"2026-09-03T01:06:18.544Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T01:05:11.052Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6cda7b5c8c1a0723868a98aaaf70fec2908753e4bf8138cb5c08584449de2e3a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"dd2cceb0-6069-41bc-8210-e2233f12a720","object_id":"sha256:6cda7b5c8c1a0723868a98aaaf70fec2908753e4bf8138cb5c08584449de2e3a","sha256":"6cda7b5c8c1a0723868a98aaaf70fec2908753e4bf8138cb5c08584449de2e3a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"gS0-VprQuFFyB6eqX7SgK2L795DqDSQEff_juhrNTPLFjSMGWpCqXDl3AV6fV1tX7O7PI1fk7TcJOiN4Qi4GBQ"}} -->
