### PR TITLE
test(ui): pin the native-OS router filter against the launcher gate

### DIFF
--- a/packages/ui/src/navigation/index.test.ts
+++ b/packages/ui/src/navigation/index.test.ts
@@ -10,7 +10,10 @@ import { resetUiRegistryHostForTests } from "../registry-host";
 import {
   ALL_TAB_GROUPS,
   BUILTIN_ROUTE_IDS,
+  LAUNCHER_AOSP_ONLY_VIEW_IDS,
   LEGACY_PREFIX_TAB_ALIASES,
+  NATIVE_OS_VIEW_IDS,
+  pathForTab,
   resolveBuiltinRouteDescriptor,
   resolveLegacyBuiltinRoute,
   TAB_PATHS,
@@ -240,4 +243,92 @@ describe("navigation index: no reintroduced hardcoded prefix alias record", () =
     expect(source).not.toMatch(/if\s*\(\s*sub\s*===\s*"documents"\s*\)/);
     expect(source).not.toMatch(/if\s*\(\s*sub\s*===\s*"select"\s*\)/);
   });
+});
+
+/**
+ * `NATIVE_OS_VIEW_IDS` is a ROUTER-level filter: `App.tsx:1668` sends any tab
+ * whose builtin id is in this list through the plugin-owned native-OS renderer
+ * (`listAppShellPages()`), falling back to a legacy renderer. Membership is
+ * therefore a claim about how a surface renders, not merely where it appears.
+ *
+ * `LAUNCHER_AOSP_ONLY_VIEW_IDS` composes that list plus `files`, and
+ * `launcher-curation.ts:99` states the intent outright — it is sourced from the
+ * canonical list "so this launcher gate and the router-level
+ * `NATIVE_OS_VIEW_IDS` filter never drift."
+ *
+ * The launcher half of that claim is well covered by
+ * `components/pages/launcher-curation.test.ts`. The router half is asserted
+ * here, because the drift the launcher tests cannot see is the one that adds a
+ * cross-platform view to the native-OS filter: the launcher keeps listing it
+ * and stays green while the router quietly changes how it renders.
+ */
+describe("the native-OS / launcher view seam", () => {
+  it("routes exactly the four native-OS surfaces", () => {
+    expect([...NATIVE_OS_VIEW_IDS]).toEqual([
+      "phone",
+      "messages",
+      "contacts",
+      "camera",
+    ]);
+  });
+
+  it("adds exactly Files to the launcher list, and appends it last", () => {
+    expect([...LAUNCHER_AOSP_ONLY_VIEW_IDS]).toEqual([
+      ...NATIVE_OS_VIEW_IDS,
+      "files",
+    ]);
+  });
+
+  /**
+   * Pinned by SUBTRACTION rather than as a second hand-written list, so adding
+   * a genuinely new native-OS surface does not need this assertion edited,
+   * while promoting a launcher-only view into the router filter still fails.
+   */
+  it("keeps Files launcher-only and out of the router filter", () => {
+    const nativeOs = new Set<string>(NATIVE_OS_VIEW_IDS);
+    const launcherOnly = LAUNCHER_AOSP_ONLY_VIEW_IDS.filter(
+      (id) => !nativeOs.has(id),
+    );
+    expect(launcherOnly).toEqual(["files"]);
+    expect(nativeOs.has("files")).toBe(false);
+  });
+
+  /**
+   * The reason the asymmetry exists, made concrete: the native-OS surfaces are
+   * root-path shells, whereas Files is an `/apps/` view that stays routable on
+   * web, desktop and iOS. Putting it in the router filter would send
+   * `/apps/files` down the native-OS renderer path wherever that surface is
+   * enabled.
+   */
+  it("separates root-path native shells from the /apps view", () => {
+    expect(NATIVE_OS_VIEW_IDS.map((id) => pathForTab(id))).toEqual([
+      "/phone",
+      "/messages",
+      "/contacts",
+      "/camera",
+    ]);
+    expect(pathForTab("files")).toBe("/apps/files");
+  });
+
+  it("lists no id twice in either list", () => {
+    expect([...new Set(NATIVE_OS_VIEW_IDS)]).toEqual([...NATIVE_OS_VIEW_IDS]);
+    expect([...new Set(LAUNCHER_AOSP_ONLY_VIEW_IDS)]).toEqual([
+      ...LAUNCHER_AOSP_ONLY_VIEW_IDS,
+    ]);
+  });
+
+  // A generated table over an empty list registers zero cases and reports
+  // green, so pin the arity the tables below are generated from.
+  it("covers every launcher-gated view", () => {
+    expect(NATIVE_OS_VIEW_IDS).toHaveLength(4);
+    expect(LAUNCHER_AOSP_ONLY_VIEW_IDS).toHaveLength(5);
+  });
+
+  it.each(LAUNCHER_AOSP_ONLY_VIEW_IDS)(
+    "%s is a builtin route with a tab path, so the gate cannot list a dead id",
+    (id) => {
+      expect(BUILTIN_ROUTE_IDS as readonly string[]).toContain(id);
+      expect((TAB_PATHS as Record<string, string>)[id]).toBe(pathForTab(id));
+    },
+  );
 });


### PR DESCRIPTION
# What

`launcher-curation.ts:99` states an invariant outright: `LAUNCHER_AOSP_ONLY_VIEW_IDS` is sourced from the canonical navigation list *"so this launcher gate and the router-level `NATIVE_OS_VIEW_IDS` filter never drift."*

One direction of that claim was untested — and it is the direction with the worse failure mode.

```
$ grep -rln NATIVE_OS_VIEW_IDS packages/ | grep -E 'test|spec'
(no matches)
```

