### PR TITLE
test(cloud): isolate each clause of the backup delta shape guard

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.test.ts
@@ -4,15 +4,19 @@ import type { AgentBackupStateData } from "../../db/schemas/agent-sandboxes";
 import {
   applyBackupDelta,
   type BackupChainNode,
+  type BackupDelta,
   computeStateHash,
   diffBackupState,
   emptyBackupState,
   estimateDeltaBytes,
   estimateStateBytes,
   incrementalChainDepth,
+  isBackupDelta,
   isEmptyDelta,
   planIncrementalBackup,
   reconstructFromChain,
+  requireBackupDelta,
+  requireBackupStateData,
   resolveBackupChain,
   resolveBackupChainBytes,
   selectPrunableBackupIds,
@@ -324,5 +328,72 @@ describe("resolveBackupChainBytes (#17172 retained-implies-restorable)", () => {
       sized("other", "full", null, 999_999),
     ];
     expect(resolveBackupChainBytes(nodes, "b")).toBe(120);
+  });
+});
+
+describe("isBackupDelta clause isolation", () => {
+  const completeDelta: BackupDelta = {
+    filesChanged: { "a.txt": "1" },
+    filesRemoved: ["b.txt"],
+    configChanged: { k: 1 },
+    configRemoved: ["j"],
+    memoriesBaseCount: 1,
+    memoriesAppended: [mem("appended", 2)],
+  };
+
+  const DELTA_KEYS = [
+    "filesChanged",
+    "filesRemoved",
+    "configChanged",
+    "configRemoved",
+    "memoriesBaseCount",
+    "memoriesAppended",
+  ] as const;
+
+  test("recognizes a complete delta and refuses to read it as full state", () => {
+    expect(isBackupDelta(completeDelta)).toBe(true);
+    expect(requireBackupDelta(completeDelta, "bk_delta")).toBe(completeDelta);
+    expect(() => requireBackupStateData(completeDelta, "bk_delta")).toThrow(
+      /bk_delta did not contain a full-state payload/,
+    );
+  });
+
+  test("recognizes a full state and refuses to read it as a delta", () => {
+    const full = state({ memories: [mem("only", 1)] });
+    expect(isBackupDelta(full)).toBe(false);
+    expect(requireBackupStateData(full, "bk_full")).toBe(full);
+    expect(() => requireBackupDelta(full, "bk_full")).toThrow(
+      /bk_full did not contain a delta payload/,
+    );
+  });
+
+  // Every clause carries its own weight: a payload missing any single delta
+  // field must fail closed rather than reach applyBackupDelta, which reads all
+  // six unguarded. Four of the six then throw, but a missing `memoriesBaseCount`
+  // silently carries the parent's entire memory list and a missing
+  // `memoriesAppended` silently appends a null entry — corruption of a restored
+  // agent's history, not a crash. Asserted per clause so dropping any one of
+  // them from the guard fails here.
+  test.each(DELTA_KEYS)("rejects a delta payload missing %s", (missing) => {
+    const { [missing]: _dropped, ...partial } = completeDelta;
+    const payload = partial as unknown as BackupDelta;
+
+    expect(isBackupDelta(payload)).toBe(false);
+    expect(() => requireBackupDelta(payload, "bk_partial")).toThrow(
+      /bk_partial did not contain a delta payload/,
+    );
+    // The other branch accepts it, so the guard is the only thing standing
+    // between a truncated delta and a state-data read.
+    expect(requireBackupStateData(payload, "bk_partial")).toBe(payload);
+  });
+
+  test("an explicitly undefined delta field still satisfies its clause", () => {
+    // `in` tests key presence, not definedness — pinned so a future switch to a
+    // truthiness check is a deliberate change rather than an accident.
+    const withUndefined = {
+      ...completeDelta,
+      memoriesAppended: undefined,
+    } as unknown as BackupDelta;
+    expect(isBackupDelta(withUndefined)).toBe(true);
   });
 });


### PR DESCRIPTION
# What

`isBackupDelta` decides which of two mutually exclusive interpretations a stored backup payload gets. Both restore paths depend on it:

```ts
state = requireBackupStateData(row.state_data, row.id);              // base
state = applyBackupDelta(state, requireBackupDelta(row.state_data, row.id));  // chain member
```

It is a six-clause conjunction, and **not one of the six clauses is pinned**. On `develop`, dropping any single clause leaves every related suite green:

| mutant | `agent-backup-diff` | `agent-backup-verifier` | `agent-sandboxes` |
|---|---|---|---|
| drop `"filesChanged" in value` | 0 fail | 0 fail | 0 fail |
| drop `"filesRemoved" in value` | 0 fail | 0 fail | 0 fail |
| drop `"configChanged" in value` | 0 fail | 0 fail | 0 fail |
| drop `"configRemoved" in value` | 0 fail | 0 fail | 0 fail |
| drop `"memoriesBaseCount" in value` | 0 fail | 0 fail | 0 fail |
| drop `"memoriesAppended" in value` | 0 fail | 0 fail | 0 fail |

