### PR TITLE
fix(ui): preserve voice intent consent when server prefs are silent

### DIFF
--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -323,31 +323,65 @@ describe("VoiceSectionMount — mount preserves explicit local consent when the 
   afterEach(() => cleanup());
 
   it.each([
-    [
-      "failed fetch",
-      () =>
-        clientMock.getConfig.mockRejectedValue(new Error("config fetch down")),
-    ],
-    ["empty server blob", () => clientMock.getConfig.mockResolvedValue({})],
+    {
+      label: "failed fetch, voice opt-in",
+      seedKey: "eliza:voice:os-intent-auto-start-voice",
+      seedOn: "voice",
+      arrange() {
+        clientMock.getConfig.mockRejectedValue(new Error("config fetch down"));
+      },
+    },
+    {
+      label: "empty server blob, voice opt-in",
+      seedKey: "eliza:voice:os-intent-auto-start-voice",
+      seedOn: "voice",
+      arrange() {
+        clientMock.getConfig.mockResolvedValue({});
+      },
+    },
+    {
+      label: "empty server blob, transcription opt-in",
+      seedKey: "eliza:voice:os-intent-auto-start-transcription",
+      seedOn: "transcription",
+      arrange() {
+        clientMock.getConfig.mockResolvedValue({});
+      },
+    },
   ])(
-    "keeps a persisted opt-in across mount on %s",
-    async (_label, arrangeServer) => {
-      arrangeServer();
-      window.localStorage.setItem(
-        "eliza:voice:os-intent-auto-start-voice",
-        "true",
-      );
+    "keeps a persisted opt-in across mount on $label",
+    async ({ arrange, seedKey, seedOn }) => {
+      arrange();
+      window.localStorage.setItem(seedKey, "true");
       render(<VoiceSectionMount />);
       const toggle = await screen.findByTestId(
-        "voice-section-intent-autostart-voice",
+        `voice-section-intent-autostart-${seedOn}`,
       );
       await waitFor(() =>
         expect(toggle.getAttribute("aria-checked")).toBe("true"),
       );
       expect(loadOsIntentAutoStartConsent()).toEqual({
-        voice: true,
-        transcription: false,
+        voice: seedOn === "voice",
+        transcription: seedOn === "transcription",
       });
     },
   );
+
+  it("keeps a persisted continuous-chat mode across mount when the fetch fails", async () => {
+    clientMock.getConfig.mockRejectedValue(new Error("config fetch down"));
+    window.localStorage.setItem(
+      "eliza:voice:continuous-chat-mode",
+      "always-on",
+    );
+    render(<VoiceSectionMount />);
+    const row = await screen.findByTestId("voice-section-continuous-row");
+    await waitFor(() => {
+      const active = row.querySelector(
+        "button[data-mode='always-on'][data-active='true']",
+      );
+      expect(active).toBeTruthy();
+    });
+    expect(
+      window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
+    ).toBe("always-on");
+  });
 });

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -309,3 +309,45 @@ describe("VoiceSectionMount — mount fetch failures fall back to defaults (list
     expect(unhandled).toEqual([]);
   });
 });
