### PR TITLE
test(cloud): pin inference admission settlement math and dispatch detection

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-admission-settlement.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-settlement.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Settlement math and dispatch-failure recognition for the inference admission
+ * gate. These decide how much of a request is charged against a real credit
+ * balance versus consumed conservatively at the gate, so every branch is
+ * asserted on its own rather than through one representative case.
+ *
+ * Mock-free: this surface is pure and reaches no database, cache or Durable
+ * Object.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CreditReconciliationResult } from "./credits";
+import {
+  collectedInferenceCost,
+  InferenceAdmissionDispatchMarkError,
+  InferenceAdmissionGateUnavailableError,
+  type InferenceAdmissionLease,
+  InferenceAdmissionLeaseRejectedError,
+  inferenceSettlementAmounts,
+  isInferenceAdmissionDispatchMarkError,
+} from "./inference-admission-gate";
+
+function lease(estimatedCostUsd: number): InferenceAdmissionLease {
+  return {
+    organizationId: "org-1",
+    requestId: "req-1",
+    estimatedCostUsd,
+    gate: {} as InferenceAdmissionLease["gate"],
+    providerDispatched: false,
+  };
+}
+
+function reconciliation(
+  overrides: Partial<CreditReconciliationResult> = {},
+): CreditReconciliationResult {
+  return {
+    reservedAmount: 1,
+    actualCost: 1,
+    settlementTransactionIds: [],
+    adjustmentType: "none",
+    ...overrides,
+  };
+}
+
+describe("collectedInferenceCost", () => {
+  test("without reconciliation the estimate is a floor, never a ceiling", () => {
+    // The gate already consumed the estimate, so an under-run cannot refund it.
+    expect(collectedInferenceCost(lease(0.5), 0.2, null)).toBe(0.5);
+    expect(collectedInferenceCost(lease(0.5), 0.9, null)).toBe(0.9);
+    expect(collectedInferenceCost(lease(0.5), 0.5, null)).toBe(0.5);
+  });
+
+  test("an uncollected overage keeps that same floor rather than trusting the debit", () => {
+    const uncollected = reconciliation({ adjustmentType: "uncollected_overage" });
+    expect(collectedInferenceCost(lease(0.5), 0.2, uncollected)).toBe(0.5);
+    expect(collectedInferenceCost(lease(0.5), 0.9, uncollected)).toBe(0.9);
+  });
+
+  test("a reported collectedAmount wins over both the estimate and the actual", () => {
+    const collected = reconciliation({ collectedAmount: 0.3 });
+    // Below the estimate and below the actual: the authoritative debit decides.
+    expect(collectedInferenceCost(lease(0.5), 0.9, collected)).toBe(0.3);
+  });
+
+  test("collectedAmount of exactly zero is reported, not treated as absent", () => {
+    // `!== undefined` rather than truthiness: a zero-collection replay must not
+    // silently fall through to the estimate.
+    expect(collectedInferenceCost(lease(0.5), 0.9, reconciliation({ collectedAmount: 0 }))).toBe(0);
+  });
+
+  test("with reconciliation but no collectedAmount the actual is used as-is", () => {
+    // Note this is NOT floored by the estimate — the reconciled path is trusted.
+    expect(collectedInferenceCost(lease(0.5), 0.2, reconciliation())).toBe(0.2);
+  });
+
+  test("rejects a non-finite or negative actual cost", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -0.01]) {
+      expect(() => collectedInferenceCost(lease(0.5), bad, null)).toThrow(
+        InferenceAdmissionGateUnavailableError,
+      );
+    }
+    expect(collectedInferenceCost(lease(0), 0, null)).toBe(0);
+  });
+
+  test("rejects a non-finite or negative collectedAmount", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+      expect(() =>
+        collectedInferenceCost(lease(0.5), 0.2, reconciliation({ collectedAmount: bad })),
+      ).toThrow(/collectedAmount/);
+    }
+  });
+});
+
+describe("inferenceSettlementAmounts", () => {
+  test("with no reconciliation both halves are the gate-consumed amount", () => {
+    expect(inferenceSettlementAmounts(lease(0.5), 0.2, null)).toEqual({
+      balanceBackedUsd: 0.2,
+      gateConsumedUsd: 0.5,
+    });
+  });
+
+  test("a reported collectedAmount backs the balance and the gate alike", () => {
+    expect(
+      inferenceSettlementAmounts(lease(0.5), 0.9, reconciliation({ collectedAmount: 0.3 })),
+    ).toEqual({ balanceBackedUsd: 0.3, gateConsumedUsd: 0.3 });
+  });
+
+  test("an uncollected overage caps the balance-backed half at the reservation", () => {
+    // The gate consumes the full floor, but only the reserved amount was ever
+    // actually backed by credits — the difference is the uncollected overage.
+    expect(
+      inferenceSettlementAmounts(
+        lease(0.5),
+        0.9,
+        reconciliation({ adjustmentType: "uncollected_overage", reservedAmount: 0.4 }),
+      ),
+    ).toEqual({ balanceBackedUsd: 0.4, gateConsumedUsd: 0.9 });
+  });
+
+  test("an uncollected overage never reports more backed than consumed", () => {
+    // reservedAmount above the consumed total must clamp, not inflate.
+    expect(
+      inferenceSettlementAmounts(
+        lease(0.5),
+        0.2,
+        reconciliation({ adjustmentType: "uncollected_overage", reservedAmount: 10 }),
+      ),
+    ).toEqual({ balanceBackedUsd: 0.5, gateConsumedUsd: 0.5 });
+  });
+
+  test("a plain reconciliation backs the actual while the gate keeps its floor", () => {
+    expect(inferenceSettlementAmounts(lease(0.5), 0.2, reconciliation())).toEqual({
+      balanceBackedUsd: 0.2,
+      gateConsumedUsd: 0.2,
+    });
+  });
+
+  test("rejects a non-finite reservedAmount on the uncollected-overage path", () => {
+    expect(() =>
+      inferenceSettlementAmounts(
+        lease(0.5),
+        0.9,
+        reconciliation({ adjustmentType: "uncollected_overage", reservedAmount: Number.NaN }),
+      ),
+    ).toThrow(/reservedAmount/);
+  });
+
+  test("balance-backed never exceeds gate-consumed on any branch", () => {
+    const cases: Array<[number, CreditReconciliationResult | null]> = [
+      [0.2, null],
+      [0.9, null],
+      [0.2, reconciliation()],
+      [0.9, reconciliation({ collectedAmount: 0.3 })],
+      [0.9, reconciliation({ adjustmentType: "uncollected_overage", reservedAmount: 0.4 })],
+      [0.2, reconciliation({ adjustmentType: "uncollected_overage", reservedAmount: 10 })],
+    ];
+    for (const [actual, rec] of cases) {
+      const { balanceBackedUsd, gateConsumedUsd } = inferenceSettlementAmounts(
+        lease(0.5),
+        actual,
+        rec,
+      );
+      expect(balanceBackedUsd).toBeLessThanOrEqual(gateConsumedUsd);
+    }
+  });
+});
+
+describe("isInferenceAdmissionDispatchMarkError", () => {
+  test("recognizes the error directly and through a cause chain", () => {
+    const dispatch = new InferenceAdmissionDispatchMarkError("mark failed");
+    expect(isInferenceAdmissionDispatchMarkError(dispatch)).toBe(true);
+    expect(isInferenceAdmissionDispatchMarkError(new Error("wrapped", { cause: dispatch }))).toBe(
+      true,
+    );
+    expect(
+      isInferenceAdmissionDispatchMarkError(
+        new Error("outer", { cause: new Error("inner", { cause: dispatch }) }),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not treat the base unavailable error as a dispatch failure", () => {
+    // The subclass carries a different settlement rule, so the parent must not
+    // match — otherwise every gate outage would settle as zero.
+    expect(
+      isInferenceAdmissionDispatchMarkError(new InferenceAdmissionGateUnavailableError()),
+    ).toBe(false);
+  });
+
+  test("returns false for non-errors and empty chains", () => {
+    for (const value of [undefined, null, "dispatch", 42, {}, new Error("plain")]) {
+      expect(isInferenceAdmissionDispatchMarkError(value)).toBe(false);
+    }
+  });
+
+  test("stops at the depth limit rather than walking forever", () => {
+    // 12 hops are inspected; a dispatch error buried deeper is not found.
+    const buildChain = (depth: number): Error => {
+      let error: Error = new InferenceAdmissionDispatchMarkError("deep");
+      for (let index = 0; index < depth; index += 1) {
+        error = new Error(`wrap-${index}`, { cause: error });
+      }
+      return error;
+    };
+    expect(isInferenceAdmissionDispatchMarkError(buildChain(11))).toBe(true);
+    expect(isInferenceAdmissionDispatchMarkError(buildChain(12))).toBe(false);
+  });
+
+  test("terminates on a cyclic cause chain instead of hanging", () => {
+    const first = new Error("first");
+    const second = new Error("second", { cause: first });
+    (first as { cause?: unknown }).cause = second;
+    expect(isInferenceAdmissionDispatchMarkError(first)).toBe(false);
+  });
+});
+
+describe("InferenceAdmissionLeaseRejectedError", () => {
+  test("keeps both amounts as fields and renders them at four decimals", () => {
+    const error = new InferenceAdmissionLeaseRejectedError(1.23456, 0.5);
+    expect(error.requiredUsd).toBe(1.23456);
+    expect(error.availableUsd).toBe(0.5);
+    expect(error.name).toBe("InferenceAdmissionLeaseRejectedError");
+    expect(error.message).toBe(
+      "Inference admission lease rejected. Required: $1.2346, Available: $0.5000",
+    );
+  });
+});


### PR DESCRIPTION
# What

Three untested things in `inference-admission-gate.ts` decide how much money moves:

- **`collectedInferenceCost`** — how much a finished request actually cost, given the lease estimate and an optional reconciliation;
- **`inferenceSettlementAmounts`** — the split between what a real credit balance backed and what the gate consumed conservatively;
- **`isInferenceAdmissionDispatchMarkError`** — whether a failure settles at **zero** because the Durable Object may already have committed the dispatch intent.

The file has no sibling test. Each of these has several branches that differ only in which of `actual`, `estimatedCostUsd`, `collectedAmount` and `reservedAmount` wins, so a single representative case would leave most of them free to change silently.

# The change

One new file, 20 tests, **no mocks** — this surface is pure and reaches no database, cache or Durable Object.

Branches asserted on their own:

- **the estimate is a floor, never a ceiling** — the gate already consumed it, so an under-run cannot refund it (checked below, above and exactly at the estimate);
- **the uncollected-overage path keeps that same floor** rather than trusting the debit;
- **a reported `collectedAmount` wins** over both the estimate and the actual;
- **`collectedAmount` of exactly `0` is honoured, not treated as absent** — the code tests `!== undefined` rather than truthiness, and a zero-collection replay must not fall through to the estimate;
- **the reconciled-but-uncollected path is *not* floored by the estimate**, which is the one asymmetry in the function and is now pinned;
- **the uncollected overage caps the balance-backed half at `reservedAmount`**, and clamps rather than inflates when the reservation exceeds what was consumed;
- an invariant sweep over all six shapes: **balance-backed never exceeds gate-consumed**;
- `finiteNonNegative` rejecting `NaN`, `Infinity` and negatives for both `actualCostUsd` and `collectedAmount`, while allowing a legitimate `0`.

For the cause walker: direct match, one- and two-deep `cause` chains, **the base `InferenceAdmissionGateUnavailableError` deliberately *not* matching** its subclass (otherwise every gate outage would settle as zero), non-errors, the depth limit at exactly 11 versus 12 hops, and a cyclic chain.

# Evidence

Mutation-tested — **6 of 7 killed**:

| mutant | result |
|---|---|
| no-reconciliation floor: `Math.max(actual, estimate)` → `actual` | killed (2) |
| uncollected-overage floor: `Math.max` → `actual` | killed (2) |
| `collectedAmount !== undefined` → truthiness | killed (2) |
| settlement cap: `Math.min` → `Math.max` on `reservedAmount` | killed (3) |
| `finiteNonNegative` stops rejecting negatives | killed (2) |
| cause-walk depth `12` → `4` | killed |
| **remove the cycle guard (`seen` set)** | **survived** |

Runs: 20 pass / 0 fail. All `*inference-admission*` suites under `--isolate`: **232 tests across 21 files, 0 fail**. `bun run --cwd packages/cloud/shared typecheck` clean; `biome check` clean.

# The one survivor, and why I did not write a test for it

Removing the `seen` set from `isInferenceAdmissionDispatchMarkError` changes no observable behaviour: the `depth < 12` bound already terminates the walk, so a cyclic `cause` chain returns `false` either way and never hangs. The cycle guard is defence in depth against a future edit that raises or removes that bound — not an untested branch.

So there is nothing a test could assert that the depth limit does not already guarantee, and I would **keep the guard**: it is the thing that stays correct if the depth limit ever changes. Flagging it here so the survivor is not mistaken for a coverage hole later.

# Scope

Test-only; no production file is modified.

Separately, while sweeping for the fail-open pattern from #30469 I checked the other unguarded date comparisons in this package and they are all safe — `sql-membership.ts` validates `validUntil` with `Number.isFinite` on every write path, `container-stop-job-service.ts` requires a canonical ISO round-trip, and the `expires_at` comparisons all read a database `timestamp` column. No further fix is needed there; recording it so the ground stays covered.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MKQQHFAPDSWYFS9ABXZRF8","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T21:45:26.319Z","completed_at":"2026-09-03T21:46:17.049Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T21:45:26.978Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b8fd717e19af22036ed06898b8bbcf8b7bdd0ff149cf3d51c7a567542ece724c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4f7996bd-ff37-4638-bbae-8948cfee0586","object_id":"sha256:b8fd717e19af22036ed06898b8bbcf8b7bdd0ff149cf3d51c7a567542ece724c","sha256":"b8fd717e19af22036ed06898b8bbcf8b7bdd0ff149cf3d51c7a567542ece724c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"2Hi4hsf4EKdf4da7zS_TZWVKGGtWfnmB8rW1e3b9tN0j8KXU2mgRCfKh6nqcVuQIVnVRSQ0hzCK71wT2kBdFBg"}} -->
