### PR TITLE
test(shared): pin the connector-id registry and its core/local seam

### DIFF
--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Pins the canonical connector-id registry that config validation and
+ * connector enumeration read across the stack.
+ *
+ * `CONNECTOR_IDS` is a composed list — core connectors followed by app-local
+ * extensions — and `packages/agent/src/config/schema.ts` walks it to build the
+ * heartbeat-target help text, keying its dedupe on `id.trim().toLowerCase()`
+ * and skipping anything that normalizes to empty. Those three operations are
+ * silent: a duplicate, a case-variant, or a blank entry is absorbed rather than
+ * reported, so the invariants they rely on are asserted here at the source.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  CONNECTOR_IDS,
+  type ConnectorId,
+  ELIZA_LOCAL_CONNECTOR_IDS,
+} from "./schema.js";
+
+/**
+ * The whole registry, in order. Named in full rather than by count or by
+ * spot-check: this is the assertion that fails on a silent ADDITION as well as
+ * a removal, and per-entry cases cannot see an addition.
+ */
+const EXPECTED_CONNECTOR_IDS = [
+  "bluebubbles",
+  "telegram",
+  "telegramAccount",
+  "discord",
+  "discordLocal",
+  "slack",
+  "twitter",
+  "whatsapp",
+  "imessage",
+  "farcaster",
+  "lens",
+  "msteams",
+  "feishu",
+  "matrix",
+  "nostr",
+  "blooio",
+  "twitch",
+  "mattermost",
+  "googlechat",
+  "wechat",
+] as const;
+
+describe("CONNECTOR_IDS registry", () => {
+  it("is exactly the canonical list, in order", () => {
+    expect([...CONNECTOR_IDS]).toEqual([...EXPECTED_CONNECTOR_IDS]);
+  });
+
+  it.each(EXPECTED_CONNECTOR_IDS)("includes %s", (id) => {
+    expect(CONNECTOR_IDS).toContain(id);
+  });
+
+  // `it.each` over an empty list registers zero cases and still reports green,
+  // so the table above cannot stand alone — this pins the arity the table is
+  // generated from.
+  it("registers one case per connector", () => {
+    expect(EXPECTED_CONNECTOR_IDS).toHaveLength(20);
+    expect(CONNECTOR_IDS).toHaveLength(EXPECTED_CONNECTOR_IDS.length);
+  });
+});
+
+describe("the core/local seam", () => {
+  it("is exactly the app-local extensions", () => {
+    expect([...ELIZA_LOCAL_CONNECTOR_IDS]).toEqual(["wechat"]);
+  });
+
+  /**
+   * Pins the local tail by SUBTRACTION rather than by a second hand-written
+   * copy: the core half is not exported, so deriving it from the composed list
+   * keeps this honest if a core connector is added, and still fails if a local
+   * one is promoted to core.
+   */
+  it("appends the local extensions after every core connector", () => {
+    const local = new Set<string>(ELIZA_LOCAL_CONNECTOR_IDS);
+    const coreHalf = CONNECTOR_IDS.filter((id) => !local.has(id));
+    const localHalf = CONNECTOR_IDS.filter((id) => local.has(id));
+
+    expect([...CONNECTOR_IDS]).toEqual([...coreHalf, ...localHalf]);
+    expect(localHalf).toEqual([...ELIZA_LOCAL_CONNECTOR_IDS]);
+    expect(coreHalf).toHaveLength(19);
+  });
+
+  it("keeps the two halves disjoint", () => {
+    const local = new Set<string>(ELIZA_LOCAL_CONNECTOR_IDS);
+    const core = CONNECTOR_IDS.filter((id) => !local.has(id));
+    expect(core.filter((id) => local.has(id))).toEqual([]);
+  });
+});
+
+/**
+ * The consumer in `packages/agent/src/config/schema.ts` normalizes with
+ * `id.trim().toLowerCase()` and `continue`s on a falsy result. Each invariant
+ * below is one thing that silently loses an entry there rather than failing.
+ */
+describe("invariants the heartbeat-target consumer depends on", () => {
+  it("contains no duplicate ids", () => {
+    expect([...new Set(CONNECTOR_IDS)]).toEqual([...CONNECTOR_IDS]);
+  });
+
+  it("contains no two ids that collide once lowercased", () => {
+    const lowered = CONNECTOR_IDS.map((id) => id.toLowerCase());
+    const collisions = lowered.filter(
+      (id, index) => lowered.indexOf(id) !== index,
+    );
+    expect(collisions).toEqual([]);
+  });
+
+  it("contains no id that normalizes to empty", () => {
+    expect(CONNECTOR_IDS.filter((id) => !id.trim())).toEqual([]);
+  });
+
+  it("contains no id carrying whitespace, so trimming is a no-op", () => {
+    expect(CONNECTOR_IDS.filter((id) => id !== id.trim())).toEqual([]);
+    expect(CONNECTOR_IDS.filter((id) => /\s/.test(id))).toEqual([]);
+  });
+
+  it("survives the consumer's normalize-and-dedupe without losing an entry", () => {
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const id of CONNECTOR_IDS) {
+      const normalized = id.trim().toLowerCase();
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      ordered.push(normalized);
+    }
+    expect(ordered).toEqual(CONNECTOR_IDS.map((id) => id.toLowerCase()));
+  });
+});
+
+describe("ConnectorId", () => {
+  it("admits every registry member and nothing else", () => {
+    const ids: ConnectorId[] = [...CONNECTOR_IDS];
+    expect(ids).toHaveLength(CONNECTOR_IDS.length);
+    // @ts-expect-error a connector id outside the registry is not assignable
+    const notAConnector: ConnectorId = "myspace";
+    expect(notAConnector).toBe("myspace");
+  });
+});


