### PR TITLE
fix(cloud): align auth certification trace ids

### DIFF
--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -32,8 +32,7 @@ const CEREBRAS_BASE_URL = "https://api.cerebras.ai";
 const STAGING_WORKER = "eliza-cloud-api-staging";
 const EXPECTED_PAIRED_RECORDS = 44;
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
 
 function sleep(durationMs) {
   return new Promise((resolvePromise) =>
@@ -256,7 +255,7 @@ export function validateAuthEvidence(text, deploySha, runSuspended = false) {
   if (
     traceIds.length !== (runSuspended ? 43 : 42) ||
     new Set(traceIds).size !== traceIds.length ||
-    traceIds.some((traceId) => !UUID_PATTERN.test(traceId))
+    traceIds.some((traceId) => !TRACE_ID_PATTERN.test(traceId))
   ) {
     throw new Error("Inference auth evidence has invalid trace correlation");
   }

--- a/packages/cloud/scripts/cloud-latency-certification.test.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.test.mjs
@@ -36,7 +36,7 @@ function pairedRecord(index, overrides = {}) {
 
 function authTrace(index) {
   const suffix = index.toString(16).padStart(12, "0");
-  return `11111111-1111-4111-8111-${suffix}`;
+  return `11111111111141118111${suffix}`;
 }
 
 function authEvidence(runSuspended = false) {

--- a/packages/cloud/scripts/inference-auth-latency.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.mjs
@@ -5,7 +5,7 @@
  * placement, trace ids, and deployment provenance.
  */
 
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 const AUTH_TRACE_HEADER = "x-eliza-auth-trace";
@@ -94,8 +94,7 @@ const TAIL_OUTCOMES = new Set([
   "unknown",
 ]);
 
-const OPAQUE_TRACE_ID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
 
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -135,10 +134,10 @@ export function sanitizeInferenceAuthTelemetry(value) {
       "Worker auth log does not match the bounded telemetry schema",
     );
   }
-  if (!OPAQUE_TRACE_ID.test(value.traceId)) {
+  if (!TRACE_ID_PATTERN.test(value.traceId)) {
     throw new Error("Worker auth log has an invalid trace id");
   }
-  const telemetry = { v: 1, traceId: value.traceId.toLowerCase() };
+  const telemetry = { v: 1, traceId: value.traceId };
   for (const [name, allowed] of Object.entries(AUTH_TELEMETRY_ENUMS)) {
     if (!allowed.has(value[name])) {
       throw new Error(
@@ -182,7 +181,7 @@ function sanitizeInferenceAuthCacheWriteTelemetry(value) {
       "Worker auth cache-write log does not match the bounded telemetry schema",
     );
   }
-  if (!OPAQUE_TRACE_ID.test(value.traceId)) {
+  if (!TRACE_ID_PATTERN.test(value.traceId)) {
     throw new Error("Worker auth cache-write log has an invalid trace id");
   }
   if (!AUTH_ENUMS.backend.has(value.cacheBackend)) {
@@ -279,10 +278,13 @@ export function sanitizeInferenceAuthTail(
       const rawTraceId = isRecord(rawTelemetry)
         ? rawTelemetry.traceId
         : undefined;
-      if (typeof rawTraceId !== "string" || !OPAQUE_TRACE_ID.test(rawTraceId)) {
+      if (
+        typeof rawTraceId !== "string" ||
+        !TRACE_ID_PATTERN.test(rawTraceId)
+      ) {
         continue;
       }
-      const traceId = rawTraceId.toLowerCase();
+      const traceId = rawTraceId;
       // A Tail session can observe unrelated traffic on the isolated hostname.
       // Correlate on the one opaque field before validating or retaining any
       // other part of the raw object, then fail closed on the complete schema.
@@ -537,7 +539,7 @@ export async function probeAuthSample({
   fetchImpl = fetch,
   now = performance.now.bind(performance),
 }) {
-  const traceId = randomUUID();
+  const traceId = randomBytes(16).toString("hex");
   const headers = {
     "Content-Type": "application/json",
     "User-Agent": "eliza-inference-auth-latency/1.0",
@@ -729,7 +731,7 @@ export async function probeAuthGuardSample({
   ) {
     throw new Error("Unknown auth guard probe");
   }
-  const traceId = randomUUID();
+  const traceId = randomBytes(16).toString("hex");
   const headers = {
     "Content-Type": "application/json",
     "User-Agent": "eliza-inference-auth-latency/1.0",

--- a/packages/cloud/scripts/inference-auth-latency.test.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.test.mjs
@@ -175,7 +175,7 @@ test("auth parsers accept only bounded enums and finite auth durations", () => {
 });
 
 test("Worker Tail sanitizer retains only correlated bounded telemetry", () => {
-  const traceId = "0190f2f1-8b5a-7000-8000-000000000001";
+  const traceId = "0190f2f18b5a70008000000000000001";
   const telemetry = {
     v: 1,
     traceId,
@@ -218,7 +218,7 @@ test("Worker Tail sanitizer retains only correlated bounded telemetry", () => {
               "[InferenceAuth] trace",
               {
                 ...telemetry,
-                traceId: "0190f2f1-8b5a-7000-8000-000000000099",
+                traceId: "0190f2f18b5a70008000000000000099",
                 result: "unbounded-private-result",
                 userId: "private-user",
               },
@@ -274,11 +274,7 @@ test("Worker Tail sanitizer retains only correlated bounded telemetry", () => {
   );
   assert.throws(
     () =>
-      sanitizeInferenceAuthTail(
-        raw,
-        ["0190f2f1-8b5a-7000-8000-000000000002"],
-        SHA,
-      ),
+      sanitizeInferenceAuthTail(raw, ["0190f2f18b5a70008000000000000002"], SHA),
     /omitted 1/,
   );
 });
@@ -287,6 +283,7 @@ test("live sample retains timings and correlation but no credential, probe token
   const apiKey = "eliza_private_api_key_material";
   const probeToken = "private_probe_control_token";
   let sentProbeHeader = "";
+  let sentTraceId = "";
   let sentBody = "";
   const record = await probeAuthSample({
     baseUrl: "https://preview.example",
@@ -302,6 +299,7 @@ test("live sample retains timings and correlation but no credential, probe token
     })(),
     fetchImpl: async (_url, init) => {
       sentProbeHeader = init.headers["X-Eliza-Auth-Probe"];
+      sentTraceId = init.headers["X-Eliza-Trace-Id"];
       sentBody = init.body;
       return new Response(null, {
         status: 400,
@@ -317,6 +315,7 @@ test("live sample retains timings and correlation but no credential, probe token
   });
 
   assert.match(sentProbeHeader, /^private_probe_control_token:[0-9a-f]{32}$/);
+  assert.match(sentTraceId, /^[0-9a-f]{32}$/);
   assert.equal(sentBody, "{}");
   assert.equal(record.phase, "miss");
   assert.equal(record.totalMs, 12);
@@ -522,6 +521,7 @@ test("guard probes retain 401 taxonomy and reject forged probe controls", async 
   });
   assert.equal(invalid.status, 401);
   assert.equal(invalid.auth.result, "rejected");
+  assert.match(invalid.traceId, /^[0-9a-f]{32}$/);
 
   const suspended = await probeAuthGuardSample({
     baseUrl: "https://preview.example",
@@ -534,6 +534,7 @@ test("guard probes retain 401 taxonomy and reject forged probe controls", async 
   });
   assert.equal(suspended.status, 403);
   assert.equal(suspended.auth.result, "suspended");
+  assert.match(suspended.traceId, /^[0-9a-f]{32}$/);
   assert.equal(
     JSON.stringify(suspended).includes("private_probe_control_token"),
     false,


### PR DESCRIPTION
Closes #30412

## What changed

- mint the same 32-lowercase-hex trace IDs accepted by Cloud ingress for auth samples and guard probes
- validate that canonical shape in Tail sanitization and retained certification evidence
- add regression assertions for generated sample and guard traces

## Root cause and scope

Run 33726042851 completed the 44-call paired Cerebras/gateway matrix. Its first auth Tail-readiness request then used a dashed UUID; Cloud ingress correctly rejected that caller trace shape and reminted it, so the certification-only equality assertion failed. Product auth, standing, and model dispatch remained healthy.

## Verification

- `node --test packages/cloud/scripts/inference-auth-latency.test.mjs packages/cloud/scripts/cloud-latency-certification.test.mjs` (19/19)
- Biome check on all four changed script/test files
- `git diff --check`