### PR TITLE
test(cloud): pin the absent-bridge waiver generation fence

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -5976,6 +5976,69 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
     }
   });
 
+  test("prepareAgentDelete refuses an acknowledged absent-bridge waiver once a bridge is back under the lock", async () => {
+    // The acknowledged absent-bridge path deletes a data-bearing container with
+    // no capture at all, so the generation revalidation under the lifecycle lock
+    // is its only remaining protection: the capture decision is made before the
+    // lock, and a re-provision in that window gives the agent a reachable bridge
+    // again. Deleting on the stale waiver would destroy state that is capturable
+    // by the time the lock is held. The sibling case above proves the matching
+    // generation is accepted; this one proves a moved generation is refused.
+    const { svc, spyTarget } = await makeCaptureSvc();
+    const captured = {
+      ...customSandbox(),
+      status: "deletion_failed" as const,
+      bridge_url: null,
+      deletion_attempt_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      deletion_started_at: new Date("2026-08-13T00:00:00.000Z"),
+    };
+    // Re-provisioned between the capture decision and the lock.
+    const live = {
+      ...captured,
+      bridge_url: "https://bridge.invalid/agent",
+      environment_revision: captured.environment_revision + 1,
+    };
+    const lockLifecycle = spyOn(spyTarget, "lockLifecycle").mockResolvedValue(undefined);
+    const getForMutation = spyOn(spyTarget, "getAgentForLifecycleMutation").mockResolvedValue(live);
+    const activeProvision = spyOn(spyTarget, "hasActiveProvisionJobTx").mockResolvedValue(false);
+    const activeReplacement = spyOn(spyTarget, "hasActiveReplacementJobTx").mockResolvedValue(
+      false,
+    );
+    const persist = spyOn(spyTarget, "persistSnapshotWithinTransaction");
+    const set = mock(() => ({
+      where: mock(() => ({ returning: mock(async () => []) })),
+    }));
+    const update = mock(() => ({ set }));
+    upgradeTransactionImpl = async (fn) => fn({ execute: async () => ({ rows: [] }), update });
+    try {
+      const result = (await (
+        svc as unknown as {
+          prepareAgentDelete: (...args: unknown[]) => Promise<{ ok: boolean; error?: string }>;
+        }
+      ).prepareAgentDelete(live.id, live.organization_id, "user_request", {
+        snapshot: null,
+        captureAuthority: captured,
+        captureWaiverGeneration: {
+          bridgeUrl: null,
+          environmentRevision: captured.environment_revision,
+          sandboxId: captured.sandbox_id,
+        },
+        captureWaiverAlreadyPersisted: false,
+        existingBackup: null,
+      })) as { ok: boolean; error?: string };
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("lifecycle generation moved");
+      expect(persist).not.toHaveBeenCalled();
+      expect(set).not.toHaveBeenCalled();
+    } finally {
+      upgradeTransactionImpl = null;
+      lockLifecycle.mockRestore();
+      getForMutation.mockRestore();
+      activeProvision.mockRestore();
+      activeReplacement.mockRestore();
+      persist.mockRestore();
+    }
+  });
   test("prepareAgentDelete revalidates an unlocked backup candidate under the lifecycle lock", async () => {
     const { svc, spyTarget } = await makeCaptureSvc();
     const deletionAttemptId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";


### PR DESCRIPTION
# What

#30344 added a delete path that destroys a data-bearing container with **no capture at all**:

```ts
} else if (!snapshotSource.bridge_url) {
  if (options.stateLossAcknowledged) {
    preDeleteCaptureAuthority = snapshotSource;
    captureWaiverGeneration = { bridgeUrl: null, ... };
```

Its own comment names what authorizes that: the acknowledged job tuple, *"revalidated here"* under the lifecycle lock. That revalidation is:

```ts
if (!captureAuthority || !snapshotCaptureStillCanonical(rec, captureAuthority)) {
  return { ok: false, error: "Refusing to delete: the agent's lifecycle generation moved after the pre-deletion capture; retry the delete." };
}
```

**Replace that whole condition with `if (false)` and the suite is 276 pass, 0 fail.**

# The two guards #30344 added are honestly covered — I checked those first

| mutant | result |
| --- | --- |
| `options.stateLossAcknowledged` → `true` (every absent-bridge delete proceeds) | 1 failed — `a data-bearing error row with no reachable bridge fails closed` |
| persist the waiver unconditionally (fabricate a `null` bridge URL into the row) | 1 failed — `prepareAgentDelete accepts an acknowledged absent-bridge generation without fabricating a persisted URL` |
| **`if (!captureAuthority \|\| !snapshotCaptureStillCanonical(...))` → `if (false)`** | **276 pass — survives** |

The fence predates this PR. What changed is that it is now *load-bearing in a new way*: on the acknowledged absent-bridge path there is no capture and no persisted waiver URL, so the generation comparison is the only thing left.

# Why the test named for it does not reach it

`an acknowledged retry with no reachable bridge is fenced to that exact generation` mocks `prepareAgentDelete` wholesale:

```ts
const prepare = spyOn(spyTarget, "prepareAgentDelete").mockResolvedValue({ ok: false, error: "halted by test after capture phase" });
...
expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, "user_request", { ... });
```

That asserts the *arguments handed to* the fence. The name describes the guard; the assertion describes the call site.

# The change

One test that reaches the fence through the window that actually exists: the capture decision is made **before** the lifecycle lock, so a re-provision inside that window gives the agent a reachable bridge again. The record read under the lock carries a `bridge_url` and a bumped `environment_revision`, while `captureAuthority` is the old absent-bridge snapshot.

Deleting on that stale waiver destroys state that is capturable by the time the lock is held — which is exactly the outcome the fence exists to prevent. The sibling case above already proves a *matching* generation is accepted; this proves a moved one is refused.

```ts
expect(result.ok).toBe(false);
expect(result.error).toContain("lifecycle generation moved");
expect(persist).not.toHaveBeenCalled();
expect(set).not.toHaveBeenCalled();
```

# Verification

| run | result |
| --- | --- |
| unmutated, this head | **277 pass / 0 fail** (66.9s) |
| whole fence → `if (false)` | 276 pass / **1 failed** — only the new test |
| only the canonical half removed (`if (!captureAuthority)`) | 276 pass / **1 failed** — only the new test |

The second row matters: the test discriminates the `snapshotCaptureStillCanonical` comparison specifically, not merely the null check next to it.

`biome check` clean on the touched file.

# Test-only gate

- **Realistic regression prevented:** losing the generation revalidation lets an acknowledged absent-bridge delete run against a re-provisioned agent, destroying state that had become capturable — unrecoverable, and invisible to every current test.
- **Observing consumer:** `ElizaSandboxService.deleteAgent` → `prepareAgentDelete`, under the lifecycle lock.
- **Why existing coverage does not own it:** demonstrated by mutation above — the case named for the fence mocks the function containing it.

Test-only; no runtime source is touched. +63/-0.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JG1XQ9GREEFQEJ1R8G76SV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T02:02:37.161Z","completed_at":"2026-09-03T02:03:21.543Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T02:02:37.827Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"02030dd5152065e04f2f2b35077282b90e20428382c7fd62e491b80d19362479","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ff2a1634-0eaf-418c-842e-a11f77be9163","object_id":"sha256:02030dd5152065e04f2f2b35077282b90e20428382c7fd62e491b80d19362479","sha256":"02030dd5152065e04f2f2b35077282b90e20428382c7fd62e491b80d19362479"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"_iapVn9MvihQ14xU0p2E44tNYDWIAfxeV1YxuSh7mdn4wPcfqau1tk1J9FQt3erB4A0lOsD-RRLcMg_kcVEIAQ"}} -->
