### PR TITLE
test(app-core): pin the remote-target resume authority decision

### DIFF
--- a/packages/app-core/platforms/electrobun/src/remote-target-resume.test.ts
+++ b/packages/app-core/platforms/electrobun/src/remote-target-resume.test.ts
@@ -1,0 +1,372 @@
+/**
+ * `RemoteTargetDesktopService.resumeEligibleLoopback` — the decision that runs
+ * after a desktop restart and decides whether this machine may resume acting
+ * as a remote-control target.
+ *
+ * Its docstring states the invariant plainly: "Missing/corrupt credential or
+ * journal state never degrades into a fresh enrollment or an unpinned runner."
+ * That is a fail-closed security property, and none of it was asserted — the
+ * two suites in this directory exercise the runner and the same-host
+ * integration path, not this decision.
+ *
+ * Deterministic: the vault, journal, relay transport and clock are all
+ * constructor-injected. `claimNext` returns nothing, so a resumed runner idles
+ * instead of reaching the network.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RemoteTargetDesktopService } from "./remote-target-rpc";
+import type { RemoteTargetDurableState } from "./remote-target-store";
+import {
+  type RemoteTargetRelayTransport,
+  RemoteTargetTransportError,
+} from "./remote-target-transport";
+
+const NOW = 1_800_000_000_000;
+const API_BASE = "http://127.0.0.1:5173";
+// The loopback executor refuses a token under 16 characters.
+const API_TOKEN = "loopback-token-0123456789";
+
+const services: RemoteTargetDesktopService[] = [];
+
+afterEach(async () => {
+  for (const service of services.splice(0)) {
+    await service.stop().catch(() => undefined);
+  }
+});
+
+type Session = RemoteTargetDurableState["sessions"][string];
+
+/** A journal session that satisfies every "active authority" clause. */
+function activeSession(overrides: Record<string, unknown> = {}): Session {
+  return {
+    activationState: "active",
+    stoppedAt: null,
+    grant: { sessionId: "session-1", revokedAt: null, expiresAt: null },
+    ...overrides,
+  } as unknown as Session;
+}
+
+function stateWith(
+  sessions: Record<string, Session>,
+): RemoteTargetDurableState {
+  return { version: 1, sessions, commands: {} } as RemoteTargetDurableState;
+}
+
+function makeService(options: {
+  enrollment: unknown;
+  state: RemoteTargetDurableState;
+  commitActivation?: () => Promise<unknown>;
+}): {
+  service: RemoteTargetDesktopService;
+  claimNext: ReturnType<typeof vi.fn>;
+  state: RemoteTargetDurableState;
+} {
+  const state = options.state;
+  const vault = {
+    load: vi.fn(async () => options.enrollment),
+  } as never;
+  const stateStore = {
+    read: vi.fn(async () => state),
+    clear: vi.fn(async () => undefined),
+    transact: vi.fn(
+      async (operation: (s: RemoteTargetDurableState) => unknown) => {
+        return await operation(state);
+      },
+    ),
+  } as never;
+  const claimNext = vi.fn(async () => null);
+  const commitActivation = vi.fn(
+    options.commitActivation ?? (async () => ({ ok: true })),
+  );
+  const transport = new Proxy(
+    { claimNext, commitActivation },
+    {
+      get(target, prop) {
+        // A Proxy get trap receives `string | symbol`, so the index type has
+        // to admit both.
+        if (prop in target)
+          return (target as Record<string | symbol, unknown>)[prop];
+        // Any other relay call in this path would be a surprise; make it loud.
+        return async () => {
+          throw new Error(`unexpected transport.${String(prop)}`);
+        };
+      },
+    },
+  ) as unknown as RemoteTargetRelayTransport;
+
+  const service = new RemoteTargetDesktopService(
+    vault,
+    stateStore,
+    transport,
+    () => NOW,
+  );
+  services.push(service);
+  return { service, claimNext, state };
+}
+
+function resume(service: RemoteTargetDesktopService) {
+  return service.resumeEligibleLoopback({
+    apiBase: API_BASE,
+    apiToken: API_TOKEN,
+  });
+}
+
+describe("no credentials means no resume", () => {
+  it("reports not_enrolled when the vault is empty and nothing is active", async () => {
+    const { service } = makeService({ enrollment: null, state: stateWith({}) });
+    await expect(resume(service)).resolves.toEqual({
+      resumed: false,
+      reason: "not_enrolled",
+    });
+  });
+
+  it("reports not_enrolled for a vault record that is not fully enrolled", async () => {
+    // A half-written or superseded record must not be treated as authority.
+    for (const status of ["pending", "revoked", "unknown"]) {
+      const { service } = makeService({
+        enrollment: { status },
+        state: stateWith({}),
+      });
+      await expect(resume(service)).resolves.toEqual({
+        resumed: false,
+        reason: "not_enrolled",
+      });
+    }
+  });
+
+  it("THROWS when the journal holds a live grant but the credentials are gone", async () => {
+    // This is the fail-closed case that matters. Returning `not_enrolled` here
+    // would look like a clean first run and invite a fresh enrollment, quietly
+    // orphaning a controller grant that is still live in the journal.
+    const { service } = makeService({
+      enrollment: null,
+      state: stateWith({ "session-1": activeSession() }),
+    });
+    await expect(resume(service)).rejects.toThrow(
+      /credentials are unavailable for the durable active session/i,
+    );
+  });
+});
+
+describe("enrolled, but nothing left to resume", () => {
+  it("reports no_active_authority when every session is inert", async () => {
+    const { service } = makeService({
+      enrollment: { status: "enrolled" },
+      state: stateWith({}),
+    });
+    await expect(resume(service)).resolves.toEqual({
+      resumed: false,
+      reason: "no_active_authority",
+    });
+  });
+
+  it("leaves the runner STOPPED when there is no authority to act on", async () => {
+    // `resumed: false` must also mean "not running". A runner started here
+    // would poll the relay for commands with no grant backing it.
+    const { service, claimNext } = makeService({
+      enrollment: { status: "enrolled" },
+      state: stateWith({}),
+    });
+    await resume(service);
+    await expect(service.status()).resolves.toMatchObject({ running: false });
+    expect(claimNext).not.toHaveBeenCalled();
+  });
+
+  it("a resumed decision leaves the runner RUNNING", async () => {
+    const { service } = makeService({
+      enrollment: { status: "enrolled" },
+      state: stateWith({ "session-1": activeSession() }),
+    });
+    await expect(resume(service)).resolves.toEqual({
+      resumed: true,
+      reason: "active_authority",
+    });
+    await expect(service.status()).resolves.toMatchObject({ running: true });
+  });
+});
+
+describe("every clause of the active-authority test", () => {
+  async function resumeWith(overrides: Record<string, unknown>) {
+    const { service } = makeService({
+      enrollment: { status: "enrolled" },
+      state: stateWith({ "session-1": activeSession(overrides) }),
+    });
+    return await resume(service);
+  }
+
+  it("resumes on a fully live session", async () => {
+    await expect(resumeWith({})).resolves.toEqual({
+      resumed: true,
+      reason: "active_authority",
+    });
+  });
+
+  it("a stopped session is not authority", async () => {
+    await expect(resumeWith({ stoppedAt: NOW - 1_000 })).resolves.toEqual({
+      resumed: false,
+      reason: "no_active_authority",
+    });
+  });
+
+  it("a revoked grant is not authority", async () => {
+    await expect(
+      resumeWith({ grant: { revokedAt: NOW - 1_000, expiresAt: null } }),
+    ).resolves.toEqual({ resumed: false, reason: "no_active_authority" });
+  });
+
+  it("an expired grant is not authority", async () => {
+    await expect(
+      resumeWith({ grant: { revokedAt: null, expiresAt: NOW - 1 } }),
+    ).resolves.toEqual({ resumed: false, reason: "no_active_authority" });
+  });
+
+  it("expiry is inclusive: a grant expiring exactly now still counts", async () => {
+    // `expiresAt >= now`. The boundary decides whether a grant dies a
+    // millisecond early on every restart.
+    await expect(
+      resumeWith({ grant: { revokedAt: null, expiresAt: NOW } }),
+    ).resolves.toEqual({ resumed: true, reason: "active_authority" });
+  });
+
+  it("a null expiry never expires", async () => {
+    await expect(
+      resumeWith({ grant: { revokedAt: null, expiresAt: null } }),
+    ).resolves.toEqual({ resumed: true, reason: "active_authority" });
+  });
+});
+
+describe("a staged activation is resolved against the relay before deciding", () => {
+  const staged = () =>
+    stateWith({ "session-1": activeSession({ activationState: "staged" }) });
+
+  it("a relay that CONFIRMS the commit promotes the session to active authority", async () => {
+    // Recovery runs before the decision is read, so a confirmed commit is
+    // indistinguishable from having been active all along — and should be.
+    const { service, state } = makeService({
+      enrollment: { status: "enrolled" },
+      state: staged(),
+    });
+    await expect(resume(service)).resolves.toEqual({
+      resumed: true,
+      reason: "active_authority",
+    });
+    expect(state.sessions["session-1"]?.activationState).toBe("active");
+  });
+
+  it("a relay that reports the grant GONE drops it instead of resuming on it", async () => {
+    // 404/409/410 mean the controller-side grant no longer exists. Coming up
+    // on it would resume authority the relay has already retired.
+    for (const status of [404, 409, 410]) {
+      const { service, state } = makeService({
+        enrollment: { status: "enrolled" },
+        state: staged(),
+        commitActivation: async () => {
+          throw new RemoteTargetTransportError("gone", status);
+        },
+      });
+      await expect(resume(service)).resolves.toEqual({
+        resumed: false,
+        reason: "no_active_authority",
+      });
+      expect(state.sessions["session-1"]).toBeUndefined();
+    }
+  });
+
+  it("a relay OUTAGE leaves the grant staged and resumes as activation_recovery", async () => {
+    // This is the only path to `activation_recovery`: the commit could not be
+    // confirmed, so the runner comes up to keep retrying rather than either
+    // discarding a real grant or claiming an authority it has not confirmed.
+    for (const status of [0, 408, 429, 500, 503]) {
+      const { service, state } = makeService({
+        enrollment: { status: "enrolled" },
+        state: staged(),
+        commitActivation: async () => {
+          throw new RemoteTargetTransportError("offline", status);
+        },
+      });
+      await expect(resume(service)).resolves.toEqual({
+        resumed: true,
+        reason: "activation_recovery",
+      });
+      expect(state.sessions["session-1"]?.activationState).toBe("staged");
+    }
+  });
+
+  it("an unclassified relay error propagates rather than guessing", async () => {
+    // 401/403 are neither "gone" nor "offline". Silently choosing either would
+    // discard a live grant or resume without authority.
+    const { service } = makeService({
+      enrollment: { status: "enrolled" },
+      state: staged(),
+      commitActivation: async () => {
+        throw new RemoteTargetTransportError("forbidden", 403);
+      },
+    });
+    await expect(resume(service)).rejects.toThrow(/HTTP 403/);
+  });
+
+  it("a stopped or revoked staged session is never committed at all", async () => {
+    for (const overrides of [
+      { activationState: "staged", stoppedAt: NOW - 1 },
+      {
+        activationState: "staged",
+        grant: { sessionId: "session-1", revokedAt: NOW - 1, expiresAt: null },
+      },
+    ]) {
+      const commitActivation = vi.fn(async () => ({ ok: true }));
+      const { service } = makeService({
+        enrollment: { status: "enrolled" },
+        state: stateWith({ "session-1": activeSession(overrides) }),
+        commitActivation,
+      });
+      await expect(resume(service)).resolves.toEqual({
+        resumed: false,
+        reason: "no_active_authority",
+      });
+      expect(commitActivation).not.toHaveBeenCalled();
+    }
+  });
+
+  it("recovery is skipped entirely when the vault is not enrolled", async () => {
+    const commitActivation = vi.fn(async () => ({ ok: true }));
+    const { service } = makeService({
+      enrollment: null,
+      state: staged(),
+      commitActivation,
+    });
+    await expect(resume(service)).resolves.toEqual({
+      resumed: false,
+      reason: "not_enrolled",
+    });
+    expect(commitActivation).not.toHaveBeenCalled();
+  });
+});
+
+describe("configuration is serialized", () => {
+  it("a rejected configuration does not poison the queue", async () => {
+    // `enqueueConfiguration` swallows the tail's rejection precisely so one
+    // failed configure cannot wedge every later one.
+    const { service } = makeService({
+      enrollment: null,
+      state: stateWith({ "session-1": activeSession() }),
+    });
+    await expect(resume(service)).rejects.toThrow();
+    await expect(resume(service)).rejects.toThrow();
+  });
+
+  it("concurrent resumes settle without interleaving", async () => {
+    const { service } = makeService({
+      enrollment: { status: "enrolled" },
+      state: stateWith({}),
+    });
+    const results = await Promise.all([
+      resume(service),
+      resume(service),
+      resume(service),
+    ]);
+    for (const result of results) {
+      expect(result).toEqual({ resumed: false, reason: "no_active_authority" });
+    }
+  });
+});


