### PR TITLE
test(cloud): pin the staging-session exchange configuration gate

### DIFF
--- a/packages/cloud/shared/src/lib/auth/staging-session-binding.config.test.ts
+++ b/packages/cloud/shared/src/lib/auth/staging-session-binding.config.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Pins the configuration gate of the staging-only API-key-to-browser-session
+ * bridge: the signing-key contract (`readStagingSessionSigningConfig`), its
+ * boolean wrapper, and the four-conjunct enablement predicate.
+ *
+ * These are the checks that keep the exchange off everywhere but staging and
+ * keep its signing key cryptographically distinct from every Steward secret,
+ * so each clause is asserted on its own rather than through one happy path.
+ * Deliberately mock-free: this surface reaches no repository, so the module
+ * imports as-is.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  isStagingSessionExchangeEnabled,
+  isStagingSessionSigningConfigured,
+  readStagingSessionSigningConfig,
+  STAGING_SESSION_EXCHANGE_VERSION,
+  STAGING_SESSION_MAX_TTL_SECONDS,
+  STAGING_SESSION_TOKEN_TYP,
+  type StagingSessionBindingEnv,
+  StagingSessionConfigurationError,
+  StagingSessionEligibilityError,
+} from "./staging-session-binding";
+
+const SECRET = "staging-session-signing-secret-abcdefghijklmnop";
+const KEY_ID = "staging-qa-v1-primary";
+
+function signingEnv(overrides: Partial<StagingSessionBindingEnv> = {}): StagingSessionBindingEnv {
+  return {
+    STAGING_SESSION_EXCHANGE_SIGNING_SECRET: SECRET,
+    STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: KEY_ID,
+    ...overrides,
+  };
+}
+
+function enabledEnv(overrides: Partial<StagingSessionBindingEnv> = {}): StagingSessionBindingEnv {
+  return {
+    NODE_ENV: "production",
+    ENVIRONMENT: "staging",
+    STAGING_SESSION_EXCHANGE_ENABLED: "true",
+    STAGING_SESSION_EXCHANGE_VERSION: STAGING_SESSION_EXCHANGE_VERSION,
+    ...overrides,
+  };
+}
+
+describe("readStagingSessionSigningConfig — signing secret", () => {
+  test("returns the trimmed secret and key id for a well-formed pair", () => {
+    expect(
+      readStagingSessionSigningConfig(
+        signingEnv({
+          STAGING_SESSION_EXCHANGE_SIGNING_SECRET: `  ${SECRET}  `,
+          STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: `\t${KEY_ID}\n`,
+        }),
+      ),
+    ).toEqual({ secret: SECRET, keyId: KEY_ID });
+  });
+
+  test("rejects a missing secret", () => {
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_SECRET: undefined }),
+      ),
+    ).toThrow(StagingSessionConfigurationError);
+  });
+
+  test("rejects a whitespace-only secret rather than accepting the padding as length", () => {
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_SECRET: " ".repeat(64) }),
+      ),
+    ).toThrow(/SIGNING_SECRET is missing or too short/);
+  });
+
+  test("length is measured after trimming: 32 padded to 40 is still too short", () => {
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_SECRET: `    ${"a".repeat(31)}    ` }),
+      ),
+    ).toThrow(/too short/);
+  });
+
+  test("31 characters is too short and 32 is the accepted boundary", () => {
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_SECRET: "a".repeat(31) }),
+      ),
+    ).toThrow(/too short/);
+    expect(
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_SECRET: "a".repeat(32) }),
+      ).secret,
+    ).toBe("a".repeat(32));
+  });
+});
+
+describe("readStagingSessionSigningConfig — signing key id", () => {
+  test("rejects a missing key id", () => {
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: undefined }),
+      ),
+    ).toThrow(/SIGNING_KEY_ID is invalid/);
+  });
+
+  test("requires the staging-qa-v1- prefix at the start of the value", () => {
+    for (const keyId of ["staging-qa-v2-primary", "qa-v1-primary", "x-staging-qa-v1-primary"]) {
+      expect(() =>
+        readStagingSessionSigningConfig(
+          signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: keyId }),
+        ),
+      ).toThrow(/SIGNING_KEY_ID is invalid/);
+    }
+  });
+
+  test("requires a non-empty suffix and caps it at 48 characters", () => {
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: "staging-qa-v1-" }),
+      ),
+    ).toThrow(/SIGNING_KEY_ID is invalid/);
+    expect(
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: `staging-qa-v1-${"a".repeat(48)}` }),
+      ).keyId,
+    ).toBe(`staging-qa-v1-${"a".repeat(48)}`);
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: `staging-qa-v1-${"a".repeat(49)}` }),
+      ),
+    ).toThrow(/SIGNING_KEY_ID is invalid/);
+  });
+
+  test("accepts only the dot/underscore/hyphen punctuation set in the suffix", () => {
+    expect(
+      readStagingSessionSigningConfig(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: "staging-qa-v1-a.b_c-D9" }),
+      ).keyId,
+    ).toBe("staging-qa-v1-a.b_c-D9");
+    for (const suffix of ["a/b", "a b", "a:b", "a+b", "a%2f"]) {
+      expect(() =>
+        readStagingSessionSigningConfig(
+          signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: `staging-qa-v1-${suffix}` }),
+        ),
+      ).toThrow(/SIGNING_KEY_ID is invalid/);
+    }
+  });
+
+  test("the pattern is end-anchored: trailing junk after a valid suffix is rejected", () => {
+    expect(() =>
+      readStagingSessionSigningConfig(
+        signingEnv({
+          STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: "staging-qa-v1-primary\nstaging-qa-v1-evil",
+        }),
+      ),
+    ).toThrow(/SIGNING_KEY_ID is invalid/);
+  });
+});
+
+describe("readStagingSessionSigningConfig — the key must be dedicated", () => {
+  // Each Steward secret is a separate collision to rule out; one shared
+  // assertion would let two of the three comparisons be deleted silently.
+  const collisions: Array<[string, keyof StagingSessionBindingEnv]> = [
+    ["STEWARD_JWT_SECRET", "STEWARD_JWT_SECRET"],
+    ["STEWARD_SESSION_SECRET", "STEWARD_SESSION_SECRET"],
+    ["ELIZA_SERVICE_JWT_SECRET", "ELIZA_SERVICE_JWT_SECRET"],
+  ];
+
+  for (const [label, key] of collisions) {
+    test(`rejects a signing secret equal to ${label}`, () => {
+      expect(() => readStagingSessionSigningConfig(signingEnv({ [key]: SECRET }))).toThrow(
+        /must be dedicated/,
+      );
+    });
+
+    test(`the ${label} comparison is made on trimmed values`, () => {
+      expect(() => readStagingSessionSigningConfig(signingEnv({ [key]: `  ${SECRET}  ` }))).toThrow(
+        /must be dedicated/,
+      );
+    });
+  }
+
+  test("an unset Steward secret does not collide with an unset-looking signing secret", () => {
+    expect(readStagingSessionSigningConfig(signingEnv()).secret).toBe(SECRET);
+  });
+
+  test("a Steward secret that merely shares a prefix is not a collision", () => {
+    expect(
+      readStagingSessionSigningConfig(signingEnv({ STEWARD_JWT_SECRET: `${SECRET}x` })).secret,
+    ).toBe(SECRET);
+  });
+});
+
+describe("isStagingSessionSigningConfigured", () => {
+  test("is true for a valid pair and false for each configuration failure", () => {
+    expect(isStagingSessionSigningConfigured(signingEnv())).toBe(true);
+    expect(
+      isStagingSessionSigningConfigured(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_SECRET: "short" }),
+      ),
+    ).toBe(false);
+    expect(
+      isStagingSessionSigningConfigured(
+        signingEnv({ STAGING_SESSION_EXCHANGE_SIGNING_KEY_ID: "nope" }),
+      ),
+    ).toBe(false);
+    expect(isStagingSessionSigningConfigured(signingEnv({ STEWARD_JWT_SECRET: SECRET }))).toBe(
+      false,
+    );
+  });
+
+  test("propagates a non-configuration failure instead of reporting 'not configured'", () => {
+    const hostile = {
+      get STAGING_SESSION_EXCHANGE_SIGNING_SECRET(): string {
+        throw new TypeError("environment read failed");
+      },
+    } as unknown as StagingSessionBindingEnv;
+    expect(() => isStagingSessionSigningConfigured(hostile)).toThrow(TypeError);
+  });
+});
+
+describe("isStagingSessionExchangeEnabled", () => {
+  test("is true only when all four conditions hold together", () => {
+    expect(isStagingSessionExchangeEnabled(enabledEnv())).toBe(true);
+  });
+
+  // One conjunct at a time: a predicate that dropped any single clause would
+  // still pass a test that only ever flips everything at once.
+  const clauses: Array<[string, Partial<StagingSessionBindingEnv>]> = [
+    ["NODE_ENV is not production", { NODE_ENV: "development" }],
+    ["NODE_ENV is unset", { NODE_ENV: undefined }],
+    ["ENVIRONMENT is not staging", { ENVIRONMENT: "production" }],
+    ["ENVIRONMENT is unset", { ENVIRONMENT: undefined }],
+    ["the enable flag is unset", { STAGING_SESSION_EXCHANGE_ENABLED: undefined }],
+    ["the enable flag is a different version string", { STAGING_SESSION_EXCHANGE_VERSION: "v2" }],
+    ["the version is unset", { STAGING_SESSION_EXCHANGE_VERSION: undefined }],
+  ];
+
+  for (const [label, override] of clauses) {
+    test(`is false when ${label}`, () => {
+      expect(isStagingSessionExchangeEnabled(enabledEnv(override))).toBe(false);
+    });
+  }
+
+  test("the enable flag is the exact string 'true', not a truthy value", () => {
+    for (const value of ["TRUE", "True", "1", "yes", "on", " true"]) {
+      expect(
+        isStagingSessionExchangeEnabled(enabledEnv({ STAGING_SESSION_EXCHANGE_ENABLED: value })),
+      ).toBe(false);
+    }
+  });
+
+  test("an empty environment is not enabled", () => {
+    expect(isStagingSessionExchangeEnabled({})).toBe(false);
+  });
+});
+
+describe("exchange constants and error types", () => {
+  test("the wire constants are pinned", () => {
+    expect(STAGING_SESSION_EXCHANGE_VERSION).toBe("v1");
+    expect(STAGING_SESSION_TOKEN_TYP).toBe("eliza-staging-session+jwt");
+    expect(STAGING_SESSION_MAX_TTL_SECONDS).toBe(3600);
+  });
+
+  test("StagingSessionConfigurationError carries its own name", () => {
+    const error = new StagingSessionConfigurationError("boom");
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("StagingSessionConfigurationError");
+    expect(error.message).toBe("boom");
+  });
+
+  test("StagingSessionEligibilityError keeps the reason off the message", () => {
+    const error = new StagingSessionEligibilityError("tenant");
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("StagingSessionEligibilityError");
+    expect(error.reason).toBe("tenant");
+    // The reason is a structured field for logs; the message stays generic so
+    // it can be surfaced without disclosing which check rejected the subject.
+    expect(error.message).toBe("Staging session subject is not eligible");
+    expect(error.message).not.toContain("tenant");
+  });
+});


