### PR TITLE
test(ci): run every workflow-contract test, not a hand-list

### DIFF
--- a/.github/workflows/pr-static-smoke.yml
+++ b/.github/workflows/pr-static-smoke.yml
@@ -131,16 +131,19 @@ jobs:
       - name: Validate CI Bun version pin contract
         run: node packages/scripts/ci-bun-version-contract.mjs --inventory "$RUNNER_TEMP/bun-runtime-inventory.json"
 
+      # Whole directory, not a hand-list. `packages/scripts` is not a workspace
+      # package, so `run-all-tests.mjs` never reaches it and
+      # `audit-test-lane-membership.mjs` cannot see it either -- it accounts for
+      # named workspace packages. Enumerating files here meant a new
+      # workflow-contract test was dead on arrival unless its author also
+      # remembered to edit this list. `pr-static-smoke-workflow.test.ts` now
+      # fails closed if any test that reads `.github/workflows/` is not covered.
       - name: Test required workflow contracts
         run: >-
           bun test
           packages/cloud/shared/scripts/messaging-gateway-preflight.test.mjs
-          packages/scripts/__tests__/homepage-deploy-workflow.test.ts
-          packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts
-          packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
-          packages/scripts/__tests__/ci-bun-version-contract.test.ts
-          packages/scripts/__tests__/github-action-pinning.test.ts
-          packages/scripts/__tests__/pr-static-smoke-workflow.test.ts
+          packages/scripts/__tests__
+          packages/scripts/cloud/admin/repair-mobile-app-auth-registration.test.ts
 
       - name: Upload Bun runtime resolution inventory
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/packages/scripts/__tests__/pr-static-smoke-workflow.test.ts
+++ b/packages/scripts/__tests__/pr-static-smoke-workflow.test.ts
@@ -1,8 +1,8 @@
 /** Verifies PR admission combines source contracts, PostgreSQL subscription authority, affected static checks, billing replay, and Windows security. */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { listPackages } from "../lib/workspaces.mjs";
 
@@ -222,9 +222,10 @@ describe("PR Static Smoke workflow", () => {
     expect(commands).toContain(
       "packages/cloud/shared/scripts/messaging-gateway-preflight.test.mjs",
     );
-    expect(commands).toContain(
-      "packages/scripts/__tests__/pr-static-smoke-workflow.test.ts",
-    );
+    // This file used to be named here individually. It is now covered by the
+    // directory, together with every other workflow-contract test -- see
+    // "runs every test that reads a workflow file" below.
+    expect(commands).toContain("packages/scripts/__tests__");
     expect(commands).toContain("bun run build:core");
     expect(commands).toContain("run lint:check --concurrency=4 --affected");
     expect(commands).toContain("run typecheck --concurrency=4 --affected");
@@ -246,5 +247,74 @@ describe("PR Static Smoke workflow", () => {
       "mock-backed payment replay Playwright proof",
     );
     expect(workflowReadme).not.toMatch(/does\s+not run tests/);
+  });
+
+  // `packages/scripts` is not a workspace package, so `run-all-tests.mjs` never
+  // reaches it and `audit-test-lane-membership.mjs` -- which accounts for named
+  // workspace packages -- cannot see it either. Nothing else in CI runs these
+  // files. A workflow-contract test that no lane runs is not a guard; it is a
+  // file. Fail closed here so a new one cannot arrive dead.
+  test("runs every test that reads a workflow file", () => {
+    const contractStep = (workflow.jobs?.["source-smoke"]?.steps ?? []).find(
+      (step) => step.name === "Test required workflow contracts",
+    );
+    const covered = splitWords(contractStep?.run);
+    expect(covered.length).toBeGreaterThan(0);
+
+    const isCovered = (rel: string) =>
+      covered.some(
+        (entry) =>
+          entry === rel || rel.startsWith(`${entry.replace(/\/+$/, "")}/`),
+      );
+
+    const testFilePattern = /[._](?:test|spec)\.[^./]+$/i;
+    const skipDirs = new Set(["node_modules", "dist", ".turbo"]);
+    const found: string[] = [];
+    const uncovered: string[] = [];
+
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir)) {
+        if (skipDirs.has(entry)) continue;
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!testFilePattern.test(entry)) continue;
+        // The marker is the subject, not the runner: a test that reads a
+        // workflow file is asserting a CI contract, wherever it lives.
+        if (!readFileSync(full, "utf8").includes(".github/workflows/"))
+          continue;
+        const rel = relative(repoRoot, full).split("\\").join("/");
+        found.push(rel);
+        if (!isCovered(rel)) uncovered.push(rel);
+      }
+    };
+    walk(join(repoRoot, "packages/scripts"));
+
+    // A broken walk or a marker that matched nothing would satisfy the real
+    // assertion below without having checked a single file.
+    expect(found.length).toBeGreaterThan(40);
+    expect(uncovered).toEqual([]);
+  });
+
+  test("the completeness guard is not vacuous", () => {
+    // A broken walk or a marker that matches nothing would pass the assertion
+    // above without checking anything.
+    const contractStep = (workflow.jobs?.["source-smoke"]?.steps ?? []).find(
+      (step) => step.name === "Test required workflow contracts",
+    );
+    expect(splitWords(contractStep?.run)).toContain(
+      "packages/scripts/__tests__",
+    );
+    expect(
+      readFileSync(
+        join(
+          repoRoot,
+          "packages/scripts/__tests__/homepage-deploy-workflow.test.ts",
+        ),
+        "utf8",
+      ),
+    ).toContain(".github/workflows/");
   });
 });


