### PR TITLE
test(plugin-browser): pin the workspace form guards, tab projection and history

### DIFF
--- a/plugins/plugin-browser/src/workspace/browser-workspace-forms.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-forms.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Pure helpers behind the workspace browser's form and navigation actions:
+ * the two element type-guards, the control-value writer, the tab-state
+ * projection, and the history stack.
+ *
+ * None of them were referenced by any test in the plugin. The history stack in
+ * particular implements the forward-truncation rule every browser has, and a
+ * projection that leaked a runtime field into serialized tab state would carry
+ * a live JSDOM handle with it.
+ *
+ * Real jsdom, no mocks — it is already a direct dependency of this plugin.
+ */
+
+import { JSDOM } from "jsdom";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  cloneWebBrowserWorkspaceTabState,
+  ensureBrowserWorkspaceCheckboxElement,
+  ensureBrowserWorkspaceFormControlElement,
+  pushWebBrowserWorkspaceHistory,
+  setBrowserWorkspaceControlValue,
+} from "./browser-workspace-forms";
+import type { WebBrowserWorkspaceTabState } from "./browser-workspace-types";
+
+let document: Document;
+
+beforeEach(() => {
+  document = new JSDOM("<!doctype html><body></body>").window.document;
+});
+
+function element(html: string): Element {
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  const child = host.firstElementChild;
+  if (!child) throw new Error("fixture produced no element");
+  return child;
+}
+
+describe("ensureBrowserWorkspaceFormControlElement", () => {
+  it("accepts the three control tags", () => {
+    for (const html of [
+      "<input>",
+      "<textarea></textarea>",
+      "<select><option>a</option></select>",
+    ]) {
+      expect(() =>
+        ensureBrowserWorkspaceFormControlElement(element(html), "fill"),
+      ).not.toThrow();
+    }
+  });
+
+  it("returns the SAME element, not a copy", () => {
+    const input = element("<input>");
+    expect(ensureBrowserWorkspaceFormControlElement(input, "type")).toBe(input);
+  });
+
+  it("refuses anything else, naming the subaction that asked", () => {
+    for (const html of [
+      "<div></div>",
+      "<button></button>",
+      "<span contenteditable></span>",
+      "<form></form>",
+      "<label></label>",
+    ]) {
+      expect(() =>
+        ensureBrowserWorkspaceFormControlElement(element(html), "select"),
+      ).toThrow(
+        /workspace select requires an input, textarea, or select target/,
+      );
+    }
+  });
+
+  it("reports whichever subaction was passed", () => {
+    for (const subaction of [
+      "clipboard",
+      "fill",
+      "keyboardinserttext",
+      "keyboardtype",
+      "select",
+      "type",
+    ] as const) {
+      expect(() =>
+        ensureBrowserWorkspaceFormControlElement(
+          element("<div></div>"),
+          subaction,
+        ),
+      ).toThrow(new RegExp(`workspace ${subaction} requires`));
+    }
+  });
+});
+
+describe("ensureBrowserWorkspaceCheckboxElement", () => {
+  it("accepts a checkbox and a radio", () => {
+    for (const html of ['<input type="checkbox">', '<input type="radio">']) {
+      expect(() =>
+        ensureBrowserWorkspaceCheckboxElement(element(html), "check"),
+      ).not.toThrow();
+    }
+  });
+
+  it("accepts an uppercase type attribute", () => {
+    // The DOM's `.type` getter lowercases a recognised keyword, so the guard
+    // sees "checkbox" regardless of how the author wrote it.
+    for (const html of ['<input type="CHECKBOX">', '<input type="Radio">']) {
+      expect(() =>
+        ensureBrowserWorkspaceCheckboxElement(element(html), "uncheck"),
+      ).not.toThrow();
+    }
+  });
+
+  it("refuses a padded type attribute, because the DOM resolves it to text", () => {
+    // `type=" radio "` is not a recognised keyword, so `.type` reports "text"
+    // and the element genuinely is a text input — refusing is correct. The
+    // guard's own trim()/toLowerCase() therefore never changes the outcome for
+    // a real DOM; it only guards a hand-rolled element-like object.
+    const input = element('<input type=" radio ">') as HTMLInputElement;
+    expect(input.type).toBe("text");
+    expect(() =>
+      ensureBrowserWorkspaceCheckboxElement(input, "uncheck"),
+    ).toThrow(/requires a checkbox or radio input target/);
+  });
+
+  it("refuses an input that is not checkable", () => {
+    // A text input has a `.checked` property that silently accepts writes and
+    // does nothing, so a loose guard here fails invisibly at runtime.
+    for (const html of [
+      "<input>",
+      '<input type="text">',
+      '<input type="submit">',
+      '<input type="hidden">',
+    ]) {
+      expect(() =>
+        ensureBrowserWorkspaceCheckboxElement(element(html), "check"),
+      ).toThrow(/requires a checkbox or radio input target/);
+    }
+  });
+
+  it("refuses non-input tags even when they look checkable", () => {
+    for (const html of [
+      '<div type="checkbox"></div>',
+      '<select type="checkbox"></select>',
+      '<button type="checkbox"></button>',
+    ]) {
+      expect(() =>
+        ensureBrowserWorkspaceCheckboxElement(element(html), "check"),
+      ).toThrow(/requires a checkbox or radio input target/);
+    }
+  });
+});
+
+describe("setBrowserWorkspaceControlValue", () => {
+  it("sets the live value AND the attribute so serialized HTML agrees", () => {
+    // `.value` alone is invisible to outerHTML, so a page snapshot or a
+    // re-parse would lose whatever the agent typed.
+    const input = element("<input>") as HTMLInputElement;
+    setBrowserWorkspaceControlValue(input, "typed");
+    expect(input.value).toBe("typed");
+    expect(input.getAttribute("value")).toBe("typed");
+  });
+
+  it("also mirrors into textContent for a textarea", () => {
+    // A textarea's serialized content is its text node, not a value attribute.
+    const area = element("<textarea>old</textarea>") as HTMLTextAreaElement;
+    setBrowserWorkspaceControlValue(area, "new");
+    expect(area.value).toBe("new");
+    expect(area.textContent).toBe("new");
+  });
+
+  it("does NOT write textContent for a non-textarea", () => {
+    const select = element(
+      "<select><option value='a'>a</option><option value='b'>b</option></select>",
+    ) as HTMLSelectElement;
+    const before = select.textContent;
+    setBrowserWorkspaceControlValue(select, "b");
+    expect(select.value).toBe("b");
+    expect(select.textContent).toBe(before);
+  });
+
+  it("clears cleanly with an empty string", () => {
+    const input = element('<input value="old">') as HTMLInputElement;
+    setBrowserWorkspaceControlValue(input, "");
+    expect(input.value).toBe("");
+    expect(input.getAttribute("value")).toBe("");
+  });
+});
+
+describe("cloneWebBrowserWorkspaceTabState", () => {
+  function tabState(): WebBrowserWorkspaceTabState {
+    return {
+      id: "tab-1",
+      title: "Example",
+      url: "https://example.com/",
+      partition: "default",
+      kind: "web",
+      visible: true,
+      createdAt: 1,
+      updatedAt: 2,
+      lastFocusedAt: 3,
+      // Runtime-only fields that must never reach serialized tab state.
+      dom: { window: {} },
+      history: ["https://example.com/"],
+      historyIndex: 0,
+      loadedUrl: "https://example.com/",
+    } as unknown as WebBrowserWorkspaceTabState;
+  }
+
+  it("projects exactly the serializable fields", () => {
+    expect(
+      Object.keys(cloneWebBrowserWorkspaceTabState(tabState())).sort(),
+    ).toEqual([
+      "createdAt",
+      "id",
+      "kind",
+      "lastFocusedAt",
+      "partition",
+      "title",
+      "updatedAt",
+      "url",
+      "visible",
+    ]);
+  });
+
+  it("carries no runtime handle into the clone", () => {
+    // `dom` holds a live JSDOM window. Leaking it would make tab state
+    // unserializable and pin the whole document in memory.
+    const clone = cloneWebBrowserWorkspaceTabState(tabState()) as Record<
+      string,
+      unknown
+    >;
+    for (const key of ["dom", "history", "historyIndex", "loadedUrl"]) {
+      expect(clone).not.toHaveProperty(key);
+    }
+    expect(() => JSON.stringify(clone)).not.toThrow();
+  });
+
+  it("is a detached copy: mutating it does not touch the source", () => {
+    const source = tabState();
+    const clone = cloneWebBrowserWorkspaceTabState(source);
+    clone.title = "changed";
+    expect(source.title).toBe("Example");
+  });
+});
+
+describe("pushWebBrowserWorkspaceHistory", () => {
+  function tab(history: string[], historyIndex: number) {
+    return { history, historyIndex } as unknown as WebBrowserWorkspaceTabState;
+  }
+
+  it("appends when already at the tip", () => {
+    const state = tab(["/a", "/b"], 1);
+    pushWebBrowserWorkspaceHistory(state, "/c");
+    expect(state.history).toEqual(["/a", "/b", "/c"]);
+    expect(state.historyIndex).toBe(2);
+  });
+
+  it("TRUNCATES forward history when navigating from a back position", () => {
+    // This is the defining browser rule: going back and then navigating
+    // discards everything that was ahead. Without the slice, the forward
+    // entries survive and Forward would jump to a page the user abandoned.
+    const state = tab(["/a", "/b", "/c", "/d"], 1);
+    pushWebBrowserWorkspaceHistory(state, "/new");
+    expect(state.history).toEqual(["/a", "/b", "/new"]);
+    expect(state.historyIndex).toBe(2);
+  });
+
+  it("truncates everything when back at the very first entry", () => {
+    const state = tab(["/a", "/b", "/c"], 0);
+    pushWebBrowserWorkspaceHistory(state, "/new");
+    expect(state.history).toEqual(["/a", "/new"]);
+    expect(state.historyIndex).toBe(1);
+  });
+
+  it("always leaves the index pointing at the new entry", () => {
+    for (const [history, index] of [
+      [[], -1],
+      [["/a"], 0],
+      [["/a", "/b", "/c"], 2],
+      [["/a", "/b", "/c"], 0],
+    ] as const) {
+      const state = tab([...history], index);
+      pushWebBrowserWorkspaceHistory(state, "/x");
+      expect(state.historyIndex).toBe(state.history.length - 1);
+      expect(state.history[state.historyIndex]).toBe("/x");
+    }
+  });
+
+  it("starts a fresh stack from an empty history", () => {
+    const state = tab([], -1);
+    pushWebBrowserWorkspaceHistory(state, "/first");
+    expect(state.history).toEqual(["/first"]);
+    expect(state.historyIndex).toBe(0);
+  });
+
+  it("keeps a repeated URL as its own entry", () => {
+    // No de-duplication: reloading the same URL is a real navigation, and
+    // collapsing it would desynchronize the index from the user's Back count.
+    const state = tab(["/a"], 0);
+    pushWebBrowserWorkspaceHistory(state, "/a");
+    expect(state.history).toEqual(["/a", "/a"]);
+    expect(state.historyIndex).toBe(1);
+  });
+
+  it("replaces the array rather than mutating the previous one in place", () => {
+    // Callers snapshot `history` for undo/inspection; an in-place splice would
+    // retroactively change a snapshot they already hold.
+    const original = ["/a", "/b", "/c"];
+    const state = tab(original, 1);
+    pushWebBrowserWorkspaceHistory(state, "/new");
+    expect(original).toEqual(["/a", "/b", "/c"]);
+    expect(state.history).not.toBe(original);
+  });
+});


