### PR TITLE
test(cloud): pin the SIWS message parse and signature verify

### DIFF
--- a/packages/cloud/shared/src/lib/utils/siws-helpers.test.ts
+++ b/packages/cloud/shared/src/lib/utils/siws-helpers.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Exercises the SIWS message parser and validator directly.
+ *
+ * `siws-helpers.security.test.ts` covers the uri/chainId binding through
+ * `validateAndConsumeSIWS`; nothing referenced `parseSiwsMessage` or
+ * `validateSIWSMessage`. Mutating each guard, the signature check itself
+ * (`if (!ok)`) survived — so these pin the parse and the verify, not the
+ * nonce store.
+ *
+ * Signatures here are REAL ed25519 signatures (tweetnacl) over the REAL
+ * message bytes; nothing is stubbed.
+ */
+
+import { describe, expect, test } from "bun:test";
+import bs58 from "bs58";
+import nacl from "tweetnacl";
+import { buildSiwsMessage, parseSiwsMessage, validateSIWSMessage } from "./siws-helpers";
+
+const HOST = "app.example.com";
+const URI = "https://app.example.com";
+const CHAIN = "solana:mainnet";
+const NONCE = "0123456789abcdef0123456789abcdef";
+
+function keypair() {
+  const kp = nacl.sign.keyPair();
+  return { kp, address: bs58.encode(kp.publicKey) };
+}
+
+function signed(
+  over: Partial<Parameters<typeof buildSiwsMessage>[0]> = {},
+  mutate: (message: string) => string = (m) => m,
+) {
+  const { kp, address } = keypair();
+  const message = mutate(
+    buildSiwsMessage({
+      domain: HOST,
+      address,
+      statement: "Sign in",
+      uri: URI,
+      chainId: CHAIN,
+      nonce: NONCE,
+      issuedAt: new Date(),
+      ...over,
+    }),
+  );
+  const signature = bs58.encode(
+    nacl.sign.detached(new TextEncoder().encode(message), kp.secretKey),
+  );
+  return { message, signature, address, kp };
+}
+
+describe("parseSiwsMessage", () => {
+  test("round-trips what buildSiwsMessage produces", () => {
+    const { kp, address } = keypair();
+    const issuedAt = new Date("2026-01-02T03:04:05.000Z");
+    const expirationTime = new Date("2026-01-02T04:04:05.000Z");
+    const message = buildSiwsMessage({
+      domain: HOST,
+      address,
+      statement: "Sign in",
+      uri: URI,
+      chainId: CHAIN,
+      nonce: NONCE,
+      issuedAt,
+      expirationTime,
+    });
+    const parsed = parseSiwsMessage(message);
+    expect(parsed).toMatchObject({
+      domain: HOST,
+      address,
+      statement: "Sign in",
+      uri: URI,
+      version: "1",
+      chainId: CHAIN,
+      nonce: NONCE,
+    });
+    expect(parsed.issuedAt.toISOString()).toBe(issuedAt.toISOString());
+    expect(parsed.expirationTime?.toISOString()).toBe(expirationTime.toISOString());
+    expect(parsed.notBefore).toBeUndefined();
+    expect(kp.publicKey.length).toBe(32);
+  });
+
+  test("parses a message with no statement", () => {
+    const { address } = keypair();
+    const message = buildSiwsMessage({
+      domain: HOST,
+      address,
+      uri: URI,
+      chainId: CHAIN,
+      nonce: NONCE,
+      issuedAt: new Date(),
+    });
+    const parsed = parseSiwsMessage(message);
+    expect(parsed.statement).toBeUndefined();
+    expect(parsed.uri).toBe(URI);
+  });
+
+  // A statement is detected by "the line after the blank has no colon". A
+  // statement that legitimately contains one is therefore read as a field
+  // line, not as the statement — pinned as the parser's actual behaviour so a
+  // future change to the heuristic is a visible decision.
+  test("does not treat a colon-bearing statement as a statement", () => {
+    const { address } = keypair();
+    const message = buildSiwsMessage({
+      domain: HOST,
+      address,
+      statement: "Sign in: to Eliza",
+      uri: URI,
+      chainId: CHAIN,
+      nonce: NONCE,
+      issuedAt: new Date(),
+    });
+    const parsed = parseSiwsMessage(message);
+    expect(parsed.statement).toBeUndefined();
+    expect(parsed.uri).toBe(URI);
+    expect(parsed.nonce).toBe(NONCE);
+  });
+
+  test("rejects a message shorter than the minimum line count", () => {
+    expect(() => parseSiwsMessage("a\nb\nc")).toThrow(/too short/);
+  });
+
+  test.each([
+    ["a missing header", "not a header at all"],
+    ["a header with trailing text", `${HOST} wants you to sign in with your Solana account: now`],
+  ])("rejects %s", (_label, header) => {
+    const { address } = keypair();
+    const body = [
+      header,
+      address,
+      "",
+      `URI: ${URI}`,
+      "Version: 1",
+      `Chain ID: ${CHAIN}`,
+      `Nonce: ${NONCE}`,
+      `Issued At: ${new Date().toISOString()}`,
+    ].join("\n");
+    expect(() => parseSiwsMessage(body)).toThrow(/missing header/);
+  });
+
+  // The address pattern is anchored at both ends. Without the trailing `$`,
+  // an address with appended bytes parses as valid and is then handed to
+  // bs58.decode as the signer identity.
+  test.each([
+    ["trailing punctuation", "11111111111111111111111111111112!"],
+    ["a leading zero (not base58)", "011111111111111111111111111111112"],
+    ["too short", "1111111111111111111111111111111"],
+    ["a non-base58 alphabet", "OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO"],
+    ["an empty line", ""],
+  ])("rejects an address with %s", (_label, address) => {
+    const body = [
+      `${HOST} wants you to sign in with your Solana account:`,
+      address,
+      "",
+      `URI: ${URI}`,
+      "Version: 1",
+      `Chain ID: ${CHAIN}`,
+      `Nonce: ${NONCE}`,
+      `Issued At: ${new Date().toISOString()}`,
+    ].join("\n");
+    expect(() => parseSiwsMessage(body)).toThrow(/valid base58 Solana address|too short/);
+  });
+
+  test.each([
+    ["URI", "URI"],
+    ["Version", "Version"],
+    ["Chain ID", "Chain ID"],
+    ["Nonce", "Nonce"],
+    ["Issued At", "Issued At"],
+  ])("rejects a message missing %s", (_label, field) => {
+    const { address } = keypair();
+    const lines = [
+      `${HOST} wants you to sign in with your Solana account:`,
+      address,
+      "",
+      `URI: ${URI}`,
+      "Version: 1",
+      `Chain ID: ${CHAIN}`,
+      `Nonce: ${NONCE}`,
+      `Issued At: ${new Date().toISOString()}`,
+      "Padding One: x",
+      "Padding Two: x",
+    ].filter((line) => !line.startsWith(`${field}:`));
+    expect(() => parseSiwsMessage(lines.join("\n"))).toThrow(/missing required field/);
+  });
+
+  test("rejects an unparseable Issued At", () => {
+    const { address } = keypair();
+    const body = [
+      `${HOST} wants you to sign in with your Solana account:`,
+      address,
+      "",
+      `URI: ${URI}`,
+      "Version: 1",
+      `Chain ID: ${CHAIN}`,
+      `Nonce: ${NONCE}`,
+      "Issued At: yesterday-ish",
+    ].join("\n");
+    expect(() => parseSiwsMessage(body)).toThrow(/Issued At is not a valid date/);
+  });
+});
+
+describe("validateSIWSMessage", () => {
+  test("accepts a real signature over a well-formed message", () => {
+    const { message, signature, address } = signed();
+    const result = validateSIWSMessage(message, signature, HOST);
+    expect(result.address).toBe(address);
+    expect(result.parsed.nonce).toBe(NONCE);
+  });
+
+  // The one that mattered most: nothing in the suite failed when the
+  // `nacl.sign.detached.verify` result was ignored.
+  test("rejects a signature made by a different key", () => {
+    const { message } = signed();
+    const other = nacl.sign.keyPair();
+    const foreign = bs58.encode(
+      nacl.sign.detached(new TextEncoder().encode(message), other.secretKey),
+    );
+    expect(() => validateSIWSMessage(message, foreign, HOST)).toThrow(/signature invalid/);
+  });
+
+  test("rejects a valid signature over different bytes", () => {
+    const { signature } = signed();
+    const { message: otherMessage } = signed({ nonce: "f".repeat(32) });
+    expect(() => validateSIWSMessage(otherMessage, signature, HOST)).toThrow(/signature invalid/);
+  });
+
+  // A single flipped byte anywhere in the signed text must invalidate it.
+  test("rejects a message tampered with after signing", () => {
+    const { message, signature } = signed();
+    const tampered = message.replace(`URI: ${URI}`, `URI: ${URI}/evil`);
+    expect(tampered).not.toBe(message);
+    expect(() => validateSIWSMessage(tampered, signature, HOST)).toThrow();
+  });
+
+  test("rejects a domain that is not the app host", () => {
+    const { message, signature } = signed({ domain: "evil.example.com" });
+    expect(() => validateSIWSMessage(message, signature, HOST)).toThrow(
+      /domain does not match app host/,
+    );
+  });
+
+  test("rejects a signature that is not 64 bytes", () => {
+    const { message } = signed();
+    const short = bs58.encode(new Uint8Array(63));
+    expect(() => validateSIWSMessage(message, short, HOST)).toThrow(/signature is not 64 bytes/);
+  });
+
+  // A 32-byte address is enforced separately from the base58 alphabet: a
+  // base58 string can be the right shape and still decode to the wrong length.
+  test("rejects an address that decodes to fewer than 32 bytes", () => {
+    // 31 high bytes so the base58 form is long enough to satisfy the address
+    // pattern — the point is that a well-formed address string can still
+    // decode to the wrong key length.
+    const shortKey = bs58.encode(new Uint8Array(31).fill(255));
+    expect(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(shortKey)).toBe(true);
+    const message = [
+      `${HOST} wants you to sign in with your Solana account:`,
+      shortKey,
+      "",
+      `URI: ${URI}`,
+      "Version: 1",
+      `Chain ID: ${CHAIN}`,
+      `Nonce: ${NONCE}`,
+      `Issued At: ${new Date().toISOString()}`,
+    ].join("\n");
+    expect(() => validateSIWSMessage(message, bs58.encode(new Uint8Array(64)), HOST)).toThrow(
+      /not a 32-byte ed25519 public key/,
+    );
+  });
+
+  test("rejects an expired message even with a valid signature", () => {
+    const { message, signature } = signed({
+      expirationTime: new Date(Date.now() - 60_000),
+    });
+    expect(() => validateSIWSMessage(message, signature, HOST)).toThrow(/has expired/);
+  });
+
+  test("accepts a message whose expiration is still in the future", () => {
+    const { message, signature } = signed({
+      expirationTime: new Date(Date.now() + 600_000),
+    });
+    expect(() => validateSIWSMessage(message, signature, HOST)).not.toThrow();
+  });
+
+  test("rejects a message that is not yet valid", () => {
+    const { message, signature } = signed(
+      {},
+      (m) => `${m}\nNot Before: ${new Date(Date.now() + 600_000).toISOString()}`,
+    );
+    expect(() => validateSIWSMessage(message, signature, HOST)).toThrow(/not yet valid/);
+  });
+
+  test("accepts a Not Before that has already passed", () => {
+    const { message, signature } = signed(
+      {},
+      (m) => `${m}\nNot Before: ${new Date(Date.now() - 600_000).toISOString()}`,
+    );
+    expect(() => validateSIWSMessage(message, signature, HOST)).not.toThrow();
+  });
+
+  // Recorded rather than asserted-as-desirable: `Expiration Time` and
+  // `Not Before` are parsed with `new Date(...)` and never checked for NaN,
+  // and `NaN <= now` / `NaN > now` are both false — so an unparseable value
+  // skips the window check instead of failing closed. `siwe-helpers.ts` has
+  // the same shape at its own lines 159/162, so this is a shared design point
+  // rather than a SIWS-only slip. Pinned here so a future NaN guard is a
+  // deliberate change with a failing test to update, not a silent one.
+  test.each([["Expiration Time"], ["Not Before"]])(
+    "currently ignores an unparseable %s rather than failing closed",
+    (field) => {
+      const { message, signature } = signed({}, (m) => `${m}\n${field}: whenever`);
+      const parsed = parseSiwsMessage(message);
+      const value = field === "Expiration Time" ? parsed.expirationTime : parsed.notBefore;
+      expect(value).toBeInstanceOf(Date);
+      expect(Number.isNaN(value?.getTime())).toBe(true);
+      expect(() => validateSIWSMessage(message, signature, HOST)).not.toThrow();
+    },
+  );
+
+  test("enforces the uri and chainId binding when one is supplied", () => {
+    const { message, signature } = signed();
+    expect(() =>
+      validateSIWSMessage(message, signature, HOST, { uri: URI, chainId: CHAIN }),
+    ).not.toThrow();
+    expect(() =>
+      validateSIWSMessage(message, signature, HOST, {
+        uri: "https://evil.example.com",
+        chainId: CHAIN,
+      }),
+    ).toThrow(/uri does not match/);
+    expect(() =>
+      validateSIWSMessage(message, signature, HOST, {
+        uri: URI,
+        chainId: "solana:devnet",
+      }),
+    ).toThrow(/chainId does not match/);
+  });
+});
+
+describe("buildSiwsMessage", () => {
+  test("emits Version 1 and omits absent optional lines", () => {
+    const { address } = keypair();
+    const message = buildSiwsMessage({
+      domain: HOST,
+      address,
+      uri: URI,
+      chainId: CHAIN,
+      nonce: NONCE,
+      issuedAt: new Date("2026-01-02T03:04:05.000Z"),
+    });
+    expect(message.split("\n")).toEqual([
+      `${HOST} wants you to sign in with your Solana account:`,
+      address,
+      "",
+      `URI: ${URI}`,
+      "Version: 1",
+      `Chain ID: ${CHAIN}`,
+      `Nonce: ${NONCE}`,
+      "Issued At: 2026-01-02T03:04:05.000Z",
+    ]);
+    expect(parseSiwsMessage(message).version).toBe("1");
+  });
+});


