### PR TITLE
test(cloud): isolate the digest clause of the pool rollout admission

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
@@ -113,32 +113,35 @@ describe("processFleetUpgradeCycle shared image-change capacity", () => {
 });
 
 describe("warm-pool image rollout admission", () => {
-  test("only a completed zero-failure pre-pull authorizes rollout", () => {
-    expect(prePullAllowsPoolImageRollout(null)).toBe(false);
-    expect(
-      prePullAllowsPoolImageRollout({
-        attempted: 2,
-        failed: 1,
-        configuredImage,
-        targetDigest,
-      }),
-    ).toBe(false);
-    expect(
-      prePullAllowsPoolImageRollout({
-        attempted: 0,
-        failed: 0,
-        configuredImage,
-        targetDigest: null,
-      }),
-    ).toBe(false);
-    expect(
-      prePullAllowsPoolImageRollout({
-        attempted: 0,
-        failed: 0,
-        configuredImage,
-        targetDigest,
-      }),
-    ).toBe(false);
+  // One case per clause of the admission conjunction. The digest clause needs
+  // `attempted > 0` to isolate it: a summary that is both zero-attempt and
+  // undigested is refused by the attempt clause alone, so it cannot tell you
+  // whether the digest clause still exists.
+  const refusedCases = [
+    ["the pre-pull is disabled", null],
+    [
+      "no node was attempted",
+      { attempted: 0, failed: 0, configuredImage, targetDigest },
+    ],
+    [
+      "a node failed to pre-pull",
+      { attempted: 2, failed: 1, configuredImage, targetDigest },
+    ],
+    [
+      "the digest never resolved despite attempted nodes",
+      { attempted: 1, failed: 0, configuredImage, targetDigest: null },
+    ],
+    [
+      "the sweep neither attempted nor resolved",
+      { attempted: 0, failed: 0, configuredImage, targetDigest: null },
+    ],
+  ] as const;
+
+  test.each(refusedCases)("refuses rollout when %s", (_name, summary) => {
+    expect(prePullAllowsPoolImageRollout(summary)).toBe(false);
+  });
+
+  test("authorizes rollout only for an attempted, zero-failure, digested sweep", () => {
     expect(
       prePullAllowsPoolImageRollout({
         attempted: 1,
@@ -147,6 +150,26 @@ describe("warm-pool image rollout admission", () => {
         targetDigest,
       }),
     ).toBe(true);
+  });
+
+  test("an undigested summary would re-resolve the tag rather than skip", async () => {
+    // Why the digest clause is load-bearing rather than redundant with the
+    // rollout's own `!targetDigest` guard: the rollout falls back to
+    // `resolveImageDigest(configuredImage)` when the summary carries no digest,
+    // so admitting one would resolve a *fresh* digest at a later moment — the
+    // mutable-tag fallback the caller comment says must never happen once the
+    // sweep knows an immutable target.
+    const resolveImageDigest = mock(async () => null);
+    __setDepsForTests({
+      containersEnv: { defaultAgentImage: () => configuredImage },
+      resolveImageDigest,
+    } as never);
+    const summary = await processPoolImageRolloutCycle({
+      configuredImage,
+      targetDigest: null,
+    });
+    expect(resolveImageDigest).toHaveBeenCalledWith(configuredImage);
+    expect(summary.action).toBe("skipped_no_digest");
   });
 
   test("passes one resolved immutable digest into the manager and exposes counts", async () => {


### PR DESCRIPTION
# What

`prePullAllowsPoolImageRollout` is the gate on a destructive operation — its own doc comment says so, and `prePullTarget` is what lets `processPoolImageRolloutCycle` fence and replace warm-pool nodes:

```ts
prePullTarget = prePullAllowsPoolImageRollout(summary) ? summary : null;
…
if (prePullTarget) { await runBoundedPhase(logger, "warm pool image rollout cycle", …) }
```

Four clauses. Three are pinned; the fourth is not. On `develop`:

| mutant | `provisioning-worker.image-rollout.test.ts` |
|---|---|
| drop `summary !== null` | 5 pass / 1 fail |
| drop `summary.attempted > 0` | 5 pass / 1 fail |
| drop `summary.failed === 0` | 5 pass / 1 fail |
| **drop `summary.targetDigest !== null`** | **6 pass / 0 fail** |

The digest clause can be deleted entirely and the suite stays green.

# Why it is masked

The existing fixture list has two undigested-adjacent cases, and neither isolates the clause:

```ts
{ attempted: 0, failed: 0, targetDigest: null }   // refused by the attempt clause anyway
{ attempted: 0, failed: 0, targetDigest }         // isolates the attempt clause
```

There is no `{ attempted > 0, failed: 0, targetDigest: null }`, so nothing distinguishes "refused because no node was attempted" from "refused because the digest never resolved."

# Why the clause is load-bearing, not redundant

`processPoolImageRolloutCycle` has its own `if (!targetDigest)` guard, so it is tempting to read the admission clause as belt-and-braces. It isn't, because of the line above that guard:

```ts
const targetDigest =
  resolvedTarget?.targetDigest ?? (await resolveImageDigest(configuredImage));
```

An admitted summary carrying a null digest does not skip — it **re-resolves the digest from the mutable tag**, at a later moment than the pre-pull. That is exactly what the caller comment forbids:

> Never fall back to a mutable tag once this sweep knows the immutable target.

So with the clause gone, a sweep that pre-pulled nodes but never resolved a digest would authorize the rollout, and the rollout would then fence and replace warm-pool nodes against an image that may differ from whatever was pre-pulled — voiding the pre-pull's entire purpose.

**This is not currently reachable**, and I want to be exact about that: `processPrePullImagesCycle` returns early with `{ attempted: 0, …, targetDigest: null }` when the digest does not resolve, so `attempted > 0 && targetDigest === null` cannot be produced today, and it is the only producer of a `PrePullImagesSummary`. The clause is defence in depth against that ordering changing — a pre-pull that resolved the digest after contacting nodes, or a second producer, would make it live. Today, deleting it is a free change and nothing tells you it mattered.

# The change

Tests only. The existing single test becomes a labelled case table with one entry per clause, plus the isolating case:

```ts
["the digest never resolved despite attempted nodes",
 { attempted: 1, failed: 0, configuredImage, targetDigest: null }],
```

and one test recording *why* the clause exists — driving `processPoolImageRolloutCycle` with an undigested target and asserting it calls `resolveImageDigest` rather than refusing up front.

I first wrote that rationale test with a digest-returning mock and it walked into the warm-pool manager and failed on unrelated deps; returning `null` takes the `skipped_no_digest` path and still proves the fallback fires, which is the whole point.

# Evidence

`bun test admin/daemons/provisioning-worker.image-rollout.test.ts` → **12 pass / 0 fail** (was 6), 55 `expect()` calls.

| mutant | before | after |
|---|---|---|
| drop `summary !== null` | 1 fail | **1 fail** |
| drop `summary.attempted > 0` | 1 fail | **1 fail** |
| drop `summary.failed === 0` | 1 fail | **1 fail** |
| drop `summary.targetDigest !== null` | **0 fail** | **1 fail** |
| `failed === 0` → `failed >= 0` | — | **1 fail** |
| `attempted > 0` → `attempted >= 0` | — | **1 fail** |

**6 of 6 killed**, where the digest clause previously had no detector at all.

Every sibling suite in the package, run file by file:

```
provisioning-worker-env-reconcile.test.ts               13 pass  0 fail
provisioning-worker.backup-verify.test.ts                2 pass  0 fail
provisioning-worker.deletion-reconcile.test.ts           8 pass  0 fail
provisioning-worker.image-rollout.test.ts               12 pass  0 fail
provisioning-worker.orphan-liveness-gate.test.ts         3 pass  0 fail
provisioning-worker.pool-health.test.ts                  4 pass  0 fail
provisioning-worker.pre-delete-backup-cleanup.test.ts    3 pass  0 fail
provisioning-worker.replenish.test.ts                    3 pass  0 fail
provisioning-worker.test.ts                             65 pass  0 fail
```

`bunx @biomejs/biome check` on the file → clean.

# Context

Same sweep as #30418, #30407 and #30410: multi-clause guards where one term has no fixture that isolates it.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1K817QDPA64AM3RS7Q4X1ZT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T09:01:40.461Z","completed_at":"2026-09-03T09:04:58.261Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T09:01:41.086Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d569b5d3aba6cc4539d4244e96d29edec96aec0b85b1f2bad051b4707b712e2f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a31d81a6-5974-4de2-8bde-6e24246d946e","object_id":"sha256:d569b5d3aba6cc4539d4244e96d29edec96aec0b85b1f2bad051b4707b712e2f","sha256":"d569b5d3aba6cc4539d4244e96d29edec96aec0b85b1f2bad051b4707b712e2f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"By39RUCvQpaEn8D-Rvb8RdnQJDZQk2d_u-V52CeMMuyZmHFmwKmLyrP-OVTBPpCkgrc-igEG4yOxZGPii7b6Bw"}} -->
