### PR TITLE
test(cloud): pin the inline payload ceiling and object key derivation

### DIFF
--- a/packages/cloud/shared/src/lib/storage/object-store.inline-gate.test.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store.inline-gate.test.ts
@@ -1,0 +1,285 @@
+/**
+ * The inline-payload ceiling and object-key derivation for heavy SQL payloads.
+ *
+ * The ceiling exists because unbounded inline writes put a quarter-gigabyte
+ * failure dump in `jobs.error` (#22553), so its byte counter, its env parsing
+ * and its boundary all matter. `byteLength` is hand-rolled specifically to
+ * avoid materializing a second payload-sized buffer, and its comment claims it
+ * matches `TextEncoder` "including unpaired surrogates" — that claim is
+ * asserted here against `TextEncoder` itself rather than trusted.
+ *
+ * Mock-free: every case drives the real exports through `process.env`, which
+ * `getCloudAwareEnv()` falls through to outside a request.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  assertInlinePayloadFits,
+  buildObjectFieldKey,
+  InlinePayloadTooLargeError,
+  inlinePayloadCeilingBytes,
+  shouldUseObjectStorage,
+} from "./object-store";
+
+const DEFAULT_CEILING = 1024 * 1024;
+const HIGH_SURROGATE = String.fromCharCode(0xd83d);
+const LOW_SURROGATE = String.fromCharCode(0xdc00);
+
+const STORAGE_ENV = [
+  "SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES",
+  "SQL_HEAVY_PAYLOAD_STORAGE",
+  "HEAVY_PAYLOAD_STORAGE",
+  "STORAGE_PROVIDER",
+  "STORAGE_ENDPOINT",
+  "STORAGE_ACCESS_KEY_ID",
+  "STORAGE_SECRET_ACCESS_KEY",
+  "STORAGE_HEAVY_PAYLOADS_BUCKET",
+] as const;
+
+/** Minimal S3-compatible configuration that makes `storageConfigured()` true. */
+function configureObjectStorage(): void {
+  process.env.STORAGE_PROVIDER = "s3";
+  process.env.STORAGE_ENDPOINT = "https://storage.example.invalid";
+  process.env.STORAGE_ACCESS_KEY_ID = "access-key";
+  process.env.STORAGE_SECRET_ACCESS_KEY = "secret-key";
+  process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "heavy-payloads";
+}
+
+afterEach(() => {
+  for (const key of STORAGE_ENV) delete process.env[key];
+});
+
+/** Recovers the counter's own answer for `value` through the thrown error. */
+function measuredBytes(value: string): number {
+  process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "1024";
+  try {
+    assertInlinePayloadFits("field", `${value}${"a".repeat(1025)}`);
+  } catch (error) {
+    if (error instanceof InlinePayloadTooLargeError) return error.sizeBytes - 1025;
+    throw error;
+  }
+  throw new Error("expected the padded value to exceed the ceiling");
+}
+
+describe("the inline byte counter matches TextEncoder", () => {
+  const cases: Array<[string, string]> = [
+    ["ascii", "plain-ascii-payload"],
+    ["two-byte (Latin-1 supplement)", "café-ünïcödé"],
+    ["two-byte (Cyrillic)", "привет"],
+    ["three-byte (CJK)", "日本語テキスト"],
+    ["four-byte (astral, surrogate pair)", "🚀🛰🌍"],
+    ["mixed widths", "a√日🚀"],
+    ["empty", ""],
+  ];
+
+  for (const [label, value] of cases) {
+    test(`agrees on ${label}`, () => {
+      expect(measuredBytes(value)).toBe(new TextEncoder().encode(value).length);
+    });
+  }
+
+  test("agrees on a lone high surrogate", () => {
+    // The comment claims parity with TextEncoder's U+FFFD replacement, which is
+    // three bytes. A counter that assumed every high surrogate starts a pair
+    // would report four and silently under-count the real payload.
+    expect(measuredBytes(HIGH_SURROGATE)).toBe(new TextEncoder().encode(HIGH_SURROGATE).length);
+    expect(measuredBytes(HIGH_SURROGATE)).toBe(3);
+  });
+
+  test("agrees on a lone low surrogate and on a reversed pair", () => {
+    for (const value of [LOW_SURROGATE, `${LOW_SURROGATE}${HIGH_SURROGATE}`]) {
+      expect(measuredBytes(value)).toBe(new TextEncoder().encode(value).length);
+    }
+  });
+
+  test("two adjacent surrogates of the SAME half are not a pair", () => {
+    // Only high-then-low is a pair. Both of these are two independent
+    // replacement characters (3 + 3), and each pins one half of the pairing
+    // range: widening the start test to accept a low surrogate, or the
+    // continuation test to accept a high one, turns 6 bytes into 4.
+    for (const value of [
+      `${HIGH_SURROGATE}${HIGH_SURROGATE}`,
+      `${LOW_SURROGATE}${LOW_SURROGATE}`,
+    ]) {
+      expect(measuredBytes(value)).toBe(new TextEncoder().encode(value).length);
+      expect(measuredBytes(value)).toBe(6);
+    }
+  });
+
+  test("agrees on a high surrogate at the very end of the string", () => {
+    // The pairing branch reads index + 1, so a trailing high surrogate is the
+    // off-by-one case.
+    const trailing = `ok${HIGH_SURROGATE}`;
+    expect(measuredBytes(trailing)).toBe(new TextEncoder().encode(trailing).length);
+  });
+});
+
+describe("inlinePayloadCeilingBytes env parsing", () => {
+  test("defaults to 1 MiB when unset", () => {
+    expect(inlinePayloadCeilingBytes()).toBe(DEFAULT_CEILING);
+  });
+
+  test("falls back to the default rather than trusting an implausible floor", () => {
+    // Below 1024 an operator has almost certainly mis-set the variable; taking
+    // it literally would refuse every payload.
+    for (const raw of ["0", "1023", "-5000", "not-a-number", "NaN", "Infinity"]) {
+      process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = raw;
+      expect(inlinePayloadCeilingBytes()).toBe(DEFAULT_CEILING);
+    }
+  });
+
+  test("accepts 1024 as the lowest honoured value and floors a fraction", () => {
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "1024";
+    expect(inlinePayloadCeilingBytes()).toBe(1024);
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "2048.9";
+    expect(inlinePayloadCeilingBytes()).toBe(2048);
+  });
+});
+
+describe("assertInlinePayloadFits", () => {
+  test("permits a payload exactly at the ceiling and refuses one byte more", () => {
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "1024";
+    expect(() => assertInlinePayloadFits("error", "a".repeat(1024))).not.toThrow();
+    expect(() => assertInlinePayloadFits("error", "a".repeat(1025))).toThrow(
+      InlinePayloadTooLargeError,
+    );
+  });
+
+  test("measures bytes, not characters", () => {
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "1024";
+    // 400 astral characters are 1,600 UTF-8 bytes but only 800 UTF-16 units,
+    // so a length-based check would let this through.
+    expect(() => assertInlinePayloadFits("error", "🚀".repeat(400))).toThrow(
+      InlinePayloadTooLargeError,
+    );
+  });
+
+  test("carries the field, the measured size and the ceiling for the caller", () => {
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "1024";
+    try {
+      assertInlinePayloadFits("jobs.error", "a".repeat(2000));
+      throw new Error("expected a refusal");
+    } catch (error) {
+      expect(error).toBeInstanceOf(InlinePayloadTooLargeError);
+      const typed = error as InlinePayloadTooLargeError;
+      expect(typed.code).toBe("INLINE_PAYLOAD_TOO_LARGE");
+      expect(typed.field).toBe("jobs.error");
+      expect(typed.sizeBytes).toBe(2000);
+      expect(typed.maxInlineBytes).toBe(1024);
+      expect(typed.message).toContain("jobs.error");
+      expect(typed.message).toContain("SQL_HEAVY_PAYLOAD_STORAGE");
+    }
+  });
+});
+
+describe("buildObjectFieldKey", () => {
+  const base = {
+    namespace: "jobs" as never,
+    organizationId: "11111111-2222-4333-8444-555555555555",
+    objectId: "job-abc",
+    field: "error",
+    createdAt: new Date("2026-03-04T05:06:07.000Z"),
+    extension: "json" as const,
+  };
+
+  test("lays out namespace / org / UTC day / object / field.ext", () => {
+    expect(buildObjectFieldKey(base)).toBe(
+      "jobs/11111111-2222-4333-8444-555555555555/2026-03-04/job-abc/error.json",
+    );
+  });
+
+  test("the day segment is UTC, not local", () => {
+    // A local-date key would move the object between days for half the world.
+    expect(
+      buildObjectFieldKey({ ...base, createdAt: new Date("2026-03-04T23:59:59.999Z") }),
+    ).toContain("/2026-03-04/");
+    expect(
+      buildObjectFieldKey({ ...base, createdAt: new Date("2026-03-05T00:00:00.000Z") }),
+    ).toContain("/2026-03-05/");
+  });
+
+  test("a version becomes its own filename segment before the extension", () => {
+    expect(buildObjectFieldKey({ ...base, version: "g7" })).toBe(
+      "jobs/11111111-2222-4333-8444-555555555555/2026-03-04/job-abc/error.g7.json",
+    );
+  });
+
+  test("no caller-supplied segment can introduce a path separator", () => {
+    // This is what keeps a hostile objectId or field from escaping its prefix.
+    const key = buildObjectFieldKey({
+      ...base,
+      organizationId: "../../other-org",
+      objectId: "../../../etc/passwd",
+      field: "a/b\\c",
+      version: "v/1",
+    });
+    const segments = key.split("/");
+    expect(segments).toHaveLength(5);
+    expect(segments[0]).toBe("jobs");
+    expect(segments[1]).toBe(".._.._other-org");
+    expect(segments[2]).toBe("2026-03-04");
+    expect(segments[3]).toBe(".._.._.._etc_passwd");
+    expect(segments[4]).toBe("a_b_c.v_1.json");
+  });
+
+  test("collapses every character outside the key alphabet", () => {
+    const hostile = `sp ce${String.fromCharCode(9)}tab é🚀?#%`;
+    const objectSegment = buildObjectFieldKey({ ...base, objectId: hostile }).split("/")[3];
+    expect(objectSegment).toMatch(/^[a-zA-Z0-9._=-]+$/);
+    expect(objectSegment).not.toContain(" ");
+  });
+
+  test("keeps the alphabet's own characters intact", () => {
+    expect(buildObjectFieldKey({ ...base, objectId: "Ab9._=-" }).split("/")[3]).toBe("Ab9._=-");
+  });
+});
+
+describe("shouldUseObjectStorage", () => {
+  test("is true when storage is configured and no mode overrides it", () => {
+    configureObjectStorage();
+    expect(shouldUseObjectStorage()).toBe(true);
+  });
+
+  test("inline overrides fully configured storage", () => {
+    // Asserted against configured storage on purpose: with nothing configured
+    // the fallthrough returns false anyway, so an inline branch that stopped
+    // matching would be invisible.
+    configureObjectStorage();
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "inline";
+    expect(shouldUseObjectStorage()).toBe(false);
+  });
+
+  test("is false when the mode is inline and nothing is configured", () => {
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "inline";
+    expect(shouldUseObjectStorage()).toBe(false);
+  });
+
+  test("an explicit r2 mode with storage configured is true", () => {
+    configureObjectStorage();
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "r2";
+    expect(shouldUseObjectStorage()).toBe(true);
+  });
+
+  test("SQL_HEAVY_PAYLOAD_STORAGE wins over the legacy HEAVY_PAYLOAD_STORAGE", () => {
+    configureObjectStorage();
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "inline";
+    process.env.HEAVY_PAYLOAD_STORAGE = "r2";
+    expect(shouldUseObjectStorage()).toBe(false);
+  });
+
+  test("the legacy variable still applies on its own", () => {
+    configureObjectStorage();
+    process.env.HEAVY_PAYLOAD_STORAGE = "inline";
+    expect(shouldUseObjectStorage()).toBe(false);
+  });
+
+  test("demanding r2 without a configured bucket fails loudly, not silently inline", () => {
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "r2";
+    expect(() => shouldUseObjectStorage()).toThrow(/no Worker R2 binding|S3-compatible/i);
+  });
+
+  test("with no mode set and nothing configured it stays inline", () => {
+    expect(shouldUseObjectStorage()).toBe(false);
+  });
+});