### PR DESCRIPTION
# What

`RemoteTargetDesktopService.resumeEligibleLoopback` decides whether a desktop may resume acting as a **remote-control target** after a restart. Its docstring makes a fail-closed promise:

> Missing/corrupt credential or journal state never degrades into a fresh enrollment or an unpinned runner.

Nothing asserted it. The two suites in this directory cover the runner and the same-host integration path, not this decision. This adds 20 tests. No production change.

# The decision table

| vault | active sessions | staged sessions | outcome |
|---|---|---|---|
| not enrolled | ≥1 | — | **throws** |
| not enrolled | 0 | — | `not_enrolled`, runner stopped |
| enrolled | ≥1 | — | `active_authority`, runner **running** |
| enrolled | 0 | ≥1 (unresolved) | `activation_recovery`, runner **running** |
| enrolled | 0 | 0 | `no_active_authority`, runner stopped |

The throw is the one that matters. Returning `not_enrolled` there would look like a clean first run and invite a fresh enrollment, quietly orphaning a controller grant that is still live in the journal. That substitution is now a failing mutant.

Every clause of the active-authority filter is covered individually — not staged, not stopped, not revoked, not expired — including that **expiry is inclusive** (`expiresAt >= now`), so a grant expiring exactly now still counts rather than dying a millisecond early on every restart.

