### PR TITLE
test(agent-skills): pin the dev-cloud exclusion on the skill inherit path

### DIFF
--- a/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
+++ b/plugins/plugin-agent-skills/src/security/skill-execution-env.test.ts
@@ -200,6 +200,95 @@ describe("buildSkillExecutionEnv", () => {
   });
 });
 
+/**
+ * When a dev-cloud authority is in force, the inherit loop skips every
+ * dev-cloud-owned key so the authority resolver — not the ambient process — is
+ * what supplies it. Nothing exercised that `continue`: deleting it left all 13
+ * tests green.
+ *
+ * For the canonical spellings the guard is redundant, because the resolver loop
+ * below rewrites each key anyway. It stops being redundant the moment the
+ * ambient variable is spelled in another case, which is the same POSIX hazard
+ * this file already defends against on the overlay path.
+ */
+describe("buildSkillExecutionEnv under a dev-cloud authority", () => {
+  const AMBIENT = "ambient-fleet-key";
+
+  function withAuthority(
+    authority: string,
+    extra: Record<string, string>,
+  ): Record<string, string> {
+    return buildSkillExecutionEnv(
+      {
+        PATH: "/usr/bin",
+        ELIZA_DEV_SOURCE: "1",
+        ELIZA_DEV_CLOUD_ENV_AUTHORITY: authority,
+        ...extra,
+      } as NodeJS.ProcessEnv,
+      {},
+    );
+  }
+
+  it.each(["staging-default", "offline"])(
+    "%s deactivates Cloud rather than inheriting the ambient key",
+    (authority) => {
+      const env = withAuthority(authority, {
+        ELIZAOS_CLOUD_API_KEY: AMBIENT,
+        ELIZA_CLOUD_URL: "https://ambient.example",
+      });
+
+      expect(env.ELIZAOS_CLOUD_API_KEY).toBe("");
+      expect(env.ELIZA_CLOUD_URL).toBe("");
+      expect(Object.values(env)).not.toContain(AMBIENT);
+    },
+  );
+
+  it.each(["staging-explicit", "production", "self-hosted"])(
+    "%s passes the authority's own value through",
+    (authority) => {
+      const env = withAuthority(authority, { ELIZAOS_CLOUD_API_KEY: AMBIENT });
+      expect(env.ELIZAOS_CLOUD_API_KEY).toBe(AMBIENT);
+    },
+  );
+
+  it.each(["elizaos_cloud_api_key", "Elizaos_Cloud_Api_Key"])(
+    "refuses an ambient dev-cloud key spelled as %s",
+    (spelling) => {
+      // The resolver writes the canonical name, so an off-case ambient variable
+      // is not overwritten by it. Without the inherit-loop skip, the child gets
+      // TWO variables: the deactivated canonical one AND the real credential
+      // under the spelling the ambient process used.
+      const env = withAuthority("staging-default", { [spelling]: AMBIENT });
+
+      expect(env.ELIZAOS_CLOUD_API_KEY).toBe("");
+      expect(env).not.toHaveProperty(spelling);
+      const leaked = Object.entries(env).filter(
+        ([, value]) => value === AMBIENT,
+      );
+      expect(leaked).toEqual([]);
+    },
+  );
+
+  it("leaves the filter alone when no authority is declared", () => {
+    // `ELIZA_DEV_SOURCE` is the switch; without it there is no authority and the
+    // agent-scoped key must inherit normally, or every non-dev deployment loses
+    // its cloud identity.
+    const env = buildSkillExecutionEnv(
+      {
+        PATH: "/usr/bin",
+        ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-default",
+        ELIZAOS_CLOUD_API_KEY: AMBIENT,
+      } as NodeJS.ProcessEnv,
+      {},
+    );
+
+    expect(resolveDevCloudEnvAuthority({
+      ELIZA_DEV_CLOUD_ENV_AUTHORITY: "staging-default",
+    } as NodeJS.ProcessEnv)).toBeNull();
+    expect(env.ELIZAOS_CLOUD_API_KEY).toBe(AMBIENT);
+  });
+});
+
 describe("isInheritableSkillEnvKey", () => {
   it("agrees with what the filter emits, so eligibility cannot report green then fail", () => {
     // The eligibility check calls this; if the two disagreed, a skill would be


### PR DESCRIPTION
# What

`buildSkillExecutionEnv` skips every dev-cloud-owned key while copying the parent environment, so that the authority resolver — not the ambient process — is what supplies it:

```ts
for (const [key, value] of Object.entries(processEnv)) {
  if (devCloudAuthority && isDevCloudOwnedSkillEnvKey(key)) continue;   // ← this
  if (value !== undefined && isInheritableSkillEnvKey(key)) result[key] = value;
}
```

Deleting that `continue` leaves the suite at **13 pass / 0 fail**. So does removing the `.toUpperCase()` from `isDevCloudOwnedSkillEnvKey`.

# Why it isn't redundant, which is the interesting part

My first instinct was that the skip is dead weight: the resolver loop underneath rewrites each of those keys anyway. I ran both variants across all five authorities to check rather than assume, and for the canonical spellings that is exactly right — identical output, every time:

```
                    ORIGINAL                          MUTANT
staging-default     API_KEY=""                        API_KEY=""
staging-explicit    API_KEY="AMBIENT-KEY"             API_KEY="AMBIENT-KEY"
production          API_KEY="AMBIENT-KEY"             API_KEY="AMBIENT-KEY"
offline             API_KEY=""                        API_KEY=""
self-hosted         API_KEY="AMBIENT-KEY"             API_KEY="AMBIENT-KEY"
```

It stops being redundant when the ambient variable is spelled in a different case. `isDevCloudOwnedSkillEnvKey` and `isInheritableSkillEnvKey` both uppercase before matching, but the resolver loop writes the **canonical** name — so an off-case ambient entry is inherited and never overwritten:

```
ambient spelling          ORIGINAL                          MUTANT
ELIZAOS_CLOUD_API_KEY     [["ELIZAOS_CLOUD_API_KEY",""]]    [["ELIZAOS_CLOUD_API_KEY",""]]
elizaos_cloud_api_key     [["ELIZAOS_CLOUD_API_KEY",""]]    [["elizaos_cloud_api_key","AMBIENT-KEY"],
                                                             ["ELIZAOS_CLOUD_API_KEY",""]]
Elizaos_Cloud_Api_Key     [["ELIZAOS_CLOUD_API_KEY",""]]    [["Elizaos_Cloud_Api_Key","AMBIENT-KEY"],
                                                             ["ELIZAOS_CLOUD_API_KEY",""]]
```

Under `staging-default` — the authority whose whole point is that Cloud is deactivated — the child would get two variables: the neutralised canonical one, and the live credential under the ambient spelling. This is the same POSIX hazard the file already names and defends against on the *overlay* path ("POSIX treats `GEMINI_API_KEY` and `Gemini_Api_Key` as two variables"); the inherit path relies on this skip instead, and nothing held it there.

# The change

Test-only, one `describe` block:

- **`staging-default` and `offline` deactivate rather than inherit** — both keys `""`, and the ambient value appears nowhere in the result.
- **`staging-explicit`, `production`, `self-hosted` pass the authority's value through** — so the block can't be satisfied by simply dropping everything.
- **Two off-case spellings are refused**, asserting no key at all carries the ambient value rather than just checking the canonical name.
- **No `ELIZA_DEV_SOURCE` means no authority** — the switch itself, or every non-dev deployment silently loses its cloud identity.

# Evidence

`bunx vitest run src/security/skill-execution-env.test.ts`: **21 passed** (was 13).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 13 / 0 | **21 / 0** |
| drop the inherit-loop `continue` | **survives** | **2 failed** |
| `isDevCloudOwnedSkillEnvKey` without `.toUpperCase()` | **survives** | **2 failed** |
| drop the dev-cloud skip on the overlay loop | 4 failed | **4 failed** |
| drop `"ELIZA_CLOUD_URL"` from the owned set | 2 failed | **4 failed** |
| drop the authority resolver loop entirely | 4 failed | **11 failed** |

**5/5 killed, was 3/5**, and the two that already died now die harder. Sibling suites in the same directory unchanged (35 passed). Biome clean, `tsc --noEmit` clean. No source file is touched.

# Screened and not filed

The rest of this file is well covered: admitting a fleet-scoped key (`DATABASE_URL`) to the allowlist, dropping the case-fold in `isInheritableSkillEnvKey`, removing the overlay case-collision dedupe, and removing the empty-`PATH` refusal each already fail the existing suite. The dev-cloud exclusion was the one guard in it with nothing behind it.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KHR19QTHH579NZF8J1WNJW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T11:51:24.727Z","completed_at":"2026-09-03T11:55:59.704Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T11:51:25.333Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"45e889796da109bdcafc7dba45e2e0e29e7290729bf3e7e10aeced6be14a3429","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5b2d8235-6156-41b6-8168-e959bfbf1013","object_id":"sha256:45e889796da109bdcafc7dba45e2e0e29e7290729bf3e7e10aeced6be14a3429","sha256":"45e889796da109bdcafc7dba45e2e0e29e7290729bf3e7e10aeced6be14a3429"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"NJa2rp2FV9wes0ELw9zOxK5CgAGKiTqkGfMw893r6AwgFoMJh6m2BqU6P5FKYA0yQMDVVd--bkJZFvDHL_AwBw"}} -->
