### PR TITLE
fix(agent): stop fetchWithTimeout from discarding a caller's abort signal

### DIFF
--- a/packages/agent/src/providers/media-provider.fetch.test.ts
+++ b/packages/agent/src/providers/media-provider.fetch.test.ts
@@ -1,0 +1,250 @@
+/**
+ * `fetchWithTimeout` — the shared network primitive behind every media
+ * provider in this file (twenty-plus call sites), and previously untested.
+ *
+ * Deterministic: every case talks to a local HTTP server on an ephemeral port,
+ * the same approach `api/server-helpers-fetch.test.ts` uses for the sibling
+ * `fetchWithTimeoutGuard`. No stubbed `fetch`, no network.
+ */
+
+import { getEventListeners } from "node:events";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMediaProviders, fetchWithTimeout } from "./media-provider";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ url: string }> {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}/` };
+}
+
+/** A server that never answers, so only an abort can end the request. */
+function neverResponds(): Promise<{ url: string }> {
+  return listen((req, res) => {
+    const handle = setTimeout(() => res.end("late"), 30_000);
+    req.on("close", () => clearTimeout(handle));
+  });
+}
+
+function isAbort(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+describe("fetchWithTimeout", () => {
+  it("returns the response and passes method, headers and body through", async () => {
+    let seenMethod: string | undefined;
+    let seenHeader: string | undefined;
+    let seenBody = "";
+    const { url } = await listen((req, res) => {
+      seenMethod = req.method;
+      seenHeader = req.headers["x-provider-key"] as string | undefined;
+      req.on("data", (chunk) => {
+        seenBody += String(chunk);
+      });
+      req.on("end", () => res.end("ok"));
+    });
+
+    const response = await fetchWithTimeout(url, {
+      method: "POST",
+      headers: { "x-provider-key": "secret" },
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+
+    expect(response.ok).toBe(true);
+    expect(await response.text()).toBe("ok");
+    expect(seenMethod).toBe("POST");
+    expect(seenHeader).toBe("secret");
+    expect(JSON.parse(seenBody)).toEqual({ prompt: "a cat" });
+  });
+
+  it("does not treat a non-2xx response as a failure", async () => {
+    // The providers check `response.ok` themselves and read the error body;
+    // rejecting here would hide their messages behind a generic network error.
+    const { url } = await listen((_req, res) => {
+      res.statusCode = 429;
+      res.end("rate limited");
+    });
+
+    const response = await fetchWithTimeout(url, { method: "GET" });
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(429);
+    expect(await response.text()).toBe("rate limited");
+  });
+
+  it("aborts once timeoutMs elapses", async () => {
+    const { url } = await listen((req, res) => {
+      const handle = setTimeout(() => res.end("late"), 5_000);
+      req.on("close", () => clearTimeout(handle));
+    });
+
+    await expect(
+      fetchWithTimeout(url, { method: "GET" }, 40),
+    ).rejects.toSatisfy(isAbort);
+  });
+
+  it("does not abort a request that finishes inside the timeout", async () => {
+    const { url } = await listen((_req, res) => res.end("fast"));
+    const response = await fetchWithTimeout(url, { method: "GET" }, 5_000);
+    expect(await response.text()).toBe("fast");
+  });
+
+  it("clears its timer on success, leaving no pending handle", async () => {
+    // A leaked timer keeps the event loop alive for the full timeout and, in a
+    // long-lived agent, accumulates one handle per provider call.
+    const { url } = await listen((_req, res) => res.end("ok"));
+    const before = process.getActiveResourcesInfo?.().length ?? 0;
+    await fetchWithTimeout(url, { method: "GET" }, 60_000);
+    const after = process.getActiveResourcesInfo?.().length ?? 0;
+    expect(after).toBeLessThanOrEqual(before);
+  });
+
+  it("clears its timer when the request FAILS, not only when it succeeds", async () => {
+    // `.finally` rather than `.then` is what makes this true.
+    const before = process.getActiveResourcesInfo?.().length ?? 0;
+    await expect(
+      fetchWithTimeout("http://127.0.0.1:1/", { method: "GET" }, 60_000),
+    ).rejects.toThrow();
+    const after = process.getActiveResourcesInfo?.().length ?? 0;
+    expect(after).toBeLessThanOrEqual(before);
+  });
+
+  it("honours a caller signal that is ALREADY aborted, without opening a request", async () => {
+    let reached = false;
+    const { url } = await listen((_req, res) => {
+      reached = true;
+      res.end("should not happen");
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      fetchWithTimeout(
+        url,
+        { method: "GET", signal: controller.signal },
+        60_000,
+      ),
+    ).rejects.toSatisfy(isAbort);
+    expect(reached).toBe(false);
+  });
+
+  it("honours a caller signal aborted MID-FLIGHT", async () => {
+    // Without chaining, replacing `init.signal` silently drops cancellation and
+    // the caller waits out the whole timeout instead.
+    const { url } = await neverResponds();
+    const controller = new AbortController();
+    const pending = fetchWithTimeout(
+      url,
+      { method: "GET", signal: controller.signal },
+      60_000,
+    );
+    queueMicrotask(() => controller.abort());
+
+    await expect(pending).rejects.toSatisfy(isAbort);
+  });
+
+  it("cancels well before the timeout would have fired", async () => {
+    // Proves the abort came from the caller, not from the timer.
+    const { url } = await neverResponds();
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    const pending = fetchWithTimeout(
+      url,
+      { method: "GET", signal: controller.signal },
+      30_000,
+    );
+    setTimeout(() => controller.abort(), 20);
+
+    await expect(pending).rejects.toSatisfy(isAbort);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("still times out normally when a caller signal is supplied but never fires", async () => {
+    const { url } = await neverResponds();
+    const controller = new AbortController();
+
+    await expect(
+      fetchWithTimeout(url, { method: "GET", signal: controller.signal }, 40),
+    ).rejects.toSatisfy(isAbort);
+  });
+
+  it("removes its abort listener, so a reused caller signal does not accumulate them", async () => {
+    // `{ once: true }` only self-removes on a listener that actually FIRES.
+    // A signal reused across many provider calls — the normal case for a
+    // per-request cancellation token — would otherwise grow one dead listener
+    // per completed call.
+    const { url } = await listen((_req, res) => res.end("ok"));
+    const controller = new AbortController();
+
+    for (let index = 0; index < 5; index += 1) {
+      await fetchWithTimeout(
+        url,
+        { method: "GET", signal: controller.signal },
+        60_000,
+      );
+    }
+
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+    expect(() => controller.abort()).not.toThrow();
+  });
+});
+
+describe("createMediaProviders", () => {
+  it("is fail-fast: an unusable image slot aborts the whole bundle", () => {
+    // The four factories are evaluated eagerly inside one object literal, so
+    // the bundle is all-or-nothing rather than partially populated. Worth
+    // pinning because a caller cannot rely on reading `.audio` off a result
+    // whose `.image` could not be built.
+    expect(() =>
+      createMediaProviders(undefined, { cloudMediaDisabled: true }),
+    ).toThrow(/No image provider configured and cloud media is disabled/);
+  });
+
+  it("surfaces the cloud-mode guidance when cloud media is enabled", () => {
+    expect(() =>
+      createMediaProviders(undefined, {
+        cloudMediaDisabled: false,
+        elizaCloudApiKey: "eliza_cloud_key",
+        elizaCloudBaseUrl: "https://api.elizacloud.ai/api/v1",
+      }),
+    ).toThrow(/ModelType\.IMAGE/);
+  });
+
+  it("reports the IMAGE slot first, so its message is the one an operator sees", () => {
+    // Image is constructed before video, audio and vision. If that order ever
+    // changes, an operator debugging a missing image config would be handed a
+    // video error instead.
+    try {
+      createMediaProviders(undefined, { cloudMediaDisabled: true });
+      expect.unreachable("expected the bundle to refuse");
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain("image provider");
+      expect(message).not.toContain("video provider");
+      expect(message).not.toContain("audio provider");
+    }
+  });
+});

--- a/packages/agent/src/providers/media-provider.ts
+++ b/packages/agent/src/providers/media-provider.ts
@@ -35,17 +35,36 @@ import type {
 // Fetch Utilities
 // ============================================================================
 
-/** Fetch with an AbortController-based timeout (default 30s). */
+/**
+ * Fetch with an AbortController-based timeout (default 30s).
+ *
+ * A caller-supplied `init.signal` is chained rather than discarded: replacing
+ * it outright would silently drop cancellation, so a caller that aborts its
+ * own request would keep waiting for the full timeout. This mirrors
+ * `fetchWithTimeoutGuard` in `api/server-helpers-fetch.ts`.
+ */
 export function fetchWithTimeout(
   url: string,
   init: RequestInit,
   timeoutMs = 30_000,
 ): Promise<Response> {
   const controller = new AbortController();
+  const upstreamSignal = init.signal;
+  const onUpstreamAbort = () => controller.abort();
+
+  if (upstreamSignal) {
+    if (upstreamSignal.aborted) {
+      controller.abort();
+    } else {
+      upstreamSignal.addEventListener("abort", onUpstreamAbort, { once: true });
+    }
+  }
+
   const timer = setTimeout(() => controller.abort(), timeoutMs);
-  return fetch(url, { ...init, signal: controller.signal }).finally(() =>
-    clearTimeout(timer),
-  );
+  return fetch(url, { ...init, signal: controller.signal }).finally(() => {
+    clearTimeout(timer);
+    upstreamSignal?.removeEventListener("abort", onUpstreamAbort);
+  });
 }
 
 async function withProviderErrorBoundary<T>(


### PR DESCRIPTION
# The defect

`fetchWithTimeout` in `packages/agent/src/providers/media-provider.ts` spreads `init` and then overwrites `signal` with its own controller's:

```ts
const controller = new AbortController();
const timer = setTimeout(() => controller.abort(), timeoutMs);
return fetch(url, { ...init, signal: controller.signal })   // <- init.signal discarded
```

A caller-supplied `AbortSignal` is silently dropped. A request the caller cancels **keeps running until the full timeout elapses** — 30s by default, 120s for audio, 300s for the Veo polling path.

This helper backs **every media provider in the file** — twenty-plus call sites across FAL, OpenAI, Google, xAI, Anthropic, ElevenLabs and Suno — and it had **no tests at all**. Neither did the fifteen provider classes; the two existing suites reference only the four factory functions.

# The repo already knows the right shape

`fetchWithTimeoutGuard` in `packages/agent/src/api/server-helpers-fetch.ts` — same package — chains the upstream signal properly, handling both the already-aborted case and a later abort. This change makes `fetchWithTimeout` mirror it:

```ts
const upstreamSignal = init.signal;
const onUpstreamAbort = () => controller.abort();

