### PR TITLE
test(shared): isolate every legacy cloud key the migration prunes

### DIFF
--- a/packages/shared/src/contracts/first-run-options.migration.test.ts
+++ b/packages/shared/src/contracts/first-run-options.migration.test.ts
@@ -29,6 +29,141 @@ describe("migrateLegacyRuntimeConfig", () => {
     });
   });
 
+  /**
+   * Each routing key needs its own case: the loop deletes them one at a time,
+   * so dropping a single name from the list leaves that field behind while the
+   * other four still migrate and every other assertion stays green. `enabled:
+   * false` is carried in each case so the `cloud` block survives the prune and
+   * can be compared exactly.
+   */
+  it.each([
+    ["provider", "elizacloud"],
+    ["remoteApiBase", "https://legacy.example"],
+    ["remoteAccessToken", "legacy-token"],
+    ["inferenceMode", "local"],
+    ["runtime", "local"],
+  ])("prunes the legacy cloud.%s field", (key, value) => {
+    const config: Record<string, unknown> = {
+      cloud: { enabled: false, [key]: value },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ enabled: false });
+  });
+
+  // A generated table over an empty list registers zero cases and reports
+  // green, so pin the arity the table is generated from.
+  it("covers every legacy routing key", () => {
+    const config: Record<string, unknown> = {
+      cloud: {
+        enabled: false,
+        provider: "elizacloud",
+        remoteApiBase: "https://legacy.example",
+        remoteAccessToken: "legacy-token",
+        inferenceMode: "local",
+        runtime: "local",
+      },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ enabled: false });
+  });
+
+  /**
+   * The legacy remote credential is MIGRATED, not discarded — it moves to
+   * `deploymentTarget.remoteAccessToken`. That makes a missed prune a
+   * duplication rather than a loss: the same secret would remain in the legacy
+   * `cloud` block as well, and migrated configs are written back to disk. Assert
+   * it exists exactly once in the serialized result.
+   */
+  it("moves the legacy remote credential instead of copying it", () => {
+    const config: Record<string, unknown> = {
+      cloud: {
+        enabled: false,
+        remoteApiBase: "https://legacy.example",
+        remoteAccessToken: "legacy-token",
+      },
+    };
+    migrateLegacyRuntimeConfig(config);
+
+    expect(config.cloud).toEqual({ enabled: false });
+    expect(config.deploymentTarget).toMatchObject({
+      runtime: "remote",
+      remoteApiBase: "https://legacy.example",
+      remoteAccessToken: "legacy-token",
+    });
+    expect(JSON.stringify(config).split("legacy-token")).toHaveLength(2);
+  });
+
+  /**
+   * `LEGACY_CLOUD_SERVICE_KEYS` is a second, independent list pruned from
+   * `cloud.services`. Nothing referenced any of its five names, so each is
+   * isolated here the same way.
+   */
+  it.each(["inference", "tts", "media", "embeddings", "rpc"])(
+    "prunes the legacy cloud.services.%s flag",
+    (key) => {
+      const config: Record<string, unknown> = {
+        cloud: { enabled: false, services: { [key]: true } },
+      };
+      migrateLegacyRuntimeConfig(config);
+      expect(config.cloud).toEqual({ enabled: false });
+    },
+  );
+
+  it("covers every legacy service key", () => {
+    const config: Record<string, unknown> = {
+      cloud: {
+        enabled: false,
+        services: {
+          inference: true,
+          tts: true,
+          media: true,
+          embeddings: true,
+          rpc: true,
+        },
+      },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ enabled: false });
+  });
+
+  /**
+   * The two collapse steps are separate and both conditional: an emptied
+   * `services` block is removed, and a `cloud` block emptied by that removal is
+   * removed in turn. Without the first, migration leaves `cloud: { services: {} }`
+   * behind — which is not a legacy field, so nothing later prunes it.
+   */
+  it("drops a services block emptied by the prune", () => {
+    const config: Record<string, unknown> = {
+      cloud: { services: { tts: true } },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toBeUndefined();
+  });
+
+  it("keeps a services block that still holds an unrecognized flag", () => {
+    const config: Record<string, unknown> = {
+      cloud: { services: { tts: true, custom: true } },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ services: { custom: true } });
+  });
+
+  it("keeps a cloud block that still holds an unrecognized field", () => {
+    const config: Record<string, unknown> = {
+      cloud: { enabled: false, agentId: "agent-1" },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ enabled: false, agentId: "agent-1" });
+  });
+
+  it("drops an already-empty services block without touching cloud.enabled", () => {
+    const config: Record<string, unknown> = {
+      cloud: { enabled: false, services: {} },
+    };
+    migrateLegacyRuntimeConfig(config);
+    expect(config.cloud).toEqual({ enabled: false });
+  });
+
   it("still drops a cloud block that only held legacy routing keys", () => {
     const config: Record<string, unknown> = {
       cloud: { inferenceMode: "local" },


### PR DESCRIPTION
# What

`migrateLegacyRuntimeConfig` deletes legacy fields from a user's on-disk config and writes the result back. The existing suite is 39 lines and pins the one invariant its own docstring calls out — that `cloud.enabled === false` survives, being "the sole persisted representation of the local-only opt-out."

That invariant is well chosen and well covered. What surrounds it is not: **9 of 13 mutations to the two prune lists and the collapse logic leave all 57 tests green.**

| mutant | before |
|---|---|
| stop pruning `cloud.provider` | 1 failed |
| stop pruning `cloud.inferenceMode` | 2 failed |
| stop pruning `cloud.runtime` | 1 failed |
| drop the empty-`cloud` collapse | 1 failed |
| stop pruning `cloud.remoteApiBase` | **survives** |
| stop pruning `cloud.remoteAccessToken` | **survives** |
| stop pruning `cloud.services.inference` | **survives** |
| stop pruning `cloud.services.tts` | **survives** |
| stop pruning `cloud.services.media` | **survives** |
| stop pruning `cloud.services.embeddings` | **survives** |
| stop pruning `cloud.services.rpc` | **survives** |
| remove the `services` prune loop entirely | **survives** |
| drop the empty-`services` collapse | **survives** |

`LEGACY_CLOUD_SERVICE_KEYS` — a second, independent five-name list — had **no test naming any of its members**, and neither did `remoteApiBase` or `remoteAccessToken`.

# The change

Test-only, +135 lines to the existing migration suite. No source change.

- **Each of the ten prune-list names isolated in its own case.** The loops `delete` one key at a time, so removing a single name leaves that field on disk while the other four still migrate — invisible to any assertion that checks the list in aggregate. Each case carries `enabled: false` so the `cloud` block survives the prune and can be compared exactly.
- **Both generated tables paired with an explicit arity assertion**, since a table over an empty list registers zero cases and reports green.
- **The two collapse steps separated.** An emptied `services` block is removed, and a `cloud` block emptied by *that* removal is removed in turn. Without the first, migration leaves `cloud: { services: {} }` behind — and `services` is not itself a legacy field, so nothing later prunes it. Also pinned: a `services` block holding an unrecognized flag survives carrying only that flag, and a `cloud` block holding an unrecognized field (`agentId`) is kept.

# One correction worth recording

My first read of the `remoteAccessToken` survivor was that a missed prune would leave a credential behind after migration. I probed it before writing the assertion, and that framing is wrong: the token is **migrated**, to `deploymentTarget.remoteAccessToken`. So a missed prune is a **duplication**, not a retention — the same secret would sit in both the legacy and the modern location, in a file written back to disk.

Still worth pinning, and the assertion follows the corrected shape rather than a scarier one:

```ts
expect(config.cloud).toEqual({ enabled: false });
expect(config.deploymentTarget).toMatchObject({
  remoteApiBase: "https://legacy.example",
  remoteAccessToken: "legacy-token",
});
expect(JSON.stringify(config).split("legacy-token")).toHaveLength(2);
```

The last line is the one that matters — it asserts the secret appears exactly once in the serialized result, which is what "moved" means and what a per-field check cannot express.

# Evidence

Every mutant executed at `8ad809aa89`, one at a time, across the four shared suites that import this module (`first-run-options.migration`, `.connections`, `.routing`, `first-run-cerebras`).

**13 of 13 now die**, up from 4 of 13:

| mutant | before | after |
|---|---|---|
| stop pruning `remoteApiBase` | survived | **3 failed** |
| stop pruning `remoteAccessToken` | survived | **3 failed** |
| stop pruning `services.inference` | survived | **2 failed** |
| stop pruning `services.tts` | survived | **4 failed** |
| stop pruning `services.media` | survived | **2 failed** |
| stop pruning `services.embeddings` | survived | **2 failed** |
| stop pruning `services.rpc` | survived | **2 failed** |
| remove the `services` prune loop | survived | **2 failed** |
| drop the empty-`services` collapse | survived | **8 failed** |
| stop pruning `provider` | 1 failed | 3 failed |
| stop pruning `inferenceMode` | 2 failed | 4 failed |
| stop pruning `runtime` | 1 failed | 3 failed |
| drop the empty-`cloud` collapse | 1 failed | 2 failed |

I also re-ran the mutant the original suite exists to stop — adding `"enabled"` to `LEGACY_CLOUD_ROUTING_KEYS` — and it now fails **17** tests instead of 4. The pre-existing guard is unaffected; it just has more company.

**Suites:** the four importing suites → **74 passed** (was 57). Whole `src/contracts/` directory → **831 passed**. `bun run --cwd packages/shared typecheck` → exit **0**. Biome on the changed file → clean first try, no `--write` needed.

# Follow-up I am deliberately not taking here

`packages/core/src/contracts/first-run-options.ts` is a hand-maintained mirror of this file — the two differ only in indentation (tabs vs spaces) today, and I found no codegen step and no CI check that keeps them in sync. Its test file, `packages/core/src/contracts/first-run-options.test.ts`, is 27 lines and names none of the ten keys, so the same 9 mutants presumably survive there.

I have left it alone: this PR is one file and one suite, and copying 135 lines into a mirror is a different decision from covering the original — it may be that the right move is a sync check rather than duplicated tests. Flagging it so the choice is yours rather than implied by my diff.

No source change. Every behaviour asserted here is behaviour the migration already has; I verified each by executing it before writing the assertion.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1M0MGRG2232CKC6XP8TCWJY","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T16:11:38.128Z","completed_at":"2026-09-03T16:16:15.497Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T16:11:38.471Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ba315637f29c069756e3ac406f2d1caf5a74ac2fa44e0dd9f32e047598916184","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"191ac9ad-34e7-456c-87dd-f6e62f7f8d4e","object_id":"sha256:ba315637f29c069756e3ac406f2d1caf5a74ac2fa44e0dd9f32e047598916184","sha256":"ba315637f29c069756e3ac406f2d1caf5a74ac2fa44e0dd9f32e047598916184"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"nlqMKImshlwjY5kceqWMLJBtYULpbHncnHqgwxnDS9kMMzOWuBgTQoVfftnH_VEslvrNqSbqIuT0s48sdqSzCA"}} -->
