### PR TITLE
test(cloud): isolate every clause of the staging-session user gate

### DIFF
--- a/packages/cloud/shared/src/lib/auth/staging-session-user-gate.test.ts
+++ b/packages/cloud/shared/src/lib/auth/staging-session-user-gate.test.ts
@@ -1,0 +1,268 @@
+/**
+ * `loadVerifiedStagingSessionUser` is the identity half of the staging-only
+ * API-key-to-browser-session bridge: a ten-clause fail-closed disjunction that
+ * must return `null` unless the user, the organization and the Steward
+ * projection all still agree with the signed binding.
+ *
+ * Every clause is asserted on its own. A single happy path plus a single
+ * rejection would leave eight of them free to be deleted silently, and each
+ * one is a distinct way for a revoked or expired subject to keep a session.
+ *
+ * The harness is real: the actual repository query runs against in-process
+ * PGlite with the production Drizzle DDL applied by `pushSchemaToTestDb`. The
+ * trailing loud guard fails the suite if PGlite never initialized, so the
+ * database cases can never pass vacuously.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 120_000;
+const ORG_ID = "00000000-0000-4000-8000-0000000004a1";
+const OTHER_ORG_ID = "00000000-0000-4000-8000-0000000004a2";
+const STEWARD_USER_ID = "steward-staging-subject";
+
+let dbWrite: typeof import("../../db/client").dbWrite;
+let closeDb: typeof import("../../db/client").closeDatabaseConnectionsForTests | undefined;
+let loadVerifiedStagingSessionUser: typeof import("./staging-session-binding").loadVerifiedStagingSessionUser;
+let users: typeof import("../../db/schemas/users").users;
+let pgliteReady = true;
+let seq = 0;
+
+type UserOverrides = {
+  is_active?: boolean;
+  is_anonymous?: boolean;
+  deleted_at?: Date | null;
+  expires_at?: Date | null;
+  organization_id?: string | null;
+  steward_user_id?: string;
+};
+
+/** Inserts one user in ORG_ID with the documented-good shape, then applies overrides. */
+async function seedUser(overrides: UserOverrides = {}): Promise<string> {
+  seq += 1;
+  const id = `00000000-0000-4000-8000-${String(seq).padStart(12, "0")}`;
+  await dbWrite.insert(users).values({
+    id,
+    organization_id: ORG_ID,
+    steward_user_id: `${STEWARD_USER_ID}-${seq}`,
+    is_active: true,
+    is_anonymous: false,
+    deleted_at: null,
+    expires_at: null,
+    ...overrides,
+  } as never);
+  return id;
+}
+
+function bindingFor(userId: string, organizationId = ORG_ID) {
+  return {
+    version: "v1" as const,
+    apiKeyId: "00000000-0000-4000-8000-0000000004ff",
+    cloudUserId: userId,
+    organizationId,
+    credentialFingerprint: "f".repeat(64),
+    sessionIssuedAt: 0,
+    sessionMaxExpiresAt: 0,
+  };
+}
+
+function stewardIdFor(userId: string): string {
+  return `${STEWARD_USER_ID}-${userId.slice(-12).replace(/^0+/, "")}`;
+}
+
+async function load(
+  userId: string,
+  options?: { stewardUserId?: string; now?: Date; org?: string },
+) {
+  return await loadVerifiedStagingSessionUser({
+    binding: bindingFor(userId, options?.org),
+    stewardUserId: options?.stewardUserId ?? stewardIdFor(userId),
+    now: options?.now,
+  });
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../db/client"));
+    const { pushSchemaToTestDb } = await import("../../db/push-schema-for-tests");
+    const { organizations } = await import("../../db/schemas/organizations");
+    ({ users } = await import("../../db/schemas/users"));
+    await pushSchemaToTestDb({ users, organizations });
+    await dbWrite.insert(organizations).values([
+      { id: ORG_ID, name: "staging-org", slug: "staging-org", is_active: true },
+      { id: OTHER_ORG_ID, name: "other-org", slug: "other-org", is_active: true },
+    ] as never);
+    ({ loadVerifiedStagingSessionUser } = await import("./staging-session-binding"));
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[staging-session-user-gate] PGlite unavailable:", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+test(
+  "accepts a user whose row, organization and Steward id all match the binding",
+  async () => {
+    if (!pgliteReady) return;
+    const id = await seedUser();
+    const user = await load(id);
+    expect(user).not.toBeNull();
+    expect(user?.id).toBe(id);
+    expect(user?.organization?.id).toBe(ORG_ID);
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects a cloudUserId that has no row at all",
+  async () => {
+    if (!pgliteReady) return;
+    expect(
+      await loadVerifiedStagingSessionUser({
+        binding: bindingFor("00000000-0000-4000-8000-0000000004fe"),
+        stewardUserId: STEWARD_USER_ID,
+      }),
+    ).toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects a deactivated user",
+  async () => {
+    if (!pgliteReady) return;
+    const id = await seedUser({ is_active: false });
+    expect(await load(id)).toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects an anonymous user",
+  async () => {
+    if (!pgliteReady) return;
+    const id = await seedUser({ is_anonymous: true });
+    expect(await load(id)).toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects a soft-deleted user",
+  async () => {
+    if (!pgliteReady) return;
+    const id = await seedUser({ deleted_at: new Date("2020-01-01T00:00:00.000Z") });
+    expect(await load(id)).toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "expiry is inclusive at the boundary and open in both directions",
+  async () => {
+    if (!pgliteReady) return;
+    const at = new Date("2030-01-01T00:00:00.000Z");
+    const id = await seedUser({ expires_at: at });
+
+    // `<= now` — an expiry exactly at `now` is already spent.
+    expect(await load(id, { now: at })).toBeNull();
+    expect(await load(id, { now: new Date(at.getTime() + 1) })).toBeNull();
+    expect(await load(id, { now: new Date(at.getTime() - 1) })).not.toBeNull();
+
+    // A null expiry never expires, whatever `now` is.
+    const immortal = await seedUser({ expires_at: null });
+    expect(await load(immortal, { now: new Date("2999-01-01T00:00:00.000Z") })).not.toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects a user whose organization is not the one in the binding",
+  async () => {
+    if (!pgliteReady) return;
+    const id = await seedUser({ organization_id: OTHER_ORG_ID });
+    expect(await load(id)).toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects a user with no organization at all",
+  async () => {
+    if (!pgliteReady) return;
+    const id = await seedUser({ organization_id: null });
+    expect(await load(id)).toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects a user in a deactivated organization",
+  async () => {
+    if (!pgliteReady) return;
+    const { organizations } = await import("../../db/schemas/organizations");
+    const { eq } = await import("drizzle-orm");
+    const deadOrg = "00000000-0000-4000-8000-0000000004b9";
+    await dbWrite
+      .insert(organizations)
+      .values([{ id: deadOrg, name: "dead-org", slug: "dead-org", is_active: false }] as never);
+    const id = await seedUser({ organization_id: deadOrg });
+
+    expect(await load(id, { org: deadOrg })).toBeNull();
+
+    // Reactivating the same organization is the only thing that changes, so the
+    // rejection above is attributable to `organization.is_active` alone.
+    await dbWrite
+      .update(organizations)
+      .set({ is_active: true })
+      .where(eq(organizations.id, deadOrg));
+    expect(await load(id, { org: deadOrg })).not.toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "rejects a Steward id that does not match, and compares it trimmed",
+  async () => {
+    if (!pgliteReady) return;
+    const id = await seedUser();
+    const expected = stewardIdFor(id);
+
+    expect(await load(id, { stewardUserId: `${expected}-other` })).toBeNull();
+    expect(await load(id, { stewardUserId: expected.toUpperCase() })).toBeNull();
+    expect(await load(id, { stewardUserId: "" })).toBeNull();
+    // The stored value is trimmed before comparison; the supplied one is not.
+    expect(await load(id, { stewardUserId: ` ${expected} ` })).toBeNull();
+
+    const paddedSteward = "padded-steward-subject";
+    const padded = await seedUser({ steward_user_id: `  ${paddedSteward}  ` });
+    expect(await load(padded, { stewardUserId: paddedSteward })).not.toBeNull();
+  },
+  TIMEOUT,
+);
+
+test(
+  "defaults `now` to the current time when the caller omits it",
+  async () => {
+    if (!pgliteReady) return;
+    const past = await seedUser({ expires_at: new Date(Date.now() - 60_000) });
+    const future = await seedUser({ expires_at: new Date(Date.now() + 60_000) });
+    expect(await load(past)).toBeNull();
+    expect(await load(future)).not.toBeNull();
+  },
+  TIMEOUT,
+);
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// Without this a broken import or failed schema push would skip every case
+// above and the suite would pass vacuously.
+test("PGlite harness initialized (DB cases above are not vacuous)", () => {
+  expect(pgliteReady).toBe(true);
+});


### PR DESCRIPTION
# What

`loadVerifiedStagingSessionUser` is the identity half of the staging-only API-key-to-browser-session bridge. It is a **ten-clause fail-closed disjunction**: the user row, its organization, and the Steward projection must all still agree with the signed binding, or the session is refused.

```ts
if (
  !user || !user.is_active || user.is_anonymous || user.deleted_at !== null ||
  (user.expires_at !== null && user.expires_at.getTime() <= now.getTime()) ||
  user.organization_id !== input.binding.organizationId ||
  !user.organization || !user.organization.is_active ||
  user.organization.id !== input.binding.organizationId ||
  user.steward_user_id.trim() !== input.stewardUserId
) return null;
```

Each clause is a separate way for a revoked, expired, deactivated or re-homed subject to keep a live browser session. Nothing covered any of them.

# The change

One new file, 12 tests, **no mocks**. The real repository query runs against in-process PGlite with the **production Drizzle DDL** applied by `pushSchemaToTestDb`.

Mocks were the wrong tool here: `findWithOrganizationForWrite` uses drizzle's relational `with: { organization: true }`, so a hand-rolled minimal DDL would not match what the query actually selects. Pushing the real `users` and `organizations` definitions costs nothing and exercises the genuine join. A trailing loud guard fails the suite if PGlite never initializes, so the database cases cannot pass vacuously.

Each clause is asserted on its own, plus:

- **the expiry boundary in both directions** — `<= now` means an expiry landing exactly on `now` is already spent, so `now`, `now+1ms` and `now-1ms` are all pinned, and a null expiry is checked against the year 2999;
- **the `.trim()` on the stored Steward id** — a padded stored value matches its unpadded counterpart, while a padded *supplied* value does not (only the stored side is trimmed);
- **`now` defaulting to the current time** when the caller omits it;
- the deactivated-organization case **reactivates that same organization and re-runs**, so the rejection is attributable to `organization.is_active` alone rather than to anything else about the fixture.

# Evidence

Twelve clause mutants, **nine killed**:

| mutant | result |
|---|---|
| drop `!user` | killed |
| drop `!user.is_active` | killed |
| drop `user.is_anonymous` | killed |
| drop `user.deleted_at !== null` | killed |
| drop the whole `expires_at` clause | killed (2 tests) |
| weaken the boundary `<=` → `<` | killed |
| drop `!user.organization.is_active` | killed |
| drop the Steward id comparison | killed |
| drop `.trim()` on the stored Steward id | killed |

Runs: 12 pass / 0 fail. `src/lib/auth/` under `--isolate`: **190 tests across 21 files, 0 fail**. `bun run --cwd packages/cloud/shared typecheck` clean, `biome check` clean.

# The three survivors are redundant by construction, not untested

Three mutants survive, and I want to be explicit that I chased them rather than papering over them:

- `user.organization_id !== binding.organizationId`
- `!user.organization`
- `user.organization.id !== binding.organizationId`

Dropping any **one** survives; dropping any **pair** is killed (verified for the first+third and first+second). They are mutually redundant, and the reason is the foreign key:

- `organization_id` references `organizations.id`, so whenever the relation resolves, `user.organization.id` **is** `user.organization_id` — the first and third clauses cannot disagree;
- inserting a user with a dangling `organization_id` is rejected by the database (I tried it), so `!user.organization` is reachable only when the column is `NULL` — and then the first clause has already fired.

So no test can isolate any one of these three; that is a property of the code and the schema, not a gap in the suite. **I did not write tests to chase them, and I am not proposing to delete any of them** — on a fail-closed auth gate the redundancy is cheap, and `!user.organization` additionally guards the `user.organization.id` dereference on the next line, which would otherwise throw on a null-organization user instead of returning `null`.

If you would rather have the redundancy documented in the source than rediscovered, a one-line comment on those three clauses would be the place; I left the code untouched since this is a test-only PR.

# Scope

Test-only; no production file is modified. Independent of #30462, which covers the *configuration* half of the same module in a separate file — no overlap and no conflict.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MJQ9TS1QA0N70GEMM4CMHC","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T21:27:43.705Z","completed_at":"2026-09-03T21:28:30.001Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T21:27:44.506Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"0ae451d0b4cb4b1f946a07a81252901d5166c49ed9d331867943c3087a104a5a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"af6b40c4-47dd-456c-90ea-e46cfb176b29","object_id":"sha256:0ae451d0b4cb4b1f946a07a81252901d5166c49ed9d331867943c3087a104a5a","sha256":"0ae451d0b4cb4b1f946a07a81252901d5166c49ed9d331867943c3087a104a5a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"F7nNlufChDkBxkeEfSF3g31yUD2JoMCTQlHbRhdu5lqPUFk5ivxvpxLKF2ruPrakvZ1qzVkIfEfUU6q1lZcvBg"}} -->