And `resumed: false` is asserted to also mean *not running*, via `service.status()`. A runner started on a "no authority" path would poll the relay for commands with nothing backing it.

# I got the staged-activation contract wrong first, and the failures corrected me

My initial tests assumed a staged session simply yields `activation_recovery`. It doesn't. `resumeEligibleLoopback` calls `recoverStagedActivations()` **before** reading the decision, so the answer depends on what the relay says:

| relay response to `commitActivation` | journal effect | resume outcome |
|---|---|---|
| success | session promoted to `active` | `active_authority` |
| 404 / 409 / 410 (grant gone) | session **deleted** | `no_active_authority` |
| 0 / 408 / 429 / 5xx (outage) | stays `staged` | `activation_recovery` |
| anything else (e.g. 403) | — | **propagates** |

So **a relay outage is the only path to `activation_recovery`** — the runner comes up to keep retrying rather than either discarding a real grant or claiming authority it hasn't confirmed. That's a genuinely nice piece of design and it now has tests that say so. All four rows are asserted, including that a 403 is neither "gone" nor "offline" and must not be silently classified as either.

Also asserted: a stopped or revoked staged session is **never committed at all** (`commitActivation` not called), and recovery is skipped entirely when the vault isn't enrolled.

# Mutation testing: 18 mutants, 18 killed