### PR DESCRIPTION
# What

`packages/shared/src/config/schema.ts` holds `CONNECTOR_IDS` — the authoritative connector-id registry that, per its own docstring, "config validation and connector-enumeration code across the stack reference." It is the **only significant file in `packages/shared/src/config/` with no test file at all**; `config.ts`, `branding.ts`, `cloud-only.ts`, `allowed-hosts.ts`, `runtime-mode.ts`, `plugin-auto-enable.ts` and a dozen others each have one.

Nothing anywhere referenced it from a test:

```
$ grep -rln CONNECTOR_IDS packages/ plugins/ | grep -E 'test|spec'
(no matches)
```

So all 20 entries, and the core/local seam that composes them, could be changed for free.

# Why this list in particular

`packages/agent/src/config/schema.ts:1138` walks the registry to build the heartbeat-target help text:

```ts
for (const id of CONNECTOR_IDS) {
  const normalized = id.trim().toLowerCase();
  if (!normalized || seen.has(normalized)) continue;
  seen.add(normalized);
  ordered.push(normalized);
}
```

Three of those operations are **silent**. A duplicate entry, a case-variant of an existing entry, or an entry that trims to empty is absorbed by `continue` rather than reported — the connector just quietly stops appearing in the help text. The registry carries `telegram` alongside `telegramAccount` and `discord` alongside `discordLocal`, so case-variant collisions are a live hazard rather than a theoretical one.

The invariants that loop depends on were asserted nowhere. They are now asserted at the source, where a contributor editing the list will see them.

# The change

Test-only, one new file, +141 lines. No source change.

- **The whole registry, named in order.** This is the assertion that catches a silent *addition*; per-entry cases cannot.
- **An `it.each` per connector**, paired with an explicit arity assertion — a generated table over an empty list registers zero cases and reports green, so the table cannot stand alone.
- **The seam pinned by subtraction.** `ELIZA_CORE_CONNECTOR_IDS` is not exported, so the core half is derived from the composed list rather than hand-copied:

  ```ts
  const local = new Set<string>(ELIZA_LOCAL_CONNECTOR_IDS);
  const coreHalf = CONNECTOR_IDS.filter((id) => !local.has(id));
  const localHalf = CONNECTOR_IDS.filter((id) => local.has(id));
  expect([...CONNECTOR_IDS]).toEqual([...coreHalf, ...localHalf]);
  ```

  That stays honest when a core connector is added, and still fails if a local one is promoted to core.