### PR DESCRIPTION
# What

`siws-helpers.security.test.ts` covers one thing well: the uri/chainId binding, through `validateAndConsumeSIWS`. Nothing referenced **`parseSiwsMessage`** or **`validateSIWSMessage`** — the message parser and the signature validator that sit under it.

# Evidence

Mutating each guard to a no-op, against the existing 4 tests:

| mutant | before | after |
|---|---|---|
| **`if (!ok)` around `nacl.sign.detached.verify`** | **survived** | killed |
| `pubkeyBytes.length !== 32` | **survived** | killed |
| `signatureBytes.length !== 64` | **survived** | killed |
| `parsed.domain !== expectedHost` | **survived** | killed |
| expiration window check | **survived** | killed |
| not-before window check | **survived** | killed |
| `lines.length < 7` | **survived** | killed |
| header regex: drop the trailing `$` | **survived** | killed |
| `SOLANA_ADDRESS_RE`: drop the trailing `$` | **survived** | killed |
| `SOLANA_ADDRESS_RE.test(address)` → `false` | **survived** | killed |
| required-field check → `false` | **survived** | killed |
| `Number.isNaN(issuedAt.getTime())` → `false` | **survived** | killed |
| statement heuristic `!line.includes(":")` → `true` | **survived** | killed |
| `buildSiwsMessage`: `Version: 1` → `Version: 2` | **survived** | killed |
| uri binding | killed | killed |
| chainId binding | killed | killed |
| header regex: drop the leading `^` | survived | **survived** — redundant, see below |

