### PR TITLE
test(cloud): pin OIDC redirect matching, secret rotation and scope intersection

### DIFF
--- a/packages/cloud/shared/src/lib/oidc/clients.authorization.test.ts
+++ b/packages/cloud/shared/src/lib/oidc/clients.authorization.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Runtime authorization for the OpenID Connect provider: redirect-URI matching,
+ * client-secret verification across a rotation window, and scope intersection.
+ *
+ * These are the three decisions made on every authorize/token request, and the
+ * first two are the classic OIDC attack surface — a redirect matcher that
+ * normalizes or prefix-matches hands an attacker the authorization code, and a
+ * secret check that stops at the first hash leaks which one is current.
+ *
+ * `isRegisteredRedirectUri` documents "Exact string equality — no
+ * normalization, no prefix, no wildcard", so each of those three is asserted
+ * separately rather than through one "rejects a bad URI" case.
+ *
+ * Registry entries are loaded through the real `OIDC_CLIENTS` parse path; no
+ * mocks.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  _resetOidcClientCacheForTests,
+  getOidcClient,
+  intersectScopes,
+  isOidcClientRegistryConfigured,
+  isRegisteredRedirectUri,
+  listOidcClients,
+  type OidcClient,
+  verifyOidcClientSecret,
+} from "./clients";
+import { sha256Hex } from "./crypto";
+
+const CLIENT_ID = "elizahub-forgejo";
+const CALLBACK = "https://hub.example/user/oauth2/elizacloud/callback";
+
+function entry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    client_id: CLIENT_ID,
+    client_secret_sha256: "a".repeat(64),
+    redirect_uris: [CALLBACK],
+    allowed_scopes: ["openid", "email", "profile", "groups"],
+    claims_policy: { groups: true, roles: true, tenant_id: true, eliza_agents: false },
+    ...overrides,
+  };
+}
+
+/** Loads a registry the way the Worker does, then returns the parsed client. */
+function loadClient(overrides: Record<string, unknown> = {}): OidcClient {
+  process.env.OIDC_CLIENTS = JSON.stringify([entry(overrides)]);
+  _resetOidcClientCacheForTests();
+  const client = getOidcClient(CLIENT_ID);
+  if (!client) throw new Error("fixture registry failed to load");
+  return client;
+}
+
+afterEach(() => {
+  delete process.env.OIDC_CLIENTS;
+  delete process.env.OIDC_REDIRECT_URI_ALIASES;
+  _resetOidcClientCacheForTests();
+});
+
+describe("isRegisteredRedirectUri is exact string equality", () => {
+  test("accepts only the byte-identical registered callback", () => {
+    const client = loadClient();
+    expect(isRegisteredRedirectUri(client, CALLBACK)).toBe(true);
+  });
+
+  test("rejects an absent redirect_uri instead of defaulting to the registered one", () => {
+    const client = loadClient();
+    expect(isRegisteredRedirectUri(client, null)).toBe(false);
+    expect(isRegisteredRedirectUri(client, "")).toBe(false);
+  });
+
+  test("no prefix matching: a registered callback is not a namespace", () => {
+    const client = loadClient();
+    for (const attacker of [
+      `${CALLBACK}/../../evil`,
+      `${CALLBACK}/evil`,
+      `${CALLBACK}.evil.example`,
+      `${CALLBACK}?next=https://evil.example`,
+      `${CALLBACK}#evil`,
+    ]) {
+      expect(isRegisteredRedirectUri(client, attacker)).toBe(false);
+    }
+  });
+
+  test("no normalization: trailing slash, case and encoding all differ", () => {
+    const client = loadClient();
+    for (const variant of [
+      `${CALLBACK}/`,
+      CALLBACK.replace("hub.example", "HUB.EXAMPLE"),
+      CALLBACK.replace("https://", "HTTPS://"),
+      CALLBACK.replace("/callback", "/call%62ack"),
+      CALLBACK.replace("https://hub.example", "https://hub.example:443"),
+    ]) {
+      expect(isRegisteredRedirectUri(client, variant)).toBe(false);
+    }
+  });
+
+  test("no wildcards: a wildcard redirect_uri is refused by the registry itself", () => {
+    // Stronger than the matcher being exact — an operator cannot register a
+    // wildcard at all, so the open-redirector shape never reaches the matcher.
+    expect(() => loadClient({ redirect_uris: ["*"] })).toThrow(/redirect_uri/i);
+  });
+
+  test("a URL-shaped glob registers, but matches only itself", () => {
+    // `https://hub.example/*` is a syntactically valid URL, so the registry
+    // accepts it. The matcher must still treat it as a literal path and not as
+    // a pattern covering the callbacks beneath it.
+    const glob = "https://hub.example/*";
+    const client = loadClient({ redirect_uris: [glob] });
+    expect(isRegisteredRedirectUri(client, glob)).toBe(true);
+    expect(isRegisteredRedirectUri(client, CALLBACK)).toBe(false);
+    expect(isRegisteredRedirectUri(client, "https://hub.example/anything")).toBe(false);
+  });
+
+  test("every registered callback matches, not only the first", () => {
+    const second = "https://hub.example/other/callback";
+    const client = loadClient({ redirect_uris: [CALLBACK, second] });
+    expect(isRegisteredRedirectUri(client, CALLBACK)).toBe(true);
+    expect(isRegisteredRedirectUri(client, second)).toBe(true);
+  });
+});
+
+describe("verifyOidcClientSecret", () => {
+  const SECRET = "correct-horse-battery-staple";
+  const OTHER = "rotated-next-secret";
+
+  test("accepts the secret behind the registered digest", async () => {
+    const client = loadClient({ client_secret_sha256: await sha256Hex(SECRET) });
+    expect(await verifyOidcClientSecret(client, SECRET)).toBe(true);
+  });
+
+  test("rejects a wrong secret, and an absent one without hashing", async () => {
+    const client = loadClient({ client_secret_sha256: await sha256Hex(SECRET) });
+    expect(await verifyOidcClientSecret(client, `${SECRET}x`)).toBe(false);
+    expect(await verifyOidcClientSecret(client, "")).toBe(false);
+    expect(await verifyOidcClientSecret(client, null)).toBe(false);
+    expect(await verifyOidcClientSecret(client, undefined)).toBe(false);
+  });
+
+  test("a rotation window accepts both the old and the new secret", async () => {
+    // Order matters: the second listed digest must be reachable, which is what
+    // makes a rotation window usable at all.
+    const client = loadClient({
+      client_secret_sha256: [await sha256Hex(SECRET), await sha256Hex(OTHER)],
+    });
+    expect(await verifyOidcClientSecret(client, SECRET)).toBe(true);
+    expect(await verifyOidcClientSecret(client, OTHER)).toBe(true);
+    expect(await verifyOidcClientSecret(client, "neither")).toBe(false);
+  });
+
+  test("the digest comparison is case-insensitive on the registered side only", async () => {
+    // parseSecretHashes lowercases the registry value, so an operator pasting
+    // an uppercase digest still works; the presented secret is never folded.
+    const client = loadClient({ client_secret_sha256: (await sha256Hex(SECRET)).toUpperCase() });
+    expect(await verifyOidcClientSecret(client, SECRET)).toBe(true);
+    expect(await verifyOidcClientSecret(client, SECRET.toUpperCase())).toBe(false);
+  });
+});
+
+describe("intersectScopes", () => {
+  test("grants the intersection in the order the client requested", () => {
+    const client = loadClient();
+    expect(intersectScopes(client, ["profile", "openid", "email"])).toEqual([
+      "profile",
+      "openid",
+      "email",
+    ]);
+  });
+
+  test("drops scopes the registry did not allow rather than granting them", () => {
+    const client = loadClient();
+    expect(intersectScopes(client, ["openid", "eliza_agents", "admin"])).toEqual(["openid"]);
+  });
+
+  test("deduplicates a repeated request without reordering", () => {
+    const client = loadClient();
+    expect(intersectScopes(client, ["email", "openid", "email"])).toEqual(["email", "openid"]);
+  });
+
+  test("is a subset of the request, never the full allowlist", () => {
+    // The canonical mistake is returning everything allowed when a narrow
+    // request comes in; the result must never contain an unrequested scope.
+    const client = loadClient();
+    const granted = intersectScopes(client, ["openid"]);
+    expect(granted).toEqual(["openid"]);
+    expect(granted).not.toContain("profile");
+    expect(intersectScopes(client, [])).toEqual([]);
+  });
+});
+
+describe("registry presence helpers", () => {
+  test("reports unconfigured when OIDC_CLIENTS is unset or blank", () => {
+    delete process.env.OIDC_CLIENTS;
+    _resetOidcClientCacheForTests();
+    expect(isOidcClientRegistryConfigured()).toBe(false);
+    process.env.OIDC_CLIENTS = "   ";
+    _resetOidcClientCacheForTests();
+    expect(isOidcClientRegistryConfigured()).toBe(false);
+  });
+
+  test("reports configured and lists every registered client once loaded", () => {
+    loadClient();
+    expect(isOidcClientRegistryConfigured()).toBe(true);
+    const listed = listOidcClients();
+    expect(listed.map((client) => client.client_id)).toEqual([CLIENT_ID]);
+  });
+});


