### PR TITLE
fix(cloud): gate paid outbound provider calls

### DIFF
--- a/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/blooio/[orgId]/route.ts
@@ -128,7 +128,9 @@ async function handleBlooioWebhook(c: AppContext): Promise<Response> {
     // Handle different event types
     switch (payload.event) {
       case "message.received":
-        await handleIncomingMessage(orgId, payload);
+        await handleIncomingMessage(orgId, payload, (promise) =>
+          c.executionCtx.waitUntil(promise),
+        );
         break;
 
       case "message.sent":
@@ -188,6 +190,7 @@ app.post("/", rateLimit(RateLimitPresets.AGGRESSIVE), (c) =>
 async function handleIncomingMessage(
   orgId: string,
   event: BlooioWebhookEvent,
+  defer: (promise: Promise<unknown>) => void,
 ): Promise<void> {
   const [{ messageRouterService }, { agentGatewayRouterService }] =
     await Promise.all([
@@ -288,7 +291,7 @@ async function handleIncomingMessage(
     metadata: messageContext.metadata,
   });
 
-  if (!routed.handled) {
+  if (!routed.handled || !routed.userId) {
     logger.info("[BlooioWebhook] Message did not resolve to an owned Agent", {
       orgId,
       reason: routed.reason,
@@ -308,6 +311,7 @@ async function handleIncomingMessage(
       agentId: routed.agentId,
       agentOrganizationId: routed.organizationId,
       agentUserId: routed.userId,
+      defer,
     });
 
     if (sent.status === "delivered") {

--- a/packages/cloud/api/webhooks/twilio/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/twilio/[orgId]/route.ts
@@ -248,7 +248,7 @@ async function handleIncomingMessage(
     metadata: messageContext.metadata,
   });
 
-  if (!routed.handled) {
+  if (!routed.handled || !routed.userId) {
     logger.warn("[TwilioWebhook] Failed to route message to owned Agent", {
       orgId,
       reason: routed.reason,
@@ -268,6 +268,7 @@ async function handleIncomingMessage(
       agentId: routed.agentId,
       agentOrganizationId: routed.organizationId,
       agentUserId: routed.userId,
+      defer: (promise) => c.executionCtx.waitUntil(promise),
     });
 
     const responseTime = Date.now() - startTime;

--- a/packages/cloud/api/webhooks/whatsapp/[orgId]/route.ts
+++ b/packages/cloud/api/webhooks/whatsapp/[orgId]/route.ts
@@ -121,7 +121,9 @@ async function handleWhatsAppWebhook(c: AppContext): Promise<Response> {
       }
 
       try {
-        await handleIncomingMessage(orgId, msg);
+        await handleIncomingMessage(orgId, msg, (promise) =>
+          c.executionCtx.waitUntil(promise),
+        );
       } catch (error) {
         // error-policy:J4 isolate ordinary message failures and release their claim.
         logger.error("[WhatsAppWebhook] Failed to process message", {
@@ -181,6 +183,7 @@ async function handleWhatsAppVerification(c: AppContext): Promise<Response> {
 async function handleIncomingMessage(
   orgId: string,
   msg: WhatsAppIncomingMessage,
+  defer: (promise: Promise<unknown>) => void,
 ): Promise<void> {
   const text = msg.text?.trim();
   if (!text) {
@@ -288,14 +291,16 @@ async function handleIncomingMessage(
     if (
       !routeResult.handled ||
       !routeResult.agentId ||
-      !routeResult.organizationId
+      !routeResult.organizationId ||
+      !routeResult.userId
     ) {
       const phoneRouteResult =
         await messageRouterService.routeIncomingMessage(messageContext);
       if (
         !phoneRouteResult.success ||
         !phoneRouteResult.agentId ||
-        !phoneRouteResult.organizationId
+        !phoneRouteResult.organizationId ||
+        !phoneRouteResult.userId
       ) {
         logger.info(
           "[WhatsAppWebhook] Message received (agent routing not configured)",
@@ -325,6 +330,8 @@ async function handleIncomingMessage(
           organizationId: phoneRouteResult.organizationId,
           agentId: phoneRouteResult.agentId,
           agentOrganizationId: phoneRouteResult.organizationId,
+          agentUserId: phoneRouteResult.userId,
+          defer,
         });
 
         if (sent.status === "delivered") {
@@ -370,6 +377,7 @@ async function handleIncomingMessage(
       agentId: routeResult.agentId,
       agentOrganizationId: routeResult.organizationId,
       agentUserId: routeResult.userId,
+      defer,
     });
 
     if (sent.status === "delivered") {

--- a/packages/cloud/shared/src/lib/api/a2a/handlers.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/handlers.ts
@@ -7,6 +7,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { a2aTaskStoreService, type TaskStoreEntry } from "../../services/a2a-task-store";
 import { contentModerationService } from "../../services/content-moderation";
+import { resolveOutboundMessageStanding } from "../../services/outbound-message-standing";
 import { logger } from "../../utils/logger";
 import { parseUntrustedA2AMessageSendParams } from "./request-validation";
 import {
@@ -44,6 +45,28 @@ import {
   type TaskGetParams,
   type TaskState,
 } from "./types";
+
+const A2A_NO_PROVIDER_SKILLS = new Set([
+  "chat_with_agent",
+  "check_balance",
+  "get_usage",
+  "list_agents",
+  "save_memory",
+  "retrieve_memories",
+  "list_containers",
+  "create_conversation",
+  "delete_memory",
+  "get_conversation_context",
+  "video_generation",
+  "generate_video",
+  "get_user_profile",
+  "profile",
+]);
+
+/** Unknown skills fall through to chat completion and therefore require standing. */
+export function a2aSkillCanDispatchProvider(skillId: string | undefined): boolean {
+  return !skillId || !A2A_NO_PROVIDER_SKILLS.has(skillId);
+}
 
 // Task store helpers
 async function getTaskStore(
@@ -107,16 +130,32 @@ export async function handleMessageSend(
     throw new Error("Message must contain at least one part");
   }
 
-  // Check if user is blocked due to moderation violations
-  if (await contentModerationService.shouldBlockUser(ctx.user.id)) {
-    throw new Error("Account suspended due to policy violations");
-  }
-
   // Extract text content for moderation
   const textContent = message.parts
     .filter((p): p is { type: "text"; text: string } => p.type === "text")
     .map((p) => p.text)
     .join("\n");
+
+  const requestedSkill = message.parts.find(
+    (part): part is { type: "data"; data: Record<string, unknown> } => part.type === "data",
+  )?.data.skill;
+  const skillId = typeof requestedSkill === "string" ? requestedSkill : undefined;
+  if (a2aSkillCanDispatchProvider(skillId)) {
+    const standing = await resolveOutboundMessageStanding(ctx.user.organization_id, ctx.user.id);
+    if (!standing.allowed) {
+      logger.error("[A2A] Account standing denied provider-capable skill", {
+        organizationId: ctx.user.organization_id,
+        userId: ctx.user.id,
+        skillId: skillId ?? "chat_completion",
+        reason: standing.reason,
+        source: standing.source,
+        providerDispatched: false,
+      });
+      throw new Error(`Account standing denied: ${standing.reason}`);
+    }
+  } else if (await contentModerationService.shouldBlockUser(ctx.user.id)) {
+    throw new Error("Account suspended due to policy violations");
+  }
 
   if (textContent) {
     contentModerationService.moderateInBackground(textContent, ctx.user.id, undefined, (result) => {

--- a/packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/skills.money-guard.test.ts
@@ -17,6 +17,11 @@ const storeTask = mock(async () => undefined);
 const addMessageToHistory = mock(async () => undefined);
 const shouldBlockUser = mock(async () => false);
 const moderateInBackground = mock(() => undefined);
+const resolveOutboundMessageStanding = mock(async () => ({
+  allowed: true as const,
+  source: "cache" as const,
+}));
+const loggerError = mock();
 
 mock.module("ai", () => ({
   APICallError: class APICallError extends Error {},
@@ -200,8 +205,13 @@ mock.module("../../services/content-moderation", () => ({
   },
 }));
 
+mock.module("../../services/outbound-message-standing", () => ({
+  resolveOutboundMessageStanding,
+}));
+
 mock.module("../../utils/logger", () => ({
   logger: {
+    error: loggerError,
     warn: () => unexpectedDependencyCall("logger.warn"),
   },
 }));
@@ -228,6 +238,9 @@ function resetAllowedMocks() {
   addMessageToHistory.mockClear();
   shouldBlockUser.mockClear();
   moderateInBackground.mockClear();
+  resolveOutboundMessageStanding.mockReset();
+  resolveOutboundMessageStanding.mockResolvedValue({ allowed: true, source: "cache" });
+  loggerError.mockClear();
 }
 
 beforeEach(() => {
@@ -235,6 +248,52 @@ beforeEach(() => {
 });
 
 describe("A2A latent paid skill guards", () => {
+  test("provider-capable skill inventory is guarded while local skills stay free", async () => {
+    const { a2aSkillCanDispatchProvider } = await import("./handlers");
+    for (const skillId of [
+      undefined,
+      "chat_completion",
+      "image_generation",
+      "web_search",
+      "extract_page",
+      "browser_session",
+      "unknown_falls_back_to_chat",
+    ]) {
+      expect(a2aSkillCanDispatchProvider(skillId)).toBe(true);
+    }
+    for (const skillId of ["check_balance", "get_usage", "list_agents", "save_memory"]) {
+      expect(a2aSkillCanDispatchProvider(skillId)).toBe(false);
+    }
+  });
+
+  test("bad standing blocks a provider-capable request before task or provider work", async () => {
+    const { handleMessageSend } = await import("./handlers");
+    resolveOutboundMessageStanding.mockResolvedValueOnce({
+      allowed: false,
+      source: "cache",
+      reason: "organization_inactive",
+    });
+    const params: MessageSendParams = {
+      message: {
+        role: "user",
+        parts: [
+          { type: "text", text: "generate" },
+          { type: "data", data: { skill: "image_generation" } },
+        ],
+      },
+    };
+
+    await expect(handleMessageSend(params, handlerContext)).rejects.toThrow(
+      "Account standing denied: organization_inactive",
+    );
+    expect(resolveOutboundMessageStanding).toHaveBeenCalledTimes(1);
+    expect(storeTask).not.toHaveBeenCalled();
+    expect(addMessageToHistory).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith(
+      "[A2A] Account standing denied provider-capable skill",
+      expect.objectContaining({ reason: "organization_inactive", providerDispatched: false }),
+    );
+  });
   test("chat_completion rejects caller policy before pricing, billing, or provider dispatch", async () => {
     const { executeSkillChatCompletion } = await import("./skills");
 

--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -9,6 +9,10 @@ export const CacheKeys = {
     rateLimitTier: (orgId: string) => `orgtier:${orgId}:v1`,
     pattern: (orgId: string) => `org:${orgId}:*`,
   },
+  outboundMessageStanding: {
+    actor: (orgId: string, userId: string) => `outbound-message-standing:${orgId}:${userId}:v1`,
+    organizationPattern: (orgId: string) => `outbound-message-standing:${orgId}:*:v1`,
+  },
   analytics: {
     overview: (orgId: string, timeRange: "daily" | "weekly" | "monthly") =>
       `analytics:overview:${orgId}:${timeRange}:v1`,
@@ -262,6 +266,7 @@ export const CacheTTL = {
     dashboard: 300, // 5 minutes - stale after 180s
     rateLimitTier: 3600, // 1 hour - mutation paths invalidate overrides immediately
   },
+  outboundMessageStanding: 30,
   analytics: {
     overview: {
       daily: 300, // 5 minutes

--- a/packages/cloud/shared/src/lib/services/admin.ts
+++ b/packages/cloud/shared/src/lib/services/admin.ts
@@ -24,6 +24,7 @@ import {
   invalidateInferenceSessionAuthContexts,
 } from "./inference-auth-cache";
 import { setInferenceSubjectActive } from "./inference-credential-revocation";
+import { invalidateOutboundMessageStanding } from "./outbound-message-standing";
 
 /**
  * Clear the inference auth-context cache (#9899) for every API key a user owns.
@@ -35,12 +36,15 @@ async function invalidateUserInferenceContext(userId: string): Promise<void> {
     apiKeysRepository.listByUser(userId),
     dbRead.query.users.findFirst({
       where: eq(users.id, userId),
-      columns: { steward_user_id: true },
+      columns: { steward_user_id: true, organization_id: true },
     }),
   ]);
   await Promise.all([
     invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash)),
     invalidateInferenceSessionAuthContexts(user?.steward_user_id ? [user.steward_user_id] : []),
+    user?.organization_id
+      ? invalidateOutboundMessageStanding(user.organization_id, userId)
+      : Promise.resolve(true),
   ]);
 }
 

--- a/packages/cloud/shared/src/lib/services/message-router/index.test.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.test.ts
@@ -22,6 +22,10 @@ const loggerDebug = mock();
 const loggerWarn = mock();
 const loggerError = mock();
 const originalFetch = globalThis.fetch;
+const resolveOutboundMessageStanding = mock(async () => ({
+  allowed: true as const,
+  source: "cache" as const,
+}));
 
 const insertBuilder = {
   values: insertValues,
@@ -29,6 +33,7 @@ const insertBuilder = {
 };
 const selectBuilder = {
   from: mock(() => selectBuilder),
+  leftJoin: mock(() => selectBuilder),
   where: mock(() => selectBuilder),
   limit: selectLimit,
 };
@@ -125,6 +130,10 @@ mock.module("../../utils/logger", () => ({
   },
 }));
 
+mock.module("../outbound-message-standing", () => ({
+  resolveOutboundMessageStanding,
+}));
+
 const { messageRouterService } = await import("./index");
 
 describe("MessageRouterService contact recording", () => {
@@ -152,8 +161,47 @@ describe("MessageRouterService contact recording", () => {
     loggerDebug.mockClear();
     loggerWarn.mockClear();
     loggerError.mockClear();
+    resolveOutboundMessageStanding.mockReset();
+    resolveOutboundMessageStanding.mockResolvedValue({ allowed: true, source: "cache" });
     findHydratedById.mockClear();
     findHydratedById.mockResolvedValue(null);
+  });
+
+  test("denies bad standing before credential lookup or provider dispatch", async () => {
+    resolveOutboundMessageStanding.mockResolvedValueOnce({
+      allowed: false,
+      source: "cache",
+      reason: "moderation_blocked",
+    });
+
+    const delivery = await messageRouterService.sendMessage({
+      provider: "blooio",
+      organizationId: "gateway-org",
+      from: "+14159611510",
+      to: "+14155550100",
+      body: "must not dispatch",
+      agentUserId: "blocked-user",
+    });
+
+    expect(delivery).toEqual({
+      status: "failed",
+      provider: "blooio",
+      code: "DELIVERY_ACCOUNT_STANDING_DENIED",
+      retryable: false,
+      standingReason: "moderation_blocked",
+    });
+    expect(resolveOutboundMessageStanding).toHaveBeenCalledTimes(1);
+    expect(secretsGet).not.toHaveBeenCalled();
+    expect(blooioApiRequest).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith(
+      "[MessageRouter] Account standing denied outbound message",
+      expect.objectContaining({
+        organizationId: "gateway-org",
+        userId: "blocked-user",
+        reason: "moderation_blocked",
+        providerDispatched: false,
+      }),
+    );
   });
 
   test("records a phone contact after a successful agent outbound message", async () => {
@@ -568,6 +616,7 @@ describe("MessageRouterService contact recording", () => {
         id: "phone-number-1",
         agent_id: "agent-1",
         organization_id: "organization-1",
+        user_id: "user-1",
       },
     ]);
     createPhoneMessage.mockRejectedValueOnce(storageFailure);
@@ -595,6 +644,7 @@ describe("MessageRouterService contact recording", () => {
         id: "phone-number-1",
         agent_id: "agent-1",
         organization_id: "organization-1",
+        user_id: "user-1",
       },
     ]);
     updateWhere.mockRejectedValueOnce(new Error(sentinelUpdateBody));
@@ -611,6 +661,7 @@ describe("MessageRouterService contact recording", () => {
       agentId: "agent-1",
       phoneNumberId: "phone-number-1",
       organizationId: "organization-1",
+      userId: "user-1",
     });
 
     expect(createPhoneMessage).toHaveBeenCalledTimes(1);

--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../db/repositories/phone-metadata-readers";
 import { agentPhoneContacts } from "../../../db/schemas/agent-phone-contacts";
 import { agentPhoneNumbers, type PhoneMessageLog } from "../../../db/schemas/agent-phone-numbers";
+import { userCharacters } from "../../../db/schemas/user-characters";
 import { boundedProviderFetch } from "../../utils/bounded-provider-fetch";
 import { logger } from "../../utils/logger";
 
@@ -68,6 +69,7 @@ export interface MessageRouteResult {
   agentId?: string;
   phoneNumberId?: string;
   organizationId?: string;
+  userId?: string;
   error?: string;
 }
 
@@ -86,7 +88,8 @@ export interface SendMessageParams {
   organizationId: string;
   agentId?: string;
   agentOrganizationId?: string;
-  agentUserId?: string;
+  agentUserId: string;
+  defer?: (promise: Promise<unknown>) => void;
   contactDisplayName?: string;
 }
 
@@ -102,6 +105,7 @@ export type MessageDeliveryOutcome =
       code: string;
       retryable: boolean;
       providerStatus?: number;
+      standingReason?: string;
     };
 
 function deliveryFailed(
@@ -109,6 +113,7 @@ function deliveryFailed(
   code: string,
   retryable: boolean,
   providerStatus?: number,
+  standingReason?: string,
 ): MessageDeliveryOutcome {
   return {
     status: "failed",
@@ -116,6 +121,7 @@ function deliveryFailed(
     code,
     retryable,
     ...(providerStatus === undefined ? {} : { providerStatus }),
+    ...(standingReason === undefined ? {} : { standingReason }),
   };
 }
 
@@ -184,6 +190,7 @@ class MessageRouterService {
         agent_id: string;
         id: string;
         organization_id: string;
+        user_id: string | null;
       }>;
       try {
         phoneMapping = await dbWrite
@@ -191,8 +198,10 @@ class MessageRouterService {
             agent_id: agentPhoneNumbers.agent_id,
             id: agentPhoneNumbers.id,
             organization_id: agentPhoneNumbers.organization_id,
+            user_id: userCharacters.user_id,
           })
           .from(agentPhoneNumbers)
+          .leftJoin(userCharacters, eq(userCharacters.id, agentPhoneNumbers.agent_id))
           .where(
             and(
               eq(agentPhoneNumbers.phone_number, normalizedTo),
@@ -218,6 +227,14 @@ class MessageRouterService {
       }
 
       const mapping = phoneMapping[0];
+      if (!mapping.user_id) {
+        logger.error("[MessageRouter] Phone route has no standing actor", {
+          agentId: mapping.agent_id,
+          organizationId: mapping.organization_id,
+          provider: providerDiagnostic(message.provider),
+        });
+        return { success: false, error: "Phone route has no active account owner" };
+      }
 
       // Log the incoming message
       await this.logMessage({
@@ -259,6 +276,7 @@ class MessageRouterService {
         agentId: mapping.agent_id,
         phoneNumberId: mapping.id,
         organizationId: mapping.organization_id,
+        userId: mapping.user_id,
       };
     } catch (error) {
       logger.error("[MessageRouter] Error routing message", {
@@ -467,6 +485,44 @@ class MessageRouterService {
       provider: providerDiagnostic(params.provider),
       organizationId: params.organizationId,
     });
+
+    let standing;
+    try {
+      const { resolveOutboundMessageStanding } = await import("../outbound-message-standing");
+      standing = await resolveOutboundMessageStanding(params.organizationId, params.agentUserId, {
+        defer: params.defer,
+      });
+    } catch (error) {
+      // error-policy:J4 standing infrastructure failure becomes a retryable,
+      // typed no-dispatch outcome at the outbound transport boundary.
+      logger.error("[MessageRouter] Account-standing resolution failed", {
+        provider: providerDiagnostic(params.provider),
+        organizationId: params.organizationId,
+        userId: params.agentUserId,
+        decision: "unavailable",
+        providerDispatched: false,
+        ...phoneErrorDiagnostic(error),
+      });
+      return deliveryFailed(params.provider, "DELIVERY_ACCOUNT_STANDING_UNAVAILABLE", true);
+    }
+    if (!standing.allowed) {
+      logger.error("[MessageRouter] Account standing denied outbound message", {
+        provider: providerDiagnostic(params.provider),
+        organizationId: params.organizationId,
+        userId: params.agentUserId,
+        decision: "denied",
+        reason: standing.reason,
+        source: standing.source,
+        providerDispatched: false,
+      });
+      return deliveryFailed(
+        params.provider,
+        "DELIVERY_ACCOUNT_STANDING_DENIED",
+        false,
+        undefined,
+        standing.reason,
+      );
+    }
 
     const contactRequired = this.contactWriteRequired(params);
 

--- a/packages/cloud/shared/src/lib/services/organizations.ts
+++ b/packages/cloud/shared/src/lib/services/organizations.ts
@@ -16,6 +16,7 @@ import {
   invalidateInferenceSessionAuthContexts,
 } from "./inference-auth-cache";
 import { setInferenceOrganizationActive } from "./inference-credential-revocation";
+import { invalidateOutboundMessageStanding } from "./outbound-message-standing";
 
 /**
  * Service for organization operations with caching support.
@@ -113,6 +114,7 @@ export class OrganizationsService {
     // entries so credentials under the now-inactive org can no longer fast-path.
     if (data.is_active === false) {
       await this.invalidateInferenceAuthForOrganization(id);
+      await invalidateOutboundMessageStanding(id);
     }
     if (data.is_active === true) {
       await setInferenceOrganizationActive(id, true);
@@ -135,6 +137,7 @@ export class OrganizationsService {
     // Resolve + evict the org's cached IAC identities BEFORE the delete cascade
     // removes the api_keys rows, so the key_hash set is read while it still exists.
     await this.invalidateInferenceAuthForOrganization(id);
+    await invalidateOutboundMessageStanding(id);
     await organizationsRepository.delete(id);
     // Invalidate cache after delete
     await this.invalidateCache(id);

--- a/packages/cloud/shared/src/lib/services/outbound-message-standing.test.ts
+++ b/packages/cloud/shared/src/lib/services/outbound-message-standing.test.ts
@@ -1,0 +1,97 @@
+/** Proves outbound standing uses one cache read and asynchronous no-readback projection. */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+
+const cacheRead = mock();
+const cacheWrite = mock(async () => ({ kind: "written" as const, backend: "memory" as const }));
+const cacheDelete = mock(async () => true);
+const cacheDeletePattern = mock(async () => true);
+const selectLimit = mock();
+const selectBuilder = {
+  from: mock(() => selectBuilder),
+  leftJoin: mock(() => selectBuilder),
+  where: mock(() => selectBuilder),
+  limit: selectLimit,
+};
+
+mock.module("../cache/client", () => ({
+  cache: {
+    getWithOutcome: cacheRead,
+    setWithOutcome: cacheWrite,
+    delConfirmed: cacheDelete,
+    delPatternConfirmed: cacheDeletePattern,
+  },
+}));
+
+mock.module("../../db/helpers", () => ({
+  dbWrite: { select: mock(() => selectBuilder) },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { warn: mock() },
+}));
+
+const { resolveOutboundMessageStanding } = await import("./outbound-message-standing");
+
+beforeEach(() => {
+  cacheRead.mockReset();
+  cacheWrite.mockClear();
+  selectLimit.mockReset();
+});
+
+test("cached denial explains the reason with exactly one read and no database or write", async () => {
+  cacheRead.mockResolvedValueOnce({
+    kind: "hit",
+    backend: "cloudflare-kv",
+    value: {
+      v: 1,
+      organizationId: "org-1",
+      userId: "user-1",
+      cachedAt: Date.now(),
+      decision: "denied",
+      reason: "moderation_blocked",
+    },
+  });
+
+  await expect(resolveOutboundMessageStanding("org-1", "user-1")).resolves.toEqual({
+    allowed: false,
+    source: "cache",
+    reason: "moderation_blocked",
+  });
+  expect(cacheRead).toHaveBeenCalledTimes(1);
+  expect(selectLimit).not.toHaveBeenCalled();
+  expect(cacheWrite).not.toHaveBeenCalled();
+});
+
+test("a miss hydrates once and defers one cache write without a readback", async () => {
+  cacheRead.mockResolvedValueOnce({ kind: "miss", backend: "cloudflare-kv" });
+  selectLimit.mockResolvedValueOnce([
+    {
+      userId: "user-1",
+      userActive: true,
+      userDeletedAt: null,
+      userLifecycleState: "active",
+      userDeletionRequestId: null,
+      organizationId: "org-1",
+      organizationActive: true,
+      organizationLifecycleState: "active",
+      organizationLifecycleRevision: 4,
+      organizationDeletionRequestId: null,
+      moderationStatus: "clean",
+      moderationViolations: 0,
+    },
+  ]);
+  const deferred: Promise<unknown>[] = [];
+
+  await expect(
+    resolveOutboundMessageStanding("org-1", "user-1", {
+      defer: (promise) => deferred.push(promise),
+    }),
+  ).resolves.toEqual({ allowed: true, source: "authoritative" });
+  expect(cacheRead).toHaveBeenCalledTimes(1);
+  expect(selectLimit).toHaveBeenCalledTimes(1);
+  expect(cacheWrite).toHaveBeenCalledTimes(1);
+  expect(cacheRead).toHaveBeenCalledTimes(1);
+  expect(deferred).toHaveLength(1);
+  await Promise.all(deferred);
+});

--- a/packages/cloud/shared/src/lib/services/outbound-message-standing.ts
+++ b/packages/cloud/shared/src/lib/services/outbound-message-standing.ts
@@ -1,0 +1,188 @@
+/**
+ * Resolves the account-standing decision for customer-funded outbound messages.
+ * A warm dispatch consumes one cache read; a miss hydrates the complete actor,
+ * membership, organization lifecycle, and moderation decision in one SQL query
+ * and projects it asynchronously without reading the cache back.
+ */
+
+import { eq } from "drizzle-orm";
+import { dbWrite } from "../../db/helpers";
+import { userModerationStatus } from "../../db/schemas/moderation-violations";
+import { organizations } from "../../db/schemas/organizations";
+import { users } from "../../db/schemas/users";
+import { cache } from "../cache/client";
+import { CacheKeys, CacheTTL } from "../cache/keys";
+import { logger } from "../utils/logger";
+import { organizationLifecycleAllowsNewWork } from "./account-lifecycle-authority";
+
+const VERSION = 1 as const;
+
+export type OutboundMessageStandingReason =
+  | "account_missing"
+  | "account_inactive"
+  | "membership_missing"
+  | "organization_inactive"
+  | "moderation_blocked";
+
+export type OutboundMessageStandingDecision =
+  | { allowed: true; source: "cache" | "authoritative" }
+  | {
+      allowed: false;
+      source: "cache" | "authoritative";
+      reason: OutboundMessageStandingReason;
+    };
+
+interface CachedStanding {
+  v: typeof VERSION;
+  organizationId: string;
+  userId: string;
+  cachedAt: number;
+  decision: "allowed" | "denied";
+  reason?: OutboundMessageStandingReason;
+}
+
+export interface OutboundMessageStandingOptions {
+  defer?: (promise: Promise<unknown>) => void;
+}
+
+const reasons = new Set<OutboundMessageStandingReason>([
+  "account_missing",
+  "account_inactive",
+  "membership_missing",
+  "organization_inactive",
+  "moderation_blocked",
+]);
+
+function isCachedStanding(
+  value: unknown,
+  organizationId: string,
+  userId: string,
+): value is CachedStanding {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    entry.v === VERSION &&
+    entry.organizationId === organizationId &&
+    entry.userId === userId &&
+    typeof entry.cachedAt === "number" &&
+    Number.isFinite(entry.cachedAt) &&
+    (entry.decision === "allowed" ||
+      (entry.decision === "denied" &&
+        typeof entry.reason === "string" &&
+        reasons.has(entry.reason as OutboundMessageStandingReason)))
+  );
+}
+
+function decisionFromEntry(
+  entry: CachedStanding,
+  source: "cache" | "authoritative",
+): OutboundMessageStandingDecision {
+  return entry.decision === "allowed"
+    ? { allowed: true, source }
+    : { allowed: false, source, reason: entry.reason as OutboundMessageStandingReason };
+}
+
+function projectStanding(entry: CachedStanding, options: OutboundMessageStandingOptions): void {
+  const projection = cache
+    .setWithOutcome(
+      CacheKeys.outboundMessageStanding.actor(entry.organizationId, entry.userId),
+      entry,
+      CacheTTL.outboundMessageStanding,
+      { keyClass: "inference_auth" },
+    )
+    .then(() => undefined)
+    .catch((error) => {
+      // error-policy:J7 the authoritative decision already governs this send;
+      // projection failure is diagnostic and must not fabricate authorization.
+      logger.warn("[OutboundMessageStanding] asynchronous projection failed", {
+        organizationId: entry.organizationId,
+        userId: entry.userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  if (options.defer) options.defer(projection);
+  else void projection;
+}
+
+/** Resolve standing with exactly one cache read and no post-write readback. */
+export async function resolveOutboundMessageStanding(
+  organizationId: string,
+  userId: string,
+  options: OutboundMessageStandingOptions = {},
+): Promise<OutboundMessageStandingDecision> {
+  const key = CacheKeys.outboundMessageStanding.actor(organizationId, userId);
+  const cached = await cache.getWithOutcome<unknown>(key, { keyClass: "inference_auth" });
+  if (cached.kind === "hit" && isCachedStanding(cached.value, organizationId, userId)) {
+    return decisionFromEntry(cached.value, "cache");
+  }
+
+  const [standing] = await dbWrite
+    .select({
+      userId: users.id,
+      userActive: users.is_active,
+      userDeletedAt: users.deleted_at,
+      userLifecycleState: users.account_lifecycle_state,
+      userDeletionRequestId: users.account_deletion_request_id,
+      organizationId: users.organization_id,
+      organizationActive: organizations.is_active,
+      organizationLifecycleState: organizations.account_lifecycle_state,
+      organizationLifecycleRevision: organizations.account_lifecycle_revision,
+      organizationDeletionRequestId: organizations.account_deletion_request_id,
+      moderationStatus: userModerationStatus.status,
+      moderationViolations: userModerationStatus.totalViolations,
+    })
+    .from(users)
+    .leftJoin(organizations, eq(organizations.id, users.organization_id))
+    .leftJoin(userModerationStatus, eq(userModerationStatus.userId, users.id))
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  let reason: OutboundMessageStandingReason | undefined;
+  if (!standing) reason = "account_missing";
+  else if (
+    !standing.userActive ||
+    standing.userDeletedAt !== null ||
+    standing.userLifecycleState !== "active" ||
+    standing.userDeletionRequestId !== null
+  )
+    reason = "account_inactive";
+  else if (!standing.organizationId || standing.organizationId !== organizationId)
+    reason = "membership_missing";
+  else if (
+    standing.organizationLifecycleState !== "active" ||
+    !organizationLifecycleAllowsNewWork({
+      state: standing.organizationLifecycleState,
+      revision: standing.organizationLifecycleRevision ?? 0,
+      active: standing.organizationActive ?? false,
+      deletionRequestId: standing.organizationDeletionRequestId,
+    })
+  )
+    reason = "organization_inactive";
+  else if (standing.moderationStatus === "banned" || (standing.moderationViolations ?? 0) >= 5)
+    reason = "moderation_blocked";
+
+  const entry: CachedStanding = {
+    v: VERSION,
+    organizationId,
+    userId,
+    cachedAt: Date.now(),
+    decision: reason ? "denied" : "allowed",
+    ...(reason ? { reason } : {}),
+  };
+  projectStanding(entry, options);
+  return decisionFromEntry(entry, "authoritative");
+}
+
+/** Evict one actor or every actor in an organization after lifecycle mutation. */
+export async function invalidateOutboundMessageStanding(
+  organizationId: string,
+  userId?: string,
+): Promise<boolean> {
+  return userId
+    ? cache.delConfirmed(CacheKeys.outboundMessageStanding.actor(organizationId, userId), {
+        keyClass: "inference_auth",
+      })
+    : cache.delPatternConfirmed(
+        CacheKeys.outboundMessageStanding.organizationPattern(organizationId),
+      );
+}

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -30,6 +30,7 @@ import {
   setInferenceSessionBindingActive,
   setInferenceSubjectActive,
 } from "./inference-credential-revocation";
+import { invalidateOutboundMessageStanding } from "./outbound-message-standing";
 
 type PersonalDeliveryIdentitySource = Partial<
   Pick<User | UserIdentity, "telegram_id" | "discord_id" | "phone_number">
@@ -133,6 +134,11 @@ export class UsersService {
     if (typeof walletAddress === "string") {
       promises.push(cache.del(CacheKeys.user.byWalletAddress(walletAddress)));
       promises.push(cache.del(CacheKeys.user.byWalletAddressWithOrg(walletAddress)));
+    }
+    if (user.organization_id) {
+      promises.push(
+        invalidateOutboundMessageStanding(user.organization_id, user.id).then(() => undefined),
+      );
     }
     await Promise.all(promises);
     logger.debug("[UsersService] Invalidated cache for user:", user.id);


### PR DESCRIPTION
Closes #30358

## Summary
- add one cache-read account-standing gate before paid Twilio, Blooio, and WhatsApp delivery credential lookup/provider dispatch
- hydrate cache misses with one authoritative SQL query and project one cache update asynchronously with no readback
- return a safe cached denial reason and emit detailed structured no-dispatch diagnostics
- carry the resolved agent owner through inbound routing and guard provider-capable legacy A2A skills if that dormant surface is reactivated
- invalidate standing projections on account, organization, and moderation lifecycle changes

## Verification
- focused standing cache tests prove one read, one deferred write, and no readback
- message router tests prove denial occurs before secrets/provider dispatch
- Twilio, Blooio, WhatsApp, and A2A focused tests pass in isolated lanes
- shared package typecheck/lint and cloud API build were run on the implementation revision; exact-head CI will re-run after this push
