### PR TITLE
fix(cloud): expose closed Dedicated startup process state

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1323,24 +1323,29 @@ jobs:
             fi
             unset probe_status
             jq -e '
-              keys == ["container", "logs", "schemaVersion", "tailscale", "targetCount"] and
-              .schemaVersion == 1 and
+              keys == ["container", "logs", "runtime", "schemaVersion", "tailscale", "targetCount"] and
+              .schemaVersion == 2 and
               .targetCount == 1 and
-              (.container | keys == ["exitCode", "inspect", "status"]) and
+              (.container | keys == ["exitCode", "imageMatchesConfigured", "inspect", "status"]) and
               (.container.inspect == "success" or .container.inspect == "error") and
               (.container.status | IN("created", "running", "paused", "restarting", "removing", "exited", "dead", "unknown")) and
               (.container.exitCode == null or (.container.exitCode | type == "number")) and
+              (.container.imageMatchesConfigured == null or (.container.imageMatchesConfigured | type == "boolean")) and
               (.tailscale | keys == ["authUrlPresent", "backendState", "daemonPresent", "ipPresent", "machineAuthorized", "query", "socketPresent"]) and
               (.tailscale.query == "success" or .tailscale.query == "error") and
               (.tailscale.backendState == null or (.tailscale.backendState | IN("NeedsLogin", "NeedsMachineAuth", "NoState", "Running", "Starting", "Stopped"))) and
               (.tailscale.machineAuthorized == null or (.tailscale.machineAuthorized | type == "boolean")) and
               ([.tailscale.authUrlPresent, .tailscale.daemonPresent, .tailscale.ipPresent, .tailscale.socketPresent] | all(type == "boolean")) and
               (.logs | keys == ["agentStarted", "authKeyRejected", "interactiveAuthRequired", "tailscaleUpFailed"]) and
