### PR TITLE
fix(cloud): report whether the mesh diagnostic's observations happened

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1324,7 +1324,7 @@ jobs:
             unset probe_status
             jq -e '
               keys == ["container", "logs", "runtime", "schemaVersion", "tailscale", "targetCount"] and
-              .schemaVersion == 2 and
+              .schemaVersion == 3 and
               .targetCount == 1 and
               (.container | keys == ["exitCode", "imageMatchesConfigured", "inspect", "status"]) and
               (.container.inspect == "success" or .container.inspect == "error") and
@@ -1336,9 +1336,11 @@ jobs:
               (.tailscale.backendState == null or (.tailscale.backendState | IN("NeedsLogin", "NeedsMachineAuth", "NoState", "Running", "Starting", "Stopped"))) and
               (.tailscale.machineAuthorized == null or (.tailscale.machineAuthorized | type == "boolean")) and
               ([.tailscale.authUrlPresent, .tailscale.daemonPresent, .tailscale.ipPresent, .tailscale.socketPresent] | all(type == "boolean")) and
-              (.logs | keys == ["agentStarted", "authKeyRejected", "interactiveAuthRequired", "tailscaleUpFailed"]) and
+              (.logs | keys == ["agentStarted", "authKeyRejected", "interactiveAuthRequired", "query", "tailscaleUpFailed"]) and
+              (.logs.query == "success" or .logs.query == "error") and
               ([.logs.agentStarted, .logs.authKeyRejected, .logs.interactiveAuthRequired, .logs.tailscaleUpFailed] | all(type == "boolean")) and
-              (.runtime | keys == ["agentProcessPresent", "entrypointProcessPresent", "forceNoise443Enabled", "pid1", "stuckCliEscapePresent", "tailscaleUpProcessPresent"]) and
+              (.runtime | keys == ["agentProcessPresent", "entrypointProcessPresent", "forceNoise443Enabled", "pid1", "query", "stuckCliEscapePresent", "tailscaleUpProcessPresent"]) and
+              (.runtime.query == "success" or .runtime.query == "error") and
               (.runtime.pid1 | IN("agent", "entrypoint", "other", "tailscale-up", "unknown")) and
               ([.runtime.agentProcessPresent, .runtime.entrypointProcessPresent, .runtime.forceNoise443Enabled, .runtime.stuckCliEscapePresent, .runtime.tailscaleUpProcessPresent] | all(type == "boolean"))
             ' <<<"$diagnostic" >/dev/null
@@ -1353,10 +1355,12 @@ jobs:
               "private_mesh_tailscale_socket=" + (.tailscale.socketPresent | tostring),
               "private_mesh_tailscale_daemon=" + (.tailscale.daemonPresent | tostring),
               "private_mesh_tailscale_ip=" + (.tailscale.ipPresent | tostring),
+              "private_mesh_log_query=" + .logs.query,
               "private_mesh_log_auth_key_rejected=" + (.logs.authKeyRejected | tostring),
               "private_mesh_log_interactive_auth=" + (.logs.interactiveAuthRequired | tostring),
               "private_mesh_log_tailscale_up_failed=" + (.logs.tailscaleUpFailed | tostring),
               "private_mesh_log_agent_started=" + (.logs.agentStarted | tostring),
+              "private_mesh_runtime_query=" + .runtime.query,
               "private_mesh_runtime_pid1=" + .runtime.pid1,
               "private_mesh_runtime_agent_process=" + (.runtime.agentProcessPresent | tostring),
               "private_mesh_runtime_entrypoint_process=" + (.runtime.entrypointProcessPresent | tostring),

--- a/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.test.ts
@@ -1,10 +1,14 @@
 /** Tests the privacy-safe classifiers used by the live Dedicated mesh diagnostic. */
 
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   classifyContainerLogs,
   classifyRuntimeProcessState,
   classifyTailscaleStatus,