### PR DESCRIPTION
# What

Eleven exports in `browser-workspace-forms.ts` — the helpers behind the workspace browser's form and navigation actions — were referenced by **no test in the plugin**. This adds 23, using real jsdom (already a direct dependency here). No production change.

# The history stack

`pushWebBrowserWorkspaceHistory` implements the forward-truncation rule every browser has:

```ts
const nextHistory = tab.history.slice(0, tab.historyIndex + 1);
nextHistory.push(nextUrl);
```

Going back and then navigating must discard everything ahead. Without the slice, Forward would jump to a page the user abandoned. Covered: append at the tip, truncate from a back position, truncate from index 0, an empty stack, and that the index always lands on the new entry across four starting shapes.

Two behaviours pinned as decisions rather than accidents:

- **A repeated URL stays its own entry.** Reloading is a real navigation; collapsing it would desynchronize the index from the user's Back count.
- **The array is replaced, not spliced in place.** Callers snapshot `history`; an in-place mutation would retroactively change a snapshot they already hold. That mutant is now a failing test.

# The tab projection

`cloneWebBrowserWorkspaceTabState` is an allowlist projection of nine fields. The runtime state it projects *from* also carries `dom` — a **live JSDOM window** — plus `history`, `historyIndex` and `loadedUrl`.