### PR DESCRIPTION
# What

`packages/cloud/shared/src/lib/storage/object-store.ts` is the gate that keeps a quarter-gigabyte failure dump out of a SQL text column, and it had **no tests**. Ten of its twenty-three exports were referenced by no test file in the repo.

This adds `object-store.inline-gate.test.ts` — 31 tests, mock-free; every case drives the real exports through `process.env`.

# The claim worth asserting

`byteLength` is **hand-rolled on purpose** — the comment says `TextEncoder.encode()` "would transiently duplicate a 250 MB dump before the ceiling could reject or clamp it." That's the right call, but it means the counter is a second UTF-8 implementation, and its comment makes a specific claim:

> BMP code points and unpaired surrogates encode to three bytes; the latter matches TextEncoder's U+FFFD replacement behavior.

So the tests assert that claim **against `TextEncoder` itself**, not against hand-computed numbers: ASCII, Latin-1, Cyrillic, CJK, astral pairs, mixed widths, empty, a lone high surrogate, a lone low surrogate, a reversed pair, a high surrogate at the very end of the string (the `index + 1` off-by-one), and two adjacent surrogates of the same half.

`byteLength` isn't exported. Rather than export it for testability, the tests recover its answer through the public surface — set the ceiling to 1024, pad the value past it, read `InlinePayloadTooLargeError.sizeBytes`, subtract the padding. No production change.

