### PR TITLE
test(cloud): pin the dedicated proxy's trace echo and failed-phase timing

### DIFF
--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -489,6 +489,26 @@ describe("dedicated-agent-proxy — trace ingress", () => {
     expect(JSON.stringify(warnCalls)).not.toContain(invalidTrace);
   });
 
+  test("an invalid trace is not echoed back on the response either", async () => {
+    // The upstream request and the logs were already pinned above. The
+    // response header is the third place the caller-supplied value can escape,
+    // and it is written from a separate copy of the id in the timing recorder:
+    // dropping the validation there fails no assertion without this one.
+    const invalidTrace = "0123456789ABCDEF0123456789ABCDEF";
+    const request = makeRequest("agent-local-token", undefined, {
+      "X-Eliza-Trace-Id": invalidTrace,
+    });
+
+    const response = await handleDedicatedAgentProxy(
+      request,
+      ENV,
+      urlOf(request),
+      AGENT,
+    );
+
+    expect(response.headers.get("x-eliza-trace-id")).toBeNull();
+  });
+
   test("does not write the always-on timing log for a traced non-chat request", async () => {
     const request = makeRequest("agent-local-token", undefined, {
       "X-Eliza-Trace-Id": "0123456789abcdef0123456789abcdef",
@@ -1681,6 +1701,20 @@ describe("dedicated-agent-proxy — CORS + unroutable short-circuit (#15347)", (
     const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
     expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
     expect(captured).not.toBeNull(); // forwarded to the CP
+  });
+
+  test("a phase that throws still reports its duration", async () => {
+    // `measure` records in a `finally`, so a rejected phase is still timed.
+    // That is the case an operator most needs: without it, the one request
+    // that failed auth is also the one with no `dedicated_auth` sample.
+    authResult = "throw";
+    const r = makeRequest(undefined, ORIGIN);
+
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    const serverTiming = res.headers.get("server-timing") ?? "";
+    expect(serverTiming).toMatch(/dedicated_auth;dur=\d+(?:\.\d+)?/);
+    expect(serverTiming).toMatch(/dedicated_total;dur=\d+(?:\.\d+)?/);
   });
 });
 


### PR DESCRIPTION
# What

I approved #30390 myself in review, so I mutation-tested it again once it merged. Two mutants survive its 56 tests. Tests only — **no source change**; the code is right, the guards just aren't pinned.

## 1. Deleting the trace-id validation changes nothing

`createDedicatedProxyTiming` keeps a browser-supplied `x-eliza-trace-id` only if `isInferenceTraceId` accepts it, and `finish()` echoes it onto the response. Replacing that with `const traceId = rawTraceId;` — **no validation at all** — leaves all 56 green.

There *is* a test named `drops an invalid trace before the agent mints its replacement`. It pins two of the three places the caller's value can escape:

| escape route | pinned before |
|---|---|
| upstream request header | ✅ `requireCapturedRequest()` |
| warn logs | ✅ `JSON.stringify(warnCalls)` |
| **response header** | ❌ |

The response header is written from a **separate copy** of the id, captured in the timing recorder's closure — so stripping it upstream and stripping it from the echo are two different code paths, and only one was covered. The new test sits directly beneath the existing one so the third route lives beside the other two.

## 2. `measure`'s `finally` is unpinned

Replacing

```ts
try { return await operation(); } finally { phaseDurations.set(phase, …); }
```

with success-only recording also leaves all 56 green. But `auth` has a `catch` around it that continues into unauthenticated pass-through — so without the `finally`, **the one request that failed auth is also the one with no `dedicated_auth` sample**, which is backwards for the operator this instrumentation exists to serve.

# Evidence

| mutant | before | after |
|---|---|---|
| drop `isInferenceTraceId`, echo raw | 56 pass | **1 fail** |
| `try/finally` → success-only | 56 pass | **1 fail** |
| widen the validator to case-insensitive hex | — | **1 fail** *(bonus)* |
| never echo the trace id | 1 fail | 1 fail |
| clobber an existing `server-timing` | 1 fail | 1 fail |
| drop the `dedicated_total` metric | 1 fail | 1 fail |

The third row wasn't planned: the new response-echo test also pins the lowercase-only rule the existing invalid-trace fixture (`0123456789ABCDEF…`) quietly depends on.

**58 pass** (from 56), `biome` clean with no fixes applied, `tsc --noEmit` over `packages/cloud/api` reports nothing for this file.

# Two things I checked and closed rather than file

- **The echoed trace id is not an injection vector.** The proxy reflects caller input into a response header, and there are *two* `isInferenceTraceId` implementations — core's, and a Worker-safe stub that `wrangler.toml` aliases `@elizaos/core` to, so the stub is what actually runs in production. Both are exactly `/^[0-9a-f]{32}$/`: anchored, bounded, lowercase hex. Clean.
- **The 2317-line stub's completeness is already gated.** 169 exported names; 8 distinct names imported from `@elizaos/core` across `packages/cloud/api`; **0** missing. And `check:worker-bundle` (a real `wrangler deploy --dry-run`) is chained into that package's `typecheck`, so a missing named export fails the bundle. No gap to close.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JS58EMK8KJP6WPXQ11GY4Q","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T04:41:43.637Z","completed_at":"2026-09-03T04:46:06.379Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T04:41:44.511Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0b1f84bac7d6ad7379f46239d3464e1a23eb34478ab1290de4e0ccbdc822033d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"efd89b2c-6351-40c8-bf94-c2ae4dc9041a","object_id":"sha256:0b1f84bac7d6ad7379f46239d3464e1a23eb34478ab1290de4e0ccbdc822033d","sha256":"0b1f84bac7d6ad7379f46239d3464e1a23eb34478ab1290de4e0ccbdc822033d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"gC2ZuQpnd53zjW_mvHuQM9OBRq1vnVmytGd5jkt-67iudiqOW_K9oqpFlczpMzlIefmTJ8bHSQO9sZomJ9xwAQ"}} -->
