### PR TITLE
test(cloud): cover the two untested open-redirect resolvers

### DIFF
--- a/packages/cloud/shared/src/lib/security/redirect-validation.test.ts
+++ b/packages/cloud/shared/src/lib/security/redirect-validation.test.ts
@@ -4,6 +4,9 @@ import {
   assertAllowedAbsoluteRedirectUrl,
   isAllowedAbsoluteRedirectUrl,
   isSafeRelativeRedirectPath,
+  LOOPBACK_REDIRECT_ORIGINS,
+  resolveOAuthSuccessRedirectUrl,
+  resolveSafeRedirectTarget,
   sanitizeRelativeRedirectPath,
 } from "./redirect-validation";
 
@@ -45,5 +48,119 @@ describe("absolute redirect URLs", () => {
   test("assertAllowedAbsoluteRedirectUrl returns URL or throws", () => {
     expect(assertAllowedAbsoluteRedirectUrl("https://eliza.ai/x", ALLOW).hostname).toBe("eliza.ai");
     expect(() => assertAllowedAbsoluteRedirectUrl("https://evil.com/", ALLOW)).toThrow(/Invalid/);
+  });
+});
+
+/**
+ * The two resolvers below carry five production call sites between them and had
+ * no test at all: every case in this file exercised the relative helpers or
+ * `isAllowedAbsoluteRedirectUrl`. Dropping `parsed.origin === base.origin` from
+ * `resolveSafeRedirectTarget` — the entire open-redirect guard for that
+ * function — left the suite green.
+ */
+
+const BASE = "https://app.eliza.ai";
+const FALLBACK = "/home";
+
+describe("resolveSafeRedirectTarget", () => {
+  test("returns an absolute URL only when it is same-origin", () => {
+    expect(resolveSafeRedirectTarget(`${BASE}/settings`, BASE, FALLBACK).toString()).toBe(
+      `${BASE}/settings`,
+    );
+    // The guard. Without it this returns the attacker's URL.
+    expect(resolveSafeRedirectTarget("https://evil.example/steal", BASE, FALLBACK).toString()).toBe(
+      `${BASE}${FALLBACK}`,
+    );
+  });
+
+  test.each([
+    ["a sibling host that merely shares a suffix", "https://evil-app.eliza.ai/x"],
+    ["the same host on a different scheme", "http://app.eliza.ai/x"],
+    ["the same host on a different port", "https://app.eliza.ai:8443/x"],
+    ["embedded credentials on the allowed origin", "https://user:pw@app.eliza.ai/x"],
+    ["a non-http scheme", "javascript:alert(1)"],
+    ["a protocol-relative target", "//evil.example/x"],
+    ["an unparseable value", "http://[::1"],
+  ])("falls back for %s", (_label, value) => {
+    expect(resolveSafeRedirectTarget(value, BASE, FALLBACK).toString()).toBe(`${BASE}${FALLBACK}`);
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+  ])("falls back for %s without treating it as a path", (_label, value) => {
+    expect(resolveSafeRedirectTarget(value, BASE, FALLBACK).toString()).toBe(`${BASE}${FALLBACK}`);
+  });
+
+  test("resolves a relative path against the base rather than the caller's string", () => {
+    expect(resolveSafeRedirectTarget("/agents/1", BASE, FALLBACK).toString()).toBe(
+      `${BASE}/agents/1`,
+    );
+  });
+});
+
+describe("resolveOAuthSuccessRedirectUrl", () => {
+  const resolve = (value: string | null | undefined, origins: readonly string[] = []) =>
+    resolveOAuthSuccessRedirectUrl({
+      value,
+      baseUrl: BASE,
+      fallbackPath: FALLBACK,
+      allowedAbsoluteOrigins: origins,
+    });
+
+  test("accepts same-origin and allowlisted absolute targets", () => {
+    expect(resolve(`${BASE}/done`)).toEqual({
+      target: new URL(`${BASE}/done`),
+      rejected: false,
+    });
+    expect(resolve("https://desktop.eliza.ai/cb", ["https://desktop.eliza.ai"])).toEqual({
+      target: new URL("https://desktop.eliza.ai/cb"),
+      rejected: false,
+    });
+  });
+
+  test("an absent value is a fallback but NOT a rejection", () => {
+    // `rejected` is what callers log a refusal on, so the two branches that
+    // both return the fallback have to stay distinguishable.
+    expect(resolve(null)).toEqual({ target: new URL(BASE + FALLBACK), rejected: false });
+    expect(resolve("/done")).toEqual({ target: new URL(`${BASE}/done`), rejected: false });
+    expect(resolve("https://evil.example/x").rejected).toBe(true);
+  });
+
+  test.each([
+    ["an origin absent from the allowlist", "https://evil.example/x", []],
+    [
+      "an allowlisted host on another scheme",
+      "http://desktop.eliza.ai/cb",
+      ["https://desktop.eliza.ai"],
+    ],
+    [
+      "credentials smuggled onto an allowlisted origin",
+      "https://u:p@desktop.eliza.ai/cb",
+      ["https://desktop.eliza.ai"],
+    ],
+    ["a non-http scheme", "javascript:alert(1)", ["https://desktop.eliza.ai"]],
+  ])("rejects %s", (_label, value, origins) => {
+    expect(resolve(value, origins as string[])).toEqual({
+      target: new URL(BASE + FALLBACK),
+      rejected: true,
+    });
+  });
+
+  test("the loopback entries match any port, and only loopback hosts", () => {
+    const origins = [...LOOPBACK_REDIRECT_ORIGINS];
+    for (const accepted of [
+      "http://localhost:3000/cb",
+      "http://127.0.0.1:54321/cb",
+      "https://localhost:8443/cb",
+      "https://127.0.0.1:9443/cb",
+    ]) {
+      expect(resolve(accepted, origins).rejected).toBe(false);
+    }
+    // The wildcard is expanded into a regex, so a host that merely starts with
+    // the loopback name must not match it.
+    expect(resolve("http://localhost.evil.example:3000/cb", origins).rejected).toBe(true);
+    expect(resolve("http://127.0.0.1.evil.example:3000/cb", origins).rejected).toBe(true);
   });
 });


