### PR TITLE
test(core): pin the tool diagnostic depth bound at its boundary

### DIFF
--- a/packages/core/src/security/tool-diagnostics.test.ts
+++ b/packages/core/src/security/tool-diagnostics.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
 	composeToolDiagnosticRedactor,
 	projectCompleteModelCallValue,
+	projectCompleteToolValueForModel,
 	projectModelCallDiagnosticValue,
 	projectProtectedModelCallValue,
 	projectToolDiagnosticArgs,
@@ -295,5 +296,63 @@ describe("projectToolDiagnosticArgs", () => {
 		);
 		expect(projected?.token).toBe(TOOL_DIAGNOSTIC_MASK);
 		expect(projected?.count).toBe(2);
+	});
+});
+
+describe("tool diagnostic depth bound", () => {
+	const identity = (text: string) => text;
+
+	/** `wrappers` nested objects around a leaf, so nesting depth is exact. */
+	function nested(wrappers: number): unknown {
+		let value: unknown = { leaf: "DEPTH-CANARY" };
+		for (let i = 0; i < wrappers; i += 1) value = { next: value };
+		return value;
+	}
+
+	function maskDepth(projected: unknown): number | null {
+		let cursor: unknown = projected;
+		for (let depth = 0; depth < 64; depth += 1) {
+			if (cursor === TOOL_DIAGNOSTIC_MASK) return depth;
+			if (typeof cursor !== "object" || cursor === null) return null;
+			cursor = (cursor as { next?: unknown }).next;
+		}
+		return null;
+	}
+
+	// The depth cap is what stops a hostile or runaway tool payload from
+	// walking the projector, and it is also what decides how much nested
+	// diagnostic data reaches a log. Pinned from BOTH sides at the exact
+	// boundary: raising or lowering the bound by one has to fail here, not
+	// only the extreme values a smoke test would catch.
+	it("renders the deepest level inside the bound", () => {
+		const projected = projectToolDiagnosticValue(nested(7), identity);
+		expect(JSON.stringify(projected)).toContain("DEPTH-CANARY");
+		expect(maskDepth(projected)).toBeNull();
+	});
+
+	it("masks one level past the bound, and masks exactly there", () => {
+		const projected = projectToolDiagnosticValue(nested(8), identity);
+		expect(JSON.stringify(projected)).not.toContain("DEPTH-CANARY");
+		// The mask replaces the eighth nested value; everything shallower is
+		// still rendered, so truncation is bounded rather than total.
+		expect(maskDepth(projected)).toBe(8);
+	});
+
+	it("keeps masking at the same depth for deeper payloads", () => {
+		expect(maskDepth(projectToolDiagnosticValue(nested(20), identity))).toBe(8);
+	});
+
+	// The complete model-bound projection documents itself as being "without
+	// diagnostic depth masking". Pinned against the same fixtures, so unifying
+	// the two projectors cannot silently start truncating model input.
+	it("does not apply the depth bound to the complete model-bound projection", () => {
+		for (const wrappers of [8, 20]) {
+			const projected = projectCompleteToolValueForModel(
+				nested(wrappers),
+				identity,
+			);
+			expect(JSON.stringify(projected)).toContain("DEPTH-CANARY");
+			expect(maskDepth(projected)).toBeNull();
+		}
 	});
 });


### PR DESCRIPTION
# What

`MAX_TOOL_DIAGNOSTIC_DEPTH = 8` bounds the tool-diagnostic projector in `packages/core/src/security/`. It appears at five sites and decides two things: how far the projector will walk a tool payload, and how much nested tool data reaches a diagnostic log.

Its value is not pinned. Moving it by one in either direction leaves the suite green:

| mutant | `tool-diagnostics.test.ts` |
|---|---|
| `8` → `7` | **18 pass / 0 fail** |
| `8` → `9` | **18 pass / 0 fail** |
| `8` → `64` | 17 pass / 1 fail |
| `8` → `1` | 13 pass / 5 fail |

Only the extremes are caught, by tests that happen to nest 18 levels deep for other reasons. Nothing sits at the boundary, so the specific number is currently a free variable — including upward, which widens what a hostile or runaway payload can push into a log.

# The change

Tests only. A helper that nests exactly `n` objects around a leaf, plus a `maskDepth` walker that reports where `TOOL_DIAGNOSTIC_MASK` appears, and four cases:

- **7 wrappers renders** — the deepest level inside the bound still carries its payload, and no mask appears;
- **8 wrappers masks, at exactly depth 8** — asserted positionally, not just as "the payload is gone", so truncation is shown to be bounded rather than total;
- **20 wrappers still masks at depth 8** — the bound does not drift with input size;
- **the complete model-bound projection is unaffected** — `projectCompleteToolValueForModel` documents itself as being "without diagnostic depth masking", and is pinned against the same fixtures at 8 and 20 wrappers.

That last one is the pair I most wanted: the diagnostic projector and the complete projector differ *only* by this bound, so unifying them is an easy refactor to make by accident. With this test, doing so either starts truncating model input or stops truncating diagnostics, and both fail.

I established the boundary by executing the projector rather than reading the comparison — `depth >= MAX` is evaluated on the value's own depth, and the off-by-one is easy to get wrong from the source alone.

# Evidence

`bunx vitest run src/security/tool-diagnostics.test.ts` → **22 passed** (was 18).

| mutant | before | after |
|---|---|---|
| `8` → `7` | 0 fail | **3 fail** |
| `8` → `9` | 0 fail | **2 fail** |
| `8` → `6` | — | **3 fail** |
| `8` → `10` | — | **2 fail** |
| `8` → `64` | 1 fail | **3 fail** |
| `8` → `1` | 5 fail | **8 fail** |
| `depth >= MAX` → `depth > MAX` | — | **2 fail** |

**7 of 7 killed**, where ±1 in either direction previously had no detector.

`bunx @biomejs/biome check` → clean (no reformatting needed). `bunx tsc --noEmit -p packages/core/tsconfig.json` → no errors in the file.

# Context

Found by sweeping for numeric guards compared against an `UPPER_SNAKE` constant whose name never appears in a test — the one-sided-threshold shape from #30410. Related: #30418–#30423 in the clause-isolation series.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KAWWYDRTPR3HMC5CWVBNCG","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T09:51:44.078Z","completed_at":"2026-09-03T09:54:53.340Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T09:51:44.305Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5fb1dd5668744c6af74d3cad579f211b3d2e924bbd4cf55df8a3f97eb9e8c276","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b944cc08-3788-47e8-8dde-7afca03d4498","object_id":"sha256:5fb1dd5668744c6af74d3cad579f211b3d2e924bbd4cf55df8a3f97eb9e8c276","sha256":"5fb1dd5668744c6af74d3cad579f211b3d2e924bbd4cf55df8a3f97eb9e8c276"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"o6y2YUSsFcJFNu2wN4dl7z_MXKrrQBr6qbPm8lpwXZVPeV7ivh6dajBt5HbcQM9rO82oL2wzFRC_Bvl1gBINCg"}} -->
