### PR TITLE
test(core): cover the trajectory strict-mode guards and source registry

### DIFF
--- a/packages/core/src/trajectory-utils.classifier.test.ts
+++ b/packages/core/src/trajectory-utils.classifier.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Covers the trajectory-utils exports that no test in the repo imports: the
+ * context-object extractors, the strict-mode guards and their model-type
+ * classifier, the trajectory-logger resolver, and the training-exclusion
+ * registry.
+ *
+ * The classifier is the interesting one. It decides which `runtime.useModel`
+ * calls `ELIZA_TRAJECTORY_STRICT=1` polices, so its partition over `ModelType`
+ * is enumerated here in full rather than sampled — see the note on `PII_SCRUB`
+ * below.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getTrajectoryContext,
+	runWithTrajectoryContext,
+} from "./trajectory-context";
+import {
+	__resetTrajectorySourceRegistryForTests,
+	assertActiveTrajectoryForLlmCall,
+	assertRecordedLlmCall,
+	extractContextEventsFromTrajectory,
+	extractContextObjectFromTrajectory,
+	isExcludedFromTraining,
+	isLlmGenerationModelType,
+	isTrajectoryStrictModeEnabled,
+	normalizeTrajectoryLlmPurpose,
+	registerTrajectorySource,
+	resolveTrajectoryLogger,
+	TRAJECTORY_LLM_PURPOSES,
+} from "./trajectory-utils";
+import type { IAgentRuntime } from "./types";
+import { ModelType } from "./types";
+
+const STRICT = "ELIZA_TRAJECTORY_STRICT";
+const previousStrict = process.env[STRICT];
+
+afterEach(() => {
+	if (previousStrict === undefined) delete process.env[STRICT];
+	else process.env[STRICT] = previousStrict;
+});
+
+/** Runs `fn` with an active trajectory step id in context. */
+function withActiveStep<T>(fn: () => T): T {
+	return runWithTrajectoryContext(
+		{ trajectoryStepId: "step-1" } as never,
+		fn,
+	) as T;
+}
+
+describe("extractContextObjectFromTrajectory", () => {
+	it("reads a context object carried directly on the trajectory", () => {
+		const found = extractContextObjectFromTrajectory({
+			contextObject: { id: "ctx-1", version: "v6", events: [{ kind: "a" }] },
+		});
+		expect(found?.id).toBe("ctx-1");
+		expect(found?.version).toBe("v6");
+		expect(found?.events).toHaveLength(1);
+	});
+
+	it("falls back to metadata.contextObject", () => {
+		const found = extractContextObjectFromTrajectory({
+			metadata: { contextObject: { events: [] } },
+		});
+		expect(found).not.toBeNull();
+	});
+
+	it("prefers the direct object over the metadata copy", () => {
+		const found = extractContextObjectFromTrajectory({
+			contextObject: { id: "direct", events: [] },
+			metadata: { contextObject: { id: "from-metadata", events: [] } },
+		});
+		expect(found?.id).toBe("direct");
+	});
+
+	it("supplies defaults for a missing or blank id and version", () => {
+		for (const id of [undefined, "", "   ", 7]) {
+			const found = extractContextObjectFromTrajectory({
+				contextObject: { id, events: [] },
+			});
+			expect(found?.id).toBe("context-object");
+			expect(found?.version).toBe("v5");
+		}
+	});
+
+	it("copies the event array instead of aliasing it", () => {
+		// A caller that mutates the returned events must not corrupt the source.
+		const events = [{ kind: "a" }];
+		const found = extractContextObjectFromTrajectory({
+			contextObject: { events },
+		});
+		expect(found?.events).not.toBe(events);
+		found?.events.push({ kind: "b" } as never);
+		expect(events).toHaveLength(1);
+	});
+
+	it("returns null for anything without an events array", () => {
+		for (const value of [
+			null,
+			undefined,
+			"trajectory",
+			7,
+			[],
+			{},
+			{ contextObject: {} },
+			{ contextObject: { events: "not-an-array" } },
+			{ metadata: "nope", contextObject: null },
+		]) {
+			expect(extractContextObjectFromTrajectory(value)).toBeNull();
+		}
+	});
+});
+
+describe("extractContextEventsFromTrajectory", () => {
+	it("prefers the context object's events", () => {
+		const events = extractContextEventsFromTrajectory({
+			contextObject: { events: [{ kind: "from-context-object" }] },
+			events: [{ kind: "top-level" }],
+		});
+		expect(events).toEqual([{ kind: "from-context-object" }]);
+	});
+
+	it("falls back to a top-level events array, then to metadata.contextEvents", () => {
+		expect(
+			extractContextEventsFromTrajectory({ events: [{ kind: "top" }] }),
+		).toEqual([{ kind: "top" }]);
+		expect(
+			extractContextEventsFromTrajectory({
+				metadata: { contextEvents: [{ kind: "meta" }] },
+			}),
+		).toEqual([{ kind: "meta" }]);
+	});
+
+	it("copies rather than aliases each source", () => {
+		const events = [{ kind: "a" }];
+		expect(extractContextEventsFromTrajectory({ events })).not.toBe(events);
+		const metaEvents = [{ kind: "a" }];
+		expect(
+			extractContextEventsFromTrajectory({
+				metadata: { contextEvents: metaEvents },
+			}),
+		).not.toBe(metaEvents);
+	});
+
+	it("returns null when no source carries events", () => {
+		for (const value of [null, "x", 7, {}, { metadata: {} }]) {
+			expect(extractContextEventsFromTrajectory(value)).toBeNull();
+		}
+	});
+});
+
+describe("isTrajectoryStrictModeEnabled", () => {
+	it("is off when the variable is unset", () => {
+		delete process.env[STRICT];
+		expect(isTrajectoryStrictModeEnabled()).toBe(false);
+	});
+
+	it("is on for the documented truthy spellings", () => {
+		for (const raw of ["1", "true", "TRUE", "yes", "on"]) {
+			process.env[STRICT] = raw;
+			expect(isTrajectoryStrictModeEnabled()).toBe(true);
+		}
+	});
+
+	it("stays off for falsy spellings, including the string 'false'", () => {
+		// "false" is truthy as a JS string; a bare Boolean() would enable strict
+		// mode for an operator who explicitly turned it off.
+		for (const raw of ["", "0", "false", "no", "off"]) {
+			process.env[STRICT] = raw;
+			expect(isTrajectoryStrictModeEnabled()).toBe(false);
+		}
+	});
+});
+
+describe("normalizeTrajectoryLlmPurpose", () => {
+	it("accepts every declared purpose", () => {
+		for (const purpose of TRAJECTORY_LLM_PURPOSES) {
+			expect(normalizeTrajectoryLlmPurpose(purpose)).toBe(purpose);
+		}
+	});
+
+	it("trims and lowercases before matching", () => {
+		expect(normalizeTrajectoryLlmPurpose("  PLANNER  ")).toBe("planner");
+		expect(normalizeTrajectoryLlmPurpose("Evaluator")).toBe("evaluator");
+	});
+
+	it("defaults to external_llm for unknown, empty and nullish input", () => {
+		for (const value of [undefined, null, "", "   ", "nonsense"]) {
+			expect(normalizeTrajectoryLlmPurpose(value)).toBe("external_llm");
+		}
+	});
+
+	it("honours an explicit fallback only when the value does not match", () => {
+		expect(normalizeTrajectoryLlmPurpose(undefined, "planner")).toBe("planner");
+		expect(normalizeTrajectoryLlmPurpose("bogus", "action")).toBe("action");
+		expect(normalizeTrajectoryLlmPurpose("optimizer", "action")).toBe(
+			"optimizer",
+		);
+	});
+});
+
+describe("isLlmGenerationModelType", () => {
+	it("classifies every text-generation slot as generative", () => {
+		for (const modelType of [
+			ModelType.TEXT_NANO,
+			ModelType.TEXT_SMALL,
+			ModelType.TEXT_MEDIUM,
+			ModelType.TEXT_LARGE,
+			ModelType.TEXT_MEGA,
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+			ModelType.TEXT_REASONING_SMALL,
+			ModelType.TEXT_REASONING_LARGE,
+			ModelType.TEXT_COMPLETION,
+			ModelType.RESEARCH,
+		]) {
+			expect(isLlmGenerationModelType(modelType)).toBe(true);
+		}
+	});
+
+	it("classifies structured-output slots by their OBJECT_ prefix", () => {
+		// No OBJECT_* member exists on ModelType today; the prefix rule is
+		// forward-looking, so it is pinned directly.
+		expect(isLlmGenerationModelType("OBJECT_SMALL")).toBe(true);
+		expect(isLlmGenerationModelType("OBJECT_LARGE")).toBe(true);
+		expect(isLlmGenerationModelType("OBJECTIVE")).toBe(false);
+	});
+
+	it("excludes the embedding, tokenizer and speech slots the docstring names", () => {
+		for (const modelType of [
+			ModelType.TEXT_EMBEDDING,
+			ModelType.TEXT_EMBEDDING_BATCH,
+			ModelType.TEXT_TOKENIZER_ENCODE,
+			ModelType.TEXT_TOKENIZER_DECODE,
+			ModelType.TEXT_TO_SPEECH,
+			ModelType.TRANSCRIPTION,
+		]) {
+			expect(isLlmGenerationModelType(modelType)).toBe(false);
+		}
+	});
+
+	it("excludes the media slots", () => {
+		for (const modelType of [
+			ModelType.IMAGE,
+			ModelType.IMAGE_DESCRIPTION,
+			ModelType.AUDIO,
+			ModelType.VIDEO,
+		]) {
+			expect(isLlmGenerationModelType(modelType)).toBe(false);
+		}
+	});
+
+	it("normalizes case and surrounding whitespace", () => {
+		expect(isLlmGenerationModelType("  text_large  ")).toBe(true);
+		expect(isLlmGenerationModelType("Text_Embedding")).toBe(false);
+	});
+
+	it("is false for empty and non-string input rather than throwing", () => {
+		for (const value of [undefined, null, "", "   ", 7, {}, []]) {
+			expect(isLlmGenerationModelType(value)).toBe(false);
+		}
+	});
+
+	it("leaves NO ModelType member unclassified", () => {
+		// Guards against a new slot silently landing in neither bucket by
+		// accident; every member must yield a boolean decision.
+		for (const modelType of Object.values(ModelType)) {
+			expect(typeof isLlmGenerationModelType(modelType)).toBe("boolean");
+		}
+	});
+
+	it("currently does NOT police PII_SCRUB — see the PR note", () => {
+		// PII_SCRUB is a real `runtime.useModel` LLM call (pii-scrub-seam.ts)
+		// that can be served by Eliza Cloud, yet it is none of the three
+		// categories the docstring says are "intentionally excluded"
+		// (embeddings, tokenizers, speech/transcription/media). This assertion
+		// records today's behavior so the discrepancy is explicit and a decision
+		// to change it is a one-line diff plus this line.
+		expect(isLlmGenerationModelType(ModelType.PII_SCRUB)).toBe(false);
+	});
+});
+
+describe("assertActiveTrajectoryForLlmCall", () => {
+	it("returns null and does not throw when strict mode is off", () => {
+		delete process.env[STRICT];
+		expect(assertActiveTrajectoryForLlmCall()).toBeNull();
+	});
+
+	it("throws in strict mode with no active trajectory step", () => {
+		process.env[STRICT] = "1";
+		expect(() => assertActiveTrajectoryForLlmCall()).toThrow(
+			/trajectory-strict/,
+		);
+	});
+
+	it("returns the active step id in strict mode instead of throwing", () => {
+		process.env[STRICT] = "1";
+		expect(withActiveStep(() => assertActiveTrajectoryForLlmCall())).toBe(
+			"step-1",
+		);
+	});
+
+	it("names the offending call in the message so the fix is locatable", () => {
+		process.env[STRICT] = "1";
+		try {
+			assertActiveTrajectoryForLlmCall({
+				actionType: "runtime.useModel",
+				model: "gpt-x",
+				modelType: "TEXT_LARGE",
+				purpose: "action",
+			});
+			throw new Error("expected a strict-mode refusal");
+		} catch (error) {
+			const message = (error as Error).message;
+			expect(message).toContain("actionType=runtime.useModel");
+			expect(message).toContain("model=gpt-x");
+			expect(message).toContain("modelType=TEXT_LARGE");
+			expect(message).toContain("purpose=action");
+			// The remedy is part of the contract, not decoration.
+			expect(message).toContain("recordLlmCall");
+			expect(message).toContain("withStandaloneTrajectory");
+		}
+	});
+
+	it("omits the parenthetical entirely when no context is supplied", () => {
+		process.env[STRICT] = "1";
+		try {
+			assertActiveTrajectoryForLlmCall({});
+			throw new Error("expected a strict-mode refusal");
+		} catch (error) {
+			expect((error as Error).message).toContain("outside trajectory.");
+		}
+	});
+});
+
+describe("assertRecordedLlmCall", () => {
+	it("is a no-op outside strict mode", () => {
+		delete process.env[STRICT];
+		expect(() => assertRecordedLlmCall()).not.toThrow();
+	});
+
+	it("reports the missing trajectory first, before the wrapping complaint", () => {
+		// Order matters: telling a caller to wrap in recordLlmCall is useless
+		// advice when the real problem is that no trajectory is running.
+		process.env[STRICT] = "1";
+		expect(() => assertRecordedLlmCall()).toThrow(/outside trajectory/);
+	});
+
+	it("throws the unwrapped-call error when a trajectory IS active", () => {
+		process.env[STRICT] = "1";
+		expect(() => withActiveStep(() => assertRecordedLlmCall())).toThrow(
+			/not wrapped by recordLlmCall/,
+		);
+	});
+});
+
+describe("resolveTrajectoryLogger", () => {
+	function runtimeWith(
+		service: unknown,
+		byType: unknown[] = [],
+	): IAgentRuntime {
+		return {
+			getService: vi.fn(() => service),
+			getServicesByType: vi.fn(() => byType),
+		} as unknown as IAgentRuntime;
+	}
+
+	it("returns null when nothing looks like a trajectory logger", () => {
+		expect(resolveTrajectoryLogger(runtimeWith(null))).toBeNull();
+		expect(resolveTrajectoryLogger(runtimeWith({}))).toBeNull();
+	});
+
+	it("prefers the candidate that can actually start a trajectory", () => {
+		// startTrajectory scores 100; everything else combined scores less, so a
+		// rich-but-unstartable logger must never win.
+		const rich = {
+			startStep: () => "s",
+			endTrajectory: () => undefined,
+			logLlmCall: () => undefined,
+			flushWriteQueue: () => undefined,
+			applyReward: () => undefined,
+		};
+		const starter = { startTrajectory: () => "t" };
+		expect(resolveTrajectoryLogger(runtimeWith(rich, [starter]))).toBe(starter);
+	});
+
+	it("picks the more complete of two starters", () => {
+		const minimal = { startTrajectory: () => "t" };
+		const complete = {
+			startTrajectory: () => "t",
+			startStep: () => "s",
+			endTrajectory: () => undefined,
+			logLlmCall: () => undefined,
+			applyReward: () => undefined,
+		};
+		expect(resolveTrajectoryLogger(runtimeWith(minimal, [complete]))).toBe(
+			complete,
+		);
+	});
+
+	it("counts EVERY optional capability, not just the headline one", () => {
+		// Each optional method carries its own positive weight. Listing the plain
+		// starter first means the richer candidate wins only if that specific
+		// weight is actually added — a zeroed weight leaves a tie, and a tie
+		// keeps the first.
+		for (const capability of [
+			"startStep",
+			"endTrajectory",
+			"logLlmCall",
+			"flushWriteQueue",
+			"applyReward",
+		]) {
+			const plain = { startTrajectory: () => "t" };
+			const richer = {
+				startTrajectory: () => "t",
+				[capability]: () => undefined,
+			};
+			expect(resolveTrajectoryLogger(runtimeWith(plain, [richer]))).toBe(
+				richer,
+			);
+		}
+	});
+
+	it("keeps the first candidate on a scoring tie", () => {
+		const first = { startTrajectory: () => "t" };
+		const second = { startTrajectory: () => "t" };
+		expect(resolveTrajectoryLogger(runtimeWith(first, [second]))).toBe(first);
+	});
+
+	it("does not consider the same instance twice", () => {
+		const logger = { startTrajectory: () => "t" };
+		expect(resolveTrajectoryLogger(runtimeWith(logger, [logger, logger]))).toBe(
+			logger,
+		);
+	});
+
+	it("still finds a logger registered only by service type", () => {
+		const logger = { startTrajectory: () => "t" };
+		expect(resolveTrajectoryLogger(runtimeWith(null, [logger]))).toBe(logger);
+	});
+});
+
+describe("the training-exclusion registry", () => {
+	beforeEach(() => {
+		__resetTrajectorySourceRegistryForTests();
+	});
+
+	afterEach(() => {
+		__resetTrajectorySourceRegistryForTests();
+	});
+
+	it("reports an unregistered source as includable", () => {
+		expect(isExcludedFromTraining("unknown-source")).toBe(false);
+	});
+
+	it("round-trips an excluded source", () => {
+		registerTrajectorySource("private-corpus", { excludeFromTraining: true });
+		expect(isExcludedFromTraining("private-corpus")).toBe(true);
+	});
+
+	it("reports a registered but non-excluded source as includable", () => {
+		registerTrajectorySource("public-corpus", { excludeFromTraining: false });
+		expect(isExcludedFromTraining("public-corpus")).toBe(false);
+		registerTrajectorySource("bare", {} as never);
+		expect(isExcludedFromTraining("bare")).toBe(false);
+	});
+
+	it("trims consistently on both write and read", () => {
+		registerTrajectorySource("  spaced  ", { excludeFromTraining: true });
+		expect(isExcludedFromTraining("spaced")).toBe(true);
+		expect(isExcludedFromTraining("  spaced  ")).toBe(true);
+	});
+
+	it("is case-sensitive, so a near-miss name does NOT inherit the exclusion", () => {
+		// Fail-open on an unknown name is the documented behavior; this pins that
+		// a differently-cased name is genuinely a different source rather than
+		// silently matching.
+		registerTrajectorySource("Private", { excludeFromTraining: true });
+		expect(isExcludedFromTraining("private")).toBe(false);
+	});
+
+	it("ignores a blank or non-string registration instead of storing it", () => {
+		registerTrajectorySource("", { excludeFromTraining: true });
+		registerTrajectorySource("   ", { excludeFromTraining: true });
+		registerTrajectorySource(undefined as never, { excludeFromTraining: true });
+		expect(isExcludedFromTraining("")).toBe(false);
+		expect(isExcludedFromTraining("   ")).toBe(false);
+	});
+
+	it("copies the options so a later mutation cannot flip the verdict", () => {
+		const opts = { excludeFromTraining: true };
+		registerTrajectorySource("snapshot", opts);
+		opts.excludeFromTraining = false;
+		expect(isExcludedFromTraining("snapshot")).toBe(true);
+	});
+
+	it("treats a nullish source name as includable", () => {
+		for (const value of [null, undefined, 7 as never]) {
+			expect(isExcludedFromTraining(value)).toBe(false);
+		}
+	});
+
+	it("lets a later registration replace an earlier one", () => {
+		registerTrajectorySource("flips", { excludeFromTraining: true });
+		registerTrajectorySource("flips", { excludeFromTraining: false });
+		expect(isExcludedFromTraining("flips")).toBe(false);
+	});
+});
+
+describe("trajectory context plumbing used by the guards", () => {
+	it("exposes the active step id the guards read", () => {
+		expect(getTrajectoryContext()?.trajectoryStepId).toBeUndefined();
+		expect(withActiveStep(() => getTrajectoryContext()?.trajectoryStepId)).toBe(
+			"step-1",
+		);
+	});
+});


