### PR TITLE
test(cloud): pin the outbound standing moderation threshold

### DIFF
--- a/packages/cloud/shared/src/lib/services/outbound-message-standing.test.ts
+++ b/packages/cloud/shared/src/lib/services/outbound-message-standing.test.ts
@@ -122,7 +122,53 @@ const deniedStandingCases = [
     rows: [{ ...activeStandingRow, moderationStatus: "banned" }],
     reason: "moderation_blocked",
   },
+  {
+    // The moderation clause is a disjunction, and only its `banned` arm was
+    // covered: a row with a clean status and the violation count at the
+    // threshold is the only fixture that fails when the count is compared
+    // against a different number, or when that half of the clause is deleted
+    // outright.
+    name: "violation count at the threshold without a ban",
+    rows: [{ ...activeStandingRow, moderationStatus: "clean", moderationViolations: 5 }],
+    reason: "moderation_blocked",
+  },
 ] as const;
+
+const allowedModerationCases = [
+  // Below the threshold, and absent. Together with the denial row above these
+  // fix the comparison from both sides: without them the threshold can be
+  // lowered, and the `?? 0` default can be replaced by any blocking number,
+  // with nothing to notice.
+  { name: "one violation below the threshold", moderationViolations: 4 },
+  { name: "no recorded violation count", moderationViolations: null },
+] as const;
+
+for (const scenario of allowedModerationCases) {
+  test(`authoritative standing allows ${scenario.name}`, async () => {
+    cacheRead.mockResolvedValueOnce({ kind: "miss", backend: "cloudflare-kv" });
+    selectLimit.mockResolvedValueOnce([
+      {
+        ...activeStandingRow,
+        moderationStatus: "clean",
+        moderationViolations: scenario.moderationViolations,
+      },
+    ]);
+    const deferred: Promise<unknown>[] = [];
+
+    await expect(
+      resolveOutboundMessageStanding("org-1", "user-1", {
+        defer: (promise) => deferred.push(promise),
+      }),
+    ).resolves.toEqual({ allowed: true, source: "authoritative" });
+    expect(cacheWrite).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ decision: "allowed" }),
+      expect.any(Number),
+      expect.any(Object),
+    );
+    await Promise.all(deferred);
+  });
+}
 
 for (const scenario of deniedStandingCases) {
   test(`authoritative standing denies ${scenario.name}`, async () => {


### PR DESCRIPTION
# What

#30400 merged with the moderation clause still half-tested. It is a disjunction:

```ts
else if (standing.moderationStatus === "banned" || (standing.moderationViolations ?? 0) >= 5)
  reason = "moderation_blocked";
```

`deniedStandingCases` covers the `banned` arm and nothing else, so **every mutant of the other arm survives** — checked against all four suites that reach this guard (`outbound-message-standing`, `message-router`, `skills.money-guard`, and `cloud/api`'s `paid-route-standing`):

| mutant | before |
|---|---|
| `>= 5` → `>= 6` | survives |
| `>= 5` → `>= 4` | survives |
| `>= 5` → `> 5` | survives |
| delete the violations half (`banned` only) | survives |
| `?? 0` → `?? 99` | survives |
| delete the `banned` half (violations only) | **killed** |

The last row is the tell: one arm of the disjunction is pinned and the other is invisible. A `banned` fixture satisfies the clause on its own, so nothing it asserts depends on the comparison being there, being `>=`, or being `5`.

The `?? 0` survivor is the one I'd least want to keep. `moderationViolations` comes from a left join (`userModerationStatus.totalViolations`), so it is genuinely `null` for a user with no moderation record — the overwhelmingly common case. Replacing that default with any number ≥ 5 denies every clean user, and today no test notices.

# The change

Tests only, +46/-0, into the existing table.

One denial row — clean status, count at the threshold — which is the only fixture that can distinguish the comparison from its absence:

```ts
{
  name: "violation count at the threshold without a ban",
  rows: [{ ...activeStandingRow, moderationStatus: "clean", moderationViolations: 5 }],
  reason: "moderation_blocked",
},
```

And two allowed rows, in a small sibling loop, so the comparison is fixed from *below* as well — a denial-only table can always be satisfied by lowering the threshold:

```ts
{ name: "one violation below the threshold", moderationViolations: 4 },
{ name: "no recorded violation count",       moderationViolations: null },
```

`4` is what makes `>= 4` fail; `null` is what makes `?? 99` fail. Neither is reachable from the denial table, which is why they are a separate case rather than more rows in it.

# Evidence

Baseline on `3ce7195c8b`: `outbound-message-standing` 7 pass, `message-router` 19, `skills.money-guard` 7, `paid-route-standing` 8 — all clean, run file-by-file.

After: `outbound-message-standing` **10 pass / 0 fail**; the other three unchanged.

Every mutant re-run against all four suites:

| mutant | after |
|---|---|
| `>= 5` → `>= 6` | **1 failed** |
| `>= 5` → `>= 4` | **1 failed** |
| `>= 5` → `> 5` | **1 failed** |
| delete the violations half | **1 failed** |
| delete the `banned` half | **1 failed** |
| `?? 0` → `?? 99` | **1 failed** |

**6 / 6 killed**, up from 1 / 6, with the baseline restored green between each. No failure leaks into the other three suites, so the new fixtures are doing the work rather than a shared mock.

`bunx @biomejs/biome check` → no fixes applied. `bunx tsc --noEmit` in `packages/cloud/shared` → exit 0.

# Context

Raised during my review of #30400 and offered there as an optional follow-up rather than a blocking ask, since the PR's own subject was elsewhere. It merged without it, so I am sending it myself.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1K0KFB8G6JDV84FZF493MJN","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T06:51:49.480Z","completed_at":"2026-09-03T06:54:48.091Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T06:51:50.534Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"602017d1bee28a70cea983e9de16d3bfaf01b5065ac0c35c4115b3ca5df879ea","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"68611ea0-0d37-4edc-a34c-1161afb6d043","object_id":"sha256:602017d1bee28a70cea983e9de16d3bfaf01b5065ac0c35c4115b3ca5df879ea","sha256":"602017d1bee28a70cea983e9de16d3bfaf01b5065ac0c35c4115b3ca5df879ea"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"WM02ytLBAtO3It0tlteuQ9eXe3mlmq15mjdT1cPH3_TVeQ7fF151DljPWUZHLVd0_4fIGXL14ytHEe2qpOgJCA"}} -->
