### PR TITLE
fix(ci): repair post-merge develop gates

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -52,11 +52,11 @@ on:
         required: false
         type: string
         default: ""
-    # Keep caller-scope secrets explicit. Telegram's authority receipt and
-    # live credentials are intentionally absent from both this callable schema
-    # and the caller map. The entry workflow proves the environment-specific
-    # runtime authority; deploy-api resolves fixed credential names only from
-    # its own protected Environment context for atomic Worker publication.
+    # Keep caller-scope secrets explicit. Telegram's live credentials are
+    # declared so the workflow can reference their fixed names, but the caller
+    # deliberately does not forward them. The entry workflow proves the
+    # environment-specific runtime authority; deploy-api resolves the values
+    # from its own protected Environment for atomic Worker publication.
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -91,6 +91,10 @@ on:
       ELIZA_APP_BLOOIO_PHONE_NUMBER:
         required: false
       ELIZA_APP_BLOOIO_WEBHOOK_SECRET:
+        required: false
+      ELIZA_APP_TELEGRAM_BOT_TOKEN:
+        required: false
+      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:
         required: false
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET:
         required: false
@@ -1400,11 +1404,12 @@ jobs:
           # The edge Telegram route needs both values in the Worker. They are
           # required and replaced atomically with the exact attested source;
           # activation is still a separate protected, live-proven rollout.
-          # These fixed names are resolved in this job's protected Environment,
-          # never forwarded through workflow_call. The format expression keeps
-          # actionlint from treating them as caller-provided reusable secrets.
-          ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')] }}
-          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')] }}
+          # These fixed names are resolved directly in this job's protected
+          # Environment and are never forwarded through workflow_call. A
+          # computed secrets[] key is evaluated without these Environment
+          # values in a reusable workflow and silently becomes blank.
+          ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
           # Personal Shared Blooio is the public-number messaging surface in
           # both protected environments. Commit the environment-specific
           # values atomically with the exact Worker source below.

--- a/packages/app-core/scripts/docker-entrypoint.test.ts
+++ b/packages/app-core/scripts/docker-entrypoint.test.ts
@@ -178,7 +178,7 @@ sleep 5
 }
 
 const TAILSCALE_DELAYED_SUCCESS_FIXTURE = `#!/bin/sh
-printf '%s\\n' "$@" > "$TAILSCALE_ARGS_LOG"
+printf '%s\\n' "$@" >> "$TAILSCALE_ARGS_LOG"
 sleep 1
 exit 0
 `;

