### PR TITLE
fix(cloud): keep inference admission at the edge

### DIFF
--- a/packages/cloud/api/__tests__/edge-api-worker-placement-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/edge-api-worker-placement-wrangler.test.ts
@@ -1,0 +1,23 @@
+/** Pins caller-local placement for the mixed stateful edge/API Worker. */
+
+import { describe, expect, test } from "bun:test";
+
+type PlacementConfig = { placement?: { mode?: string } };
+type WorkerConfig = PlacementConfig & {
+  env?: { staging?: PlacementConfig; production?: PlacementConfig };
+};
+
+describe("edge/API Worker placement", () => {
+  test("declares no Smart Placement in any environment", async () => {
+    const config = Bun.TOML.parse(
+      await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
+    ) as WorkerConfig;
+    for (const [label, scope] of [
+      ["top level", config],
+      ["staging", config.env?.staging],
+      ["production", config.env?.production],
+    ] as const) {
+      expect(scope?.placement, label).toBeUndefined();
+    }
+  });
+});

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -504,12 +504,12 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 name = "eliza-cloud-api-staging"
 workers_dev = false
 
-# Smart Placement soak (#15513): run this Worker near the origins it fetches
-# (api.cerebras.ai / api.openai.com) instead of near the caller — the measured
-# Worker->origin hop is ~500ms of every inference call's TTFT. Staging-only
-# until the before/after ttfb comparison on api-staging holds; production
-# follows in its own change.
-placement = { mode = "smart" }
+# Keep this edge/API Worker in Cloudflare's default caller-local placement.
+# Inference performs authentication and serial Durable Object admission before
+# provider dispatch; moving the whole fetch handler near an inferred HTTP
+# origin adds a cross-region round trip to every stateful phase. If a backend
+# needs placement, split it behind an unplaced edge Worker and certify that
+# boundary independently before changing this contract.
 routes = [
   # Canonical browser hosts belong to the eliza-app Pages project. Pages
   # Functions proxy /api and auth protocol paths to this Worker.
@@ -821,14 +821,12 @@ simple = { limit = 120, period = 60 }
 [env.production]
 name = "eliza-cloud-api-prod"
 
-# Smart Placement (#15513, prod leg): staging soak showed mode=smart applied
-# cleanly but staging traffic is too thin for Cloudflare's placement analyzer
-# to ever qualify it — prod volume is what it learns from. Fail-safe by
-# design: CF only moves execution when its analysis concludes it improves
-# performance (back-end-heavy requests to api.cerebras.ai / api.openai.com /
-# Hyperdrive); otherwise requests keep default placement. Rollback = delete
-# this line + redeploy.
-placement = { mode = "smart" }
+# Keep this edge/API Worker in Cloudflare's default caller-local placement.
+# Inference performs authentication and serial Durable Object admission before
+# provider dispatch; moving the whole fetch handler near an inferred HTTP
+# origin adds a cross-region round trip to every stateful phase. If a backend
+# needs placement, split it behind an unplaced edge Worker and certify that
+# boundary independently before changing this contract.
 workers_dev = false
 # Canonical routes serve the API and UUID agents. The cloud.eliza.app browser
 # host belongs to Pages; legacy routes remain redirect ingress during the

--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -22,6 +22,7 @@ import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 
 import {
+  isCloudflarePlacement,
   sanitizeInferenceAuthTail,
   summarizeDeferredCacheWrites,
   waitForInferenceAuthTail,
@@ -164,6 +165,25 @@ export function validatePairedEvidence(text, deploySha) {
     if (record.ci?.sha !== deploySha) {
       throw new Error(
         "Paired latency evidence is not bound to the dispatch SHA",
+      );
+    }
+    const placement = record.headers?.["cf-placement"];
+    if (
+      record.target === "gateway" &&
+      placement !== undefined &&
+      !isCloudflarePlacement(placement)
+    ) {
+      throw new Error(
+        "Gateway latency evidence contains an invalid Worker placement",
+      );
+    }
+    if (
+      record.target === "gateway" &&
+      typeof placement === "string" &&
+      placement.startsWith("remote-")
+    ) {
+      throw new Error(
+        "Gateway latency evidence observed remote Worker placement",
       );
     }
   }

--- a/packages/cloud/scripts/cloud-latency-certification.test.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.test.mjs
@@ -30,6 +30,7 @@ function pairedRecord(index, overrides = {}) {
     transportOk: true,
     proofMatched: true,
     ci: { sha: SHA },
+    headers: index % 2 === 0 ? {} : { "cf-placement": "local-ORD" },
     ...overrides,
   };
 }
@@ -234,6 +235,54 @@ test("paired certification requires exactly 44 balanced successful proofs", () =
     () => validatePairedEvidence(jsonl(records.slice(1)), SHA),
     /44 records/,
   );
+  assert.throws(
+    () =>
+      validatePairedEvidence(
+        jsonl(
+          records.map((record, index) =>
+            index === 1
+              ? { ...record, headers: { "cf-placement": "remote-FRA" } }
+              : record,
+          ),
+        ),
+        SHA,
+      ),
+    /remote Worker placement/,
+  );
+  assert.doesNotThrow(() =>
+    validatePairedEvidence(
+      jsonl(
+        records.map((record) =>
+          record.target === "gateway" ? { ...record, headers: {} } : record,
+        ),
+      ),
+      SHA,
+    ),
+  );
+  for (const placement of [
+    "REMOTE-FRA",
+    "remote",
+    "banana",
+    42,
+    null,
+    {},
+    [],
+  ]) {
+    assert.throws(
+      () =>
+        validatePairedEvidence(
+          jsonl(
+            records.map((record, index) =>
+              index === 1
+                ? { ...record, headers: { "cf-placement": placement } }
+                : record,
+            ),
+          ),
+          SHA,
+        ),
+      /invalid Worker placement/,
+    );
+  }
 });
 
 test("auth certification separates required guards from optional suspended standing", () => {

--- a/packages/cloud/scripts/inference-auth-latency.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.mjs
@@ -470,8 +470,15 @@ export function parseAuthServerTiming(value) {
   return timings;
 }
 
+const CLOUDFLARE_PLACEMENT_PATTERN = /^(?:local|remote)-[A-Z]{3}$/;
+
+/** Accepts the documented cf-placement mode and airport-code wire shape. */
+export function isCloudflarePlacement(value) {
+  return typeof value === "string" && CLOUDFLARE_PLACEMENT_PATTERN.test(value);
+}
+
 function boundedPlacement(value) {
-  return /^(?:local|remote-[A-Z]{3})$/.test(value ?? "") ? value : "unknown";
+  return isCloudflarePlacement(value) ? value : "unknown";
 }
 
 function boundedColo(value) {

--- a/packages/cloud/scripts/inference-auth-latency.test.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  isCloudflarePlacement,
   parseArgs,
   parseAuthServerTiming,
   parseAuthTrace,
@@ -18,6 +19,15 @@ import {
 } from "./inference-auth-latency.mjs";
 
 const SHA = "a".repeat(40);
+
+test("Cloudflare placement values retain only documented local and remote colos", () => {
+  assert.equal(isCloudflarePlacement("local-ORD"), true);
+  assert.equal(isCloudflarePlacement("remote-FRA"), true);
+  assert.equal(isCloudflarePlacement("local"), false);
+  assert.equal(isCloudflarePlacement("remote"), false);
+  assert.equal(isCloudflarePlacement("LOCAL-ORD"), false);
+  assert.equal(isCloudflarePlacement(null), false);
+});
 
 function authHeader(phase) {
   return phase === "hit"


### PR DESCRIPTION
Closes #30411

## What changed

- remove Smart Placement from both staging and production API Worker configuration so mixed auth, Durable Object admission, and provider routing execute caller-local by default
- pin that no-placement invariant with a parsed Wrangler contract test across top-level, staging, and production scopes
- record the architectural rule that backend-specific placement must be split behind an unplaced edge Worker
- make exact-SHA live latency certification accept an absent beta header or exact local-XYZ, explicitly reject exact remote-XYZ, and fail closed on every other present shape
- share the documented Cloudflare placement validator with the auth-latency probe, correcting its prior local-XYZ to unknown downgrade

## Live evidence driving the fix

Run 33726042851 at deployed SHA 3ce7195c8bf56d2dc37d94306115183af49b9fcc completed 22/22 direct and 22/22 gateway calls. Every staging gateway sample entered via ORD but executed at cf-placement=remote-FRA. Warm gateway p50/p95 regressed to 737.61/4123.02 ms while direct Cerebras was 89.86/284.13 ms. The standing cache read remained 3 ms p50; sequential middle/reserve/setup phases each rose to roughly 112-123 ms.

Production currently reports local-ORD, so removing Smart Placement preserves its observed caller-local execution while preventing the analyzer from moving this stateful mixed Worker remotely later. This PR does not deploy production; the normal production release remains gated by exact-SHA staging certification.

## Verification

- 21/21 focused tests across certification, auth probe, and Wrangler placement contract
- Biome check on all changed scripts and tests
- Wrangler staging dry-run
- git diff --check
- independent reviews incorporated: strict placement-header schema, parsed config invariant, shared documented local/remote colo validator

After merge, deploy the exact SHA to staging and rerun the 44-call certification.

Official platform guidance: https://developers.cloudflare.com/workers/configuration/placement/ and https://developers.cloudflare.com/durable-objects/reference/data-location/