### PR TITLE
fix(plugin-x): await the async predicate in getTweetsWhere

### DIFF
--- a/plugins/plugin-x/src/client/tweets-query.test.ts
+++ b/plugins/plugin-x/src/client/tweets-query.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Timeline pagination guard and the tweet-query helpers.
+ *
+ * `nextTimelinePageCursor` is what stops a repeating provider cursor from
+ * looping forever, and `getTweetWhere` / `getTweetsWhere` are the public
+ * filtering surface exposed on the client. None of them had tests.
+ *
+ * No network: every case drives an in-memory async iterable.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  getTweetsWhere,
+  getTweetWhere,
+  nextTimelinePageCursor,
+  type Tweet,
+} from "./tweets";
+
+function tweet(overrides: Partial<Tweet>): Tweet {
+  return { id: "0", text: "", isRetweet: false, ...overrides } as Tweet;
+}
+
+async function* streamOf(tweets: Tweet[]): AsyncGenerator<Tweet> {
+  for (const entry of tweets) yield entry;
+}
+
+const sample = [
+  tweet({ id: "1", text: "keep", isRetweet: false }),
+  tweet({ id: "2", text: "drop", isRetweet: true }),
+  tweet({ id: "3", text: "keep", isRetweet: false }),
+];
+
+const ids = (tweets: Tweet[]) => tweets.map((entry) => entry.id);
+
+describe("nextTimelinePageCursor", () => {
+  it("ends the run on a terminal page", () => {
+    const seen = new Set<string>();
+    expect(
+      nextTimelinePageCursor("mentions", undefined, seen, 3),
+    ).toBeUndefined();
+    expect(seen.size).toBe(0);
+  });
+
+  it("ends the run on an empty-string cursor", () => {
+    // `""` is falsy, so it must be treated as terminal rather than recorded
+    // and then re-reported as a repeat on the following page.
+    const seen = new Set<string>();
+    expect(nextTimelinePageCursor("mentions", "", seen, 1)).toBeUndefined();
+    expect(seen.size).toBe(0);
+  });
+
+  it("records and returns a fresh cursor", () => {
+    const seen = new Set<string>();
+    expect(nextTimelinePageCursor("mentions", "cursor-a", seen, 1)).toBe(
+      "cursor-a",
+    );
+    expect(seen.has("cursor-a")).toBe(true);
+  });
+
+  it("refuses an immediately repeated cursor", () => {
+    const seen = new Set<string>(["cursor-a"]);
+    expect(() =>
+      nextTimelinePageCursor("mentions", "cursor-a", seen, 2),
+    ).toThrow(/repeated a page cursor/);
+  });
+
+  it("refuses a LONGER cycle, not just an immediate repeat", () => {
+    // A -> B -> A is the case a "same as last cursor" check would miss, and it
+    // loops just as permanently.
+    const seen = new Set<string>();
+    nextTimelinePageCursor("mentions", "A", seen, 1);
+    nextTimelinePageCursor("mentions", "B", seen, 2);
+    expect(() => nextTimelinePageCursor("mentions", "A", seen, 3)).toThrow(
+      /repeated a page cursor/,
+    );
+  });
+
+  it("carries the source and page count for diagnosis", () => {
+    const seen = new Set<string>(["cursor-a"]);
+    try {
+      nextTimelinePageCursor("home-timeline", "cursor-a", seen, 7);
+      expect.unreachable("expected a pagination refusal");
+    } catch (error) {
+      const typed = error as Error & {
+        code?: string;
+        context?: Record<string, unknown>;
+      };
+      expect(typed.code).toBe("X_TIMELINE_PAGINATION_CURSOR_REPEATED");
+      expect(typed.message).toContain("home-timeline");
+      expect(typed.context).toMatchObject({
+        source: "home-timeline",
+        pageCount: 7,
+      });
+    }
+  });
+
+  it("does not record a cursor it refused", () => {
+    // Otherwise the guard's own bookkeeping would grow on every failure.
+    const seen = new Set<string>(["cursor-a"]);
+    expect(() =>
+      nextTimelinePageCursor("mentions", "cursor-a", seen, 2),
+    ).toThrow();
+    expect(seen.size).toBe(1);
+  });
+
+  it("keeps separate runs independent through their own Set", () => {
+    const first = new Set<string>();
+    const second = new Set<string>();
+    expect(nextTimelinePageCursor("a", "shared", first, 1)).toBe("shared");
+    expect(nextTimelinePageCursor("b", "shared", second, 1)).toBe("shared");
+  });
+});
+
+describe("getTweetWhere", () => {
+  it("returns the first match for a partial-object query", async () => {
+    const found = await getTweetWhere(streamOf(sample), { text: "keep" });
+    expect(found?.id).toBe("1");
+  });
+
+  it("returns null when nothing matches", async () => {
+    const found = await getTweetWhere(streamOf(sample), { text: "absent" });
+    expect(found).toBeNull();
+  });
+
+  it("matches every key of a multi-key query, not just one", async () => {
+    expect(
+      (await getTweetWhere(streamOf(sample), { text: "keep", isRetweet: true }))
+        ?.id,
+    ).toBeUndefined();
+    expect(
+      (await getTweetWhere(streamOf(sample), { text: "drop", isRetweet: true }))
+        ?.id,
+    ).toBe("2");
+  });
+
+  it("accepts a synchronous predicate", async () => {
+    const found = await getTweetWhere(
+      streamOf(sample),
+      (entry) => entry.id === "3",
+    );
+    expect(found?.id).toBe("3");
+  });
+
+  it("awaits an ASYNC predicate", async () => {
+    const found = await getTweetWhere(
+      streamOf(sample),
+      async (entry) => entry.text === "keep" && entry.id === "3",
+    );
+    expect(found?.id).toBe("3");
+  });
+
+  it("stops consuming the stream once it has a match", async () => {
+    let produced = 0;
+    async function* counted() {
+      for (const entry of sample) {
+        produced += 1;
+        yield entry;
+      }
+    }
+    await getTweetWhere(counted(), { id: "1" });
+    expect(produced).toBe(1);
+  });
+});
+
+describe("getTweetsWhere", () => {
+  it("collects every match for a partial-object query", async () => {
+    expect(
+      ids(await getTweetsWhere(streamOf(sample), { text: "keep" })),
+    ).toEqual(["1", "3"]);
+  });
+
+  it("returns an empty array rather than null when nothing matches", async () => {
+    expect(await getTweetsWhere(streamOf(sample), { text: "absent" })).toEqual(
+      [],
+    );
+  });
+
+  it("accepts a synchronous predicate", async () => {
+    expect(
+      ids(
+        await getTweetsWhere(
+          streamOf(sample),
+          (entry) => entry.isRetweet === true,
+        ),
+      ),
+    ).toEqual(["2"]);
+  });
+
+  it("awaits an ASYNC predicate instead of keeping everything", async () => {
+    // `TweetQuery` permits `Promise<boolean>`. An unawaited Promise is always
+    // truthy, so the filter would return all three tweets — a filter that
+    // filters nothing, and silently.
+    expect(
+      ids(
+        await getTweetsWhere(
+          streamOf(sample),
+          async (entry) => entry.text === "keep",
+        ),
+      ),
+    ).toEqual(["1", "3"]);
+  });
+
+  it("honours an async predicate that rejects everything", async () => {
+    expect(await getTweetsWhere(streamOf(sample), async () => false)).toEqual(
+      [],
+    );
+  });
+
+  it("preserves stream order", async () => {
+    expect(ids(await getTweetsWhere(streamOf(sample), () => true))).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+  });
+
+  it("propagates a rejected predicate rather than dropping the tweet", async () => {
+    await expect(
+      getTweetsWhere(streamOf(sample), async () => {
+        throw new Error("predicate failed");
+      }),
+    ).rejects.toThrow(/predicate failed/);
+  });
+
+  it("compares strictly, so a loosely-equal value does NOT match", async () => {
+    // `"0" == 0` is true. A `==` comparison would let a numeric id from a
+    // caller match a string id from the API, silently widening the filter.
+    const numericQuery = { id: 0 } as unknown as Partial<Tweet>;
+    expect(
+      await getTweetsWhere(streamOf([tweet({ id: "0" })]), numericQuery),
+    ).toEqual([]);
+    const emptyStringQuery = { text: "" } as Partial<Tweet>;
+    expect(
+      ids(
+        await getTweetsWhere(
+          streamOf([tweet({ id: "9", text: "" })]),
+          emptyStringQuery,
+        ),
+      ),
+    ).toEqual(["9"]);
+  });
+
+  it("treats an empty query object as matching everything", async () => {
+    // `Object.keys({}).every(...)` is vacuously true. Pinned so the behaviour
+    // is a decision rather than an accident of the implementation.
+    expect(ids(await getTweetsWhere(streamOf(sample), {}))).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+  });
+});

