### PR TITLE
test(core): pin every clause of the PII pseudonym snapshot gate

### DIFF
--- a/packages/core/src/security/pii-pseudonym-map.test.ts
+++ b/packages/core/src/security/pii-pseudonym-map.test.ts
@@ -17,7 +17,9 @@
 
 import { describe, expect, test, vi } from "vitest";
 import {
+	assertValidSnapshot,
 	CorpusPseudonymMap,
+	type PseudonymClusterRecord,
 	PseudonymMapIntegrityError,
 	type PseudonymMapSnapshot,
 } from "./pii-pseudonym-map.js";
@@ -576,5 +578,183 @@ describe("snapshot validation is fail-closed", () => {
 		} finally {
 			vi.unstubAllGlobals();
 		}
+	});
+});
+
+/**
+ * `assertValidSnapshot` is the fail-closed gate on the SECRET artifact. It runs
+ * on two inputs that are not the map's own output: `fromSnapshot` (a caller-
+ * supplied snapshot) and `PseudonymMapStore.load`, whose own comment calls the
+ * decrypted bytes "untrusted persisted input".
+ *
+ * The block above covers the snapshot-level clauses and the three headline
+ * cluster invariants (duplicate cluster, shared pseudonym, shared identity).
+ * These pin the per-field clauses beside them, each by its own message so that
+ * one clause standing in for another is a failure rather than a pass, plus the
+ * two type-coercion edges the shape allows.
+ *
+ * The consequence of a missing clause is not a lenient parse: `fromSnapshot`
+ * immediately does `[...record.aliases]`, `record.identities.map(...)` and
+ * `[...record.evidence]`, so a shape that slips past the gate becomes a raw
+ * TypeError from the constructor instead of the structured
+ * `PseudonymMapIntegrityError` both callers are written against.
+ */
+describe("assertValidSnapshot pins every per-cluster clause", () => {
+	function cluster(
+		over: Partial<Record<keyof PseudonymClusterRecord, unknown>> = {},
+	): PseudonymClusterRecord {
+		return {
+			clusterId: "entity:p1",
+			kind: "person",
+			pseudonym: "Alice Adams",
+			aliases: ["John Smith"],
+			identities: [{ platform: "discord", handle: "jsmith" }],
+			evidence: ["same discord handle"],
+			firstSeen: 1_750_000_000_000,
+			rulesetVersion: RULESET,
+			supersededPseudonyms: [],
+			...over,
+		} as PseudonymClusterRecord;
+	}
+
+	function snapshot(...clusters: readonly PseudonymClusterRecord[]): unknown {
+		return { version: 1, salt: SALT, clusters };
+	}
+
+	test("accepts the fixture the negative cases are built from", () => {
+		expect(() => assertValidSnapshot(snapshot(cluster()))).not.toThrow();
+	});
+
+	test.each([
+		["cluster is not an object", null],
+		["cluster is not an object", "entity:p1"],
+	] as const)("rejects a non-object cluster (%s)", (message, value) => {
+		expect(() =>
+			assertValidSnapshot({
+				version: 1,
+				salt: SALT,
+				clusters: [value],
+			}),
+		).toThrow(message);
+	});
+
+	test.each([
+		["clusterId", { clusterId: 7 }, /has no clusterId/],
+		["clusterId empty", { clusterId: "" }, /has no clusterId/],
+		["kind", { kind: 7 }, /has no kind/],
+		["kind empty", { kind: "" }, /has no kind/],
+		["pseudonym", { pseudonym: 7 }, /has no pseudonym/],
+		["firstSeen", { firstSeen: "1750000000000" }, /has no firstSeen/],
+		["firstSeen null", { firstSeen: null }, /has no firstSeen/],
+		["rulesetVersion", { rulesetVersion: 7 }, /has no rulesetVersion/],
+	] as const)(
+		"rejects a bad %s by its own message",
+		(_label, over, expected) => {
+			expect(() => assertValidSnapshot(snapshot(cluster(over)))).toThrow(
+				expected,
+			);
+		},
+	);
+
+	// Each list field is checked twice: "not an array at all" and "an array
+	// holding one wrong-typed element". Dropping the element-level `.some(...)`
+	// half leaves the first case passing, so only the pair pins the clause.
+	test.each([
+		["aliases", "aliases", /malformed aliases/],
+		["evidence", "evidence", /malformed evidence/],
+		[
+			"supersededPseudonyms",
+			"supersededPseudonyms",
+			/malformed supersededPseudonyms/,
+		],
+	] as const)(
+		"rejects %s that is not a list of strings",
+		(_l, key, expected) => {
+			expect(() =>
+				assertValidSnapshot(snapshot(cluster({ [key]: "John Smith" }))),
+			).toThrow(expected);
+			expect(() =>
+				assertValidSnapshot(snapshot(cluster({ [key]: ["ok", 7] }))),
+			).toThrow(expected);
+		},
+	);
+
+	test.each([
+		["not a list", { identities: {} }],
+		["a null entry", { identities: [null] }],
+		["a non-string platform", { identities: [{ platform: 7, handle: "a" }] }],
+		["a missing handle", { identities: [{ platform: "discord" }] }],
+	] as const)("rejects identities with %s", (_label, over) => {
+		expect(() => assertValidSnapshot(snapshot(cluster(over)))).toThrow(
+			/malformed identities/,
+		);
+	});
+
+	// The bijectivity check folds case before comparing, and it has to: the
+	// reverse index built by `fromSnapshot` is keyed on
+	// `pseudonym.toLowerCase()`, so "Alice Adams" and "alice adams" in one
+	// snapshot would silently collapse to a single reverse-lookup entry and two
+	// real people would share one surrogate. Comparing raw strings here would
+	// admit exactly that snapshot.
+	test("treats two pseudonyms differing only in case as the same pseudonym", () => {
+		expect(() =>
+			assertValidSnapshot(
+				snapshot(
+					cluster(),
+					cluster({
+						clusterId: "entity:p2",
+						pseudonym: "alice adams",
+						identities: [],
+					}),
+				),
+			),
+		).toThrow(/no longer bijective/);
+	});
+
+	test("still admits two genuinely different pseudonyms", () => {
+		expect(() =>
+			assertValidSnapshot(
+				snapshot(
+					cluster(),
+					cluster({
+						clusterId: "entity:p2",
+						pseudonym: "Bob Brown",
+						identities: [{ platform: "discord", handle: "bbrown" }],
+					}),
+				),
+			),
+		).not.toThrow();
+	});
+
+	// The version gate is `!== 1`, not a numeric comparison. A JSON artifact
+	// hand-edited (or written by another tool) with a quoted version is a
+	// different encoding of the contract and must not be read as v1.
+	test.each([["1"], [1.0000001], [true], [null], [undefined]] as const)(
+		"rejects version %s",
+		(version) => {
+			expect(() =>
+				assertValidSnapshot({ version, salt: SALT, clusters: [] }),
+			).toThrow(/unsupported snapshot version/);
+		},
+	);
+
+	// `salt` is checked for type before length. A non-string salt has no
+	// `.length`, so a length-only guard would wave it through and the map would
+	// mint from a non-string seed.
+	test.each([[7], [null], [{}], [["s"]]] as const)(
+		"rejects a non-string salt (%s)",
+		(salt) => {
+			expect(() =>
+				assertValidSnapshot({ version: 1, salt, clusters: [] }),
+			).toThrow(/missing its mint salt/);
+		},
+	);
+
+	test("reports the first offending cluster, not the last", () => {
+		expect(() =>
+			assertValidSnapshot(
+				snapshot(cluster({ clusterId: "entity:bad", kind: "" }), cluster()),
+			),
+		).toThrow(/"entity:bad" has no kind/);
 	});
 });