# Mutation testing

I mutated `object-store.ts` in 15 places and required each mutant to fail the suite. **15/15 killed.** Two rounds — the first round had three survivors, and each one taught me something:

| survivor | why it lived | fix |
|---|---|---|
| pair-start upper bound `0xdbff` → `0xdfff` | a reversed `low+high` pair is `3+3` under both the original and the mutant | added `high+high` and `low+low`, which are 6 bytes originally and **4** under the mutants |
| continuation lower bound `0xdc00` → `0xd800` | same reason | same case covers both halves |
| `mode === "inline"` → a string that never matches | with nothing configured the function falls through to `storageConfigured() === false` **anyway**, so a broken inline branch was invisible | assert `inline` against *fully configured* storage, where the correct answer flips |

That third one is the one I'd flag to a reviewer: a `shouldUseObjectStorage` test written against an unconfigured environment proves nothing about the inline branch, because false is the answer either way.

Also killed: byte widths 1/2/3/4, the `1024`-byte env floor, `Math.floor` vs `ceil`, the `>` vs `>=` ceiling boundary, `=` in the segment alphabet, the `slice(0, 10)` UTC day, `SQL_HEAVY_PAYLOAD_STORAGE` winning over the legacy `HEAVY_PAYLOAD_STORAGE`, `r2`-without-a-bucket throwing instead of silently going inline, and the version filename segment.

