### PR TITLE
test(cloud): pin the reconciliation threshold from below

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts
@@ -483,6 +483,39 @@ describe("reconcile refund-then-throw + settler re-invoke (#11512)", () => {
     expect(await orgTransactions(payerOrgId, "refund")).toHaveLength(1);
   });
 
+  test("a difference below the reconciliation threshold is not a material refund", async () => {
+    if (!pgliteReady) return;
+    // The threshold's other side. The suite already pins a difference exactly
+    // AT it (above), which catches a widened tolerance — but nothing catches a
+    // narrowed one, and the constant exists to absorb float noise: shrinking it
+    // turns IEEE-754 residue into refund transactions and spurious drift
+    // errors. A half-threshold difference must settle as no-op, not refund.
+    const { appId, payerUserId, payerOrgId, creatorUserId } = await seed();
+    const deduction = await appCreditsService.deductCredits({
+      appId,
+      userId: payerUserId,
+      baseCost: 0.000001,
+      description: "sub-threshold app debit",
+    });
+    expect(deduction.transactionId).toBeTruthy();
+    const balanceAfterDebit = await orgBalance(payerOrgId);
+
+    const result = await appCreditsService.reconcileCredits({
+      appId,
+      userId: payerUserId,
+      organizationId: payerOrgId,
+      estimatedBaseCost: 0.000001,
+      actualBaseCost: 0.0000005,
+      description: "sub-threshold reconcile",
+      reservationTransactionId: deduction.transactionId,
+    });
+
+    expect(result.action).not.toBe("refund");
+    expect(await orgBalance(payerOrgId)).toBeCloseTo(balanceAfterDebit, 6);
+    expect(await orgTransactions(payerOrgId, "refund")).toHaveLength(0);
+    expect(await creatorBalance(creatorUserId)).toBe(0);
+  });
+
   test("refund uses the debit's immutable creator and markup despite supplied app drift", async () => {
     if (!pgliteReady) return;
     const owner = await seed();


### PR DESCRIPTION
# What

`RECONCILIATION_THRESHOLD = 0.000001` is the float-comparison tolerance for credit reconciliation. It appears at eight decision sites in `app-credits.ts`, and the load-bearing one is the early no-op:

```ts
// Skip reconciliation for negligible differences
if (Math.abs(baseCostDifference) < RECONCILIATION_THRESHOLD) {
  await markReservationSettled();
  return { reconciled: false, difference: 0, action: "none", … };
}
```

The suite pins that constant from **one side only**. `app-credits-reconcile-double-refund.test.ts` already has *"a backed refund exactly at the reconciliation threshold settles"*, which catches a widened tolerance — but nothing catches a narrowed one:

| mutant | `double-refund` | `credits-reconcile` | `idempotency` |
|---|---|---|---|
| `0.000001` → `1` | 5 pass / 6 fail | 37 / 0 | 17 / 2 fail |
| `0.000001` → `0.01` | 10 pass / 1 fail | 37 / 0 | 19 / 0 |
| **`0.000001` → `0.0000000001`** | **11 pass / 0 fail** | **37 / 0** | **19 / 0** |

Shrinking it by four orders of magnitude is a free change. That is the direction the constant exists to prevent: it is there to absorb IEEE-754 residue in cost arithmetic, so a tolerance below the noise floor turns ordinary rounding into `action: "refund"` transactions and into spurious drift errors at the `Math.abs(persistedAmount - totalCost) > RECONCILIATION_THRESHOLD` sites.

# The change

Tests only — one case, the mirror of the existing at-threshold test, in the same PGlite harness:

- debit `0.000001`, then reconcile with `estimatedBaseCost: 0.000001` and `actualBaseCost: 0.0000005` — a half-threshold difference;
- assert `result.action` is not `"refund"`, the org balance is unchanged, no refund transaction row exists, and creator earnings stay zero.

The difference is computed from the passed-in arguments before any persistence, so a half-threshold value is a real in-memory difference regardless of column precision.

# Evidence

`bun test src/lib/services/__tests__/app-credits-reconcile-double-refund.test.ts` → **12 pass / 0 fail** (was 11), 94 `expect()` calls.

| mutant | before | after |
|---|---|---|
| `0.000001` → `0.0000000001` | 0 fail | **1 fail** |
| `0.000001` → `0` | 0 fail | **2 fail** |
| `0.000001` → `0.0000005` | 0 fail | **1 fail** |
| `0.000001` → `0.01` | 1 fail | **1 fail** |
| `0.000001` → `1` | 6 fail | **6 fail** |

The `0.0000005` row is the tight one: the threshold is now pinned to within a factor of two from below, not merely against being zeroed.

Sibling suites unchanged: `credits-reconcile.test.ts` 37 pass, `app-credits-idempotency.test.ts` 19 pass. `bunx @biomejs/biome check` → clean (no reformatting). `bunx tsc --noEmit -p packages/cloud/shared/tsconfig.json` → no errors in the file.

# One mutant I did not chase

`const isMaterialRefund = -baseCostDifference >= RECONCILIATION_THRESHOLD` (line 1221) can be rewritten to `> 0` with the suite still green. That is not a coverage gap: the `Math.abs(...) < RECONCILIATION_THRESHOLD` guard above returns early, so by the time `isMaterialRefund` is evaluated every remaining difference already exceeds the threshold and the two expressions agree. The comparison is subsumed rather than untested, and no fixture can distinguish it — so I have left it alone rather than adding a case that would look like coverage without being any.

# Context

Found by the same sweep as #30424 and #30425: numeric guards compared against an `UPPER_SNAKE` constant whose name appears in no test file. Screened clean and not filed this pass: the three `*_GATE_MAX_ATTEMPTS` budgets in `inference-admission-gate.ts`, all of which already fail on ±1.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KCKGM49G6H5K2HMWDPTDXV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T10:21:33.701Z","completed_at":"2026-09-03T10:28:25.965Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T10:21:34.307Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c4016e51d6493e71627c9da81dd689565429cac6a61e62e9a5752034e0070573","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8902356f-763c-473a-9f3a-e5693e226c22","object_id":"sha256:c4016e51d6493e71627c9da81dd689565429cac6a61e62e9a5752034e0070573","sha256":"c4016e51d6493e71627c9da81dd689565429cac6a61e62e9a5752034e0070573"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"2NZHovC4EYc4LU_pAU2epN15wu4bxNIi5lZDV8000H43OifNkn_y3c9c16Edes9PKHL5mfA1i6UKL16zCB2ADQ"}} -->