A spread instead of an explicit field list would drag that window into serializable tab state, making it unserializable and pinning the whole document in memory. The test asserts the exact key set, that none of the four runtime fields survive, and that the result actually round-trips through `JSON.stringify`.

# An assumption of mine that the tests corrected

I first wrote a test asserting `type=" radio "` is accepted, on the strength of the guard's own `trim().toLowerCase()`. It's refused — and that's right. The DOM's `.type` IDL getter resolves an unrecognised keyword to `"text"`, so that element genuinely *is* a text input.

I rewrote it as two tests: an uppercase `type="CHECKBOX"` is accepted (the IDL getter lowercases recognised keywords), and a padded attribute is refused, with the assertion `expect(input.type).toBe("text")` making the reason explicit. Worth knowing: **the guard's own `trim()`/`toLowerCase()` never changes the outcome for a real DOM** — it only matters for a hand-rolled element-like object. I've left it alone; it's harmless and the intent is clear.

# Also pinned

- **Both type-guards, in both directions.** `ensureBrowserWorkspaceCheckboxElement` rejects a text/submit/hidden input — which matters because a text input has a `.checked` property that silently accepts writes and does nothing, so a loose guard fails invisibly at runtime. It also rejects non-input tags carrying `type="checkbox"`.
- **Each guard names the subaction that asked**, across all six control subactions.
- **`setBrowserWorkspaceControlValue` writes the `value` attribute, not just `.value`.** `.value` alone is invisible to `outerHTML`, so a page snapshot or re-parse would lose whatever the agent typed. It mirrors into `textContent` for a textarea (whose serialized content is its text node) and must *not* do so for a select — both directions asserted.

