### PR TITLE
fix(agent): stop advertising X-Server-Token twice in the CORS allow-list

### DIFF
--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -57,7 +57,6 @@ export const CORS_ALLOWED_HEADERS = [
   "X-ElizaOS-Turn-Correlation",
   "X-ElizaOS-Turn-Attempt",
   "X-Eliza-Trace-Id",
-  "X-Server-Token",
 ].join(", ");
 
 /**

--- a/packages/agent/test/api/server-helpers-auth.test.ts
+++ b/packages/agent/test/api/server-helpers-auth.test.ts
@@ -89,6 +89,86 @@ describe("applyCors", () => {
     expect(allowedHeaders).toContain("X-ElizaOS-Turn-Attempt");
   });
 
+  /**
+   * `CORS_ALLOWED_HEADERS` is a pre-joined string emitted verbatim as
+   * `Access-Control-Allow-Headers`. The preflight assertions above compare the
+   * response header against that same constant, so they hold for any contents
+   * — including a repeated name, which is how `X-Server-Token` came to be
+   * listed twice. These assertions look at the contents instead.
+   */
+  describe("CORS_ALLOWED_HEADERS contents", () => {
+    const names = CORS_ALLOWED_HEADERS.split(",").map((header) =>
+      header.trim(),
+    );
+
+    it("lists no header twice", () => {
+      expect([...new Set(names)]).toEqual(names);
+    });
+
+    it("advertises exactly the intended header set", () => {
+      expect(names).toEqual([
+        "Content-Type",
+        "Authorization",
+        "X-API-Token",
+        "X-Api-Key",
+        "X-Eliza-Token",
+        "X-ElizaOS-Token",
+        "X-Server-Token",
+        "X-Waifu-Chat-Access-Token",
+        "X-Eliza-Export-Token",
+        "X-Eliza-Client-Id",
+        "X-ElizaOS-Client-Id",
+        "X-Eliza-Terminal-Token",
+        "X-Eliza-Platform",
+        "X-Eliza-UI-Language",
+        "X-ElizaOS-UI-Language",
+        "X-Browser-Bridge-Companion-Id",
+        "X-Eliza-Browser-Companion-Id",
+        "X-Eliza-CSRF",
+        "X-ElizaOS-Turn-Correlation",
+        "X-ElizaOS-Turn-Attempt",
+        "X-Eliza-Trace-Id",
+      ]);
+    });
+
+    /**
+     * Three headers exist in both a legacy `X-Eliza-*` and a canonical
+     * `X-ElizaOS-*` spelling. A dedicated agent serves clients of both
+     * vintages, so dropping either half silently breaks one of them — and the
+     * pair is easy to prune as an apparent duplicate.
+     */
+    it.each([
+      ["X-Eliza-Token", "X-ElizaOS-Token"],
+      ["X-Eliza-Client-Id", "X-ElizaOS-Client-Id"],
+      ["X-Eliza-UI-Language", "X-ElizaOS-UI-Language"],
+    ])("keeps both the %s and %s spellings", (legacy, canonical) => {
+      expect(names).toContain(legacy);
+      expect(names).toContain(canonical);
+    });
+
+    /**
+     * Every header `packages/ui/src/api/client-base.ts` sends to an agent's
+     * REST surface must be advertised, or the credentialed preflight from the
+     * Capacitor WebView rejects the request.
+     */
+    it.each([
+      "X-ElizaOS-Client-Id",
+      "X-ElizaOS-UI-Language",
+      "X-ElizaOS-Turn-Correlation",
+      "X-ElizaOS-Turn-Attempt",
+      "X-Eliza-Trace-Id",
+    ])("advertises %s, which the UI client sends", (header) => {
+      expect(names).toContain(header);
+    });
+
+    it("advertises a header for every name the emitted string carries", () => {
+      expect(names).toHaveLength(21);
+      expect(
+        names.every((header) => /^[A-Za-z][A-Za-z0-9-]*$/.test(header)),
+      ).toBe(true);
+    });
+  });
+
   it("never enables ambient browser credentials for reflected cloud origins", () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     const res = new HeaderCapture();


### PR DESCRIPTION
# What

`CORS_ALLOWED_HEADERS` in `packages/agent/src/api/server-helpers-auth.ts` lists **`X-Server-Token` twice** — once at the top of the token group and again as the final entry. It is a pre-joined string emitted verbatim:

```
Access-Control-Allow-Headers: Content-Type, Authorization, …, X-Server-Token, …, X-Eliza-Trace-Id, X-Server-Token
```

22 entries, 21 distinct. Browsers tolerate the repeat, so the impact is a malformed advertised header rather than a broken request — I'd rather say that plainly than inflate it.

# Why nothing caught it

The preflight tests assert the response header against the constant that produced it:

```ts
expect(res.headers.get("Access-Control-Allow-Headers")).toBe(CORS_ALLOWED_HEADERS);
```

That holds for *any* contents. A separate `toContain` test does name six headers by hand, which is real coverage — but it leaves the other fifteen, and neither form can see a duplicate.

Measured, rather than asserted:

| mutant | against the existing suite |
|---|---|
| remove the duplicate `X-Server-Token` | **26/26 green — survives** |
| replace `X-Eliza-CSRF` with `X-Attacker-Supplied` | **26/26 green — survives** |
| delete `X-ElizaOS-Turn-Correlation` | 1 failed (the `toContain` test names it) |

The second row is the one that bothered me more than the duplicate: a header name could be silently changed to anything and the suite would not notice.

# The change

- Delete the duplicate entry. **One line of source.**
- Add a `CORS_ALLOWED_HEADERS contents` block that asserts the *contents* rather than comparing the string to itself: no duplicates, the exact 21-name list in order, and the arity the tables are generated from.
- Pin the **three dual-spelling pairs** (`X-Eliza-Token`/`X-ElizaOS-Token`, `X-Eliza-Client-Id`/`X-ElizaOS-Client-Id`, `X-Eliza-UI-Language`/`X-ElizaOS-UI-Language`). A dedicated agent serves clients of both vintages, and a legacy/canonical pair is exactly what a future cleanup prunes as an apparent duplicate — which is, after all, how this PR started.
- Pin the five headers `packages/ui/src/api/client-base.ts` actually sends, so the allow-list can't drift out from under the client that depends on it.

# Evidence

Every mutant executed at `754c012046`, one at a time. **7 of 7 die.**

| mutant | result |
|---|---|
| control | **37 passed** |
| reintroduce the duplicate | **3 failed** |
| replace `X-Eliza-CSRF` with a bogus name | **1 failed** |
| drop legacy `X-Eliza-Token` | 3 failed |
| drop legacy `X-Eliza-UI-Language` | 3 failed |
| drop `X-Eliza-Trace-Id` (the UI sends it) | 3 failed |
| add an unlisted `X-New-Header` | 2 failed |
| drop `X-Browser-Bridge-Companion-Id` | 2 failed |

**Suites:** `test/api/server-helpers-auth.test.ts` → **37 passed** (was 26). Whole `test/api/` directory → **275 passed**, 15 files. `bun run --cwd packages/agent typecheck` → exit **0**. Biome on both changed files → clean.

# Two divergences I checked and did NOT file

The same-named list in `packages/app-core/src/api/server-cors.ts` has 13 entries against this file's 21, and `packages/cloud/shared/src/lib/cors-constants.ts` carries a third, with a comment saying its client-id/UI-language block "Mirrors the dedicated-agent allow-headers in `packages/agent/src/api/server-helpers-auth.ts`". Both looked like drift. Neither is:

- **app-core is a deliberate subset.** For the three headers with both a legacy and a canonical spelling it accepts only the canonical one; every single-spelling header it needs is present. The remainder it omits (`X-Server-Token`, `X-Waifu-Chat-Access-Token`, the two browser-companion ids, `X-Eliza-Trace-Id`) are agent-server surfaces app-core does not serve.
- **`X-Eliza-Trace-Id` missing from app-core is correct.** This one I nearly filed. The UI sends it — but only under `isDedicatedCloudAgentBase(this.baseUrl)` (`client-base.ts:2900`), i.e. only to `<agentId>.cloud.eliza.app`, never to the local app-core server. An unconditional read of that call site would have produced a wrong bug report.

I have not tried to unify the three lists. They serve three different origins with three different auth surfaces, and the cloud file's comment scopes its mirroring claim to a specific block rather than the whole list — so a shared constant would need a policy decision about which headers are genuinely common. That's a maintainer call, not something to encode in a drive-by.

# Scope

One line of source, 80 lines of test. No behaviour change beyond the header value no longer repeating a name.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1M1TJPTC6QEEW16PDMC0JT3","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T16:32:25.306Z","completed_at":"2026-09-03T16:37:55.851Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T16:32:25.506Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e0666adf616c053cf1f517139cae737dca7ebee6e1b9911a44f430736e9ec1d7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3d348be0-a027-4f9d-a3d1-955a2cbac821","object_id":"sha256:e0666adf616c053cf1f517139cae737dca7ebee6e1b9911a44f430736e9ec1d7","sha256":"e0666adf616c053cf1f517139cae737dca7ebee6e1b9911a44f430736e9ec1d7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"BzDmgYAd9l1wVT9QWOY7WeVjGv0OkJeRQ9ryP0aIN0nK0pzpSKMg0FFrTBgXO8xdp7B4QWi95o8ySyXiqarLDw"}} -->