### PR DESCRIPTION
# What

`packages/cloud/shared/src/lib/auth/staging-session-binding.ts` is 497 lines with 15 exports and **no test file anywhere in the repo**. It authorizes the staging-only API-key-to-browser-session bridge.

Its configuration gate decides two security-relevant things before any identity work happens:

- **whether the exchange is reachable at all** — `isStagingSessionExchangeEnabled` is a four-conjunct predicate; if any single clause were dropped the bridge could open outside staging;
- **whether its signing key is dedicated** — `readStagingSessionSigningConfig` refuses a secret equal to `STEWARD_JWT_SECRET`, `STEWARD_SESSION_SECRET` or `ELIZA_SERVICE_JWT_SECRET`. The source comment explains why: that separation is the rollback boundary, so an older Steward-only verifier stays *cryptographically* unable to accept a QA token whose custom claims it cannot revalidate.

Nothing was pinning either.

# The change

One new file, 33 tests, **no `mock.module` and no mocks of any kind**. This surface reaches no repository, so the module imports as-is — verified by probe before writing anything. That matters here: the sibling suites in this directory register process-global module mocks, and staying mock-free keeps this file out of that entirely.

Each clause is asserted on its own rather than through one happy path:

- **secret floor** — 31 rejected, 32 accepted, and length measured *after* trimming (`"    " + 31 chars + "    "` is 39 characters long and still rejected).
- **key-id pattern** `/^staging-qa-v1-[A-Za-z0-9._-]{1,48}$/` — start anchor (`x-staging-qa-v1-…` rejected), end anchor, empty suffix rejected, 48 accepted / 49 rejected, and the punctuation set (`.`/`_`/`-` accepted; `/`, space, `:`, `+`, `%2f` rejected).
- **dedication** — three separate cases, one per Steward secret, plus a fourth proving the comparison is made on trimmed values, plus a negative proving a merely shared *prefix* is not a collision.
- **`isStagingSessionSigningConfigured`** — true/false, and a hostile env whose getter throws a `TypeError` proves the catch **re-throws** a non-configuration failure instead of silently reporting "not configured".
- **enablement** — the happy path, then each of the four conjuncts flipped individually, then that the flag is the exact string `"true"` (not `"TRUE"`, `"1"`, `"yes"`, `"on"`, `" true"`).
- **`StagingSessionEligibilityError`** — the `reason` is a structured field and the message stays generic, so it can be surfaced without disclosing which check rejected the subject.

