### PR TITLE
test(cloud): name every reserved username instead of the set's first entry

### DIFF
--- a/packages/cloud/shared/src/lib/utils/agent-username.test.ts
+++ b/packages/cloud/shared/src/lib/utils/agent-username.test.ts
@@ -7,6 +7,7 @@ import {
   RESERVED_USERNAMES,
   slugify,
   USERNAME_MAX_LENGTH,
+  USERNAME_MIN_LENGTH,
   validateUsername,
 } from "./agent-username";
 
@@ -34,6 +35,75 @@ describe("validateUsername", () => {
     const ok = validateUsername("Cool-Agent");
     expect(ok.valid).toBe(true);
     expect(ok.normalized).toBe("cool-agent");
+  });
+
+  /**
+   * The assertion above reads the set's first element, so it holds for any
+   * non-empty set and cannot notice an entry leaving the list. Every reserved
+   * name is a real top-level surface (`/chat/@admin`, `@login`, `@settings`),
+   * and an entry that quietly disappears becomes a handle anyone can claim.
+   * Pin the membership itself, then the behaviour of each entry.
+   */
+  test("reserves exactly the documented set of route names", () => {
+    expect([...RESERVED_USERNAMES].sort()).toEqual([
+      "admin",
+      "api",
+      "app",
+      "chat",
+      "dashboard",
+      "eliza",
+      "elizaos",
+      "help",
+      "login",
+      "logout",
+      "me",
+      "new",
+      "null",
+      "profile",
+      "settings",
+      "signup",
+      "support",
+      "system",
+      "undefined",
+      "user",
+      "www",
+    ]);
+    for (const reserved of RESERVED_USERNAMES) {
+      // An entry stored with a capital could never match `normalized`, so it
+      // would read as protection while being dead weight.
+      expect(reserved).toBe(reserved.toLowerCase());
+    }
+  });
+
+  test.each([...RESERVED_USERNAMES])("refuses %s by name", (reserved) => {
+    const result = validateUsername(reserved);
+    expect(result.valid).toBe(false);
+    expect(result.normalized).toBeUndefined();
+    // `me` is two characters, so the length check answers first and the
+    // reserved branch is unreachable for it through this entry point. It still
+    // does work: CharactersService seeds `RESERVED_USERNAMES` into the taken-name
+    // set when generating, so it blocks a collision there.
+    expect(result.error).toMatch(reserved.length < USERNAME_MIN_LENGTH ? /at least/ : /reserved/);
+  });
+
+  test("the reserved check is case-folded, not raw", () => {
+    // The guard reads `normalized`, not the caller's string. Reading the raw
+    // input instead leaves the whole list bypassable by shifting one character:
+    // `Admin` would come back `{ valid: true, normalized: "admin" }` and take
+    // the `/chat/@admin` route. Nothing above distinguishes the two reads.
+    const reachable = [...RESERVED_USERNAMES].filter((name) => name.length >= USERNAME_MIN_LENGTH);
+    expect(reachable.length).toBeGreaterThan(0);
+    for (const reserved of reachable) {
+      for (const spelling of [
+        reserved.toUpperCase(),
+        reserved[0].toUpperCase() + reserved.slice(1),
+      ]) {
+        const result = validateUsername(spelling);
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/reserved/);
+        expect(result.normalized).toBeUndefined();
+      }
+    }
   });
 });
 


### PR DESCRIPTION
# What

`agent-username.test.ts` checks the reserved-handle list like this:

```ts
const reserved = [...RESERVED_USERNAMES][0];
expect(validateUsername(reserved).error).toMatch(/reserved/);
```

That assertion holds for **any non-empty set**. It reads whichever name happens to sort first, so it cannot notice an entry leaving the list — deleting one just promotes the next.

Measured on `develop`, deleting each name individually:

| mutant | result |
|---|---|
| drop `"admin"` | **6 pass / 0 fail** |
| drop `"api"` / `"chat"` / `"login"` / `"settings"` / `"www"` / … | **6 pass / 0 fail** |
| **all 21 entries, one at a time** | **21/21 survive** |
| empty the check entirely (`if (false)`) | 5 pass / 1 fail |

