### PR TITLE
fix(ci): align Telegram secret deployment contracts

### DIFF
--- a/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
@@ -42,12 +42,10 @@ describe("Personal Shared Telegram edge deploy contract", () => {
   test("sources both Telegram credentials from the protected environment", () => {
     const token = prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN ?? "";
     const webhookSecret = prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET ?? "";
-    expect(token).toContain("secrets[format(");
-    expect(token).toContain("'ELIZA_APP_TELEGRAM_'");
-    expect(token).toContain("'BOT_TOKEN'");
-    expect(webhookSecret).toContain("secrets[format(");
-    expect(webhookSecret).toContain("'ELIZA_APP_TELEGRAM_'");
-    expect(webhookSecret).toContain("'WEBHOOK_SECRET'");
+    expect(token).toBe("$" + "{{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}");
+    expect(webhookSecret).toBe(
+      "$" + "{{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}",
+    );
   });
 
   test("includes both credentials in the atomic Worker version", () => {

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -107,12 +107,10 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
     const verify = step("Verify required Worker secret binding names");
 
     expect(prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toBe(
-      "$" +
-        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')] }}",
+      "$" + "{{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}",
     );
     expect(prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toBe(
-      "$" +
-        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')] }}",
+      "$" + "{{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}",
     );
     expect(prepare.run).toContain("telegram_runtime_secret_names=(");
     expect(prepare.run).toContain('[ "$DEPLOY_ENVIRONMENT" = "production" ]');


### PR DESCRIPTION
## Summary
- update the two stale deployment contract tests to require direct protected-environment Telegram secret references
- preserve the production fail-closed and atomic binding assertions
- restore the develop scenario/script lane after #30397

Closes part of #30280.

## Verification
- `bun test packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts packages/scripts/__tests__/homepage-deploy-workflow.test.ts` (28 pass)
- `bun run test:scripts` (pass)
- Biome check on both changed files (pass)
- `git diff --check` (pass)