### PR TITLE
test(cloud): use canonical ElizaError export

### DIFF
--- a/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
@@ -6,7 +6,7 @@
  * parsed to 3600 and became configuration nobody set.
  */
 import { describe, expect, test } from "bun:test";
-import { ElizaError } from "@elizaos/core";
+import { ElizaError } from "@elizaos/core/errors";
 import { parseIntegerEnvValue } from "../src/integer-env";
 
 const NAME = "VOICE_AUDIO_TTL_SECONDS";


### PR DESCRIPTION
## Summary

- import ElizaError from the canonical @elizaos/core/errors export used by the gateway implementation
- remove constructor-identity coupling between the root barrel and subpath module instances
- restore both deterministic gateway-discord integer parser assertions

Closes #30483.

## Evidence

- exact base: 27f2ce9dedb055356de80e01e6e71f8bbbaf9d00
- exact head: 9dfc3c61ef0fca348965e844392c99270f9cfff2
- focused gateway-discord parser test: 9/9 passed
- real Worker group-h-misc rerun: 78 passed, 4 skipped, 0 failed; no route change warranted
- Biome and diff check: passed
- exact-head root bun run verify: passed

The pre-rebase full cloud aggregate traversed all batches but returned nonzero on the older base; the changed deterministic test, owning typecheck/lint, real Worker group, and exact rebased root gate are green.