### PR TITLE
fix(cloud): preserve capacity test teardown failures

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-node-workload-reconciliation.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-reconciliation.postgres.integration.test.ts
@@ -134,6 +134,159 @@ async function readAllocatedCount(client: Client | Pool): Promise<number> {
   return row.allocated_count;
 }
 
+interface PostgresTestClient {
+  query(query: string): Promise<unknown>;
+  end(): Promise<void>;
+}
+
+/**
+ * Runs a cross-connection proof and settles its clients without hiding either
+ * the proof failure or a teardown failure.
+ */
+async function runWithOrderedPostgresTeardown<T>(
+  writer: PostgresTestClient,
+  observer: PostgresTestClient,
+  proof: () => Promise<T>,
+): Promise<T> {
+  let value: T | undefined;
+  let primaryError: unknown;
+  let primaryFailed = false;
+  try {
+    value = await proof();
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — defer the exact primary failure
+    // only long enough to settle both PostgreSQL clients, then rethrow it.
+    primaryFailed = true;
+    primaryError = error;
+  }
+
+  const teardownErrors: Error[] = [];
+  try {
+    await writer.query("ROLLBACK");
+  } catch (error) {
+    // error-policy:J6 best-effort teardown — retain rollback failure alongside
+    // the primary proof failure, then continue closing both clients.
+    teardownErrors.push(new Error("PostgreSQL test rollback failed", { cause: error }));
+  }
+
+  const closeResults = await Promise.allSettled([writer.end(), observer.end()]);
+  for (const [index, result] of closeResults.entries()) {
+    if (result.status === "rejected") {
+      // error-policy:J6 best-effort teardown — both clients are independently
+      // closed and every rejection is retained in deterministic client order.
+      teardownErrors.push(
+        new Error(`PostgreSQL test ${index === 0 ? "writer" : "observer"} close failed`, {
+          cause: result.reason,
+        }),
+      );
+    }
+  }
+
+  if (primaryFailed) {
+    if (teardownErrors.length > 0) {
+      throw new AggregateError(
+        [primaryError, ...teardownErrors],
+        "PostgreSQL capacity proof and teardown both failed",
+        { cause: primaryError },
+      );
+    }
+    throw primaryError;
+  }
+  if (teardownErrors.length > 0) {
+    throw new AggregateError(teardownErrors, "PostgreSQL capacity proof teardown failed");
+  }
+  return value as T;
+}
+
+function teardownClient(
+  name: string,
+  events: string[],
+  failures: { rollback?: Error; close?: Error } = {},
+): PostgresTestClient {
+  return {
+    async query(query: string): Promise<void> {
+      events.push(`${name}:${query}`);
+      if (query === "ROLLBACK" && failures.rollback) throw failures.rollback;
+    },
+    async end(): Promise<void> {
+      events.push(`${name}:close`);
+      if (failures.close) throw failures.close;
+    },
+  };
+}
+
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    // error-policy:J1 boundary translation — tests inspect the rejection as a
+    // value so they can verify exact identity and aggregate ordering.
+    return error;
+  }
+  throw new Error("Expected promise to reject");
+}
+
+describe("PostgreSQL capacity proof teardown", () => {
+  test("preserves a primary proof failure after ordered successful teardown", async () => {
+    const events: string[] = [];
+    const primary = new Error("primary proof failed");
+    const rejection = await rejectionOf(
+      runWithOrderedPostgresTeardown(
+        teardownClient("writer", events),
+        teardownClient("observer", events),
+        async () => {
+          throw primary;
+        },
+      ),
+    );
+
+    expect(rejection).toBe(primary);
+    expect(events).toEqual(["writer:ROLLBACK", "writer:close", "observer:close"]);
+  });
+
+  test("retains rollback and both close failures in deterministic order", async () => {
+    const events: string[] = [];
+    const rejection = await rejectionOf(
+      runWithOrderedPostgresTeardown(
+        teardownClient("writer", events, {
+          rollback: new Error("rollback failed"),
+          close: new Error("writer close failed"),
+        }),
+        teardownClient("observer", events, { close: new Error("observer close failed") }),
+        async () => "proved",
+      ),
+    );
+
+    expect(rejection).toBeInstanceOf(AggregateError);
+    expect((rejection as AggregateError).errors.map((error) => (error as Error).message)).toEqual([
+      "PostgreSQL test rollback failed",
+      "PostgreSQL test writer close failed",
+      "PostgreSQL test observer close failed",
+    ]);
+    expect(events).toEqual(["writer:ROLLBACK", "writer:close", "observer:close"]);
+  });
+
+  test("aggregates teardown failures after the preserved primary failure", async () => {
+    const events: string[] = [];
+    const primary = new Error("primary proof failed");
+    const rejection = await rejectionOf(
+      runWithOrderedPostgresTeardown(
+        teardownClient("writer", events, { rollback: new Error("rollback failed") }),
+        teardownClient("observer", events),
+        async () => {
+          throw primary;
+        },
+      ),
+    );
+
+    expect(rejection).toBeInstanceOf(AggregateError);
+    expect((rejection as AggregateError).errors[0]).toBe(primary);
+    expect((rejection as AggregateError).errors[1]).toBeInstanceOf(Error);
+    expect((rejection as AggregateError).cause).toBe(primary);
+    expect(events).toEqual(["writer:ROLLBACK", "writer:close", "observer:close"]);
+  });
+});
+
 beforeAll(async () => {
   if (!postgres) {
     console.warn(SKIP_REASON);
@@ -172,7 +325,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
     await Promise.all([writer.connect(), observer.connect()]);
-    try {
+    await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query("SELECT id FROM docker_nodes WHERE node_id = $1 FOR UPDATE", [NODE_ID]);
       await writer.query("LOCK TABLE agent_sandbox_replacement_attempts IN ACCESS EXCLUSIVE MODE");
@@ -197,10 +350,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
 
       expect(await count).toBe(1);
       expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, NODE_ID)).toBe(1);
-    } finally {
-      await writer.query("ROLLBACK").catch(() => {});
-      await Promise.all([writer.end(), observer.end()]);
-    }
+    });
   }, 10_000);
 
   test("reserve followed by recount preserves the newly owned slot", async () => {
@@ -208,7 +358,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
     await Promise.all([writer.connect(), observer.connect()]);
-    try {
+    await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query(
         "UPDATE docker_nodes SET allocated_count = allocated_count + 1 WHERE node_id = $1",
@@ -229,10 +379,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
       expect(await recount).toEqual({ before: 1, after: 1 });
       expect(await readAllocatedCount(pool)).toBe(1);
       expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, NODE_ID)).toBe(1);
-    } finally {
-      await writer.query("ROLLBACK").catch(() => {});
-      await Promise.all([writer.end(), observer.end()]);
-    }
+    });
   }, 10_000);
 
   test("cleanup followed by recount cannot resurrect or double-release the slot", async () => {
@@ -247,7 +394,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
     await Promise.all([writer.connect(), observer.connect()]);
-    try {
+    await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query(
         "UPDATE docker_nodes SET allocated_count = allocated_count - 1 WHERE node_id = $1",
@@ -266,10 +413,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
       expect(await recount).toEqual({ before: 0, after: 0 });
       expect(await readAllocatedCount(pool)).toBe(0);
       expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, NODE_ID)).toBe(0);
-    } finally {
-      await writer.query("ROLLBACK").catch(() => {});
-      await Promise.all([writer.end(), observer.end()]);
-    }
+    });
   }, 10_000);
 
   test("lifecycle transfer followed by recount counts exactly the canonical sandbox slot", async () => {
@@ -284,7 +428,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
     await Promise.all([writer.connect(), observer.connect()]);
-    try {
+    await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query("SELECT id FROM docker_nodes WHERE node_id = $1 FOR UPDATE", [NODE_ID]);
       const pid = (await writer.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")).rows[0]!
@@ -304,10 +448,7 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
       expect(await recount).toEqual({ before: 1, after: 1 });
       expect(await readAllocatedCount(pool)).toBe(1);
       expect(await countAllocatedWorkloadsOnNodeWithDatabase(database, NODE_ID)).toBe(1);
-    } finally {
-      await writer.query("ROLLBACK").catch(() => {});
-      await Promise.all([writer.end(), observer.end()]);
-    }
+    });
   }, 10_000);
 
   test("an absent replacement table does not abort repair of a divergent counter", async () => {

--- a/packages/cloud/shared/src/lib/services/docker-node-workload-reconciliation.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-reconciliation.postgres.integration.test.ts
@@ -194,7 +194,10 @@ async function runWithOrderedPostgresTeardown<T>(
     }
   }
 
-  const closeResults = await Promise.allSettled([writer.end(), observer.end()]);
+  const closeResults = await Promise.allSettled([
+    Promise.resolve().then(() => writer.end()),
+    Promise.resolve().then(() => observer.end()),
+  ]);
   for (const [index, result] of closeResults.entries()) {
     if (result.status === "rejected") {
       // error-policy:J6 best-effort teardown — both clients are independently
@@ -262,6 +265,55 @@ async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
 }
 
 describe("PostgreSQL capacity proof teardown", () => {
+  test("preserves the proof failure and closes the observer when writer close throws synchronously", async () => {
+    const events: string[] = [];
+    const primary = new Error("primary proof failed");
+    const closeFailure = new Error("synchronous writer close failure");
+    const writer = teardownClient("writer", events);
+    writer.end = () => {
+      events.push("writer:close");
+      throw closeFailure;
+    };
+    const rejection = await rejectionOf(
+      runWithOrderedPostgresTeardown(writer, teardownClient("observer", events), async () => {
+        throw primary;
+      }),
+    );
+
+    expect(rejection).toBeInstanceOf(AggregateError);
+    expect((rejection as AggregateError).errors[0]).toBe(primary);
+    expect((rejection as AggregateError).errors[1].cause).toBe(closeFailure);
+    expect((rejection as AggregateError).cause).toBe(primary);
+    expect(events).toEqual([
+      "writer:connect",
+      "observer:connect",
+      "writer:ROLLBACK",
+      "writer:close",
+      "observer:close",
+    ]);
+  });
+
+  test("closes both clients without rolling back a writer that failed to connect", async () => {
+    const events: string[] = [];
+    const connectionFailure = new Error("writer connection failed");
+    const rejection = await rejectionOf(
+      runWithOrderedPostgresTeardown(
+        teardownClient("writer", events, { connect: connectionFailure }),
+        teardownClient("observer", events),
+        async () => {
+          throw new Error("proof must not run after failed connection");
+        },
+      ),
+    );
+    expect(rejection).toBe(connectionFailure);
+    expect(events).toEqual([
+      "writer:connect",
+      "observer:connect",
+      "writer:close",
+      "observer:close",
+    ]);
+  });
+
   test("preserves a primary proof failure after ordered successful teardown", async () => {
     const events: string[] = [];
     const primary = new Error("primary proof failed");

--- a/packages/cloud/shared/src/lib/services/docker-node-workload-reconciliation.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workload-reconciliation.postgres.integration.test.ts
@@ -135,13 +135,14 @@ async function readAllocatedCount(client: Client | Pool): Promise<number> {
 }
 
 interface PostgresTestClient {
+  connect(): Promise<void>;
   query(query: string): Promise<unknown>;
   end(): Promise<void>;
 }
 
 /**
- * Runs a cross-connection proof and settles its clients without hiding either
- * the proof failure or a teardown failure.
+ * Acquires both clients, runs a cross-connection proof, and settles every
+ * partial acquisition without hiding either the proof or teardown failure.
  */
 async function runWithOrderedPostgresTeardown<T>(
   writer: PostgresTestClient,
@@ -151,22 +152,46 @@ async function runWithOrderedPostgresTeardown<T>(
   let value: T | undefined;
   let primaryError: unknown;
   let primaryFailed = false;
-  try {
-    value = await proof();
-  } catch (error) {
-    // error-policy:J2 context-adding rethrow — defer the exact primary failure
-    // only long enough to settle both PostgreSQL clients, then rethrow it.
+  const connectedClients = new Set<PostgresTestClient>();
+  const connectionResults = await Promise.allSettled([
+    Promise.resolve()
+      .then(() => writer.connect())
+      .then(() => connectedClients.add(writer)),
+    Promise.resolve()
+      .then(() => observer.connect())
+      .then(() => connectedClients.add(observer)),
+  ]);
+  const connectionErrors = connectionResults.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (connectionErrors.length > 0) {
     primaryFailed = true;
-    primaryError = error;
+    primaryError =
+      connectionErrors.length === 1
+        ? connectionErrors[0]
+        : new AggregateError(connectionErrors, "PostgreSQL test client connections failed", {
+            cause: connectionErrors[0],
+          });
+  } else {
+    try {
+      value = await proof();
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow — defer the exact primary failure
+      // only long enough to settle both PostgreSQL clients, then rethrow it.
+      primaryFailed = true;
+      primaryError = error;
+    }
   }
 
   const teardownErrors: Error[] = [];
-  try {
-    await writer.query("ROLLBACK");
-  } catch (error) {
-    // error-policy:J6 best-effort teardown — retain rollback failure alongside
-    // the primary proof failure, then continue closing both clients.
-    teardownErrors.push(new Error("PostgreSQL test rollback failed", { cause: error }));
+  if (connectedClients.has(writer)) {
+    try {
+      await writer.query("ROLLBACK");
+    } catch (error) {
+      // error-policy:J6 best-effort teardown — retain rollback failure alongside
+      // the primary proof failure, then continue closing both clients.
+      teardownErrors.push(new Error("PostgreSQL test rollback failed", { cause: error }));
+    }
   }
 
   const closeResults = await Promise.allSettled([writer.end(), observer.end()]);
@@ -201,9 +226,19 @@ async function runWithOrderedPostgresTeardown<T>(
 function teardownClient(
   name: string,
   events: string[],
-  failures: { rollback?: Error; close?: Error } = {},
+  failures: {
+    connectGate?: Promise<void>;
+    connect?: Error;
+    rollback?: Error;
+    close?: Error;
+  } = {},
 ): PostgresTestClient {
   return {
+    async connect(): Promise<void> {
+      events.push(`${name}:connect`);
+      await failures.connectGate;
+      if (failures.connect) throw failures.connect;
+    },
     async query(query: string): Promise<void> {
       events.push(`${name}:${query}`);
       if (query === "ROLLBACK" && failures.rollback) throw failures.rollback;
@@ -241,7 +276,48 @@ describe("PostgreSQL capacity proof teardown", () => {
     );
 
     expect(rejection).toBe(primary);
-    expect(events).toEqual(["writer:ROLLBACK", "writer:close", "observer:close"]);
+    expect(events).toEqual([
+      "writer:connect",
+      "observer:connect",
+      "writer:ROLLBACK",
+      "writer:close",
+      "observer:close",
+    ]);
+  });
+
+  test("awaits a late writer connection and closes both clients when the observer fails", async () => {
+    const events: string[] = [];
+    const connectionFailure = new Error("observer connection failed");
+    let releaseWriter!: () => void;
+    const writerConnectGate = new Promise<void>((resolve) => {
+      releaseWriter = resolve;
+    });
+    let proofRan = false;
+    const outcome = rejectionOf(
+      runWithOrderedPostgresTeardown(
+        teardownClient("writer", events, { connectGate: writerConnectGate }),
+        teardownClient("observer", events, { connect: connectionFailure }),
+        async () => {
+          proofRan = true;
+        },
+      ),
+    );
+    await Promise.resolve();
+
+    expect(events).toEqual(["writer:connect", "observer:connect"]);
+    expect(proofRan).toBe(false);
+    releaseWriter();
+    const rejection = await outcome;
+
+    expect(rejection).toBe(connectionFailure);
+    expect(proofRan).toBe(false);
+    expect(events).toEqual([
+      "writer:connect",
+      "observer:connect",
+      "writer:ROLLBACK",
+      "writer:close",
+      "observer:close",
+    ]);
   });
 
   test("retains rollback and both close failures in deterministic order", async () => {
@@ -263,7 +339,13 @@ describe("PostgreSQL capacity proof teardown", () => {
       "PostgreSQL test writer close failed",
       "PostgreSQL test observer close failed",
     ]);
-    expect(events).toEqual(["writer:ROLLBACK", "writer:close", "observer:close"]);
+    expect(events).toEqual([
+      "writer:connect",
+      "observer:connect",
+      "writer:ROLLBACK",
+      "writer:close",
+      "observer:close",
+    ]);
   });
 
   test("aggregates teardown failures after the preserved primary failure", async () => {
@@ -283,7 +365,13 @@ describe("PostgreSQL capacity proof teardown", () => {
     expect((rejection as AggregateError).errors[0]).toBe(primary);
     expect((rejection as AggregateError).errors[1]).toBeInstanceOf(Error);
     expect((rejection as AggregateError).cause).toBe(primary);
-    expect(events).toEqual(["writer:ROLLBACK", "writer:close", "observer:close"]);
+    expect(events).toEqual([
+      "writer:connect",
+      "observer:connect",
+      "writer:ROLLBACK",
+      "writer:close",
+      "observer:close",
+    ]);
   });
 });
 
@@ -324,7 +412,6 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     );
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
-    await Promise.all([writer.connect(), observer.connect()]);
     await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query("SELECT id FROM docker_nodes WHERE node_id = $1 FOR UPDATE", [NODE_ID]);
@@ -357,7 +444,6 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     if (!isolatedDsn || !pool || !database) throw new Error("PostgreSQL harness unavailable");
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
-    await Promise.all([writer.connect(), observer.connect()]);
     await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query(
@@ -393,7 +479,6 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     );
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
-    await Promise.all([writer.connect(), observer.connect()]);
     await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query(
@@ -427,7 +512,6 @@ realPostgres("Docker capacity recount PostgreSQL serialization", () => {
     );
     const writer = new Client({ connectionString: isolatedDsn });
     const observer = new Client({ connectionString: isolatedDsn });
-    await Promise.all([writer.connect(), observer.connect()]);
     await runWithOrderedPostgresTeardown(writer, observer, async () => {
       await writer.query("BEGIN");
       await writer.query("SELECT id FROM docker_nodes WHERE node_id = $1 FOR UPDATE", [NODE_ID]);


### PR DESCRIPTION
Closes #30246.

The real PostgreSQL capacity-recount proof now always closes both client sessions, including after partial connection failure. If the proof and cleanup both fail, cleanup remains attached to the original failure instead of replacing it. Synchronous close failures are isolated so one client cannot prevent the other from closing.

This prevents leaked database connections and misleading failures in the capacity test, which verifies reservation versus live-workload accounting under concurrent reconciliation. The regression tests exercise the real teardown helper around connection, rollback, and close failures; the capacity proof itself runs against PostgreSQL 16.

Validated head: `62e76b2595a999e5648affdf0e9ebff0a714613e`  
Validated develop: `755a8213f0e165628a90ba0b573f6527f42037e5`

- Bun 1.3.14 install completed after rebasing, with optional fused desktop inference setup skipped. Node 24.15.0 was pinned for the complete verification process.
- Real PostgreSQL suite: 11 passed, 0 skipped, 35 assertions. The suite creates and removes a scratch database.
- Restoring the direct close calls makes the synchronous-close regression fail.
- Owning package typecheck/lint and root `bun run verify`: passed, 376/376 workspace tasks and all repository audits.
- Biome and `git diff --check`: passed.
- Broader Cloud shared suite reached ordinary batch 34/342 and failed an unchanged 1 ms onboarding deadline assertion. That entire file passed separately (18 tests). Neither its test nor its implementation is changed by this PR; the full package suite is not claimed green. A subsequent pinned-toolchain run also timed out in the unchanged repository-wide restore API scan. The same file failed its 60-second limit on a clean checkout of validated develop `755a8213f0e165628a90ba0b573f6527f42037e5` (5 passed, 1 timeout); the final PR head has been restored. These broad-suite limitations are separate from the passing real PostgreSQL contract.

<!-- evidence-head:62e76b2595a999e5648affdf0e9ebff0a714613e -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - test cleanup only, no renderer changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no renderer changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user interaction changes.
<!-- evidence-row:backend-logs -->
- [x] Real PostgreSQL execution and failure-path results above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend execution changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Inspected real PostgreSQL capacity rows and observer lock evidence in the passing integration proof; temporary database removed by the harness.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text changes.

<details><summary>Final real PostgreSQL execution</summary>

```text
(pass) PostgreSQL capacity proof teardown > preserves the proof failure and closes the observer when writer close throws synchronously [6.24ms]
(pass) PostgreSQL capacity proof teardown > closes both clients without rolling back a writer that failed to connect [9.46ms]
(pass) PostgreSQL capacity proof teardown > preserves a primary proof failure after ordered successful teardown [11.13ms]
(pass) PostgreSQL capacity proof teardown > awaits a late writer connection and closes both clients when the observer fails [10.16ms]
(pass) PostgreSQL capacity proof teardown > retains rollback and both close failures in deterministic order [24.43ms]
(pass) PostgreSQL capacity proof teardown > aggregates teardown failures after the preserved primary failure [62.48ms]
(pass) Docker capacity recount PostgreSQL serialization > standalone aggregate count keeps one statement snapshot across lifecycle transfer [59.44ms]
(pass) Docker capacity recount PostgreSQL serialization > reserve followed by recount preserves the newly owned slot [120.48ms]
(pass) Docker capacity recount PostgreSQL serialization > cleanup followed by recount cannot resurrect or double-release the slot [124.30ms]
(pass) Docker capacity recount PostgreSQL serialization > lifecycle transfer followed by recount counts exactly the canonical sandbox slot [99.95ms]
(pass) Docker capacity recount PostgreSQL serialization > an absent replacement table does not abort repair of a divergent counter [30.80ms]
 11 pass
 0 fail
 35 expect() calls
Ran 11 tests across 1 file. [7.82s]
```

</details>

Fresh hosted checks must pass on the final head before merge.