--- a/packages/app/test/ui-smoke/all-views-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-interaction.spec.ts
@@ -996,6 +996,32 @@ test.describe("every-view interaction coverage", () => {
       // request may be rejected. Without this, an invalid or rejecting
       // fixture prunes the editor coverage while the case stays green.
       if (view.id === "automations") {
+        await page.getByRole("button", { name: "New automation" }).click();
+        await page.getByRole("menuitem", { name: "New workflow" }).click();
+        await expect(page.getByTestId("workflow-studio")).toBeVisible({
+          timeout: 30_000,
+        });
+        await page.getByLabel("Workflow name").fill("Interaction audit");
+        const createResponse = page.waitForResponse(
+          (response) =>
+            response.request().method() === "POST" &&
+            new URL(response.url()).pathname === "/api/workflow/workflows",
+        );
+        await page.getByLabel("Save workflow").click();
+        await createResponse;
+        await expect
+          .poll(
+            () =>
+              workflowSurfaceResponses.filter(
+                (response) =>
+                  response.method === "GET" &&
+                  (response.pathname === "/api/triggers" ||
+                    response.pathname.endsWith("/executions") ||
+                    response.pathname.endsWith("/revisions")),
+              ).length,
+            { timeout: 15_000 },
+          )
+          .toBeGreaterThanOrEqual(3);
         const observed = workflowSurfaceResponses
           .map((r) => `${r.method} ${r.pathname} -> ${r.status}`)
           .join("\n");

--- a/packages/app/test/ui-smoke/files-view-share-journey.spec.ts
+++ b/packages/app/test/ui-smoke/files-view-share-journey.spec.ts
@@ -90,7 +90,9 @@ test("files view: share a file (Web Share API invoked with the served url + titl
   const cards = page.getByTestId("file-card");
   await expect(cards).toHaveCount(2, { timeout: 60_000 });
 
-  // The Share control is present (the injected Web Share API made it supported).
+  // The Share control is present in the file's overflow menu (the injected
+  // Web Share API made it supported).
+  await page.getByTestId("file-actions").first().click();
   const shareBtn = page.getByTestId("file-share").first();
   await expect(shareBtn).toBeVisible();
   await shareBtn.click();

--- a/packages/app/test/ui-smoke/home-widget-priority.spec.ts
+++ b/packages/app/test/ui-smoke/home-widget-priority.spec.ts
@@ -13,7 +13,7 @@ import {
   seedAppStorage,
   UI_SMOKE_CPU_ONLY_HARDWARE,
 } from "./helpers";
-import { navigateHomeLauncher } from "./helpers/launcher-navigation";
+import { launcherGrid } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
 
 // #9143 — the home launcher mounts <WidgetHost slot="home"> and ranks the
@@ -763,10 +763,20 @@ test.describe("home widget priority (#9143)", () => {
     });
     await screenshot(page, "mobile");
 
-    // Home and Launcher are paired rail pages. Exercise the real rail before
-    // capturing the launcher half at the mobile viewport.
-    const grid = await navigateHomeLauncher(page, "launcher", {
-      input: "mouse",
+    // This spec owns widget ranking rather than gesture recognition. Exercise
+    // the rail through its real desktop control, then return to the mobile
+    // viewport for the launcher capture; dedicated pager specs own swipes.
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.getByTestId("rail-pager-edge-next").click();
+    await expect(page.getByTestId("home-launcher-surface")).toHaveAttribute(
+      "data-page",
+      "launcher",
+      { timeout: 10_000 },
+    );
+    await page.setViewportSize({ width: 390, height: 844 });
+    const grid = launcherGrid(page);
+    await expect(grid).toBeVisible({
+      timeout: 15_000,
     });
     await expect(grid.getByTestId("launcher-tile-settings")).toBeVisible({
       timeout: 15_000,

--- a/packages/app/test/ui-smoke/views-background-sweep.spec.ts
+++ b/packages/app/test/ui-smoke/views-background-sweep.spec.ts
@@ -69,6 +69,7 @@ async function installReadyDesktopStatusBridge(
   page: import("@playwright/test").Page,
 ): Promise<void> {
   await page.addInitScript(() => {
+    const secureStore = new Map<string, string>();
     type Bridge = {
       request?: Record<string, (params?: unknown) => Promise<unknown>>;
       onMessage?: (m: string, l: (p: unknown) => void) => void;
@@ -87,17 +88,98 @@ async function installReadyDesktopStatusBridge(
       pendingRestartReasons: [],
       startup: { phase: "running", attempt: 0 },
     };
-    win.__ELIZA_ELECTROBUN_RPC__ = {
+    const readyLaunch = {
+      phase: "ready",
+      agent: {
+        state: "running",
+        port: null,
+        apiBase: null,
+        startedAt: now - 60_000,
+        error: null,
+      },
+      boot: {
+        runtimePhase: "running",
+        pluginsLoaded: 0,
+        pluginsFailed: 0,
+        database: "ok",
+      },
+      auth: { checked: true, required: false },
+      firstRun: { checked: true, complete: true, cloudProvisioned: true },
+      remotes: { seeded: true, requiredStarted: false, errors: [] },
+      localModel: { backgroundDownloadQueued: false, blocking: false },
+      diagnostics: { logPath: "", statusPath: "" },
+      recovery: {
+        canRetry: false,
+        canOpenLogs: false,
+        canCreateBugReport: false,
+      },
+      updatedAt: new Date(now).toISOString(),
+    };
+    const readyBoot = {
+      state: "running",
+      phase: "running",
+      lastError: null,
+      pluginsLoaded: 0,
+      pluginsFailed: 0,
+      database: "ok",
+      agentName: "Playwright Smoke",
+      port: null,
+      startedAt: now - 60_000,
+    };
+    const withReadyStatus = (bridge?: Bridge): Bridge => ({
       request: {
-        ...(existing?.request ?? {}),
+        ...(bridge?.request ?? {}),
+        desktopGetVersion: async () => ({ runtime: "playwright-smoke" }),
+        desktopRegisterShortcut: async () => ({ success: true }),
+        desktopSetTrayMenu: async () => undefined,
+        secureStoreGet: async ({ kind }: { kind: string }) =>
+          secureStore.has(kind)
+            ? { ok: true, value: secureStore.get(kind) }
+            : { ok: false, reason: "not_found" },
+        secureStoreSet: async ({
+          kind,
+          value,
+        }: {
+          kind: string;
+          value: string;
+        }) => {
+          secureStore.set(kind, value);
+          return { ok: true };
+        },
+        secureStoreDelete: async ({ kind }: { kind: string }) => ({
+          ok: true,
+          deleted: secureStore.delete(kind),
+        }),
+        getAgentStatus: async () => readyStatus,
+        launchProgress: async () => readyLaunch,
+        bootProgress: async () => readyBoot,
         agentGetStatus: async () => readyStatus,
         permissionsGetAll: async () => ({}),
         permissionsIsShellEnabled: async () => false,
         permissionsGetPlatform: async () => "linux",
       },
-      onMessage: existing?.onMessage ?? (() => {}),
-      offMessage: existing?.offMessage ?? (() => {}),
-    };
+      onMessage: bridge?.onMessage ?? (() => {}),
+      offMessage: bridge?.offMessage ?? (() => {}),
+    });
+    let currentBridge = withReadyStatus(existing);
+    Object.defineProperty(win, "__ELIZA_ELECTROBUN_RPC__", {
+      configurable: true,
+      get() {
+        return currentBridge;
+      },
+      set(nextBridge: Bridge | undefined) {
+        currentBridge = withReadyStatus(nextBridge);
+      },
+    });
+    localStorage.setItem(
+      "elizaos:active-server",
+      JSON.stringify({
+        id: "local:playwright-smoke",
+        kind: "local",
+        label: "Playwright Smoke",
+        apiBase: window.location.origin,
+      }),
+    );
   });
 }
 

--- a/packages/app/test/ui-smoke/voice-profile-lifecycle.spec.ts
+++ b/packages/app/test/ui-smoke/voice-profile-lifecycle.spec.ts
@@ -307,7 +307,7 @@ for (const viewport of [
     );
     await bindInput.scrollIntoViewIfNeeded();
     await expect(bindInput).toBeInViewport();
-    const composer = page.getByPlaceholder("Ask Eliza");
+    const composer = page.getByTestId("chat-composer-textarea");
     const [bindBox, composerBox] = await Promise.all([
       bindInput.boundingBox(),
       composer.boundingBox(),

--- a/packages/scenario-runner/src/scenario-action-scope.test.ts
+++ b/packages/scenario-runner/src/scenario-action-scope.test.ts
@@ -152,6 +152,25 @@ describe("enterScenarioActionScope", () => {
     scope.restore();
     expect(runtime.actions.map((entry) => entry.name)).toEqual(["REPLY"]);
   });
+
+  it("drops seed plugin registrations with their actions", () => {
+    const runtime = {
+      actions: [action("REPLY")],
+      plugins: [plugin("bootstrap", ["REPLY"])],
+    } as unknown as Parameters<typeof enterScenarioActionScope>[0];
+
+    const scope = enterScenarioActionScope(
+      runtime,
+      scenarioDeclaring("seeded", []),
+      [],
+    );
+    runtime.plugins.push(plugin("seed-fixture", ["SEED_ONLY"]));
+    runtime.actions.push(action("SEED_ONLY"));
+    scope.restore();
+
+    expect(runtime.actions.map((entry) => entry.name)).toEqual(["REPLY"]);
+    expect(runtime.plugins.map((entry) => entry.name)).toEqual(["bootstrap"]);
+  });
 });
 
 /**

--- a/packages/scenario-runner/src/scenario-action-scope.ts
+++ b/packages/scenario-runner/src/scenario-action-scope.ts
@@ -17,7 +17,10 @@
  * lifetime of one scenario, every action contributed by a batch peer's declared
  * plugin that this scenario did not declare, and by restoring the runtime's
  * action list afterwards so a scenario's seed-registered actions do not leak
- * forward either.
+ * forward either. The plugin registry is restored with the action list so a
+ * later scenario can re-register a seed plugin whose scoped actions were
+ * removed; retaining only its registry entry creates a false "already loaded"
+ * state and leaves its actions permanently unavailable.
  */
 
 import type { Action, AgentRuntime } from "@elizaos/core";
@@ -98,6 +101,7 @@ export function enterScenarioActionScope(
   scenarioDeclaredActionNames?: readonly string[],
 ): { hiddenActionNames: string[]; restore: () => void } {
   const snapshot = [...runtime.actions];
+  const pluginSnapshot = [...runtime.plugins];
   const hidden = foreignScenarioActionNames(
     runtime,
     scenario,
@@ -112,6 +116,7 @@ export function enterScenarioActionScope(
     hiddenActionNames: [...hidden].sort(),
     restore: () => {
       runtime.actions.splice(0, runtime.actions.length, ...snapshot);
+      runtime.plugins.splice(0, runtime.plugins.length, ...pluginSnapshot);
     },
   };
 }

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -487,6 +487,10 @@ describe("homepage deployment workflow", () => {
       "ELIZA_APP_TELEGRAM_BOT_TOKEN",
       "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
     ] as const;
+    const reusableEnvironmentSecrets = [
+      "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+    ] as const;
     const referencedSecrets = [
       ...releaseWorkflow.matchAll(/\bsecrets\.([A-Z0-9_]+)/g),
     ]
@@ -511,7 +515,9 @@ describe("homepage deployment workflow", () => {
       Object.keys(
         parsedReleaseWorkflow.on?.workflow_call?.secrets ?? {},
       ).sort(),
-    ).toEqual(expectedCallerSecrets);
+    ).toEqual(
+      [...expectedCallerSecrets, ...reusableEnvironmentSecrets].sort(),
+    );
     for (const name of expectedCallerSecrets) {
       expect(callerSecretMap[name], name).toBe(
         githubExpression(`secrets.${name}`),
@@ -523,18 +529,18 @@ describe("homepage deployment workflow", () => {
     }
     for (const name of environmentOnlySecrets) {
       expect(callerSecretMap).not.toHaveProperty(name);
+    }
+    expect(parsedReleaseWorkflow.on?.workflow_call?.secrets).not.toHaveProperty(
+      "TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+    );
+    for (const name of reusableEnvironmentSecrets) {
       expect(
-        parsedReleaseWorkflow.on?.workflow_call?.secrets,
-      ).not.toHaveProperty(name);
+        parsedReleaseWorkflow.on?.workflow_call?.secrets?.[name],
+        name,
+      ).toEqual({ required: false });
     }
     expect(releaseWorkflow).not.toContain(
       "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
-    );
-    expect(releaseWorkflow).not.toContain(
-      "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
-    );
-    expect(releaseWorkflow).not.toContain(
-      "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
     );
 
     const apiDeploy = parsedReleaseWorkflow.jobs?.["deploy-api"];
@@ -546,14 +552,10 @@ describe("homepage deployment workflow", () => {
       githubExpression("inputs.target_environment"),
     );
     expect(secretPreparation.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toBe(
-      githubExpression(
-        "secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')]",
-      ),
+      githubExpression("secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN"),
     );
     expect(secretPreparation.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toBe(
-      githubExpression(
-        "secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')]",
-      ),
+      githubExpression("secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET"),
     );
   });
 

--- a/packages/ui/src/components/settings/DesktopIntegrationSection.stories.tsx
+++ b/packages/ui/src/components/settings/DesktopIntegrationSection.stories.tsx
@@ -1,6 +1,7 @@
 /** Desktop launch-at-login Settings states backed by the native RPC contract. */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ComponentType } from "react";
+import { userEvent } from "storybook/test";
 import type { ElectrobunRendererRpc } from "../../bridge";
 import { withMockApp } from "../../storybook/mock-providers.helpers";
 import { DesktopIntegrationSection } from "./DesktopIntegrationSection";
@@ -62,9 +63,7 @@ export const MutationFailed: Story = {
       '[data-agent-id="general-launch-on-login"]',
     );
     if (!toggle) throw new Error("Launch at sign-in control did not render");
-    await import("storybook/test").then(({ userEvent }) =>
-      userEvent.click(toggle),
-    );
+    await userEvent.click(toggle);
   },
 };
 

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-scenario-harness.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/orchestrator-scenario-harness.ts
@@ -690,6 +690,10 @@ class OrchestratorScenarioHarness {
           source: "scenario-runner",
           deviceProfile: profile.id,
         },
+        acceptanceCriteria: [
+          `${profile.id} delegates to a coding sub-agent`,
+          "the selected host account metadata is persisted",
+        ],
       })) as TaskDetail;
       const detail = (await this.taskService.spawnAgentForTask(task.id, {
         label: profile.id === "desktop" ? "Ada" : "Lin",
@@ -976,7 +980,7 @@ export function registerCalibratedJudgeFixture(
       modelType: ModelType.TEXT_LARGE,
       prompt: (value: string) =>
         value.includes("Score the candidate response against the rubric") &&
-        value.includes("Respond with ONLY a compact JSON object"),
+        value.includes("Respond with ONLY a JSON object on one line"),
     },
     response: (call: DeterministicModelCall) => {
       const prompt = call.params.prompt ?? "";

--- a/plugins/plugin-discord/__tests__/interaction-replay-render.test.ts
+++ b/plugins/plugin-discord/__tests__/interaction-replay-render.test.ts
@@ -191,10 +191,10 @@ describe("#14527 button-tap replay renders link-out blocks natively", () => {
 		await handleInteractionCreate(service as never, interaction as never);
 
 		expect(interaction.followUp).toHaveBeenCalledTimes(1);
-		// No resolver URL: no fabricated dead button, while the surrounding reply
-		// prose remains deliverable without duplicating the task-card title.
+		// No resolver URL: no fabricated dead button, while both the surrounding
+		// reply and task-card label remain deliverable as complete fallback prose.
 		expect(follows[0]?.components ?? []).toHaveLength(0);
-		expect(follows[0]?.content).toBe("Opening your task.");
+		expect(follows[0]?.content).toBe("Opening your task.\n\nShip the release");
 	});
 
 	it("delivers via followUp in a group DM where channel.send is unavailable", async () => {

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -113,8 +113,8 @@ describe("renderDiscordInteractions", () => {
 		const out = renderDiscordInteractions({
 			text: `Task created.\n[TASK:${id}]Ship it [CONFIG:@elizaos/plugin-gmail][/TASK]`,
 		} as Content);
-		expect(out.text).toBe("Task created.");
 		expect(out.text).not.toContain("[CONFIG:");
+		expect(out.text).toBe("Task created.\n\nShip it");
 		expect(out.components).toHaveLength(0);
 	});
 
@@ -239,8 +239,8 @@ describe("buildDiscordReplyPayload — canonical resolver derivation (#14527)", 
 			text: `Task created.\n[TASK:${TASK_ID}]Ship it[/TASK]`,
 		} as Content);
 		expect(out.components).toHaveLength(0);
-		expect(out.needsFreeTextReply).toBe(false);
-		expect(out.text).toBe("Task created.");
+		expect(out.needsFreeTextReply).toBe(true);
+		expect(out.text).toBe("Task created.\n\nShip it");
 	});
 
 	it("still renders choice buttons regardless of app-origin config", () => {


### PR DESCRIPTION
Closes #30280

Repairs the deterministic failures discovered on the exact post-merge develop SHA:

- restores scenario plugin/action isolation and current orchestrator judge fixtures
- updates browser smoke fixtures/selectors to exercise the real current UI contracts
- fixes Storybook interaction loading and Docker Tailscale argument capture
- aligns Discord fallback expectations with complete semantic output
- resolves protected Telegram credentials directly inside the reusable deploy job so production Worker publication does not receive blank values

Local evidence:
- `bun install`
- `bun run verify` (376/376 tasks)
- orchestrator PR scenario lane: 15/15
- Story gate shard: 205/205, broken=0, needs-runtime=0
- focused browser repairs: 9/9
- Discord focused tests: 20/20
- cloud shared-to-dedicated upgrade: 1/1
- workflow trigger policy and pinned actionlint: pass
- `bun run --cwd packages/app audit:app` running against this exact head; results will be posted before merge
