### PR TITLE
fix(cloud): fail closed on an unparseable SIWS/SIWE message timestamp

### DIFF
--- a/packages/cloud/shared/src/lib/utils/siw-timestamp-failopen.test.ts
+++ b/packages/cloud/shared/src/lib/utils/siw-timestamp-failopen.test.ts
@@ -1,0 +1,161 @@
+/**
+ * SIWS and SIWE both compare an optional message timestamp with `<=` / `>`.
+ * Those comparisons are FALSE for NaN, so a present-but-unparseable
+ * `Expiration Time` made a signed message never expire, and an unparseable
+ * `Not Before` made it immediately valid — a fail-open on two auth paths.
+ *
+ * Both helpers had the same shape and both are covered here: SIWS parsed the
+ * field with a bare `new Date(...)`, and viem's `parseSiweMessage` hands back a
+ * truthy `Invalid Date` for the same input. Fixing only one would have left the
+ * identical hole one file away.
+ *
+ * Signatures are real (ed25519 via tweetnacl for SIWS, secp256k1 via viem for
+ * SIWE); only the nonce store is an in-memory stand-in for Redis.
+ */
+
+import { describe, expect, test } from "bun:test";
+import bs58 from "bs58";
+import nacl from "tweetnacl";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import type { CompatibleRedis } from "../cache/redis-factory";
+import { issueNonce as issueSiweNonce, validateAndConsumeSIWE } from "./siwe-helpers";
+import { buildSiwsMessage, issueSiwsNonce, validateAndConsumeSIWS } from "./siws-helpers";
+
+const HOST = "app.example.com";
+const URI = "https://app.example.com";
+const SOLANA_CHAIN = "solana:mainnet";
+const EVM_CHAIN = 1;
+// Generated per run, like the SIWS side's `nacl.sign.keyPair()` — a
+// checked-in key literal is a secret shape the SCM scanner has to reason
+// about, and nothing here depends on a fixed address.
+const PRIVATE_KEY = generatePrivateKey();
+
+function mockRedis(): CompatibleRedis {
+  const store = new Map<string, string>();
+  return {
+    async setex(key: string, _ttl: number, value: string) {
+      store.set(key, value);
+      return "OK";
+    },
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async getdel(key: string) {
+      const value = store.get(key) ?? null;
+      store.delete(key);
+      return value;
+    },
+  } as unknown as CompatibleRedis;
+}
+
+const MINUTE = 60_000;
+const past = () => new Date(Date.now() - MINUTE).toISOString();
+const future = () => new Date(Date.now() + MINUTE).toISOString();
+
+/** Signs a SIWS message with the given extra timestamp lines appended. */
+async function siws(extraLines: string[]): Promise<void> {
+  const redis = mockRedis();
+  const nonce = await issueSiwsNonce(redis, { uri: URI, chainId: SOLANA_CHAIN });
+  const keyPair = nacl.sign.keyPair();
+  const address = bs58.encode(keyPair.publicKey);
+  const message = [
+    buildSiwsMessage({
+      domain: HOST,
+      address,
+      statement: "Sign in",
+      uri: URI,
+      chainId: SOLANA_CHAIN,
+      nonce,
+      issuedAt: new Date(),
+    }),
+    ...extraLines,
+  ].join("\n");
+  const signature = bs58.encode(
+    nacl.sign.detached(new TextEncoder().encode(message), keyPair.secretKey),
+  );
+  await validateAndConsumeSIWS(redis, message, signature, HOST);
+}
+
+/** Signs a SIWE message with the given extra timestamp lines appended. */
+async function siwe(extraLines: string[]): Promise<void> {
+  const redis = mockRedis();
+  const nonce = await issueSiweNonce(redis, { uri: URI, chainId: EVM_CHAIN });
+  const account = privateKeyToAccount(PRIVATE_KEY);
+  const message = [
+    `${HOST} wants you to sign in with your Ethereum account:`,
+    account.address,
+    "",
+    "Sign in",
+    "",
+    `URI: ${URI}`,
+    "Version: 1",
+    `Chain ID: ${EVM_CHAIN}`,
+    `Nonce: ${nonce}`,
+    `Issued At: ${new Date().toISOString()}`,
+    ...extraLines,
+  ].join("\n");
+  const signature = await account.signMessage({ message });
+  await validateAndConsumeSIWE(redis, message, signature as `0x${string}`, HOST);
+}
+
+describe("SIWS message window fails closed on an unparseable timestamp", () => {
+  test("a well-formed message with no timestamps is still accepted", async () => {
+    await siws([]);
+  });
+
+  test("a future Expiration Time is accepted and a past one is rejected", async () => {
+    await siws([`Expiration Time: ${future()}`]);
+    await expect(siws([`Expiration Time: ${past()}`])).rejects.toThrow(/has expired/i);
+  });
+
+  test("an unparseable Expiration Time is rejected, not treated as no expiry", async () => {
+    await expect(siws(["Expiration Time: not-a-date"])).rejects.toThrow(
+      /Expiration Time is not a valid date/i,
+    );
+  });
+
+  test("an unparseable Not Before is rejected, not treated as already valid", async () => {
+    await expect(siws(["Not Before: not-a-date"])).rejects.toThrow(
+      /Not Before is not a valid date/i,
+    );
+  });
+
+  test("a plausible-looking but invalid calendar date is still rejected", async () => {
+    // The shape parses as a string but not as a date; this is the realistic
+    // malformed value, not obvious garbage.
+    await expect(siws(["Expiration Time: 2026-13-45T99:99:99Z"])).rejects.toThrow(
+      /Expiration Time is not a valid date/i,
+    );
+  });
+
+  test("a future Not Before is still rejected as not-yet-valid", async () => {
+    await expect(siws([`Not Before: ${future()}`])).rejects.toThrow(/not yet valid/i);
+  });
+});
+
+describe("SIWE message window fails closed on an unparseable timestamp", () => {
+  test("a well-formed message with no timestamps is still accepted", async () => {
+    await siwe([]);
+  });
+
+  test("a future Expiration Time is accepted and a past one is rejected", async () => {
+    await siwe([`Expiration Time: ${future()}`]);
+    await expect(siwe([`Expiration Time: ${past()}`])).rejects.toThrow(/has expired/i);
+  });
+
+  test("an unparseable Expiration Time is rejected, not treated as no expiry", async () => {
+    await expect(siwe(["Expiration Time: not-a-date"])).rejects.toThrow(
+      /timestamp is not a valid date: Expiration Time/i,
+    );
+  });
+
+  test("an unparseable Not Before is rejected, not treated as already valid", async () => {
+    await expect(siwe(["Not Before: not-a-date"])).rejects.toThrow(
+      /timestamp is not a valid date: Not Before/i,
+    );
+  });
+
+  test("a future Not Before is still rejected as not-yet-valid", async () => {
+    await expect(siwe([`Not Before: ${future()}`])).rejects.toThrow(/not yet valid/i);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/siwe-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/siwe-helpers.ts
@@ -25,6 +25,7 @@ const SIWE_NONCE_INVALID = "SIWE nonce invalid or already used";
 const SIWE_SIGNATURE_INVALID = "SIWE signature invalid";
 const SIWE_EXPIRED = "SIWE message has expired";
 const SIWE_NOT_YET_VALID = "SIWE message not yet valid";
+const SIWE_TIMESTAMP_INVALID = "SIWE message timestamp is not a valid date";
 
 const NONCE_BYTES = 16;
 
@@ -156,6 +157,16 @@ export async function validateSIWEMessage(
   }
 
   const now = Date.now();
+  // `parseSiweMessage` returns an Invalid Date (truthy, NaN time) for a present
+  // but unparseable timestamp. Both comparisons below are false for NaN, so
+  // without this guard a malformed Expiration Time would never expire and a
+  // malformed Not Before would always be already-valid. Fail closed instead.
+  if (parsed.expirationTime && Number.isNaN(parsed.expirationTime.getTime())) {
+    throw new Error(`${SIWE_TIMESTAMP_INVALID}: Expiration Time`);
+  }
+  if (parsed.notBefore && Number.isNaN(parsed.notBefore.getTime())) {
+    throw new Error(`${SIWE_TIMESTAMP_INVALID}: Not Before`);
+  }
   if (parsed.expirationTime && parsed.expirationTime.getTime() <= now) {
     throw new Error(SIWE_EXPIRED);
   }

--- a/packages/cloud/shared/src/lib/utils/siws-helpers.ts
+++ b/packages/cloud/shared/src/lib/utils/siws-helpers.ts
@@ -104,6 +104,19 @@ async function consumeSiwsNonce(redis: CompatibleRedis, nonce: string): Promise<
   return value !== null;
 }
 
+/**
+ * Parses an optional SIWS timestamp field, failing closed on a present but
+ * unparseable value rather than letting NaN slip past the window comparisons.
+ */
+function parseOptionalTimestamp(value: string | undefined, label: string): Date | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`SIWS message ${label} is not a valid date`);
+  }
+  return parsed;
+}
+
 export function parseSiwsMessage(message: string): SiwsMessage {
   const lines = message.split("\n");
   if (lines.length < 7) {
@@ -155,10 +168,12 @@ export function parseSiwsMessage(message: string): SiwsMessage {
   if (Number.isNaN(issuedAt.getTime())) {
     throw new Error("SIWS message Issued At is not a valid date");
   }
-  const expirationTime = fields["Expiration Time"]
-    ? new Date(fields["Expiration Time"])
-    : undefined;
-  const notBefore = fields["Not Before"] ? new Date(fields["Not Before"]) : undefined;
+  // An unparseable timestamp must be rejected, not ignored: `new Date("x")`
+  // yields NaN, and both window checks below compare with `<=` / `>`, which are
+  // false for NaN — so a malformed Expiration Time would make the message
+  // never expire and a malformed Not Before would make it immediately valid.
+  const expirationTime = parseOptionalTimestamp(fields["Expiration Time"], "Expiration Time");
+  const notBefore = parseOptionalTimestamp(fields["Not Before"], "Not Before");
 
   return {
     domain,


### PR DESCRIPTION
# What

Both wallet sign-in helpers gate a signed message on optional `Expiration Time` and `Not Before` fields:

```ts
if (parsed.expirationTime && parsed.expirationTime.getTime() <= now) throw …
if (parsed.notBefore && parsed.notBefore.getTime() > now) throw …
```

`<=` and `>` are **false for NaN**. Neither helper checked whether the parsed date was valid, so a present-but-unparseable timestamp slipped straight through both guards:

- a malformed **`Expiration Time`** made a signed message **never expire**;
- a malformed **`Not Before`** made it **immediately valid**.

The value is inside the signed payload, so the signature is genuine — signature verification cannot catch this. The timestamp field is exactly the control that is supposed to bound how long a signed message stays usable.

**SIWS already gets this right for `Issued At`**, which has an explicit NaN check and throws. `Expiration Time` and `Not Before` were parsed with a bare `new Date(...)` two lines below it and never checked.

# Both mirrors were affected

I checked the SIWE side rather than assuming viem sanitised it. `parseSiweMessage` returns a **truthy `Invalid Date`** for a malformed value:

```
future             expirationTime= valid
garbage            expirationTime= Invalid Date
garbage notBefore  notBefore= Invalid Date
```

So the identical NaN comparison sits in `siwe-helpers.ts`. Fixing only SIWS would have left the same hole one file away, on a route that is just as reachable — which is why this PR touches both.

# Evidence: the fail-open, demonstrated

Real ed25519 signatures via `tweetnacl` over messages built by the repo's own `buildSiwsMessage`, through the real `validateAndConsumeSIWS`:

| message | before this PR |
|---|---|
| no expiry | accepted |
| past `Expiration Time` | rejected — *"SIWS message has expired"* |
| future `Expiration Time` | accepted |
| **`Expiration Time: not-a-date`** | **accepted** |
| future `Not Before` | rejected — *"not yet valid"* |
| **`Not Before: not-a-date`** | **accepted** |

# The change

- **SIWS** — optional timestamps go through a small helper that throws on an unparseable value, matching how `Issued At` is already handled.
- **SIWE** — both fields are NaN-guarded before the window comparisons, with a dedicated `SIWE message timestamp is not a valid date` error naming which field.

Rejecting is the right direction rather than treating a bad value as absent: a message that carries an `Expiration Time` is *asserting* a bound, and silently discarding it is how the message ends up unbounded.

# Verification

- New suite: **11 tests, 0 fail** — both mirrors, real signatures on both sides (ed25519 via tweetnacl, secp256k1 via viem), including a plausible-looking but invalid calendar date (`2026-13-45T99:99:99Z`) rather than only obvious garbage.
- **On unmodified `develop` the suite fails 5 of 11, across both mirrors.** The other 6 are controls that pass before *and* after, so valid behaviour is unchanged.
- Mutation-tested the fix — all four killed:

| mutant | result |
|---|---|
| drop the SIWS NaN check | killed (3) |
| SIWS helper returns `undefined` instead of throwing | killed (3) |
| drop the SIWE `expirationTime` guard | killed |
| drop the SIWE `notBefore` guard | killed |

- Existing `siws-helpers.security.test.ts` + `siwe-helpers.security.test.ts`: **9 pass / 0 fail**.
- `src/lib/utils/` under `--isolate`: **358 tests across 55 files, 0 fail**.
- `bun run --cwd packages/cloud/shared typecheck` clean; `biome check` clean.

# Blast radius

Three production callers: `api/auth/siws/verify`, `api/auth/siwe/verify`, and `api/users/me/wallet/attach`. A malformed timestamp becomes a rejection instead of a silent accept. Legitimate clients emit ISO-8601 through `buildSiwsMessage` or viem, so no valid sign-in changes — every control case in the suite confirms that.

One judgement call worth surfacing: an **empty** `Expiration Time:` line is still treated as absent rather than rejected, because the field is falsy at that point and an empty value asserts no bound. If you would rather that were also a hard error, it is a one-line change and I am happy to make it.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MK31BMRVA4K1EGJGNFBWW6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T21:34:08.244Z","completed_at":"2026-09-03T21:34:57.729Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T21:34:08.895Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e14f9b7dbee95eb32b2cb41c9ff505eb5e46988576b8c253bd2474c1541fc46f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0d206e3a-623d-4ffe-80cb-a8a7944d9b01","object_id":"sha256:e14f9b7dbee95eb32b2cb41c9ff505eb5e46988576b8c253bd2474c1541fc46f","sha256":"e14f9b7dbee95eb32b2cb41c9ff505eb5e46988576b8c253bd2474c1541fc46f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"yRSapgM7cRRXMoVqk8xfQ4EASAtpZvOVvGOTAL0muOZE2p8FdRirRvwLGCJAeGER1ncsZooyk53SZ6eHM50MBw"}} -->
