### PR TITLE
test(cloud): bound the inference ingress native deadline

### DIFF
--- a/packages/cloud/api/src/inference-ingress-rate-limit.test.ts
+++ b/packages/cloud/api/src/inference-ingress-rate-limit.test.ts
@@ -97,6 +97,13 @@ describe("inference ingress rate limit", () => {
   test("bounds a stalled binding and observes its late rejection", async () => {
     let rejectBinding: ((error: Error) => void) | undefined;
     const { app, routeCalls } = createApp();
+    // The point of the deadline is that a stalled platform counter cannot delay
+    // inference. Without an elapsed-time bound this case passes at any deadline
+    // -- 2s and 4s both leave the suite green -- so the wait itself is asserted.
+    // The observed cost is the 20ms deadline plus ~2ms of overhead; the budget
+    // is deliberately loose so it fails on a regressed constant, not on a slow
+    // machine.
+    const startedAt = performance.now();
     const response = await app.fetch(
       request(),
       envWith({
@@ -107,8 +114,10 @@ describe("inference ingress rate limit", () => {
         },
       }),
     );
+    const elapsedMs = performance.now() - startedAt;
 
     expect(response.status).toBe(200);
+    expect(elapsedMs).toBeLessThan(250);
     expect(routeCalls()).toBe(1);
     rejectBinding?.(new Error("late binding rejection"));
     await new Promise((resolve) => setTimeout(resolve, 0));


### PR DESCRIPTION
# What

`inference-ingress-rate-limit.ts` (new in #30351) races Cloudflare's counter against a deadline so that a stalled platform limiter cannot delay inference — the module's own header says so:

> Cloudflare's machine-local counter is primary, with a short deadline and a bounded per-isolate fallback **so a platform stall cannot delay inference**.

```ts
const NATIVE_DEADLINE_MS = 20;
```

The suite has a test named for exactly that bound — `bounds a stalled binding and observes its late rejection` — and it never measures the wait. **The deadline can regress two-hundred-fold and the suite stays green.**

| `NATIVE_DEADLINE_MS` | suite on develop | wall clock |
| --- | --- | --- |
| `20` (shipped) | 6 pass | 0.30s |
| `200` | 6 pass | 0.37s |
| `2_000` | 6 pass | 2.18s |
| `4_000` | 6 pass | **4.18s** |

The 4-second run is the whole point: the suite sits there for four seconds waiting on a stalled binding and reports `6 pass, 0 fail`.

# The change

Measure the wait in the case that is already named for it. I repaired the existing test rather than adding a sibling — a second test would leave the misleading name attached to an assertion that still proves nothing.

```ts
const startedAt = performance.now();
const response = await app.fetch(request(), envWith({ limit() { return new Promise(...); } }));
const elapsedMs = performance.now() - startedAt;

expect(response.status).toBe(200);
expect(elapsedMs).toBeLessThan(250);
```

# The budget is measured, not guessed

Five stalled-binding requests at the shipped deadline: **23.3, 22.1, 22.1, 22.1, 21.9 ms** — the 20 ms deadline plus ~2 ms of overhead. 250 ms is ~11× headroom, so it fails on a regressed constant rather than on a slow machine.

| mutant | result |
| --- | --- |
| deadline `250` | **1 failed / 5 passed** |
| deadline `300` | **1 failed / 5 passed** |
| deadline `2_000` | **1 failed / 5 passed** |
| deadline `4_000` | **1 failed / 5 passed** |
| unmutated, 3 consecutive runs | 6 pass, 6 pass, 6 pass |

Stated plainly: this budget does **not** kill a regression to 200 ms. That is the price of a bound that cannot flake, and I would rather ship a bound that holds than one that goes red on a loaded runner.

# Two more invariants are unpinned — recorded, not fixed here

Swept the rest of the module so this reports the whole file rather than only the line I touched:

| mutant | result |
| --- | --- |
| `MAX_REQUESTS` `600` → `6000` | 1 failed — **pinned** |
| remove the `OPTIONS` preflight bypass | 1 failed — **pinned** |
| remove the `makeRoom()` call (the `MAX_KEYS` memory bound) | 6 pass — **survives** |
| drop the LRU refresh `buckets.delete(key)` in `consumeFallback` | 6 pass — **survives** |

Neither survivor is observable from outside the module: `buckets` is private and eviction needs 4,096 distinct keys before it changes any response. Pinning them means adding a test-only accessor next to the existing `_resetInferenceIngressRateLimit`, which is a source change and a separate decision — happy to do it in a follow-up if you want the memory bound covered.

# Test-only gate

- **Realistic regression prevented:** raising or removing the deadline puts the full latency of a stalled Cloudflare rate-limiter binding directly in front of every inference request — the exact failure #30351 was opened to remove.
- **Observing consumer:** `inferenceIngressRateLimit()` is the first middleware on the inference shell, ahead of route authentication.
- **Why existing coverage does not own it:** demonstrated by mutation above — the test named for the bound passes at 4 s.

# Verification

- `bun test api/src/inference-ingress-rate-limit.test.ts` → **6 pass / 0 fail**, three consecutive runs
- With the neighbours, `inference-app.test.ts` + `inference-chat-csrf.test.ts` → **23 pass / 0 fail**
- `biome check` clean on the touched file

Test-only; no runtime source is touched. +9/-0.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JF0XWBD5VNJTD4XGQC6V6Y","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T01:44:35.979Z","completed_at":"2026-09-03T01:45:20.378Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T01:44:37.136Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"435af7106b1f7e8758ab479878f26985dfce71949e431a91336bce088462ea32","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5584927d-52d9-4e56-a090-68ebefaacf05","object_id":"sha256:435af7106b1f7e8758ab479878f26985dfce71949e431a91336bce088462ea32","sha256":"435af7106b1f7e8758ab479878f26985dfce71949e431a91336bce088462ea32"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"QDQ0-KyeQkngq-DPNYQxb692UsOtqFrECPdbVDR_6IwJ4CxxEewBkcRsB8Vle72MLY6lVDAG6SpFDpgRQ6YhDA"}} -->
