### PR TITLE
test(agent): pin the Steward tail of the dev-cloud owned-key authority

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -15,8 +15,10 @@ import {
   createDevCloudConfigAuthorityView,
   createDevCloudRuntimeSettingsAuthorityOverlay,
   DEV_CLOUD_ENV_AUTHORITY_KEY,
-  type DEV_CLOUD_ENV_OWNED_KEYS,
+  DEV_CLOUD_ENV_OWNED_KEYS,
   DEV_CLOUD_ENV_RESTORE_KEYS,
+  isDevCloudEnvOwnedKey,
+  isDevCloudInternalEnvKey,
   mergeDevCloudConfigAuthorityMutation,
   resetDevCloudEnvAuthorityForTests,
   resolveDevCloudEnvAuthority,
@@ -1550,4 +1552,84 @@ describe("stale vault/config key clobber guard (#11038)", () => {
       "eliza_…(len 18)",
     );
   });
+});
+
+/**
+ * `isDevCloudEnvOwnedKey` answers from an explicit list OR five `ELIZA*CLOUD_`
+ * prefixes, and 63 of the list's 72 entries are already matched by a prefix —
+ * deleting any of those changes nothing, which is why sampling them all
+ * "survives". The nine that are NOT prefix-matched are the Steward tuple, and
+ * they carry the fleet-scoped credentials (`STEWARD_API_KEY`,
+ * `STEWARD_AGENT_TOKEN`). For those the list is the only thing answering.
+ */
+describe("dev cloud owned-key authority", () => {
+  const PREFIXES = [
+    "ELIZAOS_CLOUD_",
+    "ELIZA_CLOUD_",
+    "ELIZA_DEV_CLOUD_",
+    "ELIZACLOUD_",
+    "WAIFU_ELIZA_CLOUD_",
+  ];
+
+  const listOnlyKeys = [...DEV_CLOUD_ENV_OWNED_KEYS].filter(
+    (key) => !PREFIXES.some((prefix) => key.toUpperCase().startsWith(prefix)),
+  );
+
+  it("the list carries exactly the Steward tuple beyond the prefix arms", () => {
+    expect(listOnlyKeys).toEqual([
+      "STEWARD_API_URL",
+      "STEWARD_TENANT_ID",
+      "STEWARD_AGENT_ID",
+      "ELIZA_STEWARD_AGENT_ID",
+      "STEWARD_API_KEY",
+      "STEWARD_AGENT_TOKEN",
+      "STEWARD_TRADE_SESSION_ID",
+      "STEWARD_HYPERLIQUID_TRADE_SESSION_ID",
+      "STEWARD_POLYMARKET_TRADE_SESSION_ID",
+    ]);
+  });
+
+  it.each(
+    [...DEV_CLOUD_ENV_OWNED_KEYS].filter(
+      (key) => !PREFIXES.some((prefix) => key.toUpperCase().startsWith(prefix)),
+    ),
+  )("%s is owned by the launcher, list-answered", (key) => {
+    expect(isDevCloudEnvOwnedKey(key)).toBe(true);
+    // The predicate uppercases, and a persisted config key is whatever spelling
+    // was written; both must reach the same answer.
+    expect(isDevCloudEnvOwnedKey(key.toLowerCase())).toBe(true);
+  });
+
+  it.each(PREFIXES)(
+    "%s is matched as a family, not only by listed names",
+    (prefix) => {
+      const unlisted = `${prefix}NOT_A_LISTED_NAME`;
+      expect(DEV_CLOUD_ENV_OWNED_KEYS).not.toContain(unlisted);
+      expect(isDevCloudEnvOwnedKey(unlisted)).toBe(true);
+    },
+  );
+
+  it.each(["SMALL_MODEL", "LARGE_MODEL", "OPENAI_API_KEY", "STEWARD"])(
+    "%s is not claimed by the dev-cloud authority",
+    (key) => {
+      // The list's own comment: generic model aliases still belong to
+      // direct/local providers when the dev target is offline. A widened prefix
+      // would take them, and take the provider's key with them.
+      expect(isDevCloudEnvOwnedKey(key)).toBe(false);
+    },
+  );
+
+  it.each([
+    "ELIZA_DEV_SOURCE",
+    "ELIZA_DEV_CLOUD_TARGET",
+    DEV_CLOUD_ENV_AUTHORITY_KEY,
+  ])(
+    "the internal launcher marker %s is never owned, despite matching a prefix",
+    (key) => {
+      // These match `ELIZA_DEV_CLOUD_`/`ELIZA_DEV_` shapes but are excluded
+      // first. Persisted config must not be able to fabricate them.
+      expect(isDevCloudInternalEnvKey(key)).toBe(true);
+      expect(isDevCloudEnvOwnedKey(key)).toBe(false);
+    },
+  );
 });


