### PR TITLE
test(ui): pin server-wins direction for voice intent consent

### DIFF
--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -384,4 +384,30 @@ describe("VoiceSectionMount — mount preserves explicit local consent when the 
       window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
     ).toBe("always-on");
   });
+
+  it("lets an explicit server false revoke a stale local opt-in", async () => {
+    clientMock.getConfig.mockResolvedValue({
+      messages: {
+        voice: {
+          osIntentAutoStartVoice: false,
+          osIntentAutoStartTranscription: false,
+        },
+      },
+    });
+    window.localStorage.setItem(
+      "eliza:voice:os-intent-auto-start-voice",
+      "true",
+    );
+    render(<VoiceSectionMount />);
+    const toggle = await screen.findByTestId(
+      "voice-section-intent-autostart-voice",
+    );
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-checked")).toBe("false"),
+    );
+    expect(loadOsIntentAutoStartConsent()).toEqual({
+      voice: false,
+      transcription: false,
+    });
+  });
 });

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -385,7 +385,7 @@ describe("VoiceSectionMount — mount preserves explicit local consent when the 
     ).toBe("always-on");
   });
 
-  it("lets an explicit server false revoke a stale local opt-in", async () => {
+  it("lets an explicit server false revoke stale local opt-ins, both legs", async () => {
     clientMock.getConfig.mockResolvedValue({
       messages: {
         voice: {
@@ -398,16 +398,34 @@ describe("VoiceSectionMount — mount preserves explicit local consent when the 
       "eliza:voice:os-intent-auto-start-voice",
       "true",
     );
+    window.localStorage.setItem(
+      "eliza:voice:os-intent-auto-start-transcription",
+      "true",
+    );
     render(<VoiceSectionMount />);
-    const toggle = await screen.findByTestId(
+    const voiceToggle = await screen.findByTestId(
       "voice-section-intent-autostart-voice",
     );
-    await waitFor(() =>
-      expect(toggle.getAttribute("aria-checked")).toBe("false"),
+    const transcriptionToggle = await screen.findByTestId(
+      "voice-section-intent-autostart-transcription",
     );
+    await waitFor(() => {
+      expect(voiceToggle.getAttribute("aria-checked")).toBe("false");
+      expect(transcriptionToggle.getAttribute("aria-checked")).toBe("false");
+    });
     expect(loadOsIntentAutoStartConsent()).toEqual({
       voice: false,
       transcription: false,
     });
+    // The routing authority reads the on-disk mirror, so the stale opt-in
+    // must be rewritten there too — not just overridden in React state.
+    expect(
+      window.localStorage.getItem("eliza:voice:os-intent-auto-start-voice"),
+    ).toBe("false");
+    expect(
+      window.localStorage.getItem(
+        "eliza:voice:os-intent-auto-start-transcription",
+      ),
+    ).toBe("false");
   });
 });


### PR DESCRIPTION
Add the missing consent-revocation regression: when the server explicitly disables voice and transcription shortcuts, mounting Settings overrides both previously enabled local flags and rewrites their persisted values.

This checks the opposite direction from the existing local-opt-in tests. Replacing server precedence with local-or-server consent makes the new test fail; restoring the production implementation passes all 14 tests in the focused suite.

Validation on `4886fb82fa630ff79bf6706c8f2281d7ad86f400`, based on `9612ff217a00465f63f1854b53ebcd65e2461dcd`, Bun 1.3.14 / Node 24.15.0:
- Mutation: 1 failed / 13 passed with the incorrect precedence; 14 passed with production code restored.
- Full UI suite: 13,533 passed, 7 skipped; two unrelated timing failures in Files navigation and ChatOverlay fuzzing. Both complete, unchanged files passed on rerun: 165 tests. No timeouts or assertions were relaxed.
- UI typecheck and lint passed.
- Root `bun run verify`: all 376 workspace tasks and repository audits passed.
- `bun install` and final clean-tree checks passed.

No production code changes. App visual captures and live voice/model trajectories are N/A: this test pins an existing consent contract without changing rendered or microphone behavior.

<!-- evidence-head:4886fb82fa630ff79bf6706c8f2281d7ad86f400 -->