+  withObservationQuery,
 } from "./managed-dedicated-mesh-state-diagnostic";
 
 describe("managed Dedicated mesh-state diagnostic", () => {
@@ -87,6 +91,118 @@ describe("managed Dedicated mesh-state diagnostic", () => {
       tailscaleUpProcessPresent: false,
       forceNoise443Enabled: false,
       stuckCliEscapePresent: false,
+    });
+  });
+
+  test("marks an observation that never happened as an error", () => {
+    // `observe()` returns exactly this for any failure, including a
+    // `docker exec` against a container that is not running.
+    const failed = withObservationQuery(
+      { ok: false, output: "" },
+      classifyRuntimeProcessState,
+    );
+
+    expect(failed.query).toBe("error");
+    // The classified facts are still all-false, which is precisely why the
+    // discriminator has to be there: without it this is indistinguishable
+    // from a live container whose entrypoint and agent are both gone.
+    expect(failed.agentProcessPresent).toBe(false);
+    expect(failed.entrypointProcessPresent).toBe(false);
+  });
+
+  test("keeps a successful observation's facts intact", () => {
+    const observed = withObservationQuery(
+      {
+        ok: true,
+        output: ["pid1=entrypoint", "entrypoint=present", "agent=absent"].join(
+          "\n",
+        ),
+      },
+      classifyRuntimeProcessState,
+    );
+
+    expect(observed).toEqual({
+      query: "success",
+      pid1: "entrypoint",
+      agentProcessPresent: false,
+      entrypointProcessPresent: true,
+      tailscaleUpProcessPresent: false,
+      forceNoise443Enabled: false,
+      stuckCliEscapePresent: false,
+    });
+  });
+
+  test("the observation's own query is not shadowed by a classifier's", () => {
+    // classifyTailscaleStatus reports a `query` of its own, from a parse
+    // failure rather than a failed observation. If a caller ever routes a
+    // classifier like that through here, the observation-level answer is the
+    // one the artifact promises.
+    const shadowed = withObservationQuery({ ok: false, output: "" }, () => ({
+      query: "success" as const,
+      backendState: null,
+    }));
+
+    expect(shadowed.query).toBe("error");
+    expect(shadowed.backendState).toBeNull();
+  });
+
+  test("discriminates empty container logs from unread ones", () => {
+    // A container that started cleanly and logged nothing matching, versus a
+    // `docker logs` that never ran. Same four booleans; different query.
+    const read = withObservationQuery(
+      { ok: true, output: "" },
+      classifyContainerLogs,
+    );
+    const unread = withObservationQuery(
+      { ok: false, output: "" },
+      classifyContainerLogs,
+    );
+
+    expect(read.query).toBe("success");
+    expect(unread.query).toBe("error");
+    expect({ ...read, query: null }).toEqual({ ...unread, query: null });
+  });
+
+  // `run()` needs a live SSH client, so the call sites that assemble the
+  // published artifact cannot be exercised here. Pin them against the source
+  // instead: a classifier that reaches the artifact without passing through
+  // `withObservationQuery` is the whole defect, and it would otherwise be
+  // invisible to every test in this file.
+  describe("the emitted artifact's observation call sites", () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(
+      path.join(here, "managed-dedicated-mesh-state-diagnostic.ts"),
+      "utf8",
+    );
+    const repoRoot = path.resolve(here, "../../../..");
+    const workflow = readFileSync(
+      path.join(repoRoot, ".github/workflows/live-smoke.yml"),
+      "utf8",
+    );
+
+    test("both classifiers are wrapped, and neither is called bare", () => {
+      expect(source).toMatch(
+        /withObservationQuery\(\s*logs\s*,\s*classifyContainerLogs\s*[,)]/,
+      );
+      expect(source).toMatch(
+        /withObservationQuery\(\s*runtime\s*,\s*classifyRuntimeProcessState\s*[,)]/,
+      );
+      expect(source).not.toContain("classifyContainerLogs(logs.output)");
+      expect(source).not.toContain(
+        "classifyRuntimeProcessState(runtime.output)",
+      );
+    });
+
+    test("the live-smoke contract accepts the discriminators it will receive", () => {
+      // A schema the emitter produces but the workflow's jq rejects fails at
+      // canary time, not in CI, so keep the two ends pinned to each other.
+      expect(source).toContain("schemaVersion: 3,");
+      expect(workflow).toContain(".schemaVersion == 3 and");
+      for (const field of [".runtime.query", ".logs.query"]) {
+        expect(workflow).toContain(
+          `(${field} == "success" or ${field} == "error")`,
+        );
+      }
     });
   });
 });

