### PR TITLE
fix(app): restore desktop browser smoke contracts

### DIFF
--- a/packages/app/test/ui-smoke/helpers/launcher-navigation.ts
+++ b/packages/app/test/ui-smoke/helpers/launcher-navigation.ts
@@ -17,21 +17,52 @@ async function railGestureY(
   page: Page,
   target: Locator,
   currentPage: LauncherPage,
+  x: number,
 ): Promise<number> {
   const box = await target.boundingBox();
   if (!box) throw new Error(`${currentPage} launcher page has no bounding box`);
-  if (currentPage === "launcher") return box.y + box.height * 0.14;
 
   // Notification rows own their own horizontal dismiss gesture. Starting in
-  // the header keeps launcher navigation on the parent rail on narrow screens.
+  // the header usually keeps launcher navigation on the parent rail on narrow
+  // screens. Test-only badges can overlay that coordinate, though, so resolve
+  // an actual hit-tested point inside the active rail half before pressing.
   const notificationCenter = page.getByTestId("home-notification-center");
   const notificationBox =
-    (await notificationCenter.count()) > 0
+    currentPage === "home" && (await notificationCenter.count()) > 0
       ? await notificationCenter.boundingBox()
       : null;
-  return notificationBox && notificationBox.y > box.y
-    ? (box.y + notificationBox.y) / 2
-    : box.y + box.height * 0.14;
+  const preferredY =
+    notificationBox && notificationBox.y > box.y
+      ? (box.y + notificationBox.y) / 2
+      : box.y + box.height * 0.14;
+  const candidates = [
+    preferredY,
+    ...[0.14, 0.22, 0.32, 0.42, 0.52, 0.62].map(
+      (ratio) => box.y + box.height * ratio,
+    ),
+  ];
+  const targetTestId = `home-launcher-${currentPage}-page`;
+  const usableY = await page.evaluate(
+    ({ candidates, targetTestId, x }) => {
+      for (const y of candidates) {
+        const hit = document.elementFromPoint(x, y);
+        if (
+          hit?.closest(`[data-testid="${targetTestId}"]`) &&
+          !hit.closest("[data-notif-row]")
+        ) {
+          return y;
+        }
+      }
+      return null;
+    },
+    { candidates, targetTestId, x },
+  );
+  if (usableY === null) {
+    throw new Error(
+      `${currentPage} launcher page has no unobstructed drag point`,
+    );
+  }
+  return usableY;
 }
 
 async function dragRail(
@@ -47,7 +78,7 @@ async function dragRail(
   const direction = currentPage === "home" ? -1 : 1;
   const startX = box.x + box.width * (currentPage === "home" ? 0.72 : 0.28);
   const endX = startX + direction * box.width * 0.54;
-  const y = await railGestureY(page, target, currentPage);
+  const y = await railGestureY(page, target, currentPage, startX);
   const touchCapable = await page.evaluate(
     () =>
       navigator.maxTouchPoints > 0 ||
@@ -94,6 +125,10 @@ async function dragRail(
   await page.mouse.down();
   for (let step = 1; step <= 8; step += 1) {
     await page.mouse.move(startX + ((endX - startX) * step) / 8, y);
+    // Let the renderer observe motion across real frames. A zero-duration drag
+    // can begin and end within one busy frame, so the pager never sees enough
+    // velocity or displacement to commit even though CDP delivered every move.
+    await page.waitForTimeout(16);
   }
   await page.mouse.up();
 }

--- a/packages/app/test/ui-smoke/home-widget-priority.spec.ts
+++ b/packages/app/test/ui-smoke/home-widget-priority.spec.ts
@@ -454,6 +454,7 @@ async function seedHomeWidgetStorage(page: Page): Promise<void> {
 
 async function installReadyDesktopStatusBridge(page: Page): Promise<void> {
   await page.addInitScript(() => {
+    const secureStore = new Map<string, string>();
     type Bridge = {
       request?: Record<string, (params?: unknown) => Promise<unknown>>;
       onMessage?: (
@@ -522,6 +523,24 @@ async function installReadyDesktopStatusBridge(page: Page): Promise<void> {
         desktopGetVersion: async () => ({ runtime: "playwright-smoke" }),
         desktopRegisterShortcut: async () => ({ success: true }),
         desktopSetTrayMenu: async () => undefined,
+        secureStoreGet: async ({ kind }: { kind: string }) =>
+          secureStore.has(kind)
+            ? { ok: true, value: secureStore.get(kind) }
+            : { ok: false, reason: "not_found" },
+        secureStoreSet: async ({
+          kind,
+          value,
+        }: {
+          kind: string;
+          value: string;
+        }) => {
+          secureStore.set(kind, value);
+          return { ok: true };
+        },
+        secureStoreDelete: async ({ kind }: { kind: string }) => ({
+          ok: true,
+          deleted: secureStore.delete(kind),
+        }),
         getAgentStatus: async () => readyStatus,
         launchProgress: async () => readyLaunch,
         bootProgress: async () => readyBoot,

--- a/packages/app/test/ui-smoke/settings-background.spec.ts
+++ b/packages/app/test/ui-smoke/settings-background.spec.ts
@@ -271,6 +271,7 @@ async function seedSettingsBackgroundStorage(
 
 async function installReadyDesktopStatusBridge(page: Page): Promise<void> {
   await page.addInitScript(() => {
+    const secureStore = new Map<string, string>();
     type Bridge = {
       request?: Record<string, (params?: unknown) => Promise<unknown>>;
       onMessage?: (
@@ -339,6 +340,24 @@ async function installReadyDesktopStatusBridge(page: Page): Promise<void> {
         desktopGetVersion: async () => ({ runtime: "playwright-smoke" }),
         desktopRegisterShortcut: async () => ({ success: true }),
         desktopSetTrayMenu: async () => undefined,
+        secureStoreGet: async ({ kind }: { kind: string }) =>
+          secureStore.has(kind)
+            ? { ok: true, value: secureStore.get(kind) }
+            : { ok: false, reason: "not_found" },
+        secureStoreSet: async ({
+          kind,
+          value,
+        }: {
+          kind: string;
+          value: string;
+        }) => {
+          secureStore.set(kind, value);
+          return { ok: true };
+        },
+        secureStoreDelete: async ({ kind }: { kind: string }) => ({
+          ok: true,
+          deleted: secureStore.delete(kind),
+        }),
         getAgentStatus: async () => readyStatus,
         launchProgress: async () => readyLaunch,
         bootProgress: async () => readyBoot,


### PR DESCRIPTION
Fixes #30391.

## What changed

- give the desktop-emulating home and settings browser fixtures an in-memory implementation of the secure-store RPC contract (`secureStoreGet`, `secureStoreSet`, and `secureStoreDelete`)
- select a launcher swipe origin with `elementFromPoint` so the real pointer lands on an unobstructed rail point rather than the build badge or a notification row
- pace the pointer steps by one frame so the browser receives a stable drag gesture

## Regression prevented

These browser tests boot the real renderer while advertising desktop RPC support. Without the secure-store methods, active-server and authentication persistence fail during boot. Separately, the fixed swipe coordinate can be covered by the build badge, so the event never reaches the launcher rail and navigation remains on Home. The existing unit coverage does not exercise the composed renderer bridge or browser hit-testing boundary.

## Exact-head evidence

Commit: `c75ebd02e2278b68cf18a34955600ed0d0782172`

- focused Chromium UI smoke: 2/2 passed
- Biome check for all three changed files: passed
- app typecheck: passed
- guide parity (`check:agents-claude`): passed
- root build: 132/132 tasks passed; 22/22 plugin view bundles built
- root `bun run verify`: passed
- required app audit: 219/219 Playwright scenarios passed; `broken=0`, `needs-work=0`; OCR triage completed successfully