if (upstreamSignal) {
  if (upstreamSignal.aborted) {
    controller.abort();
  } else {
    upstreamSignal.addEventListener("abort", onUpstreamAbort, { once: true });
  }
}

const timer = setTimeout(() => controller.abort(), timeoutMs);
return fetch(url, { ...init, signal: controller.signal }).finally(() => {
  clearTimeout(timer);
  upstreamSignal?.removeEventListener("abort", onUpstreamAbort);
});
```

**No caller passes a signal today**, so this is a latent trap rather than an active outage, and behaviour is byte-identical when `init.signal` is undefined. I'm fixing it because the next caller to reach for cancellation would get silence, not an error.

I deliberately did **not** adopt the guard's `TimeoutError` renaming — that would change what the providers' error boundary reports, which is beyond this fix.

# Causal evidence

Restoring `develop`'s implementation under the new suite fails three tests, and the mid-flight case takes the **full 30 seconds** — which is precisely the bug:

```
× honours a caller signal that is ALREADY aborted, without opening a request      5ms
× honours a caller signal aborted MID-FLIGHT                                  30005ms
× cancels well before the timeout would have fired                            30003ms

Tests  3 failed | 11 passed (14)
```

# Mutation testing: 8 mutants, 7 killed

| mutant | result |
|---|---|
| already-aborted branch removed | killed |
| upstream listener never attached | killed |
| `clearTimeout` removed | killed |
| timeout never armed | killed |
| controller signal not passed to `fetch` | killed |
| default `timeoutMs` changed | killed |
| `removeEventListener` removed | killed |
| `{ once: true }` dropped | **survived — redundant, see below** |

The listener-removal mutant only died after I made the leak *observable*. Asserting that `controller.abort()` doesn't throw was not enough: a stale listener aborting an already-settled controller is harmless. `getEventListeners(signal, "abort")` from `node:events` is what actually sees it, and the test now drives five sequential requests through one signal and asserts zero listeners remain.

**The `{ once: true }` survivor is genuine redundancy, not a coverage hole.** If the listener fires, `once` removes it; if it never fires, the `finally` removes it. Either mechanism alone suffices, so no test can distinguish them. I'd keep both — the pair is what makes the "reused signal" case safe regardless of which way the race resolves.

# The tests

`media-provider.fetch.test.ts`, 14 tests, driven against a local HTTP server on an ephemeral port — the same approach `server-helpers-fetch.test.ts` uses for the sibling helper. No stubbed `fetch`, no network, no timing luck.

- method, headers and body pass through unchanged
- a **non-2xx response is not a failure** — the providers check `response.ok` themselves and read the error body, so rejecting here would hide their messages behind a generic network error
- aborts once `timeoutMs` elapses; does **not** abort a request that finishes in time
- the timer is cleared on success **and on failure** — `.finally` rather than `.then` is what makes the second one true, and a leaked timer in a long-lived agent accumulates one handle per provider call
- the three caller-signal cases: already aborted (and the server is never reached), aborted mid-flight, and supplied-but-never-fired (which must still time out normally)
- a caller abort resolves in well under the 30s timeout, proving it came from the caller and not the timer

Plus three for `createMediaProviders`, which was also untested: it is **fail-fast and all-or-nothing** — the four factories are evaluated eagerly inside one object literal, so an unusable image slot aborts the bundle before audio, video or vision are constructed, and the image message is the one an operator actually sees.

# Evidence

```
bunx vitest run packages/agent/src/providers/media-provider.fetch.test.ts   → 14 pass
  with the existing media-provider suite                                    → 42 pass across 2 files
bun run --cwd packages/agent typecheck                                      → clean
bunx @biomejs/biome check                                                   → clean
```

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MRBTHDWB0N6XQZQSXBWTJJ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T23:06:19.053Z","completed_at":"2026-09-03T23:07:01.268Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T23:06:19.794Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e68a6f1ae1b850b26b5278daffbb2e9ff1a57f7591645cf96bd5ecfb889141be","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"82eafeed-a5a3-432b-9725-d5383345ca2a","object_id":"sha256:e68a6f1ae1b850b26b5278daffbb2e9ff1a57f7591645cf96bd5ecfb889141be","sha256":"e68a6f1ae1b850b26b5278daffbb2e9ff1a57f7591645cf96bd5ecfb889141be"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"XP6i6_tyJdyUvF-HaEu4RyrhJuZ5Jo2eSSNuT_Tq8m8tcjt66qNH5DaTzHCVxhuM4LAsmH7s5T3-6VTMpfm8AQ"}} -->
