### PR TITLE
test(core): isolate each clause of the reflection evaluation gate

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../../types/index.ts";
 import { parseExtractorOutputTolerant } from "./factExtractor.schema.ts";
 import {
+	canEvaluateMessage,
 	factMemoryEvaluator,
 	identityEvaluator,
 	relationshipEvaluator,
@@ -526,5 +527,113 @@ describe("reflection context preserves the complete room entity set", () => {
 		expect(runtime.getEntitiesForRoom).toHaveBeenCalledTimes(1);
 		// One shared conversation read plus factMemory's room/entity fact reads.
 		expect(runtime.getMemories).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe("canEvaluateMessage clause isolation", () => {
+	// Every reflection evaluator gates its `shouldRun` on this predicate, and
+	// preference-items gates on it too. A clause that stops being checked lets
+	// a turn reach the extraction model and write results back into durable
+	// fact / relationship / identity memory. Asserted one clause at a time,
+	// because a fixture that violates several at once cannot tell you which
+	// checks still exist.
+
+	it("admits an ordinary user turn", () => {
+		expect(canEvaluateMessage(message())).toBe(true);
+	});
+
+	it("still admits a turn when a semantic signal is explicitly present", () => {
+		expect(canEvaluateMessage(message(), { semanticSignal: true })).toBe(true);
+		expect(canEvaluateMessage(message(), {})).toBe(true);
+	});
+
+	it("refuses when the caller reports no semantic signal", () => {
+		expect(canEvaluateMessage(message(), { semanticSignal: false })).toBe(
+			false,
+		);
+	});
+
+	it("refuses a turn with no usable text", () => {
+		expect(canEvaluateMessage(message(""))).toBe(false);
+		expect(canEvaluateMessage(message("   "))).toBe(false);
+		expect(
+			canEvaluateMessage({
+				...message(),
+				content: {},
+			} as Memory),
+		).toBe(false);
+	});
+
+	it("refuses a turn with no author", () => {
+		expect(
+			canEvaluateMessage({
+				...message(),
+				entityId: undefined,
+			} as unknown as Memory),
+		).toBe(false);
+	});
+
+	it("refuses a turn with no room", () => {
+		expect(
+			canEvaluateMessage({
+				...message(),
+				roomId: undefined,
+			} as unknown as Memory),
+		).toBe(false);
+	});
+
+	// The runtime's own compaction and summary records are the reason this
+	// clause exists: mining them would write the agent's synthesized state back
+	// into durable memory as though a participant had said it. Detection has
+	// three independent inputs — metadata.source, metadata.tags, and the text
+	// marker — so each is asserted separately.
+	const syntheticArtifacts: Array<[string, Memory]> = [
+		[
+			"metadata.source names the compactor",
+			{ ...message(), metadata: { source: "compaction" } } as unknown as Memory,
+		],
+		[
+			"a metadata tag names a summary",
+			{ ...message(), metadata: { tags: ["summary"] } } as unknown as Memory,
+		],
+		[
+			"the text carries a conversation-summary marker",
+			message("[conversation summary] Berlin came up"),
+		],
+		[
+			"the text is a compacted planner trajectory",
+			message("Compacted prior planner trajectory steps 1-4"),
+		],
+	];
+
+	it.each(syntheticArtifacts)(
+		"refuses a synthetic artifact when %s",
+		(_name, artifact) => {
+			expect(canEvaluateMessage(artifact)).toBe(false);
+		},
+	);
+
+	it("gates every reflection evaluator on the same predicate", async () => {
+		// The clause table above is only meaningful if the evaluators actually
+		// consult it, so pin the wiring rather than assuming it.
+		const artifact = message("[conversation summary] Berlin came up");
+		for (const evaluator of [
+			factMemoryEvaluator,
+			relationshipEvaluator,
+			identityEvaluator,
+		]) {
+			expect(
+				await evaluator.shouldRun({
+					message: artifact,
+					options: undefined,
+				} as never),
+			).toBe(false);
+			expect(
+				await evaluator.shouldRun({
+					message: message(),
+					options: undefined,
+				} as never),
+			).toBe(true);
+		}
 	});
 });


### PR DESCRIPTION
# What

`canEvaluateMessage` decides whether a turn reaches the reflection extractors. All four evaluators in `reflection-items.ts` gate their `shouldRun` on it, and `preference-items.ts` does too. When it returns true, the turn goes to a structured-output model call whose results are written back into durable fact, relationship and identity memory.

Five clauses. Four have no fixture:

| mutant | `reflection-items.test.ts` | `preference-items.test.ts` |
|---|---|---|
| drop `options?.semanticSignal !== false` | 0 fail | 0 fail |
| drop `message.content.text?.trim()` | 0 fail | 1 fail |
| drop `message.entityId` | 0 fail | 0 fail |
| drop `message.roomId` | 0 fail | 0 fail |
| **drop `!isSyntheticConversationArtifactMemory(message)`** | **0 fail** | **0 fail** |

Coverage is thin in aggregate as well: inverting the whole predicate fails **one** test, in `preference-items.test.ts`. `reflection-items.test.ts` — the suite for the file that defines the gate and for the three evaluators that consult it — does not notice at all.

The synthetic-artifact clause is the one I would least like to be free. It is what stops the runtime's own compaction records and conversation summaries from being mined as though a participant had said them, and the results of that mining are durable: facts, relationship edges and identity claims persisted back into memory. Deleting that clause today changes no test anywhere.

# The change

Tests only, appended to the existing suite. One case per clause, plus the parts of the contract that are easy to break by accident:

- an ordinary turn is admitted;
- `semanticSignal: false` refuses, while `true` and an absent option both admit — the clause is `!== false`, not `=== true`, so "no opinion" means allowed;
- empty text, whitespace-only text and absent `content.text` all refuse;
- a turn with no author refuses; a turn with no room refuses;
- synthetic artifacts refuse, asserted once per detection input, since `isSyntheticConversationArtifactMemory` has three independent ones: `metadata.source`, `metadata.tags`, and the text marker;
- and the wiring: `factMemoryEvaluator`, `relationshipEvaluator` and `identityEvaluator` each return `false` from `shouldRun` for an artifact and `true` for a real turn. A clause table is only worth having if the evaluators actually consult the predicate, so that is pinned rather than assumed.

# Evidence

`bunx vitest run src/features/advanced-capabilities/evaluators/reflection-items.test.ts` → **26 passed** (was 15).

| mutant | before | after |
|---|---|---|
| drop `options?.semanticSignal !== false` | 0 fail | **1 fail** |
| drop `message.content.text?.trim()` | 0 fail | **1 fail** |
| drop `message.entityId` | 0 fail | **1 fail** |
| drop `message.roomId` | 0 fail | **1 fail** |
| drop `!isSyntheticConversationArtifactMemory(message)` | 0 fail | **5 fail** |
| `semanticSignal !== false` → `=== true` | 0 fail | **3 fail** |

**6 of 6 killed**, from 1 of 5 (and that one only in a sibling package's suite).

Neighbouring suites unchanged:

```
reflection-items.test.ts   26 passed
preference-items.test.ts   24 passed
experience-items.test.ts    5 passed
```

`bunx @biomejs/biome check` → clean. `bunx tsc --noEmit -p packages/core/tsconfig.json` → no errors in the file.

# Context

Same sweep as #30418, #30419, #30420 and #30421. Two candidates screened before this one — `capturedTerminalOutputIsSafe` and `isStagingSessionExchangeEnabled` — were already pinned clause by clause and needed nothing.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1K9R5KP9HVDW7GVPMB0EM9K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T09:31:40.534Z","completed_at":"2026-09-03T09:36:08.376Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T09:31:41.225Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"70d71c68383c78b108b89e57a8e730a073f992835f91d2e752056d1da19a613e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c1eedfad-132e-4583-b3ec-5bdb3d320d45","object_id":"sha256:70d71c68383c78b108b89e57a8e730a073f992835f91d2e752056d1da19a613e","sha256":"70d71c68383c78b108b89e57a8e730a073f992835f91d2e752056d1da19a613e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"OkIHx_cJQngrYoNaByF41ObsRYGvPhTJ5k6NSKfsYs9A7wUdL-Vecjs-YRwfYnOJHw74FuD-t8avbJUtTmRLDQ"}} -->