**15 of 17 survived; 16 now die.** 4 → **36 passing**. `bun run --cwd packages/cloud/shared typecheck` → exit 0, biome clean.

The first row is the one I'd read first: **removing SIWS signature verification entirely broke nothing.** The existing tests all sign correctly, so `verify` returning `false` was never exercised. There are now three separate cases for it — a signature from a different keypair, a valid signature over different bytes, and a message tampered with after signing.

Signatures throughout are real ed25519 over the real message bytes; nothing is stubbed, and this file needs no Redis at all.

# Two parser behaviours worth pinning explicitly

**The address pattern is anchored at both ends.** Drop the `$` and `<valid address>!` parses as a valid address and is handed to `bs58.decode` as the signer identity. Also covered: a leading `0` (not in the base58 alphabet), a too-short string, a non-base58 alphabet, and an empty line.

**A base58 string of the right shape can still decode to the wrong key length.** `bs58.encode(new Uint8Array(31).fill(255))` is 43 characters and passes the address pattern, so the explicit 32-byte check is doing separate work from the regex.

**The statement heuristic is "the line after the blank has no colon".** A statement that legitimately contains a colon (`"Sign in: to Eliza"`) is therefore *not* read as a statement. That is the parser's actual behaviour, and the test records it as such rather than as an aspiration — so a future change to the heuristic is a visible decision with a failing test to update.

