### PR TITLE
test(cloud): pin the caller-forbidden env suffix boundaries

### DIFF
--- a/packages/cloud/shared/src/lib/services/remote-docker-runtime-mode.test.ts
+++ b/packages/cloud/shared/src/lib/services/remote-docker-runtime-mode.test.ts
@@ -80,6 +80,82 @@ describe("applyRemoteDockerRuntimeMode", () => {
   });
 });
 
+/**
+ * The cases above name eleven of the fourteen forbidden suffixes between them,
+ * and `CAPABILITY_ROUTER_URL` is not one: only its plural sibling
+ * `CAPABILITY_ROUTER_URLS` appears, and deleting the singular entry leaves the
+ * whole suite green. Nothing pins the matcher's shape either — it is
+ * `upper === suffix || upper.endsWith(`_${suffix}`)` after a trim and an
+ * uppercase, and every one of those four decisions can be removed without a
+ * failure.
+ */
+describe("isCallerForbiddenEnvKey boundaries", () => {
+  const FORBIDDEN_SUFFIXES = [
+    "TERMINAL_RUN_TOKEN",
+    "ALLOW_UNAUTHENTICATED_STDIO_MCP",
+    "DEV_AUTH_BYPASS",
+    "ALLOW_NULL_ORIGIN",
+    "ENABLE_SELF_EDIT",
+    "DEV_MODE",
+    "CAPABILITY_ROUTER_URL",
+    "CAPABILITY_ROUTER_URLS",
+    "CAPABILITY_ROUTER_TOKEN",
+    "SKILLS_REGISTRY",
+    "CLAWHUB_REGISTRY",
+    "SKILLS_MARKETPLACE_URL",
+    "WORKSPACE_SKILLS_DIR",
+    "EXTRA_SKILLS_DIRS",
+  ] as const;
+
+  test.each(FORBIDDEN_SUFFIXES)("drops %s bare and under a vendor prefix", (suffix) => {
+    // Both arms of the matcher, per entry: the bare name is the `===` arm and
+    // the prefixed one is the `endsWith("_" + suffix)` arm. A case that only
+    // ever uses a prefix cannot notice the exact arm going away.
+    const applied = applyRemoteDockerRuntimeMode({
+      [suffix]: "caller-set",
+      [`ELIZA_${suffix}`]: "caller-set",
+      [`VITE_ACME_${suffix}`]: "caller-set",
+      KEEP_ME: "preserved",
+    });
+
+    expect(Object.keys(applied).sort()).toEqual(["ELIZA_CLOUD_PAIR_DIRECT_RELAY", "KEEP_ME"]);
+  });
+
+  test("the separator is load-bearing: a suffix must end a segment, not a string", () => {
+    // Without the underscore in `endsWith`, these are deleted too. They are
+    // ordinary caller variables that merely end in the same letters, and this
+    // filter runs on stored rows that are replayed on every restart — so
+    // over-matching silently removes configuration a customer already set.
+    const applied = applyRemoteDockerRuntimeMode({
+      LEGACYDEV_MODE: "keep",
+      MYSKILLS_REGISTRY: "keep",
+      XENABLE_SELF_EDIT: "keep",
+    });
+
+    expect(Object.keys(applied).sort()).toEqual([
+      "ELIZA_CLOUD_PAIR_DIRECT_RELAY",
+      "LEGACYDEV_MODE",
+      "MYSKILLS_REGISTRY",
+      "XENABLE_SELF_EDIT",
+    ]);
+  });
+
+  test.each([
+    ["lowercase", "eliza_dev_auth_bypass"],
+    ["mixed case", "Eliza_Dev_Auth_Bypass"],
+    ["leading and trailing spaces", "  ELIZA_DEV_AUTH_BYPASS  "],
+    ["a bare name in lowercase", "dev_auth_bypass"],
+  ])("normalises %s before matching", (_label, key) => {
+    // The stored `environment_vars` row is caller-authored JSON, so the key is
+    // whatever spelling the caller chose. The guard trims and uppercases for
+    // exactly that reason; without either step the same switch arrives spelled
+    // differently and survives.
+    const applied = applyRemoteDockerRuntimeMode({ [key]: "1", KEEP_ME: "preserved" });
+
+    expect(Object.keys(applied).sort()).toEqual(["ELIZA_CLOUD_PAIR_DIRECT_RELAY", "KEEP_ME"]);
+  });
+});
+
 describe("DockerSandboxProvider remote runtime mode", () => {
   test("forces the flag before every remote create attempt", async () => {
     const provider = new DockerSandboxProvider();


### PR DESCRIPTION
# What

`applyRemoteDockerRuntimeMode` is described in its own header as "the point every one of those paths funnels through" — the write routes can't hold a denylist, because the stored `environment_vars` row is replayed verbatim on every provision, restart and blue/green upgrade. So this one matcher decides whether a caller-supplied auth bypass, self-edit switch, capability-router endpoint or skill registry reaches a managed container.

The existing suite names eleven of the fourteen forbidden suffixes. Four things it doesn't hold, measured on `develop`:

| mutant | result |
|---|---|
| delete `"CAPABILITY_ROUTER_URL"` (only the plural sibling is tested) | **6 pass / 0 fail** |
| `endsWith(`_${suffix}`)` → `endsWith(suffix)` — over-match | **6 pass / 0 fail** |
| drop `.trim()` from the key normaliser | **6 pass / 0 fail** |
| drop `.toUpperCase()` from the key normaliser | **6 pass / 0 fail** |

`CAPABILITY_ROUTER_URL` is the sibling that differs from `CAPABILITY_ROUTER_URLS` by one character, and it is the singular one — the entry a reader would assume is covered because its neighbour is.

# The change

Test-only, one `describe` block.

**A row per suffix, exercising both arms of the matcher.** The predicate is `upper === suffix || upper.endsWith(`_${suffix}`)`; the existing cases mostly use vendor-prefixed spellings, so the exact arm was thinly held. Each entry now arrives bare, under `ELIZA_`, and under `VITE_ACME_` in the same case, and the assertion is on the *whole* remaining key set rather than three `not.toHaveProperty` calls — so a new entry added to the list is pinned the moment its row is added.

**The separator gets a case of its own.** Without the underscore, `LEGACYDEV_MODE`, `MYSKILLS_REGISTRY` and `XENABLE_SELF_EDIT` are deleted too. This is the direction that matters for a denylist applied to *stored* rows: over-matching silently strips configuration a customer already set, on every subsequent restart, with no error.

**Normalisation is asserted from the caller's side.** The row is caller-authored JSON, so the key is whatever spelling the caller chose — `eliza_dev_auth_bypass`, `Eliza_Dev_Auth_Bypass`, `  ELIZA_DEV_AUTH_BYPASS  `, and a bare lowercase name. The guard already trims and uppercases for that reason; nothing held it there.

# Evidence

`bun test src/lib/services/remote-docker-runtime-mode.test.ts`: **25 pass / 0 fail** (was 6).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 6 / 0 | **25 / 0** |
| delete `"CAPABILITY_ROUTER_URL"` | survives | **1 failed** |
| `endsWith` without the underscore | survives | **1 failed** |
| drop `.trim()` | survives | **1 failed** |
| drop `.toUpperCase()` | survives | **3 failed** |
| drop the `upper === suffix` arm | 2 failed | **17 failed** |
| drop the `endsWith` arm | 3 failed | **20 failed** |
| delete `"DEV_MODE"` | 1 failed | **2 failed** |

**7/7 killed, was 3/7.** Biome clean, `tsc --noEmit` clean. No source file is touched, and the two `DockerSandboxProvider` cases that prove the create path actually calls this helper are unchanged.

# On the two normalisation survivors

I want to be accurate about these rather than overstate them. I could not demonstrate an end-to-end escalation from either: the agent-side readers look up exact, canonical names, so a surviving `dev_auth_bypass` or `  ELIZA_DEV_AUTH_BYPASS  ` would not be honoured by the code that consumes it today. They are defence-in-depth.

They are still worth pinning here, for the reason the file's own comment gives: this function is the funnel precisely because the surfaces upstream of it accept `environmentVars` with no denylist, and it is a filter over caller-chosen key spellings. `.trim()` and `.toUpperCase()` are deliberate normalisation steps, and a refactor that drops one currently costs nothing.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KJA71MATJMSX2S57XZE30T","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T12:01:20.436Z","completed_at":"2026-09-03T12:04:50.282Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T12:01:21.069Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"807610b8fc0f90ff0bb2791c930229410741ad23766593eb06937f1d16261f8e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ca79b9a1-3977-4bcf-a8f8-d78c8b705457","object_id":"sha256:807610b8fc0f90ff0bb2791c930229410741ad23766593eb06937f1d16261f8e","sha256":"807610b8fc0f90ff0bb2791c930229410741ad23766593eb06937f1d16261f8e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"gdfqDCTvBXQrzL970PPuIUrOGxUTKuhnJyrEzoPS-GOfonVPwQz4AoT7CM4XFAwIgKXqIop_GygQr_qAR2IlBg"}} -->