### PR DESCRIPTION
# What

Nine exports of `packages/core/src/trajectory-utils.ts` are imported by **no test in the repo** — checked against all five sibling suites and then repo-wide across every `.test`/`.spec` file. One of them is `isLlmGenerationModelType`, which decides *which `runtime.useModel` calls `ELIZA_TRAJECTORY_STRICT=1` polices at all*.

This adds `trajectory-utils.classifier.test.ts` — 50 tests, no production change (`git diff` on `trajectory-utils.ts` is empty).

# A question for you: `PII_SCRUB` is not policed by strict mode

The classifier's docstring says:

> Embeddings, tokenizers, and speech/transcription/media models are intentionally excluded from strict trajectory enforcement.

I enumerated the classifier over every `ModelType` member. Exactly one member is classified non-generative while fitting **none** of those three categories: **`PII_SCRUB`**.

It is a real LLM call, not a local helper — `packages/core/src/security/pii-scrub-seam.ts:205` does `runtime.useModel(ModelType.PII_SCRUB, params)` for the escalation tier, served either by the on-device GGUF or by Eliza Cloud depending on registration priority, carrying user text. Under `ELIZA_TRAJECTORY_STRICT=1` that call is not asserted to be inside a trajectory, because `isLlmGenerationModelType("PII_SCRUB") === false` and the guard in `prompt-optimization.ts:1376` never fires.

