### PR TITLE
test(cloud): name every chat SSE done field and pin the fallback edges

### DIFF
--- a/packages/cloud/shared/src/lib/services/chat-sse-frames.test.ts
+++ b/packages/cloud/shared/src/lib/services/chat-sse-frames.test.ts
@@ -57,6 +57,184 @@ describe("normalizeChatSseDonePayload", () => {
     });
   });
 
+  // The allowlist is a proxy boundary: every name in it is a field the shared
+  // client reducer reads, and anything absent from it is dropped. Both halves
+  // matter, so name each field individually rather than asserting a handful and
+  // trusting the rest — deleting a single entry silently stops that field
+  // crossing while every other assertion stays green.
+  const DONE_METADATA_FIELD_CASES = [
+    ["transcriptVisibility", "internal"],
+    ["agentName", "Eliza"],
+    ["userMessageId", "upstream-user"],
+    ["assistantEphemeral", true],
+    ["historyRefreshRequired", true],
+    ["thought", "considering the request"],
+    ["noResponseReason", "ignored"],
+    ["failureKind", "no_provider"],
+    ["accountConnect", { provider: "openai" }],
+    ["localInference", { provider: "mobile-local-direct-reply" }],
+    ["actionResults", [{ actionName: "VIEWS", success: true }]],
+    ["usage", { totalTokens: 4 }],
+  ] as const satisfies readonly (readonly [string, unknown][]);
+
+  test.each(DONE_METADATA_FIELD_CASES)(
+    "carries %s across the proxy boundary and omits it when upstream does",
+    (field, value) => {
+      expect(
+        normalizeChatSseDonePayload({ [field]: value }, { messageId: "id", fullText: "text" }),
+      ).toEqual({
+        [field]: value,
+        messageId: "id",
+        text: "text",
+        fullText: "text",
+      });
+      expect(
+        Object.hasOwn(
+          normalizeChatSseDonePayload({}, { messageId: "id", fullText: "text" }),
+          field,
+        ),
+      ).toBe(false);
+    },
+  );
+
+  // A generated `test.each` table registers zero cases over an empty list and
+  // still reports green, so pin the exact key set independently. This also
+  // fails on a silent ADDITION, which per-field cases cannot see.
+  test("forwards exactly the allowlisted keys and no others", () => {
+    const payload = Object.fromEntries(
+      DONE_METADATA_FIELD_CASES.map(([field, value]) => [field, value]),
+    );
+    expect(
+      Object.keys(
+        normalizeChatSseDonePayload(payload, { messageId: "id", fullText: "text" }),
+      ).sort(),
+    ).toEqual(
+      [
+        ...DONE_METADATA_FIELD_CASES.map(([field]) => field),
+        "messageId",
+        "text",
+        "fullText",
+      ].sort(),
+    );
+  });
+
+  test("drops every field outside the allowlist", () => {
+    const smuggled = {
+      metadata: { internal: true },
+      sessionId: "sess-1",
+      provider: "openai",
+      apiKey: "sk-should-never-cross",
+      cost: 0.01,
+      headers: { authorization: "Bearer x" },
+      raw: "upstream-debug",
+      type: "token",
+      error: "boom",
+    };
+    const normalized = normalizeChatSseDonePayload(smuggled, {
+      messageId: "id",
+      fullText: "text",
+    });
+    for (const field of Object.keys(smuggled)) {
+      expect(Object.hasOwn(normalized, field)).toBe(false);
+    }
+    expect(Object.keys(normalized).sort()).toEqual(["fullText", "messageId", "text"]);
+  });
+
+  // `Object.hasOwn`, not truthiness or `in`: an upstream that sends the field
+  // explicitly as `undefined` has still SENT it, and the key is forwarded. This
+  // distinguishes the guard from `if (payload[field] !== undefined)`, which
+  // would drop it, and from a plain truthiness check, which would also drop
+  // `false` and `0`.
+  test("forwards an explicitly undefined allowlisted field as a present key", () => {
+    const normalized = normalizeChatSseDonePayload(
+      { thought: undefined },
+      { messageId: "id", fullText: "text" },
+    );
+    expect(Object.hasOwn(normalized, "thought")).toBe(true);
+    expect(normalized.thought).toBeUndefined();
+  });
+
+  test.each([
+    ["a falsy boolean", "assistantEphemeral", false],
+    ["a zero-valued count", "usage", 0],
+    ["an empty string", "agentName", ""],
+  ])("forwards %s rather than dropping it", (_label, field, value) => {
+    expect(
+      normalizeChatSseDonePayload({ [field]: value }, { messageId: "id", fullText: "text" }),
+    ).toEqual({
+      [field]: value,
+      messageId: "id",
+      text: "text",
+      fullText: "text",
+    });
+  });
+
+  // An empty `fullText` is a legitimate terminal value, not a missing one: the
+  // ambient voice gate emits `{ fullText: "", noResponseReason: "ignored" }` to
+  // suppress a turn. A truthiness check here would substitute the accumulated
+  // text and un-suppress it, so the `typeof === "string"` test is load-bearing.
+  test("preserves an empty upstream fullText instead of falling back", () => {
+    expect(
+      normalizeChatSseDonePayload(
+        { fullText: "", noResponseReason: "ignored" },
+        { messageId: "id", fullText: "accumulated" },
+      ),
+    ).toEqual({
+      noResponseReason: "ignored",
+      messageId: "id",
+      text: "",
+      fullText: "",
+    });
+  });
+
+  test("prefers fullText over text and falls back when neither is a string", () => {
+    expect(
+      normalizeChatSseDonePayload(
+        { fullText: "authoritative", text: "secondary" },
+        { messageId: "id", fullText: "accumulated" },
+      ).fullText,
+    ).toBe("authoritative");
+    expect(
+      normalizeChatSseDonePayload({ text: "secondary" }, { messageId: "id", fullText: "acc" })
+        .fullText,
+    ).toBe("secondary");
+    expect(
+      normalizeChatSseDonePayload({ text: 7 }, { messageId: "id", fullText: "acc" }).fullText,
+    ).toBe("acc");
+  });
+
+  // The upstream id is trusted only when it is a non-blank string; each
+  // rejected shape needs its own case, and the accepted neighbour above proves
+  // the cases discriminate rather than always falling back.
+  test.each([
+    ["whitespace only", "   "],
+    ["empty", ""],
+    ["a non-string", 42],
+    ["null", null],
+  ])("falls back to the generated messageId when upstream sends %s", (_label, upstream) => {
+    expect(
+      normalizeChatSseDonePayload(
+        { messageId: upstream },
+        {
+          messageId: "generated",
+          fullText: "text",
+        },
+      ).messageId,
+    ).toBe("generated");
+  });
+
+  test("trusts a padded upstream messageId verbatim, without trimming it", () => {
+    expect(
+      normalizeChatSseDonePayload(
+        { messageId: " upstream " },
+        {
+          messageId: "generated",
+          fullText: "text",
+        },
+      ).messageId,
+    ).toBe(" upstream ");
+  });
+
   test("uses generated identity and accumulated text only when upstream omits them", () => {
     expect(
       normalizeChatSseDonePayload({}, { messageId: "generated", fullText: "accumulated" }),


### PR DESCRIPTION
# What

`normalizeChatSseDonePayload` is a **proxy boundary**. Its `DONE_METADATA_FIELDS` allowlist decides which upstream fields on a dedicated agent's terminal `done` frame reach the shared UI reducer; anything absent is dropped. Both halves are load-bearing — a name removed from the list silently stops that field crossing, and a name added lets new upstream data through.

Twelve names, and **7 of them were never mentioned by a test**. Deleting an entry one at a time against the existing suite:

| deleted entry | before |
|---|---|
| `userMessageId`, `failureKind`, `accountConnect`, `actionResults`, `usage` | killed |
| `transcriptVisibility` | **survives** |
| `agentName` | **survives** |
| `assistantEphemeral` | **survives** |
| `historyRefreshRequired` | **survives** |
| `thought` | **survives** |
| `noResponseReason` | **survives** |
| `localInference` | **survives** |

The existing single `toEqual` names five fields and one dropped extra. That's a good assertion — it just leaves the other seven to be deleted for free. Each survivor is a field a consumer reads: `transcriptVisibility` gates `conversation-message-filter.ts:44`, `assistantEphemeral` drives the ephemeral branch in `useStreamingText.ts:234`, `historyRefreshRequired` triggers the refetch at `useChatSend.ts:2061`, `agentName` is parsed at `parsers.ts:31`, `localInference` flows through `useChatCallbacks.ts:108`, and `noResponseReason` is read by `voice-workbench-player.ts:358`.

# The change

Test-only, +178 lines to `chat-sse-frames.test.ts`. No source change.

`DONE_METADATA_FIELDS` is not exported, so the list is pinned **behaviourally**, through the function callers actually use rather than by importing the constant.

A `test.each` over all twelve names asserts each field round-trips on its own *and* is absent when upstream omits it. Because a generated table over an empty collection registers zero cases and still reports green, the exact key set is asserted separately — that assertion also catches a silent **addition**, which per-field cases cannot see:

```ts
expect(Object.keys(normalizeChatSseDonePayload(payload, fallback)).sort()).toEqual(
  [...DONE_METADATA_FIELD_CASES.map(([field]) => field), "messageId", "text", "fullText"].sort(),
);
```

# Three edges I found while probing, all previously unpinned

**An empty `fullText` must survive.** `typeof payload.fullText === "string"` is not stylistic — the ambient voice gate emits `{ fullText: "", noResponseReason: "ignored" }` to suppress a turn (`AMBIENT_GATE_PIXEL_VERIFICATION.md:55`). A truthiness check substitutes the accumulated text and un-suppresses it. Now pinned directly.

**`Object.hasOwn` is the right guard, and the distinction is observable.** An upstream that sends `thought: undefined` has still *sent* it, and the key is forwarded with an `undefined` value. `payload[field] !== undefined` would drop it; plain truthiness would also drop `false` and `0`. All three are now distinguished, including cases for `assistantEphemeral: false`, `usage: 0` and `agentName: ""`.

**The upstream `messageId` is trusted only when non-blank, and is not trimmed.** Each rejected shape gets its own case (whitespace-only, empty, non-string, `null`), with an accepted padded neighbour (`" upstream "` is trusted verbatim) so the cases discriminate rather than always falling back.

# Evidence

Every mutant executed at `9be826b931`, one at a time.

**All twelve entries, deleted individually:** 12/12 now fail (was 5/12).

**Branch mutants, 8/8 killed:**

| mutant | result |
|---|---|
| `Object.hasOwn(payload, field)` → `payload[field] !== undefined` | 1 fail |
| `Object.hasOwn(payload, field)` → `payload[field]` | 4 fail |
| `typeof payload.fullText === "string"` → `payload.fullText` | 1 fail |
| `typeof payload.text === "string"` → `payload.text` | 1 fail |
| drop the `upstreamMessageId.trim()` check | 2 fail |
| `messageId` guard → plain truthiness | 2 fail |
| return `upstreamMessageId.trim()` instead of the raw value | 1 fail |
| seed `normalized` with `{ ...payload }` (bypass the allowlist) | 2 fail |

That last one is the one I most wanted to hold: it is the shape a well-meaning refactor takes, and it turns the allowlist into a no-op.

**Suite:** `bun test src/lib/services/chat-sse-frames.test.ts` → **29 pass / 0 fail / 55 assertions** (was 4 / 0 / 6).

`bun run --cwd packages/cloud/shared typecheck` → `Done!`. Biome on the changed file → clean (I ran `--write` for formatting only; the diff stays inside this one file).

**Regressions checked in both trees:** `packages/ui/src/api/client-cloud-canonical-sse-replay.test.ts` → 2 pass. Running the whole `src/lib/services/shared-runtime/` directory reports 618 pass / 106 fail — **identical on `origin/develop`**, so that is pre-existing cross-contamination from running the directory in one invocation, not this change. Stated because a directory-level number is easy to misread as a regression.

# What I deliberately did not do

I did not add a test asserting a consumer for `thought`. It is in the allowlist and forwarded, but the only reference I could find in the UI is a type declaration comment at `useStreamingText.ts:86` — I could not demonstrate a live reader, so pinning one would encode a claim I cannot back. It is covered as a list member, nothing more.

I also did not touch the source. Every finding here is a coverage gap, not a defect; the implementation does the right thing at each of the three edges, which is exactly why they were worth pinning before a refactor makes one of them wrong.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KYAWXJNR7W94N0T9KXNXXR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T15:31:25.746Z","completed_at":"2026-09-03T15:37:24.198Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T15:31:26.577Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0caaa1501097e0ba2611096786771994ce84ba5eed09b9a65cf73cc13e706637","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4557c249-bcc3-412e-b1c6-66070581a0f7","object_id":"sha256:0caaa1501097e0ba2611096786771994ce84ba5eed09b9a65cf73cc13e706637","sha256":"0caaa1501097e0ba2611096786771994ce84ba5eed09b9a65cf73cc13e706637"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Dcrl6njunhyhOwxYVaRVFJ9-Va9JdPnZ1fh7fpLzhEczmsPBJoqSufH1TxnzVmhbjI4EJFZoUfIxOe6ffdROAA"}} -->
