### PR TITLE
fix(cloud): reject missing app auth before limiter on two more routes

### DIFF
--- a/packages/cloud/api/eliza-app/identity-link/start/route.auth-order.test.ts
+++ b/packages/cloud/api/eliza-app/identity-link/start/route.auth-order.test.ts
@@ -1,0 +1,60 @@
+/** Proves missing eliza-app credentials fail locally before shared rate-limit infrastructure. */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const limiterCalls = mock(() => undefined);
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit:
+    () => async (c: { json: (body: unknown, status: number) => Response }) => {
+      limiterCalls();
+      return c.json({ code: "RATE_LIMIT_UNAVAILABLE" }, 503);
+    },
+}));
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppSessionService: {
+    validateAuthHeader: mock(async () => null),
+  },
+}));
+
+mock.module("@/lib/services/eliza-app/identity-link", () => ({
+  startIdentityLink: mock(async () => null),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), warn: mock() },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/api/eliza-app/identity-link/start", route);
+
+test("missing Authorization returns 401 without consulting the distributed limiter", async () => {
+  limiterCalls.mockClear();
+
+  const response = await app.request("/api/eliza-app/identity-link/start", {
+    method: "POST",
+  });
+
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toEqual({
+    success: false,
+    error: "Authorization header required",
+    code: "UNAUTHORIZED",
+  });
+  expect(limiterCalls).not.toHaveBeenCalled();
+});
+
+test("an authenticated-shaped request still traverses the strict limiter", async () => {
+  limiterCalls.mockClear();
+
+  const response = await app.request("/api/eliza-app/identity-link/start", {
+    method: "POST",
+    headers: { Authorization: "Bearer test" },
+  });
+
+  expect(response.status).toBe(503);
+  expect(limiterCalls).toHaveBeenCalledTimes(1);
+});

--- a/packages/cloud/api/eliza-app/identity-link/start/route.ts
+++ b/packages/cloud/api/eliza-app/identity-link/start/route.ts
@@ -4,7 +4,7 @@
  * messaging handle they want bound; the channel side confirms it through
  * /api/eliza-app/identity-link/confirm.
  */
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import {
@@ -22,62 +22,88 @@ const startSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.post("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
-  try {
-    const authHeader = c.req.header("Authorization");
-    if (!authHeader) {
-      return c.json(
-        {
-          success: false,
-          error: "Authorization header required",
-          code: "UNAUTHORIZED",
-        },
-        401,
-      );
-    }
-    const session = await elizaAppSessionService.validateAuthHeader(authHeader);
-    if (!session) {
-      return c.json(
-        {
-          success: false,
-          error: "Invalid or expired session",
-          code: "INVALID_SESSION",
-        },
-        401,
-      );
-    }
-
-    const parsed = startSchema.safeParse(await c.req.json().catch(() => null));
-    if (!parsed.success) {
-      return c.json(
-        {
-          success: false,
-          error: "platform must be one of telegram, discord, whatsapp, phone",
-          code: "VALIDATION_ERROR",
-        },
-        400,
-      );
-    }
-
-    const result = await startIdentityLink({
-      userId: session.userId,
-      organizationId: session.organizationId,
-      platform: parsed.data.platform,
-    });
-
-    return c.json({
-      success: true,
-      data: {
-        code: result.code,
-        platform: result.platform,
-        expires_at: result.expiresAt.toISOString(),
-        instructions: `Send "${result.code}" as a message from the ${result.platform} account you want to link. The code expires in 10 minutes.`,
+// A request with no Authorization header is already a guaranteed 401, so
+// answer it locally rather than spending a Redis round trip on the shared
+// limiter first. The global per-IP backstop in bootstrap-app still bounds
+// credential-less floods; this only removes the second, distributed hop.
+const rejectMissingAuthHeader: MiddlewareHandler<AppEnv> = async (c, next) => {
+  if (!c.req.header("Authorization")) {
+    return c.json(
+      {
+        success: false,
+        error: "Authorization header required",
+        code: "UNAUTHORIZED",
       },
-    });
-  } catch (error) {
-    logger.error("[IdentityLink Start] Error", { error });
-    return failureResponse(c, error);
+      401,
+    );
   }
-});
+  await next();
+};
+
+app.post(
+  "/",
+  rejectMissingAuthHeader,
+  rateLimit(RateLimitPresets.STRICT),
+  async (c) => {
+    try {
+      const authHeader = c.req.header("Authorization");
+      if (!authHeader) {
+        return c.json(
+          {
+            success: false,
+            error: "Authorization header required",
+            code: "UNAUTHORIZED",
+          },
+          401,
+        );
+      }
+      const session =
+        await elizaAppSessionService.validateAuthHeader(authHeader);
+      if (!session) {
+        return c.json(
+          {
+            success: false,
+            error: "Invalid or expired session",
+            code: "INVALID_SESSION",
+          },
+          401,
+        );
+      }
+
+      const parsed = startSchema.safeParse(
+        await c.req.json().catch(() => null),
+      );
+      if (!parsed.success) {
+        return c.json(
+          {
+            success: false,
+            error: "platform must be one of telegram, discord, whatsapp, phone",
+            code: "VALIDATION_ERROR",
+          },
+          400,
+        );
+      }
+
+      const result = await startIdentityLink({
+        userId: session.userId,
+        organizationId: session.organizationId,
+        platform: parsed.data.platform,
+      });
+
+      return c.json({
+        success: true,
+        data: {
+          code: result.code,
+          platform: result.platform,
+          expires_at: result.expiresAt.toISOString(),
+          instructions: `Send "${result.code}" as a message from the ${result.platform} account you want to link. The code expires in 10 minutes.`,
+        },
+      });
+    } catch (error) {
+      logger.error("[IdentityLink Start] Error", { error });
+      return failureResponse(c, error);
+    }
+  },
+);
 
 export default app;

--- a/packages/cloud/api/eliza-app/user/phone/route.auth-order.test.ts
+++ b/packages/cloud/api/eliza-app/user/phone/route.auth-order.test.ts
@@ -1,0 +1,60 @@
+/** Proves missing eliza-app credentials fail locally before shared rate-limit infrastructure. */
+
+import { expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const limiterCalls = mock(() => undefined);
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit:
+    () => async (c: { json: (body: unknown, status: number) => Response }) => {
+      limiterCalls();
+      return c.json({ code: "RATE_LIMIT_UNAVAILABLE" }, 503);
+    },
+}));
+
+mock.module("@/lib/services/eliza-app", () => ({
+  elizaAppSessionService: {
+    validateAuthHeader: mock(async () => null),
+  },
+  elizaAppUserService: {
+    getById: mock(async () => null),
+    update: mock(async () => null),
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), warn: mock(), info: mock() },
+}));
+
+const { default: route } = await import("./route");
+const app = new Hono().route("/api/eliza-app/user/phone", route);
+
+test("missing Authorization returns 401 without consulting the distributed limiter", async () => {
+  limiterCalls.mockClear();
+
+  const response = await app.request("/api/eliza-app/user/phone", {
+    method: "POST",
+  });
+
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toEqual({
+    success: false,
+    error: "Authorization header required",
+    code: "UNAUTHORIZED",
+  });
+  expect(limiterCalls).not.toHaveBeenCalled();
+});
+
+test("an authenticated-shaped request still traverses the standard limiter", async () => {
+  limiterCalls.mockClear();
+
+  const response = await app.request("/api/eliza-app/user/phone", {
+    method: "POST",
+    headers: { Authorization: "Bearer test" },
+  });
+
+  expect(response.status).toBe(503);
+  expect(limiterCalls).toHaveBeenCalledTimes(1);
+});