### PR DESCRIPTION
# What

`redirect-validation.ts` exports seven functions and the suite has **four tests**. Every one of them exercises the relative helpers or `isAllowedAbsoluteRedirectUrl`. The two resolvers — which carry five production call sites between them — have no test at all.

The consequence, measured on `develop`:

| mutant | result |
|---|---|
| `resolveSafeRedirectTarget`: drop `parsed.origin === base.origin` | **4 pass / 0 fail** |
| `resolveOAuthSuccessRedirectUrl`: drop the same-origin acceptance | **4 pass / 0 fail** |
| `resolveOAuthSuccessRedirectUrl`: `rejected: true` → `rejected: false` | **4 pass / 0 fail** |
| delete any of the four `LOOPBACK_REDIRECT_ORIGINS` entries | **4 pass / 0 fail** |

The first one is the whole open-redirect guard for that function. Without it, `resolveSafeRedirectTarget("https://evil.example/steal", "https://app.eliza.ai", "/home")` returns the attacker's URL, and the file's own header comment — "a miss here lets an attacker bounce an authenticated user to a hostile site" — describes exactly that.

# The change

Test-only, two `describe` blocks.

**`resolveSafeRedirectTarget`** — same-origin accepted, then a table of seven refusals: a sibling host sharing a suffix (`evil-app.eliza.ai`), the same host on another scheme, the same host on another port, embedded credentials, a non-http scheme, a protocol-relative target, and an unparseable value. Plus the three empty inputs, and a relative path resolving against the base.

**`resolveOAuthSuccessRedirectUrl`** — same-origin and allowlisted origins accepted; a refusal table covering an origin absent from the allowlist, an allowlisted host on another scheme, credentials smuggled onto an allowlisted origin, and a non-http scheme.

**The `rejected` flag gets its own case.** Two branches return the fallback and only one is a refusal: `rejected` is what callers log on, so `null` in must stay `rejected: false` while a hostile absolute URL is `rejected: true`. Asserting only the `target` would let the flag be pinned to a constant — it survives the whole suite on `develop`.

**The loopback wildcard is asserted in both directions.** `LOOPBACK_REDIRECT_ORIGINS` is expanded into `^http://localhost:.*$` by `isAllowedOrigin`, so the interesting case is not that `http://localhost:3000` is accepted but that `http://localhost.evil.example:3000` is **not**. Both loopback hosts are exercised on both schemes, so each of the four entries is individually named.

# Evidence

`bun test src/lib/security/redirect-validation.test.ts`: **23 pass / 0 fail** (was 4).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 4 / 0 | **23 / 0** |
| `rST`: drop origin equality | survives | **4 failed** |
| `rST`: drop the credentials check | survives | **1 failed** |
| `rOSRU`: drop same-origin acceptance | survives | **1 failed** |
| `rOSRU`: drop the scheme + credentials guard | survives | **1 failed** |
| `rOSRU`: `rejected` always `false` | survives | **4 failed** |
| drop `"http://localhost:*"` | survives | **1 failed** |
| drop `"http://127.0.0.1:*"` | survives | **1 failed** |
| drop `"https://localhost:*"` | survives | **1 failed** |
| drop `"https://127.0.0.1:*"` | survives | **1 failed** |
| `isSafeRelativeRedirectPath`: drop the `//` guard | 2 failed | **3 failed** |

**11/11 killed, was 1/11.** Biome clean, `tsc --noEmit` clean. No source file is touched.

Writing it caught one gap in my own first draft: the `https://127.0.0.1:*` entry still survived because the loopback case only used `https://localhost`. Running the deletion mutant per entry rather than on the array as a whole is what surfaced it.

# One mutant I did not chase

In `resolveSafeRedirectTarget`, dropping `isHttpUrl(parsed)` on its own survives — and should. `new URL("javascript:alert(1)").origin` is the string `"null"`, which can never equal a real `base.origin`, so the origin check already refuses every non-http scheme that parses. The two are not independent there. (In `isAllowedAbsoluteRedirectUrl` the scheme check is *not* redundant, because a `"*"` allowlist entry would otherwise accept anything — that path is covered by the existing test.)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KH5PA15EKQP9EPQA6GCRBZ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T11:41:23.649Z","completed_at":"2026-09-03T11:45:18.967Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T11:41:24.249Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7860ac25b815731f8afa080a795f01ce2a791fc6d898cf03d375b96d8429b165","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"664e64a9-ae68-4bf2-8a6f-59c8385464ae","object_id":"sha256:7860ac25b815731f8afa080a795f01ce2a791fc6d898cf03d375b96d8429b165","sha256":"7860ac25b815731f8afa080a795f01ce2a791fc6d898cf03d375b96d8429b165"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Rb0DTJQtHRIqfIvtcJr2FvqJ1XfIuo6qVsq_VPqSsCotCADA6IcarhPQ4iBdv9YhVKFLZzlU-RXaudCYvY-KCQ"}} -->