Across `remote-target-rpc.ts` and `remote-target-runner.ts`:

- the fail-closed throw replaced with `not_enrolled`
- each of the four active-filter clauses dropped individually
- `expiresAt >= now` → `>`, and expiry ignored entirely
- both staged-filter clauses dropped
- `activation_recovery` relabelled `active_authority`
- recovery run when not enrolled, and recovery skipped entirely
- runner started on `no_active_authority` and on `not_enrolled`; runner *not* started on `active_authority`
- `410` dropped from the gone set; `5xx` dropped from the transient set; the unclassified-error rethrow turned into `continue`
- the staged commit filter ignoring `revokedAt`

One of these needed a second pass. "Runner started on `no_active_authority`" initially survived because I was only asserting that `claimNext` hadn't been called — too indirect. Switching to `service.status()` killed it and two more lifecycle mutants I added afterwards.

# A red herring I checked before reporting

`remote-target-runner.test.ts` shows **2 failures under a bare `bun test`** on unmodified `develop`. That is a wrong-runner artifact, not a defect: this directory has its own `vitest.electrobun.config.ts`, and under that config it is **39 pass / 0 fail**. Worth knowing if anyone else runs into it.

# Evidence

```
bunx vitest run --config vitest.electrobun.config.ts src/remote-target-resume.test.ts
  → 20 pass
  with src/remote-target-runner.test.ts                → 59 pass across 2 files
bun test src/remote-target-resume.test.ts              → 20 pass (green under both runners)
bunx tsc --noEmit                                      → clean
bunx @biomejs/biome check                              → clean
```

Tests only — `git diff` touches no source file.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MSHMQFJ4SFDRFPZYMQQYC0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T23:26:58.287Z","completed_at":"2026-09-03T23:27:41.180Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T23:26:59.040Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5f5b1ba2739cc75012f0457d8fb3b00869e0a776d8173a3d9460720ed7da1573","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"495c0977-5c5c-48d4-b0d8-b883e53e7e01","object_id":"sha256:5f5b1ba2739cc75012f0457d8fb3b00869e0a776d8173a3d9460720ed7da1573","sha256":"5f5b1ba2739cc75012f0457d8fb3b00869e0a776d8173a3d9460720ed7da1573"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"nmzBQtBDFsrM5Cm3uysozwJ5W_5_v8MG7GQR8dc92w43vyptcXpeuCOz-FKhZ4mJVGBKjFABjFl-1CWIcgTDAg"}} -->
