### PR TITLE
fix(deploy): restore production Telegram Worker secrets

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -52,11 +52,11 @@ on:
         required: false
         type: string
         default: ""
-    # Keep caller-scope secrets explicit. Telegram's authority receipt and
-    # live credentials are intentionally absent from both this callable schema
-    # and the caller map. The entry workflow proves the environment-specific
-    # runtime authority; deploy-api resolves fixed credential names only from
-    # its own protected Environment context for atomic Worker publication.
+    # Keep caller-scope secrets explicit. Telegram's live credentials are
+    # declared so the workflow can reference their fixed names, but the caller
+    # deliberately does not forward them. The entry workflow proves the
+    # environment-specific runtime authority; deploy-api resolves the values
+    # from its own protected Environment for atomic Worker publication.
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -91,6 +91,10 @@ on:
       ELIZA_APP_BLOOIO_PHONE_NUMBER:
         required: false
       ELIZA_APP_BLOOIO_WEBHOOK_SECRET:
+        required: false
+      ELIZA_APP_TELEGRAM_BOT_TOKEN:
+        required: false
+      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET:
         required: false
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET:
         required: false
@@ -1400,11 +1404,12 @@ jobs:
           # The edge Telegram route needs both values in the Worker. They are
           # required and replaced atomically with the exact attested source;
           # activation is still a separate protected, live-proven rollout.
-          # These fixed names are resolved in this job's protected Environment,
-          # never forwarded through workflow_call. The format expression keeps
-          # actionlint from treating them as caller-provided reusable secrets.
-          ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')] }}
-          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')] }}
+          # These fixed names are resolved directly in this job's protected
+          # Environment and are never forwarded through workflow_call. A
+          # computed secrets[] key is evaluated without these Environment
+          # values in a reusable workflow and silently becomes blank.
+          ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+          ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
           # Personal Shared Blooio is the public-number messaging surface in
           # both protected environments. Commit the environment-specific
           # values atomically with the exact Worker source below.

--- a/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
+++ b/packages/cloud/scripts/__tests__/personal-telegram-edge-deploy-contract.test.ts
@@ -42,12 +42,10 @@ describe("Personal Shared Telegram edge deploy contract", () => {
   test("sources both Telegram credentials from the protected environment", () => {
     const token = prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN ?? "";
     const webhookSecret = prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET ?? "";
-    expect(token).toContain("secrets[format(");
-    expect(token).toContain("'ELIZA_APP_TELEGRAM_'");
-    expect(token).toContain("'BOT_TOKEN'");
-    expect(webhookSecret).toContain("secrets[format(");
-    expect(webhookSecret).toContain("'ELIZA_APP_TELEGRAM_'");
-    expect(webhookSecret).toContain("'WEBHOOK_SECRET'");
+    expect(token).toBe("$" + "{{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}");
+    expect(webhookSecret).toBe(
+      "$" + "{{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}",
+    );
   });
 
   test("includes both credentials in the atomic Worker version", () => {

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -107,12 +107,10 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
     const verify = step("Verify required Worker secret binding names");
 
     expect(prepare.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toBe(
-      "$" +
-        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')] }}",
+      "$" + "{{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}",
     );
     expect(prepare.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toBe(
-      "$" +
-        "{{ secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')] }}",
+      "$" + "{{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}",
     );
     expect(prepare.run).toContain("telegram_runtime_secret_names=(");
     expect(prepare.run).toContain('[ "$DEPLOY_ENVIRONMENT" = "production" ]');

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -487,6 +487,10 @@ describe("homepage deployment workflow", () => {
       "ELIZA_APP_TELEGRAM_BOT_TOKEN",
       "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
     ] as const;
+    const reusableEnvironmentSecrets = [
+      "ELIZA_APP_TELEGRAM_BOT_TOKEN",
+      "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
+    ] as const;
     const referencedSecrets = [
       ...releaseWorkflow.matchAll(/\bsecrets\.([A-Z0-9_]+)/g),
     ]
@@ -511,7 +515,9 @@ describe("homepage deployment workflow", () => {
       Object.keys(
         parsedReleaseWorkflow.on?.workflow_call?.secrets ?? {},
       ).sort(),
-    ).toEqual(expectedCallerSecrets);
+    ).toEqual(
+      [...expectedCallerSecrets, ...reusableEnvironmentSecrets].sort(),
+    );
     for (const name of expectedCallerSecrets) {
       expect(callerSecretMap[name], name).toBe(
         githubExpression(`secrets.${name}`),
@@ -523,18 +529,18 @@ describe("homepage deployment workflow", () => {
     }
     for (const name of environmentOnlySecrets) {
       expect(callerSecretMap).not.toHaveProperty(name);
+    }
+    expect(parsedReleaseWorkflow.on?.workflow_call?.secrets).not.toHaveProperty(
+      "TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+    );
+    for (const name of reusableEnvironmentSecrets) {
       expect(
-        parsedReleaseWorkflow.on?.workflow_call?.secrets,
-      ).not.toHaveProperty(name);
+        parsedReleaseWorkflow.on?.workflow_call?.secrets?.[name],
+        name,
+      ).toEqual({ required: false });
     }
     expect(releaseWorkflow).not.toContain(
       "secrets.TELEGRAM_IDENTITY_AUTHORITY_SHA256",
-    );
-    expect(releaseWorkflow).not.toContain(
-      "secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN",
-    );
-    expect(releaseWorkflow).not.toContain(
-      "secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET",
     );
 
     const apiDeploy = parsedReleaseWorkflow.jobs?.["deploy-api"];
@@ -546,14 +552,10 @@ describe("homepage deployment workflow", () => {
       githubExpression("inputs.target_environment"),
     );
     expect(secretPreparation.env?.ELIZA_APP_TELEGRAM_BOT_TOKEN).toBe(
-      githubExpression(
-        "secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'BOT_TOKEN')]",
-      ),
+      githubExpression("secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN"),
     );
     expect(secretPreparation.env?.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET).toBe(
-      githubExpression(
-        "secrets[format('{0}{1}', 'ELIZA_APP_TELEGRAM_', 'WEBHOOK_SECRET')]",
-      ),
+      githubExpression("secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET"),
     );
   });
 


### PR DESCRIPTION
## Summary

- read Telegram Worker secrets directly from the protected deployment environment inside the reusable workflow
- keep the callable secret schema optional while callers intentionally rely on environment-owned values
- update all deployment contract tests to enforce the working secret path

## Verification

- focused deployment contracts: 28/28 passed
- workflow trigger audit passed
- actionlint passed for cloud-cf-release.yml
- full repository verify: 376/376 tasks passed

This is the production backport of the already-merged develop repair. It addresses the production deployment failure tracked in #30280.