### PR TITLE
fix(cloud): retry cold inference rate admission

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -538,6 +538,281 @@ describe("InferenceAdmissionGate", () => {
     ).rejects.toBeInstanceOf(InferenceAdmissionGateUnavailableError);
   });
 
+  test("replays one rate-limit operation after a lost transport acknowledgement", async () => {
+    const storage = new TestStorage();
+    let gate = createGate(storage);
+    let attempts = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            attempts += 1;
+            const response = await gate.fetch(new Request(request, init));
+            if (attempts === 1) {
+              gate = createGate(storage);
+              throw new DOMException(
+                "injected lost rate-limit acknowledgement",
+                "TimeoutError",
+              );
+            }
+            return response;
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      await expect(
+        consumeInferenceRateLimit({
+          organizationId: "org-a",
+          endpointType: "completions",
+          windowMs: 60_000,
+          maxRequests: 2,
+        }),
+      ).resolves.toMatchObject({ allowed: true, remaining: 1 });
+    });
+    expect(attempts).toBe(2);
+    expect(
+      storage.read<{ completions: { count: number } }>("rate-limits"),
+    ).toMatchObject({ completions: { count: 1 } });
+  });
+
+  test("fails a late replay after more than 64 interleaved operations and eviction without recounting", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(61_000);
+    const storage = new TestStorage();
+    let gate = createGate(storage);
+    const requests: Array<{ path: string; body: string }> = [];
+    let attempts = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            requests.push({
+              path: new URL(incoming.url).pathname,
+              body: await incoming.clone().text(),
+            });
+            attempts += 1;
+            const response = await gate.fetch(incoming);
+            if (attempts === 1) {
+              const body = JSON.parse(requests[0]!.body) as Record<
+                string,
+                unknown
+              >;
+              for (let index = 0; index < 63; index += 1) {
+                expect(
+                  (
+                    await post(gate, "/rate-limit", {
+                      ...body,
+                      operationId: `interleaved-rate-operation-${index}`,
+                    })
+                  ).status,
+                ).toBe(200);
+              }
+              clock.mockReturnValue(71_001);
+              expect(
+                (
+                  await post(gate, "/rate-limit", {
+                    ...body,
+                    operationId: "interleaved-rate-operation-63",
+                    operationDeadlineAt: 74_001,
+                  })
+                ).status,
+              ).toBe(200);
+              gate = createGate(storage);
+              throw new DOMException(
+                "injected lost rate-limit acknowledgement",
+                "TimeoutError",
+              );
+            }
+            return response;
+          },
+        }),
+      },
+    };
+
+    try {
+      await runWithCloudBindingsAsync(bindings, async () => {
+        await expect(
+          consumeInferenceRateLimit({
+            organizationId: "org-a",
+            endpointType: "completions",
+            windowMs: 60_000,
+            maxRequests: 1_000,
+          }),
+        ).rejects.toBeInstanceOf(InferenceAdmissionGateUnavailableError);
+      });
+
+      expect(requests).toHaveLength(2);
+      expect(requests[1]).toEqual(requests[0]);
+      const persisted = storage.read<{
+        completions: {
+          count: number;
+          receipts: Array<{ operationId: string }>;
+        };
+      }>("rate-limits");
+      expect(persisted).toMatchObject({ completions: { count: 65 } });
+      expect(persisted?.completions.receipts).toEqual([
+        expect.objectContaining({
+          operationId: "interleaved-rate-operation-63",
+        }),
+      ]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("retries a cold rate-limit 503 but not a definitive denial", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    let attempts = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            attempts += 1;
+            if (attempts === 1) {
+              return Response.json(
+                { code: "inference_admission_gate_starting" },
+                { status: 503 },
+              );
+            }
+            return gate.fetch(new Request(request, init));
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      await expect(
+        consumeInferenceRateLimit({
+          organizationId: "org-a",
+          endpointType: "completions",
+          windowMs: 60_000,
+          maxRequests: 1,
+        }),
+      ).resolves.toMatchObject({ allowed: true, remaining: 0 });
+    });
+    expect(attempts).toBe(2);
+
+    attempts = 0;
+    await runWithCloudBindingsAsync(
+      {
+        INFERENCE_ADMISSION_GATES: {
+          getByName: (_name: string) => ({
+            fetch: async () => {
+              attempts += 1;
+              return Response.json(
+                {
+                  allowed: false,
+                  remaining: 0,
+                  resetAt: Date.now() + 60_000,
+                  retryAfter: 60,
+                },
+                { status: 429 },
+              );
+            },
+          }),
+        },
+      },
+      async () => {
+        await expect(
+          consumeInferenceRateLimit({
+            organizationId: "org-a",
+            endpointType: "completions",
+            windowMs: 60_000,
+            maxRequests: 1,
+          }),
+        ).resolves.toMatchObject({ allowed: false, remaining: 0 });
+      },
+    );
+    expect(attempts).toBe(1);
+  });
+
+  test("binds a rate-limit operation receipt to its policy and validity deadline", async () => {
+    const gate = createGate();
+    const windowStartedAt = Math.floor(Date.now() / 60_000) * 60_000;
+    const operationDeadlineAt = Date.now() + 3_000;
+    expect(
+      (
+        await post(gate, "/rate-limit", {
+          operationId: "rate-operation-a",
+          operationDeadlineAt,
+          endpointType: "completions",
+          windowMs: 60_000,
+          maxRequests: 2,
+          windowStartedAt,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await post(gate, "/rate-limit", {
+          operationId: "rate-operation-a",
+          operationDeadlineAt,
+          endpointType: "completions",
+          windowMs: 60_000,
+          maxRequests: 3,
+          windowStartedAt,
+        })
+      ).status,
+    ).toBe(409);
+    expect(
+      (
+        await post(gate, "/rate-limit", {
+          operationId: "rate-operation-a",
+          operationDeadlineAt: operationDeadlineAt + 1,
+          endpointType: "completions",
+          windowMs: 60_000,
+          maxRequests: 2,
+          windowStartedAt,
+        })
+      ).status,
+    ).toBe(409);
+  });
+
+  test("prunes replay receipts after the bounded internal retry window", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(61_000);
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    const body = {
+      endpointType: "completions",
+      windowMs: 60_000,
+      maxRequests: 10,
+      windowStartedAt: 60_000,
+    };
+    try {
+      expect(
+        (
+          await post(gate, "/rate-limit", {
+            ...body,
+            operationId: "expired-rate-operation",
+            operationDeadlineAt: 64_000,
+          })
+        ).status,
+      ).toBe(200);
+      clock.mockReturnValue(71_001);
+      expect(
+        (
+          await post(gate, "/rate-limit", {
+            ...body,
+            operationId: "current-rate-operation",
+            operationDeadlineAt: 74_001,
+          })
+        ).status,
+      ).toBe(200);
+      expect(
+        storage.read<{
+          completions: { receipts: Array<{ operationId: string }> };
+        }>("rate-limits")?.completions.receipts,
+      ).toEqual([
+        expect.objectContaining({ operationId: "current-rate-operation" }),
+      ]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   test("rate-only requests use synchronous SQLite KV and preserve the legacy key", async () => {
     const storage = new TestStorage();
     storage.rejectAsyncRateLimitStorage = true;

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -85,6 +85,10 @@ interface LeaseIdentityRequest {
 }
 
 interface RateLimitRequest {
+  /** Stable across an internal transport retry so one arrival consumes once. */
+  operationId?: string;
+  /** Rejects an acknowledgement-ambiguous retry after its caller stopped waiting. */
+  operationDeadlineAt?: number;
   endpointType: string;
   windowMs: number;
   maxRequests: number;
@@ -149,6 +153,22 @@ interface RateLimitWindow {
   windowMs: number;
   maxRequests: number;
   count: number;
+  receipts?: RateLimitReceipt[];
+}
+
+interface RateLimitReceipt {
+  operationId: string;
+  operationDeadlineAt: number;
+  expiresAt: number;
+  windowStartedAt: number;
+  windowMs: number;
+  maxRequests: number;
+  decision: {
+    allowed: boolean;
+    remaining: number;
+    resetAt: number;
+    retryAfter?: number;
+  };
 }
 
 type RateLimitWindows = Record<string, RateLimitWindow>;
@@ -168,6 +188,11 @@ const MAX_LEASE_AGE_MS = 20 * 60_000;
 const RECOVERY_RETRY_MS = 60_000;
 const MAX_ACTIVE_LEASES = 2_048;
 const MAX_SETTLED_REQUEST_IDS = 2_048;
+const RATE_LIMIT_OPERATION_VALIDITY_MS = 3_000;
+// Both internal attempts finish within three seconds. Retaining every receipt
+// for ten seconds covers all retryable in-flight operations without imposing a
+// concurrency-sensitive FIFO cap; the next request prunes expired receipts.
+const RATE_LIMIT_RECEIPT_TTL_MS = 10_000;
 const MAX_ALARM_LEASE_MUTATIONS = 32;
 const MAX_RECOVERY_CONTEXT_BYTES = 32_768;
 // 512 KiB fits only because this class is SQLite-backed (wrangler migration
@@ -355,7 +380,15 @@ function cloneRateLimitWindows(windows: RateLimitWindows): RateLimitWindows {
   return Object.fromEntries(
     Object.entries(windows).map(([endpointType, window]) => [
       endpointType,
-      { ...window },
+      {
+        ...window,
+        ...(window.receipts && {
+          receipts: window.receipts.map((receipt) => ({
+            ...receipt,
+            decision: { ...receipt.decision },
+          })),
+        }),
+      },
     ]),
   );
 }
@@ -1029,6 +1062,14 @@ export class InferenceAdmissionGate {
 
   private async rateLimit(request: RateLimitRequest): Promise<Response> {
     if (
+      (request.operationId === undefined) !==
+        (request.operationDeadlineAt === undefined) ||
+      (request.operationId !== undefined &&
+        (!validTrimmedId(request.operationId) ||
+          request.operationId.length > 128)) ||
+      (request.operationDeadlineAt !== undefined &&
+        (!Number.isSafeInteger(request.operationDeadlineAt) ||
+          request.operationDeadlineAt <= 0)) ||
       !RATE_LIMIT_ENDPOINTS.has(request.endpointType) ||
       !Number.isSafeInteger(request.windowMs) ||
       request.windowMs <= 0 ||
@@ -1053,6 +1094,45 @@ export class InferenceAdmissionGate {
     const windowStartedAt = request.windowStartedAt ?? currentWindowStartedAt;
     const windows = cloneRateLimitWindows(this.loadRateLimitWindows());
     const existing = windows[request.endpointType];
+    const activeReceipts =
+      existing?.receipts?.filter((candidate) => candidate.expiresAt > now) ??
+      [];
+    const receipt = request.operationId
+      ? activeReceipts.find(
+          (candidate) => candidate.operationId === request.operationId,
+        )
+      : undefined;
+    if (receipt) {
+      if (
+        receipt.operationDeadlineAt !== request.operationDeadlineAt ||
+        receipt.windowStartedAt !== windowStartedAt ||
+        receipt.windowMs !== request.windowMs ||
+        receipt.maxRequests !== request.maxRequests
+      ) {
+        return jsonError(
+          "Inference rate-limit operation was reused with a different policy",
+          409,
+        );
+      }
+      return Response.json(receipt.decision, {
+        status: receipt.decision.allowed ? 200 : 429,
+      });
+    }
+    if (
+      request.operationDeadlineAt !== undefined &&
+      (request.operationDeadlineAt <= now ||
+        request.operationDeadlineAt > now + RATE_LIMIT_OPERATION_VALIDITY_MS)
+    ) {
+      return Response.json(
+        {
+          success: false,
+          code: "inference_rate_limit_operation_expired",
+          error:
+            "Inference rate-limit operation is outside its validity window",
+        },
+        { status: 409 },
+      );
+    }
     if (existing && existing.windowStartedAt > windowStartedAt) {
       const resetAt = existing.windowStartedAt + existing.windowMs;
       return Response.json(
@@ -1069,30 +1149,47 @@ export class InferenceAdmissionGate {
       existing &&
       existing.windowStartedAt === windowStartedAt &&
       existing.windowMs === request.windowMs
-        ? { ...existing, maxRequests: request.maxRequests }
+        ? {
+            windowStartedAt: existing.windowStartedAt,
+            windowMs: existing.windowMs,
+            maxRequests: request.maxRequests,
+            count: existing.count,
+            ...(activeReceipts.length > 0 && { receipts: activeReceipts }),
+          }
         : {
             windowStartedAt,
             windowMs: request.windowMs,
             maxRequests: request.maxRequests,
             count: 0,
+            ...(activeReceipts.length > 0 && { receipts: activeReceipts }),
           };
     current.count = Math.min(current.count + 1, Number.MAX_SAFE_INTEGER);
+    const allowed = current.count <= request.maxRequests;
+    const resetAt = windowStartedAt + request.windowMs;
+    const decision = {
+      allowed,
+      remaining: Math.max(0, request.maxRequests - current.count),
+      resetAt,
+      retryAfter: allowed
+        ? undefined
+        : Math.max(1, Math.ceil((resetAt - now) / 1_000)),
+    };
+    if (request.operationId && request.operationDeadlineAt !== undefined) {
+      current.receipts ??= [];
+      current.receipts.push({
+        operationId: request.operationId,
+        operationDeadlineAt: request.operationDeadlineAt,
+        expiresAt: now + RATE_LIMIT_RECEIPT_TTL_MS,
+        windowStartedAt,
+        windowMs: request.windowMs,
+        maxRequests: request.maxRequests,
+        decision,
+      });
+    }
     windows[request.endpointType] = current;
     this.saveRateLimitWindows(windows);
 
-    const allowed = current.count <= request.maxRequests;
-    const resetAt = windowStartedAt + request.windowMs;
-    return Response.json(
-      {
-        allowed,
-        remaining: Math.max(0, request.maxRequests - current.count),
-        resetAt,
-        retryAfter: allowed
-          ? undefined
-          : Math.max(1, Math.ceil((resetAt - now) / 1_000)),
-      },
-      { status: allowed ? 200 : 429 },
-    );
+    return Response.json(decision, { status: allowed ? 200 : 429 });
   }
 
   private async credentialDenial(

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -30,6 +30,7 @@ const GATE_ORIGIN = "https://inference-admission.internal";
 const RATE_LIMIT_GATE_PREFIX = "rate-limit:v2:";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
+const RATE_LIMIT_GATE_MAX_ATTEMPTS = 2;
 const LEASE_GATE_MAX_ATTEMPTS = 2;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
@@ -494,18 +495,41 @@ export async function consumeInferenceRateLimit(params: {
   }
 
   const activeGate = activeRateLimitGate(params.organizationId, params.windowMs);
-  const response = await gateFetch(
-    params.organizationId,
-    "/rate-limit",
-    {
-      endpointType: params.endpointType,
-      windowMs: params.windowMs,
-      maxRequests: params.maxRequests,
-      windowStartedAt: activeGate.windowStartedAt,
-    },
-    activeGate.stub,
-    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
-  );
+  const operationStartedAt = Date.now();
+  const body = {
+    operationId: crypto.randomUUID(),
+    operationDeadlineAt:
+      operationStartedAt + RATE_LIMIT_GATE_MAX_ATTEMPTS * GATE_OPERATION_TIMEOUT_MS,
+    endpointType: params.endpointType,
+    windowMs: params.windowMs,
+    maxRequests: params.maxRequests,
+    windowStartedAt: activeGate.windowStartedAt,
+  };
+  let response: Response | undefined;
+  for (let attempt = 1; attempt <= RATE_LIMIT_GATE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      response = await gateFetch(
+        params.organizationId,
+        "/rate-limit",
+        body,
+        activeGate.stub,
+        AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
+      );
+    } catch (error) {
+      // error-policy:J2 gateFetch already wraps the transport failure with
+      // typed context. Retry once with the same idempotency identity, then
+      // preserve that wrapper as the exhausted operation's cause.
+      if (attempt < RATE_LIMIT_GATE_MAX_ATTEMPTS) continue;
+      throw error;
+    }
+    if (response.status >= 500 && attempt < RATE_LIMIT_GATE_MAX_ATTEMPTS) continue;
+    break;
+  }
+  if (!response) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission gate rate limit produced no response",
+    );
+  }
   if (response.status !== 200 && response.status !== 429) {
     throw new InferenceAdmissionGateUnavailableError(
       `Inference admission gate rate limit failed with status ${response.status}`,


### PR DESCRIPTION
# Relates to

Closes #30387

Definition of Done: full standard in [`CONTRIBUTING.md`](../blob/develop/CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` passed at the exact PR head.
- [x] Deterministic boundary tests cover the changed transport and persistence behavior.

# Sync with develop

- [x] Rebased onto `origin/develop` at `5f08f7f8dca52c29588756b808522730c7199a04`; zero conflicts.

# Risks

Low to medium. This changes authoritative per-organization inference rate-limit Durable Object state. The retry is bounded to one extra attempt, reuses the same captured fixed-window identity, operation ID, policy, and validity deadline, and never retries definitive 429 decisions. The Durable Object checks a matching receipt first. If the receipt has been pruned and the identical retry reaches the serialized queue after its deadline, it returns an unavailable response without incrementing. Receipt retention remains time-bounded and independent of concurrent operation count.

# Background

## What does this PR do?

`consumeInferenceRateLimit` previously made one 1.5-second `/rate-limit` Durable Object call. A cold object, transient 5xx, or lost acknowledgement therefore surfaced immediately as raw HTTP 503 `rate_limit_unavailable`. Retrying without a server receipt was unsafe because the first attempt could commit its counter before its response was lost.

This PR:

- assigns one UUID operation ID and one fail-closed validity deadline before the first internal call;
- retries transport failures and 5xx once with the identical operation ID, deadline, stub, policy, and captured fixed-window start;
- persists a time-bounded replay receipt atomically with the synchronous SQLite counter update and binds it to the policy plus deadline;
- checks a matching receipt before deadline validation so a retained committed decision remains replayable;
- rejects operation-ID reuse under different policy or deadline inputs with 409;
- rejects a missing-receipt operation outside its validity window with 409 before incrementing; and
- leaves definitive 429 decisions as single-attempt results.

The chat-completions route already overlaps this rate-limit round trip with independent cache-only preparation. Starting the separate balance lease before the rate-limit verdict would require compensating release behavior on 429 and remains outside this narrow repair.

## What kind of change is this?

Bug fix (non-breaking internal reliability change).

# Documentation changes needed?

No. This is an internal Worker-to-Durable-Object transport contract covered by source comments and regression tests.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/lib/services/inference-admission-gate.ts` for the bounded client retry, then `packages/cloud/api/src/inference-admission-gate.ts` for receipt/deadline validation. Regression cases are in `packages/cloud/api/__tests__/inference-admission-gate.test.ts`.

## Detailed testing steps

Exact PR head: `8cfc81007ba3c9c465dbaccf45d07adbaeec5740`

- `bun --config=/dev/null test packages/cloud/api/__tests__/inference-admission-gate.test.ts` — 50 pass, 0 fail, 340 assertions.
- `bun --config=/dev/null test packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts` — 17 pass, 0 fail, 69 assertions.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- `bunx biome check packages/cloud/api packages/cloud/shared` — pass, 4,063 files checked.
- `node --max-old-space-size=8192 node_modules/@typescript/typescript6/bin/tsc6 --noEmit -p packages/cloud/api/tsconfig.json` — pass.
- `bun run verify` — pass; 376/376 Turbo tasks plus all repository audits.

The immediate lost-ack test commits the first counter update, discards its response, recreates the Durable Object over the same storage, and verifies the identical retry returns the original decision once. The adversarial delayed test processes more than 64 operations, advances beyond receipt TTL, recreates the Durable Object, and verifies the late identical retry is typed unavailable while persisted count remains 65 rather than 66. Separate tests bind receipts to both policy and deadline and verify expired receipts are pruned.

# Evidence Gate

<!-- evidence-head:8cfc81007ba3c9c465dbaccf45d07adbaeec5740 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only internal Durable Object transport; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only internal Durable Object transport; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic injected 503 and acknowledgement-loss boundary tests exercise the incident; no deployment was authorized.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network contract changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - storage-backed tests inspect the persisted Durable Object counter and replay receipts directly.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or agent behavior changed.

## Backend + frontend logs

N/A - no production deployment was authorized. Deterministic Worker/DO boundary tests inject raw 503 and acknowledgement-ambiguous transport failures and inspect persisted state.

## Screenshots (before / after) + video walkthrough

N/A - backend-only internal transport change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- No staging or production request was issued because deployment was not in scope; the real Miniflare Durable Object suite and storage-backed unit tests cover the changed boundary locally.

## Maintainer CI exception record

N/A - no exception requested.