-              ([.logs.agentStarted, .logs.authKeyRejected, .logs.interactiveAuthRequired, .logs.tailscaleUpFailed] | all(type == "boolean"))
+              ([.logs.agentStarted, .logs.authKeyRejected, .logs.interactiveAuthRequired, .logs.tailscaleUpFailed] | all(type == "boolean")) and
+              (.runtime | keys == ["agentProcessPresent", "entrypointProcessPresent", "forceNoise443Enabled", "pid1", "stuckCliEscapePresent", "tailscaleUpProcessPresent"]) and
+              (.runtime.pid1 | IN("agent", "entrypoint", "other", "tailscale-up", "unknown")) and
+              ([.runtime.agentProcessPresent, .runtime.entrypointProcessPresent, .runtime.forceNoise443Enabled, .runtime.stuckCliEscapePresent, .runtime.tailscaleUpProcessPresent] | all(type == "boolean"))
             ' <<<"$diagnostic" >/dev/null
             jq -r '
               "private_mesh_container_status=" + .container.status,
               "private_mesh_container_exit_code=" + ((.container.exitCode // "none") | tostring),
+              "private_mesh_container_image_matches_configured=" + ((.container.imageMatchesConfigured // "unknown") | tostring),
               "private_mesh_tailscale_query=" + .tailscale.query,
               "private_mesh_tailscale_backend=" + (.tailscale.backendState // "unknown"),
               "private_mesh_tailscale_machine_authorized=" + ((.tailscale.machineAuthorized // "unknown") | tostring),
@@ -1351,7 +1356,13 @@ jobs:
               "private_mesh_log_auth_key_rejected=" + (.logs.authKeyRejected | tostring),
               "private_mesh_log_interactive_auth=" + (.logs.interactiveAuthRequired | tostring),
               "private_mesh_log_tailscale_up_failed=" + (.logs.tailscaleUpFailed | tostring),
-              "private_mesh_log_agent_started=" + (.logs.agentStarted | tostring)
+              "private_mesh_log_agent_started=" + (.logs.agentStarted | tostring),
+              "private_mesh_runtime_pid1=" + .runtime.pid1,
+              "private_mesh_runtime_agent_process=" + (.runtime.agentProcessPresent | tostring),
+              "private_mesh_runtime_entrypoint_process=" + (.runtime.entrypointProcessPresent | tostring),
+              "private_mesh_runtime_tailscale_up_process=" + (.runtime.tailscaleUpProcessPresent | tostring),
+              "private_mesh_runtime_force_noise_443=" + (.runtime.forceNoise443Enabled | tostring),
+              "private_mesh_runtime_stuck_cli_escape=" + (.runtime.stuckCliEscapePresent | tostring)
             ' <<<"$diagnostic"
             unset diagnostic
 

--- a/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   classifyContainerLogs,
+  classifyRuntimeProcessState,
   classifyTailscaleStatus,
 } from "./managed-dedicated-mesh-state-diagnostic";
 
@@ -51,6 +52,41 @@ describe("managed Dedicated mesh-state diagnostic", () => {
       interactiveAuthRequired: true,
       tailscaleUpFailed: true,
       agentStarted: false,
+    });
+  });
+
+  test("retains only closed container startup process facts", () => {
+    expect(
+      classifyRuntimeProcessState(
+        [
+          "pid1=entrypoint",
+          "agent=absent",
+          "entrypoint=present",
+          "tailscale_up=present",
+          "force_noise_443=enabled",
+          "stuck_cli_escape=present",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      pid1: "entrypoint",
+      agentProcessPresent: false,
+      entrypointProcessPresent: true,
+      tailscaleUpProcessPresent: true,
+      forceNoise443Enabled: true,
+      stuckCliEscapePresent: true,
+    });
+  });
+
+  test("fails closed for missing or unrecognized process facts", () => {
+    expect(
+      classifyRuntimeProcessState("pid1=private-command\nagent=present"),
+    ).toEqual({
+      pid1: "unknown",
+      agentProcessPresent: true,
+      entrypointProcessPresent: false,
+      tailscaleUpProcessPresent: false,
+      forceNoise443Enabled: false,
+      stuckCliEscapePresent: false,
     });
   });
 });

--- a/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.ts
@@ -32,6 +32,15 @@ type MeshLocator = {
 
 type CommandObservation = { ok: boolean; output: string };
 
+type RuntimeProcessState = {
+  pid1: "agent" | "entrypoint" | "other" | "tailscale-up" | "unknown";
+  agentProcessPresent: boolean;
+  entrypointProcessPresent: boolean;
+  tailscaleUpProcessPresent: boolean;
+  forceNoise443Enabled: boolean;
+  stuckCliEscapePresent: boolean;
+};
+
 function record(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -93,6 +102,32 @@ export function classifyContainerLogs(output: string): {
       /starting (?:eliza|agent)|server (?:started|listening)|agent runtime started/i.test(
         output,
       ),
+  };
+}
+
+export function classifyRuntimeProcessState(
+  output: string,
+): RuntimeProcessState {
+  const facts = new Map(
+    output
+      .split("\n")
+      .map((line) => line.trim().split("=", 2))
+      .filter((pair): pair is [string, string] => pair.length === 2),
+  );
+  const pid1 = facts.get("pid1");
+  return {
+    pid1:
+      pid1 === "agent" ||
+      pid1 === "entrypoint" ||
+      pid1 === "other" ||
+      pid1 === "tailscale-up"
+        ? pid1
+        : "unknown",
+    agentProcessPresent: facts.get("agent") === "present",
+    entrypointProcessPresent: facts.get("entrypoint") === "present",
+    tailscaleUpProcessPresent: facts.get("tailscale_up") === "present",
+    forceNoise443Enabled: facts.get("force_noise_443") === "enabled",
+    stuckCliEscapePresent: facts.get("stuck_cli_escape") === "present",
   };
 }
 
@@ -206,6 +241,43 @@ async function run(suffix: string): Promise<void> {
       ssh,
       `docker exec ${id} tailscale --socket=/tmp/tailscaled.sock ip -4`,
     );
+    const runtime = await observe(
+      ssh,
+      `docker exec ${id} sh -c '
+        pid1=other
+        agent=absent
+        entrypoint=absent
+        tailscale_up=absent
+        for f in /proc/[0-9]*/cmdline; do
+          pid=$(printf "%s" "$f" | cut -d/ -f3)
+          [ "$pid" = "$$" ] && continue
+          cmd=$(tr "\\000" " " < "$f" 2>/dev/null || true)
+          exe=$(readlink "/proc/$pid/exe" 2>/dev/null || true)
+          case "$cmd" in *docker-entrypoint.sh*) entrypoint=present ;; esac
+          case "$cmd" in *packages/agent/dist/bin.js*start*) agent=present ;; esac
+          case "$exe:$cmd" in */tailscale:*" up "*) tailscale_up=present ;; esac
+          if [ "$pid" = "1" ]; then
+            case "$exe:$cmd" in
+              */tailscale:*" up "*) pid1=tailscale-up ;;
+              *packages/agent/dist/bin.js*start*) pid1=agent ;;
+              *docker-entrypoint.sh*) pid1=entrypoint ;;
+            esac
+          fi
+        done
+        [ "\${TS_FORCE_NOISE_443:-}" = "1" ] && force_noise_443=enabled || force_noise_443=disabled
+        if grep -q ts_daemon_running_with_ip ./packages/app-core/scripts/docker-entrypoint.sh 2>/dev/null; then
+          stuck_cli_escape=present
+        else
+          stuck_cli_escape=absent
+        fi
+        printf "pid1=%s\\nagent=%s\\nentrypoint=%s\\ntailscale_up=%s\\nforce_noise_443=%s\\nstuck_cli_escape=%s\\n" \
+          "$pid1" "$agent" "$entrypoint" "$tailscale_up" "$force_noise_443" "$stuck_cli_escape"
+      '`,
+    );
+    const image = await observe(
+      ssh,
+      `docker inspect --format '{{.Config.Image}}' ${id}`,
+    );
     const logs = await observe(ssh, `docker logs --tail 400 ${id}`);
 
     let state: Record<string, unknown> | null = null;
@@ -235,14 +307,21 @@ async function run(suffix: string): Promise<void> {
       typeof state?.ExitCode === "number" ? state.ExitCode : null;
     const tailscale = classifyTailscaleStatus(status.output);
     const logSignals = classifyContainerLogs(logs.output);
+    const runtimeState = classifyRuntimeProcessState(runtime.output);
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: the protected worker EnvironmentFile owns this deployment value.
+    const configuredImage = process.env.ELIZA_AGENT_IMAGE?.trim();
     console.log(
       `MESH_DIAGNOSTIC=${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         targetCount: 1,
         container: {
           inspect: inspect.ok ? "success" : "error",
           status: containerStatus,
           exitCode,
+          imageMatchesConfigured:
+            image.ok && configuredImage
+              ? image.output.trim() === configuredImage
+              : null,
         },
         tailscale: {
           socketPresent:
@@ -255,6 +334,7 @@ async function run(suffix: string): Promise<void> {
           ipPresent: ip.ok && ip.output.trim().length > 0,
         },
         logs: logSignals,
+        runtime: runtimeState,
       })}`,
     );
   } finally {


### PR DESCRIPTION
Closes the remaining diagnostic gap in #29341.

The failed post-deploy Dedicated canary has a ready tenant database and a terminal provision job, but its preserved container regressed to `NeedsLogin` after a prior observation reached `Running` with a mesh address. This adds a privacy-safe process/image contract to the exact-container diagnostic so operators can distinguish an entrypoint blocked in `tailscale up` from an agent process that started but failed health.

The workflow emits only enums and booleans: PID 1 category, entrypoint/agent/`tailscale up` process presence, configured-image equality, `TS_FORCE_NOISE_443` equality, and stuck-CLI escape presence. It never exports process command lines, environment values, logs, identifiers, keys, or addresses.

Verification:
- `bun test packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.test.ts`
- Cloud shared typecheck
- `actionlint .github/workflows/live-smoke.yml`
- `bun run verify` (376/376 repository tasks; all remaining audits passed)

Live acceptance will deploy this exact source to the staging provisioning worker and inspect only the already-failed, quiesced canary before cleanup.