### PR TITLE
fix(cloud): correlate deployed browser chat timing

### DIFF
--- a/packages/app/test/cloud-live-chat-correlation.test.ts
+++ b/packages/app/test/cloud-live-chat-correlation.test.ts
@@ -1,0 +1,65 @@
+/** Verifies privacy-safe browser chat correlation reduction and retry selection. */
+
+import { describe, expect, it } from "vitest";
+import {
+  createCloudLiveChatCorrelationCapture,
+  parseCloudLiveChatCorrelation,
+  sanitizePreforward,
+  sanitizeServerTiming,
+} from "./cloud-live-chat-correlation";
+
+const TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+describe("Cloud live chat correlation evidence", () => {
+  it("retains only validated identifiers and canonical numeric timings", () => {
+    expect(
+      parseCloudLiveChatCorrelation({
+        "x-eliza-trace-id": TRACE_ID,
+        "server-timing":
+          'dedicated_auth;dur=1.250;desc="Bearer private", gateway;dur=42',
+        "x-eliza-preforward-ms": "total=5.0;auth=1;mid=2;reserve=1;setup=1",
+        "x-eliza-provider-request-id": "req_cerebras-123.abc",
+      }),
+    ).toEqual({
+      traceId: TRACE_ID,
+      serverTiming: "dedicated_auth;dur=1.25, gateway;dur=42",
+      preforward: "total=5;auth=1;mid=2;reserve=1;setup=1",
+      providerRequestId: "req_cerebras-123.abc",
+    });
+  });
+
+  it("drops arbitrary and malformed values instead of publishing them", () => {
+    expect(sanitizeServerTiming('gateway;desc="private prompt"')).toBeNull();
+    expect(sanitizeServerTiming("gateway;dur=Infinity")).toBeNull();
+    expect(sanitizePreforward("total=5;auth=1;mid=2;reserve=1")).toBeNull();
+    expect(
+      parseCloudLiveChatCorrelation({
+        "x-eliza-trace-id": TRACE_ID.toUpperCase(),
+        "x-eliza-provider-request-id": "Bearer private-secret",
+      }),
+    ).toBeNull();
+  });
+
+  it("binds evidence to the latest successful stream after a warming retry", () => {
+    const capture = createCloudLiveChatCorrelationCapture();
+    const endpoint =
+      "https://agent.example/api/conversations/private/messages/stream";
+    capture.observe("POST", endpoint, 503, {
+      "x-eliza-trace-id": "a".repeat(32),
+    });
+    capture.observe("GET", endpoint, 200, {
+      "x-eliza-trace-id": "b".repeat(32),
+    });
+    expect(() => capture.requireSuccessful()).toThrow("lacked a valid trace");
+    capture.observe("POST", endpoint, 200, {
+      "x-eliza-trace-id": TRACE_ID,
+      "server-timing": "dedicated_total;dur=4",
+    });
+    expect(capture.requireSuccessful()).toEqual({
+      traceId: TRACE_ID,
+      serverTiming: "dedicated_total;dur=4",
+      preforward: null,
+      providerRequestId: null,
+    });
+  });
+});

--- a/packages/app/test/cloud-live-chat-correlation.test.ts
+++ b/packages/app/test/cloud-live-chat-correlation.test.ts
@@ -1,36 +1,44 @@
 /** Verifies privacy-safe browser chat correlation reduction and retry selection. */
 
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   createCloudLiveChatCorrelationCapture,
   parseCloudLiveChatCorrelation,
+  requireDedicatedChatCorrelation,
   sanitizePreforward,
   sanitizeServerTiming,
 } from "./cloud-live-chat-correlation";
 
 const TRACE_ID = "0123456789abcdef0123456789abcdef";
