### PR TITLE
test(cloud): pin both text-pricing cache TTL boundaries

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
@@ -480,3 +480,107 @@ test("canonical token pricing rejects an incomplete required rate instead of fab
     })),
   ).rejects.toThrow("invalid or incomplete token rates");
 });
+
+// The text-pricing cache has three age bands — fresh, stale-but-servable, and
+// expired — and both boundaries decide what a caller is billed at. Neither was
+// pinned: moving TEXT_PRICING_FRESH_TTL_MS or TEXT_PRICING_HARD_TTL_SECONDS,
+// or relaxing either `>=` to `>`, left this suite green. Each boundary is
+// asserted from both sides, one millisecond apart, through the public API.
+const TTL_EPOCH = 1_700_000_000_000;
+const STALE_RATES = { inputUnitPrice: 0.000009, outputUnitPrice: 0.000009 };
+
+function seedTextPricingAt(now: ReturnType<typeof spyOn<DateConstructor, "now">>) {
+  now.mockReturnValue(TTL_EPOCH);
+}
+
+test("text pricing serves from cache below the fresh TTL and reloads at it", async () => {
+  __clearPersistedPricingCache();
+  stubColdDurableCache();
+  const now = spyOn(Date, "now").mockReturnValue(TTL_EPOCH);
+
+  for (const [ageMs, expectedLoads] of [
+    [59_999, 0],
+    [60_000, 1],
+  ] as const) {
+    const key = `token-fresh-${ageMs}`;
+    seedTextPricingAt(now);
+    await getCachedTextPricingRates(
+      key,
+      { input: true, output: true },
+      mock(async () => TOKEN_RATES),
+      {},
+    );
+
+    now.mockReturnValue(TTL_EPOCH + ageMs);
+    const loader = mock(async () => TOKEN_RATES);
+    await expect(
+      getCachedTextPricingRates(key, { input: true, output: true }, loader, {}),
+    ).resolves.toEqual(TOKEN_RATES);
+    expect(loader).toHaveBeenCalledTimes(expectedLoads);
+  }
+});
+
+test("only stale worker reads schedule background hydration", async () => {
+  __clearPersistedPricingCache();
+  stubColdDurableCache();
+  const now = spyOn(Date, "now").mockReturnValue(TTL_EPOCH);
+
+  for (const [ageMs, expectedBackground] of [
+    [59_999, 0],
+    [60_000, 1],
+  ] as const) {
+    const key = `token-hydration-${ageMs}`;
+    seedTextPricingAt(now);
+    await getCachedTextPricingRates(
+      key,
+      { input: true, output: true },
+      mock(async () => TOKEN_RATES),
+      {},
+    );
+
+    now.mockReturnValue(TTL_EPOCH + ageMs);
+    const background: Promise<unknown>[] = [];
+    await expect(
+      getCachedTextPricingRates(
+        key,
+        { input: true, output: true },
+        mock(async () => TOKEN_RATES),
+        workerOptions(background),
+      ),
+    ).resolves.toEqual(TOKEN_RATES);
+    expect(background).toHaveLength(expectedBackground);
+  }
+});
+
+test("stale-but-bounded rates are served from cache while expired rates reload", async () => {
+  __clearPersistedPricingCache();
+  stubColdDurableCache();
+  const now = spyOn(Date, "now").mockReturnValue(TTL_EPOCH);
+
+  // Distinguishes a stale serve from an eviction: only a reload can return the
+  // NEW rates, so the boundary is observable in the billed value itself.
+  for (const [ageMs, expected] of [
+    [899_999, TOKEN_RATES],
+    [900_000, STALE_RATES],
+  ] as const) {
+    const key = `token-hard-${ageMs}`;
+    seedTextPricingAt(now);
+    await getCachedTextPricingRates(
+      key,
+      { input: true, output: true },
+      mock(async () => TOKEN_RATES),
+      {},
+    );
+
+    now.mockReturnValue(TTL_EPOCH + ageMs);
+    const background: Promise<unknown>[] = [];
+    await expect(
+      getCachedTextPricingRates(
+        key,
+        { input: true, output: true },
+        mock(async () => STALE_RATES),
+        workerOptions(background),
+      ),
+    ).resolves.toEqual(expected);
+  }
+});


### PR DESCRIPTION
# What

The text-pricing cache has three age bands, and both boundaries decide what a caller is billed at:

