### PR TITLE
fix(cloud): honor runner fleet failover for worker deploys

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   determine-env:
     name: Determine environment
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     outputs:
       environment: ${{ steps.env.outputs.environment }}
       branch: ${{ steps.env.outputs.branch }}
@@ -121,7 +121,7 @@ jobs:
 
   deploy:
     name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }} @ ${{ needs.determine-env.outputs.deployment_sha }})
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env
     concurrency:
       group: deploy-eliza-provisioning-worker-mutate-${{ needs.determine-env.outputs.environment }}-${{ format('run-{0}', github.run_id) }}

--- a/packages/cloud/infra/AGENT-RUNTIME-ARCHITECTURE.md
+++ b/packages/cloud/infra/AGENT-RUNTIME-ARCHITECTURE.md
@@ -877,7 +877,16 @@ schema preflight.
   no host or database mutation, but "online" is insufficient fleet health.
   Deployment receipts must therefore distinguish runner startup failure from
   host deployment failure, and operators should alert on repeated no-log job
-  terminations.
+  terminations. After merge, the same `_diag/pages` collision recurred on
+  runners 11, 13, and 15 while the repository-wide emergency gate already said
+  `HETZNER_FLEET_ONLINE=false`. The provisioning deployment was the exception:
+  it ignored that gate and hard-routed both admission and mutation to the
+  unhealthy generic runner labels. The workflow now uses the canonical
+  fail-closed selector for both jobs: hosted `ubuntu-24.04` unless the fleet is
+  explicitly set to lowercase `true`, otherwise the quarantinable
+  `[self-hosted, hetzner-robot]` pool. The per-slot repair remains the
+  repository-owned `cloud/runners/repair-runner-slot.sh` runbook; deployment no
+  longer depends on those repairs completing before a release can proceed.
 - The provisioning host no longer needs outbound Git authentication, removing
   a mutable credential/configuration dependency from disaster recovery and
   ordinary rollout.

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -69,13 +69,19 @@ function deployStep(name: string): WorkflowStep {
 }
 
 describe("provisioning worker deployment contract", () => {
-  it("routes both jobs to the online generic self-hosted fleet", () => {
+  it("uses hosted deployment capacity unless the Hetzner fleet is explicitly healthy", () => {
+    const selector =
+      "runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && " +
+      "'[\"ubuntu-24.04\"]' || '[\"self-hosted\",\"hetzner-robot\"]') }}";
     expect(
-      workflow.match(/^\s+runs-on: \[self-hosted, Linux, X64\]$/gm),
+      workflow.split(selector),
+    ).toHaveLength(3);
+    expect(
+      workflow.match(/^\s+runs-on: \[self-hosted, Linux, X64\]$/gm) ?? [],
+    ).toHaveLength(0);
+    expect(
+      workflow.match(/HETZNER_FLEET_ONLINE/g),
     ).toHaveLength(2);
-    expect(workflow).not.toContain("HETZNER_FLEET_ONLINE");
-    expect(workflow).not.toContain("ubuntu-24.04");
-    expect(workflow).not.toContain("hetzner-robot");
   });
 
   it("resolves one immutable SHA and deploys exactly that snapshot", () => {


### PR DESCRIPTION
Closes the deployment availability gap found while validating #29341. The provisioning-worker workflow was the only deployment path hard-routed to generic self-hosted runners even while HETZNER_FLEET_ONLINE=false. Multiple runners then failed before user steps with the known _diag/pages collision. Both admission and mutation jobs now use the repository canonical fail-closed fleet selector, with hosted ubuntu-24.04 unless the quarantinable hetzner-robot pool is explicitly enabled.\n\nVerification:\n- 42 focused workflow/routing contract tests pass\n- repository Hetzner fleet routing audit passes with 64 selectors across 17 workflows\n- final exact-head hosted and live deployment evidence will be attached before merge