--- a/packages/cloud/api/eliza-app/user/phone/route.ts
+++ b/packages/cloud/api/eliza-app/user/phone/route.ts
@@ -10,7 +10,7 @@
  * POST /api/eliza-app/user/phone
  */
 
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import {
@@ -163,11 +163,35 @@ async function handleLinkPhone(request: Request): Promise<Response> {
 }
 
 const honoRouter = new Hono<AppEnv>();
-honoRouter.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
-  try {
-    return await handleLinkPhone(c.req.raw);
-  } catch (error) {
-    return failureResponse(c, error);
+
+// `handleLinkPhone` already answers a missing Authorization header with this
+// exact 401, so running the shared limiter first spends a Redis round trip on
+// a request that can only fail. The global per-IP backstop in bootstrap-app
+// still bounds credential-less floods; this only removes the distributed hop.
+const rejectMissingAuthHeader: MiddlewareHandler<AppEnv> = async (c, next) => {
+  if (!c.req.header("Authorization")) {
+    return c.json(
+      {
+        success: false,
+        error: "Authorization header required",
+        code: "UNAUTHORIZED",
+      },
+      401,
+    );
   }
-});
+  await next();
+};
+
+honoRouter.post(
+  "/",
+  rejectMissingAuthHeader,
+  rateLimit(RateLimitPresets.STANDARD),
+  async (c) => {
+    try {
+      return await handleLinkPhone(c.req.raw);
+    } catch (error) {
+      return failureResponse(c, error);
+    }
+  },
+);
 export default honoRouter;


