### PR TITLE
test(ui): pin the shared-REST-base handoff guard

### DIFF
--- a/packages/ui/src/api/client-cloud-handoff-target.test.ts
+++ b/packages/ui/src/api/client-cloud-handoff-target.test.ts
@@ -283,6 +283,68 @@ describe("startCloudAgentHandoff — dedicated migration target", () => {
       expect.anything(),
     );
   });
+
+  it("never switches onto a control-plane shared REST base that the record advertises as its web UI", async () => {
+    // The sibling cases all stop earlier: `webUiUrl: null` means the record
+    // carries no dedicated URL at all, so `hasDedicatedUrl` rejects them before
+    // the base is ever classified. Here the record *does* advertise a URL and
+    // reports a dedicated tier, so `!agent`, `execution_tier`, `hasDedicatedUrl`
+    // and the `status !== "running"` checks all pass -- and the URL it
+    // advertises is the control-plane shared REST adapter, which is exactly
+    // what `isDirectCloudSharedAgentBase(base) && !isLocalDedicatedProxy`
+    // exists to refuse. The mock answers the whole switch path, so without that
+    // guard the handoff completes onto a base that hosts no dedicated runtime.
+    const dedicatedId = "00000000-0000-4000-8000-000000000003";
+    const cloudApiBase = DEFAULT_DIRECT_CLOUD_API_BASE_URL;
+    const sharedRestBase = `${cloudApiBase}/api/v1/eliza/agents/${dedicatedId}`;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === sharedRestBase) {
+        return {
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: {
+              id: dedicatedId,
+              status: "running",
+              executionTier: "dedicated",
+              webUiUrl: sharedRestBase,
+            },
+          }),
+        };
+      }
+      if (url === `${sharedRestBase}/api/health`) {
+        return { status: 200, json: async () => ({ ready: true }) };
+      }
+      if (url.endsWith("/messages")) {
+        return { status: 200, json: async () => ({ messages: [] }) };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client } = fakeClient({});
+    const onSwitch = vi.fn();
+    const result = await client.startCloudAgentHandoff({
+      agentId: "shared-1",
+      sharedApiBase: SHARED_BASE,
+      conversationId: "shared-1",
+      dedicatedAgentId: dedicatedId,
+      cloudApiBase,
+      authToken: "tok",
+      onSwitch,
+      intervalMs: 1,
+      timeoutMs: 20,
+      log: () => {},
+    });
+
+    expect(result.status).toBe("timed-out");
+    expect(onSwitch).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      `${sharedRestBase}/api/health`,
+      expect.anything(),
+    );
+  });
 });
 
 describe("startCloudAgentHandoff — proxy-readiness gate (#15901)", () => {


### PR DESCRIPTION
# What

`resolveReadyBase` refuses to hand off onto a base that is the control-plane **shared REST adapter**:

```ts
if (isDirectCloudSharedAgentBase(base) && !isLocalDedicatedProxy) {
  return null;
}
```

Delete that guard and the whole handoff-target suite stays green. Nothing reaches it.

# Why nothing reaches it

Both existing shared-row cases send `webUiUrl: null`, so the record carries no dedicated URL at all and `hasDedicatedUrl` rejects it **two guards earlier** — the base is never classified. That is symmetric masking: with the shared-base guard deleted, `hasDedicatedUrl` still refuses those fixtures, so they cannot see the deletion.

# The change

One test with a record that passes every earlier guard: `status: "running"`, `executionTier: "dedicated"`, and a `webUiUrl` that *is* the control-plane shared REST base. So `!agent`, `execution_tier`, `hasDedicatedUrl` and the status check all pass, `resolveCloudAgentApiBase` resolves to exactly the shape `isDirectCloudSharedAgentBase` matches, and the production host keeps `isLocalDedicatedProxy` false. The mock answers the whole switch path (detail, `/api/health`, `/messages`), so the guard is the only thing between the fixture and a completed switch.

This is the realistic shape, not a contrived one: a control plane that fills `webUiUrl` with the adapter route it already serves is how a record ends up dedicated-looking and shared-hosted at once.

# Mutation matrix

Each guard deleted from `client-cloud.ts` independently and reverted, against this head:

| deleted guard | result |
| --- | --- |
| `isDirectCloudSharedAgentBase(base) && !isLocalDedicatedProxy` | **1 failed / 9 passed** — killed |
| `if (!agent) return null;` | 10 passed |
| `if (!hasDedicatedUrl) return null;` | 10 passed |
| `if (agent.status && agent.status !== "running") return null;` | 10 passed |
| `if (agent.execution_tier === "shared") return null;` | 10 passed |
| `if (!dedicatedAgentId && sourceIsSharedAdapter) return null;` | 10 passed |

Exactly one guard, which is what makes it a pin rather than a coincidence. (The last two rows are the guards #30376 pins; this PR is deliberately disjoint from that one and touches a different case in the same file.)

# One thing I checked and did not act on

`hasDedicatedUrl` looks redundant with the shared-base guard — whenever it is false, the base derives from `agentId` + the resolved cloud base and is always shared-shaped, so the later guard would catch it anyway. It is not redundant: if `resolveDirectCloudAuthApiBase` returns an empty string the base is empty, `isDirectCloudSharedAgentBase("")` is false, and `hasDedicatedUrl` is the only guard left. It stays reachable, and I did not fabricate that state just to pin it.

# Test-only gate

- **Realistic regression prevented:** reverting the shared-base guard lets the client "switch" the conversation onto the shared REST adapter, which hosts no dedicated runtime — user-visible as a dead post-handoff chat.
- **Observing consumer:** `startCloudAgentHandoff` → `startCloudConversationHandoff`, whose `onSwitch` repoints the app at the returned base.
- **Why existing coverage does not own it:** demonstrated by mutation above — the guard's deletion is invisible to every current test, because they are all stopped by `hasDedicatedUrl` first.

# Verification

- `packages/ui` `src/api/client-cloud-handoff-target.test.ts` → **10 passed** (was 9)
- All 19 `packages/ui/src/api/client-cloud*.test.ts` files → **326 passed**, no failures — the new case does not disturb the sibling handoff suites
- `biome check` clean on the touched file

Test-only; no runtime source is touched. Follows from the guard sweep I posted in my review of #30376.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JEK3CATYR1396FVYVRSQPF","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T01:37:02.858Z","completed_at":"2026-09-03T01:37:44.704Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T01:37:03.149Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"739b0d9299ef6cab1d88f60ee15107ea27ed6d74b196d496aee6cd849ef549b3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8e25f5da-a3a0-4a20-8dc4-697cbb378009","object_id":"sha256:739b0d9299ef6cab1d88f60ee15107ea27ed6d74b196d496aee6cd849ef549b3","sha256":"739b0d9299ef6cab1d88f60ee15107ea27ed6d74b196d496aee6cd849ef549b3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"3TBisFNQbM5_1aLRfBSHL83HyCkyuVPCHvMmjBD4vcJh4iQWdh-i0I4aloJYshCP1vt0bo-jq1zpmXRPf4ybDw"}} -->
