### PR TITLE
test(plugin-registry): cover the secret-reveal allowlist and its elevation gate

### DIFF
--- a/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
+++ b/plugins/plugin-registry/src/api/app-plugins-routes.test.ts
@@ -7,7 +7,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   devCloudAuthority: null as string | null,
+  ensureCompatSensitiveRouteAuthorized: vi.fn(() => true),
   ensureRouteAuthorized: vi.fn(),
+  vaultGet: vi.fn(),
+  vaultReveal: vi.fn(),
   loadElizaConfig: vi.fn(),
   loadRegistry: vi.fn(),
   readCompatJsonBody: vi.fn(),
@@ -35,7 +38,8 @@ vi.mock("@elizaos/agent", () => ({
 }));
 
 vi.mock("@elizaos/app-core/api/auth", () => ({
-  ensureCompatSensitiveRouteAuthorized: vi.fn(),
+  ensureCompatSensitiveRouteAuthorized:
+    mocks.ensureCompatSensitiveRouteAuthorized,
   ensureRouteAuthorized: mocks.ensureRouteAuthorized,
 }));
 
@@ -56,7 +60,10 @@ vi.mock("@elizaos/registry/first-party", () => ({
 vi.mock("@elizaos/app-core/services/vault-mirror", () => ({
   _resetSharedVaultForTesting: vi.fn(),
   mirrorPluginSensitiveToVault: vi.fn(() => Promise.resolve({ failures: [] })),
-  sharedVault: {},
+  sharedVault: vi.fn(() => ({
+    get: mocks.vaultGet,
+    reveal: mocks.vaultReveal,
+  })),
 }));
 
 vi.mock("@elizaos/core", () => ({
@@ -1225,5 +1232,128 @@ describe("app plugin compatibility routes", () => {
       "Invalid plugin path",
     );
     expect(mocks.saveElizaConfig).toHaveBeenCalledTimes(saveCallCount);
+  });
+});
+
+/**
+ * `POST /api/plugins/:id/reveal` returns a stored secret to the caller. It is
+ * gated by two lists in this file — `REVEALABLE_KEY_PREFIXES` decides whether a
+ * key can be read at all, and `SENSITIVE_KEY_PREFIXES` decides whether reading
+ * it additionally demands the hardened loopback/elevated check. Neither list,
+ * and neither branch, had a test: no case in this suite reaches the reveal
+ * route. Deleting `SENSITIVE_KEY_PREFIXES.some(...)` outright left the whole
+ * package green.
+ */
+describe("POST /api/plugins/:id/reveal", () => {
+  const SENSITIVE_PREFIXES = ["SOLANA_", "ETHEREUM_", "EVM_", "WALLET_"];
+
+  async function reveal(key: string) {
+    // The route reads the key from the JSON body, so seeding the body mock and
+    // dispatching belong together — a call that sets one without the other
+    // would silently exercise the previous key.
+    mocks.readCompatJsonBody.mockResolvedValue({ key });
+    return await handlePluginsCompatRoutes(
+      { method: "POST", url: "/api/plugins/discord/reveal" } as never,
+      {} as never,
+      { current: null } as never,
+    );
+  }
+
+  beforeEach(() => {
+    // The outer beforeEach does not know about these mocks, and call counts are
+    // the whole point of the elevation assertions below.
+    mocks.ensureCompatSensitiveRouteAuthorized.mockClear();
+    mocks.vaultReveal.mockClear();
+    mocks.sendJson.mockClear();
+    mocks.sendJsonError.mockClear();
+    mocks.vaultReveal.mockResolvedValue("secret-value");
+    mocks.ensureCompatSensitiveRouteAuthorized.mockReturnValue(true);
+  });
+
+  it("refuses a key outside the revealable allowlist without touching the vault", async () => {
+    expect(await reveal("PRIVATE_SIGNING_SEED")).toBe(true);
+    expect(mocks.sendJsonError).toHaveBeenCalledWith(
+      expect.anything(),
+      403,
+      "Key is not in the allowlist of revealable plugin config keys",
+    );
+    // The refusal has to come before the read, or the allowlist is advisory.
+    expect(mocks.vaultReveal).not.toHaveBeenCalled();
+    expect(mocks.ensureCompatSensitiveRouteAuthorized).not.toHaveBeenCalled();
+  });
+
+  it.each(SENSITIVE_PREFIXES)(
+    "demands the elevated check for %sprefixed keys",
+    async (prefix) => {
+      expect(await reveal(`${prefix}PRIVATE_KEY`)).toBe(true);
+      expect(mocks.ensureCompatSensitiveRouteAuthorized).toHaveBeenCalledTimes(
+        1,
+      );
+    },
+  );
+
+  it.each(SENSITIVE_PREFIXES)(
+    "returns nothing when the elevated check refuses a %sprefixed key",
+    async (prefix) => {
+      mocks.ensureCompatSensitiveRouteAuthorized.mockReturnValue(false);
+      expect(await reveal(`${prefix}PRIVATE_KEY`)).toBe(true);
+      // The consequence, not the flag: a refused elevation must stop the read.
+      expect(mocks.vaultReveal).not.toHaveBeenCalled();
+      expect(mocks.sendJson).not.toHaveBeenCalledWith(
+        expect.anything(),
+        200,
+        expect.objectContaining({ value: "secret-value" }),
+      );
+    },
+  );
+
+  it("reveals an ordinary allowlisted key without demanding elevation", async () => {
+    expect(await reveal("OPENAI_API_KEY")).toBe(true);
+    expect(mocks.ensureCompatSensitiveRouteAuthorized).not.toHaveBeenCalled();
+    expect(mocks.vaultReveal).toHaveBeenCalledWith(
+      "OPENAI_API_KEY",
+      "plugins:discord:reveal",
+    );
+    expect(mocks.sendJson).toHaveBeenCalledWith(expect.anything(), 200, {
+      ok: true,
+      value: "secret-value",
+    });
+  });
+
+  it("matches both lists case-insensitively, so lowercase cannot skip elevation", async () => {
+    // Both branches uppercase before comparing. If either stopped, the same key
+    // in lowercase would change tier — the allowlist would reject a legitimate
+    // key, or worse, a wallet key would slip past the elevated check.
+    expect(await reveal("openai_api_key")).toBe(true);
+    expect(mocks.sendJsonError).not.toHaveBeenCalledWith(
+      expect.anything(),
+      403,
+      expect.anything(),
+    );
+
+    vi.clearAllMocks();
+    mocks.vaultReveal.mockResolvedValue("secret-value");
+    mocks.ensureCompatSensitiveRouteAuthorized.mockReturnValue(true);
+    expect(await reveal("solana_private_key")).toBe(true);
+    expect(mocks.ensureCompatSensitiveRouteAuthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats the sensitive prefixes as a subset of the revealable ones", async () => {
+    // `SENSITIVE_KEY_PREFIXES` is spread into `REVEALABLE_KEY_PREFIXES`. If that
+    // spread were dropped, wallet keys would fail the allowlist instead of
+    // escalating — fail-closed, but it would silently retire the elevated path,
+    // and every assertion above would still pass on the 403.
+    for (const prefix of SENSITIVE_PREFIXES) {
+      vi.clearAllMocks();
+      mocks.vaultReveal.mockResolvedValue("secret-value");
+      mocks.ensureCompatSensitiveRouteAuthorized.mockReturnValue(true);
+      expect(await reveal(`${prefix}PRIVATE_KEY`)).toBe(true);
+      expect(mocks.sendJsonError).not.toHaveBeenCalledWith(
+        expect.anything(),
+        403,
+        expect.anything(),
+      );
+      expect(mocks.vaultReveal).toHaveBeenCalledTimes(1);
+    }
   });
 });


### PR DESCRIPTION
# What

`POST /api/plugins/:id/reveal` returns a stored secret to the caller. Two lists in `app-plugins-routes.ts` decide what comes back:

```ts
const SENSITIVE_KEY_PREFIXES = ["SOLANA_", "ETHEREUM_", "EVM_", "WALLET_"];
const REVEALABLE_KEY_PREFIXES = [ /* 37 provider prefixes */ ...SENSITIVE_KEY_PREFIXES ];
```

`REVEALABLE_KEY_PREFIXES` decides whether a key may be read at all; `SENSITIVE_KEY_PREFIXES` decides whether reading it additionally demands `ensureCompatSensitiveRouteAuthorized` — the loopback/elevated check that exists, per the comment, "to prevent accidental exposure through the general plugin config UI."

**No test in this package reaches the reveal route.** Measured on `develop`:

| mutant | `app-plugins-routes.test.ts` |
|---|---|
| `if (SENSITIVE_KEY_PREFIXES.some(...))` → `if (false)` — elevation never demanded | **39 passed** |
| the allowlist check → `false` — every key revealable | **39 passed** |
| delete `"WALLET_"` from the sensitive list | **39 passed** |

Deleting the entire elevated-auth branch leaves the package green.

# The change

Test-only. One `describe` block, plus three mock adjustments so the route is reachable: `ensureCompatSensitiveRouteAuthorized` and the vault move into the hoisted `mocks` object (`sharedVault` was `{}`, which the route calls as a function).

Six cases:

- **A key outside the allowlist gets 403 and the vault is never touched** — ordering matters, or the allowlist is advisory.
- **Each of the four sensitive prefixes demands the elevated check** (a case per prefix, so a deleted entry names itself).
- **A refused elevation stops the read.** Asserted on the consequence — `vaultReveal` not called, no 200 carrying the value — rather than on the flag.
- **An ordinary allowlisted key reveals without demanding elevation**, with the exact vault scope (`plugins:discord:reveal`).
- **Both lists match case-insensitively.** If either branch stopped uppercasing, a lowercase wallet key would slip past the elevated check.
- **The sensitive prefixes are a subset of the revealable ones.** Dropping the spread fails closed — wallet keys 403 instead of escalating — but it would silently retire the elevated path, and every assertion above would still pass on the 403. This case is what distinguishes the two.

# Evidence

`bunx vitest run src/api/app-plugins-routes.test.ts`: **51 passed** (was 39).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 39/39 | **51/51** |
| elevation branch → `if (false)` | survives | **9 failed** |
| elevation return value ignored | survives | **4 failed** |
| allowlist check → `false` | survives | **1 failed** |
| `key.toUpperCase()` → `key` | survives | **1 failed** |
| `...SENSITIVE_KEY_PREFIXES` spread removed | survives | **6 failed** |
| delete `"WALLET_"` from the sensitive list | survives | **2 failed** |
| `startsWith(prefix)` → `=== prefix` (both gates) | survives | **9 failed** |

**8/8 killed, was 0/8.** Sibling suites unchanged (`plugin-routes`, `bridge-plugin-settings`, `plugin-routes.encoding`: 38 passed). Biome clean, `tsc --noEmit` clean. No source file is touched.

One harness note: the outer `beforeEach` does not know about the new mocks, so call counts accumulated across the parameterised cases and the first run failed with "expected 1 times, got 4". The block clears them itself — worth flagging because the assertions here are *about* call counts, so a stale count is the failure mode that would matter.

# An observation I'd rather raise than encode

I pinned the behaviour as it stands and did not change either list. But the two tiers are drawn on prefixes, and some allowlisted prefixes are broad enough to cover keys this repo treats as high-value elsewhere:

`ELIZA_` is revealable without elevation, and `packages/agent/src/config/blocked-env-keys.ts` lists `ELIZA_WALLET_EXPORT_TOKEN`, `ELIZA_API_TOKEN` and `ELIZA_TERMINAL_RUN_TOKEN` as secrets that must never be written through config. `DATABASE_`, `POSTGRES_`, `GITHUB_`, `AWS_` and `AZURE_` are in the same position (`DATABASE_URL`, `POSTGRES_URL`, `GITHUB_TOKEN` are all on that same blocklist).

A wallet *export* token reads to me like the "wallet private keys or other high-value secrets" the elevated tier is described as protecting. Whether that means widening `SENSITIVE_KEY_PREFIXES`, or matching on exact keys rather than prefixes, is a policy call I don't think a test should make silently — so this PR asserts today's behaviour and leaves the question here. Happy to follow up either way.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KEA5B3A5CS7KXQ8FMW0D0Q","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T10:51:24.387Z","completed_at":"2026-09-03T10:57:00.504Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T10:51:24.589Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a55de52b121df1f31d2536bb8b38ebd93b2f97aadecc125df0c44e0b5be2acb6","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9f0baec1-1c88-4864-a161-d716d184242e","object_id":"sha256:a55de52b121df1f31d2536bb8b38ebd93b2f97aadecc125df0c44e0b5be2acb6","sha256":"a55de52b121df1f31d2536bb8b38ebd93b2f97aadecc125df0c44e0b5be2acb6"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"kB4x7bUu_QYli2N--hzjnkXRy0Yuu6VPMCxRy6lmMNjP_7t_zdgpbrt6cbbhBaxRcBES5GvamP3xAN9gtfQkDQ"}} -->