`components/pages/launcher-curation.test.ts` is 931 lines and covers the launcher half properly. I checked that by mutation rather than by grep, and it holds up: deleting any of `phone`, `messages`, `contacts`, `camera`, or dropping `"files"` from the launcher list, each fails 3–4 tests. So this is **not** a zero-coverage file, and most of what a naive "name every entry" test would add is already there.

The gap is one specific mutation:

| mutant | before |
|---|---|
| add `"files"` to `NATIVE_OS_VIEW_IDS` | **61 / 61 green — survives** |

# Why that one matters

`NATIVE_OS_VIEW_IDS` is a **router-level** filter, not a listing. `App.tsx:1668`:

```ts
if (
  nativeOsSurfaceEnabled &&
  (NATIVE_OS_VIEW_IDS as readonly string[]).includes(resolveBuiltinTabId(tab))
) {
  const nativeRegistration = listAppShellPages().find(/* … */);
```

Membership routes a tab through the plugin-owned native-OS renderer, with a legacy renderer as fallback. So it is a claim about *how a surface renders*, not where it appears.

`files` is deliberately on the launcher list but **not** in that filter — per the docstring, `/apps/files` "stays routable everywhere but is only surfaced as a launcher tile on the fork." Adding it to `NATIVE_OS_VIEW_IDS` sends `/apps/files` down the native-OS renderer path wherever that surface is enabled, while every launcher assertion stays green: `LAUNCHER_AOSP_ONLY_VIEW_IDS` still contains `files`, so the launcher tests cannot see the change at all.

That is the drift the existing tests structurally cannot catch — the launcher list is *derived from* the filter, so widening the filter widens the launcher list consistently and silently.

# The change

Test-only, +91 lines to the existing `navigation/index.test.ts`. No source change.

- **`NATIVE_OS_VIEW_IDS` named exactly**, and `LAUNCHER_AOSP_ONLY_VIEW_IDS` asserted as `[...NATIVE_OS_VIEW_IDS, "files"]` — which pins the append position, not just the membership.
- **The tail pinned by subtraction**, so a genuinely new native-OS surface needs no edit here, while promoting a launcher-only view into the router filter still fails:

  ```ts
  const nativeOs = new Set<string>(NATIVE_OS_VIEW_IDS);
  expect(LAUNCHER_AOSP_ONLY_VIEW_IDS.filter((id) => !nativeOs.has(id))).toEqual(["files"]);
  expect(nativeOs.has("files")).toBe(false);
  ```

- **The reason for the asymmetry, made concrete.** The native-OS surfaces are root-path shells; Files is an `/apps/` view:

  ```ts
  expect(NATIVE_OS_VIEW_IDS.map((id) => pathForTab(id)))
    .toEqual(["/phone", "/messages", "/contacts", "/camera"]);
  expect(pathForTab("files")).toBe("/apps/files");
  ```

  This is the assertion that explains *why* the two lists differ, rather than just recording that they do.

- **No duplicates in either list** — the surviving mutant produces one, and it is worth failing on its own terms.
- **An `it.each` proving no gated id is dead**: each is in `BUILTIN_ROUTE_IDS` and its `TAB_PATHS` entry agrees with `pathForTab`. Paired with an explicit arity assertion, because a generated table over an empty list registers zero cases and reports green.

# Evidence

Every mutant executed at `f4ed4b8427`, one at a time, across **both** suites (`navigation/index.test.ts` + `launcher-curation.test.ts`). **9 of 9 die**, up from 8 of 9.

| mutant | before | after |
|---|---|---|
| add `"files"` to `NATIVE_OS_VIEW_IDS` | 61/61 green — **survived** | **5 failed** |
| delete `phone` | 4 failed | 7 failed |
| delete `messages` | 4 failed | 7 failed |
| delete `contacts` | 4 failed | 7 failed |
| delete `camera` | 3 failed | 6 failed |
| drop `"files"` from the launcher list | 3 failed | 6 failed |
| put `"files"` first instead of last | not covered | 3 failed |
| swap `phone`/`messages` order | not covered | 4 failed |
| add `"settings"` to `NATIVE_OS_VIEW_IDS` | not covered | 12 failed |

Control: **72 passed** across both files.

**Suites:** `src/navigation/` → **38 passed** (`index.test.ts` 34, up from 23). `launcher-curation.test.ts` → **38 passed**, unchanged.

`bun run --cwd packages/ui typecheck` → exit **0**. Biome on the changed file → clean first try, no `--write` needed. `git status --porcelain` confirms the diff is this one file.

# What I deliberately did not do

I did not add "name every entry" coverage for its own sake — the launcher suite already kills those mutants, and duplicating them here would be lines without leverage. The four order/duplicate/dead-id assertions are included because each kills a mutant nothing else caught; the exact-contents assertion is included because it is the only one that fails on a silent *addition*.

I also did not touch `launcher-curation.test.ts`. Its half of the invariant is covered, and the router half belongs next to the constants it constrains.

No source change: `files` is correctly excluded from the filter today. This pins that decision before a refactor treats the two lists as interchangeable.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1M025C5C637SAX3J0V3NBN2","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T16:01:36.645Z","completed_at":"2026-09-03T16:06:56.172Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T16:01:37.260Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0087c29d682a84b511eea4a9b41259b5b78db4a8dd048a599a5b381e0901f8df","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2272a65a-02ba-404e-80e1-791878fa0993","object_id":"sha256:0087c29d682a84b511eea4a9b41259b5b78db4a8dd048a599a5b381e0901f8df","sha256":"0087c29d682a84b511eea4a9b41259b5b78db4a8dd048a599a5b381e0901f8df"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"oB3UmzN_Llku5i7H9pOBtC4_qIgPzvkRO2gc4MNK2voCEIqpfvApb4uvtIJql6CizRvkckfhHHpL78BYxSffCg"}} -->