### PR DESCRIPTION
# What

Three functions in `lib/oidc/clients.ts` decide every authorize and token request, and **no test file referenced any of them**:

- **`isRegisteredRedirectUri`** — where the authorization code is allowed to be sent;
- **`verifyOidcClientSecret`** — whether a client is who it claims to be, across a rotation window;
- **`intersectScopes`** — what the issued token is actually allowed to do.

The first two are the classic OIDC attack surface. A redirect matcher that normalizes or prefix-matches hands an attacker the authorization code; a secret check that returns on the first matching hash makes a rotation window leak which digest is current.

`isRegisteredRedirectUri` carries its own documented rule — *"Exact string equality — no normalization, no prefix, no wildcard"* — which is exactly the kind of invariant a single "rejects a bad URI" test would leave two-thirds unguarded.

# The change

One new file, 17 tests, no mocks — registry entries load through the real `OIDC_CLIENTS` parse path.

The documented rule is split into its three claims:

- **no prefix** — path traversal (`…/callback/../../evil`), a nested path, a suffix-extended host (`…callback.evil.example`), an appended query, and an appended fragment;
- **no normalization** — trailing slash, host case, scheme case, percent-encoded path (`/call%62ack`), and an explicit `:443` port;
- **no wildcard** — see below;
- plus: a `null`/empty `redirect_uri` must not fall back to "the registered one", and **every** registered callback matches, not just the first.