# Mutation testing: 16 mutants, 16 killed

No survivors. Including: each accepted tag dropped from the control guard; the checkbox guard losing its tag check, losing `radio`, or accepting any type; the subaction dropped from both error messages; the `value` attribute not set; textarea mirroring removed, and applied to every control; the clone spreading the runtime object; the clone dropping a field; history append-only; history slice off by one; history mutated in place; and the index not advanced.

# A hunt that found nothing, reported for completeness

Before this I re-ran the defect class from #30480 (`getTweetsWhere` dropping an `await`): swept for async callbacks passed to `.filter`/`.some`/`.every`/`.find` (zero hits), then extracted both function bodies for every exported singular/plural pair in the repo and diffed them for `await` asymmetry. Nineteen pairs don't delegate; the two flagged are the ordinary sync-singular/async-plural shape, not the bug. Clean negative.

# Evidence

```
bunx vitest run src/workspace/browser-workspace-forms.test.ts   → 23 pass
bunx vitest run src/workspace/                                  → 108 pass across 14 files
bunx tsc --noEmit                                               → clean
bunx @biomejs/biome check                                       → clean
```

Tests only — `git diff` touches no source file.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MTJP040TC132KFGHNQHPMY","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-03T23:45:00.932Z","completed_at":"2026-09-03T23:45:42.667Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-03T23:45:01.654Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c888acb5f183e69191b49f2eb68c2fc487b1382f82f76e3a169624a4918acba9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9d739eb0-0d8d-4655-b712-e24a58253784","object_id":"sha256:c888acb5f183e69191b49f2eb68c2fc487b1382f82f76e3a169624a4918acba9","sha256":"c888acb5f183e69191b49f2eb68c2fc487b1382f82f76e3a169624a4918acba9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"4UPMLMeraqElWcUZxGcsaXQi33hyH2FvZn5N2ruJKF8OR1mS64xUvloYWZmA1IrNC58FIXPjBg1jK1AgziYpCA"}} -->