### PR DESCRIPTION
# What

`assertValidSnapshot` (`packages/core/src/security/pii-pseudonym-map.ts:648`) is the fail-closed gate on the corpus pseudonym map — the artifact that decides *one person = one surrogate* across a whole corpus. It runs on two inputs that are **not** the map's own output:

- `CorpusPseudonymMap.fromSnapshot` (`:506`), a caller-supplied snapshot;
- `PseudonymMapStore.load` (`pii-pseudonym-map-store.ts:157`), whose own comment calls the decrypted bytes *"untrusted persisted input"*.

Its snapshot-level clauses and three headline cluster invariants are covered. The eleven per-field clauses sitting beside them are not, and the exported symbol itself is referenced by no test — every existing case reaches it indirectly through `fromSnapshot`.

# Evidence

Mutating each guard to a no-op, against the existing `pii-pseudonym-map.test.ts` + `pii-pseudonym-map-store.test.ts`:

| mutant | before | after |
|---|---|---|
| drop `cluster is not an object` | **survived** | killed |
| drop `has no clusterId` | **survived** | killed |
| `kind` guard → `false` | **survived** | killed |
| `aliases`: drop element check | **survived** | killed |
| `aliases`: drop whole guard | **survived** | killed |
| `identities`: drop whole guard | killed | killed |
| `identities`: drop the `handle` check | **survived** | killed |
| `evidence`: drop element check | **survived** | killed |
| `firstSeen` guard → `false` | **survived** | killed |
| `supersededPseudonyms`: drop element check | **survived** | killed |
| `pseudonym.toLowerCase()` → `pseudonym` | **survived** | killed |
| `salt`: drop the `typeof` half | **survived** | killed |
| `version !== 1` → `Number(version) !== 1` | **survived** | killed |
| drop `has no pseudonym` | killed | killed |
| drop duplicate-cluster check | killed | killed |
| drop shared-identity check | killed | killed |

