### PR TITLE
test(cloud): isolate each organization-lifecycle clause

### DIFF
--- a/packages/cloud/shared/src/lib/services/account-lifecycle-authority.test.ts
+++ b/packages/cloud/shared/src/lib/services/account-lifecycle-authority.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   AccountLifecycleFencedError,
+  type OrganizationLifecycleAuthority,
   organizationLifecycleAllowsNewWork,
 } from "./account-lifecycle-authority";
 
@@ -25,6 +26,30 @@ describe("organization lifecycle provider authority", () => {
       }),
     ).toBe(false);
     expect(organizationLifecycleAllowsNewWork(null)).toBe(false);
+  });
+
+  test("each clause denies on its own, not only in combination", () => {
+    // The composite fixture above flips state, active and deletionRequestId
+    // together, so any ONE of the three could be deleted from the predicate
+    // and it would still return false. Vary one field at a time against an
+    // otherwise-allowed authority so each clause is pinned by itself.
+    const allowed = {
+      state: "active",
+      revision: 7,
+      active: true,
+      deletionRequestId: null,
+    } as const satisfies OrganizationLifecycleAuthority;
+
+    expect(organizationLifecycleAllowsNewWork({ ...allowed })).toBe(true);
+
+    for (const [label, authority] of [
+      ["inactive organization", { ...allowed, active: false }],
+      ["deletion_recovery state", { ...allowed, state: "deletion_recovery" }],
+      ["deletion_irreversible state", { ...allowed, state: "deletion_irreversible" }],
+      ["deletion receipt present", { ...allowed, deletionRequestId: "request-id" }],
+    ] as const satisfies readonly (readonly [string, OrganizationLifecycleAuthority])[]) {
+      expect(organizationLifecycleAllowsNewWork(authority), label).toBe(false);
+    }
   });
 
   test("uses a non-identifying typed fence error", () => {


### PR DESCRIPTION
# What

`organizationLifecycleAllowsNewWork` fences **paid-route standing, provider admission, auto-top-up and API-key auth**. It's a four-clause conjunction, and three of the four could be deleted with every test in the repository still green.

```ts
return (
  authority !== null &&
  authority.active &&                        // ← deletable
  authority.state === "active" &&             // ← deletable
  authority.deletionRequestId === null        // ← deletable
);
```

| mutant | before |
|---|---|
| drop `authority.active` | all green |
| drop `state === "active"` | all green |
| drop `deletionRequestId === null` | all green |
| drop `authority !== null` | 1 fail |

Not thin unit coverage — I checked the later passes. Four suites touch the predicate or its consumers, and the two worst mutants leave **all 40 tests** green:

```
                                  authority   api-key   renewals
baseline                          2 pass      37 pass   1 pass
state === "active" deleted        2 pass      37 pass   1 pass
deletionRequestId check deleted   2 pass      37 pass   1 pass
```

# Why — symmetric masking, not weak assertions

The existing fixture flips all three fields **together**:

```ts
organizationLifecycleAllowsNewWork({
  state: "deletion_recovery",
  active: false,
  deletionRequestId: "request-id",
})   // → false
```

Any one clause can be gone and the composite still returns `false`. The test isn't weak; it's *structurally incapable* of isolating a clause. That's the fixable part.

# The change

One test that varies a single field at a time against an otherwise-allowed authority — inactive, `deletion_recovery`, `deletion_irreversible`, and a deletion receipt present. **Tests only; the predicate is correct.**

| mutant | after |
|---|---|
| drop `authority.active` | **1 fail** |
| drop `state === "active"` | **1 fail** |
| drop `deletionRequestId === null` | **1 fail** |
| drop `authority !== null` | **1 fail** |
| widen to `state !== "deletion_recovery"` | **1 fail** *(bonus)* |

The last row is a check on my own work: widening the state test still fails, which proves `deletion_irreversible` is genuinely excluded rather than merely absent from the fixtures.

Suite 3 pass, `biome` clean with no fixes applied. One note on evidence: `packages/cloud/shared`'s tsconfig excludes `**/*.test.ts`, so `tsc` doesn't cover this file and I'm not presenting a typecheck as proof for it.

# Two things I checked and closed rather than file

- **The swallowed-failure sentinel shape isn't systemic.** Every other `return { ok: false, … }` in `cloud/scripts/admin` and `cloud/shared` carries a reason or code; the bare `{ ok: false, output: "" }` in the mesh diagnostic was the only one, and #30398 already fixes it.
- **`decodeRequestJson`'s contract holds at all 93 call sites**, with zero missing `.ok` checks — and the reason is the typechecker, not discipline: `RequestJsonDecodeResult` is a discriminated union, so reading `.value` without narrowing is a compile error. A guard test would duplicate `tsc`.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JTVPZMH89GR7ESKVTDMP6H","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T05:11:27.988Z","completed_at":"2026-09-03T05:15:12.513Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T05:11:28.815Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a8cc63d4143d9b9ba8f018d209949018cc808b26250f73d78ebfe096870e0482","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9bf95433-3038-409f-acc7-afcce0898a85","object_id":"sha256:a8cc63d4143d9b9ba8f018d209949018cc808b26250f73d78ebfe096870e0482","sha256":"a8cc63d4143d9b9ba8f018d209949018cc808b26250f73d78ebfe096870e0482"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"tvqgFo-UTCYwvuYp5E7WSbXhw3rAZFIsbFW3fFEPH1bsH-R13LKDdcJKSFa4z3SHpG81Ca-zbtKSE2oO7FrdAg"}} -->
