### PR TITLE
test(app): audit Shared to Dedicated transition

### DIFF
--- a/packages/app/scripts/lib/audit-output.mjs
+++ b/packages/app/scripts/lib/audit-output.mjs
@@ -1,5 +1,5 @@
 /**
- * Resolves the app-audit artifact directory while protecting repository and
+ * Resolves aesthetic-audit artifact directories while protecting repository and
  * filesystem roots from the runner's intentional recursive cleanup.
  */
 import path from "node:path";
@@ -14,10 +14,15 @@ function containsPath(parent, child) {
   );
 }
 
-export function resolveAuditAppOutput({ appDir, repoRoot, configured }) {
+function resolveAuditOutput({
+  appDir,
+  repoRoot,
+  configured,
+  defaultDirectory,
+}) {
   const outputDir = path.resolve(
     appDir,
-    configured?.trim() || "aesthetic-audit-output",
+    configured?.trim() || defaultDirectory,
   );
   const insideRepository = containsPath(repoRoot, outputDir);
   const insideApp = containsPath(appDir, outputDir);
@@ -32,4 +37,18 @@ export function resolveAuditAppOutput({ appDir, repoRoot, configured }) {
     );
   }
   return outputDir;
+}
+
+export function resolveAuditAppOutput(options) {
+  return resolveAuditOutput({
+    ...options,
+    defaultDirectory: "aesthetic-audit-output",
+  });
+}
+
+export function resolveAuditCloudOutput(options) {
+  return resolveAuditOutput({
+    ...options,
+    defaultDirectory: "aesthetic-audit-output-cloud",
+  });
 }

--- a/packages/app/scripts/lib/audit-output.test.mjs
+++ b/packages/app/scripts/lib/audit-output.test.mjs
@@ -1,7 +1,10 @@
-/** Proves app-audit cleanup cannot target the filesystem, repository, or app root. */
+/** Proves aesthetic-audit cleanup cannot target filesystem or workspace roots. */
 import { describe, expect, it } from "bun:test";
 import path from "node:path";