# Evidence

Mutation-tested against the gate. **16 mutants, 16 killed, 0 survivors:**

| mutant | result |
|---|---|
| `secret.length < 32` → `< 0` | killed (3) |
| drop the `!secret` presence check | killed (1) |
| key-id regex: drop the `$` end anchor | killed (3) |
| key-id regex: drop the `^` start anchor | killed (2) |
| `{1,48}` → `{1,}` | killed (1) |
| drop the `STEWARD_JWT_SECRET` comparison | killed (3) |
| drop the `STEWARD_SESSION_SECRET` comparison | killed (2) |
| drop the `ELIZA_SERVICE_JWT_SECRET` comparison | killed (2) |
| compare collisions untrimmed | killed (1) |
| collapse the `isConfigured` catch to an unconditional `return false` | killed (1) |
| drop the `NODE_ENV === "production"` conjunct | killed (2) |
| drop the `ENVIRONMENT === "staging"` conjunct | killed (2) |
| drop the `STAGING_SESSION_EXCHANGE_ENABLED === "true"` conjunct | killed (2) |
| drop the version conjunct | killed (2) |
| `STAGING_SESSION_MAX_TTL_SECONDS` `60 * 60` → `60 * 61` | killed (1) |

Runs:

- new file alone → **33 pass / 0 fail**
- `src/lib/auth/` under the runner's `--isolate` → **211 tests, 0 fail** (178 before this PR)
- the package runner's **real ordinary batch 6** (computed via `buildTestBatches`, the batch these files actually land in), plus the new file → **165 pass / 0 fail**
- `bun run --cwd packages/cloud/shared typecheck` → clean
- `bunx @biomejs/biome check` → clean

