### PR TITLE
fix(core): mask the credential names the leaf logger already masks

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -585,6 +585,47 @@ describe("isSensitiveKeyName", () => {
 		expect(isSensitiveKeyName("accessTokens")).toBe(true);
 	});
 
+	it("flags the credential names the leaf logger masks by name", () => {
+		// These reached a sink unmasked whenever their text was pattern-inert:
+		// an opaque bearer token, a cookie header, a Discord webhook URL. The
+		// leaf logger's isSensitiveLogKey has masked all of them by name, and the
+		// doc on this predicate already claims that parity.
+		for (const key of [
+			"jwt",
+			"JWT",
+			"accessJwt",
+			"SESSION_JWT",
+			"bearer",
+			"x-bearer",
+			"cookie",
+			"sessionCookie",
+			"webhook",
+			"webhookUrl",
+			"DISCORD_WEBHOOK",
+			"sessionKey",
+			"session_key",
+			"connectionString",
+			"CONNECTION_STRING",
+		]) {
+			expect(isSensitiveKeyName(key), key).toBe(true);
+		}
+	});
+
+	it("keeps the boundary so credential lookalikes stay visible", () => {
+		// A word boundary is what separates `jwt` from `jwtIssuedAt`; without it
+		// this predicate would start masking timing and count fields.
+		for (const key of [
+			"jwtIssuedAt",
+			"jwtExpiresAt",
+			"bearerScheme",
+			"cookieCount",
+			"cookiesAccepted",
+			"primaryKey",
+		]) {
+			expect(isSensitiveKeyName(key), key).toBe(false);
+		}
+	});
+
 	it("flags the closed concat key set without catching key lookalikes", () => {
 		// master/encryption concatenations had no word boundary for the substring
 		// rules, so pattern-inert values under them leaked; the closed suffix set

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -145,6 +145,14 @@ const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
 	"auth_key",
 	"credential",
 	"authorization",
+	// Present in the leaf logger's list but previously absent here, so a value
+	// under one of these names reached a sink unmasked whenever its text was
+	// pattern-inert. A webhook URL is a full post credential (Discord/Slack).
+	"webhook",
+	"sessionkey",
+	"session_key",
+	"connectionstring",
+	"connection_string",
 ];
 
 // Exact telemetry/schema controls whose names contain "token" but whose
@@ -184,6 +192,20 @@ export function isSensitiveKeyName(key: string): boolean {
 		return false;
 	}
 	if (SENSITIVE_KEY_SUBSTRINGS.some((needle) => lower.includes(needle))) {
+		return true;
+	}
+	// Bare and suffixed credential names (`jwt`, `SESSION_JWT`, `x-bearer`,
+	// `sessionCookie`). These are too generic for substring matching, so a word
+	// boundary carries the rule: it masks `jwt` while leaving `jwtIssuedAt`
+	// visible. Mirrors the leaf logger's isSensitiveLogKey, whose doc on this
+	// predicate already claims that parity. `auth`, `session` and `dsn` are
+	// deliberately excluded: this predicate also governs non-log call sites
+	// where those names are structural containers, and their credential-shaped
+	// values are already caught by redactSensitiveText.
+	if (
+		/(?:^|[_\-. ])(jwt|bearer|cookie)$/i.test(key) ||
+		/[a-z](Jwt|Bearer|Cookie)$/.test(key)
+	) {
 		return true;
 	}
 	if (lower.includes("token") && !lower.includes("tokenid")) {


### PR DESCRIPTION
# What

`isSensitiveKeyName` is documented — in the source *and* in its test file — as the shared source of truth:

> `// Same closed set as the leaf logger's isSensitiveLogKey and the agent's isSensitiveConfigKey.`
> `* Name-based key detection (isSensitiveKeyName) is the single source of truth shared by the cloud logger's redact.context and the log-sink redactor`

`redactLogArgs` uses it for the **structural, non-opt-in** masking every sink applies. So it and `packages/logger`'s `isSensitiveLogKey` govern the same surface, and a divergence between them is an asymmetry rather than two alphabets doing two jobs.

I reimplemented both predicates verbatim and ran 52 realistic key names through each: **21 divergences, every one in the same direction — core is weaker.**

# Most of those 21 don't matter, and I checked before reporting

The value-shape scanner is a real second net. Running the actual `redactLogArgs` over ten realistic payloads:

| key | before |
| --- | --- |
| `sessionKey` | masked — `sk_` prefix |
| `connectionString` | masked — URL userinfo |
| `dsn` | masked — URL userinfo |
| `OPENAI_KEY` | masked — `sk-` prefix |

So the honest finding is only the names whose values are **pattern-inert**:

| key | value in the log, before this change |
| --- | --- |
| `jwt` | `eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1MSJ9.aBcDeFgHiJkLmNoPqRsTuVwXyZ012345` |
| `cookie` | `session=9f2b7c1d4e6a8b0c; Path=/; HttpOnly` |
| `bearer` | `AbCdEfGhIjKlMnOpQrStUvWxYz0123456789` |
| `webhookUrl` | `https://discord.com/api/webhooks/123456789/AbCdEf-…` |

All four are masked by name in `packages/logger` **today** — including `webhook`, whose entry there carries the comment *"A webhook URL is a full post credential (Discord/Slack)"*. This adopts rules already shipped in this repo rather than inventing a policy.

After: all four are `[REDACTED]`.

# What I deliberately did not add

`auth`, `session` and `dsn` are in the leaf logger's exact set and stay out of core's. This predicate also governs **non-log** call sites where those names are structural containers rather than secrets, and their credential-shaped values are already caught by `redactSensitiveText`. That reasoning is in the code comment so the remaining divergence reads as a decision, not an oversight.

`primaryKey` also stays visible — the leaf logger masks it via a generic `[a-z]Key$` rule, and a database primary key is not a credential. That's the one divergence where I think core is right.

# Mutation matrix

| mutant | result |
| --- | --- |
| remove the `jwt\|bearer\|cookie` boundary rule | **1 fail** — `flags the credential names the leaf logger masks by name` |
| remove the new substrings (`webhook`, `sessionkey`, `connectionstring`) | **1 fail** — same test |
| widen the boundary to a bare substring match | **1 fail** — `keeps the boundary so credential lookalikes stay visible` |

That third row is the one that matters: it is what stops this from becoming an over-masking change. `jwtIssuedAt`, `jwtExpiresAt`, `bearerScheme`, `cookieCount`, `cookiesAccepted` and `primaryKey` are all pinned as **not** sensitive.

# One thing I removed from my own first attempt

I initially added a `SENSITIVE_KEY_EXACT` set beside the boundary regex. Mutating the set away left every test passing — the regex already subsumes it, because its alternation starts at `^`. So the set is gone: this is one substring addition and one boundary rule, not three moving parts in a security predicate.

# Verification

- `packages/core` `src/security` → **681 pass / 40 files**
- `packages/logger` → **60 pass**
- focused `redact.test.ts` → **65 pass** (was 63)
- `biome check` clean

**One honest caveat:** six cloud suites that reach the redactor through `@elizaos/core/edge` fail in my local checkout. They fail **identically with this change stashed on clean develop**, so it is a pre-existing local dist-resolution issue in my environment, not a regression — but CI is the authority on that, not me.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JM8K95A98CVA9Z9QBC6CBS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T03:16:10.149Z","completed_at":"2026-09-03T03:17:20.907Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T03:16:10.854Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d9913dd57f8759bcc3c3d56466b17de24a2abaa66a02a4ff5a0f9192effa4297","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7ac704f2-a5bc-4115-b8e0-f5760078b30c","object_id":"sha256:d9913dd57f8759bcc3c3d56466b17de24a2abaa66a02a4ff5a0f9192effa4297","sha256":"d9913dd57f8759bcc3c3d56466b17de24a2abaa66a02a4ff5a0f9192effa4297"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"SU934aL_ejZuHww9qGsnkWW5W47hXEzy8Oerk3VAmGcQJlsXiHssrraBwD9TS3uwMkP8IfC3UWbvcebLA0YHCg"}} -->