**I did not change this.** The corpus scrub pipeline may legitimately run outside a trajectory, and adding `PII_SCRUB` to the enforced set would make strict runs throw somewhere I can't exercise from here. That's your call, not mine.

What I did instead is record today's behavior in a test that says so in its name and comment:

```ts
it("currently does NOT police PII_SCRUB — see the PR note", () => {
  expect(isLlmGenerationModelType(ModelType.PII_SCRUB)).toBe(false);
});
```

If it's deliberate, the test documents it. If it's an oversight, the fix is one line in the classifier plus flipping that one assertion.

# Four surviving mutants that I recommend you do NOT "fix"

Mutation testing left four survivors, and I checked rather than assumed. All four are in the same block:

```ts
if (!normalized) return false;
if (normalized === "TEXT_EMBEDDING" || normalized === "TEXT_TO_SPEECH" ||
    normalized.startsWith("TEXT_TOKENIZER")) {
  return false;
}
return isTextGenerationModelType(normalized) ||
       normalized.startsWith("OBJECT_") || normalized === "RESEARCH";
```

The function is **allowlist-based**, so the exclusion block above it cannot change any answer. I proved it rather than reasoning about it — a probe counted how many `ModelType` members enter the exclusion block and how many of those could otherwise reach the allowlist:

```
4 | 0 | TEXT_EMBEDDING, TEXT_TOKENIZER_ENCODE, TEXT_TOKENIZER_DECODE, TEXT_TO_SPEECH
```

