### PR TITLE
fix(scripts): fail the fleet audit on unguarded self-hosted jobs

### DIFF
--- a/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
+++ b/packages/scripts/__tests__/hetzner-fleet-routing-contract.test.ts
@@ -241,6 +241,53 @@ jobs:
     }
   });
 
+  test("rejects a job that pins a self-hosted pool without opting in at all", () => {
+    // The selector checks above only see a job that already mentions
+    // HETZNER_FLEET_ONLINE or hetzner-robot. A brand-new workflow that pins a
+    // generic self-hosted pool mentions neither, so before this rule it was not
+    // a route, was not counted, and was never validated.
+    const root = buildRepo();
+    writeFileSync(
+      join(root, ".github", "workflows", "brand-new-deploy.yml"),
+      `name: Brand new deploy
+jobs:
+  deploy:
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - run: echo deploy
+`,
+    );
+    try {
+      expect(() => validateHetznerFleetRouting(root)).toThrow(
+        /brand-new-deploy\.yml:4 \(jobs\.deploy\.runs-on\): \[self-hosted, Linux, X64\] pins a self-hosted pool without the HETZNER_FLEET_ONLINE opt-in/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("allows a physical device lane that has no hosted substitute", () => {
+    const root = buildRepo();
+    writeFileSync(
+      join(root, ".github", "workflows", "device-e2e.yml"),
+      `name: Device e2e
+jobs:
+  device:
+    runs-on: [self-hosted, Linux, ARM64, android-device]
+    steps:
+      - run: echo device
+`,
+    );
+    try {
+      expect(validateHetznerFleetRouting(root)).toEqual({
+        files: 1,
+        selectors: 1,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("the checked-in workflow set is uniformly fail-safe", () => {
     const result = validateHetznerFleetRouting(REAL_REPO_ROOT);
     expect(result.files).toBeGreaterThan(10);

--- a/packages/scripts/hetzner-fleet-routing-contract.mjs
+++ b/packages/scripts/hetzner-fleet-routing-contract.mjs
@@ -39,6 +39,13 @@ const DIRECT_RUNNER_SELECTORS = new Set([
   CERTIFICATION_DISPATCH_SELECTOR,
 ]);
 const JANITOR_WORKFLOW = "actions-zombie-janitor.yml";
+// A literal self-hosted pin is allowed only for hardware that has no hosted
+// substitute. `android-device` is the physical ARM64 handset lane: there is no
+// GitHub-hosted runner with a device attached, so failing it closed to
+// `ubuntu-24.04` would not degrade, it would just break. Every other literal
+// self-hosted pin must carry the HETZNER_FLEET_ONLINE opt-in.
+const PHYSICAL_DEVICE_LABELS = new Set(["android-device"]);
+const DIRECT_RUNNER_PATH = /^jobs\.[^.]+\.runs-on$/;
 const MATRIX_RUNNER_PATH =
   /^jobs\.[^.]+\.strategy\.matrix\.include\.\d+\.runner$/;
 const JANITOR_ROUTE_PATH =
@@ -46,6 +53,63 @@ const JANITOR_ROUTE_PATH =
 
 function lineAt(source, offset) {
   return source.slice(0, offset).split("\n").length;
+}
+
+/**
+ * Collect `jobs.<id>.runs-on` values that pin a literal self-hosted label list.
+ * `collectFleetRoutes` only sees nodes that already mention the fleet variable
+ * or the robot label, so a job hard-routed to a generic pool is invisible to
+ * it — the routing contract can check the shape of an opt-in but not the
+ * absence of one. These are the jobs that never opted in at all.
+ */
+function collectUnguardedSelfHostedRoutes(
+  node,
+  source,
+  pathParts = [],
+  routes = [],
+) {
+  if (isMap(node)) {
+    for (const pair of node.items) {
+      const key = isScalar(pair.key) ? String(pair.key.value) : "<key>";
+      collectUnguardedSelfHostedRoutes(
+        pair.value,
+        source,
+        [...pathParts, key],
+        routes,
+      );
+    }
+    return routes;
+  }
+
+  if (isSeq(node)) {
+    const routePath = pathParts.join(".");
+    const labels = node.items
+      .filter((item) => isScalar(item) && typeof item.value === "string")
+      .map((item) => String(item.value));
+    if (
+      DIRECT_RUNNER_PATH.test(routePath) &&
+      labels.length === node.items.length &&
+      labels.some((label) => label.toLowerCase() === "self-hosted") &&
+      !labels.some((label) => PHYSICAL_DEVICE_LABELS.has(label.toLowerCase()))
+    ) {
+      routes.push({
+        line: lineAt(source, node.range?.[0] ?? 0),
+        path: routePath,
+        value: `[${labels.join(", ")}]`,
+      });
+      return routes;
+    }
+    node.items.forEach((item, index) => {
+      collectUnguardedSelfHostedRoutes(
+        item,
+        source,
+        [...pathParts, String(index)],
+        routes,
+      );
+    });
+  }
+
+  return routes;
 }
 
 function collectFleetRoutes(node, source, pathParts = [], routes = []) {
@@ -104,6 +168,15 @@ export function validateHetznerFleetRouting(repoRoot) {
       );
     }
 
+    for (const unguarded of collectUnguardedSelfHostedRoutes(
+      document.contents,
+      source,
+    )) {
+      failures.push(
+        `${name}:${unguarded.line} (${unguarded.path}): ${unguarded.value} pins a self-hosted pool without the HETZNER_FLEET_ONLINE opt-in`,
+      );
+    }
+
     const routes = collectFleetRoutes(document.contents, source);
     if (routes.length === 0) continue;
     files += 1;
@@ -111,7 +184,7 @@ export function validateHetznerFleetRouting(repoRoot) {
 
     for (const route of routes) {
       const directRoute =
-        /^jobs\.[^.]+\.runs-on$/.test(route.path) &&
+        DIRECT_RUNNER_PATH.test(route.path) &&
         DIRECT_RUNNER_SELECTORS.has(route.value);
       const indirectRoute =
         MATRIX_RUNNER_PATH.test(route.path) &&


### PR DESCRIPTION
# What

`hetzner-fleet-routing-contract.mjs` cannot see a job that never opted in.

```js
if (
  typeof node.value === "string" &&
  (node.value.includes("HETZNER_FLEET_ONLINE") ||
    node.value.includes("hetzner-robot"))
) { routes.push(...) }
```

A job pinned to `[self-hosted, Linux, X64]` contains neither string, so it is never collected as a route, never counted, and never validated. **The audit checks the shape of selectors that already opted in; the absence of one is invisible to it.**

That is not hypothetical. #30379 had to hand-fix two provisioning-worker jobs hard-routed to the generic pool — and on the commit right before it, the audit was **16 pass, 0 fail**. Green on exactly the state being fixed.

I proved the class stays invisible rather than asserting it. Temp repo root, two workflows — one canonical selector, one brand-new deploy job on a bare self-hosted list:

```
validateHetznerFleetRouting(root) -> { files: 1, selectors: 1 }
```

No failure, and the unguarded workflow is not even counted as a file. So the next new deploy workflow can reintroduce #30379's defect with the audit still green.

# The change

`collectUnguardedSelfHostedRoutes` walks the same document and fails any `jobs.<id>.runs-on` that is a **literal sequence of plain scalars** containing a `self-hosted` label:

```
brand-new-deploy.yml:4 (jobs.deploy.runs-on): [self-hosted, Linux, X64] pins a
self-hosted pool without the HETZNER_FLEET_ONLINE opt-in
```

Scoping to a literal sequence is deliberate — it catches hand-pinned pools and leaves expression-valued routes to the existing selector checks, so `voice-live-e2e.yml`'s `vars`-overridable default and `prod-ops-runner.yml`'s `labels:` registration entry are untouched.

# The exception it found, and why it is allowlisted rather than fixed

Running it against the real repo immediately surfaced a third case beyond #30379's two: `android-arm64-local-e2e.yml` routes a job to `[self-hosted, Linux, ARM64, android-device]`.

That one is legitimate. There is no GitHub-hosted runner with a physical handset attached, so failing it closed to `ubuntu-24.04` would not degrade — it would just break the lane. So there is a documented `PHYSICAL_DEVICE_LABELS` allowlist, **keyed on the hardware label rather than the workflow filename**, so the exception states its reason and does not silently cover a second unrelated job that happens to live in the same file later.

# Verification

Validator on develop:

```
[hetzner-fleet-routing] verified 64 selectors across 17 workflows
```

— the same figure #30379 cited, so the new rule adds a check without disturbing the existing census.

| mutant | result |
| --- | --- |
| remove the new unguarded-route check | **1 failed** — `rejects a job that pins a self-hosted pool without opting in at all` |
| ignore `PHYSICAL_DEVICE_LABELS` | **2 failed** — the device-lane test *and* `the checked-in workflow set is uniformly fail-safe` |

The second row is the one I care about: it proves the allowlist is load-bearing against the real workflow set rather than decorative.

- `bun test __tests__/hetzner-fleet-routing-contract.test.ts __tests__/provisioning-worker-deploy-workflow.test.ts` → **44 pass / 0 fail**
- `node --check` clean; `biome check` clean
- The only removed line is one inline regex literal, replaced by the shared `DIRECT_RUNNER_PATH` constant now used by both passes

# Context

Found while reviewing #30379. It merged before I could post the review, so this is the follow-up I offered there, built instead of dropped.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JGVN7EJ8MCMJHQ6MQMF4BR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T02:16:40.431Z","completed_at":"2026-09-03T02:17:25.602Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T02:16:40.683Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d6b1faa50876b5765914cf401b4e0b034a9343a2fe3ae49213157128dfb29880","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"333c00cf-2343-43a0-96f7-f600bd607b0f","object_id":"sha256:d6b1faa50876b5765914cf401b4e0b034a9343a2fe3ae49213157128dfb29880","sha256":"d6b1faa50876b5765914cf401b4e0b034a9343a2fe3ae49213157128dfb29880"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"SftXhmIMc5ONQmbPkGcFZn2NxVJ3bVNNuaJAgoDHPt1JVAJVa68mxo2baQ5eewI05NYyhiqw6SXsOL-QIvcNBg"}} -->