# What I did not cover, and why

Only the configuration gate. `validateStagingSessionBinding`, `loadExistingStagingSessionSubjectForMint` and `loadVerifiedStagingSessionUser` all reach `../../db/repositories`, so covering them means mocking that module — and in this directory that is a process-global `mock.module` registration. `loadVerifiedStagingSessionUser` in particular is a nine-clause fail-closed disjunction that deserves clause-by-clause tests; I left it for a follow-up rather than dragging a global mock into a file that currently needs none.

One thing worth flagging separately, found while working here and **not** changed by this PR: running `bun test packages/cloud/shared/src/lib/auth/` directly reports 14 failures, because `steward-client-cache-invalidation.test.ts` stubs `InMemoryLRUCache` with only a `delete()` method and that process-global registration wins over its sibling's complete stub. It is **not** a CI defect — `scripts/run-bun-tests.mjs` always passes `--isolate`, and I confirmed the real batch is green — but it does mean the obvious local command is misleading. Happy to open that separately if you want it addressed.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MDSHZZ9BVVXZ05D28WDH9Z","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T20:01:34.719Z","completed_at":"2026-09-03T20:02:27.053Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T20:01:35.497Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5ad438f1ef70eeec86a77b92ae08c6e57040235b32128c4cd7e49851f32df4e4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c526159d-e067-4e28-910d-57a20d673a01","object_id":"sha256:5ad438f1ef70eeec86a77b92ae08c6e57040235b32128c4cd7e49851f32df4e4","sha256":"5ad438f1ef70eeec86a77b92ae08c6e57040235b32128c4cd7e49851f32df4e4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"T0eUxKLsIJ7_TXa1aJNoQlLnNKNAmW56IzOCCHoISQJcRrEcTmUqcoPWrt-1WhxyjjO_SreL_YLBuKUhkDy7Dg"}} -->