--- a/plugins/plugin-x/src/client/tweets.ts
+++ b/plugins/plugin-x/src/client/tweets.ts
@@ -988,7 +988,12 @@ export async function getTweetsWhere(
   const filtered = [];
 
   for await (const tweet of tweets) {
-    const matches = isCallback ? query(tweet) : checkTweetMatches(tweet, query);
+    // `TweetQuery` permits `Promise<boolean>`. Without the await an async
+    // predicate yields a Promise, which is always truthy, so the filter would
+    // silently return every tweet. `getTweetWhere` already awaits here.
+    const matches = isCallback
+      ? await query(tweet)
+      : checkTweetMatches(tweet, query);
 
     if (!matches) continue;
     filtered.push(tweet);


### PR DESCRIPTION
# The defect

`getTweetWhere` and `getTweetsWhere` sit five lines apart and differ by one keyword:

```ts
// getTweetWhere
const matches = isCallback ? await query(tweet) : checkTweetMatches(tweet, query);

// getTweetsWhere
const matches = isCallback ? query(tweet) : checkTweetMatches(tweet, query);
//                           ^^^^^^^^^^^^ no await
```

`TweetQuery` explicitly permits an async predicate:

```ts
export type TweetQuery =
  | Partial<Tweet>
  | ((tweet: Tweet) => boolean | Promise<boolean>);
```

An unawaited Promise is **always truthy**, so `getTweetsWhere` with an async predicate returns *every* tweet. A filter that silently filters nothing. This is public API — `client.getTweetsWhere` is documented with a usage example in `client.ts`.

I proved it by running it rather than reading it. Three tweets, an async predicate matching two:

```
getTweetsWhere → 1,2,3     ← all of them
getTweetWhere  → 1         ← correct
```

A **rejected** predicate was worse: the rejected Promise is still truthy, so the tweet was kept as a match and the rejection became an unhandled promise rejection instead of surfacing to the caller.

# The fix

Add the `await`, mirroring `getTweetWhere`. Behaviour is unchanged for synchronous predicates.

Reverting only that keyword, with the new tests in place, fails exactly three:

```
× awaits an ASYNC predicate instead of keeping everything
× honours an async predicate that rejects everything
× propagates a rejected predicate rather than dropping the tweet

Tests  3 failed | 19 passed
```

# Tests

`tweets-query.test.ts`, 23 tests, no network — every case drives an in-memory async iterable. None of these functions had any.

**`nextTimelinePageCursor`** is the guard that stops a repeating provider cursor from looping forever. Covered: a terminal `undefined` and a terminal `""` (falsy, so it must not be recorded and then re-reported as a repeat on the next page); an immediate repeat; and the **A → B → A cycle**, which a naive "same as last cursor" check would miss and which loops just as permanently. Also that the error carries `source` and `pageCount` for diagnosis, and that two concurrent runs stay independent through their own `Set`.

**The query helpers**: partial-object matching across multiple keys, sync predicates, async predicates, empty-array vs `null` on no match, stream order preserved, and that `getTweetWhere` **stops consuming the stream** once it has a match (asserted by counting what the generator produced, not by inspecting the result).

Two behaviours pinned as decisions rather than accidents:

- **`checkTweetMatches` compares strictly.** `"0" == 0` is true, so a `==` would let a numeric id from a caller match a string id from the API and silently widen the filter.
- **An empty query object matches everything**, because `Object.keys({}).every(...)` is vacuously true.

# Mutation testing: 12 mutants, 11 killed

Killed: the `await` removed (and separately removed from `getTweetWhere`), the terminal-cursor guard removed and narrowed to `undefined`-only, the repeat guard removed, the cursor recorded before the guard rather than after, `pageCount` dropped from the error context, `every` → `some`, `===` → `==`, `null` → `undefined` on no match, and `getTweetWhere` collecting all matches instead of returning at the first.

**One survivor, and it is provably equivalent.** Re-adding the refused cursor to `seenCursors` before throwing cannot be detected: the only way to reach that throw is for the cursor to *already* be in the Set, so the add is a no-op. No test can distinguish it.

# Recorded, not changed

`getLatestTweet(user, includeRetweets, max, auth)` passes the flag straight through as `{ isRetweet: includeRetweets }`. So `includeRetweets: true` selects **only retweets** rather than "retweets as well", and the `max === 1` shortcut returns the first tweet ignoring the flag entirely. That reads like a naming/semantics mismatch, but changing it would alter what existing callers get back — your call, not mine, so I left it alone and didn't write a test that would freeze it either way.

# Evidence

```
bunx vitest run src/client/tweets-query.test.ts   → 23 pass
bunx vitest run src/                              → 426 pass, 13 skipped across 43 files
bunx tsc --noEmit                                 → clean
bunx @biomejs/biome check                         → clean
```

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MT089DNJYKBYGCQEXBN9BD","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T23:34:57.069Z","completed_at":"2026-09-03T23:35:35.113Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T23:34:57.759Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a6df46b9336f5187b78a039155eaf606d7674e54136518bab6e88efb1c54eb35","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2827813f-f1ec-4261-88f3-bb10cddaff51","object_id":"sha256:a6df46b9336f5187b78a039155eaf606d7674e54136518bab6e88efb1c54eb35","sha256":"a6df46b9336f5187b78a039155eaf606d7674e54136518bab6e88efb1c54eb35"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"_FKLJN9dGeM4teBCXgE3zzsap3UmxP41WrKKIoHO4_FTnreEDLAbKzYD12T---Q-JRIs-n4qHQLXuyRNzlJHBg"}} -->