```ts
if (ageMs >= TEXT_PRICING_HARD_TTL_MS) { evict; return null; }
return { record, stale: ageMs >= TEXT_PRICING_FRESH_TTL_MS };
```

Neither boundary is pinned. Every one of these leaves `cache.test.ts` green on `develop`:

| mutant | result |
|---|---|
| `TEXT_PRICING_FRESH_TTL_MS` 60s → 59s | **21 pass / 0 fail** |
| `TEXT_PRICING_FRESH_TTL_MS` 60s → 120s | **21 pass / 0 fail** |
| `TEXT_PRICING_HARD_TTL_SECONDS` 15m → 14m | **21 pass / 0 fail** |
| `TEXT_PRICING_HARD_TTL_SECONDS` 15m → 60m | **21 pass / 0 fail** |
| `ageMs >= HARD` → `ageMs > HARD` | **21 pass / 0 fail** |
| `stale: ageMs >= FRESH` → `> FRESH` | **21 pass / 0 fail** |

Quadrupling the hard TTL is a free change today. That band is how long a rate may be served after it stopped being refreshed, so widening it silently extends the window in which a caller is billed at a superseded price — the comment above `PERSISTED_PRICING_CACHE_TTL_MS` in this same file shows the team already reasons about exactly that trade-off.

# The change

Tests only, appended to the existing suite. Both boundaries asserted from both sides, one millisecond apart, entirely through the public API — no reaching into module state:

- **fresh boundary, by loader invocation** — at 59 999 ms the cached rates are returned and the loader is never called; at 60 000 ms the loader runs.
- **fresh boundary, by background hydration** — through the worker (`cacheOnly`) path: a fresh read schedules nothing on `executionCtx.waitUntil`, a stale read schedules exactly one hydration.
- **hard boundary, by the billed value itself** — seed the cache with one set of rates, then read at 899 999 ms and 900 000 ms with a loader that returns *different* rates. Inside the bound the old rates are served from cache; at the bound the entry is gone and the new rates come back. Only a reload can produce the new value, so the boundary is observable in the number the caller is billed at rather than in an internal flag.

Time is controlled with `spyOn(Date, "now")`, and each age uses its own cache key — my first probe reused one key and the age-899 999 read re-cached the entry, which made the next read look fresh. Separate keys keep each boundary independent.

# Evidence

`bun test src/lib/services/ai-pricing/cache.test.ts` → **24 pass / 0 fail** (was 21), 88 `expect()` calls.

| mutant | before | after |
|---|---|---|
| `FRESH_TTL_MS` 60s → 59s | 0 fail | **2 fail** |
| `FRESH_TTL_MS` 60s → 120s | 0 fail | **2 fail** |
| `HARD_TTL_SECONDS` 15m → 14m | 0 fail | **1 fail** |
| `HARD_TTL_SECONDS` 15m → 60m | 0 fail | **1 fail** |
| `ageMs >= HARD` → `> HARD` | 0 fail | **1 fail** |
| `stale: ageMs >= FRESH` → `> FRESH` | 0 fail | **2 fail** |

**6 of 6 killed, from 0 of 6.**

`cache.error-policy.test.ts` → 3 pass, unchanged. `bunx @biomejs/biome check` → clean. `bunx tsc --noEmit -p packages/cloud/shared/tsconfig.json` → no errors in the file.

# Context

Found by the same sweep as #30424: numeric guards compared against an `UPPER_SNAKE` constant whose name appears in no test file. Related clause-isolation work in #30418–#30423.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KBF52X9E3PT1P0KZPBBAK6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T10:01:42.237Z","completed_at":"2026-09-03T10:05:39.981Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T10:01:43.028Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5b42bd5798c61206b0ed8ae82c897d83787c4619d8d7edfda3c7f62e0fb2b9a0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"187a0c6b-f738-4092-bde5-39031c807945","object_id":"sha256:5b42bd5798c61206b0ed8ae82c897d83787c4619d8d7edfda3c7f62e0fb2b9a0","sha256":"5b42bd5798c61206b0ed8ae82c897d83787c4619d8d7edfda3c7f62e0fb2b9a0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"a-LNzTHCzXTG2zaw-NX4DEZtbEi5cEUE8wbtX7QFjBRr0MZ6tx3NaI1KQWLG6UTlAWaLuij_uTiDtHPkX5B8CQ"}} -->
