### PR TITLE
test(cloud): pin the OIDC client registry bounds and reserved claims

### DIFF
--- a/packages/cloud/shared/src/lib/oidc/clients.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/clients.test.ts
@@ -527,3 +527,128 @@ describe("the documented worked entries load", () => {
     expect(client.claims_mapping.mode).toBe("replace");
   });
 });
+
+/**
+ * The numeric bounds and the two validating regexes in this file had no test at
+ * all: every one of `MAX_TTL_SECONDS`, `MAX_REDIRECT_ALIAS_SOURCE_BYTES`,
+ * `MAX_REDIRECT_ALIAS_CLIENTS`, `MAX_REDIRECT_ALIASES_PER_CLIENT`,
+ * `MAX_REDIRECT_URI_BYTES`, `CLAIM_NAME_RE` and the length half of
+ * `SHA256_HEX_RE` can be widened without a failure.
+ */
+describe("registry bounds", () => {
+  test("a client secret hash must be exactly 64 hex characters", () => {
+    expect(() => parseOidcClientEntry(entry({ client_secret_sha256: "a".repeat(63) }))).toThrow(
+      /sha256 hex/,
+    );
+    expect(() => parseOidcClientEntry(entry({ client_secret_sha256: "a".repeat(65) }))).toThrow(
+      /sha256 hex/,
+    );
+    expect(() => parseOidcClientEntry(entry({ client_secret_sha256: "z".repeat(64) }))).toThrow(
+      /sha256 hex/,
+    );
+    expect(parseOidcClientEntry(entry()).secret_hashes).toEqual([SECRET_HASH]);
+  });
+
+  test("a constant claim name must start with a letter and fit 64 characters", () => {
+    // Both halves of CLAIM_NAME_RE. The length bound is asserted at its
+    // boundary rather than with an extreme, so widening the quantifier fails.
+    const ok = `a${"b".repeat(63)}`;
+    expect(
+      parseOidcClientEntry(entry({ constant_claims: { [ok]: "v" } })).constant_claims[ok],
+    ).toBe("v");
+
+    for (const name of [`a${"b".repeat(64)}`, "1leading_digit", "_leading_underscore", ""]) {
+      expect(() => parseOidcClientEntry(entry({ constant_claims: { [name]: "v" } }))).toThrow(
+        /unusable claim name/,
+      );
+    }
+  });
+
+  test("auth_time stays reserved even though the provider stopped emitting it", () => {
+    // It is the one entry that is neither in OIDC_SUPPORTED_CLAIMS nor emitted,
+    // so it reads as dead weight — and removing it passes the whole suite. The
+    // comment above the set explains why it must stay: a fixed constant would
+    // assert one authentication instant for every user forever.
+    expect(() =>
+      parseOidcClientEntry(entry({ constant_claims: { auth_time: "1700000000" } })),
+    ).toThrow(/may not override the provider claim "auth_time"/);
+  });
+
+  test.each(["nbf", "jti", "typ", "scope", "client_id"])(
+    "the JWT envelope member %s stays reserved",
+    (name) => {
+      expect(() => parseOidcClientEntry(entry({ constant_claims: { [name]: "v" } }))).toThrow(
+        /may not override the provider claim/,
+      );
+    },
+  );
+
+  test("token TTLs are clamped to the 60..3600 window rather than trusted", () => {
+    const high = parseOidcClientEntry(
+      entry({ id_token_ttl_seconds: 86_400, access_token_ttl_seconds: 3_601 }),
+    );
+    expect(high.id_token_ttl_seconds).toBe(3600);
+    expect(high.access_token_ttl_seconds).toBe(3600);
+
+    const low = parseOidcClientEntry(
+      entry({ id_token_ttl_seconds: 1, access_token_ttl_seconds: 59 }),
+    );
+    expect(low.id_token_ttl_seconds).toBe(60);
+    expect(low.access_token_ttl_seconds).toBe(60);
+
+    const exact = parseOidcClientEntry(
+      entry({ id_token_ttl_seconds: 3600, access_token_ttl_seconds: 60 }),
+    );
+    expect(exact.id_token_ttl_seconds).toBe(3600);
+    expect(exact.access_token_ttl_seconds).toBe(60);
+
+    const absent = parseOidcClientEntry(entry({ id_token_ttl_seconds: "600" }));
+    expect(absent.id_token_ttl_seconds).toBe(300);
+  });
+
+  test("each alias overlay limit is asserted by its own message", () => {
+    // The existing oversize case asserts only /OIDC_REDIRECT_URI_ALIASES/, so a
+    // 1000x byte limit still "fails closed" — on the next check down, with a
+    // different message. Matching the specific message is what pins the bound.
+    process.env.OIDC_CLIENTS = JSON.stringify([entry({ client_id: "elizahub" })]);
+
+    const cases: [string, RegExp][] = [
+      [`{"x":"${"x".repeat(16_384)}"}`, /exceeds its byte limit/],
+      [
+        JSON.stringify(
+          Object.fromEntries(
+            Array.from({ length: 33 }, (_, i) => [`c${i}`, ["https://a.example/cb"]]),
+          ),
+        ),
+        /between 1 and 32 clients/,
+      ],
+      [
+        JSON.stringify({
+          elizahub: Array.from({ length: 9 }, (_, i) => `https://a${i}.example/cb`),
+        }),
+        /between 1 and 8 callbacks/,
+      ],
+      [
+        JSON.stringify({ elizahub: [`https://a.example/${"p".repeat(2_048)}`] }),
+        /OIDC_REDIRECT_URI_ALIASES/,
+      ],
+    ];
+
+    for (const [source, message] of cases) {
+      process.env.OIDC_REDIRECT_URI_ALIASES = source;
+      _resetOidcClientCacheForTests();
+      expect(() => getOidcClient("elizahub")).toThrow(message);
+    }
+  });
+
+  test("the alias counts are accepted at their limits", () => {
+    // The rejections above are only meaningful against an accepted neighbour.
+    process.env.OIDC_CLIENTS = JSON.stringify([entry({ client_id: "elizahub" })]);
+    process.env.OIDC_REDIRECT_URI_ALIASES = JSON.stringify({
+      elizahub: Array.from({ length: 8 }, (_, i) => `https://a${i}.example/cb`),
+    });
+    _resetOidcClientCacheForTests();
+
+    expect(getOidcClient("elizahub")?.redirect_uris).toHaveLength(9);
+  });
+});


