### PR TITLE
test(cloud): name every public-token CORS path and pin the catalog preflight

### DIFF
--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -70,6 +70,94 @@ async function req(
   return app.request(path, { method, headers });
 }
 
+/**
+ * The public-token path set is what lets a registered third-party app call the
+ * API from a browser at all. Five of its twelve entries are named somewhere in
+ * this file; deleting any of the other nine leaves the suite green, and the
+ * consequence of a deletion is silent — the browser simply stops receiving
+ * `Access-Control-Allow-Origin` for that endpoint, which is precisely the bug
+ * this file's header says it exists to guard.
+ */
+const PUBLIC_TOKEN_API_PATHS = [
+  "/api/auth/pair",
+  "/api/v1/app-credits",
+  "/api/v1/chat",
+  "/api/v1/chat/completions",
+  "/api/v1/embeddings",
+  "/api/v1/generate-image",
+  "/api/v1/generate-video",
+  "/api/v1/models",
+  "/api/v1/responses",
+  "/api/v1/subscriptions/plans",
+  "/api/v1/subscriptions/plans/",
+  "/api/v1/voice",
+  "/api/v1/voice-models",
+  "/api/v1/voice-models/catalog",
+] as const;
+
+const PUBLIC_TOKEN_PREFIX_PATHS = [
+  "/api/v1/app-credits/balance",
+  "/api/v1/voice/sessions",
+  "/api/v1/models/openai/gpt-oss-120b",
+] as const;
+
+describe("public token API paths", () => {
+  test.each(PUBLIC_TOKEN_API_PATHS)("%s is a public token path", (path) => {
+    expect(isPublicTokenApiPath(path)).toBe(true);
+  });
+
+  test.each(PUBLIC_TOKEN_PREFIX_PATHS)(
+    "%s is reached by a prefix rather than an exact entry",
+    (path) => {
+      expect(isPublicTokenApiPath(path)).toBe(true);
+    },
+  );
+
+  test.each([
+    // The prefixes carry a trailing slash, so the bare names above are exact
+    // entries and not covered by them. A sibling one segment further out must
+    // stay private.
+    "/api/v1/voice-models/catalog/private",
+    "/api/v1/chat/completions/admin",
+    "/api/v1/user/wallets",
+    "/api/v1/subscriptions",
+    "/api/auth/pair/native",
+  ])("%s is not a public token path", (path) => {
+    expect(isPublicTokenApiPath(path)).toBe(false);
+  });
+});
+
+describe("read-only catalog preflight normalisation", () => {
+  test.each([
+    ["lowercase", "get"],
+    ["mixed case", "Get"],
+    ["padded with spaces", "  head  "],
+  ])("a %s requested-method still gets the narrow policy", async (_label, requestedMethod) => {
+    // `Access-Control-Request-Method` is caller-supplied, and the gate
+    // uppercases it for that reason. Drop that step and the request falls
+    // through to the general public policy, so the catalog preflight
+    // advertises exactly the mutating methods the comment above
+    // `readOnlyPublicCors` says it must never advertise or prime in the
+    // browser cache. The suite's existing preflight cases only send "GET"
+    // and "HEAD" verbatim, so nothing notices.
+    //
+    // The padded row asserts the observable behaviour, not the source's
+    // `.trim()`: the Headers API strips surrounding whitespace from a value
+    // before the middleware ever reads it, so that call cannot be reached
+    // through a request and removing it alone changes nothing.
+    const res = await req(
+      "OPTIONS",
+      "https://thirdparty.example.com",
+      true,
+      "/api/v1/subscriptions/plans",
+      requestedMethod,
+    );
+
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-methods")).toBe("GET,HEAD,OPTIONS");
+  });
+});
+
 describe("isFirstPartyOrigin", () => {
   test("recognizes canonical and transition SPAs + localhost, rejects third-party", () => {
     expect(isFirstPartyOrigin("https://www.eliza.app")).toBe(true);


### PR DESCRIPTION
# What

`PUBLIC_TOKEN_API_PATHS` is what lets a registered third-party app call the API from a browser at all — it selects the open, non-credentialed CORS policy. This file's header says it exists as a regression guard for exactly the bug where an app "got no `Access-Control-Allow-Origin` and the browser blocked every request".

The suite names five of its twelve entries. Deleting any of the other nine leaves all 27 tests green:

| deleted entry | result on `develop` |
|---|---|
| `/api/v1/app-credits` | **27 pass / 0 fail** |
| `/api/v1/chat` | **27 pass / 0 fail** |
| `/api/v1/embeddings` | **27 pass / 0 fail** |
| `/api/v1/generate-image` | **27 pass / 0 fail** |
| `/api/v1/generate-video` | **27 pass / 0 fail** |
| `/api/v1/responses` | **27 pass / 0 fail** |
| `/api/v1/voice` | **27 pass / 0 fail** |
| `/api/v1/voice-models` | **27 pass / 0 fail** |
| `/api/v1/voice-models/catalog` | **27 pass / 0 fail** |

None is covered by the prefix arm, either: `PUBLIC_TOKEN_API_PATH_PREFIXES` entries carry a trailing slash, so `/api/v1/voice` and `/api/v1/app-credits` are genuinely exact entries. A deletion is silent — the endpoint keeps working for every non-browser caller, and only third-party browser apps break.

# The change

Test-only.

**A row per entry**, all fourteen (the two subscription-catalog paths included), plus three prefix-reached paths kept separate so the two arms of `isPublicTokenApiPath` stay distinguishable, plus five negatives — including `/api/v1/voice-models/catalog/private` and `/api/v1/chat/completions/admin`, the "one segment further out" siblings.

**The catalog preflight's method normalisation.** `Access-Control-Request-Method` is caller-supplied and the gate uppercases it before comparing. The existing preflight cases send `"GET"` and `"HEAD"` verbatim, so removing that step costs nothing — and the consequence is precise: the request falls through to the general public policy, and the catalog preflight advertises `GET,POST,PUT,PATCH,DELETE,OPTIONS`, exactly what the comment above `readOnlyPublicCors` says must never be advertised or primed in the browser cache.

# Two things I checked rather than assumed

**I did not duplicate what was already there.** My first draft added a plain GET/HEAD preflight table for the catalog paths; the suite already has one (`"allows only GET/HEAD preflight for both public subscription catalog paths"`). Dropped it — the normalisation rows are the only new coverage there.

**The `.trim()` in that gate is unreachable, and the test says so.** `requestedMethod?.trim().toUpperCase()` — removing only the `.trim()` leaves my suite green, which looked like a gap in my own test until I checked why:

```
new Headers({ "Access-Control-Request-Method": "  head  " }).get(...)  →  "head"
new Request(url, { headers: { ... "  get  " } }).headers.get(...)      →  "get"
```

The Headers API strips surrounding whitespace before the middleware ever reads the value, so that call cannot be reached through a request. The padded row is still there because it pins the observable behaviour, and the comment states plainly that it does not cover the `.trim()` line.

# Evidence

`bun test src/lib/cors/cloud-api-hono-cors.test.ts`: **52 pass / 0 fail** (was 27).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 27 / 0 | **52 / 0** |
| delete each of the nine unnamed path entries | **all survive** | **killed, each** |
| drop `.toUpperCase()` on the requested method | survives | **3 failed** |
| drop the prefix arm of `isPublicTokenApiPath` | 4 failed | **4 failed** |
| drop `.trim()` only | survives | survives — *unreachable, explained above* |

**10/10 reachable mutants killed, was 1/10.** Biome clean, `tsc --noEmit` clean. No source file is touched.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KKETN1V0ZA6TYZMBYM4R8W","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T12:21:20.161Z","completed_at":"2026-09-03T12:25:33.134Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T12:21:20.839Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ef5871798301f4f656e2bd8ca6f079f1e5e8aa5b59b0cfad3218e91d35827b8a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b912f033-3ef8-41f4-8b81-ba6739388a16","object_id":"sha256:ef5871798301f4f656e2bd8ca6f079f1e5e8aa5b59b0cfad3218e91d35827b8a","sha256":"ef5871798301f4f656e2bd8ca6f079f1e5e8aa5b59b0cfad3218e91d35827b8a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"rut-LYSWxGdts9PiFh1OjpXmiOwuCSHwIfRFFBxrMgbTqWoieznfwqJ-R72dRg-AqDtr0gMt54SJytu0Vpu5DA"}} -->
