### PR TITLE
test(core): isolate each field of the document compare-and-swap snapshot

### DIFF
--- a/packages/core/src/database/document-list-query.test.ts
+++ b/packages/core/src/database/document-list-query.test.ts
@@ -548,3 +548,103 @@ describe("document-list capability contract", () => {
 		).toEqual([ready.id]);
 	});
 });
+
+describe("documentMutationSnapshotMatches clause isolation", () => {
+	const OTHER_UUID = "00000000-0000-0000-0000-0000000000ff" as UUID;
+	const ATTEMPT_ID = "00000000-0000-0000-0000-00000000a11e" as UUID;
+
+	/** A document carrying every field the mutation snapshot compares. */
+	function snapshotDocument(overrides: Partial<Memory> = {}): Memory {
+		const base = document(21);
+		return {
+			...base,
+			metadata: {
+				...base.metadata,
+				scope: "owner-private",
+				scopedToEntityId: REQUESTER_ID,
+				addedBy: REQUESTER_ID,
+				directGrantEntityIds: [REQUESTER_ID],
+				documentRevision: 4,
+				ingestionAttemptId: ATTEMPT_ID,
+				ingestionState: "pending",
+			},
+			...overrides,
+		} as Memory;
+	}
+
+	function matchesAfter(mutate: (memory: Memory) => Memory): boolean {
+		const original = snapshotDocument();
+		const expected = readDocumentMutationSnapshot(original);
+		if (!expected) throw new Error("fixture must produce a snapshot");
+		return documentMutationSnapshotMatches(mutate(original), expected);
+	}
+
+	function withMetadata(patch: Record<string, unknown>) {
+		return (memory: Memory): Memory =>
+			({
+				...memory,
+				metadata: { ...memory.metadata, ...patch },
+			}) as Memory;
+	}
+
+	it("matches a document that is unchanged since the snapshot was taken", () => {
+		expect(matchesAfter((memory) => memory)).toBe(true);
+	});
+
+	// `compareAndSwapDocument` and `replaceDocumentRevision` return
+	// `{ status: "conflict" }` when this predicate is false, so every field it
+	// compares is a lost-update detector. Asserted one at a time: a fixture that
+	// perturbs several fields at once cannot tell you which comparisons survive.
+	const divergences: Array<[string, (memory: Memory) => Memory]> = [
+		[
+			"the row no longer reads as a document snapshot",
+			(memory) => ({ ...memory, roomId: "not-a-uuid" }) as unknown as Memory,
+		],
+		["the scope changed", withMetadata({ scope: "global" })],
+		["the room changed", (memory) => ({ ...memory, roomId: OTHER_UUID })],
+		[
+			"the owning entity changed",
+			(memory) => ({ ...memory, entityId: OTHER_UUID }),
+		],
+		[
+			"a direct grant was added",
+			withMetadata({ directGrantEntityIds: [REQUESTER_ID, OTHER_UUID] }),
+		],
+		[
+			"the private-scope target changed",
+			withMetadata({ scopedToEntityId: OTHER_UUID }),
+		],
+		["the recorded author changed", withMetadata({ addedBy: OTHER_UUID })],
+		["the revision advanced", withMetadata({ documentRevision: 5 })],
+		[
+			"a different ingestion attempt owns the row",
+			withMetadata({ ingestionAttemptId: OTHER_UUID }),
+		],
+		["the ingestion state advanced", withMetadata({ ingestionState: "ready" })],
+	];
+
+	it.each(divergences)("reports a conflict when %s", (_name, mutate) => {
+		expect(matchesAfter(mutate)).toBe(false);
+	});
+
+	it("compares direct grants by order as well as membership", () => {
+		// `uuidArraysEqual` is index-wise, so a reordered grant list is a
+		// divergence. Pinned because a set-equality rewrite would look harmless.
+		const original = snapshotDocument({
+			metadata: {
+				...snapshotDocument().metadata,
+				directGrantEntityIds: [REQUESTER_ID, OTHER_UUID],
+			},
+		} as Partial<Memory>);
+		const expected = readDocumentMutationSnapshot(original);
+		if (!expected) throw new Error("fixture must produce a snapshot");
+		const reordered = {
+			...original,
+			metadata: {
+				...original.metadata,
+				directGrantEntityIds: [OTHER_UUID, REQUESTER_ID],
+			},
+		} as Memory;
+		expect(documentMutationSnapshotMatches(reordered, expected)).toBe(false);
+	});
+});


### PR DESCRIPTION
# What

`documentMutationSnapshotMatches` is the conflict detector for document compare-and-swap. `compareAndSwapDocument`, `replaceDocumentRevision` and two sibling paths in `inMemoryAdapter.ts` all do:

```ts
if (!documentMutationSnapshotMatches(existing, params.expected)) {
  return { status: "conflict" };
}
```