### PR DESCRIPTION
# What

`clients.ts` parses `OIDC_CLIENTS` and `OIDC_REDIRECT_URI_ALIASES` — operator-supplied config that decides token lifetimes, which callbacks a relying party may use, and which claims a client can pin. The suite has 41 tests and covers the behaviour well, but **none of the file's numeric bounds or validating regexes is held by any of them.**

Measured on `develop`:

| mutant | result |
|---|---|
| `MAX_TTL_SECONDS` 3600 → 86400 | **41 pass / 0 fail** |
| `MIN_TTL_SECONDS` 60 → 1 | **41 pass / 0 fail** |
| `MAX_REDIRECT_ALIAS_SOURCE_BYTES` ×1000 | **41 pass / 0 fail** |
| `MAX_REDIRECT_ALIAS_CLIENTS` 32 → 3200 | **41 pass / 0 fail** |
| `MAX_REDIRECT_ALIASES_PER_CLIENT` 8 → 800 | **41 pass / 0 fail** |
| `MAX_REDIRECT_URI_BYTES` ×100 | **41 pass / 0 fail** |
| `CLAIM_NAME_RE` → unbounded length | **41 pass / 0 fail** |
| `CLAIM_NAME_RE` → may start with a digit | **41 pass / 0 fail** |
| `SHA256_HEX_RE` → any length | **41 pass / 0 fail** |
| delete `"auth_time"` from `RESERVED_CLAIM_NAMES` | **41 pass / 0 fail** |

The last one is the one I'd most expect to be lost in a refactor. `auth_time` is neither in `OIDC_SUPPORTED_CLAIMS` nor emitted by the provider any more, so it reads as dead weight — and the comment directly above it exists to explain why it must stay ("a fixed constant would assert one authentication instant for every user forever, which is the misrepresentation dropping the claim exists to avoid"). A comment was the only thing holding it.

# Why the alias limits looked covered but weren't

The suite has an oversize-overlay case. I assumed at first it was passing for the wrong reason and checked, because that changes what to write:

```
oversize   THREW: OIDC_REDIRECT_URI_ALIASES exceeds its byte limit
```

It does hit the right branch. The reason the ×1000 mutant survives is the assertion, not the fixture: the loop asserts `toThrow(/OIDC_REDIRECT_URI_ALIASES/)`, so with a larger limit the same input simply fails the *next* check down and still matches. The new cases assert the specific message per limit, which is what pins each bound to itself.

# The change

Test-only, one `describe` block:

- **Secret hashes** — 63 and 65 characters and a non-hex 64 all rejected, with the valid 64 accepted alongside.
- **Claim names** — both halves of `CLAIM_NAME_RE`, with the length asserted at its boundary (64 accepted, 65 rejected) rather than with an extreme, plus leading digit, leading underscore, and empty.
- **`auth_time`** and a row for each of the five JWT envelope members (`nbf`, `jti`, `typ`, `scope`, `client_id`).
- **TTL clamping** — above, below, at both limits, and the non-numeric default.
- **Alias limits, one message each** — byte limit, 33 clients, 9 callbacks, oversized URI — plus an accepted-at-the-limit case (8 callbacks → 9 total redirect URIs), since a rejection is only meaningful against an accepted neighbour.

# Evidence

`bun test src/lib/oidc/clients.test.ts`: **52 pass / 0 fail** (was 41).

Every mutant in the table above now fails, **10/10 killed, was 0/10**, against a green control. Sibling OIDC suites unchanged: `claims` 55, `config` 21, `keys` 19. Biome clean, `tsc --noEmit` clean. No source file is touched.

# One mutant I did not chase

Widening `SHA256_HEX_RE` from `[0-9a-f]` to `[0-9a-fA-F]` survives, and it is unreachable rather than untested: `parseSecretHashes` runs `hash.trim().toLowerCase()` before the test, so no uppercase input can ever reach the regex. The length half of the same regex is genuinely load-bearing and is covered above.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KM183398BXXVQQPW4997MT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T12:31:23.747Z","completed_at":"2026-09-03T12:35:36.232Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T12:31:24.518Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b4addd227f6ebaf5e8437af7a7c328254324ef1611ff3de7f6fa163c4ee805cd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4edc72fe-d371-4685-87d5-08962fbfeecb","object_id":"sha256:b4addd227f6ebaf5e8437af7a7c328254324ef1611ff3de7f6fa163c4ee805cd","sha256":"b4addd227f6ebaf5e8437af7a7c328254324ef1611ff3de7f6fa163c4ee805cd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"NEJt0GJlvpqbUZAHznOqEJk_pvVlY6A0GR08V8QqF8hUXhXoFSPAS2uG35R8kAo_bJj19zTPSrWfTuK_YcslBA"}} -->