The guard is pinned only in aggregate — inverting the whole predicate *is* caught (16 failures in the verifier suite). Every fixture in the repo carries all six keys, so nothing distinguishes a complete delta from a truncated one.

# Why each clause is load-bearing

`applyBackupDelta` reads all six fields unguarded. Executed against a base of three memories and a delta that should yield `[{id:1},{id:9}]`, dropping one field at a time:

| missing field | result |
|---|---|
| `filesChanged` | `TypeError: Cannot convert undefined or null to object` |
| `filesRemoved` | `TypeError: filesRemoved is not iterable` |
| `configChanged` | `TypeError: Cannot convert undefined or null to object` |
| `configRemoved` | `TypeError: configRemoved is not iterable` |
| **`memoriesBaseCount`** | **no throw — `[{id:1},{id:2},{id:3},{id:9}]`** |
| **`memoriesAppended`** | **no throw — `[{id:1},null]`** |

Four fail loudly. The two memory clauses do not: `slice(0, undefined)` keeps the **whole** parent list, so a truncated delta silently resurrects history the parent had compacted away; `concat(undefined)` appends a hole that JSON-round-trips to `null`, so a restored agent gets a null memory entry. Those two are the clauses whose absence corrupts a restored agent rather than crashing the restore, and they were exactly as unprotected as the other four.

The guard is the only thing between a partial payload and that behaviour, which is why the clause it drops shouldn't be a free change.

# The change

Tests only — no production change. One case per clause plus both directions of the discriminator:

- a complete delta is recognized **and** rejected by `requireBackupStateData`;
- a full state is recognized **and** rejected by `requireBackupDelta`;
- `test.each` over the six keys: a delta missing that one key fails `isBackupDelta`, makes `requireBackupDelta` throw the id-bearing error, and is accepted by the other branch — so each clause is asserted on its own;
- `in` tests key presence, not definedness. An explicitly `undefined` field still satisfies its clause today; pinned so that switching to a truthiness check becomes a deliberate change instead of an accident.

# Evidence

`bun test src/lib/services/agent-backup-diff.test.ts` → **42 pass / 0 fail** (was 33), 68 `expect()` calls.

Same mutants, after:

| mutant | before | after |
|---|---|---|
| drop `filesChanged` | 42 pass | **41 pass / 1 fail** |
| drop `filesRemoved` | 42 pass | **41 pass / 1 fail** |
| drop `configChanged` | 42 pass | **41 pass / 1 fail** |
| drop `configRemoved` | 42 pass | **41 pass / 1 fail** |
| drop `memoriesBaseCount` | 42 pass | **41 pass / 1 fail** |
| drop `memoriesAppended` | 42 pass | **41 pass / 1 fail** |
| invert the predicate | — | **33 pass / 9 fail** |
| `"memoriesAppended" in value` → `!== undefined` | 42 pass | **41 pass / 1 fail** |

**8 of 8 killed, from 0 of 8.**

Neighbouring suites unchanged, run file by file:

```
agent-backup-diff.test.ts                     42 pass  0 fail
agent-backup-diff.canonicalize-bound.test.ts   6 pass  0 fail
agent-backup-diff.safe-sort.test.ts            3 pass  0 fail
agent-backup-verifier.test.ts                 45 pass  0 fail
agent-sandboxes.test.ts                       28 pass  0 fail
```

`bunx @biomejs/biome check` on the file → clean. `bunx tsc --noEmit -p packages/cloud/shared/tsconfig.json` → no errors in the touched file.

# Context

Found while sweeping multi-clause guards for unpinned terms — the same shape as #30407 (opaque exchange-code gate) and #30410 (outbound standing threshold).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1K7FDD56K012VE171HGK8FB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T08:51:56.453Z","completed_at":"2026-09-03T08:56:02.335Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T08:51:57.183Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e81f1e95adacefd12628b47a9e195bc7a5e0e48c0aa65b3819c132fc1dcda94c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9ee0bdac-3c4c-4d44-a541-f8c43d9999d1","object_id":"sha256:e81f1e95adacefd12628b47a9e195bc7a5e0e48c0aa65b3819c132fc1dcda94c","sha256":"e81f1e95adacefd12628b47a9e195bc7a5e0e48c0aa65b3819c132fc1dcda94c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"7fR3Y8475_P9G7uVKW85vdmL7EeNYGUxIlkSYpljaSf4qgoOsNMTmqcnAnSckcMqxK-yci-ukuTB9yObCYZRDQ"}} -->
