### PR TITLE
fix(ui): trust hosted Pages onboarding aliases

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -26,6 +26,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentButton, getViewRegistry } from "./agent-surface";
 import { registerAppShellPage } from "./app-shell-registry";
 import { DEFAULT_BOOT_CONFIG, setBootConfig } from "./config/boot-config";
+import { DEFAULT_BRANDING } from "./config/branding-base";
+import { BrandingContext } from "./config/branding-react.hooks";
 import type { ViewRegistryEntry } from "./hooks/useAvailableViews";
 import { resetUiRegistryHostForTests } from "./registry-host";
 import { getActiveSurfaceRealmScope } from "./surface-realm-broker";
@@ -51,10 +53,6 @@ const authStatusMock = vi.hoisted(() => ({
     | "server_unavailable",
   refetch: vi.fn(),
   use: vi.fn(),
-}));
-
-const cloudOriginMock = vi.hoisted(() => ({
-  agentless: false,
 }));
 
 const cloudSessionState = vi.hoisted(() => ({
@@ -359,15 +357,6 @@ vi.mock("./cloud/lib/use-session-auth", () => ({
   }),
 }));
 
-vi.mock("./utils/cloud-agent-base", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("./utils/cloud-agent-base")>();
-  return {
-    ...actual,
-    isElizaCloudControlPlaneAgentlessBase: () => cloudOriginMock.agentless,
-  };
-});
-
 vi.mock("./first-run/use-first-run-conductor", () => ({
   FirstRunConductorMount: () => <div data-testid="first-run-conductor-mount" />,
   surfaceCloudLoginRetryTurn: vi.fn(),
@@ -584,6 +573,33 @@ function navigateView(detail: Record<string, unknown>) {
   });
 }
 
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
+
+function setWindowLocation(url: string): void {
+  const parsed = new URL(url);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href: parsed.href,
+      origin: parsed.origin,
+      protocol: parsed.protocol,
+      host: parsed.host,
+      hostname: parsed.hostname,
+      port: parsed.port,
+      pathname: parsed.pathname,
+      search: parsed.search,
+      hash: parsed.hash,
+      assign: vi.fn(),
+      replace: vi.fn(),
+      reload: vi.fn(),
+      toString: () => parsed.href,
+    },
+  });
+}
+
 describe("App navigate-view event wiring", () => {
   beforeEach(() => {
     window.history.replaceState(null, "", "/?shellMode=chat-overlay");
@@ -591,6 +607,7 @@ describe("App navigate-view event wiring", () => {
     // App with first-run complete and covers the surfaces under test — mark it
     // already shown.
     window.localStorage.setItem("eliza:permissions-primed", "1");
+    window.localStorage.removeItem("steward_session_token");
     setBootConfig(DEFAULT_BOOT_CONFIG);
     Reflect.deleteProperty(window, "__ELIZAOS_API_BASE__");
     Reflect.deleteProperty(window, "__ELIZA_API_TOKEN__");
@@ -601,7 +618,6 @@ describe("App navigate-view event wiring", () => {
     appState.tab = "chat";
     appState.plugins = [];
     authStatusMock.phase = "authenticated";
-    cloudOriginMock.agentless = false;
     cloudSessionState.authenticated = false;
     mediaQueryState.matches = false;
     electrobunRuntimeState.enabled = true;
@@ -623,22 +639,61 @@ describe("App navigate-view event wiring", () => {
     cleanup();
     resetUiRegistryHostForTests();
     vi.unstubAllGlobals();
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, "location", originalLocationDescriptor);
+    }
   });
 
-  it("keeps an unauthenticated shared Cloud app inside first-run onboarding", () => {
+  it("keeps the exact branded staging Pages alias inside first-run onboarding", () => {
     window.history.replaceState(null, "", "/?shellMode=full");
+    setWindowLocation("https://develop.eliza-app.pages.dev/?shellMode=full");
     appState.firstRunComplete = false;
     appState.startupPhase = "first-run-required";
     authStatusMock.phase = "unauthenticated";
-    cloudOriginMock.agentless = true;
+    window.localStorage.setItem(
+      "steward_session_token",
+      "existing-steward-session",
+    );
 
-    render(<App />);
+    render(
+      <BrandingContext.Provider
+        value={{ ...DEFAULT_BRANDING, cloudOnly: true }}
+      >
+        <App />
+      </BrandingContext.Provider>,
+    );
 
     expect(authStatusMock.use).toHaveBeenCalledWith(
       expect.objectContaining({ skip: true }),
     );
     expect(screen.getByTestId("first-run-conductor-mount")).toBeTruthy();
     expect(screen.queryByText("Open this agent from Eliza Cloud")).toBeNull();
+  });
+
+  it.each([
+    ["unbranded Pages alias", "https://develop.eliza-app.pages.dev/", false],
+    ["arbitrary branded self-host", "https://agent.example.com/", true],
+  ])("keeps the App auth gate for an %s", (_name, origin, cloudOnly) => {
+    window.history.replaceState(null, "", "/?shellMode=full");
+    setWindowLocation(`${origin}?shellMode=full`);
+    appState.firstRunComplete = false;
+    appState.startupPhase = "first-run-required";
+    authStatusMock.phase = "unauthenticated";
+    window.localStorage.setItem(
+      "steward_session_token",
+      "existing-steward-session",
+    );
+
+    render(
+      <BrandingContext.Provider value={{ ...DEFAULT_BRANDING, cloudOnly }}>
+        <App />
+      </BrandingContext.Provider>,
+    );
+
+    expect(authStatusMock.use).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: false }),
+    );
+    expect(screen.queryByTestId("first-run-conductor-mount")).toBeNull();
   });
 
   it("restores a deep route after an auth-startup retry commits the default chat path", async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -225,7 +225,7 @@ import {
 } from "./surface-realm-broker";
 import { shellHistory } from "./surface-realm-channel";
 import { TutorialConductorMount } from "./tutorial/TutorialConductor";
-import { isElizaCloudControlPlaneAgentlessBase } from "./utils/cloud-agent-base";
+import { isTrustedHostedCloudOnboardingBase } from "./utils/cloud-agent-base";
 import { confirmDesktopAction } from "./utils/desktop-dialogs";
 import { openExternalUrl } from "./utils/openExternalUrl";
 import { playCaptureSendCue, playCaptureStartCue } from "./voice/capture-cues";
@@ -2686,7 +2686,10 @@ function AppContent() {
 
   const isAgentlessCloudOrigin =
     typeof window !== "undefined" &&
-    isElizaCloudControlPlaneAgentlessBase(window.location.origin);
+    isTrustedHostedCloudOnboardingBase(
+      window.location.origin,
+      branding.cloudOnly === true,
+    );
 
   // Existing remote backends still probe during first-run so a real 401 can
   // surface their password wall. The shared Cloud app defers that probe because

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -17,6 +17,7 @@ import {
   isCloudAgentsCollectionBase,
   isElizaCloudControlPlaneAgentlessBase,
   isManagedCloudSharedAgentBase,
+  isTrustedHostedCloudOnboardingBase,
   resolveCloudEnvironmentBase,
 } from "../utils/cloud-agent-base";
 import { resolveCloudAgentApiBase } from "./client-cloud";
@@ -292,5 +293,39 @@ describe("cloud-agent-base helpers", () => {
         "https://ff479713-41c8-4d82-92b8-5f0881062189.elizacloud.ai",
       ),
     ).toBe(false);
+  });
+
+  it("trusts canonical Cloud and the exact branded HTTPS staging Pages alias", () => {
+    expect(
+      isTrustedHostedCloudOnboardingBase("https://cloud.eliza.app", false),
+    ).toBe(true);
+    expect(
+      isTrustedHostedCloudOnboardingBase("https://app.elizacloud.ai", false),
+    ).toBe(true);
+    expect(
+      isTrustedHostedCloudOnboardingBase(
+        "https://develop.eliza-app.pages.dev",
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects unbranded, insecure, self-hosted, and lookalike Pages bases", () => {
+    for (const [base, cloudOnlyBranding] of [
+      ["https://develop.eliza-app.pages.dev", false],
+      ["http://develop.eliza-app.pages.dev", true],
+      ["https://eliza-app.pages.dev", true],
+      ["https://preview.eliza-app.pages.dev", true],
+      ["https://pr-30375.preview.eliza-app.pages.dev", true],
+      ["https://agent.example.com", true],
+      ["https://other-project.pages.dev", true],
+      ["https://evil-eliza-app.pages.dev", true],
+      ["https://eliza-app.pages.dev.evil.example", true],
+      ["https://develop.eliza-app.pages.dev/api/v1/eliza/agents/agent", true],
+    ] as const) {
+      expect(isTrustedHostedCloudOnboardingBase(base, cloudOnlyBranding)).toBe(
+        false,
+      );
+    }
   });
 });

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -314,6 +314,7 @@ describe("cloud-agent-base helpers", () => {
     for (const [base, cloudOnlyBranding] of [
       ["https://develop.eliza-app.pages.dev", false],
       ["http://develop.eliza-app.pages.dev", true],
+      ["https://develop.eliza-app.pages.dev:8443", true],
       ["https://eliza-app.pages.dev", true],
       ["https://preview.eliza-app.pages.dev", true],
       ["https://pr-30375.preview.eliza-app.pages.dev", true],

--- a/packages/ui/src/state/first-run-bootstrap.test.ts
+++ b/packages/ui/src/state/first-run-bootstrap.test.ts
@@ -8,8 +8,9 @@
  *    `local`/`cloud-hybrid`) from re-onboarding while its ~30s native boot is
  *    still in flight (#16065), plus the error classification that keeps a
  *    genuine agent fault from being masked as first-run;
- *  - the #16242 gate that skips the probe on a bare Eliza Cloud control-plane
- *    origin (where the same-origin API is auth-gated and would only 401).
+ *  - the #16242/#30375 gate that skips the probe on a trusted hosted Cloud
+ *    onboarding base (where the same-origin API is auth-gated and would only
+ *    401).
  *
  * Drives the real functions with an injected probe client (real `ApiError`
  * shapes, controllable timing) — no network, nothing under test mocked. Fake
@@ -289,18 +290,33 @@ describe("detectExistingFirstRunConnection — fresh-install single shot", () =>
   });
 });
 
-describe("shouldProbeExistingLocalInstall (#16242)", () => {
-  it("is false only on a bare Cloud control-plane origin", () => {
+describe("shouldProbeExistingLocalInstall (#16242, #30375)", () => {
+  it("is false on canonical Cloud and authoritative branded Pages origins", () => {
     expect(shouldProbeExistingLocalInstall("https://app.elizacloud.ai")).toBe(
       false,
     );
     expect(shouldProbeExistingLocalInstall("https://elizacloud.ai")).toBe(
       false,
     );
+    expect(
+      shouldProbeExistingLocalInstall(
+        "https://develop.eliza-app.pages.dev",
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("continues probing unbranded Pages and arbitrary Cloud-only hosts", () => {
+    expect(
+      shouldProbeExistingLocalInstall(
+        "https://develop.eliza-app.pages.dev",
+        false,
+      ),
+    ).toBe(true);
+    expect(
+      shouldProbeExistingLocalInstall("https://agent.example.com", true),
+    ).toBe(true);
     expect(shouldProbeExistingLocalInstall("http://localhost:2138")).toBe(true);
-    expect(shouldProbeExistingLocalInstall("https://agent.example.com")).toBe(
-      true,
-    );
     expect(shouldProbeExistingLocalInstall(null)).toBe(true);
     expect(shouldProbeExistingLocalInstall(undefined)).toBe(true);
   });
@@ -332,6 +348,38 @@ describe("detectExistingFirstRunConnection — Cloud-origin gate (#16242)", () =
     // The gate returns before any protected probe is issued.
     expect(client.getFirstRunStatus).not.toHaveBeenCalled();
     expect(client.getConfig).not.toHaveBeenCalled();
+  });
+
+  it("skips the probe on an authoritative branded Pages alias (#30375)", async () => {
+    setOrigin("https://develop.eliza-app.pages.dev/");
+    const client = makeClient();
+    const result = await detectExistingFirstRunConnection({
+      client,
+      timeoutMs: 1000,
+      cloudOnlyBranding: true,
+    });
+    expect(result).toBeNull();
+    expect(client.getFirstRunStatus).not.toHaveBeenCalled();
+    expect(client.getConfig).not.toHaveBeenCalled();
+  });
+
+  it("still probes an unbranded Pages alias and arbitrary Cloud-only host", async () => {
+    for (const [origin, cloudOnlyBranding] of [
+      ["https://develop.eliza-app.pages.dev/", false],
+      ["https://agent.example.com/", true],
+    ] as const) {
+      setOrigin(origin);
+      const client = makeClient({
+        getFirstRunStatus: vi.fn(async () => ({ complete: true })),
+      });
+      const result = await detectExistingFirstRunConnection({
+        client,
+        timeoutMs: 1000,
+        cloudOnlyBranding,
+      });
+      expect(result).toMatchObject({ detectedExistingInstall: true });
+      expect(client.getFirstRunStatus).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("detects a completed backend install from first-run status", async () => {

--- a/packages/ui/src/state/first-run-bootstrap.ts
+++ b/packages/ui/src/state/first-run-bootstrap.ts
@@ -3,7 +3,7 @@
  * first-run config and resolves the initial active-server record so a returning
  * user skips re-onboarding. Reads via the injected probe client.
  */
-import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
+import { isTrustedHostedCloudOnboardingBase } from "../utils/cloud-agent-base";
 import { asRecord, readString } from "./config-readers";
 import { asApiLikeError } from "./parsers";
 import {
@@ -116,17 +116,18 @@ async function interpretAnsweredFirstRunStatus(
 /**
  * Whether the boot-time existing-install probe (GET /api/first-run/status +
  * /api/config) should run for `origin`. The probe detects a returning
- * local/self-hosted install so the user skips re-onboarding. On a bare Eliza
- * Cloud control-plane origin (cloud.eliza.app, with legacy aliases during migration) the
- * same-origin API is the managed cloud endpoint: it requires auth and hosts no
- * unauthenticated local install to detect, so probing it only yields 401
- * console noise during fresh onboarding (#16242). Skip it there — the in-chat
- * first-run conductor owns Cloud sign-in.
+ * local/self-hosted install so the user skips re-onboarding. On a trusted
+ * hosted Cloud onboarding base, the same-origin API is the managed cloud
+ * endpoint: it requires auth and hosts no unauthenticated local install to
+ * detect, so probing it only yields 401 console noise during fresh onboarding
+ * (#16242, #30375). Skip it there — the in-chat first-run conductor owns Cloud
+ * sign-in. Cloud-only branding does not grant this trust to arbitrary hosts.
  */
 export function shouldProbeExistingLocalInstall(
   origin: string | null | undefined,
+  cloudOnlyBranding = false,
 ): boolean {
-  return !isElizaCloudControlPlaneAgentlessBase(origin ?? "");
+  return !isTrustedHostedCloudOnboardingBase(origin ?? "", cloudOnlyBranding);
 }
 
 function currentOrigin(): string | null {
@@ -136,6 +137,8 @@ function currentOrigin(): string | null {
 export async function detectExistingFirstRunConnection(args: {
   client: ExistingFirstRunProbeClient;
   timeoutMs: number;
+  /** Authoritative boot branding used to recognize hosted Pages aliases. */
+  cloudOnlyBranding?: boolean;
   /**
    * Set when a committed on-device runtime (mobile `local` / `cloud-hybrid`)
    * is persisted, so the native service IS bringing the bundled agent up. That
@@ -153,11 +156,16 @@ export async function detectExistingFirstRunConnection(args: {
     return null;
   }
 
-  // Skip the probe on a bare Cloud control-plane origin: the same-origin API is
-  // auth-gated, so first-run/status + config only 401 during fresh onboarding
-  // (#16242). Gated here rather than at the restore call site so every caller
-  // inherits it and the guard is testable in isolation.
-  if (!shouldProbeExistingLocalInstall(currentOrigin())) {
+  // Skip the probe on a trusted hosted Cloud onboarding base: the same-origin
+  // API is auth-gated, so first-run/status + config only 401 during fresh
+  // onboarding (#16242, #30375). Gated here rather than at the restore call
+  // site so every caller inherits it and the guard is testable in isolation.
+  if (
+    !shouldProbeExistingLocalInstall(
+      currentOrigin(),
+      args.cloudOnlyBranding === true,
+    )
+  ) {
     return null;
   }
 

--- a/packages/ui/src/state/startup-phase-restore.mobile-probe.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.mobile-probe.test.ts
@@ -175,6 +175,30 @@ describe("runRestoringSession — mobile committed-runtime existing-install prob
     );
   });
 
+  it("forwards authoritative Cloud-only boot branding to the existing-install probe", async () => {
+    setBootConfig({
+      ...DEFAULT_BOOT_CONFIG,
+      branding: { cloudOnly: true },
+    });
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(probeMock.detectExistingFirstRunConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ cloudOnlyBranding: true }),
+    );
+  });
+
+  it("keeps the existing-install probe unbranded by default", async () => {
+    const dispatch = vi.fn();
+
+    await drive(dispatch);
+
+    expect(probeMock.detectExistingFirstRunConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ cloudOnlyBranding: false }),
+    );
+  });
+
   it("does not wait for a persisted cloud (non-agent) runtime — no bundled agent to boot", async () => {
     localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "cloud");
     const dispatch = vi.fn();

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -907,6 +907,7 @@ export async function runRestoringSession(
     try {
       probed = await detectExistingFirstRunConnection({
         client,
+        cloudOnlyBranding: getBootConfig().branding.cloudOnly === true,
         timeoutMs: isDesktop
           ? Math.min(getBackendStartupTimeoutMs(), 30_000)
           : committedMobileOnDeviceMode

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -254,6 +254,32 @@ export function isElizaCloudControlPlaneAgentlessBase(
   return isCloudAgentsCollectionBase(value);
 }
 
+const DEVELOP_ELIZA_APP_PAGES_HOSTNAME = "develop.eliza-app.pages.dev";
+
+/**
+ * True when an agentless browser host is trusted to own hosted Cloud
+ * onboarding. Canonical and legacy control-plane origins are always trusted.
+ * The deployed Cloudflare Pages staging alias is trusted only for an
+ * authoritative Cloud-only build, over HTTPS, and only on its exact hostname.
+ * Other Pages project/preview hosts and self-hosted `cloudOnly` branding must
+ * never suppress the local-install/auth gates because they are outside the
+ * credentialed API's server-authoritative origin set.
+ */
+export function isTrustedHostedCloudOnboardingBase(
+  value: string | null | undefined,
+  cloudOnlyBranding: boolean,
+): boolean {
+  if (isElizaCloudControlPlaneAgentlessBase(value)) return true;
+  if (!cloudOnlyBranding || !value?.trim()) return false;
+
+  const url = normalizeHttpUrl(value.trim());
+  if (url?.protocol !== "https:" || !isCloudAgentsCollectionBase(value)) {
+    return false;
+  }
+
+  return url.hostname.toLowerCase() === DEVELOP_ELIZA_APP_PAGES_HOSTNAME;
+}
+
 /**
  * True when `value` is a DEDICATED cloud agent base — an agent that lives on its
  * own `<agentId>.cloud.eliza.app` subdomain (not a control-plane host, not the

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -254,13 +254,13 @@ export function isElizaCloudControlPlaneAgentlessBase(
   return isCloudAgentsCollectionBase(value);
 }
 
-const DEVELOP_ELIZA_APP_PAGES_HOSTNAME = "develop.eliza-app.pages.dev";
+const DEVELOP_ELIZA_APP_PAGES_ORIGIN = "https://develop.eliza-app.pages.dev";
 
 /**
  * True when an agentless browser host is trusted to own hosted Cloud
  * onboarding. Canonical and legacy control-plane origins are always trusted.
  * The deployed Cloudflare Pages staging alias is trusted only for an
- * authoritative Cloud-only build, over HTTPS, and only on its exact hostname.
+ * authoritative Cloud-only build and only on its exact HTTPS origin.
  * Other Pages project/preview hosts and self-hosted `cloudOnly` branding must
  * never suppress the local-install/auth gates because they are outside the
  * credentialed API's server-authoritative origin set.
@@ -277,7 +277,7 @@ export function isTrustedHostedCloudOnboardingBase(
     return false;
   }
 
-  return url.hostname.toLowerCase() === DEVELOP_ELIZA_APP_PAGES_HOSTNAME;
+  return url.origin.toLowerCase() === DEVELOP_ELIZA_APP_PAGES_ORIGIN;
 }
 
 /**


### PR DESCRIPTION
# Relates to

Closes #30375.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Based on current `origin/develop` `d3ea8fd089d55f05ce69be4af282742af3885cf1`; zero conflicts.
- [x] `bun run verify` passes post-sync at PR head `f56b0d3496fa6375fd0466f3fd0cb3a6cca90704`.

# Risks

Low. This changes only hosted-cloud onboarding classification. Canonical and legacy agentless origins retain their existing behavior. The fallback requires authoritative `branding.cloudOnly`, HTTPS, and the exact `https://develop.eliza-app.pages.dev` origin. Deterministic negative tests keep the Pages apex, preview/random subdomains, arbitrary self-hosts, HTTP, non-default ports, lookalikes, and per-agent paths out of the trusted path.

# Background

## What does this PR do?

Run 33724701724 reproduced the staging renderer blocker: the Pages alias made `/api/first-run/status` return 401, the renderer restored local authority, and the app showed Pairing Required before Personal identity could issue any request. This PR adds one shared trusted-hosted-cloud onboarding predicate and uses it for both the existing-install probe and the top-level App auth gate.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

My changes do not require a project documentation change. The behavior is an internal host-classification correction covered by contract tests.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/utils/cloud-agent-base.ts`, then follow its consumers through `packages/ui/src/state/first-run-bootstrap.ts`, `packages/ui/src/state/startup-phase-restore.ts`, and `packages/ui/src/App.tsx`. The boundary and both real consumer wirings are exercised in the focused tests.

## Detailed testing steps

- `bun install` — passed.
- `bun run --cwd packages/ui test -- src/api/client-cloud-agent-base.test.ts src/state/first-run-bootstrap.test.ts src/state/startup-phase-restore.mobile-probe.test.ts src/state/top-level-auth-gate.test.ts src/state/cloud-auth-first-screen-policy.test.ts src/App.navigate-view-wiring.test.tsx src/first-run/use-first-run-conductor.test.ts` — 8 files, 193 tests passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun run --cwd packages/ui lint:check` — passed (only seven pre-existing warnings in untouched files).
- `bun run --cwd packages/app audit:app` — 219 Playwright checks passed; `broken=0`, `needs-work=0`; 216 OCR views reviewed with 0 broken.
- Recorded desktop cloud-only onboarding — 1 Playwright test passed.
- Recorded mobile cloud-only onboarding at 390 × 844 — 1 Playwright test passed.
- `bun run verify` — passed, including 376 workspace typecheck/lint tasks and repository audit gates.
- `git diff --check` — passed.

# Evidence Gate

Evidence applies to the exact commit reviewed; the rebase preserved the UI patch byte-for-byte (SHA-256 `a571ca465f0aaad749d350d31a9003024446f1371110fdd0caf55a536dedfa6e`).
<!-- evidence-head:f56b0d3496fa6375fd0466f3fd0cb3a6cca90704 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-after-mobile-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - renderer-only trust-gate change; no backend code path changed.
<!-- evidence-row:frontend-logs -->
- [x] [30417-before-live-console-network.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-before-live-console-network.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, generated-file, or audio artifact changed.
<!-- evidence-row:ocr-review -->
- [x] [30417-app-audit-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-app-audit-ocr-triage.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

Backend: N/A - renderer-only trust-gate change; no backend code path changed.

Frontend evidence includes the [live pre-fix Pages alias console/network log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-before-live-console-network.json) (showing `/api/first-run/status` 401 and `phase=pairing-required`) plus the [exact-head Playwright trace](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-after-mobile-trace.zip) for the successful cloud-only onboarding flow.

## Screenshots (before / after) + video walkthrough

The before desktop/mobile composite is a fresh live capture of `https://develop.eliza-app.pages.dev` showing Pairing Required. The after desktop/mobile composite and MP4 are exact-head local cloud-only onboarding captures using deterministic cloud route fixtures.

### Before

![Live before capture, desktop and mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-before-desktop-mobile.jpg)

### After

![Exact-head after capture, desktop and mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-after-desktop-mobile.jpg)

### Walkthrough video

https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30417-after-mobile-walkthrough.mp4

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

- The fixed Pages alias cannot be captured live until this PR is merged and deployed; merge/deploy are intentionally out of scope. Issue #30375 acceptance still requires an exact-SHA post-merge Pages run proving that a preexisting Steward session reaches `/api/v1/eliza/personal` without pairing. The App test uses the real predicate but stubs the conductor, and local Playwright is loopback-only, so neither is presented as deployed-path proof.
- An initial focused invocation used Bun's native test runner and failed because these files require Vitest/jsdom; the package's authoritative Vitest command then passed all 191 focused tests.
- An initial `mobile-chromium` capture found no matching test because that project excludes this spec. The same cloud-only test was then run successfully in the Chromium project with an explicit 390 × 844 viewport for mobile evidence.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

# Deploy Notes

No deployment was performed or requested. Normal renderer deployment after merge is sufficient.

## Database changes

N/A - no database changes.

## Deployment instructions

N/A - no manual deployment steps.