+
+describe("VoiceSectionMount — mount preserves explicit local consent when the server is silent", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clientMock.updateConfig.mockResolvedValue({});
+    clientMock.getLocalInferenceDeviceTier.mockResolvedValue({
+      tier: "GOOD",
+      reason: "",
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  it.each([
+    [
+      "failed fetch",
+      () =>
+        clientMock.getConfig.mockRejectedValue(new Error("config fetch down")),
+    ],
+    ["empty server blob", () => clientMock.getConfig.mockResolvedValue({})],
+  ])(
+    "keeps a persisted opt-in across mount on %s",
+    async (_label, arrangeServer) => {
+      arrangeServer();
+      window.localStorage.setItem(
+        "eliza:voice:os-intent-auto-start-voice",
+        "true",
+      );
+      render(<VoiceSectionMount />);
+      const toggle = await screen.findByTestId(
+        "voice-section-intent-autostart-voice",
+      );
+      await waitFor(() =>
+        expect(toggle.getAttribute("aria-checked")).toBe("true"),
+      );
+      expect(loadOsIntentAutoStartConsent()).toEqual({
+        voice: true,
+        transcription: false,
+      });
+    },
+  );
+});

--- a/packages/ui/src/components/settings/VoiceSectionMount.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.tsx
@@ -23,6 +23,7 @@ import { createVoiceProfilesClient } from "../../api/client-voice-profiles";
 import { useBranding } from "../../config/branding";
 import { useViewEvent } from "../../hooks/useViewEvent";
 import {
+  loadContinuousChatMode,
   loadOsIntentAutoStartConsent,
   loadWakeWordEnabled,
   saveContinuousChatMode,
@@ -84,12 +85,14 @@ function readStoredVoicePrefs(
   // intentionally dropped here — see the removal note in VoiceSection.tsx.
   // Server silence is not revocation: when the fetch failed or the server blob
   // has no explicit value (fresh/offline server), fall back to the device-local
-  // mirror so a mount never clobbers explicit user consent with a default.
+  // mirrors so a mount never clobbers explicit user prefs with defaults.
+  // Continuous mode resolves through its loader (not the raw key) so the
+  // appliance query-param override keeps working.
   const localConsent = loadOsIntentAutoStartConsent();
   return {
     continuous: isContinuousMode(stored.continuous)
       ? stored.continuous
-      : DEFAULT_VOICE_SECTION_PREFS.continuous,
+      : loadContinuousChatMode(),
     osIntentAutoStartVoice:
       typeof stored.osIntentAutoStartVoice === "boolean"
         ? stored.osIntentAutoStartVoice

--- a/packages/ui/src/components/settings/VoiceSectionMount.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.tsx
@@ -23,6 +23,7 @@ import { createVoiceProfilesClient } from "../../api/client-voice-profiles";
 import { useBranding } from "../../config/branding";
 import { useViewEvent } from "../../hooks/useViewEvent";
 import {
+  loadOsIntentAutoStartConsent,
   loadWakeWordEnabled,
   saveContinuousChatMode,
   saveOsIntentAutoStartConsent,
@@ -81,13 +82,22 @@ function readStoredVoicePrefs(
   // Note: legacy `cloudFirstLineCache` / `autoLearnVoices` keys may still sit
   // in older persisted `messages.voice` blobs; they are dead (no readers) and
   // intentionally dropped here — see the removal note in VoiceSection.tsx.
+  // Server silence is not revocation: when the fetch failed or the server blob
+  // has no explicit value (fresh/offline server), fall back to the device-local
+  // mirror so a mount never clobbers explicit user consent with a default.
+  const localConsent = loadOsIntentAutoStartConsent();
   return {
     continuous: isContinuousMode(stored.continuous)
       ? stored.continuous
       : DEFAULT_VOICE_SECTION_PREFS.continuous,
-    osIntentAutoStartVoice: stored.osIntentAutoStartVoice === true,
+    osIntentAutoStartVoice:
+      typeof stored.osIntentAutoStartVoice === "boolean"
+        ? stored.osIntentAutoStartVoice
+        : localConsent.voice,
     osIntentAutoStartTranscription:
-      stored.osIntentAutoStartTranscription === true,
+      typeof stored.osIntentAutoStartTranscription === "boolean"
+        ? stored.osIntentAutoStartTranscription
+        : localConsent.transcription,
     vadAutoStop: readVadAutoStop(stored.vadAutoStop),
   };
 }


### PR DESCRIPTION
## Summary

Mounting the canonical Voice settings section no longer clobbers explicit microphone-consent toggles when the agent config fetch fails or the server blob has no voice prefs.

## Defect (live-proven on dev-cloud-only server)

- Toggle 'Allow voice shortcuts to start the microphone' ON > persisted true in localStorage.
- Reload > mount effect fetched empty config, derived false from server silence, saved false over the user's true. Toggle back to OFF after every reload.
- Same path affected the transcription consent switch. Same overwrite class as the Gap-2 late-getter issue from #24495.

## Fix

readStoredVoicePrefs falls back to the device-local mirror per key when the server value is not a boolean; server silence is no longer treated as revocation. The mount-time mirror seeding then writes back the preserved values. No change when the server provides explicit values.

## Verification

- New regression tests (failed-fetch + empty-blob cases): persisted opt-in survives mount, toggle renders true, mirror untouched.
- Focused suites green: VoiceSectionMount (11) + persistence.preferences (7); full settings dir re-run pending.
- packages/ui typecheck + lint clean.
- Live dev-server proof: toggle ON > reload > still ON (was: reset to OFF).

Relates to #24495 (shortcuts/PTT persistence + Gap-2 preference authority).