### PR TITLE
test(cloud): isolate each clause of the opaque exchange-code shape gate

### DIFF
--- a/packages/cloud/api/__tests__/sso-bridge.test.ts
+++ b/packages/cloud/api/__tests__/sso-bridge.test.ts
@@ -413,12 +413,35 @@ describe("code lifecycle", () => {
   });
 
   test("malformed / missing codes are rejected before any store lookup", async () => {
-    for (const code of [undefined, "", "short", `eac_${"0".repeat(64)}`, 42]) {
+    // One case per clause of `looksLikeSsoBridgeCode`, so no fixture masks
+    // another: the prefix check and the 64-lowercase-hex check each get a case
+    // that ONLY that clause rejects. The distinction being pinned is the status
+    // pair — a shape rejection never reaches the store and answers
+    // 400/`missing_code`, while a well-formed code the store does not know
+    // answers 401/`invalid_code` (the test below). Widening the shape gate
+    // collapses one into the other, and only these fixtures notice.
+    for (const [label, code] of [
+      ["missing", undefined],
+      ["empty", ""],
+      ["too short for any shape", "short"],
+      ["non-string", 42],
+      ["right length, wrong prefix", `eac_${"0".repeat(64)}`],
+      // `esqa_` and `esso_` are both five characters, so the prefix clause is
+      // the only thing keeping a QA staging-session code out of this endpoint.
+      ["staging-session code, not a bridge code", `esqa_${"0".repeat(64)}`],
+      ["right prefix, non-hex body", `esso_${"g".repeat(64)}`],
+      ["right prefix, uppercase-hex body", `esso_${"A".repeat(64)}`],
+      ["right prefix, 63-hex body", `esso_${"0".repeat(63)}`],
+      ["right prefix, 65-hex body", `esso_${"0".repeat(65)}`],
+    ] as const) {
       const res = await call("/exchange", {
         origin: "https://cloud.eliza.app",
         body: { code },
       });
-      expect(res.status).toBe(400);
+      expect(res.status, label).toBe(400);
+      expect(((await res.json()) as { code: string }).code, label).toBe(
+        "missing_code",
+      );
     }
   });
 

--- a/packages/cloud/api/__tests__/staging-session-exchange.test.ts
+++ b/packages/cloud/api/__tests__/staging-session-exchange.test.ts
@@ -1394,6 +1394,40 @@ describe("rollback and legacy downgrade isolation", () => {
     expect((await exchange(code, verifier)).status).toBe(200);
   });
 
+  test("the QA exchange cannot recognize a legacy SSO code either", async () => {
+    // The mirror of the test above. `esso_` and `esqa_` are both five
+    // characters, so the prefix clause of `looksLikeStagingSessionCode` is the
+    // only thing separating the two families; without it a legacy bridge code
+    // would reach the versioned store and come back as 401/`invalid_code`
+    // instead of being refused on shape.
+    const response = await exchange(`esso_${"0".repeat(64)}`, null);
+    expect(response.status).toBe(400);
+    expect(((await response.json()) as { code: string }).code).toBe(
+      "missing_code",
+    );
+  });
+
+  test("each clause of the QA code shape refuses on its own", async () => {
+    // One case per clause, so no fixture masks another, and each asserts the
+    // 400/`missing_code` that says the store was never consulted — an unknown
+    // but well-formed `esqa_` code answers 401/`invalid_code` instead.
+    for (const [label, code] of [
+      ["empty", ""],
+      ["too short for any shape", "short"],
+      ["right length, wrong prefix", `eac__${"0".repeat(64)}`],
+      ["right prefix, non-hex body", `esqa_${"g".repeat(64)}`],
+      ["right prefix, uppercase-hex body", `esqa_${"A".repeat(64)}`],
+      ["right prefix, 63-hex body", `esqa_${"0".repeat(63)}`],
+      ["right prefix, 65-hex body", `esqa_${"0".repeat(65)}`],
+    ] as const) {
+      const response = await exchange(code, null);
+      expect(response.status, label).toBe(400);
+      expect(((await response.json()) as { code: string }).code, label).toBe(
+        "missing_code",
+      );
+    }
+  });
+
   test("bearer refresh refuses the non-renewable QA session", async () => {
     const token = await mintDerivedToken();
     const before = decodeJwt(token);


### PR DESCRIPTION
# What

The two opaque exchange endpoints decide **400 `missing_code` vs. 401 `invalid_code`** on a shape gate, and almost none of that gate is pinned.

`looksLikeSsoBridgeCode` and `looksLikeStagingSessionCode` are the same three clauses:

```ts
typeof value === "string" &&
value.startsWith(PREFIX) &&
HEX_64_RE.test(value.slice(PREFIX.length))
```

A code that fails them never reaches the atomic `DELETE … RETURNING` claim and answers **400 `missing_code`**. A code that passes but no store knows answers **401 `invalid_code`**. That difference is the observable contract, and widening the gate collapses one into the other.

I ran eight clause-level mutants across the two guards. **Seven survived.**

| mutant | before |
|---|---|
| bridge: drop `startsWith(SSO_BRIDGE_CODE_PREFIX)` | killed |
| bridge: drop the hex clause | **survived** |
| bridge: `HEX_64_RE` accepts uppercase | **survived** |
| bridge: `HEX_64_RE` accepts length 1–80 | **survived** |
| QA: drop `startsWith(STAGING_SESSION_CODE_PREFIX)` | **survived** |
| QA: drop the hex clause | **survived** |
| QA: `HEX_64_RE` accepts uppercase | **survived** |
| QA: `HEX_64_RE` accepts length 1–80 | **survived** |

# Why the existing tests miss it

Two different masking shapes, one per suite.

**The bridge suite had a fixture list, not a clause list.** `malformed / missing codes are rejected before any store lookup` loops over `[undefined, "", "short", `eac_${"0".repeat(64)}`, 42]`. The `eac_` case is a *wrong prefix with a correct body*, so it isolates the prefix clause — which is exactly why that one mutant died. There is no case with a *correct prefix and a wrong body*, so the hex clause is free to be anything.

**The QA suite pinned one direction of a two-way separation.** `old SSO exchange cannot recognize or burn a versioned QA code` proves the legacy bridge refuses an `esqa_` code. The mirror — the QA exchange refusing an `esso_` code — was never written. `esso_` and `esqa_` are both five characters, so the prefix clause is the *only* thing separating the two code families, and it was unpinned in the direction that matters for the newer endpoint.

# The change

Tests only, +59/-2 across the two existing suites.

- **Bridge**: extend the fixture list to one case per clause — a staging-session code (same length, wrong prefix), a non-hex body, an uppercase-hex body, a 63-hex body, a 65-hex body — and assert the `missing_code` error code, not just the 400. Each fixture is labeled so a failure names itself.
- **QA**: add the missing mirror (`the QA exchange cannot recognize a legacy SSO code either`) next to the test it mirrors, plus a per-clause loop of its own.

# Deliberately not included

`looksLikeOidcCode` and `looksLikeOidcRequestId` in `shared/src/lib/oidc/codes.ts` are the same shape and their clauses survive mutation too — but I could not find an observable difference, so pinning them would be pinning an implementation detail:

- `looksLikeOidcCode` is reachable only from `consumeOidcAuthorizationCode`, where a malformed code and an unknown code both return `null` and the token endpoint collapses both to the same `invalid_grant`. That collapse is deliberate and already tested.
- `looksLikeOidcRequestId` decides `named` in `authorize/route.ts`, which only controls whether a binding cookie that cannot exist is deleted. `resumeOidcAuthorizationRequest` returns `null` either way and the browser sees the same `Sign-in request expired` page.

Both are genuinely "unpinned but same outcome", which is not a gap. Recording it so the next sweep does not re-litigate it.

# Evidence

Baseline for the five suites that touch any of the four guards — `oidc-provider` (131), `sso-bridge` (17), `staging-session-exchange` (55), `db/repositories/oidc` (14), `oidc/request-binding` (8) — **225 pass / 0 fail**.

After the change, `bun test __tests__/sso-bridge.test.ts __tests__/staging-session-exchange.test.ts` → **74 pass / 0 fail** (was 72).

Re-ran every mutant against the new suites:

| mutant | after |
|---|---|
| bridge: drop prefix clause | 2 fail |
| bridge: drop hex clause | 1 fail |
| bridge: hex accepts uppercase | 1 fail |
| bridge: hex accepts length 1–80 | 1 fail |
| QA: drop prefix clause | 2 fail |
| QA: drop hex clause | 1 fail |
| QA: hex accepts uppercase | 1 fail |
| QA: hex accepts length 1–80 | 1 fail |

**8 / 8 killed**, baseline restored green between each.

`bunx @biomejs/biome check` on both files → no fixes applied. `bunx tsc --noEmit` in `packages/cloud/api` → exit 0.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1JWJSY641TCPTV85DX2A6KT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T05:41:33.254Z","completed_at":"2026-09-03T05:51:50.561Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T05:41:34.103Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"41b294497960cb0deca4abd796c527a923080ec1374862d9e57d87a0c0cfa426","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1318e0ce-6154-401e-9b1a-1160d4efc7ff","object_id":"sha256:41b294497960cb0deca4abd796c527a923080ec1374862d9e57d87a0c0cfa426","sha256":"41b294497960cb0deca4abd796c527a923080ec1374862d9e57d87a0c0cfa426"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"dmdfZl0IFx98aI3v5tN1Z4AvVhPQCI_9Y7H9T6zJcF9LKlqw94WXa2Z3E0pxXD6NSIrv7aA0bjjdEdyhSXhfCQ"}} -->