### PR DESCRIPTION
# What

`isDevCloudEnvOwnedKey` decides which persisted environment fields the launcher owns — i.e. which values outrank config and vault state. It answers from an explicit 72-entry list **or** five `ELIZA*CLOUD_` prefixes.

Sampling the list, every deletion survives:

| deleted entry | `eliza-cloud-config.test.ts` |
|---|---|
| `ELIZAOS_CLOUD_API_KEY`, `ELIZA_CLOUD_SESSION_TOKEN`, `ELIZACLOUD_TOKEN`, `ELIZAOS_CLOUD_EMBEDDING_API_KEY`, `ELIZA_CLOUD_AUTH_TOKEN`, `ELIZAOS_CLOUD_ENABLED`, `ELIZAOS_CLOUD_LARGE_MODEL`, `ELIZA_CLOUD_SANDBOX_TOKEN` | **60 pass / 0 fail**, each |

That looked like eight coverage gaps. It isn't — and the difference decides what to write, so I checked instead of assuming:

```
total: 72
NOT covered by a prefix (9):
  STEWARD_API_URL, STEWARD_TENANT_ID, STEWARD_AGENT_ID, ELIZA_STEWARD_AGENT_ID,
  STEWARD_API_KEY, STEWARD_AGENT_TOKEN, STEWARD_TRADE_SESSION_ID,
  STEWARD_HYPERLIQUID_TRADE_SESSION_ID, STEWARD_POLYMARKET_TRADE_SESSION_ID
```

**63 of the 72 entries are already matched by a prefix arm**, so deleting one genuinely changes nothing — they are redundant, not untested. The nine that are not prefix-matched are the Steward tuple, and for those the list is the only thing answering. Two of them, `STEWARD_API_KEY` and `STEWARD_AGENT_TOKEN`, are the fleet-scoped credentials that `blocked-env-keys.ts` also refuses to let config writes persist.

# The change

Test-only, one `describe` block, written against the derived subset rather than a copied list:

- **The Steward tail is named exactly**, computed as "list entries no prefix matches". That makes the assertion self-maintaining: if a future entry is added that a prefix already covers, nothing changes; if one is added that isn't covered, this test names it.
- **A row per list-answered key**, in canonical and lowercase spelling, since a persisted config key is whatever spelling was written.
- **A row per prefix**, each using a name that is deliberately *not* in the list, so the family arms stay distinguishable from the exact arm.
- **Negatives from the file's own comment** — `SMALL_MODEL` and `LARGE_MODEL` "still belong to direct/local providers when the dev target is offline", plus `OPENAI_API_KEY` and a bare `STEWARD`.
- **The internal launcher markers**, which match a prefix shape but are excluded first so persisted config cannot fabricate them.

# Evidence

`bunx vitest run src/runtime/eliza-cloud-config.test.ts`: **82 passed** (was 60).

| mutant | before | after |
|---|---|---|
| control (unmutated) | 60 / 0 | **82 / 0** |
| delete `STEWARD_API_KEY` from the shared tuple | survives | **1 failed** |
| delete `STEWARD_AGENT_TOKEN` | survives | **1 failed** |
| delete `ELIZA_STEWARD_AGENT_ID` | survives | **1 failed** |
| delete `STEWARD_TRADE_SESSION_ID` | survives | **1 failed** |
| drop the `ELIZAOS_CLOUD_` prefix arm | survives | **1 failed** |
| drop the internal-key exclusion | survives | **2 failed** |
| drop `.toUpperCase()` in the predicate | survives | **9 failed** |

**7/7 killed, was 0/7.** Biome clean, `tsc --noEmit` clean. No source file is touched.

# What I deliberately did not do

I did not add a row per prefix-covered entry. Sixty-three assertions that a prefix arm still works would restate one fact sixty-three times and would not fail for any change worth catching — the single per-prefix case above covers the same ground. The redundancy is worth knowing about, not worth asserting.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KN8CS2SX5BPWJZ3ZB20014","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T12:52:46.498Z","completed_at":"2026-09-03T12:58:17.012Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T12:52:47.113Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b3738e69464445474516b40386cdf21281e5b23044553b5bac27b526fca3b104","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"86a79a20-639f-4c25-9117-1e731208dd29","object_id":"sha256:b3738e69464445474516b40386cdf21281e5b23044553b5bac27b526fca3b104","sha256":"b3738e69464445474516b40386cdf21281e5b23044553b5bac27b526fca3b104"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"B2_kqsLLJycQMui6FItYl0oD2PNvn090KrjD0VJL2e_7HOAxRM-FALJmxG5O4ifN32_3Z4gAyjgYKkpKK_U2Bw"}} -->
