### PR TITLE
test(core): pin the signed-hosted URL gate and the sensitive-path guarantee

### DIFF
--- a/packages/core/src/messaging/interactions/profiles.signed-hosted.test.ts
+++ b/packages/core/src/messaging/interactions/profiles.signed-hosted.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Safety gates around interaction delivery negotiation that the existing
+ * profile suites leave unpinned: the signed-hosted URL checks, the guarantee
+ * that a `secret` block never leaves the sensitive path, and the registry's
+ * copy-on-read.
+ *
+ * The signed-hosted URL is what a connector is told to send a user to, so
+ * "https only, no embedded credentials, no fragment, parses at all" is a
+ * security boundary rather than tidiness. Each condition is asserted on its
+ * own — a single "rejects a bad URL" case would let four of the five be
+ * deleted silently.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+	ChoiceInteraction,
+	FormInteraction,
+	SecretInteraction,
+} from "../../types/interactions";
+import {
+	BUTTON_INTERACTION_PROFILE,
+	RICH_INTERACTION_PROFILE,
+} from "./profile-catalog";
+import {
+	ConnectorInteractionProfileRegistry,
+	createConnectorInteractionCapabilityProfile,
+	negotiateInteractionDelivery,
+} from "./profiles";
+
+function profile(template = RICH_INTERACTION_PROFILE) {
+	return createConnectorInteractionCapabilityProfile({
+		template,
+		source: "connector",
+		accountId: "account-a",
+		targetKind: "room",
+		targetId: "room-a",
+	});
+}
+
+/** A choice too wide for any native surface, so negotiation must fall back. */
+const wideChoice: ChoiceInteraction = {
+	kind: "choice",
+	id: "wide-1",
+	scope: "approval",
+	// Past the RICH profile's 100-item list and 100-button ceilings, so the
+	// native mode always carries a limitation and negotiation must fall back.
+	options: Array.from({ length: 150 }, (_, index) => ({
+		value: `option-${index}`,
+		label: `Option ${index}`,
+	})),
+};
+
+function negotiateWith(signedHostedUrl: string | undefined, verified = true) {
+	return negotiateInteractionDelivery(wideChoice, profile(), {
+		signedHostedUrl,
+		signedHostedUrlVerified: verified,
+	});
+}
+
+/** The signed-hosted mode is unusable, so negotiation lands elsewhere or throws. */
+function hostedWasRejected(url: string | undefined, verified = true): boolean {
+	try {
+		return negotiateWith(url, verified).mode !== "signed-hosted";
+	} catch {
+		return true;
+	}
+}
+
+describe("signed-hosted URL safety gate", () => {
+	it("accepts a well-formed https URL as the fallback", () => {
+		const result = negotiateWith("https://example.test/interaction/abc");
+		expect(result.mode).toBe("signed-hosted");
+		expect(result.reason).toBe("native-limit");
+	});
+
+	it("rejects a non-https scheme", () => {
+		// http is the one that matters; the others confirm it is a scheme
+		// allowlist and not a "not javascript:" denylist.
+		for (const url of [
+			"http://example.test/interaction/abc",
+			"ftp://example.test/interaction/abc",
+			"data:text/html,hi",
+		]) {
+			expect(hostedWasRejected(url)).toBe(true);
+		}
+	});
+
+	it("rejects credentials embedded in the URL", () => {
+		expect(hostedWasRejected("https://user@example.test/abc")).toBe(true);
+		expect(hostedWasRejected("https://user:pass@example.test/abc")).toBe(true);
+		expect(hostedWasRejected("https://:pass@example.test/abc")).toBe(true);
+	});
+
+	it("rejects a fragment", () => {
+		// A fragment never reaches the server, so anything relying on it is
+		// either a client-side redirect trick or a signature that is not covered.
+		expect(hostedWasRejected("https://example.test/abc#token")).toBe(true);
+		expect(hostedWasRejected("https://example.test/abc#")).toBe(false);
+	});
+
+	it("rejects a URL that does not parse at all", () => {
+		expect(hostedWasRejected("not a url")).toBe(true);
+		expect(hostedWasRejected("https://")).toBe(true);
+	});
+
+	it("requires the host to have verified the URL", () => {
+		expect(hostedWasRejected("https://example.test/abc", false)).toBe(true);
+	});
+
+	it("rejects an absent URL", () => {
+		expect(hostedWasRejected(undefined)).toBe(true);
+	});
+
+	it("is unavailable when the profile does not support links at all", () => {
+		// Every catalog template supports links, so this one is built: with link
+		// support withdrawn, signed-hosted can never apply no matter how good
+		// the URL is.
+		const noLinks = profile({
+			...RICH_INTERACTION_PROFILE,
+			templateId: "rich-no-links-v1",
+			limits: {
+				...RICH_INTERACTION_PROFILE.limits,
+				links: { supported: false, maxUrlBytes: 0 },
+			},
+		});
+		const result = negotiateInteractionDelivery(wideChoice, noLinks, {
+			signedHostedUrl: "https://example.test/interaction/abc",
+			signedHostedUrlVerified: true,
+		});
+		expect(result.mode).not.toBe("signed-hosted");
+	});
+
+	it("forbids a link byte cap that disagrees with link support", () => {
+		// This invariant is why the `links.supported` early return cannot be
+		// isolated by a test: a profile with links unsupported is *required* to
+		// carry maxUrlBytes 0, so the byte cap already rejects every URL.
+		expect(() =>
+			profile({
+				...RICH_INTERACTION_PROFILE,
+				templateId: "rich-bad-links-v1",
+				limits: {
+					...RICH_INTERACTION_PROFILE.limits,
+					links: { supported: false, maxUrlBytes: 2_048 },
+				},
+			}),
+		).toThrow(/must be zero when unsupported/i);
+	});
+});
+
+describe("secret blocks never leave the sensitive path", () => {
+	const secret: SecretInteraction = {
+		kind: "secret",
+		id: "secret-1",
+		secretKind: "secret",
+		fields: [{ name: "token", label: "Token", type: "secret" }],
+	};
+
+	it("routes to sensitive-request regardless of what the profile supports", () => {
+		for (const template of [
+			RICH_INTERACTION_PROFILE,
+			BUTTON_INTERACTION_PROFILE,
+		]) {
+			const result = negotiateInteractionDelivery(secret, profile(template), {
+				signedHostedUrl: "https://example.test/interaction/abc",
+				signedHostedUrlVerified: true,
+			});
+			expect(result).toEqual({
+				mode: "sensitive-request",
+				reason: "sensitive",
+				limitations: [],
+			});
+		}
+	});
+
+	it("refuses to carry a secret field on an ordinary form", () => {
+		const form: FormInteraction = {
+			kind: "form",
+			id: "form-1",
+			title: "Credentials",
+			fields: [
+				{ name: "name", label: "Name", type: "text" },
+				{ name: "token", label: "Token", type: "secret" },
+			],
+		};
+		expect(() => negotiateInteractionDelivery(form, profile())).toThrow(
+			/Secret fields cannot use an ordinary interaction form/i,
+		);
+	});
+});
+
+describe("ConnectorInteractionProfileRegistry copies on read and write", () => {
+	it("does not hand out a reference a caller can mutate", () => {
+		const registry = new ConnectorInteractionProfileRegistry();
+		const registered = registry.register(profile());
+
+		const first = registry.get(registered.profileId);
+		expect(first).not.toBeNull();
+		(first as { profileId: string }).profileId = "tampered";
+		(
+			first as { limits: { links: { maxUrlBytes: number } } }
+		).limits.links.maxUrlBytes = 1;
+
+		const second = registry.get(registered.profileId);
+		expect(second?.profileId).toBe(registered.profileId);
+		expect(second?.limits.links.maxUrlBytes).toBe(
+			registered.limits.links.maxUrlBytes,
+		);
+	});
+
+	it("returns null for an unknown profile id", () => {
+		expect(
+			new ConnectorInteractionProfileRegistry().get("ip1:missing"),
+		).toBeNull();
+	});
+});