**4/16 → 16/16.** Suite goes 36 → 66 passing. `bunx vitest run packages/core/src/security/` → **40 files, 709 passed**. `bun run --cwd packages/core typecheck` → exit 0. Biome clean (two of its formatting preferences applied to the new block; develop's copy of the file was already clean, so nothing outside my addition moved).

# Three of these are worth naming

**The bijectivity check folds case, and has to.** `fromSnapshot` builds its reverse index as `map.pseudonymsLower.set(state.pseudonym.toLowerCase(), state.clusterId)`. A snapshot holding both `"Alice Adams"` and `"alice adams"` would pass a raw-string comparison, then collapse to one reverse-lookup entry — two real people sharing one surrogate, which is precisely the property the file's header calls the hard gate. The existing shared-pseudonym test uses two *identical* strings, so it can't see the fold. The new case uses two that differ only in case.

**`salt` is checked for type before length, and the order is load-bearing.** With the `typeof` half removed, `salt: 7` gives `(7).length === 0` → `undefined === 0` → `false`, so a non-string seed reaches the mint. Only a non-string fixture catches that; an empty-string fixture (what exists today) passes either way.

**`version !== 1` is strict on purpose.** A hand-edited or foreign-tool artifact carrying `"1"` is a different encoding of the contract and shouldn't be read as v1. The mutant to a numeric comparison survived, so nothing said so.

# What the missing clauses actually cost

Not a lenient parse. `fromSnapshot` immediately does `[...record.aliases]`, `record.identities.map(...)` and `[...record.evidence]`, so a shape that slips past the gate surfaces as a raw `TypeError` from the constructor rather than the structured `PseudonymMapIntegrityError` both call sites are written against — including `load`, which is catching it to report an invalid artifact.

# Choices

- Each per-field case asserts **its own message**, not just `PseudonymMapIntegrityError`. One clause standing in for another is then a failure rather than a pass — several of the survivors above are only visible that way.
- Every list field is checked **twice**: not-an-array, and an array holding one wrong-typed element. Dropping only the `.some(...)` half leaves the first case green, so the pair is what pins the clause.
- Tests call `assertValidSnapshot` **directly**. The existing block goes through `fromSnapshot`, which is the right shape for the headline invariants but means a clause can only be observed through a constructor that does its own work afterwards.
- One ordering case (`reports the first offending cluster, not the last`), because the loop's early `throw` is the reason the error names a cluster id at all.

I did not touch `assertValidSnapshot` itself — every clause in it is correct as written; this only makes them load-bearing. No production code changes.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1M4WTTBEDQAVE5GG4SSYPDN","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T17:26:04.875Z","completed_at":"2026-09-03T17:27:25.934Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T17:26:05.490Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a4ed524bec47a42d7b5661a827d6f5010bfec87f00dc5737b938b274f63ca4e2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3bc1e9e4-9584-4602-9ad6-4e2cd98dc702","object_id":"sha256:a4ed524bec47a42d7b5661a827d6f5010bfec87f00dc5737b938b274f63ca4e2","sha256":"a4ed524bec47a42d7b5661a827d6f5010bfec87f00dc5737b938b274f63ca4e2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"ZDfYl6KU2BQrYLeE0xB976nWExiSMmEgRiYFwTDoQCYUpW_nrBsqUiu5qXW7RdbZ4Dqp2rYMdu5FZXMrTpTKCg"}} -->
