### PR TITLE
test(agent): pin the agent-specific tail of the blocked env denylist

### DIFF
--- a/packages/agent/src/config/blocked-env-keys.test.ts
+++ b/packages/agent/src/config/blocked-env-keys.test.ts
@@ -30,6 +30,94 @@ describe("BLOCKED_ENV_KEYS", () => {
     expect(BLOCKED_ENV_KEYS.has("OPINION_PRIVATE_KEY")).toBe(true);
   });
 
+  /**
+   * The spot-checks above name five of the thirteen keys this package appends
+   * on top of the core spawn policy, and the superset test below only covers
+   * what core contributes. The other eight are unasserted: deleting
+   * `EVM_PRIVATE_KEY` or `SOLANA_PRIVATE_KEY` from the set leaves every suite
+   * in this package green, and a config write could then persist a wallet key
+   * into `process.env`.
+   *
+   * Pin the agent-specific tail by subtracting core's contribution, so the
+   * assertion keeps naming exactly this package's own keys as core's list
+   * grows, and so an addition here is a deliberate edit rather than a silent
+   * one.
+   */
+  it("appends exactly the agent-specific secrets on top of the core policy", () => {
+    const agentSpecific = [...BLOCKED_ENV_KEYS]
+      .filter((key) => !BLOCKED_SPAWN_ENV_KEYS.has(key))
+      .sort();
+
+    expect(agentSpecific).toEqual([
+      "DATABASE_URL",
+      "ELIZA_API_TOKEN",
+      "ELIZA_CLOUD_CLIENT_ADDRESS_KEY",
+      "ELIZA_TERMINAL_RUN_TOKEN",
+      "ELIZA_WALLET_EXPORT_TOKEN",
+      "EVM_PRIVATE_KEY",
+      "GITHUB_TOKEN",
+      "OPINION_API_KEY",
+      "OPINION_PRIVATE_KEY",
+      "POSTGRES_URL",
+      "SOLANA_PRIVATE_KEY",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_API_KEY",
+    ]);
+  });
+
+  it.each([
+    "DATABASE_URL",
+    "ELIZA_API_TOKEN",
+    "ELIZA_CLOUD_CLIENT_ADDRESS_KEY",
+    "ELIZA_TERMINAL_RUN_TOKEN",
+    "ELIZA_WALLET_EXPORT_TOKEN",
+    "EVM_PRIVATE_KEY",
+    "GITHUB_TOKEN",
+    "OPINION_API_KEY",
+    "OPINION_PRIVATE_KEY",
+    "POSTGRES_URL",
+    "SOLANA_PRIVATE_KEY",
+    "STEWARD_AGENT_TOKEN",
+    "STEWARD_API_KEY",
+  ])("refuses %s through the predicate, not just the raw set", (key) => {
+    // Membership is not the boundary — `isBlockedEnvKey` is, and it is what the
+    // config and API gates call. None of these keys sits inside a prefix
+    // family, so the exact-set branch is the only thing that can catch them.
+    expect(isBlockedEnvKey(key)).toBe(true);
+    // The predicate folds case and surrounding whitespace before matching;
+    // these keys have to survive that path too, since a request body supplies
+    // the spelling.
+    expect(isBlockedEnvKey(key.toLowerCase())).toBe(true);
+    expect(isBlockedEnvKey(`  ${key}  `)).toBe(true);
+  });
+
+  it("collectConfigEnvVars drops every agent-specific secret", () => {
+    // The set exists to stop these reaching process.env at startup. Drive the
+    // real collector rather than re-asserting membership.
+    const agentSpecific = [...BLOCKED_ENV_KEYS].filter(
+      (key) => !BLOCKED_SPAWN_ENV_KEYS.has(key),
+    );
+    expect(agentSpecific.length).toBeGreaterThan(0);
+    const secrets = Object.fromEntries(
+      agentSpecific.map((key) => [key, "leaked"]),
+    );
+
+    // `collectConfigEnvVars` filters two separate loops — the explicit
+    // `env.vars` map and the loose string members of `env` itself. Both reach
+    // process.env, so both have to drop these keys.
+    expect(
+      collectConfigEnvVars({
+        env: { vars: { ...secrets, SAFE_FLAG: "true" } },
+      } as Parameters<typeof collectConfigEnvVars>[0]),
+    ).toEqual({ SAFE_FLAG: "true" });
+
+    expect(
+      collectConfigEnvVars({
+        env: { ...secrets, SAFE_FLAG: "true" },
+      } as Parameters<typeof collectConfigEnvVars>[0]),
+    ).toEqual({ SAFE_FLAG: "true" });
+  });
+
   it("is a superset of BLOCKED_SPAWN_ENV_KEYS so the two denylists cannot drift", () => {
     for (const key of BLOCKED_SPAWN_ENV_KEYS) {
       expect(BLOCKED_ENV_KEYS.has(key)).toBe(true);


### PR DESCRIPTION
# What

`BLOCKED_ENV_KEYS` is core's spawn-env denylist plus **thirteen agent-specific secrets** — API tokens, wallet private keys, database URLs. The suite pins core's contribution exhaustively (`for (const key of BLOCKED_SPAWN_ENV_KEYS)`), but the thirteen appended here are covered by five hand-written spot checks.

The other eight are unasserted. Deleting each one, one at a time, across every suite in this package:

| deleted key | `blocked-env-keys` | `server-helpers-plugin` | `config-routes` | `env-vars` |
|---|---|---|---|---|
| `EVM_PRIVATE_KEY` | 11/11 | 15/15 | 25/25 | 30/30 |
| `SOLANA_PRIVATE_KEY` | 11/11 | 15/15 | 25/25 | 30/30 |
| `ELIZA_WALLET_EXPORT_TOKEN` | 11/11 | 15/15 | 25/25 | 30/30 |
| `ELIZA_TERMINAL_RUN_TOKEN` | 11/11 | 15/15 | 25/25 | 30/30 |
| `ELIZA_API_TOKEN` | 11/11 | 15/15 | 25/25 | 30/30 |
| `POSTGRES_URL` | 11/11 | 15/15 | 25/25 | 30/30 |
| `GITHUB_TOKEN` | 11/11 | 15/15 | 25/25 | **2 failed** |
| `DATABASE_URL` | 11/11 | 15/15 | 25/25 | **2 failed** |

**Six of eight survive**, including both wallet private keys. `GITHUB_TOKEN` and `DATABASE_URL` are caught only incidentally, by fixtures in `env-vars.test.ts` that happen to use them.

`packages/docs/security.md` says this set exists so "an attacker with API access" cannot write security-sensitive variables. A key silently leaving it restores exactly that, and nothing in this package would notice.

# The change

Test-only, three additions to `blocked-env-keys.test.ts`.

**Pin the tail by subtraction, not by a second copy of the list:**

```ts
const agentSpecific = [...BLOCKED_ENV_KEYS]
  .filter((key) => !BLOCKED_SPAWN_ENV_KEYS.has(key))
  .sort();
expect(agentSpecific).toEqual([...13 names...]);
```

Subtracting core's set means the assertion keeps naming exactly *this* package's keys as core's list grows — it won't turn into a chore every time the spawn policy gains an entry. It is also two-directional: a silent **addition** fails it too (verified below), so growing the denylist stays a deliberate edit.

**Assert the predicate, not the container.** `isBlockedEnvKey` is what the config and API gates actually call. Each of the thirteen gets a case there, in canonical, lowercase, and whitespace-padded spelling — the shapes a request body can supply. None of them sits inside a prefix family, so the exact-set branch is the only thing that can catch them.

**Drive the collector.** `collectConfigEnvVars` is the startup path these keys must not survive. It filters in **two separate loops** — the explicit `env.vars` map and the loose string members of `env` itself — and both reach `process.env`, so the test feeds the whole tail through each.

# One thing worth flagging from writing it

My first version of the collector test passed a flat record and got back `{}`, which looked like a pass at a glance. It wasn't: `collectConfigEnvVars` takes an `ElizaConfig` and returns `{}` immediately when `cfg.env` is absent, so the call never reached a guard. Wrapping it properly is also what surfaced the second loop.

# Evidence

`bunx vitest run src/config/blocked-env-keys.test.ts`: **26 passed** (was 11).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 11/11 | **26/26** |
| drop `EVM_PRIVATE_KEY` | survives | **2 failed** |
| drop `SOLANA_PRIVATE_KEY` | survives | **2 failed** |
| drop `ELIZA_API_TOKEN` / `ELIZA_WALLET_EXPORT_TOKEN` / `ELIZA_TERMINAL_RUN_TOKEN` / `POSTGRES_URL` | survive | **2 failed** each |
| drop `GITHUB_TOKEN` / `DATABASE_URL` | caught only in `env-vars` | **2 failed** here |
| drop `STEWARD_API_KEY` (already spot-checked) | 1 failed | **5 failed** |
| **add** an unexpected key to the set | survives | **1 failed** |
| `key.trim().toUpperCase()` → `key.toUpperCase()` | 1 failed | **14 failed** |
| `key.trim().toUpperCase()` → `key.trim()` | 2 failed | **15 failed** |

**12/12 killed, was 2/12.** Siblings unchanged: `server-helpers-plugin` 15, `config-routes` 25, `env-vars` 30. Biome clean, `tsc --noEmit` clean. No source file is touched.

# Two things I looked at and left alone

- **`isBlockedEnvKey`'s `upper.length === 0` early return survives everything**, and it should: with it removed, `""` still misses the exact set and `"".startsWith(prefix)` is false for all fourteen prefixes (none is empty), so the function returns `false` either way. It is an early-out, not a guard — no fixture can separate the two.
- **`const blockedExact = [...BLOCKED_ENV_KEYS][0]` in `server-helpers-plugin.test.ts`** is the same indexing shape, but it is *not* the same problem: that test asks whether the plugin route rejects a blocked key, and any member is a fair representative because the route does not care which one it is. The list's contents are this file's responsibility, and that is where I put the assertion.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KDQV5NYTD8SM1D2F0CZC8C","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T10:41:24.149Z","completed_at":"2026-09-03T10:49:36.908Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T10:41:24.359Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6c243a7bd6ab3a509650def7608c55e70cfdc3bb13a5fbae8f671ae2a69b0a00","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"68d87ada-743f-4a1b-8a11-ab2fbe1cf93b","object_id":"sha256:6c243a7bd6ab3a509650def7608c55e70cfdc3bb13a5fbae8f671ae2a69b0a00","sha256":"6c243a7bd6ab3a509650def7608c55e70cfdc3bb13a5fbae8f671ae2a69b0a00"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"SmuAINh3bRuO2ih9lYJ20yqos3YWRNlRwKE8HEyFBUP5ERD3sXpKMMF5GEfw3sto7NCFSpNp-CF4kpfZ0dReCg"}} -->
