### PR TITLE
test(cloud): isolate each clause of the restore precreate quarantine

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-precreate-quarantine.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-precreate-quarantine.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Clause isolation for `hasExactAgentBackupRestorePrecreateQuarantine`, the
+ * gate that must hold before restore vault material leaves KMS authority
+ * (`bindAgentBackupVaultKeyGeneration`). Every term is asserted on its own so
+ * that removing any one of them fails here: the PGlite suites detect a fully
+ * inverted predicate but no single dropped clause, because their fixtures only
+ * ever present rows that satisfy all of them at once.
+ */
+import { describe, expect, test } from "bun:test";
+import type { AgentSandbox } from "../../schemas/agent-sandboxes";
+import { hasExactAgentBackupRestorePrecreateQuarantine } from "../agent-backup-restore-history";
+
+const RESTORE_ATTEMPT_ID = "rsa_01JQUARANTINE0000000000000";
+const BACKUP_ID = "bk_01JQUARANTINE0000000000000";
+const MANIFEST_SHA256 = `sha256:${"a".repeat(64)}`;
+const ACTIVATION_TOKEN_SHA256 = `sha256:${"b".repeat(64)}`;
+const MAX_ACTIVATION_TOKEN_CIPHERTEXT_BYTES = 16_384;
+
+/** A row that satisfies every clause: a pristine container_pending quarantine. */
+function quarantinedSandbox(overrides: Partial<AgentSandbox> = {}): Readonly<AgentSandbox> {
+  return {
+    deleted_at: null,
+    lifecycle_revision: 7,
+    activation_generation: RESTORE_ATTEMPT_ID,
+    activation_lifecycle_revision: 7n,
+    activation_purpose: "restore",
+    activation_backup_id: BACKUP_ID,
+    activation_backup_hash: MANIFEST_SHA256,
+    activation_token_hash: ACTIVATION_TOKEN_SHA256,
+    activation_token_ciphertext: "ciphertext",
+    activation_consent_lifecycle_revision: null,
+    activation_consent_head_backup_id: null,
+    activation_consent_head_backup_hash: null,
+    activation_phase: "container_pending",
+    activation_receipt: null,
+    activation_receipt_hash: null,
+    activation_container_id: null,
+    activation_node_id: null,
+    activation_image_digest: null,
+    activation_boot_id: null,
+    activation_authority_published_at: null,
+    activation_funding_revision: null,
+    activation_dispatched_at: null,
+    activation_completed_at: null,
+    ...overrides,
+  } as unknown as AgentSandbox;
+}
+
+function check(overrides: Partial<AgentSandbox> = {}): boolean {
+  return hasExactAgentBackupRestorePrecreateQuarantine({
+    sandbox: quarantinedSandbox(overrides),
+    restoreAttemptId: RESTORE_ATTEMPT_ID,
+    backupId: BACKUP_ID,
+    manifestSha256: MANIFEST_SHA256,
+    expectedActivationTokenSha256: ACTIVATION_TOKEN_SHA256,
+  });
+}
+
+describe("hasExactAgentBackupRestorePrecreateQuarantine clause isolation", () => {
+  test("admits a pristine container-pending restore quarantine", () => {
+    expect(check()).toBe(true);
+  });
+
+  // Binding identity: the row must be the one this restore attempt owns.
+  const identityCases = [
+    ["the sandbox is soft-deleted", { deleted_at: new Date() }],
+    ["another attempt owns the activation", { activation_generation: "rsa_other" }],
+    [
+      "the activation is not pinned to a lifecycle revision",
+      { activation_lifecycle_revision: null },
+    ],
+    ["the pinned revision has drifted from the row", { activation_lifecycle_revision: 8n }],
+    ["the activation is not a restore", { activation_purpose: "provision" }],
+    ["a different backup is staged", { activation_backup_id: "bk_other" }],
+    ["the manifest hash disagrees", { activation_backup_hash: `sha256:${"c".repeat(64)}` }],
+    ["the activation token hash disagrees", { activation_token_hash: `sha256:${"d".repeat(64)}` }],
+  ] as const;
+
+  // Token ciphertext: present, non-empty, bounded, and free of NUL.
+  const ciphertextCases = [
+    ["the ciphertext is absent", { activation_token_ciphertext: null }],
+    ["the ciphertext is not a string", { activation_token_ciphertext: 42 }],
+    ["the ciphertext is empty", { activation_token_ciphertext: "" }],
+    [
+      "the ciphertext exceeds the byte bound",
+      {
+        activation_token_ciphertext: "x".repeat(MAX_ACTIVATION_TOKEN_CIPHERTEXT_BYTES + 1),
+      },
+    ],
+    [
+      "the ciphertext carries a NUL",
+      { activation_token_ciphertext: "cipher" + String.fromCharCode(0) + "text" },
+    ],
+  ] as const;
+
+  // Consent columns belong to a different activation path and must be unset.
+  const consentCases = [
+    ["a consent lifecycle revision is recorded", { activation_consent_lifecycle_revision: 7n }],
+    ["a consent head backup id is recorded", { activation_consent_head_backup_id: BACKUP_ID }],
+    [
+      "a consent head backup hash is recorded",
+      { activation_consent_head_backup_hash: MANIFEST_SHA256 },
+    ],
+  ] as const;
+
+  // Precreate exactness: nothing downstream of container creation may exist yet.
+  const precreateCases = [
+    ["the activation has left container_pending", { activation_phase: "container_created" }],
+    ["a receipt was already recorded", { activation_receipt: "receipt" }],
+    [
+      "a receipt hash was already recorded",
+      { activation_receipt_hash: `sha256:${"e".repeat(64)}` },
+    ],
+    ["a container already exists", { activation_container_id: "container-1" }],
+    ["a node is already bound", { activation_node_id: "node-1" }],
+    ["an image digest is already pinned", { activation_image_digest: `sha256:${"f".repeat(64)}` }],
+    ["a boot id is already recorded", { activation_boot_id: "boot-1" }],
+    ["authority was already published", { activation_authority_published_at: new Date() }],
+    ["a funding revision is already bound", { activation_funding_revision: 3n }],
+    ["the activation was already dispatched", { activation_dispatched_at: new Date() }],
+    ["the activation already completed", { activation_completed_at: new Date() }],
+  ] as const;
+
+  test.each([...identityCases, ...ciphertextCases, ...consentCases, ...precreateCases])(
+    "refuses quarantine when %s",
+    (_name, overrides) => {
+      expect(check(overrides as Partial<AgentSandbox>)).toBe(false);
+    },
+  );
+
+  test("accepts a ciphertext exactly at the byte bound", () => {
+    // The bound is inclusive; pinned from both sides so tightening it to `<`
+    // becomes a deliberate change rather than an accident.
+    expect(
+      check({
+        activation_token_ciphertext: "x".repeat(MAX_ACTIVATION_TOKEN_CIPHERTEXT_BYTES),
+      } as Partial<AgentSandbox>),
+    ).toBe(true);
+  });
+
+  test("counts the ciphertext bound in UTF-8 bytes, not code units", () => {
+    // `Buffer.byteLength(..., "utf8")` — a two-byte character repeated to the
+    // code-unit bound is already over the byte bound.
+    expect(
+      check({
+        activation_token_ciphertext: "\u00e9".repeat(MAX_ACTIVATION_TOKEN_CIPHERTEXT_BYTES),
+      } as Partial<AgentSandbox>),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
# What

`hasExactAgentBackupRestorePrecreateQuarantine` is the gate that must hold before restore vault material leaves KMS authority — `bindAgentBackupVaultKeyGeneration` throws `AgentBackupCatalogConflictError("Restore vault lacks exact container-pending quarantine authority")` when it fails.

Counting the private `hasCommonAgentBackupRestoreQuarantineAuthority` it delegates to, it is a **23-clause conjunction**, and no test names it. What the PGlite suites do catch is a *fully inverted* predicate:

| | quarantine | authority | operations |
|---|---|---|---|
| baseline | 18 pass / 0 fail | 31 pass / 0 fail | 27 pass / 0 fail |
| `return (…)` → `return !(…)` | 18 / **0 fail** | 14 / **17 fail** | 20 / **7 fail** |

What none of them catch is any **single** dropped clause. Every one of the 23 terms could be deleted with all three suites green:

```
drop activation_phase === "container_pending"     -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop activation_receipt === null                  -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop activation_container_id === null             -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop activation_node_id === null                  -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop activation_boot_id === null                  -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop activation_completed_at === null             -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop activation_purpose === "restore"             -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop !activation_token_ciphertext.includes(NUL)   -> auth 0 fail, ops 0 fail, quarantine 0 fail
drop activation_consent_head_backup_id === null   -> auth 0 fail, ops 0 fail, quarantine 0 fail
…
```

The suites only ever present rows that satisfy every clause at once, so they prove the conjunction as a whole and nothing about its parts. Dropping `activation_container_id === null` — which is what stops a sandbox that already has a container from being handed fresh vault key material — is currently a free change.

# The change

Tests only, one new file. A single fixture representing a pristine `container_pending` restore quarantine, then one case per clause that violates exactly that clause, grouped by what each group protects:

- **binding identity** (8) — soft-deleted row, another attempt's activation, unpinned or drifted lifecycle revision, non-restore purpose, wrong backup, wrong manifest hash, wrong activation-token hash;
- **token ciphertext** (5) — absent, non-string, empty, over the byte bound, NUL-bearing;
- **consent columns** (3) — the three that belong to a different activation path;
- **precreate exactness** (11) — phase moved on, receipt, receipt hash, container, node, image digest, boot id, published authority, funding revision, dispatch, completion.

Plus both sides of the ciphertext bound: exactly `MAX_ACTIVATION_TOKEN_CIPHERTEXT_BYTES` is accepted, and the bound is counted in UTF-8 **bytes** — a two-byte character repeated to the code-unit limit is refused. A denial-only table can always be satisfied by loosening the bound, so it is pinned from above and below.

# Evidence

`bun test src/db/repositories/__tests__/agent-backup-restore-precreate-quarantine.test.ts` → **30 pass / 0 fail**.

Same battery, after: **22 of the 23 clauses now fail the new suite when dropped** (29 pass / 1 fail each; the `typeof … === "string"` clause fails 2).

**One survivor, and it should not block:** `activation_lifecycle_revision !== null` cannot be killed, because the clause immediately after it — `activation_lifecycle_revision === BigInt(sandbox.lifecycle_revision)` — is false for `null` regardless. `lifecycle_revision` is `.notNull().default(0)`, so `BigInt(...)` cannot throw and cannot yield `null`; the `!== null` term is genuinely subsumed. It reads as a useful narrowing hint, so I have not touched it — but no fixture can distinguish its presence from its absence, and I would rather say that than pad the suite with a case that looks like it covers the clause and doesn't.

Neighbouring suites unchanged, run file by file (combined `bun test` invocations in `cloud/shared` have produced false reds):

```
agent-backup-restore-quarantine.pglite.test.ts        18 pass  0 fail
agent-backup-restore-authority.pglite.test.ts         31 pass  0 fail
agent-backup-restore-operations.pglite.test.ts        27 pass  0 fail
agent-backup-restore-authority-binding.test.ts         2 pass  0 fail
agent-backup-global-lock-order.test.ts                 6 pass  0 fail
```

`bunx @biomejs/biome check` → clean. `bunx tsc --noEmit -p packages/cloud/shared/tsconfig.json` → no errors in the new file.

# Context

Same sweep as #30418 and #30419: multi-clause guards proven in aggregate but not per term. This one is the largest and sits on the most sensitive gate of the three.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1K8KH07JVFNRBEMBYX5XSWG","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T09:11:39.784Z","completed_at":"2026-09-03T09:20:43.435Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T09:11:40.554Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b943fdb4fd0c95db63f371fa90f28b38fdb7a665b09a89c4f92f13751bc9ee07","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"70f0e6c1-caff-49ec-b8bd-dc16ac32b07f","object_id":"sha256:b943fdb4fd0c95db63f371fa90f28b38fdb7a665b09a89c4f92f13751bc9ee07","sha256":"b943fdb4fd0c95db63f371fa90f28b38fdb7a665b09a89c4f92f13751bc9ee07"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"2u8ldS4nPoE3DkqCt1IwW5JvUcxqroJ6ErjAG84lASPDzDtylD_dXcXA8xu6ItDpImgWFDyC6QT1tpyPBk2BCg"}} -->