# One thing I found and did not change

`Expiration Time` and `Not Before` are parsed with `new Date(...)` and never checked for `NaN`. Both window comparisons are then false:

```
"whenever"  -> getTime()=NaN   expired? (t <= now): false   notYetValid? (t > now): false
```

So an **unparseable** expiry skips the window check rather than failing closed — unlike `Issued At`, which is explicitly rejected with `Number.isNaN` a few lines above.

I did not change it, for two reasons. `siwe-helpers.ts` has the identical shape at its own `:159`/`:162`, so this is a shared design point across both sign-in paths rather than a SIWS-only slip — fixing one and not the other would be worse than fixing neither. And tightening a live auth window is a semantic change to authentication, which belongs in a deliberate PR of its own, not smuggled into a test-only one.

What I did instead is pin the current behaviour with a test that says so in its name (`currently ignores an unparseable … rather than failing closed`). If you decide to add a NaN guard, that test fails and is the right place to record the new decision.

Practical impact looks limited — the message is signed, the nonce is single-use, and `Issued At` is still validated — but a client can emit a message whose expiry is silently unenforceable, and nothing says that is intended.

# One survivor left deliberately

The leading `^` in the header regex is redundant: `(.+?)` requires at least one character, so the leftmost match already begins at index 0. Executed across five header shapes — well-formed, prefixed, empty-domain, trailing-text, and no-domain — the captured domain was **identical in 5 of 5** with and without it. It is correct and worth keeping as documentation of intent; a test would be asserting a branch that cannot differ.

# Suite note

`bun test packages/cloud/shared/src/lib/utils/` reports 5 failures both with and without this file (347 → 379 tests, same 5 names). They are pre-existing logger-redaction failures on `origin/develop`, unrelated to SIWS.

# Scope

New test file only — no production code touched.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1M9PRSDT3V4YKHF4S0F9JJN","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T18:50:09.069Z","completed_at":"2026-09-03T18:51:29.345Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T18:50:09.678Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5ccc1e3001f308e97edd1b70bdf76139fbf4c19705a7d8c0ffbb0fd4a0f99828","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"20323bc9-469a-4381-ba03-f6676e48288b","object_id":"sha256:5ccc1e3001f308e97edd1b70bdf76139fbf4c19705a7d8c0ffbb0fd4a0f99828","sha256":"5ccc1e3001f308e97edd1b70bdf76139fbf4c19705a7d8c0ffbb0fd4a0f99828"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"uN8_A8Wxqf5MCtTZK9ieB9-lDPwBvYIwvlf1gnLYfqZVAD4E_imV7WmyHnQW8-VIAGp3eBfok1hYb_zhKujtAg"}} -->