- **The four consumer invariants**: no duplicates, no post-lowercase collisions, nothing normalizing to empty, no embedded whitespace — plus one test that replays the consumer's own normalize-and-dedupe loop and asserts no entry is lost.
- **`ConnectorId`**, with a `@ts-expect-error` proving a non-member is not assignable. That directive is itself the assertion: typecheck fails if the type ever widens enough to accept `"myspace"`.

# Evidence

Every mutant executed at `4b58d2b8f8`, one at a time. **28 of 28 die** (nothing survives).

**All 20 entries, deleted individually** — 20/20 fail (was 0/20; there was no test):

`bluebubbles` `telegram` `telegramAccount` `discord` `discordLocal` `slack` `twitter` `whatsapp` `imessage` `farcaster` `lens` `msteams` `feishu` `matrix` `nostr` `blooio` `twitch` `mattermost` `googlechat` → 4 failed each; `wechat` (via emptying `ELIZA_LOCAL_CONNECTOR_IDS`) → 4 failed.

**Structural mutants, 8/8 killed:**

| mutant | result |
|---|---|
| swap the seam order (`local` spread before `core`) | 2 failed |
| drop the `...ELIZA_LOCAL_CONNECTOR_IDS` spread | 4 failed |
| add `"Telegram"` (case-variant of an existing id) | **5 failed** |
| add a second `"telegram"` (exact duplicate) | **6 failed** |
| add `"signal"` (a plausible new connector) | 3 failed |
| pad `"imessage"` to `" imessage "` | 4 failed |
| blank an id to `""` | 4 failed |
| also list `"imessage"` as app-local | **7 failed** |

The three bolded rows are the ones that motivated the file: each is a change that today produces no test failure anywhere in the repo, and each silently drops a connector from the heartbeat-target help text at runtime.

**Suites:** `bunx vitest run src/config/schema.test.ts` → **31 passed** (new file). Regression-checked both consumers: `packages/shared` `src/config/` → **282 passed**, `packages/agent` `src/config/` → **613 passed**.

`bun run --cwd packages/shared typecheck` → `Done!`. Biome on the new file → clean (ran `--write` for import ordering and formatting only; `git status --porcelain` confirms the diff is this one file).

# What I deliberately did not do

I did not touch the source, and I did not add or reorder a connector. Every invariant here already holds — I verified each by executing it before writing the assertion, so none of these is a defect report. The point is that all 28 changes above are currently free, and the ones that matter most are silent at runtime rather than loud.

I also did not assert anything about which connectors are *user-visible*. `client-types-config.ts:161` notes that a per-entry `visible` flag "replaces `VISIBLE_CONNECTOR_IDS`", so visibility is deliberately no longer a property of this list, and pinning it here would re-couple something that was decoupled on purpose.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1KYX8A8XY4MT04TM03MC90A","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T15:41:27.240Z","completed_at":"2026-09-03T15:46:22.641Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T15:41:27.474Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2b77da210ec9559a91dbb1065d7fc5cf4a0db4d0e21fa042212d99de7708a4bb","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"01e99849-cdd9-4b69-9106-ae33efaa907f","object_id":"sha256:2b77da210ec9559a91dbb1065d7fc5cf4a0db4d0e21fa042212d99de7708a4bb","sha256":"2b77da210ec9559a91dbb1065d7fc5cf4a0db4d0e21fa042212d99de7708a4bb"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"W5zOzOk9KBdRq6BB0_KaHE40B8GXLc0tk4PTRj59oVTf9uwBzjmDUmV0nJI36jWoPVMNMIm-H0GohKZgJkjWAA"}} -->
