### PR TITLE
fix(cloud): forward Shared model selector into Worker E2E

### DIFF
--- a/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
+++ b/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
@@ -128,18 +128,29 @@ test.describe("shared→dedicated tier upgrade", () => {
       const SECOND = "set a reminder for Friday";
       const sendTurn = (text: string, clientMessageId: string) =>
         retrySharedRuntimeWarming(() =>
-          c("POST", convoUrl, { text, clientMessageId }),
+          c<{ text?: string; degraded?: boolean }>("POST", convoUrl, {
+            text,
+            clientMessageId,
+          }),
         );
       const firstTurn = await sendTurn(FIRST, "personal-upgrade-1");
       expect(
         firstTurn.status,
         `first shared turn: ${JSON.stringify(firstTurn.json)}`,
       ).toBe(200);
+      expect(
+        firstTurn.json.degraded,
+        `first shared turn must use the configured mock model: ${JSON.stringify(firstTurn.json)}`,
+      ).not.toBe(true);
       const secondTurn = await sendTurn(SECOND, "personal-upgrade-2");
       expect(
         secondTurn.status,
         `second shared turn: ${JSON.stringify(secondTurn.json)}`,
       ).toBe(200);
+      expect(
+        secondTurn.json.degraded,
+        `second shared turn must use the configured mock model: ${JSON.stringify(secondTurn.json)}`,
+      ).not.toBe(true);
       const sharedHistory = await retrySharedRuntimeWarming(() =>
         c<{ messages?: Array<{ role: string; text: string }> }>(
           "GET",

--- a/packages/cloud/scripts/admin/sync-api-dev-vars.ts
+++ b/packages/cloud/scripts/admin/sync-api-dev-vars.ts
@@ -115,6 +115,10 @@ const providerOverrideKeys = new Set([
   "OPENROUTER_BASE_URL",
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
+  // Shared-runtime E2E can select the loopback provider explicitly. The
+  // launcher environment is not visible inside workerd unless this selector
+  // is written alongside the provider credentials.
+  "ELIZAOS_CLOUD_SMALL_MODEL",
   "ANTHROPIC_API_KEY",
   // Cerebras is the cloud's DEFAULT text provider — a shell-exported key must
   // reach the booted worker (e.g. the creator-monetization e2e real-LLM lane),


### PR DESCRIPTION
## Summary
- forward the explicit Shared model selector into the local Cloud Worker dev-vars boundary
- assert the structured `degraded` contract for both Shared turns so HTTP 200 cannot conceal a missing model

## Root cause
The launcher set `ELIZAOS_CLOUD_SMALL_MODEL=openai/gpt-4o-mini`, but the dev-vars synchronizer copied only provider credentials and endpoints into workerd. The Worker therefore could select its default provider and return a non-persisted degraded reply with HTTP 200.

A concurrent fixture repair now also exposes the loopback server as OpenRouter. Forwarding the explicit selector remains the correct process-boundary contract; checking `degraded` makes the regression guard independent of user-facing copy.

## Validation
- `bun run verify` — 376/376 workspace tasks plus root audits passed on the original exact head
- Shared-to-Dedicated focused stack E2E — 1/1 passed after rebase on current develop and reviewer-requested structured assertion
- cloud E2E typecheck passed after final rebase
- Biome passed with 11 pre-existing undeclared-environment warnings in the dev-vars script
- exact six-spec blocking cloud stack command — 10/10 passed before the concurrent fixture repair; affected focused spec rerun after each rebase

Closes #30451