### PR TITLE
fix(ci): recover post-merge develop validation

### DIFF
--- a/packages/cloud/api/__tests__/e2e-helpers-local-target.test.ts
+++ b/packages/cloud/api/__tests__/e2e-helpers-local-target.test.ts
@@ -107,6 +107,8 @@ describe("e2e _helpers isLocalTarget", () => {
     process.env.TEST_API_BASE_URL = "http://127.0.0.1:8787";
     const fetchSpy = spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(workerdRecycleResponse())
+      .mockResolvedValueOnce(workerdRecycleResponse())
+      .mockResolvedValueOnce(workerdRecycleResponse())
       .mockResolvedValueOnce(
         Response.json({ error: "unsupported_transport" }, { status: 404 }),
       );
@@ -118,7 +120,7 @@ describe("e2e _helpers isLocalTarget", () => {
     const body = (await response.json()) as { error: string };
     expect(response.status).toBe(404);
     expect(body).toEqual({ error: "unsupported_transport" });
-    expect(fetchCount).toBe(2);
+    expect(fetchCount).toBe(4);
   });
 
   test.each(["application/json", "application/problem+json"])(
@@ -155,7 +157,7 @@ describe("e2e _helpers isLocalTarget", () => {
     expect(fetchCount).toBe(1);
   });
 
-  test("caps persistent local workerd failures at two retries", async () => {
+  test("caps persistent local workerd failures at five retries", async () => {
     process.env.TEST_API_BASE_URL = "http://127.0.0.1:8787";
     const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
       workerdRecycleResponse(),
@@ -166,7 +168,7 @@ describe("e2e _helpers isLocalTarget", () => {
     fetchSpy.mockRestore();
 
     expect(response.status).toBe(500);
-    expect(fetchCount).toBe(3);
+    expect(fetchCount).toBe(6);
   });
 
   test("does not retry a deployed target plain-text 500", async () => {

--- a/packages/cloud/api/test/e2e/_helpers/api.ts
+++ b/packages/cloud/api/test/e2e/_helpers/api.ts
@@ -15,6 +15,8 @@
  */
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const LOCAL_WRANGLER_RECYCLE_MAX_RETRIES = 5;
+const LOCAL_WRANGLER_RECYCLE_RETRY_DELAY_MS = 500;
 
 function resolveRequestTimeoutMs(): number {
   const parsed = Number(process.env.TEST_REQUEST_TIMEOUT_MS);
@@ -212,10 +214,13 @@ async function request(
   // JSON failures, and other plain-text application failures remain fail-closed.
   for (
     let attempt = 0;
-    attempt < 2 && (await isLocalWranglerRecycleResponse(method, res));
+    attempt < LOCAL_WRANGLER_RECYCLE_MAX_RETRIES &&
+    (await isLocalWranglerRecycleResponse(method, res));
     attempt++
   ) {
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) =>
+      setTimeout(resolve, LOCAL_WRANGLER_RECYCLE_RETRY_DELAY_MS),
+    );
     res = await fetch(url(path), makeInit());
   }
   recordStatus(method, path, res.status);

--- a/packages/cloud/api/test/e2e/group-h-misc.test.ts
+++ b/packages/cloud/api/test/e2e/group-h-misc.test.ts
@@ -371,10 +371,22 @@ describeE2E("Group H — GET /api/v1/apis/dexscreener/*", () => {
   });
 
   test("happy path: proxies the keyless public DexScreener upstream", async () => {
-    const res = await api.get(
-      "/api/v1/apis/dexscreener/latest/dex/search?q=SOL",
-      { headers: bearerHeaders() },
-    );
+    const getDexScreener = () =>
+      api.get("/api/v1/apis/dexscreener/latest/dex/search?q=SOL", {
+        headers: bearerHeaders(),
+      });
+    let res = await getDexScreener();
+    // This lane deliberately crosses the live public upstream boundary. Retry
+    // only its explicit transient gateway outcomes; authentication, validation,
+    // and application failures remain immediately visible.
+    for (
+      let attempt = 1;
+      attempt < 3 && [502, 503, 504].includes(res.status);
+      attempt++
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      res = await getDexScreener();
+    }
     // DexScreener needs no API key — the proxy must really forward and
     // return upstream JSON.
     expect(res.status).toBe(200);

--- a/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
+++ b/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
@@ -49,6 +49,7 @@ import type {} from "@playwright/test";
 import { runSharedToDedicatedUpgradeHandoff } from "../../../ui/src/cloud/handoff/start-tier-upgrade";
 import { authedClient } from "../src/helpers/monetization";
 import { pollSandboxStatus } from "../src/helpers/provisioning";
+import { seedModelPricing } from "../src/helpers/seed-pricing";
 import { retrySharedRuntimeWarming } from "../src/helpers/shared-runtime";
 import { expect, test } from "../src/helpers/test-fixtures";
 
@@ -92,6 +93,12 @@ test.describe("shared→dedicated tier upgrade", () => {
     await writeStoredStewardToken(authToken);
 
     try {
+      await seedModelPricing({
+        model: "openai/gpt-4o-mini",
+        billingSource: "bitrouter",
+        provider: "openai",
+      });
+
       // ── 1. The account-native Shared identity has no sandbox row. ──────
       const sharedAgentId = personalSharedAgentId({
         userId: seededUser.userId,

--- a/packages/scenario-runner/src/runtime-factory.test.ts
+++ b/packages/scenario-runner/src/runtime-factory.test.ts
@@ -398,6 +398,22 @@ describe("scenario runtime deterministic model mode", () => {
     expect(rendered).not.toContain(ownerInstruction);
   });
 
+  it("preserves complete long unframed instructions without punctuation", () => {
+    const ownerInstruction =
+      "Protect every uninterrupted focus window while still sending the standup nudge the owner explicitly marked urgent";
+    const prompt = [
+      "You are the owner's personal assistant. A scheduled task just fired and you must now write the message to send to the owner.",
+      "Instruction:",
+      ownerInstruction,
+      "",
+      "Message:",
+    ].join("\n");
+
+    expect(deterministicScheduledDispatchRenderText(prompt)).toBe(
+      "Heads up: Protect — every uninterrupted focus window while still sending the standup nudge the owner explicitly marked urgent",
+    );
+  });
+
   it("resolves the scheduled-dispatch render model call outside the fixture registry", () => {
     const prompt = [
       "You are the owner's personal assistant. A scheduled task just fired and you must now write the message to send to the owner.",

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -572,15 +572,11 @@ export function deterministicScheduledDispatchRenderText(
     .replace(/\s+/g, " ")
     .trim();
   if (ownerMessage === instruction && ownerMessage.length >= 64) {
-    const punctuationIndex = ownerMessage.search(/[,;:]/);
-    const splitIndex =
-      punctuationIndex >= 0 ? punctuationIndex : ownerMessage.indexOf(" ");
-    if (splitIndex >= 0) {
-      const suffixOffset = punctuationIndex >= 0 ? 1 : 0;
-      ownerMessage = `${ownerMessage.slice(0, splitIndex).trim()} — ${ownerMessage
-        .slice(splitIndex + suffixOffset)
-        .trim()}`;
-    }
+    const clauseBreak = ownerMessage.match(/^([^,;:]+)[,;:]\s*(.+)$/s);
+    const wordBreak = ownerMessage.match(/^(\S+)\s+(.+)$/s);
+    const messageParts = clauseBreak ?? wordBreak;
+    if (messageParts)
+      ownerMessage = `${messageParts[1].trim()} — ${messageParts[2].trim()}`;
   }
   // A deterministic stand-in for the dispatch-render model must be predictable
   // so scenarios can assert the delivered copy exactly. Prefixing the de-framed

--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -53,6 +53,9 @@ interface WorkflowDispatch {
 const workflow = Bun.YAML.parse(
   read(".github/workflows/app-live-e2e.yml"),
 ) as Workflow;
+const releaseWorkflow = Bun.YAML.parse(
+  read(".github/workflows/cloud-cf-release.yml"),
+) as Workflow;
 const cloudJob = workflow.jobs?.["cloud-live"];
 const notificationJob = workflow.jobs?.["notify-on-failure"];
 
@@ -233,9 +236,43 @@ describe("App Live E2E staging Cloud job (#18076)", () => {
       workflow.jobs?.["cloud-live"]?.env
         ?.ELIZA_UI_SMOKE_APPROVE_BILLABLE_DEDICATED_CONFIRMATION,
     ).toBeUndefined();
-    expect(read(".github/workflows/cloud-cf-release.yml")).not.toContain(
-      "ELIZA_UI_SMOKE_APPROVE_BILLABLE_DEDICATED_CONFIRMATION",
+    const releaseCall = releaseWorkflow.on?.workflow_call as
+      | {
+          inputs?: Record<
+            string,
+            {
+              default?: boolean;
+              description?: string;
+              required?: boolean;
+              type?: string;
+            }
+          >;
+        }
+      | undefined;
+    expect(releaseCall?.inputs?.run_deployed_renderer_staging).toEqual({
+      description:
+        "Run the credentialed deployed-Pages renderer proof for this staging release",
+      required: false,
+      type: "boolean",
+      default: false,
+    });
+
+    const deployedRendererJob =
+      releaseWorkflow.jobs?.["deployed-renderer-staging"];
+    expect(deployedRendererJob?.if).toBe(
+      "$" +
+        "{{ !cancelled() && inputs.target_environment == 'staging' && inputs.run_deployed_renderer_staging == true }}",
     );
+    expect(deployedRendererJob?.environment).toBe("staging");
+    const deployedBrowserStep = deployedRendererJob?.steps?.find(
+      (step) =>
+        step.name ===
+        "Run deployed Personal identity, chat, and continuity trajectory",
+    );
+    expect(
+      deployedBrowserStep?.env
+        ?.ELIZA_UI_SMOKE_APPROVE_BILLABLE_DEDICATED_CONFIRMATION,
+    ).toBe("1");
   });
 
   test("can isolate explicitly requested live lanes without changing defaults", () => {


### PR DESCRIPTION
Closes #30440.

## What changed
- tolerate bounded local workerd recycle windows without masking deployed or structured application failures
- retry only explicit transient gateway responses for the live DexScreener proxy proof
- seed the persisted model-pricing contract before the real Shared-to-Dedicated handoff path
- preserve complete deterministic scheduled-dispatch content without prohibited slicing
- validate the explicitly gated staging renderer workflow semantically instead of requiring the approval variable to be globally absent

## Evidence
- `bun run verify` (376/376 Turbo tasks plus repository audits)
- Cloud E2E Shared-to-Dedicated handoff: 1 passed
- Cloud API request-helper regression tests: 19 passed
- scenario-runner runtime-factory tests: 40 passed
- workflow contract tests: 18 passed
- core prompt-integrity tests: 9 passed
- linked workspace build: 60/60 tasks

Repairs the failures observed on exact develop merge `36147670eac43872df29bcfa44dd534d1fb0d05e` in Full run https://github.com/elizaOS/eliza/actions/runs/33759741910.
