### PR TITLE
test(deploy): follow #30397's Telegram secret form in two contracts

### DIFF
--- a/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
@@ -39,15 +39,20 @@ function namedStep(name: string): WorkflowStep {
 describe("Personal Shared Telegram edge deploy contract", () => {
   const prepare = namedStep("Prepare Worker secrets for atomic deploy");
 
+  // #30397 replaced the computed `secrets[format(...)]` key with a direct
+  // reference and declared both names in `on.workflow_call.secrets`, because a
+  // computed key evaluates without the job's Environment values inside a
+  // reusable workflow and silently publishes a blank Worker secret. The
+  // caller-side prohibition is unchanged and still enforced where it belongs,
+  // in homepage-deploy-workflow.test.ts: `cloud-cf-deploy.yml` must never
+  // forward either name. What this file owns is the consuming end.
   test("sources both Telegram credentials from the protected environment", () => {
-    const token = prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN ?? "";
-    const webhookSecret = prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET ?? "";
-    expect(token).toContain("secrets[format(");
-    expect(token).toContain("'ELIZA_APP_TELEGRAM_'");
-    expect(token).toContain("'BOT_TOKEN'");
-    expect(webhookSecret).toContain("secrets[format(");
-    expect(webhookSecret).toContain("'ELIZA_APP_TELEGRAM_'");
-    expect(webhookSecret).toContain("'WEBHOOK_SECRET'");
+    for (const name of [
+      "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+    ] as const) {
+      expect(prepare.env?.[name], name).toBe(`\${{ secrets.${name} }}`);
+    }
   });
 
   test("includes both credentials in the atomic Worker version", () => {

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -106,14 +106,18 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
     const prepare = step("Prepare Worker secrets for atomic deploy");
     const verify = step("Verify required Worker secret binding names");
 
-    expect(prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toBe(
-      "$" +
-        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')] }}",
-    );
-    expect(prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toBe(
-      "$" +
-        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')] }}",
-    );
+    // #30397 replaced the computed `secrets[format(...)]` key with a direct
+    // reference: inside a reusable workflow a computed key evaluates without
+    // the job's Environment values and silently publishes a blank Worker
+    // secret. Both names are now declared in `on.workflow_call.secrets`; the
+    // caller still never forwards them, which homepage-deploy-workflow.test.ts
+    // continues to enforce.
+    for (const name of [
+      "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+    ] as const) {
+      expect(prepare.env?.[name], name).toBe("$" + `{{ secrets.${name} }}`);
+    }
     expect(prepare.run).toContain("telegram_runtime_secret_names=(");
     expect(prepare.run).toContain('[ "$DEPLOY_ENVIRONMENT" = "production" ]');
     expect(prepare.run).toContain(


### PR DESCRIPTION
# What

#30397 merged with two deploy-contract tests still asserting the computed `secrets[format(...)]` key it deliberately replaced. I raised both by path while reviewing it; they weren't carried along. On develop at `1e2d28b6f6`:

| test | on develop |
|---|---|
| `packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts` | 6 pass, **1 fail** |
| `packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts` | 1 pass, **1 fail** |

The second one matters more than the count suggests: `packages/cloud/scripts` is inside `computeTestRoots()`, so it runs in the cloud lane — and `cloud-tests.yml` is `workflow_call`-only with `develop-full.yml` (`push: [develop]`) as its sole caller. **It fails the post-merge develop gate, not any PR check.**

The decision is settled and I'm not reopening it — the direct `secrets.<NAME>` reference and the `on.workflow_call.secrets` declaration are what merged. This just carries the two tests to it.

# The change

Both now assert the adopted form, iterating the two credential names so each is pinned individually rather than by a shared substring match:

```ts
for (const name of [
  "ELIZA_APP_TELEGRAM_BOT_TOKEN",
  "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
] as const) {
  expect(prepare.env?.[name], name).toBe(`${{ secrets.${name} }}`);
}
```

**Tests only; no workflow change.**

I also wrote into both files *why* the form changed — a computed key evaluates without the job's Environment values inside a reusable workflow and silently publishes a blank Worker secret — and pointed at `homepage-deploy-workflow.test.ts` as where the caller-side prohibition is still enforced (`cloud-cf-deploy.yml` must never forward either name). That was the one thing I asked for twice while reviewing #30397 and it's cheapest to land in the files already being touched.

# Evidence

Mutated the workflow rather than trusting two green suites:

| mutant | edge | atomic | homepage |
|---|---|---|---|
| revert the bot token to the computed key | **1 fail** | **1 fail** | **1 fail** |
| point the webhook secret's value at the bot token's name | **1 fail** | **1 fail** | **1 fail** |

The second is the one that matters — it proves the assertions are per-name rather than a generic shape match.

Wider deploy-contract set at this head: `cloud-cf-atomic-worker-secrets` 7, `homepage-deploy-workflow` 19, `personal-telegram-edge` 2, `telegram-identity-deploy-contract` 3, `verify-worker-secret-binding-names` 3 — all passing. `biome` clean, no fixes applied.

Two things I'm not claiming:

- **No typecheck.** Neither `packages/scripts` nor `packages/cloud/scripts` has a `tsconfig.json`, so `tsc` covers neither file.
- **`gateway-webhook-deploy-workflow.test.ts` is 6 pass / 2 fail here, and that's not mine.** It spawns a workflow step that uses `declare -A`, which macOS bash 3.2 lacks; that workflow runs on `ubuntu-24.04`, so it's a local artifact. Unrelated to this change.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JW07EBQBC2H7GZN60JCD11","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T05:31:24.491Z","completed_at":"2026-09-03T05:33:37.401Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T05:31:25.164Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"dfac4b9062ca3aaa3cf1787f24cd92c3a400b5048464cc4f67acff490ca16fe2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"268198b2-99da-41af-9876-f5fc8c6bbcee","object_id":"sha256:dfac4b9062ca3aaa3cf1787f24cd92c3a400b5048464cc4f67acff490ca16fe2","sha256":"dfac4b9062ca3aaa3cf1787f24cd92c3a400b5048464cc4f67acff490ca16fe2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"21DuNHjVyZfcfUKVhRXLGBkUQWU0BcP8WnmTsmEtggmt1-bPewCqbBqR87Z4NBDBlCjlLA4iyP5HqidiaK4jAw"}} -->