So the suite pins "the list is non-empty" and nothing else. Every one of those names is a live top-level surface — `/chat/@admin`, `@login`, `@settings`, `@api` — and the file's own header comment says "a loose check here enables routing spoofing".

# The one that isn't just a coverage gap

`RESERVED_USERNAMES.has(normalized)` → `has(username)` also **survives the whole suite**.

That mutant is a complete bypass of the list, not a weakening of it: `validateUsername("Admin")` would return `{ valid: true, normalized: "admin" }`, and `CharactersService.validateUsernameForUpdate` stores the normalized form — so shifting one character claims `/chat/@admin`. The code is correct today; nothing was holding it there.

A capitalised *entry* survives too (`"admin"` → `"Admin"` in the set): it can never match `normalized`, so it reads as protection while being dead weight.

# The change

Three tests appended, no source changes:

- **`reserves exactly the documented set of route names`** — the membership itself, against an explicit sorted list, plus every entry lowercase.
- **`refuses %s by name`** — a `test.each` over the set, so each name is its own case with its own label.
- **`the reserved check is case-folded, not raw`** — every reachable entry in `UPPER` and `Title` spelling.

# `me` is unreachable through this entry point, and the test says so

`"me"` is two characters, so `USERNAME_MIN_LENGTH` answers first and the reserved branch never runs for it. Rather than dropping it from the table or asserting the wrong message, the case selects its expectation:

```ts
expect(result.error).toMatch(reserved.length < USERNAME_MIN_LENGTH ? /at least/ : /reserved/);
```

It is not dead: `CharactersService.generateUniqueUsername` seeds the whole set into the taken-name set, so `"me"` still blocks a collision there. The explicit membership assertion is what pins it, since no `validateUsername` fixture can.

The case-fold test filters to reachable entries and asserts the filter is non-empty, so it can't silently degrade to zero cases.

# Evidence

`bun test src/lib/utils/agent-username.test.ts`: **29 pass / 0 fail**, 226 assertions (was 6 pass, 20 assertions).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 6 / 0 | **29 / 0** |
| `has(normalized)` → `has(username)` | 6 / 0 — survives | **28 / 1** |
| drop `"admin"` | 6 / 0 — survives | **27 / 1** |
| drop `"api"`, `"chat"`, `"login"`, `"settings"`, `"www"`, `"me"`, `"undefined"` | survive | **27 / 1** each |
| `"admin"` → `"Admin"` in the set | 6 / 0 — survives | **25 / 4** |
| `if (RESERVED_USERNAMES.has(...))` → `if (false)` | 5 / 1 | **7 / 22** |

**11/11 killed, was 0/11.** Biome clean, `tsc --noEmit` clean. The source file is untouched, so no sibling suite can be affected.

# One mutant I did not chase

Dropping `.trim()` from the normalizer survives. It is subsumed: any untrimmed input still carries a space, and `USERNAME_PATTERN` rejects spaces, so the result is invalid either way — only the error *message* differs, and no caller branches on which message it is.

# What I screened and did not file

The length and charset guards in the same file are already tight — `USERNAME_MIN_LENGTH` 3→1 and 3→5, `USERNAME_MAX_LENGTH` 30→10 and 30→300, both clause deletions, a loosened `USERNAME_PATTERN`, and dropping `.toLowerCase()` all fail the existing suite. The reserved list was the one guard in the file with no real coverage.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KD74P7QWN5RW92VQ741AKH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T10:32:16.839Z","completed_at":"2026-09-03T10:36:37.542Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T10:32:17.058Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"09bf1e442e0e185b1a55d3793003505a1bee8deaa98eab5c1e2476a3207d3380","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"e8f7e641-d20e-4b7c-b7c2-279d0bacfca6","object_id":"sha256:09bf1e442e0e185b1a55d3793003505a1bee8deaa98eab5c1e2476a3207d3380","sha256":"09bf1e442e0e185b1a55d3793003505a1bee8deaa98eab5c1e2476a3207d3380"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"hMsLrmtb5XPqbWGobvdmTjGdOPJgx7CuuFAKJp9j8nfWa8-sy1uzPvZ7oWyj1qPkwYJtA_g5PVsQoWOc_BJLBQ"}} -->
