### PR TITLE
test(browser-bridge): pin the permission, scripting and DNR facades

### DIFF
--- a/packages/browser-bridge-extension/src/webextension.permissions.test.ts
+++ b/packages/browser-bridge-extension/src/webextension.permissions.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Permission, scripting and dynamic-rule facades in the browser API wrapper.
+ *
+ * These decide whether the extension believes it may read a page, inject code,
+ * or rewrite network requests. The property that matters most is what they do
+ * when the underlying browser API is *absent*: a check that guessed `true`
+ * there would hand the caller access it was never granted.
+ *
+ * Deterministic: `chrome` is stubbed per test with only the surface each case
+ * needs, so an accidental reach for another API throws rather than passing.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  executeContentScriptFiles,
+  executeScriptInMainWorld,
+  getDynamicRules,
+  getExtensionUrl,
+  getGrantedOrigins,
+  hasAllUrlHostPermission,
+  hasManifestPermission,
+  hasWebsiteAccess,
+  isIncognitoAccessAllowed,
+  requestAllWebsiteAccess,
+  requestWebsiteAccess,
+  updateDynamicRules,
+} from "./webextension";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** A stub whose only guaranteed member is `runtime`, so reaches are visible. */
+function stubChrome(api: Record<string, unknown>): void {
+  vi.stubGlobal("chrome", { runtime: {}, ...api });
+}
+
+describe("permission checks fail CLOSED when the API is missing", () => {
+  it("hasAllUrlHostPermission is false without permissions.contains", async () => {
+    stubChrome({ permissions: {} });
+    await expect(hasAllUrlHostPermission()).resolves.toBe(false);
+  });
+
+  it("hasWebsiteAccess is false without permissions.contains", async () => {
+    stubChrome({ permissions: {} });
+    await expect(hasWebsiteAccess("https://example.com/*")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("isIncognitoAccessAllowed is false without the extension API", async () => {
+    stubChrome({ extension: {} });
+    await expect(isIncognitoAccessAllowed()).resolves.toBe(false);
+  });
+
+  it("getGrantedOrigins is empty without permissions.getAll", async () => {
+    stubChrome({ permissions: {} });
+    await expect(getGrantedOrigins()).resolves.toEqual([]);
+  });
+
+  it("getDynamicRules is empty without the declarativeNetRequest API", async () => {
+    stubChrome({ declarativeNetRequest: {} });
+    await expect(getDynamicRules()).resolves.toEqual([]);
+  });
+
+  it("hasManifestPermission is false without a manifest", () => {
+    stubChrome({});
+    expect(hasManifestPermission("scripting")).toBe(false);
+  });
+});
+
+describe("permission REQUESTS refuse loudly instead of reporting a denial", () => {
+  // A silent `false` here is indistinguishable from the user clicking Deny,
+  // which would send a caller down a "user refused" path when the truth is a
+  // broken runtime.
+  it("requestAllWebsiteAccess throws without permissions.request", async () => {
+    stubChrome({ permissions: {} });
+    await expect(requestAllWebsiteAccess()).rejects.toThrow(
+      /permissions\.request is unavailable/,
+    );
+  });
+
+  it("requestWebsiteAccess throws without permissions.request", async () => {
+    stubChrome({ permissions: {} });
+    await expect(requestWebsiteAccess("https://example.com/*")).rejects.toThrow(
+      /permissions\.request is unavailable/,
+    );
+  });
+
+  it("script injection throws rather than silently doing nothing", async () => {
+    stubChrome({ scripting: {} });
+    await expect(executeScriptInMainWorld(1, () => 1)).rejects.toThrow(
+      /scripting\.executeScript is unavailable/,
+    );
+    await expect(executeContentScriptFiles(1, ["a.js"])).rejects.toThrow(
+      /scripting\.executeScript is unavailable/,
+    );
+  });
+});
+
+describe("the exact origin patterns asked for", () => {
+  it("hasAllUrlHostPermission asks for http and https only, not <all_urls>", async () => {
+    // `<all_urls>` would additionally cover file:// and ftp://. Asking for the
+    // two schemes explicitly is what keeps the grant to normal web pages.
+    const contains = vi.fn((_query: unknown, callback: (v: boolean) => void) =>
+      callback(true),
+    );
+    stubChrome({ permissions: { contains } });
+
+    await expect(hasAllUrlHostPermission()).resolves.toBe(true);
+    expect(contains.mock.calls[0]?.[0]).toEqual({
+      origins: ["https://*/*", "http://*/*"],
+    });
+  });
+
+  it("hasWebsiteAccess asks for exactly the pattern it was given", async () => {
+    const contains = vi.fn((_query: unknown, callback: (v: boolean) => void) =>
+      callback(false),
+    );
+    stubChrome({ permissions: { contains } });
+
+    await expect(hasWebsiteAccess("https://example.com/*")).resolves.toBe(
+      false,
+    );
+    expect(contains.mock.calls[0]?.[0]).toEqual({
+      origins: ["https://example.com/*"],
+    });
+  });
+});
+
+describe("a denied request is re-checked against what is actually held", () => {
+  // Chrome can answer `false` to permissions.request while the permission is
+  // in fact already granted. Trusting that answer would make the extension
+  // re-prompt forever, or report no access it demonstrably has.
+  it("requestAllWebsiteAccess returns true when the grant is already held", async () => {
+    const request = vi.fn((_q: unknown, callback: (v: boolean) => void) =>
+      callback(false),
+    );
+    const contains = vi.fn((_q: unknown, callback: (v: boolean) => void) =>
+      callback(true),
+    );
+    stubChrome({ permissions: { request, contains } });
+
+    await expect(requestAllWebsiteAccess()).resolves.toBe(true);
+    expect(contains).toHaveBeenCalledTimes(1);
+  });
+
+  it("requestWebsiteAccess returns true when that origin is already held", async () => {
+    const request = vi.fn((_q: unknown, callback: (v: boolean) => void) =>
+      callback(false),
+    );
+    const contains = vi.fn((_q: unknown, callback: (v: boolean) => void) =>
+      callback(true),
+    );
+    stubChrome({ permissions: { request, contains } });
+
+    await expect(requestWebsiteAccess("https://example.com/*")).resolves.toBe(
+      true,
+    );
+    expect(contains.mock.calls[0]?.[0]).toEqual({
+      origins: ["https://example.com/*"],
+    });
+  });
+
+  it("does NOT re-check when the request already succeeded", async () => {
+    const request = vi.fn((_q: unknown, callback: (v: boolean) => void) =>
+      callback(true),
+    );
+    const contains = vi.fn();
+    stubChrome({ permissions: { request, contains } });
+
+    await expect(requestAllWebsiteAccess()).resolves.toBe(true);
+    expect(contains).not.toHaveBeenCalled();
+  });
+
+  it("reports false when neither the request nor the held check succeeds", async () => {
+    const request = vi.fn((_q: unknown, callback: (v: boolean) => void) =>
+      callback(false),
+    );
+    const contains = vi.fn((_q: unknown, callback: (v: boolean) => void) =>
+      callback(false),
+    );
+    stubChrome({ permissions: { request, contains } });
+
+    await expect(requestAllWebsiteAccess()).resolves.toBe(false);
+    await expect(requestWebsiteAccess("https://example.com/*")).resolves.toBe(
+      false,
+    );
+  });
+});
+
+describe("getGrantedOrigins normalizes what the browser reports", () => {
+  function withOrigins(origins: unknown): void {
+    stubChrome({
+      permissions: {
+        getAll: (callback: (v: unknown) => void) => callback({ origins }),
+      },
+    });
+  }
+
+  it("trims, drops blanks and non-strings, and sorts", async () => {
+    withOrigins([
+      "  https://z.example/*  ",
+      42,
+      "https://a.example/*",
+      "   ",
+      null,
+      "",
+    ]);
+    await expect(getGrantedOrigins()).resolves.toEqual([
+      "https://a.example/*",
+      "https://z.example/*",
+    ]);
+  });
+
+  it("returns an empty list when origins is absent or not an array", async () => {
+    for (const value of [undefined, null, "https://example.com/*", {}]) {
+      withOrigins(value);
+      await expect(getGrantedOrigins()).resolves.toEqual([]);
+    }
+  });
+
+  it("keeps duplicates rather than inventing a de-duplication rule", async () => {
+    // The browser is the source of truth for this list; silently collapsing it
+    // would hide a real duplicate-grant condition from a caller comparing sets.
+    withOrigins(["https://a.example/*", "https://a.example/*"]);
+    await expect(getGrantedOrigins()).resolves.toEqual([
+      "https://a.example/*",
+      "https://a.example/*",
+    ]);
+  });
+});
+
+describe("script injection targets the right world", () => {
+  it("executeScriptInMainWorld runs in MAIN and returns the first frame result", async () => {
+    const executeScript = vi.fn(
+      (_injection: unknown, callback: (v: unknown[]) => void) =>
+        callback([{ result: "from-page" }, { result: "from-iframe" }]),
+    );
+    stubChrome({ scripting: { executeScript } });
+
+    await expect(executeScriptInMainWorld(7, () => "x")).resolves.toBe(
+      "from-page",
+    );
+    const injection = executeScript.mock.calls[0]?.[0] as {
+      world: string;
+      target: { tabId: number };
+      args: unknown[];
+    };
+    expect(injection.world).toBe("MAIN");
+    expect(injection.target).toEqual({ tabId: 7 });
+    expect(injection.args).toEqual([]);
+  });
+
+  it("forwards args and tolerates an empty result set", async () => {
+    const executeScript = vi.fn(
+      (_injection: unknown, callback: (v: unknown[]) => void) => callback([]),
+    );
+    stubChrome({ scripting: { executeScript } });
+
+    await expect(
+      executeScriptInMainWorld(7, (a) => a, ["alpha", 1]),
+    ).resolves.toBeUndefined();
+    const injection = executeScript.mock.calls[0]?.[0] as { args: unknown[] };
+    expect(injection.args).toEqual(["alpha", 1]);
+  });
+
+  it("executeContentScriptFiles runs ISOLATED, never in the page world", async () => {
+    // MAIN would expose the injected file to page JavaScript and to anything
+    // the page has already patched onto its own globals.
+    const executeScript = vi.fn(
+      (_injection: unknown, callback: (v: unknown[]) => void) => callback([]),
+    );
+    stubChrome({ scripting: { executeScript } });
+
+    await executeContentScriptFiles(9, ["content.js", "extra.js"]);
+    const injection = executeScript.mock.calls[0]?.[0] as {
+      world: string;
+      files: string[];
+      target: { tabId: number };
+      func?: unknown;
+    };
+    expect(injection.world).toBe("ISOLATED");
+    expect(injection.files).toEqual(["content.js", "extra.js"]);
+    expect(injection.target).toEqual({ tabId: 9 });
+    expect(injection.func).toBeUndefined();
+  });
+});
+
+describe("dynamic network rules", () => {
+  it("passes the update through unchanged", async () => {
+    const updateDynamicRulesSpy = vi.fn(
+      (_options: unknown, callback: () => void) => callback(),
+    );
+    stubChrome({
+      declarativeNetRequest: { updateDynamicRules: updateDynamicRulesSpy },
+    });
+
+    const options = {
+      removeRuleIds: [1, 2],
+      addRules: [{ id: 3 }] as never,
+    };
+    await updateDynamicRules(options);
+    expect(updateDynamicRulesSpy.mock.calls[0]?.[0]).toEqual(options);
+  });
+
+  it("is a no-op, not a throw, when the API is missing", async () => {
+    // Rule updates run on startup paths; a throw there would take down the
+    // worker on a browser that does not expose declarativeNetRequest.
+    stubChrome({ declarativeNetRequest: {} });
+    await expect(
+      updateDynamicRules({ removeRuleIds: [1] }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns the rules the browser reports", async () => {
+    stubChrome({
+      declarativeNetRequest: {
+        getDynamicRules: (callback: (v: unknown[]) => void) =>
+          callback([{ id: 1 }, { id: 2 }]),
+      },
+    });
+    await expect(getDynamicRules()).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+  });
+});
+
+describe("getExtensionUrl", () => {
+  it("resolves through runtime.getURL when available", () => {
+    stubChrome({
+      runtime: { getURL: (path: string) => `chrome-extension://id/${path}` },
+    });
+    expect(getExtensionUrl("popup.html")).toBe(
+      "chrome-extension://id/popup.html",
+    );
+  });
+
+  it("falls back to the raw path rather than throwing", () => {
+    stubChrome({});
+    expect(getExtensionUrl("popup.html")).toBe("popup.html");
+  });
+});


### PR DESCRIPTION
# What

**22 of the 37 exports in `webextension.ts` were referenced by no test** — checked against all ten sibling suites in the package, not just the adjacent `webextension.test.ts`. The untested set includes *every* host-permission check and *both* script-injection helpers.

This adds 26 tests. No production change. (`isPrivilegedExtensionSender` is already well covered with twelve references — I left it alone.)

# The property that matters: what happens when the API is absent

These facades decide whether the extension believes it may read a page, inject code, or rewrite network requests. A check that guessed `true` when `chrome.permissions` is missing would hand a caller access it was never granted.

The source already gets this right, with a **deliberate asymmetry** that nothing was holding in place:

| | missing API |
|---|---|
| `hasAllUrlHostPermission`, `hasWebsiteAccess`, `isIncognitoAccessAllowed`, `hasManifestPermission` | `false` |
| `getGrantedOrigins`, `getDynamicRules` | `[]` |
| `requestAllWebsiteAccess`, `requestWebsiteAccess`, both `executeScript*` | **throw** |
| `updateDynamicRules`, `getExtensionUrl` | no-op / fall back |

The middle row is the interesting one. A silent `false` from a *request* is indistinguishable from the user clicking Deny — it would send a caller down a "user refused" path when the truth is a broken runtime. Meanwhile `updateDynamicRules` runs on startup paths, so a throw there would take down the service worker on a browser that doesn't expose `declarativeNetRequest`. Both mutants (making the request return `false`, making the rule update throw) now fail.

Each test stubs `chrome` with only the surface that case needs, so an accidental reach for another API throws rather than quietly passing.

# Three specifics worth calling out

**The origin patterns are exact.** `hasAllUrlHostPermission` asks for `["https://*/*", "http://*/*"]` — deliberately *not* `<all_urls>`, which would additionally cover `file://` and `ftp://`. Substituting `<all_urls>` is now a failing mutant.

**A denied request is re-checked.** Chrome can answer `false` to `permissions.request` while the permission is in fact already held; both helpers fall back to the `contains` check. All four combinations are covered, including that **no** re-check happens when the request already succeeded (so an unnecessary second call can't creep in).

**World separation is load-bearing.** `executeContentScriptFiles` injects `world: "ISOLATED"`; only `executeScriptInMainWorld` uses `"MAIN"`. Injecting a content-script file into MAIN would expose it to page JavaScript and to anything the page has already patched onto its own globals. Swapping either world is a failing mutant.

# Mutation testing: 17 mutants, 17 killed

No survivors.

- both fail-open mutants (`hasAllUrlHostPermission`, `isIncognitoAccessAllowed` returning `true` when unavailable)
- `<all_urls>` substituted for the explicit scheme pair
- every `getGrantedOrigins` normalization step removed individually — type filter, trim, blank filter, sort
- the post-denial re-check dropped, and separately made unconditional
- `ISOLATED` → `MAIN`, and `MAIN` → `ISOLATED`
- `results[0]` → last frame (an iframe result silently replacing the top frame's)
- request-unavailable throw → `false`; scripting-unavailable throw → no-op
- the two deliberate tolerant paths (`updateDynamicRules`, `getExtensionUrl`) turned into throws

One deliberate non-assertion: `getGrantedOrigins` **keeps duplicates**. The browser is the source of truth for that list, and silently collapsing it would hide a real duplicate-grant condition from a caller comparing sets. That's asserted as intended behaviour rather than left ambiguous.

# Evidence

```
bunx vitest run src/webextension.permissions.test.ts   → 26 pass
bunx vitest run src/                                   → 173 pass across 20 files
bunx tsc --noEmit                                      → clean
bunx @biomejs/biome check                              → clean
```

Tests only — `git diff` touches no source file.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MS106HXRKCT8S44VS1D1BN","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T23:17:52.977Z","completed_at":"2026-09-03T23:18:32.647Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T23:17:53.221Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b999ae9438690097791fd14e7da061c5501580ff9ba6d99e0edb4e29f9f8814e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"480ed8ae-2ce2-4d81-8f09-1034250a093d","object_id":"sha256:b999ae9438690097791fd14e7da061c5501580ff9ba6d99e0edb4e29f9f8814e","sha256":"b999ae9438690097791fd14e7da061c5501580ff9ba6d99e0edb4e29f9f8814e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"_gblNbtV2pgAvXdGj5T59OGAu13nmYXjT94It4t8SjjgYMpUpn5_C0ZF_jZXt2qF3-zPckCzwIQ6BHI0bcL6Cg"}} -->