Every field it compares is a lost-update detector: if a comparison stops happening, a caller holding a stale snapshot overwrites a row that moved underneath it.

It compares ten things, and **eight of them have no fixture**. Dropping each clause in turn, against `document-list-query.test.ts`:

| mutant | result |
|---|---|
| drop `actual !== null` | 18 pass / 0 fail |
| drop `actual.scope === expected.scope` | 18 pass / 0 fail |
| drop `actual.roomId === expected.roomId` | 18 pass / 0 fail |
| drop `actual.entityId === expected.entityId` | 18 pass / 0 fail |
| drop `actual.scopedToEntityId === …` | 18 pass / 0 fail |
| drop `actual.addedBy === …` | 18 pass / 0 fail |
| drop `actual.revision === …` | 18 pass / 0 fail |
| drop `actual.ingestionAttemptId === …` | 18 pass / 0 fail |
| drop the `directGrantEntityIds` compare | 17 pass / 1 fail |
| drop `actual.ingestionState === …` | 17 pass / 1 fail |

The whole predicate is covered by a single assertion with two denial cases, which are exactly the two clauses that die. `actual.revision` — the field a compare-and-swap exists to compare — is among the eight with no detector at all.

Coverage is thin in aggregate too, not just per clause. Inverting the entire predicate fails **one** test in `document-list-query.test.ts` and **zero** in `inMemoryAdapter.test.ts` and `inMemoryAdapter.access-context.test.ts`, so the adapter's conflict path never observes it.

# The change

Tests only. One fixture carrying every compared field, a snapshot taken from it, and one case per field that perturbs exactly that field:

- the row stops reading as a document snapshot at all (`roomId` no longer a UUID);
- scope, room, owning entity;
- a direct grant added; the private-scope target; the recorded author;
- the revision advanced;
- a different ingestion attempt owns the row; the ingestion state advanced.

Plus one property the type signature does not carry: `uuidArraysEqual` compares **index-wise**, so a reordered direct-grant list is a divergence. Rewriting it to set membership (`normalizedRight.includes(value)`) looks like a harmless simplification and now fails.

# Evidence

`bunx vitest run src/database/document-list-query.test.ts` → **30 passed** (was 18).

Same battery, after:

| mutant | before | after |
|---|---|---|
| drop `actual !== null` | 0 fail | **1 fail** |
| drop `scope` | 0 fail | **1 fail** |
| drop `roomId` | 0 fail | **1 fail** |
| drop `entityId` | 0 fail | **1 fail** |
| drop `scopedToEntityId` | 0 fail | **1 fail** |
| drop `addedBy` | 0 fail | **1 fail** |
| drop `revision` | 0 fail | **1 fail** |
| drop `ingestionAttemptId` | 0 fail | **1 fail** |
| drop `directGrantEntityIds` compare | 1 fail | **3 fail** |
| drop `ingestionState` | 1 fail | **2 fail** |
| `uuidArraysEqual` index-wise → set membership | 0 fail | **1 fail** |

**11 of 11 killed, from 3 of 11.**

Neighbouring suites unchanged:

```
document-list-query.test.ts                 30 passed
inMemoryAdapter.test.ts                      7 passed
inMemoryAdapter.access-context.test.ts       4 passed
documents/provider-pinned.test.ts           12 passed
documents/service-orphan-compensation.test.ts 8 passed
```

`bunx @biomejs/biome check` → clean. `bunx tsc --noEmit -p packages/core/tsconfig.json` → no errors in the file.

One note on building the fixture: `readDocumentMutationSnapshot` reads the revision from `metadata.documentRevision`, not `metadata.revision`, and `"shared"` is not in `DOCUMENT_LIST_SCOPES`. My first fixture used both and produced a null snapshot — the tests failed loudly rather than passing vacuously, which is the behaviour you want, but worth knowing if you extend the table.

# Context

Same sweep as #30418, #30419 and #30420: multi-clause guards where the suite proves the conjunction and not its terms.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1K96NGVXB2QNW4AEJT9K4VT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T09:22:07.003Z","completed_at":"2026-09-03T09:26:32.644Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T09:22:07.285Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"abbbef8f49d88c257b1ec5dca66e0d1506877f962376737c7285dfd7ee682181","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ff1b59b8-72ac-449d-830b-42f3070f702b","object_id":"sha256:abbbef8f49d88c257b1ec5dca66e0d1506877f962376737c7285dfd7ee682181","sha256":"abbbef8f49d88c257b1ec5dca66e0d1506877f962376737c7285dfd7ee682181"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Wd8hC25tyKbp9QJqdvAn92Qd7q8p1oIf2IUHFQU1jCineqBs4VeRhsWVl51zE9L2PpRor_CRWJ4CNP0VjYUXBg"}} -->