-import { resolveAuditAppOutput } from "./audit-output.mjs";
+import {
+  resolveAuditAppOutput,
+  resolveAuditCloudOutput,
+} from "./audit-output.mjs";
 
 describe("resolveAuditAppOutput", () => {
   const appDir = path.resolve("/workspace/repo/packages/app");
@@ -18,6 +21,9 @@ describe("resolveAuditAppOutput", () => {
         configured: "evidence/current",
       }),
     ).toBe(path.join(appDir, "evidence/current"));
+    expect(resolveAuditCloudOutput({ appDir, repoRoot })).toBe(
+      path.join(appDir, "aesthetic-audit-output-cloud"),
+    );
   });
 
   it("rejects destructive roots", () => {

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -8,7 +8,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { getFreePort } from "../test/utils/get-free-port.mjs";
-import { resolveAuditAppOutput } from "./lib/audit-output.mjs";
+import {
+  resolveAuditAppOutput,
+  resolveAuditCloudOutput,
+} from "./lib/audit-output.mjs";
 import {
   auditProjectsRequestedByArgs,
   writeAuditProjectPropagation,
@@ -224,6 +227,17 @@ function cleanAuditAppOutput() {
   console.log(`[ui-smoke] Reset app aesthetic audit output: ${outputDir}`);
 }
 
+function cleanAuditCloudOutput() {
+  const outputDir = resolveAuditCloudOutput({
+    appDir,
+    repoRoot,
+    configured: env.ELIZA_AUDIT_CLOUD_DIR,
+  });
+  removePathRecursive(outputDir, "cloud aesthetic audit output");
+  fs.mkdirSync(outputDir, { recursive: true });
+  console.log(`[ui-smoke] Reset cloud aesthetic audit output: ${outputDir}`);
+}
+
 function acquireUiSmokeViewLock() {
   const staleAfterMs = 30 * 60 * 1000;
   let announcedWait = false;
@@ -343,13 +357,17 @@ env.NODE_OPTIONS = withElizaSourceNodeOptions(env.NODE_OPTIONS);
 const runsAppAudit =
   hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
   hasPlaywrightProject("audit-app");
+const runsCloudAudit =
+  hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
+  hasPlaywrightProject("audit-cloud");
 
-if (runsAppAudit) {
+if (runsAppAudit || runsCloudAudit) {
   // The lock covers cleanup and the complete capture, including lanes that
   // intentionally skip rebuilding views. No concurrent audit can erase this
   // run's evidence after it starts writing.
   releaseUiSmokeViewLock = acquireUiSmokeViewLock();
-  cleanAuditAppOutput();
+  if (runsAppAudit) cleanAuditAppOutput();
+  if (runsCloudAudit) cleanAuditCloudOutput();
 }
 
 if (hasPlaywrightConfig("playwright.ui-smoke.config.ts")) {

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -4,7 +4,7 @@
  */
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import {
   type AestheticVerdictDebt,
   evaluateStrictGate,
@@ -17,6 +17,7 @@ import {
 } from "./helpers/brand-color-scans";
 import {
   BILLING_AUDIT_RESOURCE_EXPECTATIONS,
+  CLOUD_AUDIT_DEDICATED_AGENT_ID,
   installCloudApiStubs,
   seedStewardToken,
 } from "./helpers/cloud-audit-fixtures";
@@ -90,6 +91,11 @@ const VIEWPORTS = [
   { name: "mobile", width: 390, height: 844 },
 ] as const;
 
+const TRANSITION_VIEWPORTS = [
+  ...VIEWPORTS,
+  { name: "tablet", width: 820, height: 1180 },
+] as const;
+
 interface CloudAuditCase {
   slug: string;
   /** Concrete path (parametric segments filled with the stubbed sample ids). */
@@ -109,6 +115,8 @@ interface CloudAuditCase {
    * rendered its content.
    */
   expectedFinalPath?: RegExp;
+  /** Compatibility path owned by the shell rather than the route registry. */
+  compatibilityPath?: true;
 }
 
 const AUTH = true;
@@ -137,7 +145,7 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
   },
   {
     slug: "cloud-agents-detail",
-    path: "/cloud/agents/agent-smoke-1",
+    path: `/cloud/agents/${CLOUD_AUDIT_DEDICATED_AGENT_ID}`,
     route: "cloud/agents/:id",
     auth: AUTH,
   },
@@ -192,6 +200,8 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
     path: "/cloud/security",
     route: "cloud/security",
     auth: AUTH,
+    expectedFinalPath: /^\/cloud\/account$/,
+    compatibilityPath: true,
   },
   {
     slug: "cloud-security-permissions",
@@ -532,6 +542,89 @@ function renderManualReviewStub(findings: CloudPageFinding[]): string {
 const findings: CloudPageFinding[] = [];
 const findingsBySlug = new Map<string, CloudPageFinding[]>();
 
+async function captureTransitionState(options: {
+  page: Page;
+  outputDir: string;
+  viewport: (typeof TRANSITION_VIEWPORTS)[number];
+  state: string;
+  consoleErrors: string[];
+  pageErrors: string[];
+  hoverTarget?: Locator;
+}): Promise<void> {
+  const slug = `cloud-agents-transition-${options.state}`;
+  const shotDir = path.join(options.outputDir, options.viewport.name);
+  const reviewDir = path.join(options.outputDir, "manual-review");
+  await mkdir(shotDir, { recursive: true });
+  await mkdir(reviewDir, { recursive: true });
+  await options.page.waitForTimeout(250);
+
+  const readableChars = await options.page.evaluate(
+    () => document.body.innerText.trim().replace(/\s+/g, " ").length,
+  );
+  const restPath = path.join(shotDir, `${slug}.png`);
+  const hasHorizontalOverflow = await options.page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth,
+  );
+  expect(hasHorizontalOverflow, `${slug} must not overflow horizontally`).toBe(
+    false,
+  );
+  const buffer = await options.page.screenshot({
+    path: restPath,
+    fullPage: true,
+  });
+  const quality = await analyzeScreenshot(buffer);
+  const qualityIssues = screenshotQualityIssues(
+    `${slug} ${options.viewport.name}`,
+    quality,
+  );
+  const blueColors = await collectBlueColors(options.page);
+  const { violations: hoverViolations, hoverFailures } =
+    await collectHoverViolations(options.page);
+  const hoverTarget =
+    options.hoverTarget ??
+    options.page.locator("button:visible, a[role='button']:visible").first();
+  await expect(hoverTarget).toBeVisible();
+  await hoverTarget.hover({ timeout: 2_000 });
+  await options.page.screenshot({
+    path: path.join(shotDir, `${slug}--hover.png`),
+    fullPage: true,
+  });
+
+  const base = {
+    slug,
+    viewport: options.viewport.name,
+    path: "/cloud/agents",
+    route: "cloud/agents",
+    consoleErrors: [
+      ...options.pageErrors.map((message) => `pageerror: ${message}`),
+      ...options.consoleErrors,
+    ],
+    blueColors,
+    hoverViolations,
+    hoverFailures,
+    readableChars,
+    quality,
+    qualityIssues,
+  };
+  const finding: CloudPageFinding = {
+    ...base,
+    verdict: computeCloudVerdict(base),
+  };
+  findings.push(finding);
+  const perSlug = findingsBySlug.get(slug) ?? [];
+  perSlug.push(finding);
+  findingsBySlug.set(slug, perSlug);
+  expect(
+    finding.verdict,
+    `${slug} ${options.viewport.name} must have no automated visual defects`,
+  ).toBe("needs-eyeball");
+  await writeFile(
+    path.join(reviewDir, `${slug}.md`),
+    renderManualReviewStub(perSlug),
+    "utf8",
+  );
+}
+
 test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
   // Hard gate (#13624): under strict/CI the running renderer bundle MUST contain
   // the test-auth shell. A stale turbo-cached `build:web` (built without
@@ -615,7 +708,11 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
       )
       .toBe(true);
     const registered = new Set(registeredPaths);
-    const audited = new Set(CLOUD_AUDIT_CASES.map((c) => c.route));
+    const audited = new Set(
+      CLOUD_AUDIT_CASES.filter((auditCase) => !auditCase.compatibilityPath).map(
+        (auditCase) => auditCase.route,
+      ),
+    );
     const unaudited = [...registered].filter((p) => !audited.has(p));
     expect(
       unaudited,
@@ -732,9 +829,7 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
           // The loading skeleton has readable column labels, so the generic
           // paint gate cannot prove the canonical list DTO was accepted.
           await expect(
-            page.getByRole("link", { name: "Smoke Agent" }).filter({
-              visible: true,
-            }),
+            page.getByText("Eliza", { exact: true }).filter({ visible: true }),
           ).toBeVisible({ timeout: 10_000 });
         }
 
@@ -961,6 +1056,240 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
         ).toEqual([]);
       });
     }
+  }
+
+  for (const viewport of TRANSITION_VIEWPORTS) {
+    test(`Shared to Dedicated transition ${viewport.name}`, async ({
+      page,
+    }) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error.message));
+      page.on("console", (message) => {
+        if (message.type() === "error") consoleErrors.push(message.text());
+      });
+      await page.setViewportSize(viewport);
+      await seedStewardToken(page);
+      const fixture = await installCloudApiStubs(page, {
+        initialAgentState: "shared",
+        creditBalance: 42,
+      });
+      await openAppPath(page, "/cloud/agents");
+
+      const upgradeButton = page.getByTestId("agent-upgrade-tier-button");
+      await expect(upgradeButton).toHaveText("Upgrade to Dedicated");
+      await expect(page.getByText("Free", { exact: true })).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Deactivate Agent" }),
+      ).toHaveCount(0);
+      await expect(
+        page.getByRole("button", { name: "Delete Agent" }),
+      ).toHaveCount(0);
+      await captureTransitionState({
+        page,
+        outputDir,
+        viewport,
+        state: "shared",
+        consoleErrors,
+        pageErrors,
+        hoverTarget: upgradeButton,
+      });
+
+      await upgradeButton.click();
+      await expect(
+        page.getByRole("heading", {
+          name: "Upgrade to a Dedicated Agent?",
+        }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(
+          "Current balance: $42.00 · Required before activation: $9.00 (3 days)",
+        ),
+      ).toBeVisible();
+      const activateButton = page.getByTestId("agent-upgrade-tier-confirm");
+      await captureTransitionState({
+        page,
+        outputDir,
+        viewport,
+        state: "quote",
+        consoleErrors,
+        pageErrors,
+        hoverTarget: activateButton,
+      });
+
+      await activateButton.click();
+      const progress = page.getByTestId("agent-upgrade-progress");
+      await expect(progress).toBeVisible();
+      await expect.poll(() => fixture.agentState).toBe("provisioning");
+      const upgradePath =
+        "/api/v1/eliza/agents/personal%3A00000000-0000-5000-8000-000000000001/upgrade-tier";
+      await expect
+        .poll(() =>
+          fixture.requests.some(
+            (receipt) =>
+              receipt.pathname === `${upgradePath}/cutover` &&
+              receipt.status === 409,
+          ),
+        )
+        .toBe(true);
+      const expectedConflictMessage =
+        "Failed to load resource: the server responded with a status of 409 (Conflict)";
+      const expectedConflictIndex = consoleErrors.indexOf(
+        expectedConflictMessage,
+      );
+      if (expectedConflictIndex >= 0) {
+        consoleErrors.splice(expectedConflictIndex, 1);
+      }
+      await captureTransitionState({
+        page,
+        outputDir,
+        viewport,
+        state: "provisioning",
+        consoleErrors,
+        pageErrors,
+      });
+
+      fixture.completeProvisioning();
+      await expect(page).toHaveURL(
+        new RegExp(`/cloud/agents/${CLOUD_AUDIT_DEDICATED_AGENT_ID}$`),
+        { timeout: 15_000 },
+      );
+      await openAppPath(page, "/cloud/agents");
+      await expect(
+        page.getByText("Eliza", { exact: true }).filter({ visible: true }),
+      ).toBeVisible();
+      await expect(page.getByTestId("agent-upgrade-tier-button")).toHaveCount(
+        0,
+      );
+      await expect.poll(() => fixture.agentState).toBe("dedicated");
+      await captureTransitionState({
+        page,
+        outputDir,
+        viewport,
+        state: "dedicated",
+        consoleErrors,
+        pageErrors,
+        hoverTarget: page
+          .getByRole("button", { name: "Open Web UI" })
+          .filter({ visible: true })
+          .first(),
+      });
+
+      const activationRequests = fixture.requests.filter(
+        (receipt) =>
+          receipt.method === "POST" &&
+          receipt.pathname === upgradePath &&
+          receipt.status === 202,
+      );
+      expect(activationRequests).toHaveLength(1);
+      expect(activationRequests[0]?.body).toBe(
+        JSON.stringify({
+          action: "activate_dedicated",
+          quoteId:
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        }),
+      );
+      const cutoverRequests = fixture.requests.filter(
+        (receipt) => receipt.pathname === `${upgradePath}/cutover`,
+      );
+      expect(cutoverRequests.map((receipt) => receipt.status)).toEqual([
+        409, 200,
+      ]);
+      expect(cutoverRequests.at(-1)?.responseBody).toBe(
+        JSON.stringify({
+          success: true,
+          data: {
+            personalElizaId: "personal:00000000-0000-5000-8000-000000000001",
+            activeAgentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
+            runtime: "dedicated",
+            apiBase: `https://${CLOUD_AUDIT_DEDICATED_AGENT_ID}.cloud.eliza.app`,
+            importedMessages: 4,
+            importedScheduledTasks: 1,
+            importedTodos: 2,
+            importedTodoMutations: 0,
+          },
+        }),
+      );
+      expect(pageErrors).toEqual([]);
+      expect(consoleErrors).toEqual([]);
+      expect(fixture.unhandledRequests).toEqual([]);
+
+      const requestDir = path.join(outputDir, "requests");
+      await mkdir(requestDir, { recursive: true });
+      await writeFile(
+        path.join(requestDir, `shared-to-dedicated-${viewport.name}.json`),
+        JSON.stringify(fixture.requests, null, 2),
+        "utf8",
+      );
+    });
+
+    test(`zero-credit Shared agent routes to Billing ${viewport.name}`, async ({
+      page,
+    }) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error.message));
+      page.on("console", (message) => {
+        if (message.type() === "error") consoleErrors.push(message.text());
+      });
+      await page.setViewportSize(viewport);
+      await seedStewardToken(page);
+      const fixture = await installCloudApiStubs(page, {
+        initialAgentState: "shared",
+        creditBalance: 0,
+        quoteCanActivate: false,
+      });
+      await openAppPath(page, "/cloud/agents");
+
+      const addFundsButton = page.getByRole("button", {
+        name: "Add funds to upgrade",
+      });
+      await expect(addFundsButton).toBeVisible();
+      await addFundsButton.click();
+      await expect(
+        page.getByRole("alert").getByText(/Insufficient credits to upgrade\./),
+      ).toBeVisible();
+      const billingButton = page
+        .getByRole("alertdialog")
+        .getByRole("button", { name: "Add funds to upgrade" });
+      await captureTransitionState({
+        page,
+        outputDir,
+        viewport,
+        state: "zero-credit",
+        consoleErrors,
+        pageErrors,
+        hoverTarget: billingButton,
+      });
+      await billingButton.click();
+      await expect(page).toHaveURL(/\/cloud\/billing$/);
+      await expect(
+        page.getByRole("heading", { name: "Credit Balance" }),
+      ).toBeVisible();
+      await expect(page.getByText("$0.00", { exact: true })).toBeVisible();
+
+      expect(fixture.agentState).toBe("shared");
+      expect(
+        fixture.requests.filter(
+          (receipt) =>
+            receipt.method !== "GET" &&
+            receipt.pathname.startsWith(
+              "/api/v1/eliza/agents/personal%3A00000000-0000-5000-8000-000000000001/upgrade-tier",
+            ),
+        ),
+      ).toEqual([]);
+      expect(pageErrors).toEqual([]);
+      expect(consoleErrors).toEqual([]);
+      expect(fixture.unhandledRequests).toEqual([]);
+
+      const requestDir = path.join(outputDir, "requests");
+      await mkdir(requestDir, { recursive: true });
+      await writeFile(
+        path.join(requestDir, `zero-credit-${viewport.name}.json`),
+        JSON.stringify(fixture.requests, null, 2),
+        "utf8",
+      );
+    });
   }
 
   test.afterAll(async () => {

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -1062,11 +1062,18 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
     test(`Shared to Dedicated transition ${viewport.name}`, async ({
       page,
     }) => {
+      const expectedCutoverConflictMessage =
+        "Failed to load resource: the server responded with a status of 409 (Conflict)";
       const consoleErrors: string[] = [];
       const pageErrors: string[] = [];
       page.on("pageerror", (error) => pageErrors.push(error.message));
       page.on("console", (message) => {
-        if (message.type() === "error") consoleErrors.push(message.text());
+        if (
+          message.type() === "error" &&
+          message.text() !== expectedCutoverConflictMessage
+        ) {
+          consoleErrors.push(message.text());
+        }
       });
       await page.setViewportSize(viewport);
       await seedStewardToken(page);
@@ -1132,14 +1139,13 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
           ),
         )
         .toBe(true);
-      const expectedConflictMessage =
-        "Failed to load resource: the server responded with a status of 409 (Conflict)";
-      const expectedConflictIndex = consoleErrors.indexOf(
-        expectedConflictMessage,
-      );
-      if (expectedConflictIndex >= 0) {
-        consoleErrors.splice(expectedConflictIndex, 1);
-      }
+      await expect(page.getByText("Free", { exact: true })).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Deactivate Agent" }),
+      ).toHaveCount(0);
+      await expect(
+        page.getByRole("button", { name: "Delete Agent" }),
+      ).toHaveCount(0);
       await captureTransitionState({
         page,
         outputDir,
@@ -1192,9 +1198,12 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
       const cutoverRequests = fixture.requests.filter(
         (receipt) => receipt.pathname === `${upgradePath}/cutover`,
       );
-      expect(cutoverRequests.map((receipt) => receipt.status)).toEqual([
-        409, 200,
-      ]);
+      const cutoverStatuses = cutoverRequests.map((receipt) => receipt.status);
+      expect(cutoverStatuses.length).toBeGreaterThanOrEqual(2);
+      expect(cutoverStatuses.at(-1)).toBe(200);
+      expect(
+        cutoverStatuses.slice(0, -1).every((status) => status === 409),
+      ).toBe(true);
       expect(cutoverRequests.at(-1)?.responseBody).toBe(
         JSON.stringify({
           success: true,

--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -693,26 +693,27 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
         throw error;
       }
     };
-    let registeredPaths = await readRegistryPaths();
-    await expect
-      .poll(
-        async () => {
-          registeredPaths = await readRegistryPaths();
-          return registeredPaths.includes("cloud/agents");
-        },
-        {
-          message:
-            "private cloud-route registry populated by the running shell",
-          timeout: 30_000,
-        },
-      )
-      .toBe(true);
-    const registered = new Set(registeredPaths);
     const audited = new Set(
       CLOUD_AUDIT_CASES.filter((auditCase) => !auditCase.compatibilityPath).map(
         (auditCase) => auditCase.route,
       ),
     );
+    let registeredPaths = await readRegistryPaths();
+    await expect
+      .poll(
+        async () => {
+          registeredPaths = await readRegistryPaths();
+          // Private domains register in two asynchronous waves. One eager
+          // route does not prove that the complete route table is ready.
+          return [...audited].every((route) => registeredPaths.includes(route));
+        },
+        {
+          message: "all audited routes registered by the running shell",
+          timeout: 30_000,
+        },
+      )
+      .toBe(true);
+    const registered = new Set(registeredPaths);
     const unaudited = [...registered].filter((p) => !audited.has(p));
     expect(
       unaudited,
@@ -1188,13 +1189,14 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
           receipt.status === 202,
       );
       expect(activationRequests).toHaveLength(1);
-      expect(activationRequests[0]?.body).toBe(
-        JSON.stringify({
-          action: "activate_dedicated",
-          quoteId:
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        }),
-      );
+      const activationBody = activationRequests[0]?.body;
+      if (activationBody == null)
+        throw new Error("Activation request body is missing");
+      expect(JSON.parse(activationBody)).toEqual({
+        action: "activate_dedicated",
+        quoteId:
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      });
       const cutoverRequests = fixture.requests.filter(
         (receipt) => receipt.pathname === `${upgradePath}/cutover`,
       );
@@ -1204,21 +1206,6 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
       expect(
         cutoverStatuses.slice(0, -1).every((status) => status === 409),
       ).toBe(true);
-      expect(cutoverRequests.at(-1)?.responseBody).toBe(
-        JSON.stringify({
-          success: true,
-          data: {
-            personalElizaId: "personal:00000000-0000-5000-8000-000000000001",
-            activeAgentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
-            runtime: "dedicated",
-            apiBase: `https://${CLOUD_AUDIT_DEDICATED_AGENT_ID}.cloud.eliza.app`,
-            importedMessages: 4,
-            importedScheduledTasks: 1,
-            importedTodos: 2,
-            importedTodoMutations: 0,
-          },
-        }),
-      );
       expect(pageErrors).toEqual([]);
       expect(consoleErrors).toEqual([]);
       expect(fixture.unhandledRequests).toEqual([]);

--- a/packages/app/test/ui-smoke/helpers/cloud-audit-fixtures.ts
+++ b/packages/app/test/ui-smoke/helpers/cloud-audit-fixtures.ts
@@ -11,7 +11,7 @@ import {
   STEWARD_TOKEN_KEY,
   STEWARD_TOKEN_SCOPE_KEY,
 } from "@elizaos/shared/steward-session-client";
-import type { Page } from "@playwright/test";
+import type { Page, Route } from "@playwright/test";
 
 function makeJwt(payload: Record<string, unknown>): string {
   const encode = (value: object) =>
@@ -207,6 +207,40 @@ interface StubRule {
   body: unknown;
 }
 
+export type CloudAuditAgentState = "shared" | "provisioning" | "dedicated";
+
+export interface CloudAuditFixtureOptions {
+  initialAgentState?: CloudAuditAgentState;
+  creditBalance?: number;
+  quoteCanActivate?: boolean;
+}
+
+export interface CloudAuditRequestReceipt {
+  method: string;
+  url: string;
+  pathname: string;
+  status: number;
+  body: string | null;
+  responseBody: string;
+}
+
+export interface CloudAuditFixtureController {
+  readonly agentState: CloudAuditAgentState;
+  readonly requests: readonly CloudAuditRequestReceipt[];
+  readonly unhandledRequests: readonly string[];
+  completeProvisioning(): void;
+}
+
+const PERSONAL_AGENT_ID = "personal:00000000-0000-5000-8000-000000000001";
+export const CLOUD_AUDIT_DEDICATED_AGENT_ID =
+  "00000000-0000-4000-8000-000000000002";
+const DEDICATED_API_BASE = `https://${CLOUD_AUDIT_DEDICATED_AGENT_ID}.cloud.eliza.app`;
+const DEDICATED_QUOTE_ID =
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DEDICATED_JOB_ID = "00000000-0000-4000-8000-000000000003";
+const INSUFFICIENT_UPGRADE_CREDITS =
+  "Insufficient credits to upgrade. A dedicated agent costs $3.00/day of hosting, and upgrading requires a balance above $9.00 (3 days of hosting). Please add at least $9.00 to your account at /cloud/billing.";
+
 const path_ = (p: string) => (pathname: string) => pathname === p;
 const prefix = (p: string) => (pathname: string) => pathname.startsWith(p);
 
@@ -376,71 +410,18 @@ const STUB_RULES: StubRule[] = [
     match: path_("/api/browser-workspace"),
     body: { mode: "web", tabs: [] },
   },
-  // instances/ — canonical agent-list DTO plus detail.
   {
-    match: path_("/api/v1/eliza/personal"),
-    body: {
-      success: true,
-      data: {
-        identity: {
-          id: "personal:00000000-0000-5000-8000-000000000001",
-          displayName: "Eliza",
-          runtime: "dedicated",
-        },
-      },
-    },
+    match: path_("/api/status"),
+    body: { status: "running", canRespond: true },
   },
   {
-    match: path_("/api/v1/eliza/agents"),
-    body: {
-      success: true,
-      data: [
-        {
-          id: "agent-smoke-1",
-          agentName: "Smoke Agent",
-          status: "running",
-          databaseStatus: "ready",
-          lastBackupAt: null,
-          lastHeartbeatAt: NOW_ISO,
-          errorMessage: null,
-          createdAt: NOW_ISO,
-          updatedAt: NOW_ISO,
-          token_address: null,
-          token_chain: null,
-          token_name: null,
-          token_ticker: null,
-          dockerImage: null,
-          executionTier: "dedicated-lazy",
-          webUiUrl: "https://agent-smoke-1.cloud.eliza.app",
-          activeJob: null,
-        },
-      ],
-    },
-  },
-  {
-    match: path_("/api/v1/eliza/agents/agent-smoke-1"),
-    body: {
-      success: true,
-      data: {
-        id: "agent-smoke-1",
-        agentName: "Smoke Agent",
-        status: "running",
-        executionTier: "dedicated-lazy",
-        databaseStatus: "ready",
-        webUiUrl: "https://agent-smoke-1.cloud.eliza.app",
-        bridgeUrl: null,
-        errorMessage: null,
-        createdAt: NOW_ISO,
-        updatedAt: NOW_ISO,
-      },
-    },
-  },
-  {
-    match: path_("/api/v1/eliza/agents/agent-smoke-1/backups"),
+    match: path_(
+      `/api/v1/eliza/agents/${CLOUD_AUDIT_DEDICATED_AGENT_ID}/backups`,
+    ),
     body: { success: true, data: [] },
   },
   {
-    match: path_("/api/compat/agents/agent-smoke-1/logs"),
+    match: path_(`/api/compat/agents/${CLOUD_AUDIT_DEDICATED_AGENT_ID}/logs`),
     body: { success: true, data: "" },
   },
   {
@@ -496,8 +477,6 @@ const STUB_RULES: StubRule[] = [
     },
   },
   // billing/ — credits, settings, invoices, crypto (fail-soft), checkout.
-  { match: path_("/api/v1/credits/balance"), body: { balance: 42 } },
-  { match: path_("/api/credits/balance"), body: { balance: 42 } },
   {
     match: path_("/api/v1/billing/limits"),
     body: {
@@ -533,6 +512,16 @@ const STUB_RULES: StubRule[] = [
                   lastBilledAt: null,
                   nextBillingAt: BILLING_CONTAINER_NEXT_ISO,
                   estimatedNextBillingAt: null,
+                  cancellationControl: {
+                    displayAction: "stop",
+                    method: "POST",
+                    mode: "stop",
+                    endpoint:
+                      "/api/v1/billing/resources/container-smoke-api/cancel?resourceType=container",
+                    expectedLifecycleRevision: 1,
+                    eligible: true,
+                    blockers: [],
+                  },
                   ratePerHour: {
                     status: "available",
                     source: "compute-billing-rate-segments",
@@ -564,6 +553,16 @@ const STUB_RULES: StubRule[] = [
                   lastBilledAt: BILLING_SANDBOX_LAST_ISO,
                   nextBillingAt: null,
                   estimatedNextBillingAt: BILLING_SANDBOX_ESTIMATED_NEXT_ISO,
+                  cancellationControl: {
+                    displayAction: "stop_compute",
+                    method: "POST",
+                    mode: "stop",
+                    endpoint:
+                      "/api/v1/billing/resources/sandbox-smoke-research/cancel?resourceType=agent_sandbox",
+                    expectedLifecycleRevision: 2,
+                    eligible: true,
+                    blockers: [],
+                  },
                   ratePerHour: {
                     status: "available",
                     source: "compute-billing-rate-segments",
@@ -817,7 +816,7 @@ const STUB_RULES: StubRule[] = [
       approvalRequest: {
         id: "approval-smoke-1",
         organizationId: "org-smoke-1",
-        agentId: "agent-smoke-1",
+        agentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
         userId: null,
         challengeKind: "signature",
         challengePayload: {
@@ -974,8 +973,303 @@ const STUB_RULES: StubRule[] = [
   { match: path_("/api/v1/blooio/status"), body: { connected: false } },
 ];
 
-export async function installCloudApiStubs(page: Page): Promise<void> {
-  const handle = async (route: import("@playwright/test").Route) => {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function billingLimitsBody(creditBalance: number): unknown {
+  const rule = STUB_RULES.find((candidate) =>
+    candidate.match("/api/v1/billing/limits", new URLSearchParams()),
+  );
+  const body = structuredClone(rule?.body);
+  if (
+    !isRecord(body) ||
+    !isRecord(body.data) ||
+    !isRecord(body.data.v2) ||
+    !isRecord(body.data.v2.balance) ||
+    !isRecord(body.data.v2.balance.value)
+  ) {
+    throw new Error("Cloud audit billing fixture has an invalid balance shape");
+  }
+  body.data.v2.balance.value.balance = {
+    value: creditBalance.toFixed(6),
+    unit: "usd",
+    currency: "USD",
+  };
+  body.data.v2.balance.value.revision = String(creditBalance);
+  return body;
+}
+
+export async function installCloudApiStubs(
+  page: Page,
+  options: CloudAuditFixtureOptions = {},
+): Promise<CloudAuditFixtureController> {
+  let agentState = options.initialAgentState ?? "dedicated";
+  let provisioningComplete = false;
+  const creditBalance = options.creditBalance ?? 42;
+  const quoteCanActivate = options.quoteCanActivate ?? true;
+  const requests: CloudAuditRequestReceipt[] = [];
+  const unhandledRequests: string[] = [];
+  const upgradePath = `/api/v1/eliza/agents/${encodeURIComponent(PERSONAL_AGENT_ID)}/upgrade-tier`;
+  const cutoverPath = `${upgradePath}/cutover`;
+
+  const dedicatedAgent = () => ({
+    id: CLOUD_AUDIT_DEDICATED_AGENT_ID,
+    agentName: "Eliza",
+    status: agentState === "provisioning" ? "provisioning" : "running",
+    databaseStatus: agentState === "provisioning" ? "provisioning" : "ready",
+    lastBackupAt: null,
+    lastHeartbeatAt: NOW_ISO,
+    errorMessage: null,
+    createdAt: NOW_ISO,
+    updatedAt: NOW_ISO,
+    token_address: null,
+    token_chain: null,
+    token_name: null,
+    token_ticker: null,
+    dockerImage: null,
+    executionTier: "dedicated-always",
+    webUiUrl: agentState === "provisioning" ? null : DEDICATED_API_BASE,
+    activeJob:
+      agentState === "provisioning"
+        ? {
+            id: DEDICATED_JOB_ID,
+            type: "provision",
+            status: "in_progress",
+            attempts: 1,
+            maxAttempts: 3,
+            estimatedCompletionAt: FUTURE_ISO,
+            scheduledFor: NOW_ISO,
+            startedAt: NOW_ISO,
+            createdAt: NOW_ISO,
+            updatedAt: NOW_ISO,
+          }
+        : null,
+  });
+
+  const fulfill = async (
+    route: Route,
+    status: number,
+    body: unknown,
+    headers?: Record<string, string>,
+  ): Promise<void> => {
+    const request = route.request();
+    const responseBody = typeof body === "string" ? body : JSON.stringify(body);
+    await route.fulfill({
+      status,
+      contentType: "application/json",
+      headers,
+      body: responseBody,
+    });
+    requests.push({
+      method: request.method(),
+      url: request.url(),
+      pathname: new URL(request.url()).pathname,
+      status,
+      body: request.postData(),
+      responseBody,
+    });
+  };
+
+  const handleAgentFixture = async (route: Route): Promise<boolean> => {
+    const request = route.request();
+    const { pathname } = new URL(request.url());
+    const method = request.method();
+
+    if (method === "GET" && pathname === "/api/v1/eliza/personal") {
+      await fulfill(route, 200, {
+        success: true,
+        data: {
+          identity:
+            agentState === "dedicated"
+              ? {
+                  id: PERSONAL_AGENT_ID,
+                  displayName: "Eliza",
+                  runtime: "dedicated",
+                  activeAgentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
+                  apiBase: DEDICATED_API_BASE,
+                }
+              : {
+                  id: PERSONAL_AGENT_ID,
+                  displayName: "Eliza",
+                  runtime: "shared",
+                },
+        },
+      });
+      return true;
+    }
+
+    if (method === "GET" && pathname === "/api/v1/eliza/agents") {
+      await fulfill(route, 200, {
+        success: true,
+        data: agentState === "shared" ? [] : [dedicatedAgent()],
+      });
+      return true;
+    }
+
+    if (
+      method === "GET" &&
+      pathname === `/api/v1/eliza/agents/${CLOUD_AUDIT_DEDICATED_AGENT_ID}`
+    ) {
+      await fulfill(route, 200, {
+        success: true,
+        data: {
+          ...dedicatedAgent(),
+          errorCount: 0,
+          meshAddressPresent: true,
+          walletAddress: null,
+          walletProvider: null,
+          walletStatus: "none",
+          adminDetails: null,
+        },
+      });
+      return true;
+    }
+
+    if (
+      method === "GET" &&
+      (pathname === "/api/v1/credits/balance" ||
+        pathname === "/api/credits/balance")
+    ) {
+      await fulfill(route, 200, { balance: creditBalance });
+      return true;
+    }
+
+    if (method === "GET" && pathname === "/api/v1/user") {
+      await fulfill(route, 200, {
+        success: true,
+        data: {
+          ...SMOKE_USER,
+          organization: {
+            ...SMOKE_USER.organization,
+            credit_balance: creditBalance.toFixed(2),
+          },
+        },
+      });
+      return true;
+    }
+
+    if (method === "POST" && pathname === "/api/views/cloud/navigate") {
+      await fulfill(route, 200, { success: true });
+      return true;
+    }
+
+    if (method === "GET" && pathname === "/api/v1/billing/limits") {
+      await fulfill(route, 200, billingLimitsBody(creditBalance));
+      return true;
+    }
+
+    if (method === "GET" && pathname === upgradePath) {
+      await fulfill(route, 200, {
+        success: true,
+        data: {
+          quoteId: DEDICATED_QUOTE_ID,
+          sourceAgentId: PERSONAL_AGENT_ID,
+          hourlyRateUsd: 0.125,
+          dailyRateUsd: 3,
+          minimumBalanceUsd: 9,
+          minimumRunwayDays: 3,
+          balanceUsd: creditBalance,
+          deficitUsd: quoteCanActivate ? 0 : 9 - creditBalance,
+          canActivate: quoteCanActivate,
+          requiresConfirmation: true,
+          action: "activate_dedicated",
+          ...(quoteCanActivate
+            ? {}
+            : {
+                unavailableReason: INSUFFICIENT_UPGRADE_CREDITS,
+              }),
+          activation: { state: "available" },
+        },
+      });
+      return true;
+    }
+
+    if (method === "POST" && pathname === upgradePath) {
+      const expectedBody = JSON.stringify({
+        action: "activate_dedicated",
+        quoteId: DEDICATED_QUOTE_ID,
+      });
+      if (request.postData() !== expectedBody) {
+        await fulfill(route, 400, {
+          success: false,
+          error: "Activation request did not match the quoted action.",
+        });
+        return true;
+      }
+      if (!quoteCanActivate) {
+        await fulfill(route, 402, {
+          success: false,
+          error: "Add funds before activating Dedicated.",
+        });
+        return true;
+      }
+      agentState = "provisioning";
+      await fulfill(route, 202, {
+        success: true,
+        data: {
+          dedicatedAgentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
+          jobId: DEDICATED_JOB_ID,
+        },
+      });
+      return true;
+    }
+
+    if (method === "GET" && pathname === `/api/v1/jobs/${DEDICATED_JOB_ID}`) {
+      await fulfill(route, 200, {
+        success: true,
+        data: {
+          status: provisioningComplete ? "completed" : "in_progress",
+          error: null,
+          attempts: 1,
+          maxAttempts: 3,
+          estimatedCompletionAt: provisioningComplete ? null : FUTURE_ISO,
+        },
+      });
+      return true;
+    }
+
+    if (method === "POST" && pathname === cutoverPath) {
+      const expectedBody = JSON.stringify({
+        dedicatedAgentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
+      });
+      if (request.postData() !== expectedBody) {
+        await fulfill(route, 400, {
+          success: false,
+          error: "Cutover request did not name the Dedicated target.",
+        });
+        return true;
+      }
+      if (!provisioningComplete) {
+        await fulfill(route, 409, {
+          success: false,
+          code: "dedicated_not_healthy",
+          error: "Dedicated is not healthy yet.",
+        });
+        return true;
+      }
+      await fulfill(route, 200, {
+        success: true,
+        data: {
+          personalElizaId: PERSONAL_AGENT_ID,
+          activeAgentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
+          runtime: "dedicated",
+          apiBase: DEDICATED_API_BASE,
+          importedMessages: 4,
+          importedScheduledTasks: 1,
+          importedTodos: 2,
+          importedTodoMutations: 0,
+        },
+      });
+      agentState = "dedicated";
+      return true;
+    }
+
+    return false;
+  };
+
+  const handle = async (route: Route) => {
+    if (await handleAgentFixture(route)) return;
     const request = route.request();
     const url = new URL(request.url());
     const rule = STUB_RULES.find(
@@ -984,16 +1278,11 @@ export async function installCloudApiStubs(page: Page): Promise<void> {
         r.match(url.pathname, url.searchParams),
     );
     if (!rule) {
+      unhandledRequests.push(`${request.method()} ${request.url()}`);
       await route.fallback();
       return;
     }
-    await route.fulfill({
-      status: rule.status ?? 200,
-      contentType: "application/json",
-      headers: rule.headers,
-      body:
-        typeof rule.body === "string" ? rule.body : JSON.stringify(rule.body),
-    });
+    await fulfill(route, rule.status ?? 200, rule.body, rule.headers);
   };
   // Covers /api/v1/*, /api/analytics/*, /api/invoices/*, /api/credits/*,
   // /api/crypto/*, /api/mcp/*, /api/characters/*, /api/invites/*,
@@ -1004,4 +1293,25 @@ export async function installCloudApiStubs(page: Page): Promise<void> {
   await page.route("**/steward/**", handle);
   // The admin RPC-status probe has no /api prefix (worker route /admin/rpc-status).
   await page.route("**/admin/rpc-status*", handle);
+  await page.route("**/build-info.json", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ generatedAt: NOW_ISO, branch: "cloud-audit" }),
+    });
+  });
+  return {
+    get agentState() {
+      return agentState;
+    },
+    requests,
+    unhandledRequests,
+    completeProvisioning() {
+      provisioningComplete = true;
+    },
+  };
 }

--- a/packages/app/test/ui-smoke/helpers/cloud-audit-fixtures.ts
+++ b/packages/app/test/ui-smoke/helpers/cloud-audit-fixtures.ts
@@ -6,12 +6,23 @@
  * session-not-ready loading spinner instead of the real analytics/earnings
  * tab. Keeping one source of truth avoids drift between the two specs.
  */
+import { isDeepStrictEqual } from "node:util";
 import {
   STEWARD_ACTIVE_SCOPE_KEY,
   STEWARD_TOKEN_KEY,
   STEWARD_TOKEN_SCOPE_KEY,
 } from "@elizaos/shared/steward-session-client";
-import type { Page, Route } from "@playwright/test";
+import type { Page, Request, Route } from "@playwright/test";
+
+function requestBodyMatches(request: Request, expected: object): boolean {
+  try {
+    const body: unknown = request.postDataJSON();
+    return isDeepStrictEqual(body, expected);
+  } catch {
+    // error-policy:J3 Malformed request JSON is an explicit fixture rejection.
+    return false;
+  }
+}
 
 function makeJwt(payload: Record<string, unknown>): string {
   const encode = (value: object) =>
@@ -1186,11 +1197,11 @@ export async function installCloudApiStubs(
     }
 
     if (method === "POST" && pathname === upgradePath) {
-      const expectedBody = JSON.stringify({
+      const expectedBody = {
         action: "activate_dedicated",
         quoteId: DEDICATED_QUOTE_ID,
-      });
-      if (request.postData() !== expectedBody) {
+      };
+      if (!requestBodyMatches(request, expectedBody)) {
         await fulfill(route, 400, {
           success: false,
           error: "Activation request did not match the quoted action.",
@@ -1230,10 +1241,10 @@ export async function installCloudApiStubs(
     }
 
     if (method === "POST" && pathname === cutoverPath) {
-      const expectedBody = JSON.stringify({
+      const expectedBody = {
         dedicatedAgentId: CLOUD_AUDIT_DEDICATED_AGENT_ID,
-      });
-      if (request.postData() !== expectedBody) {
+      };
+      if (!requestBodyMatches(request, expectedBody)) {
         await fulfill(route, 400, {
           success: false,
           error: "Cutover request did not name the Dedicated target.",


### PR DESCRIPTION
The cloud audit previously started every agent as Dedicated, leaving the Shared upgrade and insufficient-credit journeys untested. This change drives the real renderer from Shared through quote, activation, pending cutover, and Dedicated, and verifies that insufficient credit opens Billing without an upgrade mutation.

The fixture now compares parsed JSON request bodies, so key order does not change validity. Route coverage waits for both registration waves before comparing the registered routes. Audit cleanup retains the separately owned dropdown evidence.

Closes #22535.

Validation on the reviewed revision:

- Root `bun run verify`: all 376 workspace tasks and all repository audits passed.
- Full app tests: 948 Bun tests passed, two skipped; 1,606 Vitest tests passed.
- App typecheck and lint passed; audit-output boundary tests passed.
- Full cloud audit: 106 passed, one intentional skip.
- Full app visual audit: 219 passed, zero broken or needs-work verdicts.
- Recorded desktop, mobile, and tablet transition and credit-recovery journeys: six passed. All 30 rest/hover images and six recordings were inspected.

The original fixture failed the route inventory check because it compared before the second registration wave. The repaired full audit passed. The transition checks cover activation request contents, retryable cutover, retained Shared state during provisioning, and final Dedicated visibility; they do not assert fixture-only import counters as proof of production import.

Evidence: [inspected state captures](https://github.com/elizaOS/eliza/pull/30459#issuecomment-5553885011), [MP4 walkthroughs and HTTP receipts](https://github.com/elizaOS/eliza/pull/30459#issuecomment-5553890807). Browser diagnostic report and runner log are attached in the following comment.

This is deterministic browser acceptance coverage. Live paid provisioning, production backend logs, native/device captures, and model trajectories are N/A. There is no product UI change requiring a before/after comparison.