### PR DESCRIPTION
# What

`profiles.ts` is already exercised by `session-authority.test.ts` and friends — 60 tests across three suites. I mutation-tested it against those suites, and the **signed-hosted URL safety gate is almost entirely unpinned**.

The signed-hosted URL is where a connector sends a user when a native interaction will not fit, so `signedHostedLimitations` is a security boundary. Of its six conditions, only one is currently caught if you delete it:

| mutant applied to `signedHostedLimitations` | existing 60 tests |
|---|---|
| drop `protocol !== "https:"` | **survives** |
| allow `parsed.username` | **survives** |
| allow `parsed.password` | **survives** |
| allow `parsed.hash` | **survives** |
| make a malformed URL return "safe" instead of unsafe | **survives** |
| drop `signedHostedUrlVerified` | caught |

Two more elsewhere in the file:

| mutant | existing 60 tests |
|---|---|
| remove the rule that a `secret` block always returns `sensitive-request` | **survives** |
| `registry.get()` returns the stored object instead of a `structuredClone` | **survives** |

That last pair matters as much as the URL ones: the first is the guarantee that credential-collecting blocks never take an ordinary delivery path, and the second lets a caller mutate registry state through a handed-out reference.

# The change

One new file, 13 tests, each condition on its own. Highlights:

- **scheme is an allowlist, not a `javascript:` denylist** — `http:`, `ftp:` and `data:` are all rejected, not just the obvious one;
- **credentials in three shapes** — `user@`, `user:pass@`, and `:pass@`;
- **a fragment is rejected**, and an empty `#` is not — a fragment never reaches the server, so anything depending on it is outside whatever the signature covers;
- **an unparseable URL is a negotiation failure**, matching the `error-policy:J3` comment already in the source;
- a `secret` block routes to `sensitive-request` **across two different profiles**, so the guarantee is shown to be profile-independent rather than incidental;
- registry copy-on-read is checked by mutating a **nested** limit on the returned object, not just a top-level field.

**7 of the 8 survivors above are now killed.**

# The eighth cannot be isolated, and that is a property of the schema

`if (!profile.limits.links.supported) return ["links unsupported"];` still survives, and I chased it rather than leaving it as an open question. `supportedLimit` **enforces** `maxUrlBytes === 0` whenever `links.supported` is false — a profile that says otherwise is rejected at normalization. So for every constructible profile with links unsupported, the byte cap `utf8Bytes(url) > 0` already rejects any non-empty URL, and the early return can never be the deciding clause.

It is redundant, not untested. I would **keep it** — it is the check that stays correct if the byte-cap rule ever changes — and instead added a test pinning the normalizer invariant that makes it redundant, so the reasoning is executable rather than a comment.

# A note on how I found this

My first pass used "source file has no sibling `*.test.ts`" to find untested modules, and it flagged `profiles.ts`. That was **wrong** — its coverage lives in `session-authority.test.ts`, under a different name. Measuring with mutants instead of filenames is what turned a bad lead into a real gap, and it is worth saying so plainly: the gap here is not "this file is untested", it is "these specific conditions are not asserted".

# Verification

- New suite: 13 pass / 0 fail.
- Whole `messaging/interactions/` directory: **285 tests across 13 files, 0 fail**.
- `bun run --cwd packages/core typecheck` clean; `biome check` clean.

Test-only; no production file is modified.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MM3XGAEG14CDF06R3D8M5T","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T21:52:05.643Z","completed_at":"2026-09-03T21:52:54.112Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T21:52:06.351Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5659e37f9c459fb532aa3c477c9b8e0aaa96176873cc65f1e4121f74c97d1372","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"949d7be8-e407-44f6-89c8-c3bcd5c227e5","object_id":"sha256:5659e37f9c459fb532aa3c477c9b8e0aaa96176873cc65f1e4121f74c97d1372","sha256":"5659e37f9c459fb532aa3c477c9b8e0aaa96176873cc65f1e4121f74c97d1372"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"6EIy9clmI76gpWndsm8iwGjW2cCeQqsu2Omq7lmfcq9oyLGkc_Mj2i-GL8lAcA--LT1BN9vbLu9_GCtuedRSAw"}} -->