### PR DESCRIPTION
# What

#30383 fixed `user/me`. The same shape is still on two sibling routes in the same directory:

| route | shape |
| --- | --- |
| `identity-link/start/route.ts` | `rateLimit(RateLimitPresets.STRICT)` → handler 401s on the missing header |
| `user/phone/route.ts` | `rateLimit(RateLimitPresets.STANDARD)` → `handleLinkPhone` 401s on the missing header at `:58` |

In both, a request with no `Authorization` header pays a **Redis round trip it can never use** — the per-route limiter is the Redis-backed path (`rate-limit-hono-cloudflare`, no `bindingName`), and the outcome is a guaranteed 401 either way.

I found these while reviewing #30383 and named them there as the follow-up; this is that follow-up.

# The change

The same remedy, deliberately not a variation on it: a small `MiddlewareHandler` ahead of the limiter on each route. The existing in-handler check stays — it still narrows `authHeader` for TypeScript, exactly as in the merged `user/me` fix.

Each guard returns that route's **existing** 401 body verbatim (`success: false` + `error` + `code: "UNAUTHORIZED"`), so no response shape changes.

# Why this costs no protection

Worth stating on the guard itself rather than leaving the reviewer to check: `bootstrap-app.ts` mounts a global per-IP backstop on `"*"` at 600 req/min, explicitly *"Registered before authMiddleware so unauthenticated routes are covered too."* A credential-less flood still meets a limiter before route dispatch. This removes a **distributed hop**, not a protection — which is the comment I put above each guard.

# Mutation matrix

Six mutants, each applied and reverted independently against the two new test files:

| mutant | result |
| --- | --- |
| remove the guard — `identity-link/start` | **1 fail** — `missing Authorization returns 401 without consulting the distributed limiter` |
| remove the guard — `user/phone` | **1 fail** — same test on that route |
| move the guard *after* the limiter — `identity-link/start` | **1 fail** — same test |
| move the guard *after* the limiter — `user/phone` | **1 fail** — same test |
| remove `rateLimit` entirely — `identity-link/start` | **1 fail** — `an authenticated-shaped request still traverses the strict limiter` |
| remove `rateLimit` entirely — `user/phone` | **1 fail** — the standard-limiter equivalent |

Each kills exactly one test. The order-swap rows are the point: the pair pins **ordering in both directions**, not a status code. The last two rows stop the fix from quietly becoming "no limiter at all".

# Verification

- `bun test api/eliza-app` → **21 pass / 0 fail** across 6 files
- `biome check` clean on all four touched files
- The only removed lines are the two old `app.post(...)` headers and the two `import { Hono }` lines that now also import `MiddlewareHandler`

# One note on reading the diff

`identity-link/start/route.ts` shows +134/-? because wrapping the handler reindented its body; the substantive change is ~15 lines per route. Worth reading with whitespace hidden — same caveat that applied to #30383.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JJ90RGDHAWNBF2PWK7QFA6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T02:41:26.800Z","completed_at":"2026-09-03T02:44:17.103Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T02:41:27.458Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"740c8b9b19f7bfa1eb7880d5d366da1379b4accab7e7d0d6b8110f8fc80d84c0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"968fef0f-0bbd-41a8-b3d7-6047bb4b50b6","object_id":"sha256:740c8b9b19f7bfa1eb7880d5d366da1379b4accab7e7d0d6b8110f8fc80d84c0","sha256":"740c8b9b19f7bfa1eb7880d5d366da1379b4accab7e7d0d6b8110f8fc80d84c0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"ZnDPOa6qGrNeNS4IIq9cC19udJ4pYjlChlhoj37SQXDRaqTS-pJ3w81kAessk0zgDoO3JS7Cf19EvETWucM6Cg"}} -->