+const DEDICATED_TIMING =
+  "dedicated_auth;dur=1.25, dedicated_ownership;dur=2, dedicated_routing;dur=3, dedicated_proxy_dispatch;dur=4, dedicated_total;dur=10.25";
 
 describe("Cloud live chat correlation evidence", () => {
   it("retains only validated identifiers and canonical numeric timings", () => {
     expect(
       parseCloudLiveChatCorrelation({
         "x-eliza-trace-id": TRACE_ID,
-        "server-timing":
-          'dedicated_auth;dur=1.250;desc="Bearer private", gateway;dur=42',
+        "server-timing": `private_api_key;dur=999, dedicated_auth;dur=1.250;desc="Bearer private", dedicated_ownership;dur=2, dedicated_routing;dur=3, dedicated_proxy_dispatch;dur=4, dedicated_total;dur=10.250, gateway_preforward;dur=5`,
         "x-eliza-preforward-ms": "total=5.0;auth=1;mid=2;reserve=1;setup=1",
         "x-eliza-provider-request-id": "req_cerebras-123.abc",
       }),
     ).toEqual({
       traceId: TRACE_ID,
-      serverTiming: "dedicated_auth;dur=1.25, gateway;dur=42",
+      serverTiming: `${DEDICATED_TIMING}, gateway_preforward;dur=5`,
       preforward: "total=5;auth=1;mid=2;reserve=1;setup=1",
-      providerRequestId: "req_cerebras-123.abc",
+      providerRequestIdSha256: createHash("sha256")
+        .update("req_cerebras-123.abc")
+        .digest("hex"),
     });
   });
 
   it("drops arbitrary and malformed values instead of publishing them", () => {
-    expect(sanitizeServerTiming('gateway;desc="private prompt"')).toBeNull();
-    expect(sanitizeServerTiming("gateway;dur=Infinity")).toBeNull();
+    expect(
+      sanitizeServerTiming('gateway_preforward;desc="private prompt"'),
+    ).toBeNull();
+    expect(sanitizeServerTiming("gateway_preforward;dur=Infinity")).toBeNull();
+    expect(sanitizeServerTiming("secretBearerName;dur=12")).toBeNull();
     expect(sanitizePreforward("total=5;auth=1;mid=2;reserve=1")).toBeNull();
     expect(
       parseCloudLiveChatCorrelation({
@@ -38,6 +46,26 @@ describe("Cloud live chat correlation evidence", () => {
         "x-eliza-provider-request-id": "Bearer private-secret",
       }),
     ).toBeNull();
+    expect(
+      parseCloudLiveChatCorrelation({
+        "x-eliza-trace-id": TRACE_ID,
+        "server-timing": "dedicated_total;dur=4",
+      }),
+    ).toBeNull();
+    const secretShapedProviderId = [
+      "Bearer",
+      "private",
+      "api",
+      "key",
+      "123",
+    ].join("_");
+    const hashed = parseCloudLiveChatCorrelation({
+      "x-eliza-trace-id": TRACE_ID,
+      "server-timing": DEDICATED_TIMING,
+      "x-eliza-provider-request-id": secretShapedProviderId,
+    });
+    expect(hashed?.providerRequestIdSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(hashed)).not.toContain(secretShapedProviderId);
   });
 
   it("binds evidence to the latest successful stream after a warming retry", () => {
@@ -53,13 +81,47 @@ describe("Cloud live chat correlation evidence", () => {
     expect(() => capture.requireSuccessful()).toThrow("lacked a valid trace");
     capture.observe("POST", endpoint, 200, {
       "x-eliza-trace-id": TRACE_ID,
-      "server-timing": "dedicated_total;dur=4",
+      "server-timing": DEDICATED_TIMING,
     });
     expect(capture.requireSuccessful()).toEqual({
       traceId: TRACE_ID,
-      serverTiming: "dedicated_total;dur=4",
+      serverTiming: DEDICATED_TIMING,
       preforward: null,
-      providerRequestId: null,
+      providerRequestIdSha256: null,
+      responseOrigin: "https://agent.example",
     });
+  });
+
+  it("binds the observed stream origin to the Dedicated reference API base", () => {
+    const observation = {
+      traceId: TRACE_ID,
+      serverTiming: DEDICATED_TIMING,
+      preforward: null,
+      providerRequestIdSha256: null,
+      responseOrigin: "https://agent.example",
+    };
+    expect(
+      requireDedicatedChatCorrelation(
+        { runtime: "dedicated", apiBase: "https://agent.example/" },
+        observation,
+      ),
+    ).toEqual({
+      traceId: TRACE_ID,
+      serverTiming: DEDICATED_TIMING,
+      preforward: null,
+      providerRequestIdSha256: null,
+    });
+    expect(() =>
+      requireDedicatedChatCorrelation(
+        { runtime: "dedicated", apiBase: "https://other-agent.example" },
+        observation,
+      ),
+    ).toThrow("did not match");
+    expect(() =>
+      requireDedicatedChatCorrelation(
+        { runtime: "shared", apiBase: "https://agent.example" },
+        observation,
+      ),
+    ).toThrow("did not match");
   });
 });

--- a/packages/app/test/cloud-live-chat-correlation.ts
+++ b/packages/app/test/cloud-live-chat-correlation.ts
@@ -4,18 +4,40 @@
  * response bodies, arbitrary Server-Timing descriptions, and credentials do not.
  */
 
+import { createHash } from "node:crypto";
+
 const TRACE_ID = /^[0-9a-f]{32}$/;
-const PROVIDER_REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
-const SERVER_TIMING_NAME = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
 const DECIMAL_MS = /^\d+(?:\.\d+)?$/;
 const MAX_TIMING_MS = 3_600_000;
 const PREFORWARD_FIELDS = ["total", "auth", "mid", "reserve", "setup"] as const;
+const SERVER_TIMING_NAMES = new Set([
+  "cloud_worker",
+  "gateway_preforward",
+  "upstream_headers",
+  "dedicated_auth",
+  "dedicated_ownership",
+  "dedicated_routing",
+  "dedicated_proxy_dispatch",
+  "dedicated_total",
+]);
+const REQUIRED_DEDICATED_TIMING_NAMES = [
+  "dedicated_auth",
+  "dedicated_ownership",
+  "dedicated_routing",
+  "dedicated_proxy_dispatch",
+  "dedicated_total",
+] as const;
 
 export interface CloudLiveChatCorrelationEvidence {
   traceId: string;
   serverTiming: string;
   preforward: string | null;
-  providerRequestId: string | null;
+  providerRequestIdSha256: string | null;
+}
+
+export interface CloudLiveChatCorrelationObservation
+  extends CloudLiveChatCorrelationEvidence {
+  responseOrigin: string;
 }
 
 type ResponseHeaders = Readonly<Record<string, string | undefined>>;
@@ -33,24 +55,39 @@ function canonicalDuration(raw: string): string | null {
   return String(value);
 }
 
-/** Keep metric names and durations while dropping arbitrary description text. */
+/** Keep only owned metric names and durations, dropping all other input. */
 export function sanitizeServerTiming(value: string | null): string | null {
   if (!value || value.length > 4_096) return null;
   const metrics: string[] = [];
+  const names = new Set<string>();
   for (const rawMetric of value.split(",")) {
     const [rawName, ...parameters] = rawMetric.split(";");
     const name = rawName?.trim() ?? "";
-    if (!SERVER_TIMING_NAME.test(name)) continue;
+    if (!SERVER_TIMING_NAMES.has(name)) continue;
     const durationParameters = parameters
       .map((parameter) => parameter.trim())
       .filter((parameter) => parameter.startsWith("dur="));
     if (durationParameters.length !== 1) continue;
     const duration = canonicalDuration(durationParameters[0].slice(4).trim());
     if (duration === null) continue;
+    if (names.has(name)) return null;
+    names.add(name);
     metrics.push(`${name};dur=${duration}`);
     if (metrics.length === 32) break;
   }
   return metrics.length > 0 ? metrics.join(", ") : null;
+}
+
+function hasRequiredDedicatedTimings(value: string): boolean {
+  const names = new Set(
+    value.split(",").map((metric) => metric.split(";", 1)[0]?.trim()),
+  );
+  return REQUIRED_DEDICATED_TIMING_NAMES.every((name) => names.has(name));
+}
+
+function hashProviderRequestId(value: string | null): string | null {
+  if (!value || value.length > 256) return null;
+  return createHash("sha256").update(value).digest("hex");
 }
 
 export function sanitizePreforward(value: string | null): string | null {
@@ -82,16 +119,14 @@ export function parseCloudLiveChatCorrelation(
   const traceId = header(headers, "x-eliza-trace-id");
   if (!traceId || !TRACE_ID.test(traceId)) return null;
   const serverTiming = sanitizeServerTiming(header(headers, "server-timing"));
-  if (!serverTiming) return null;
-  const providerRequestId = header(headers, "x-eliza-provider-request-id");
+  if (!serverTiming || !hasRequiredDedicatedTimings(serverTiming)) return null;
   return {
     traceId,
     serverTiming,
     preforward: sanitizePreforward(header(headers, "x-eliza-preforward-ms")),
-    providerRequestId:
-      providerRequestId && PROVIDER_REQUEST_ID.test(providerRequestId)
-        ? providerRequestId
-        : null,
+    providerRequestIdSha256: hashProviderRequestId(
+      header(headers, "x-eliza-provider-request-id"),
+    ),
   };
 }
 
@@ -113,16 +148,19 @@ export interface CloudLiveChatCorrelationCapture {
     status: number,
     headers: ResponseHeaders,
   ): void;
-  requireSuccessful(): CloudLiveChatCorrelationEvidence;
+  requireSuccessful(): CloudLiveChatCorrelationObservation;
 }
 
 export function createCloudLiveChatCorrelationCapture(): CloudLiveChatCorrelationCapture {
-  let latest: CloudLiveChatCorrelationEvidence | null = null;
+  let latest: CloudLiveChatCorrelationObservation | null = null;
   return {
     observe(method, rawUrl, status, headers) {
       if (status < 200 || status >= 300 || !isChatStream(method, rawUrl))
         return;
-      latest = parseCloudLiveChatCorrelation(headers);
+      const correlation = parseCloudLiveChatCorrelation(headers);
+      latest = correlation
+        ? { ...correlation, responseOrigin: new URL(rawUrl).origin }
+        : null;
     },
     requireSuccessful() {
       if (!latest) {
@@ -132,5 +170,31 @@ export function createCloudLiveChatCorrelationCapture(): CloudLiveChatCorrelatio
       }
       return { ...latest };
     },
+  };
+}
+
+export function requireDedicatedChatCorrelation(
+  binding: { runtime: "shared" | "dedicated"; apiBase: string },
+  observation: CloudLiveChatCorrelationObservation,
+): CloudLiveChatCorrelationEvidence {
+  let bindingOrigin: string;
+  try {
+    bindingOrigin = new URL(binding.apiBase).origin;
+  } catch {
+    throw new Error("[cloud-live] Dedicated reference API base is invalid");
+  }
+  if (
+    binding.runtime !== "dedicated" ||
+    bindingOrigin !== observation.responseOrigin
+  ) {
+    throw new Error(
+      "[cloud-live] chat response origin did not match the Dedicated reference binding",
+    );
+  }
+  return {
+    traceId: observation.traceId,
+    serverTiming: observation.serverTiming,
+    preforward: observation.preforward,
+    providerRequestIdSha256: observation.providerRequestIdSha256,
   };
 }

--- a/packages/app/test/cloud-live-chat-correlation.ts
+++ b/packages/app/test/cloud-live-chat-correlation.ts
@@ -1,0 +1,136 @@
+/**
+ * Reduces one successful live chat response to publishable correlation data.
+ * Only validated identifiers and canonical numeric timing fields survive; URLs,
+ * response bodies, arbitrary Server-Timing descriptions, and credentials do not.
+ */
+
+const TRACE_ID = /^[0-9a-f]{32}$/;
+const PROVIDER_REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const SERVER_TIMING_NAME = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
+const DECIMAL_MS = /^\d+(?:\.\d+)?$/;
+const MAX_TIMING_MS = 3_600_000;
+const PREFORWARD_FIELDS = ["total", "auth", "mid", "reserve", "setup"] as const;
+
+export interface CloudLiveChatCorrelationEvidence {
+  traceId: string;
+  serverTiming: string;
+  preforward: string | null;
+  providerRequestId: string | null;
+}
+
+type ResponseHeaders = Readonly<Record<string, string | undefined>>;
+
+function header(headers: ResponseHeaders, name: string): string | null {
+  const value = headers[name.toLowerCase()]?.trim();
+  return value ? value : null;
+}
+
+function canonicalDuration(raw: string): string | null {
+  if (!DECIMAL_MS.test(raw)) return null;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0 || value > MAX_TIMING_MS)
+    return null;
+  return String(value);
+}
+
+/** Keep metric names and durations while dropping arbitrary description text. */
+export function sanitizeServerTiming(value: string | null): string | null {
+  if (!value || value.length > 4_096) return null;
+  const metrics: string[] = [];
+  for (const rawMetric of value.split(",")) {
+    const [rawName, ...parameters] = rawMetric.split(";");
+    const name = rawName?.trim() ?? "";
+    if (!SERVER_TIMING_NAME.test(name)) continue;
+    const durationParameters = parameters
+      .map((parameter) => parameter.trim())
+      .filter((parameter) => parameter.startsWith("dur="));
+    if (durationParameters.length !== 1) continue;
+    const duration = canonicalDuration(durationParameters[0].slice(4).trim());
+    if (duration === null) continue;
+    metrics.push(`${name};dur=${duration}`);
+    if (metrics.length === 32) break;
+  }
+  return metrics.length > 0 ? metrics.join(", ") : null;
+}
+
+export function sanitizePreforward(value: string | null): string | null {
+  if (!value || value.length > 256) return null;
+  const fields = new Map<string, string>();
+  for (const part of value.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator <= 0) return null;
+    const name = part.slice(0, separator).trim();
+    const duration = canonicalDuration(part.slice(separator + 1).trim());
+    if (
+      !(PREFORWARD_FIELDS as readonly string[]).includes(name) ||
+      duration === null ||
+      fields.has(name)
+    ) {
+      return null;
+    }
+    fields.set(name, duration);
+  }
+  if (fields.size !== PREFORWARD_FIELDS.length) return null;
+  return PREFORWARD_FIELDS.map((name) => `${name}=${fields.get(name)}`).join(
+    ";",
+  );
+}
+
+export function parseCloudLiveChatCorrelation(
+  headers: ResponseHeaders,
+): CloudLiveChatCorrelationEvidence | null {
+  const traceId = header(headers, "x-eliza-trace-id");
+  if (!traceId || !TRACE_ID.test(traceId)) return null;
+  const serverTiming = sanitizeServerTiming(header(headers, "server-timing"));
+  if (!serverTiming) return null;
+  const providerRequestId = header(headers, "x-eliza-provider-request-id");
+  return {
+    traceId,
+    serverTiming,
+    preforward: sanitizePreforward(header(headers, "x-eliza-preforward-ms")),
+    providerRequestId:
+      providerRequestId && PROVIDER_REQUEST_ID.test(providerRequestId)
+        ? providerRequestId
+        : null,
+  };
+}
+
+function isChatStream(method: string, rawUrl: string): boolean {
+  if (method.trim().toUpperCase() !== "POST") return false;
+  try {
+    return /\/api\/conversations\/[^/]+\/messages\/stream$/.test(
+      new URL(rawUrl).pathname.replace(/\/+$/, ""),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export interface CloudLiveChatCorrelationCapture {
+  observe(
+    method: string,
+    rawUrl: string,
+    status: number,
+    headers: ResponseHeaders,
+  ): void;
+  requireSuccessful(): CloudLiveChatCorrelationEvidence;
+}
+
+export function createCloudLiveChatCorrelationCapture(): CloudLiveChatCorrelationCapture {
+  let latest: CloudLiveChatCorrelationEvidence | null = null;
+  return {
+    observe(method, rawUrl, status, headers) {
+      if (status < 200 || status >= 300 || !isChatStream(method, rawUrl))
+        return;
+      latest = parseCloudLiveChatCorrelation(headers);
+    },
+    requireSuccessful() {
+      if (!latest) {
+        throw new Error(
+          "[cloud-live] successful chat response lacked a valid trace correlation header",
+        );
+      }
+      return { ...latest };
+    },
+  };
+}

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -21,6 +21,10 @@ import {
   seedCloudLiveBrowserAuth,
 } from "../cloud-live-browser-auth";
 import {
+  type CloudLiveChatCorrelationEvidence,
+  createCloudLiveChatCorrelationCapture,
+} from "../cloud-live-chat-correlation";
+import {
   assertCloudLiveNamedWarmingMode,
   assertCloudLiveNamedWarmingProof,
   type CloudLiveBindingReuse,
@@ -79,7 +83,7 @@ const DEPLOYED_RENDERER_ENABLED =
   process.env.ELIZA_UI_SMOKE_DEPLOYED_RENDERER === "1";
 const DEPLOYED_RENDERER_ALIAS = "https://develop.eliza-app.pages.dev";
 const DEPLOYED_RENDERER_MANIFEST_SCHEMA = "elizaos.renderer.build/v1";
-const DEPLOYED_BROWSER_SMOKE_SCHEMA = "elizaos.cloud.deployed-browser-smoke/v1";
+const DEPLOYED_BROWSER_SMOKE_SCHEMA = "elizaos.cloud.deployed-browser-smoke/v2";
 const REQUIRE_NAMED_WARMING =
   process.env.ELIZA_UI_SMOKE_REQUIRE_NAMED_WARMING === "1";
 
@@ -348,6 +352,7 @@ async function writeDeployedBrowserSmokeEvidence(
   path: string,
   renderer: DeployedRendererIdentity,
   cloudApiOrigin: string,
+  chatCorrelation: CloudLiveChatCorrelationEvidence,
 ): Promise<void> {
   const outputPath = resolve(path);
   await mkdir(dirname(outputPath), { recursive: true });
@@ -362,6 +367,7 @@ async function writeDeployedBrowserSmokeEvidence(
         rendererBuildId: renderer.buildId,
         cloudApiOrigin,
         cloudEnvironment: "staging",
+        chatCorrelation,
         outcome: "success",
       },
       null,
@@ -423,11 +429,18 @@ async function requireActiveBinding(
 
 function installNetworkAudit(context: BrowserContext) {
   const audit = createCloudLiveNetworkAudit();
+  const chatCorrelation = createCloudLiveChatCorrelationCapture();
   context.on("request", (request) => {
     audit.observeRequest(request.method(), request.url(), request.postData());
   });
   context.on("response", (response) => {
     const responseHeaders = response.headers();
+    chatCorrelation.observe(
+      response.request().method(),
+      response.url(),
+      response.status(),
+      responseHeaders,
+    );
     const contentType = responseHeaders["content-type"];
     audit.observeResponse(
       response.request().method(),
@@ -457,7 +470,9 @@ function installNetworkAudit(context: BrowserContext) {
       request.failure()?.errorText,
     );
   });
-  return audit;
+  return Object.assign(audit, {
+    requireSuccessfulChatCorrelation: () => chatCorrelation.requireSuccessful(),
+  });
 }
 
 async function armAnchoredRetryChipObserver(
@@ -1237,6 +1252,11 @@ test.describe("real cloud login + personal identity + chat", () => {
     const challengeLogicalChatSendCount = challengeAudit.logicalChatSendCount;
     expect(challengeLogicalChatSendCount).toBe(1);
     expect(challengeAudit.unidentifiedChatSendAttemptCount).toBe(0);
+    const chatCorrelation = primaryAudit.requireSuccessfulChatCorrelation();
+    test.info().annotations.push({
+      type: "chat-trace-id",
+      description: chatCorrelation.traceId,
+    });
 
     // Reload the same document partition. A successful server history GET plus
     // both turn-anchored rows proves the turn did not survive merely in React
@@ -1411,6 +1431,7 @@ test.describe("real cloud login + personal identity + chat", () => {
           deployedBrowserEvidencePath,
           deployedRenderer as DeployedRendererIdentity,
           originContract.origin,
+          chatCorrelation,
         );
       }
     }

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -22,7 +22,9 @@ import {
 } from "../cloud-live-browser-auth";
 import {
   type CloudLiveChatCorrelationEvidence,
+  type CloudLiveChatCorrelationObservation,
   createCloudLiveChatCorrelationCapture,
+  requireDedicatedChatCorrelation,
 } from "../cloud-live-chat-correlation";
 import {
   assertCloudLiveNamedWarmingMode,
@@ -83,7 +85,7 @@ const DEPLOYED_RENDERER_ENABLED =
   process.env.ELIZA_UI_SMOKE_DEPLOYED_RENDERER === "1";
 const DEPLOYED_RENDERER_ALIAS = "https://develop.eliza-app.pages.dev";
 const DEPLOYED_RENDERER_MANIFEST_SCHEMA = "elizaos.renderer.build/v1";
-const DEPLOYED_BROWSER_SMOKE_SCHEMA = "elizaos.cloud.deployed-browser-smoke/v2";
+const DEPLOYED_BROWSER_SMOKE_SCHEMA = "elizaos.cloud.deployed-browser-smoke/v3";
 const REQUIRE_NAMED_WARMING =
   process.env.ELIZA_UI_SMOKE_REQUIRE_NAMED_WARMING === "1";
 
@@ -352,8 +354,11 @@ async function writeDeployedBrowserSmokeEvidence(
   path: string,
   renderer: DeployedRendererIdentity,
   cloudApiOrigin: string,
-  chatCorrelation: CloudLiveChatCorrelationEvidence,
+  referenceBinding: CloudLiveRuntimeBinding,
+  chatObservation: CloudLiveChatCorrelationObservation,
 ): Promise<void> {
+  const chatCorrelation: CloudLiveChatCorrelationEvidence =
+    requireDedicatedChatCorrelation(referenceBinding, chatObservation);
   const outputPath = resolve(path);
   await mkdir(dirname(outputPath), { recursive: true });
   await writeFile(
@@ -367,6 +372,10 @@ async function writeDeployedBrowserSmokeEvidence(
         rendererBuildId: renderer.buildId,
         cloudApiOrigin,
         cloudEnvironment: "staging",
+        referenceBinding: {
+          runtime: "dedicated",
+          apiBase: referenceBinding.apiBase,
+        },
         chatCorrelation,
         outcome: "success",
       },
@@ -1431,6 +1440,7 @@ test.describe("real cloud login + personal identity + chat", () => {
           deployedBrowserEvidencePath,
           deployedRenderer as DeployedRendererIdentity,
           originContract.origin,
+          referenceBinding,
           chatCorrelation,
         );
       }

--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -55,6 +55,7 @@ const browserClaimCalls: Array<{
 const authRequests: Request[] = [];
 const authDbCacheContexts: boolean[] = [];
 const sandboxDbCacheContexts: boolean[] = [];
+const infoCalls: Array<{ message: string; context: unknown }> = [];
 
 mock.module("@/lib/runtime/cloud-bindings", () => ({
   ...cloudBindingsActual,
@@ -121,7 +122,9 @@ mock.module("@/lib/utils/logger", () => ({
     ...loggerActual.logger,
     warn() {},
     error() {},
-    info() {},
+    info(message: string, context?: unknown) {
+      infoCalls.push({ message, context });
+    },
     debug() {},
   },
 }));
@@ -254,6 +257,7 @@ beforeEach(() => {
   authRequests.length = 0;
   authDbCacheContexts.length = 0;
   sandboxDbCacheContexts.length = 0;
+  infoCalls.length = 0;
   rateLimitResult = { success: true };
   rateLimitError = null;
   rateLimitKeys.length = 0;
@@ -380,6 +384,67 @@ describe("dedicated-agent-proxy — scoped voice conversation transport", () => 
 });
 
 describe("dedicated-agent-proxy — trace ingress", () => {
+  test("echoes the trace and emits secret-free auth, ownership, routing, and dispatch timings", async () => {
+    authResult = {
+      user: { id: "private-user", organization_id: "private-org" },
+    };
+    sandboxResult = runningDedicated;
+    fetchImpl = async () =>
+      new Response("ok", {
+        status: 200,
+        headers: {
+          "Server-Timing": "gateway;dur=12",
+          "X-Eliza-Preforward-Ms": "total=8;auth=1;mid=2;reserve=3;setup=2",
+          "X-Eliza-Provider-Request-Id": "req_cerebras-123",
+        },
+      });
+    const traceId = "0123456789abcdef0123456789abcdef";
+    const request = makeRequest("private-cloud-token", undefined, {
+      "X-Eliza-Trace-Id": traceId,
+    });
+
+    const response = await handleDedicatedAgentProxy(
+      request,
+      ENV,
+      urlOf(request),
+      AGENT,
+    );
+
+    expect(response.headers.get("x-eliza-trace-id")).toBe(traceId);
+    expect(response.headers.get("x-eliza-preforward-ms")).toBe(
+      "total=8;auth=1;mid=2;reserve=3;setup=2",
+    );
+    expect(response.headers.get("x-eliza-provider-request-id")).toBe(
+      "req_cerebras-123",
+    );
+    const serverTiming = response.headers.get("server-timing") ?? "";
+    expect(serverTiming).toContain("gateway;dur=12");
+    for (const phase of ["auth", "ownership", "routing", "proxy_dispatch"]) {
+      expect(serverTiming).toMatch(
+        new RegExp(`dedicated_${phase};dur=\\d+(?:\\.\\d+)?`),
+      );
+    }
+    expect(serverTiming).toMatch(/dedicated_total;dur=\d+(?:\.\d+)?/);
+
+    const timingLog = infoCalls.find(
+      ({ message }) => message === "[dedicated-proxy] correlated phase timings",
+    );
+    expect(timingLog?.context).toMatchObject({
+      traceId,
+      status: 200,
+      phases: {
+        auth: expect.any(Number),
+        ownership: expect.any(Number),
+        routing: expect.any(Number),
+        proxy_dispatch: expect.any(Number),
+      },
+      totalMs: expect.any(Number),
+    });
+    expect(JSON.stringify(timingLog)).not.toMatch(
+      /private-cloud-token|agent-secret-token|private-user|private-org/,
+    );
+  });
+
   test("forwards only a strict trace and no caller telemetry instrumentation", async () => {
     const request = makeRequest("agent-local-token", undefined, {
       "X-Eliza-Telemetry": "caller-controlled",
@@ -406,13 +471,15 @@ describe("dedicated-agent-proxy — trace ingress", () => {
   });
 
   test("drops an invalid trace before the agent mints its replacement", async () => {
+    const invalidTrace = "0123456789ABCDEF0123456789ABCDEF";
     const request = makeRequest("agent-local-token", undefined, {
-      "X-Eliza-Trace-Id": "0123456789ABCDEF0123456789ABCDEF",
+      "X-Eliza-Trace-Id": invalidTrace,
     });
 
     await handleDedicatedAgentProxy(request, ENV, urlOf(request), AGENT);
 
     expect(requireCapturedRequest().headers.get("x-eliza-trace-id")).toBeNull();
+    expect(JSON.stringify(infoCalls)).not.toContain(invalidTrace);
   });
 });
 

--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -55,7 +55,7 @@ const browserClaimCalls: Array<{
 const authRequests: Request[] = [];
 const authDbCacheContexts: boolean[] = [];
 const sandboxDbCacheContexts: boolean[] = [];
-const infoCalls: Array<{ message: string; context: unknown }> = [];
+const warnCalls: Array<{ message: string; context: unknown }> = [];
 
 mock.module("@/lib/runtime/cloud-bindings", () => ({
   ...cloudBindingsActual,
@@ -120,11 +120,11 @@ mock.module("@/lib/utils/logger", () => ({
   ...loggerActual,
   logger: {
     ...loggerActual.logger,
-    warn() {},
-    error() {},
-    info(message: string, context?: unknown) {
-      infoCalls.push({ message, context });
+    warn(message: string, context?: unknown) {
+      warnCalls.push({ message, context });
     },
+    error() {},
+    info() {},
     debug() {},
   },
 }));
@@ -257,7 +257,7 @@ beforeEach(() => {
   authRequests.length = 0;
   authDbCacheContexts.length = 0;
   sandboxDbCacheContexts.length = 0;
-  infoCalls.length = 0;
+  warnCalls.length = 0;
   rateLimitResult = { success: true };
   rateLimitError = null;
   rateLimitKeys.length = 0;
@@ -399,9 +399,15 @@ describe("dedicated-agent-proxy — trace ingress", () => {
         },
       });
     const traceId = "0123456789abcdef0123456789abcdef";
-    const request = makeRequest("private-cloud-token", undefined, {
-      "X-Eliza-Trace-Id": traceId,
-    });
+    const request = new Request(
+      makeRequest(
+        "private-cloud-token",
+        undefined,
+        { "X-Eliza-Trace-Id": traceId },
+        "/api/conversations/private/messages/stream",
+      ),
+      { method: "POST" },
+    );
 
     const response = await handleDedicatedAgentProxy(
       request,
@@ -426,10 +432,11 @@ describe("dedicated-agent-proxy — trace ingress", () => {
     }
     expect(serverTiming).toMatch(/dedicated_total;dur=\d+(?:\.\d+)?/);
 
-    const timingLog = infoCalls.find(
-      ({ message }) => message === "[dedicated-proxy] correlated phase timings",
+    const timingLog = warnCalls.find(
+      ({ message }) =>
+        message === "[dedicated-proxy] correlated chat phase timings",
     );
-    expect(timingLog?.context).toMatchObject({
+    expect(timingLog?.context).toEqual({
       traceId,
       status: 200,
       phases: {
@@ -479,7 +486,97 @@ describe("dedicated-agent-proxy — trace ingress", () => {
     await handleDedicatedAgentProxy(request, ENV, urlOf(request), AGENT);
 
     expect(requireCapturedRequest().headers.get("x-eliza-trace-id")).toBeNull();
-    expect(JSON.stringify(infoCalls)).not.toContain(invalidTrace);
+    expect(JSON.stringify(warnCalls)).not.toContain(invalidTrace);
+  });
+
+  test("does not write the always-on timing log for a traced non-chat request", async () => {
+    const request = makeRequest("agent-local-token", undefined, {
+      "X-Eliza-Trace-Id": "0123456789abcdef0123456789abcdef",
+    });
+
+    await handleDedicatedAgentProxy(request, ENV, urlOf(request), AGENT);
+
+    expect(warnCalls).toEqual([]);
+  });
+
+  test("does not write the always-on timing log for unauthenticated traced chat requests", async () => {
+    const traceId = "0123456789abcdef0123456789abcdef";
+    const tracedChat = (headers: HeadersInit) => {
+      const requestHeaders = new Headers(headers);
+      requestHeaders.set("X-Eliza-Trace-Id", traceId);
+      return new Request(
+        makeRequest(
+          undefined,
+          undefined,
+          requestHeaders,
+          "/api/conversations/private/messages/stream",
+        ),
+        { method: "POST" },
+      );
+    };
+
+    authResult = "throw";
+    let request = tracedChat({ authorization: "Bearer eliza_cloud_api_key" });
+    let response = await handleDedicatedAgentProxy(
+      request,
+      ENV,
+      urlOf(request),
+      AGENT,
+    );
+    expect(response.status).toBe(401);
+    expect(warnCalls).toEqual([]);
+
+    authResult = "forbidden";
+    request = tracedChat({ authorization: "Bearer rejected-cloud-token" });
+    response = await handleDedicatedAgentProxy(
+      request,
+      ENV,
+      urlOf(request),
+      AGENT,
+    );
+    expect(response.status).toBe(403);
+    expect(warnCalls).toEqual([]);
+  });
+
+  test("retains the always-on timing log for authenticated warming responses", async () => {
+    authResult = {
+      user: { id: "private-user", organization_id: "private-org" },
+    };
+    sandboxResult = { ...runningDedicated, status: "stopped" };
+    const traceId = "0123456789abcdef0123456789abcdef";
+    const request = new Request(
+      makeRequest(
+        "private-cloud-token",
+        undefined,
+        { "X-Eliza-Trace-Id": traceId },
+        "/api/conversations/private/messages/stream",
+      ),
+      { method: "POST" },
+    );
+
+    const response = await handleDedicatedAgentProxy(
+      request,
+      ENV,
+      urlOf(request),
+      AGENT,
+    );
+
+    expect(response.status).toBe(202);
+    expect(warnCalls).toEqual([
+      {
+        message: "[dedicated-proxy] correlated chat phase timings",
+        context: {
+          traceId,
+          status: 202,
+          phases: {
+            auth: expect.any(Number),
+            ownership: expect.any(Number),
+            routing: expect.any(Number),
+          },
+          totalMs: expect.any(Number),
+        },
+      },
+    ]);
   });
 });
 

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -370,6 +370,12 @@ function roundedDuration(startedAt: number): number {
 function createDedicatedProxyTiming(request: Request): DedicatedProxyTiming {
   const rawTraceId = request.headers.get("x-eliza-trace-id");
   const traceId = isInferenceTraceId(rawTraceId) ? rawTraceId : null;
+  const tracedChatRequest =
+    traceId !== null &&
+    request.method === "POST" &&
+    /\/api\/conversations\/[^/]+\/messages\/stream$/.test(
+      new URL(request.url).pathname.replace(/\/+$/, ""),
+    );
   const startedAt = performance.now();
   const phaseDurations = new Map<DedicatedProxyPhase, number>();
   return {
@@ -396,12 +402,19 @@ function createDedicatedProxyTiming(request: Request): DedicatedProxyTiming {
         existing ? `${existing}, ${metrics.join(", ")}` : metrics.join(", "),
       );
       if (traceId) headers.set("x-eliza-trace-id", traceId);
-      logger.info("[dedicated-proxy] correlated phase timings", {
-        traceId,
-        status,
-        totalMs,
-        phases: Object.fromEntries(phaseDurations),
-      });
+      const completedAuthenticatedRouting =
+        phaseDurations.has("ownership") && phaseDurations.has("routing");
+      if (tracedChatRequest && completedAuthenticatedRouting) {
+        // Warning is the always-on bounded sink in the Cloud logger. Emit only
+        // after authenticated ownership/routing, never for auth probes or
+        // caller-controlled paths that fail before tenant resolution.
+        logger.warn("[dedicated-proxy] correlated chat phase timings", {
+          traceId,
+          status,
+          totalMs,
+          phases: Object.fromEntries(phaseDurations),
+        });
+      }
     },
   };
 }

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -343,6 +343,69 @@ function sanitizeDedicatedTraceHeaders(headers: Headers): void {
   if (!isInferenceTraceId(traceId)) headers.delete("x-eliza-trace-id");
 }
 
+const DEDICATED_PROXY_PHASES = [
+  "auth",
+  "ownership",
+  "routing",
+  "proxy_dispatch",
+] as const;
+type DedicatedProxyPhase = (typeof DEDICATED_PROXY_PHASES)[number];
+
+interface DedicatedProxyTiming {
+  measure<T>(
+    phase: DedicatedProxyPhase,
+    operation: () => Promise<T>,
+  ): Promise<T>;
+  finish(headers: Headers, status: number): void;
+}
+
+function roundedDuration(startedAt: number): number {
+  return Math.round(Math.max(0, performance.now() - startedAt) * 1_000) / 1_000;
+}
+
+/**
+ * One request-local, secret-free timing recorder. The browser-provided trace is
+ * retained only after core validation and is the sole join key emitted to logs.
+ */
+function createDedicatedProxyTiming(request: Request): DedicatedProxyTiming {
+  const rawTraceId = request.headers.get("x-eliza-trace-id");
+  const traceId = isInferenceTraceId(rawTraceId) ? rawTraceId : null;
+  const startedAt = performance.now();
+  const phaseDurations = new Map<DedicatedProxyPhase, number>();
+  return {
+    async measure(phase, operation) {
+      const phaseStartedAt = performance.now();
+      try {
+        return await operation();
+      } finally {
+        phaseDurations.set(phase, roundedDuration(phaseStartedAt));
+      }
+    },
+    finish(headers, status) {
+      const totalMs = roundedDuration(startedAt);
+      const metrics = DEDICATED_PROXY_PHASES.flatMap((phase) => {
+        const duration = phaseDurations.get(phase);
+        return duration === undefined
+          ? []
+          : [`dedicated_${phase};dur=${duration}`];
+      });
+      metrics.push(`dedicated_total;dur=${totalMs}`);
+      const existing = headers.get("server-timing")?.trim();
+      headers.set(
+        "server-timing",
+        existing ? `${existing}, ${metrics.join(", ")}` : metrics.join(", "),
+      );
+      if (traceId) headers.set("x-eliza-trace-id", traceId);
+      logger.info("[dedicated-proxy] correlated phase timings", {
+        traceId,
+        status,
+        totalMs,
+        phases: Object.fromEntries(phaseDurations),
+      });
+    },
+  };
+}
+
 /**
  * Forward the request to the agent-router origin (the CP), preserving
  * path / method / body. When `injectBearer` is provided, the inbound auth is
@@ -356,6 +419,7 @@ async function proxyToOrigin(
   url: URL,
   injectBearer?: string,
   injectQueryCredential?: RealtimeQueryCredentialName | null,
+  timing?: DedicatedProxyTiming,
 ): Promise<Response> {
   const targetUrl = new URL(request.url);
   targetUrl.hostname = resolveOriginHost(env);
@@ -409,7 +473,10 @@ async function proxyToOrigin(
     init.body = request.body;
   }
   try {
-    return await fetch(new Request(targetUrl, init));
+    const dispatch = () => fetch(new Request(targetUrl, init));
+    return timing
+      ? await timing.measure("proxy_dispatch", dispatch)
+      : await dispatch();
   } catch (error) {
     // error-policy:J1 boundary translation — the headers-phase timeout becomes
     // a structured, retryable 504 instead of an unhandled TimeoutError (CF 1101).
@@ -825,12 +892,14 @@ function withDedicatedProxyBrowserPolicy(
   request: Request,
   url: URL,
   response: Response,
+  timing: DedicatedProxyTiming,
 ): Response {
   const headers = new Headers(response.headers);
   headers.delete("set-cookie");
   headers.delete("set-cookie2");
   headers.delete("clear-site-data");
   applyDedicatedProxyCors(request, url, headers);
+  timing.finish(headers, response.status);
 
   const webSocket = (response as Response & { webSocket?: WebSocket | null })
     .webSocket;
@@ -1016,10 +1085,11 @@ export function handleDedicatedAgentProxy(
     // connection within this request instead of reconnecting for every query.
     // The cache is connection-scoped only: credentials and ownership are still
     // revalidated on every request and no I/O object crosses Worker requests.
+    const timing = createDedicatedProxyTiming(request);
     const response = await runWithDbCacheAsync(() =>
-      proxyDedicatedAgent(request, env, url, agentId),
+      proxyDedicatedAgent(request, env, url, agentId, timing),
     );
-    return withDedicatedProxyBrowserPolicy(request, url, response);
+    return withDedicatedProxyBrowserPolicy(request, url, response, timing);
   });
 }
 
@@ -1028,6 +1098,7 @@ async function proxyDedicatedAgent(
   env: Bindings,
   url: URL,
   agentId: string,
+  timing: DedicatedProxyTiming,
 ): Promise<Response> {
   const queryCredentials = readRealtimeQueryCredentials(url);
   const headerCarriesCredential = Boolean(
@@ -1080,7 +1151,9 @@ async function proxyDedicatedAgent(
   let orgId: string;
   let userId: string;
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(authRequest);
+    const { user } = await timing.measure("auth", () =>
+      requireAuthOrApiKeyWithOrg(authRequest),
+    );
     orgId = user.organization_id;
     userId = user.id;
   } catch (error) {
@@ -1101,7 +1174,7 @@ async function proxyDedicatedAgent(
           { status: 401 },
         );
       }
-      return proxyToOrigin(request, env, url);
+      return proxyToOrigin(request, env, url, undefined, null, timing);
     }
 
     if (error instanceof ForbiddenError) {
@@ -1134,73 +1207,82 @@ async function proxyDedicatedAgent(
     // 2. Ownership — the caller's org MUST own this dedicated agent. Not
     //    owned / not found / shared fails here. Forwarding a known-valid Cloud
     //    credential would hand it to a different tenant's container.
-    const sandbox = await agentSandboxesRepository.findByIdAndOrg(
-      agentId,
-      orgId,
+    const sandbox = await timing.measure("ownership", () =>
+      agentSandboxesRepository.findByIdAndOrg(agentId, orgId),
     );
-    if (!sandbox || !isContainerBackedExecutionTier(sandbox.execution_tier)) {
-      return Response.json(
-        {
-          success: false,
-          code: "agent_access_denied",
-          error: "Agent access denied",
-        },
-        { status: 403 },
-      );
-    }
+    const routing = await timing.measure(
+      "routing",
+      async (): Promise<{ response: Response } | { agentToken: string }> => {
+        if (
+          !sandbox ||
+          !isContainerBackedExecutionTier(sandbox.execution_tier)
+        ) {
+          return {
+            response: Response.json(
+              {
+                success: false,
+                code: "agent_access_denied",
+                error: "Agent access denied",
+              },
+              { status: 403 },
+            ),
+          };
+        }
 
-    // 3. Lifecycle — a non-running agent isn't reachable; resume + 202.
-    if (sandbox.status !== "running") {
-      return resumeAndRespond(sandbox, agentId, orgId, userId);
-    }
+        // 3. Lifecycle — a non-running agent isn't reachable; resume + 202.
+        if (sandbox.status !== "running") {
+          return {
+            response: await resumeAndRespond(sandbox, agentId, orgId, userId),
+          };
+        }
 
-    // 3b. Reachability — a `running` row can still lack a routable mesh
-    //     ingress (empty headscale_ip, bridge-host fallback off — the staging
-    //     default) because the container never finished joining headscale.
-    //     Proxying it hits the CP, which returns a CORS-less 404 the browser
-    //     reads as an opaque CORS failure, dead-ending chat (#15347). Mirror
-    //     the router's own gate and short-circuit to a readable, CORS-bearing
-    //     503 so the app renders a real "starting/unavailable" state and
-    //     retries — no doomed CP round-trip.
-    const headscaleIp = (sandbox.headscale_ip ?? "").trim();
-    if (!headscaleIp && !isBridgeHostFallbackEnabled(env)) {
-      logger.warn(
-        "[dedicated-proxy] agent running but unroutable (no headscale_ip)",
-        { agentId, orgId, status: sandbox.status },
-      );
-      const response = Response.json(
-        {
-          success: false,
-          code: "agent_unroutable",
-          error:
-            "Agent is running but has no routable network ingress yet (mesh join incomplete). Retry shortly.",
-        },
-        { status: 503 },
-      );
-      response.headers.set("Retry-After", String(RETRY_AFTER_SECONDS));
-      return response;
-    }
+        // 3b. A running row without mesh ingress is not routable yet.
+        const headscaleIp = (sandbox.headscale_ip ?? "").trim();
+        if (!headscaleIp && !isBridgeHostFallbackEnabled(env)) {
+          logger.warn(
+            "[dedicated-proxy] agent running but unroutable (no headscale_ip)",
+            { agentId, orgId, status: sandbox.status },
+          );
+          const response = Response.json(
+            {
+              success: false,
+              code: "agent_unroutable",
+              error:
+                "Agent is running but has no routable network ingress yet (mesh join incomplete). Retry shortly.",
+            },
+            { status: 503 },
+          );
+          response.headers.set("Retry-After", String(RETRY_AFTER_SECONDS));
+          return { response };
+        }
 
-    // 4. Unified auth — swap the validated owner's cloud token for the agent's
-    //    own ELIZA_API_TOKEN so the container accepts the request. For a WS
-    //    upgrade the token rode in `?token=`, so rewrite that too.
-    const envVars = (sandbox.environment_vars ?? {}) as Record<string, string>;
-    const resolvedAgentToken = envVars.ELIZA_API_TOKEN?.trim();
-    if (!resolvedAgentToken) {
-      logger.error("[dedicated-proxy] agent credential unavailable", {
-        agentId,
-        orgId,
-      });
-      return Response.json(
-        {
-          success: false,
-          code: "agent_credential_unavailable",
-          error: "Agent authentication is temporarily unavailable",
-        },
-        { status: 503 },
-      );
-    }
-    agentToken = resolvedAgentToken;
+        // 4. Swap the validated owner's Cloud token for the agent credential.
+        const envVars = (sandbox.environment_vars ?? {}) as Record<
+          string,
+          string
+        >;
+        const resolvedAgentToken = envVars.ELIZA_API_TOKEN?.trim();
+        if (!resolvedAgentToken) {
+          logger.error("[dedicated-proxy] agent credential unavailable", {
+            agentId,
+            orgId,
+          });
+          return {
+            response: Response.json(
+              {
+                success: false,
+                code: "agent_credential_unavailable",
+                error: "Agent authentication is temporarily unavailable",
+              },
+              { status: 503 },
+            ),
+          };
+        }
+        return { agentToken: resolvedAgentToken };
+      },
+    );
+    if ("response" in routing) return routing.response;
+    agentToken = routing.agentToken;
   } catch (error) {
     // error-policy:J1 a validated Cloud credential never crosses into the
     // container when ownership or credential resolution fails.
@@ -1227,5 +1309,6 @@ async function proxyDedicatedAgent(
     url,
     agentToken,
     effectiveQueryCredential?.name ?? null,
+    timing,
   );
 }

--- a/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
+++ b/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
@@ -133,11 +133,17 @@ function remoteSmoke() {
     rendererBuildId: buildId,
     cloudApiOrigin: apiOrigin,
     cloudEnvironment: "staging",
+    referenceBinding: {
+      runtime: "dedicated",
+      apiBase:
+        "https://123e4567-e89b-42d3-a456-426614174000.cloud-staging.eliza.app",
+    },
     chatCorrelation: {
       traceId: "0123456789abcdef0123456789abcdef",
-      serverTiming: "dedicated_auth;dur=1.25, dedicated_total;dur=4",
+      serverTiming:
+        "dedicated_auth;dur=1.25, dedicated_ownership;dur=1, dedicated_routing;dur=1, dedicated_proxy_dispatch;dur=1, dedicated_total;dur=4.25",
       preforward: "total=3;auth=1;mid=1;reserve=1;setup=0",
-      providerRequestId: "req_cerebras-123",
+      providerRequestIdSha256: "d".repeat(64),
     },
     outcome: "success",
   };
@@ -373,11 +379,12 @@ describe("deployed renderer proof", () => {
       { ...remoteSmoke().chatCorrelation, traceId: "Bearer private-secret" },
       {
         ...remoteSmoke().chatCorrelation,
-        serverTiming: 'gateway;dur=1;desc="private prompt"',
+        serverTiming:
+          "dedicated_auth;dur=1, dedicated_ownership;dur=1, dedicated_routing;dur=1, dedicated_proxy_dispatch;dur=1, dedicated_total;dur=4, private_api_key;dur=1",
       },
       {
         ...remoteSmoke().chatCorrelation,
-        providerRequestId: "private request id with spaces",
+        providerRequestIdSha256: "private request id with spaces",
       },
       { ...remoteSmoke().chatCorrelation, credential: "private-secret" },
     ]) {
@@ -386,6 +393,33 @@ describe("deployed renderer proof", () => {
           ...inputs,
           remoteSmoke: { ...remoteSmoke(), chatCorrelation },
         }),
+      ).toThrow();
+    }
+    for (const remote of [
+      {
+        ...remoteSmoke(),
+        referenceBinding: {
+          ...remoteSmoke().referenceBinding,
+          runtime: "shared",
+        },
+      },
+      {
+        ...remoteSmoke(),
+        referenceBinding: {
+          runtime: "dedicated",
+          apiBase: "https://api-staging.eliza.app",
+        },
+      },
+      {
+        ...remoteSmoke(),
+        chatCorrelation: {
+          ...remoteSmoke().chatCorrelation,
+          serverTiming: "dedicated_total;dur=4",
+        },
+      },
+    ]) {
+      expect(() =>
+        createDeployedRendererProof({ ...inputs, remoteSmoke: remote }),
       ).toThrow();
     }
   });

--- a/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
+++ b/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
@@ -133,6 +133,12 @@ function remoteSmoke() {
     rendererBuildId: buildId,
     cloudApiOrigin: apiOrigin,
     cloudEnvironment: "staging",
+    chatCorrelation: {
+      traceId: "0123456789abcdef0123456789abcdef",
+      serverTiming: "dedicated_auth;dur=1.25, dedicated_total;dur=4",
+      preforward: "total=3;auth=1;mid=1;reserve=1;setup=0",
+      providerRequestId: "req_cerebras-123",
+    },
     outcome: "success",
   };
 }
@@ -349,7 +355,39 @@ describe("deployed renderer proof", () => {
     expect(parseDeployedRendererProof(proof)).toEqual(proof);
     expect(proof.sourceSha).toBe(sourceSha);
     expect(proof.remoteSmoke.outcome).toBe("success");
+    expect(proof.remoteSmoke.chatCorrelation).toEqual(
+      remoteSmoke().chatCorrelation,
+    );
     expect(proof.continuity.forbiddenAgentMutationCount).toBe(0);
+  });
+
+  test("rejects unsafe or unvalidated browser correlation fields", async () => {
+    const inputs = {
+      authority: authority(),
+      preflight: await publicCheck("preflight"),
+      latency: latency(),
+      continuity: continuity(),
+      postflight: await publicCheck("postflight"),
+    };
+    for (const chatCorrelation of [
+      { ...remoteSmoke().chatCorrelation, traceId: "Bearer private-secret" },
+      {
+        ...remoteSmoke().chatCorrelation,
+        serverTiming: 'gateway;dur=1;desc="private prompt"',
+      },
+      {
+        ...remoteSmoke().chatCorrelation,
+        providerRequestId: "private request id with spaces",
+      },
+      { ...remoteSmoke().chatCorrelation, credential: "private-secret" },
+    ]) {
+      expect(() =>
+        createDeployedRendererProof({
+          ...inputs,
+          remoteSmoke: { ...remoteSmoke(), chatCorrelation },
+        }),
+      ).toThrow();
+    }
   });
 
   test("rejects a stale renderer manifest before browser auth", async () => {

--- a/packages/cloud/scripts/pages-deployment-authority.mjs
+++ b/packages/cloud/scripts/pages-deployment-authority.mjs
@@ -18,7 +18,7 @@ export const PAGES_AUTHORITY_SCHEMA =
 export const PAGES_PUBLIC_CHECK_SCHEMA =
   "elizaos.cloudflare.pages-public-check/v1";
 export const DEPLOYED_BROWSER_SMOKE_SCHEMA =
-  "elizaos.cloud.deployed-browser-smoke/v1";
+  "elizaos.cloud.deployed-browser-smoke/v2";
 export const DEPLOYED_RENDERER_PROOF_SCHEMA =
   "elizaos.cloud.deployed-renderer-proof/v1";
 
@@ -68,6 +68,7 @@ const PUBLIC_RENDERER_KEYS = [
 ];
 const PUBLIC_API_KEYS = ["commit", "environment", "origin"];
 const REMOTE_SMOKE_KEYS = [
+  "chatCorrelation",
   "cloudApiOrigin",
   "cloudEnvironment",
   "outcome",
@@ -77,6 +78,18 @@ const REMOTE_SMOKE_KEYS = [
   "schema",
   "sourceSha",
 ];
+const CHAT_CORRELATION_KEYS = [
+  "preforward",
+  "providerRequestId",
+  "serverTiming",
+  "traceId",
+];
+const TRACE_ID = /^[0-9a-f]{32}$/;
+const SAFE_TIMING =
+  /^(?:[A-Za-z][A-Za-z0-9_.-]{0,63};dur=\d+(?:\.\d+)?)(?:, [A-Za-z][A-Za-z0-9_.-]{0,63};dur=\d+(?:\.\d+)?)*$/;
+const SAFE_PREFORWARD =
+  /^total=\d+(?:\.\d+)?;auth=\d+(?:\.\d+)?;mid=\d+(?:\.\d+)?;reserve=\d+(?:\.\d+)?;setup=\d+(?:\.\d+)?$/;
+const PROVIDER_REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const LATENCY_KEYS = [
   "definition",
   "firstTurnLatencyMs",
@@ -671,6 +684,11 @@ export function parseDeployedBrowserSmoke(value) {
   ) {
     fail("remote browser smoke did not close successfully");
   }
+  const correlation = requireExactKeys(
+    smoke.chatCorrelation,
+    CHAT_CORRELATION_KEYS,
+    "remoteSmoke.chatCorrelation",
+  );
   return {
     schema: DEPLOYED_BROWSER_SMOKE_SCHEMA,
     sourceSha: requireString(smoke.sourceSha, "remoteSmoke.sourceSha", SHA40),
@@ -696,6 +714,34 @@ export function parseDeployedBrowserSmoke(value) {
       smoke.cloudEnvironment,
       "remoteSmoke.cloudEnvironment",
     ),
+    chatCorrelation: {
+      traceId: requireString(
+        correlation.traceId,
+        "remoteSmoke.chatCorrelation.traceId",
+        TRACE_ID,
+      ),
+      serverTiming: requireString(
+        correlation.serverTiming,
+        "remoteSmoke.chatCorrelation.serverTiming",
+        SAFE_TIMING,
+      ),
+      preforward:
+        correlation.preforward === null
+          ? null
+          : requireString(
+              correlation.preforward,
+              "remoteSmoke.chatCorrelation.preforward",
+              SAFE_PREFORWARD,
+            ),
+      providerRequestId:
+        correlation.providerRequestId === null
+          ? null
+          : requireString(
+              correlation.providerRequestId,
+              "remoteSmoke.chatCorrelation.providerRequestId",
+              PROVIDER_REQUEST_ID,
+            ),
+    },
     outcome: "success",
   };
 }

--- a/packages/cloud/scripts/pages-deployment-authority.mjs
+++ b/packages/cloud/scripts/pages-deployment-authority.mjs
@@ -18,7 +18,7 @@ export const PAGES_AUTHORITY_SCHEMA =
 export const PAGES_PUBLIC_CHECK_SCHEMA =
   "elizaos.cloudflare.pages-public-check/v1";
 export const DEPLOYED_BROWSER_SMOKE_SCHEMA =
-  "elizaos.cloud.deployed-browser-smoke/v2";
+  "elizaos.cloud.deployed-browser-smoke/v3";
 export const DEPLOYED_RENDERER_PROOF_SCHEMA =
   "elizaos.cloud.deployed-renderer-proof/v1";
 
@@ -72,6 +72,7 @@ const REMOTE_SMOKE_KEYS = [
   "cloudApiOrigin",
   "cloudEnvironment",
   "outcome",
+  "referenceBinding",
   "rendererBuildId",
   "rendererManifestCommit",
   "rendererOrigin",
@@ -80,16 +81,32 @@ const REMOTE_SMOKE_KEYS = [
 ];
 const CHAT_CORRELATION_KEYS = [
   "preforward",
-  "providerRequestId",
+  "providerRequestIdSha256",
   "serverTiming",
   "traceId",
 ];
+const REFERENCE_BINDING_KEYS = ["apiBase", "runtime"];
 const TRACE_ID = /^[0-9a-f]{32}$/;
-const SAFE_TIMING =
-  /^(?:[A-Za-z][A-Za-z0-9_.-]{0,63};dur=\d+(?:\.\d+)?)(?:, [A-Za-z][A-Za-z0-9_.-]{0,63};dur=\d+(?:\.\d+)?)*$/;
+const SAFE_TIMING_METRICS = new Set([
+  "cloud_worker",
+  "gateway_preforward",
+  "upstream_headers",
+  "dedicated_auth",
+  "dedicated_ownership",
+  "dedicated_routing",
+  "dedicated_proxy_dispatch",
+  "dedicated_total",
+]);
+const REQUIRED_DEDICATED_TIMING_METRICS = [
+  "dedicated_auth",
+  "dedicated_ownership",
+  "dedicated_routing",
+  "dedicated_proxy_dispatch",
+  "dedicated_total",
+];
+const SAFE_TIMING_DURATION = /^\d+(?:\.\d+)?$/;
 const SAFE_PREFORWARD =
   /^total=\d+(?:\.\d+)?;auth=\d+(?:\.\d+)?;mid=\d+(?:\.\d+)?;reserve=\d+(?:\.\d+)?;setup=\d+(?:\.\d+)?$/;
-const PROVIDER_REQUEST_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const LATENCY_KEYS = [
   "definition",
   "firstTurnLatencyMs",
@@ -201,6 +218,42 @@ function requireHttpsUrl(value, label) {
     fail(`${label} must be a bare HTTPS origin`);
   }
   return parsed.origin;
+}
+
+function requireDedicatedApiBase(value, label) {
+  const origin = requireHttpsUrl(value, label);
+  const hostname = new URL(origin).hostname;
+  const suffix = ".cloud-staging.eliza.app";
+  const agentId = hostname.endsWith(suffix)
+    ? hostname.slice(0, -suffix.length)
+    : "";
+  if (!UUID.test(agentId)) {
+    fail(`${label} must be a staging Dedicated agent origin`);
+  }
+  return origin;
+}
+
+function requireDedicatedServerTiming(value, label) {
+  const raw = requireString(value, label);
+  if (raw.length > 4_096) fail(`${label} is invalid`);
+  const names = new Set();
+  for (const metric of raw.split(", ")) {
+    const match = metric.match(/^([^;]+);dur=(.+)$/);
+    if (
+      !match ||
+      !SAFE_TIMING_METRICS.has(match[1]) ||
+      !SAFE_TIMING_DURATION.test(match[2]) ||
+      Number(match[2]) > 3_600_000 ||
+      names.has(match[1])
+    ) {
+      fail(`${label} is invalid`);
+    }
+    names.add(match[1]);
+  }
+  if (!REQUIRED_DEDICATED_TIMING_METRICS.every((name) => names.has(name))) {
+    fail(`${label} lacks required Dedicated phases`);
+  }
+  return raw;
 }
 
 function requireIsoTimestamp(value, label) {
@@ -689,6 +742,14 @@ export function parseDeployedBrowserSmoke(value) {
     CHAT_CORRELATION_KEYS,
     "remoteSmoke.chatCorrelation",
   );
+  const referenceBinding = requireExactKeys(
+    smoke.referenceBinding,
+    REFERENCE_BINDING_KEYS,
+    "remoteSmoke.referenceBinding",
+  );
+  if (referenceBinding.runtime !== "dedicated") {
+    fail("remoteSmoke.referenceBinding.runtime must be dedicated");
+  }
   return {
     schema: DEPLOYED_BROWSER_SMOKE_SCHEMA,
     sourceSha: requireString(smoke.sourceSha, "remoteSmoke.sourceSha", SHA40),
@@ -714,16 +775,22 @@ export function parseDeployedBrowserSmoke(value) {
       smoke.cloudEnvironment,
       "remoteSmoke.cloudEnvironment",
     ),
+    referenceBinding: {
+      runtime: "dedicated",
+      apiBase: requireDedicatedApiBase(
+        referenceBinding.apiBase,
+        "remoteSmoke.referenceBinding.apiBase",
+      ),
+    },
     chatCorrelation: {
       traceId: requireString(
         correlation.traceId,
         "remoteSmoke.chatCorrelation.traceId",
         TRACE_ID,
       ),
-      serverTiming: requireString(
+      serverTiming: requireDedicatedServerTiming(
         correlation.serverTiming,
         "remoteSmoke.chatCorrelation.serverTiming",
-        SAFE_TIMING,
       ),
       preforward:
         correlation.preforward === null
@@ -733,13 +800,13 @@ export function parseDeployedBrowserSmoke(value) {
               "remoteSmoke.chatCorrelation.preforward",
               SAFE_PREFORWARD,
             ),
-      providerRequestId:
-        correlation.providerRequestId === null
+      providerRequestIdSha256:
+        correlation.providerRequestIdSha256 === null
           ? null
           : requireString(
-              correlation.providerRequestId,
-              "remoteSmoke.chatCorrelation.providerRequestId",
-              PROVIDER_REQUEST_ID,
+              correlation.providerRequestIdSha256,
+              "remoteSmoke.chatCorrelation.providerRequestIdSha256",
+              SHA256,
             ),
     },
     outcome: "success",

--- a/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
@@ -275,7 +275,7 @@ describe("Cloudflare deployed browser workflow contract", () => {
     expect(browserStep.run).not.toContain("webServer");
   });
 
-  test("combines every strict observation before deriving receipt v3", () => {
+  test("combines every strict observation before deriving receipt v4", () => {
     for (const input of [
       '--authority "$AUTHORITY_PATH"',
       '--preflight "$PREFLIGHT_PATH"',

--- a/packages/scripts/__tests__/staging-cloud-receipt.test.ts
+++ b/packages/scripts/__tests__/staging-cloud-receipt.test.ts
@@ -86,11 +86,17 @@ function deployedProofFile(
       rendererBuildId: buildId,
       cloudApiOrigin: apiOrigin,
       cloudEnvironment: "staging",
+      referenceBinding: {
+        runtime: "dedicated",
+        apiBase:
+          "https://123e4567-e89b-42d3-a456-426614174000.cloud-staging.eliza.app",
+      },
       chatCorrelation: {
         traceId: "0123456789abcdef0123456789abcdef",
-        serverTiming: "dedicated_auth;dur=1.25, dedicated_total;dur=4",
+        serverTiming:
+          "dedicated_auth;dur=1.25, dedicated_ownership;dur=1, dedicated_routing;dur=1, dedicated_proxy_dispatch;dur=1, dedicated_total;dur=4.25",
         preforward: "total=3;auth=1;mid=1;reserve=1;setup=0",
-        providerRequestId: "req_cerebras-123",
+        providerRequestIdSha256: "d".repeat(64),
       },
       outcome: "success",
     },
@@ -207,11 +213,11 @@ describe("staging Cloud live receipt", () => {
     expect(receipt.annotations.historyContinuityPassed).toBe(false);
   });
 
-  test("sets schema v3 and deployedRendererTested only from a closed proof file", () => {
+  test("persists closed correlation in receipt v4 from a validated proof file", () => {
     const receipt = createStagingCloudReceipt(
       args({ "deployed-proof-file": deployedProofFile() }),
     );
-    expect(receipt.schemaVersion).toBe(3);
+    expect(receipt.schemaVersion).toBe(4);
     expect(receipt.annotations).toEqual({
       cloudApiOrigin: "https://api-staging.eliza.app",
       cloudEnvironment: "staging",
@@ -227,6 +233,15 @@ describe("staging Cloud live receipt", () => {
       deploymentIdSha256: "c".repeat(64),
       rendererBuildId: "a".repeat(64),
       rendererManifestCommit: exactSha,
+      runtime: "dedicated",
+      referenceApiBaseSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      chatCorrelation: {
+        traceId: "0123456789abcdef0123456789abcdef",
+        serverTiming:
+          "dedicated_auth;dur=1.25, dedicated_ownership;dur=1, dedicated_routing;dur=1, dedicated_proxy_dispatch;dur=1, dedicated_total;dur=4.25",
+        preforward: "total=3;auth=1;mid=1;reserve=1;setup=0",
+        providerRequestIdSha256: "d".repeat(64),
+      },
       publicPreflightPassed: true,
       remoteBrowserSmokePassed: true,
       publicPostflightPassed: true,

--- a/packages/scripts/__tests__/staging-cloud-receipt.test.ts
+++ b/packages/scripts/__tests__/staging-cloud-receipt.test.ts
@@ -86,6 +86,12 @@ function deployedProofFile(
       rendererBuildId: buildId,
       cloudApiOrigin: apiOrigin,
       cloudEnvironment: "staging",
+      chatCorrelation: {
+        traceId: "0123456789abcdef0123456789abcdef",
+        serverTiming: "dedicated_auth;dur=1.25, dedicated_total;dur=4",
+        preforward: "total=3;auth=1;mid=1;reserve=1;setup=0",
+        providerRequestId: "req_cerebras-123",
+      },
       outcome: "success",
     },
     latency: {

--- a/packages/scripts/write-staging-cloud-receipt.mjs
+++ b/packages/scripts/write-staging-cloud-receipt.mjs
@@ -195,7 +195,7 @@ export function createStagingCloudReceipt(argv) {
 
   return {
     ...receipt,
-    schemaVersion: 3,
+    schemaVersion: 4,
     deployment: {
       proofSha256: createHash("sha256").update(deployedProofRaw).digest("hex"),
       cloudflarePagesAlias: deployedProof.authority.aliasUrl,
@@ -203,6 +203,11 @@ export function createStagingCloudReceipt(argv) {
       deploymentIdSha256: deployedProof.authority.deploymentIdSha256,
       rendererBuildId: deployedProof.preflight.renderer.buildId,
       rendererManifestCommit: deployedProof.sourceSha,
+      runtime: deployedProof.remoteSmoke.referenceBinding.runtime,
+      referenceApiBaseSha256: createHash("sha256")
+        .update(deployedProof.remoteSmoke.referenceBinding.apiBase)
+        .digest("hex"),
+      chatCorrelation: deployedProof.remoteSmoke.chatCorrelation,
       publicPreflightPassed: true,
       remoteBrowserSmokePassed: true,
       publicPostflightPassed: true,


### PR DESCRIPTION
Closes #30386

## Summary
- persist the successful deployed browser chat trace, allowlisted `Server-Timing`, preforward breakdown, and SHA-256 provider request correlation in the uploaded staging receipt
- capture the actual chat response origin and require it to equal the staging Dedicated reference binding API origin before evidence is written
- require all Dedicated auth, ownership, routing, proxy-dispatch, and total timing metrics
- emit one always-on, closed-schema warning only after authenticated ownership/routing completes for a valid traced chat request; unauthenticated 401/403 callers and non-chat probes emit nothing, while successful and warming post-auth attempts remain observable
- preserve upstream timing/correlation headers and avoid nginx or agent-router changes

## Verification
- app correlation/evidence tests: 7 passed
- Dedicated proxy unit tests: 56 passed
- Pages authority, staging receipt, and deployed workflow tests: 27 passed
- Cloud API typecheck, 708-route contract audit, and Worker dry-run: passed
- app typecheck: passed
- Biome check for all 10 touched files: passed
- exact PR-range gitleaks scan: passed
- `git show --check`: passed

Regression coverage rejects mismatched response/reference origins, injected secret-shaped metric names, missing Dedicated metrics, shared or invalid runtime bindings, and unauthenticated traced 401/403 logging. It retains authenticated warming timing logs and proves the uploaded receipt carries the sanitized correlation envelope.

## Live evidence boundary
The protected deployed Playwright run requires a deployed revision plus the protected staging access key and authenticated account. Browser evidence schema v3 and staging receipt v4 preserve the safe cross-provider join data needed for Cloudflare/Railway correlation.