### PR DESCRIPTION
# What

`packages/scripts` is **not a workspace package**. `listPackages()` returns 151 packages and it isn't one of them, so:

- `run-all-tests.mjs` iterates workspace packages and never reaches it
- `audit-test-lane-membership.mjs` — whose own docstring says it exists to catch *"a maintained test file a script never runs at all"* — accounts for **named workspace packages**, so it structurally cannot see the directory

The only CI coverage was six paths enumerated by hand in one `pr-static-smoke.yml` step. An audit over things that opted in can't see a thing that never opted in.

# Measured, not estimated

`packages/scripts` holds **177** test files. Exactly **9** are referenced by any workflow or root script. **168 run nowhere.**

168 is too blunt a number to act on, so I narrowed to a principled predicate — a test whose *subject* is a CI contract, i.e. one that reads a `.github/workflows/` file:

| | count |
|---|---|
| test files under `packages/scripts` reading a workflow | **58** |
| of those, covered by a CI lane | 6 |
| **running in no lane at all** | **52** |

Those 52 include the three that guard how the protected Telegram deploy credentials resolve — the same ones #30397 currently breaks.

# The change

Run the directory instead of a hand-list, plus the one workflow-reading test that lives outside it (`packages/scripts/cloud/admin/repair-mobile-app-auth-registration.test.ts`).

A wider list would just drift again, so the actual fix is a **fail-closed completeness guard** in `pr-static-smoke-workflow.test.ts`: walk `packages/scripts`, take every test file that reads `.github/workflows/`, and assert each is covered by that step — exactly or by directory prefix. **The marker is the subject, not the runner**, so a new workflow-contract test can't arrive dead wherever its author puts it.

# Before proposing to add 159 files to CI, I ran them

**1503 pass, 8 skip, 2 fail, 77s.**

I chased the two failures rather than filing them:

```
bash: line 48: declare: -A: invalid option
```

That's macOS **bash 3.2** lacking associative arrays. The `declare -A` lives in `deploy-gateway-webhook.yml`, and both that workflow and pr-static-smoke's `source-smoke` job run on `ubuntu-24.04` (bash 5). **Local artifact, not a repo defect** — I didn't file it, and I can't reproduce a bash 5 run from here, so flagging it as the one thing I couldn't verify. If it does surface on the runner, say so and I'll gate that file rather than leave the lane red.

# Evidence

The exact command CI will now run:

```
1530 pass, 8 skip, 2 fail (both the bash 3.2 artifact) across 161 files — 75s
```

**Mutants against the guard — 4, all killed:**

| mutant | result |
|---|---|
| revert the workflow to the six-file hand-list | 2 fail |
| drop the one covered file outside `__tests__` | 1 fail |
| widen the marker so it matches every file | 1 fail |
| make the walk return nothing | **survived at first** |

The vacuity mutant survived because my "not vacuous" test asserted the step and one file's marker, but never that the walk *found* anything. Fixed by collecting what the walk finds and asserting >40 files — that's the real anti-vacuity property, and it's killed now.

One pre-existing assertion legitimately broke: it pinned this test file by name in the step, which the directory now covers. Updated it to the directory with a pointer to the new completeness test, rather than deleting a check.

`pr-static-smoke-workflow.test.ts` 8 pass, `actionlint` clean, `biome` clean.

# Cost

The step goes from a handful of files to ~75s. That's the price of the 52 contract tests actually guarding something; if you'd rather keep the lane fast, the same guard works against a narrower command — the completeness property is independent of how wide the step is.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JR2FXATTMNVY1MPG2J7DCZ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T04:22:44.394Z","completed_at":"2026-09-03T04:31:12.097Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T04:22:45.032Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4fdc246a3427e7708e2f9796352e8e9b8b057f6466595e31d57d62e950b30a24","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9fb2e62e-d9bb-458d-b4a2-7dbf0ce7c559","object_id":"sha256:4fdc246a3427e7708e2f9796352e8e9b8b057f6466595e31d57d62e950b30a24","sha256":"4fdc246a3427e7708e2f9796352e8e9b8b057f6466595e31d57d62e950b30a24"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"R31nermP5Ai778bsYXQgXdXOCEMVzGqupBksMNFicXDEQw2LvM8S30ZB-E4xdNveApwFJAKT2y57_TPe92M3Ag"}} -->
