### PR TITLE
test(shared): name every chat upload MIME type and pin the count bounds

### DIFF
--- a/packages/shared/src/chat-upload-limits.test.ts
+++ b/packages/shared/src/chat-upload-limits.test.ts
@@ -11,10 +11,12 @@ import {
   CHAT_IMAGE_MIME_TYPES,
   CHAT_UPLOAD_MIME_TYPE_SET,
   CHAT_UPLOAD_MIME_TYPES,
+  MAX_CHAT_ATTACHMENT_NAME_LENGTH,
   MAX_CHAT_IMAGE_BASE64_BYTES,
   MAX_CHAT_IMAGE_RAW_BYTES,
   MAX_CHAT_MEDIA_BASE64_BYTES,
   MAX_CHAT_MEDIA_RAW_BYTES,
+  MAX_CHAT_UPLOAD_ATTACHMENTS,
   maxRawBytesForBase64,
 } from "./chat-upload-limits.ts";
 
@@ -90,5 +92,76 @@ describe("MIME allowlists", () => {
     expect(CHAT_IMAGE_MIME_TYPE_SET.has("image/heic")).toBe(false);
     expect(CHAT_IMAGE_MIME_TYPE_SET.has("image/heif")).toBe(false);
     expect(CHAT_IMAGE_MIME_TYPE_SET.has("image/svg+xml")).toBe(false);
+  });
+});
+
+/**
+ * The exclusion case above covers `CHAT_IMAGE_MIME_TYPES` only. The wider
+ * upload allowlist has no equivalent, so `"text/html"` can be appended to it
+ * with both this suite and the agent parity suite green — and every individual
+ * entry in either list can be deleted just as quietly.
+ */
+describe("chat upload allowlist membership", () => {
+  it.each(CHAT_IMAGE_MIME_TYPES)("keeps %s in the image allowlist", (mime) => {
+    expect(CHAT_IMAGE_MIME_TYPE_SET.has(mime)).toBe(true);
+    // The image list is spread into the upload list; a divergence here means a
+    // type the client will send as an image is refused by the upload endpoint.
+    expect(CHAT_UPLOAD_MIME_TYPE_SET.has(mime)).toBe(true);
+  });
+
+  it.each(CHAT_UPLOAD_MIME_TYPES)(
+    "keeps %s in the upload allowlist",
+    (mime) => {
+      expect(CHAT_UPLOAD_MIME_TYPE_SET.has(mime)).toBe(true);
+    },
+  );
+
+  it("names the exact contents of both lists", () => {
+    // `it.each` over an empty array registers no cases at all, so the two
+    // tables above cannot notice a list being emptied. These also make an
+    // ADDITION a deliberate edit rather than a silent one.
+    expect([...CHAT_IMAGE_MIME_TYPES]).toEqual([
+      "image/jpeg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+    ]);
+    expect(CHAT_UPLOAD_MIME_TYPES).toHaveLength(23);
+    expect(CHAT_UPLOAD_MIME_TYPE_SET.size).toBe(CHAT_UPLOAD_MIME_TYPES.length);
+  });
+
+  it.each([
+    "text/html",
+    "application/xhtml+xml",
+    "image/svg+xml",
+    "text/javascript",
+    "application/javascript",
+    "application/xml",
+  ])(
+    "keeps the active document type %s out of the upload allowlist",
+    (mime) => {
+      // Not because this list is the XSS boundary — it is not. `media-store.ts`
+      // serves anything outside `isInlineSafeMime` with
+      // `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff` and a
+      // sandbox CSP, and that holds today. But the two live in different packages
+      // and neither knows about the other, so this list should not quietly start
+      // accepting document types on the assumption that the other layer will
+      // always catch them.
+      expect(CHAT_UPLOAD_MIME_TYPE_SET.has(mime)).toBe(false);
+    },
+  );
+});
+
+describe("chat upload count and name bounds", () => {
+  it("caps attachments per message at 4", () => {
+    // A per-message fan-out bound: raising it multiplies both the request size
+    // and the number of stored objects a single message can create.
+    expect(MAX_CHAT_UPLOAD_ATTACHMENTS).toBe(4);
+  });
+
+  it("caps an attachment file name at 255 characters", () => {
+    // 255 is the POSIX single-component limit, which is what makes a stored
+    // name writable as a filename on the media volume.
+    expect(MAX_CHAT_ATTACHMENT_NAME_LENGTH).toBe(255);
   });
 });


### PR DESCRIPTION
# What

`chat-upload-limits.ts` holds two MIME allowlists and four numeric bounds. The suite has a good exclusion case — but only for the *image* list:

```ts
expect(CHAT_IMAGE_MIME_TYPE_SET.has("image/heic")).toBe(false);
expect(CHAT_IMAGE_MIME_TYPE_SET.has("image/heif")).toBe(false);
expect(CHAT_IMAGE_MIME_TYPE_SET.has("image/svg+xml")).toBe(false);
```

`CHAT_UPLOAD_MIME_TYPES` — the 23-entry list the upload endpoint actually accepts — has no equivalent, and neither list has per-entry coverage. Measured on `develop`, against both this suite and the agent parity suite:

| mutant | `shared` | `agent` parity |
|---|---|---|
| **append `"text/html"`** to the upload list | **7 / 0** | **10 / 10** |
| append `"image/svg+xml"` to the image list | 6 / **1 fail** | 10 / 10 |
| delete `image/gif` | **7 / 0** | **10 / 10** |
| delete `image/webp`, `audio/aac`, `video/quicktime`, `text/csv`, `application/json` | **7 / 0** each | **10 / 10** each |
| `MAX_CHAT_UPLOAD_ATTACHMENTS` 4 → 400 | **7 / 0** | **10 / 10** |
| `MAX_CHAT_ATTACHMENT_NAME_LENGTH` 255 → 25500 | **7 / 0** | **10 / 10** |

So the guard the file's own header advertises — "free of the phone-photo formats (HEIC/HEIF/SVG) the client must re-encode" — stops at the image list, and two of the four bounds have nothing behind them.

# On `text/html`, stated carefully

This allowlist is **not** the XSS boundary, and I want to be precise rather than alarming. `media-store.ts` serves anything outside `isInlineSafeMime` with `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff` and `default-src 'none'; sandbox` — I read that path, and it holds for `text/html` today.

The reason it is still worth an assertion is that the two live in different packages and neither references the other. `chat-upload-limits.ts` is in `packages/shared`; the disposition rule is in `packages/agent`. This list should not start accepting active document types on the assumption that a layer it does not know about will always catch them.

# The change

Test-only:

- **A row per entry in each list**, so a deletion names itself. The image rows also assert membership in the upload set, since the image list is spread into it and a divergence would mean a type the client sends as an image is refused on upload.
- **Both lists named exactly**, plus a length check. `it.each` over an emptied array registers zero cases, so the tables above cannot notice a list being cleared — and naming the contents makes an *addition* deliberate too.
- **Six active document types asserted absent** from the upload set (`text/html`, `application/xhtml+xml`, `image/svg+xml`, two JavaScript spellings, `application/xml`).
- **The two unpinned bounds**, each with the reason it has that value: 4 is a per-message fan-out cap, 255 is the POSIX single-component limit that makes a stored name writable on the media volume.

# Evidence

`bun test src/chat-upload-limits.test.ts`: **43 pass / 0 fail** (was 7).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 7 / 0 | **43 / 0** |
| append `"text/html"` | survives | **2 failed** |
| append `"image/svg+xml"` | 1 failed | **3 failed** |
| delete any of the six sampled entries | survives, each | **killed, each** |
| `MAX_CHAT_UPLOAD_ATTACHMENTS` ×100 | survives | **1 failed** |
| `MAX_CHAT_ATTACHMENT_NAME_LENGTH` ×100 | survives | **1 failed** |

**9/9 killed, was 1/9.** Agent-side siblings unchanged (`chat-upload-limits.parity` + `media-store`: 84 passed). Biome clean. No source file is touched.

The two base64 ceilings already had coverage — `MAX_CHAT_IMAGE_BASE64_BYTES` fails this suite when widened and `MAX_CHAT_MEDIA_BASE64_BYTES` fails the agent parity suite — so I left them alone.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KMN4FPNSF2VWC4W06T2JJT","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T12:42:15.414Z","completed_at":"2026-09-03T12:46:25.694Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T12:42:16.014Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"25648714346c319975b2ba4bfb03d1443dfcd7a3d699e9560f166e8d2246d122","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"61f6c109-b5ac-468a-acff-0547f74e7fae","object_id":"sha256:25648714346c319975b2ba4bfb03d1443dfcd7a3d699e9560f166e8d2246d122","sha256":"25648714346c319975b2ba4bfb03d1443dfcd7a3d699e9560f166e8d2246d122"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"8CeOI9n1elhcxA0QjTWv03OyUHC0fSFxVQLuDhGuxVYMWV6H3oBKokOMuKhU2DJehDM3QxG1XIrcyP8fAT70Bg"}} -->