--- a/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-mesh-state-diagnostic.ts
@@ -131,6 +131,32 @@ export function classifyRuntimeProcessState(
   };
 }
 
+/**
+ * Stamp an observation with whether it actually happened.
+ *
+ * `observe()` returns `{ ok: false, output: "" }` for every failure, and
+ * `docker exec` fails outright whenever the container is not running — a state
+ * this diagnostic explicitly expects (`created`, `exited`, `dead`). The status
+ * classifier gets this for free: an empty string cannot parse, so it already
+ * reports `query: "error"`. The process and log classifiers cannot, because an
+ * empty string is a perfectly valid input that yields all-`false`. Without a
+ * discriminator an unobserved container is published as five definite
+ * negatives, which reads as "the entrypoint and the agent both failed to
+ * start" — the exact conclusion the runtime facts exist to distinguish.
+ */
+export function withObservationQuery<T extends object>(
+  observation: CommandObservation,
+  classify: (output: string) => T,
+): Omit<T, "query"> & { query: "success" | "error" } {
+  return {
+    ...classify(observation.output),
+    // Last on purpose. The status classifier already reports its own `query`
+    // from a parse failure, so a classifier field could shadow this one; the
+    // observation-level answer is the one the artifact promises, and it wins.
+    query: observation.ok ? "success" : "error",
+  };
+}
+
 async function observe(
   client: DockerSSHClient,
   command: string,
@@ -306,13 +332,16 @@ async function run(suffix: string): Promise<void> {
     const exitCode =
       typeof state?.ExitCode === "number" ? state.ExitCode : null;
     const tailscale = classifyTailscaleStatus(status.output);
-    const logSignals = classifyContainerLogs(logs.output);
-    const runtimeState = classifyRuntimeProcessState(runtime.output);
+    const logSignals = withObservationQuery(logs, classifyContainerLogs);
+    const runtimeState = withObservationQuery(
+      runtime,
+      classifyRuntimeProcessState,
+    );
     // biome-ignore lint/suspicious/noUndeclaredEnvVars: the protected worker EnvironmentFile owns this deployment value.
     const configuredImage = process.env.ELIZA_AGENT_IMAGE?.trim();
     console.log(
       `MESH_DIAGNOSTIC=${JSON.stringify({
-        schemaVersion: 2,
+        schemaVersion: 3,
         targetCount: 1,
         container: {
           inspect: inspect.ok ? "success" : "error",


### PR DESCRIPTION
# What

`#30394` added the `runtime` process facts. I reviewed it and raised one gap; it merged at the reviewed head, so this implements the fix rather than re-arguing it.

`observe()` returns `{ ok: false, output: "" }` for **every** failure, and `docker exec` fails outright whenever the container is not running — `created`, `exited`, `dead`, all states this diagnostic's own status enum expects.

`classifyTailscaleStatus` gets a discriminator for free: an empty string can't parse, so it already reports `query: "error"`. The process and log classifiers can't — an empty string is *valid input* that yields all-`false`. So an unobserved container was published as five definite negatives:

```
classifyRuntimeProcessState("")
-> {"pid1":"unknown","agentProcessPresent":false,"entrypointProcessPresent":false, …}
```

and the workflow rendered `private_mesh_runtime_agent_process=false`, `private_mesh_runtime_entrypoint_process=false` with nothing marking them unobserved. Those are exactly the two facts `#30394` exists to distinguish ("an entrypoint blocked in `tailscale up` from an agent process that started but failed health") — a failed exec silently answers *neither*, which is a third conclusion, and the wrong one.

`pid1` doesn't rescue it: truncated output gives `pid1: "other"` with all booleans false, identical to a successful observation that matched nothing.

# The change

`withObservationQuery(observation, classify)` stamps the `success | error` shape `tailscale` already carries. `schemaVersion` → 3, and the live-smoke jq contract widened to match. `live-smoke.yml` is the only consumer, so the bump is self-contained.

**`logs` is fixed too, deliberately.** `classifyContainerLogs` has the identical shape and the identical consequence — a failed `docker logs` publishes `agentStarted: false` as a definite negative. Fixing one while editing the file and leaving its twin would be worse than fixing both. The thesis is now uniform: every observation in this artifact reports whether it happened.

# One thing worth flagging to maintainers

My first version put `query` before the spread and constrained the parameter with `query?: never`, so a classifier reporting its own `query` wouldn't compile. Then I checked whether that constraint is *enforced*, and it isn't:

- `packages/cloud/scripts` has no `package.json` and no `tsconfig.json`
- `packages/cloud/shared/tsconfig.json` includes only `src/**`

**Nothing typechecks this directory.** My own `tsc --noEmit -p tsconfig.json` there had been silently vacuous — failing with `TS5058: The specified path does not exist`. A control experiment (append a definite type error, observe no report) is what caught it.

So I replaced the unenforceable compile-time constraint with a runtime one: spread first, `query` last, so the observation-level answer can't be shadowed, pinned by a test. That's a guarantee this repo can actually hold today. Whether `packages/cloud/scripts` should be typechecked at all is a separate call, and yours.

# Evidence

**Mutation table — 7 mutants, all killed:**

| mutant | result |
|---|---|
| `query` always `"success"` | 3 fail |
| `query` **before** the spread (shadowable) | 1 fail |
| invert the ternary | 4 fail |
| `logs` left unwrapped | 1 fail |
| `runtime` left unwrapped | 1 fail |
| workflow jq left at `schemaVersion == 2` | 1 fail |
| workflow drops the `.runtime.query` enum | 1 fail |

The two call-site mutants **survived at first**. `run()` needs a live SSH client, so the code that assembles the artifact is unreachable from any test — the exact place the defect lives. I stopped trying to unit-test it and pinned the call sites against the source text instead, the style this package already uses for its shell and workflow assertions, plus a test tying the emitter's `schemaVersion` to the jq that has to accept it. A schema the emitter produces but the workflow rejects fails at canary time, not in CI.

**The workflow contract, executed rather than eyeballed.** I extracted the jq program straight out of `live-smoke.yml` and built the artifact by calling the **real** classifiers, not a hand-written fixture:

| input | verdict |
|---|---|
| failed observation (`query: "error"`) | accepted |
| healthy observation (`query: "success"`) | accepted |
| stale emitter still at `schemaVersion: 2` | **rejected** |
| `runtime` block missing `query` | **rejected** |

**Gates:** diagnostic suite **11 pass** (up from 5), `managed-dedicated-canary-workflow` 7 pass, `live-cloud-provision-smoke` 26 pass, `actionlint` clean on `live-smoke.yml`, `biome` clean.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JPVV1MT4A273T4XVNEG8PB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T04:01:37.844Z","completed_at":"2026-09-03T04:06:55.540Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T04:01:38.500Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"241461b57f69e41cb776ba32278f8da2f1a481f483e2950b5394da32447a35b7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c2ca3849-49e4-4d00-a45c-3461be889650","object_id":"sha256:241461b57f69e41cb776ba32278f8da2f1a481f483e2950b5394da32447a35b7","sha256":"241461b57f69e41cb776ba32278f8da2f1a481f483e2950b5394da32447a35b7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"A3-cw1ohwxfLAaZ0KgFK6Q7ZEFTNaZZ0lst3X0gwdHk7nWEQvPzPJPq43-0Znb-O6UslDWqgHDwIB6_xSBNJBw"}} -->