Four enter it; **zero** would be accepted by the allowlist without it. Deleting the whole block, or the `!normalized` early return, changes no output today. No test can kill those mutants, and writing one would mean asserting an unreachable branch.

**Keep the block.** It is the executable form of the docstring, and it becomes load-bearing the moment someone adds an `OBJECT_`-prefixed embedding slot or widens `TEXT_GENERATION_MODEL_TYPES`. I'm reporting it so the survivors don't read as a coverage hole.

# The one survivor that WAS a real gap

`applyReward`'s scoring weight in `resolveTrajectoryLogger` survived, because my first test compared candidates differing in four capabilities at once — a zeroed weight still left the richer one ahead. Replaced with a loop that varies exactly **one** optional capability against a plain starter listed *first*, so the richer candidate wins only if that specific weight is counted (the tie-break keeps the first).

All six weights then die individually, including `flushWriteQueue` at weight 2:

| weight | mutant | result |
|---|---|---|
| `startTrajectory` 100 | → 1 | killed |
| `startStep` 10 | → 0 | killed |
| `endTrajectory` 10 | → 0 | killed |
| `logLlmCall` 10 | → 0 | killed |
| `flushWriteQueue` 2 | → 0 | killed |
| `applyReward` 20 | → 0 | killed |

**27 distinct mutants: 23 killed, 4 proven structurally redundant.**

