### PR TITLE
fix(cloud): reject missing app auth before limiter

### DIFF
--- a/packages/cloud/api/eliza-app/user/me/route.auth-order.test.ts
+++ b/packages/cloud/api/eliza-app/user/me/route.auth-order.test.ts
@@ -1,0 +1,61 @@
+/** Proves missing eliza-app credentials fail locally before shared rate-limit infrastructure. */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const limiterCalls = mock(() => undefined);
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit:
+    () => async (c: { json: (body: unknown, status: number) => Response }) => {
+      limiterCalls();
+      return c.json({ code: "RATE_LIMIT_UNAVAILABLE" }, 503);
+    },
+}));
+
+mock.module("@/db/repositories/organizations", () => ({
+  organizationsRepository: {
+    findById: mock(async () => null),
+  },
+}));
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppSessionService: {
+    validateAuthHeader: mock(async () => null),
+  },
+  elizaAppUserService: {
+    getById: mock(async () => null),
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: mock() },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/api/eliza-app/user/me", route);
+
+test("missing Authorization returns 401 without consulting the distributed limiter", async () => {
+  limiterCalls.mockClear();
+
+  const response = await app.request("/api/eliza-app/user/me");
+
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toEqual({
+    error: "Authorization header required",
+    code: "UNAUTHORIZED",
+  });
+  expect(limiterCalls).not.toHaveBeenCalled();
+});
+
+test("an authenticated-shaped request still traverses the standard limiter", async () => {
+  limiterCalls.mockClear();
+
+  const response = await app.request("/api/eliza-app/user/me", {
+    headers: { Authorization: "Bearer test" },
+  });
+
+  expect(response.status).toBe(503);
+  expect(limiterCalls).toHaveBeenCalledTimes(1);
+});

--- a/packages/cloud/api/eliza-app/user/me/route.ts
+++ b/packages/cloud/api/eliza-app/user/me/route.ts
@@ -20,61 +20,77 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
-  const authHeader = c.req.header("Authorization");
-  if (!authHeader) {
-    return c.json(
-      { error: "Authorization header required", code: "UNAUTHORIZED" },
-      401,
-    );
-  }
-
-  const session = await elizaAppSessionService.validateAuthHeader(authHeader);
-  if (!session) {
-    return c.json(
-      { error: "Invalid or expired session", code: "INVALID_SESSION" },
-      401,
-    );
-  }
-
-  const user = await elizaAppUserService.getById(session.userId);
-  if (!user) {
-    logger.warn("[ElizaApp UserMe] User not found", { userId: session.userId });
-    return c.json({ error: "User not found", code: "USER_NOT_FOUND" }, 404);
-  }
-
-  let organization = null;
-  if (user.organization_id) {
-    const org = await organizationsRepository.findById(user.organization_id);
-    if (org) {
-      organization = {
-        id: org.id,
-        name: org.name,
-        credit_balance: org.credit_balance,
-      };
+app.get(
+  "/",
+  async (c, next) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader) {
+      return c.json(
+        { error: "Authorization header required", code: "UNAUTHORIZED" },
+        401,
+      );
     }
-  }
+    await next();
+  },
+  rateLimit(RateLimitPresets.STANDARD),
+  async (c) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader) {
+      return c.json(
+        { error: "Authorization header required", code: "UNAUTHORIZED" },
+        401,
+      );
+    }
 
-  return c.json({
-    user: {
-      id: user.id,
-      telegram_id: user.telegram_id,
-      telegram_username: user.telegram_username,
-      telegram_first_name: user.telegram_first_name,
-      discord_id: user.discord_id,
-      discord_username: user.discord_username,
-      discord_global_name: user.discord_global_name,
-      discord_avatar_url: user.discord_avatar_url,
-      whatsapp_id: user.whatsapp_id,
-      whatsapp_name: user.whatsapp_name,
-      phone_number: user.phone_number,
-      name: user.name,
-      avatar: user.avatar,
-      organization_id: user.organization_id,
-      created_at: user.created_at.toISOString(),
-    },
-    organization,
-  });
-});
+    const session = await elizaAppSessionService.validateAuthHeader(authHeader);
+    if (!session) {
+      return c.json(
+        { error: "Invalid or expired session", code: "INVALID_SESSION" },
+        401,
+      );
+    }
+
+    const user = await elizaAppUserService.getById(session.userId);
+    if (!user) {
+      logger.warn("[ElizaApp UserMe] User not found", {
+        userId: session.userId,
+      });
+      return c.json({ error: "User not found", code: "USER_NOT_FOUND" }, 404);
+    }
+
+    let organization = null;
+    if (user.organization_id) {
+      const org = await organizationsRepository.findById(user.organization_id);
+      if (org) {
+        organization = {
+          id: org.id,
+          name: org.name,
+          credit_balance: org.credit_balance,
+        };
+      }
+    }
+
+    return c.json({
+      user: {
+        id: user.id,
+        telegram_id: user.telegram_id,
+        telegram_username: user.telegram_username,
+        telegram_first_name: user.telegram_first_name,
+        discord_id: user.discord_id,
+        discord_username: user.discord_username,
+        discord_global_name: user.discord_global_name,
+        discord_avatar_url: user.discord_avatar_url,
+        whatsapp_id: user.whatsapp_id,
+        whatsapp_name: user.whatsapp_name,
+        phone_number: user.phone_number,
+        name: user.name,
+        avatar: user.avatar,
+        organization_id: user.organization_id,
+        created_at: user.created_at.toISOString(),
+      },
+      organization,
+    });
+  },
+);
 
 export default app;


### PR DESCRIPTION
Closes #30382

Rejects a missing eliza-app Authorization header with the existing structured 401 before consulting distributed rate-limit infrastructure. Requests carrying Authorization still traverse the standard limiter and session validation.

Focused tests prove the no-credential path performs zero limiter calls and the authenticated-shaped path remains rate limited.