# Also pinned

- **Bytes, not characters.** 400 astral characters are 1,600 UTF-8 bytes but only 800 UTF-16 units — a `.length` check would let that through the ceiling.
- **The env floor.** `0`, `1023`, `-5000`, `not-a-number`, `NaN` and `Infinity` all fall back to 1 MiB; `1024` is honoured; `2048.9` floors to `2048`.
- **The error contract**: `code`, `field`, `sizeBytes`, `maxInlineBytes`, and that the message names both the field and `SQL_HEAVY_PAYLOAD_STORAGE` so an operator knows the remedy.
- **`safeSegment` as a path-separator barrier.** An organizationId of `../../other-org`, an objectId of `../../../etc/passwd`, a field of `a/b\c` and a version of `v/1` still produce exactly **five** key segments. This is what keeps a hostile id from escaping its tenant prefix.
- **The day segment is UTC**, asserted at `23:59:59.999Z` and `00:00:00.000Z` — a local-date key would move objects between days for half the world.

# Evidence

```
bun test packages/cloud/shared/src/lib/storage/object-store.inline-gate.test.ts
  → 31 pass / 0 fail

bun test --isolate packages/cloud/shared/src/lib/storage/
  → 79 pass / 0 fail across 7 files

bun run --cwd packages/cloud/shared typecheck   → clean
bunx @biomejs/biome check                       → clean
```

`object-store.ts` is byte-identical to `develop` after the mutation runs — `git diff` on it is empty. Tests only.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MN37V9VE7E0FXVS84JCHGF","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T22:09:12.041Z","completed_at":"2026-09-03T22:09:59.035Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T22:09:13.011Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4e926c88374fa6475cd0a17c5a2a51efc7aa6fa9c834b54327dd123f13e23752","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"62d5217e-f0c4-4ba7-8c15-13885abc3408","object_id":"sha256:4e926c88374fa6475cd0a17c5a2a51efc7aa6fa9c834b54327dd123f13e23752","sha256":"4e926c88374fa6475cd0a17c5a2a51efc7aa6fa9c834b54327dd123f13e23752"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"CeqXycUZ81QMawXbs-kAiD967bGj-RhAo6Qkfvd-WMkwDnFQW4iMrffaonKSG-OTkNu9jxy2xCR4V_hJMdkVCQ"}} -->