Also killed: the context-object id/version defaults, event arrays aliased instead of copied, purpose normalization losing its trim or its lowercase, the fallback argument ignored, the `OBJECT_` prefix loosened to `OBJECT`, `RESEARCH` dropped from the generative set, the strict guard ignoring an active step or passing unconditionally, the recorded-depth check inverted, the resolver's tie-break flipped and its zero-score floor removed, and every trimming/snapshot rule in the source registry.

# Also pinned

- **`isTrajectoryStrictModeEnabled` stays off for `"false"`, `"no"`, `"off"`** — all truthy as JS strings, so a bare `Boolean()` would enable strict mode for an operator who explicitly turned it off.
- **The strict-mode message carries its own remedy.** It names `actionType`, `model`, `modelType` and `purpose`, and mentions both `recordLlmCall` and `withStandaloneTrajectory` — asserted, because that text is what a developer acts on.
- **`assertRecordedLlmCall` reports the missing trajectory first.** Telling a caller to wrap in `recordLlmCall` is useless advice when no trajectory is running at all; both orderings are asserted.
- **Extractors copy, never alias.** Mutating a returned `events` array must not corrupt the source trajectory.
- **The source registry snapshots its options.** Mutating the object you passed to `registerTrajectorySource` after the fact cannot flip a training-exclusion verdict — and names are trimmed identically on write and read.

# Evidence

```
bunx vitest run packages/core/src/trajectory-utils.classifier.test.ts   → 50 pass
all six trajectory-utils suites                                        → 97 pass across 6 files
bun run --cwd packages/core typecheck                                  → clean
bunx @biomejs/biome check                                              → clean
```

`trajectory-utils.ts` is byte-identical to `develop` after the mutation runs.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MP3A31S7ERS8SZ582MFWCH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T22:26:42.913Z","completed_at":"2026-09-03T22:27:26.634Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T22:26:43.642Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"290c009248a1462b4d86100c0e72d3daf8ce3171bfb99c4611fe5e1c0513d5d6","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b5f068e0-121d-4e32-b77e-bc7e04e8ba8c","object_id":"sha256:290c009248a1462b4d86100c0e72d3daf8ce3171bfb99c4611fe5e1c0513d5d6","sha256":"290c009248a1462b4d86100c0e72d3daf8ce3171bfb99c4611fe5e1c0513d5d6"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"ufJlsoEO_gajRsbhQ3u0K_1FEAxl0SUTfrFB2QJt286N7SGzSROJfuwh5M-NpjcGmUtUyPfbJOFQXTIhFj01Cg"}} -->