For the secret: the rotation window is asserted in both directions (old *and* new digest accepted, so the second listed hash is provably reachable), an absent secret is rejected without hashing, and the registry lowercases the stored digest while the presented secret is never case-folded.

For scopes: request order is preserved, duplicates collapse without reordering, unlisted scopes are dropped, and the result is proven to be a **subset of the request** rather than the full allowlist.

# A test failure corrected my assumption, and the result is better

I expected `redirect_uris: ["*"]` to register and then match only the literal `"*"`. It does not: **the registry refuses a bare `*` at parse time**, which is a stronger guarantee than the matcher merely being exact. I rewrote the test to assert what actually happens.

A URL-shaped glob like `https://hub.example/*` *is* syntactically valid and does register, so there is a second case showing it still matches only itself and not the callbacks beneath it.

# Evidence

Mutation-tested — **9 of 9 killed**:

| mutant | result |
|---|---|
| exact match → `startsWith` prefix match | killed (2) |
| exact match → case-insensitive compare | killed |
| match only the first registered URI | killed |
| a `null` redirect_uri falls through to allowed | killed |
| an absent client secret is accepted | killed |
| only the first secret hash is checked | killed |
| `intersectScopes` returns the whole allowlist | killed (4) |
| deduplication dropped | killed |
| allowlist ignored entirely | killed |

Runs: 17 pass / 0 fail. `src/lib/oidc/` under `--isolate`: **248 tests across 12 files, 0 fail**. `bun run --cwd packages/cloud/shared typecheck` clean; `biome check` clean.

# What these tests do not prove

The constant-time property of `verifyOidcClientSecret` is **not** covered, and I checked rather than assuming. Rewriting `matched = true` as an early `return true` passes the whole suite — functionally identical, timing-wise not. So the loop's docstring claim ("never leaks which one matched") rests on review, not on this suite; a timing assertion would be flaky and I did not write a fake one. Flagging it so the coverage is not read as broader than it is.

# Scope

Test-only; no production file is modified.

This complements my open #30436, which covers registry **parsing** (`parseOidcClientEntry`, `getOidcClient`) in `clients.test.ts`. These are the runtime **authorization** functions, in a separate file — no overlap and no conflict between the two.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MMGPGJJ6V8T7RTA4T4DCHY","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T21:59:04.467Z","completed_at":"2026-09-03T21:59:54.304Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T21:59:05.175Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f1041c7483449eba99510c98d4c028d84caee1bb467da64452b911d4c83febad","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"ac1f185a-dc0f-493f-ad15-97f472647ff2","object_id":"sha256:f1041c7483449eba99510c98d4c028d84caee1bb467da64452b911d4c83febad","sha256":"f1041c7483449eba99510c98d4c028d84caee1bb467da64452b911d4c83febad"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"3ZNk78t2nUswTZEWFBZZuh_3BFuaIve06rvFdobql4hawppIGI7VVHfFpMnNdUFaZstBhKhxKfgRaWfrycWpAA"}} -->
