### PR TITLE
fix(ci): make fused inference setup opt-in

### DIFF
--- a/.github/actions/setup-bun-workspace/action.yml
+++ b/.github/actions/setup-bun-workspace/action.yml
@@ -34,6 +34,13 @@ inputs:
     description: "Whether to run the repo postinstall step explicitly"
     required: false
     default: "true"
+  setup-fused-inference:
+    description: >-
+      Whether repo postinstall should provision and verify the desktop fused
+      inference runtime. Generic CI lanes must leave this disabled; only the
+      desktop contract and release build opt in.
+    required: false
+    default: "false"
   cache-bun-install:
     description: >-
       Whether to restore/save the global Bun install cache. Disable this for
@@ -432,6 +439,7 @@ runs:
           sleep 5
         done
       env:
+        ELIZA_SKIP_FUSED_INFERENCE_SETUP: ${{ inputs.setup-fused-inference != 'true' && '1' || '' }}
         # When the system-Python guard above found a usable interpreter,
         # `pythonLocation` is never set (actions/setup-python@v6 was skipped),
         # so prefer the probed binary and only fall back to the downloaded
@@ -495,6 +503,7 @@ runs:
       env:
         SKIP_AVATAR_CLONE: ${{ inputs.skip-avatar-clone == 'true' && '1' || '' }}
         ELIZA_NO_VISION_DEPS: ${{ inputs.no-vision-deps == 'true' && '1' || '' }}
+        ELIZA_SKIP_FUSED_INFERENCE_SETUP: ${{ inputs.setup-fused-inference != 'true' && '1' || '' }}
 
     - name: Ensure workspace + native-plugin symlinks (postinstall safety net)
       # `bun run postinstall` chains `bun scripts/patch-*` steps before

--- a/.github/workflows/electrobun-contract.yml
+++ b/.github/workflows/electrobun-contract.yml
@@ -90,6 +90,7 @@ jobs:
           install-native-deps: "false"
           skip-avatar-clone: "true"
           no-vision-deps: "true"
+          setup-fused-inference: "true"
 
       - name: Build exact Electrobun desktop tree
         run: node packages/app-core/scripts/desktop-build.mjs build

--- a/.github/workflows/pr-static-smoke.yml
+++ b/.github/workflows/pr-static-smoke.yml
@@ -379,7 +379,9 @@ jobs:
           trap 'docker stop "$container" >/dev/null 2>&1 || true' EXIT
           docker run --rm --detach --name "$container" \
             --env POSTGRES_HOST_AUTH_METHOD=trust --publish 5432:5432 postgres:16-alpine
-          until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
+          # The image's temporary initialization server accepts Unix sockets
+          # before restarting. Wait for TCP, which the test uses.
+          until docker exec "$container" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; do
             sleep 1
           done
           bun test --config=/dev/null --isolate \

--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -537,6 +537,8 @@ jobs:
 
       - name: Run repository postinstall patches
         run: bun run postinstall
+        env:
+          ELIZA_SKIP_FUSED_INFERENCE_SETUP: ""
 
       - name: Align version with release tag
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,8 @@ env:
   NODE_VERSION: "24.15.0"
   NODE_NO_WARNINGS: "1"
   NODE_OPTIONS: "--max-old-space-size=8192"
-  # This suite never launches the packaged local-inference runtime. Avoid a
-  # fan-out of identical 67 MB Hugging Face downloads during workspace setup;
-  # dedicated desktop/device workflows retain the real installer coverage.
+  # Generic lanes skip desktop inference setup. The desktop-contract job opts
+  # in through setup-bun-workspace so its native build remains verified.
   ELIZA_SKIP_FUSED_INFERENCE_SETUP: "1"
   # Baseline PR jobs are secret-free. Dedicated live jobs inject provider keys
   # locally and remain opt-in/scheduled where external services are involved.
@@ -522,6 +521,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --frozen-lockfile
           install-native-deps: "false"
+          setup-fused-inference: "true"
 
       - name: Build workspace packages for Vitest resolution
         run: bun run build:core

--- a/packages/scripts/__tests__/ci-fused-inference-setup-contract.test.ts
+++ b/packages/scripts/__tests__/ci-fused-inference-setup-contract.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Exercises real Bun install and postinstall lifecycles using the CI actions'
+ * environment, so generic jobs skip native setup and desktop owners enter it.
+ * An unsupported probe platform rejects before any host or network mutation.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type Step = {
+  name?: string;
+  uses?: string;
+  with?: Record<string, string>;
+  env?: Record<string, string>;
+};
+type Workflow = { jobs: Record<string, { steps: Step[] }> };
+type Action = {
+  inputs: Record<string, { default: string }>;
+  runs: { steps: Step[] };
+};
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+function readYaml(relativePath: string): Record<string, unknown> {
+  return Bun.YAML.parse(
+    readFileSync(`${repoRoot}${relativePath}`, "utf8"),
+  ) as Record<string, unknown>;
+}
+
+// This restricted grammar has the same string truthiness and short-circuit
+// behavior in JavaScript and GitHub Actions; other syntax fails explicitly.
+function resolveSkip(
+  value: string | undefined,
+  input: string,
+): string | undefined {
+  if (value === undefined || !value.startsWith("${{")) return value;
+  const parts =
+    /^\$\{\{ inputs\.setup-fused-inference (==|!=) 'true' && '([^']*)' \|\| '([^']*)' \}\}$/.exec(
+      value,
+    );
+  if (!parts) throw new Error(`Unsupported setup expression: ${value}`);
+  const matches = input.toLowerCase() === "true";
+  const condition = parts[1] === "==" ? matches : !matches;
+  return (condition && parts[2]) || parts[3];
+}
+
+function runLifecycle(
+  step: Step,
+  input: string,
+  command: string[],
+  enabled: boolean,
+): void {
+  const fixture = mkdtempSync(join(tmpdir(), "ci-fused-lifecycle-"));
+  try {
+    writeFileSync(
+      join(fixture, "package.json"),
+      JSON.stringify({
+        name: "ci-fused-lifecycle-fixture",
+        private: true,
+        scripts: { postinstall: "bun probe.mjs" },
+      }),
+    );
+    const installer = new URL(
+      "../../app-core/scripts/ensure-fused-inference-install.mjs",
+      import.meta.url,
+    ).href;
+    writeFileSync(
+      join(fixture, "probe.mjs"),
+      `import { ensureFusedInferenceInstall } from ${JSON.stringify(installer)};\nawait ensureFusedInferenceInstall({ platform: "ci-contract" });\n`,
+    );
+    const env = { ...process.env };
+    delete env.ELIZA_SKIP_FUSED_INFERENCE_SETUP;
+    const skip = resolveSkip(step.env?.ELIZA_SKIP_FUSED_INFERENCE_SETUP, input);
+    if (skip !== undefined) env.ELIZA_SKIP_FUSED_INFERENCE_SETUP = skip;
+    const result = spawnSync(process.execPath, command, {
+      cwd: fixture,
+      env,
+      encoding: "utf8",
+      timeout: 20_000,
+    });
+    if (result.error) throw result.error;
+    const output = result.stdout + result.stderr;
+    if (enabled) {
+      expect(result.status).not.toBe(0);
+      expect(output).toContain(
+        "unsupported desktop platform for fused inference: ci-contract",
+      );
+    } else {
+      expect(result.status).toBe(0);
+      expect(output).toContain("skipped by ELIZA_SKIP_FUSED_INFERENCE_SETUP=1");
+    }
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+}
+
+function workspaceSetup(workflowPath: string, jobName: string): Step {
+  const workflow = readYaml(workflowPath) as Workflow;
+  const step = workflow.jobs[jobName]?.steps.find(
+    (candidate) => candidate.uses === "./.github/actions/setup-bun-workspace",
+  );
+  if (!step)
+    throw new Error(`${workflowPath}:${jobName} has no workspace setup`);
+  return step;
+}
+
+function namedStep(
+  workflowPath: string,
+  jobName: string,
+  stepName: string,
+): Step {
+  const workflow = readYaml(workflowPath) as Workflow;
+  const step = workflow.jobs[jobName]?.steps.find(
+    (candidate) => candidate.name === stepName,
+  );
+  if (!step) throw new Error(`${workflowPath}:${jobName} has no ${stepName}`);
+  return step;
+}
+
+describe("CI fused inference setup ownership", () => {
+  const action = readYaml(
+    ".github/actions/setup-bun-workspace/action.yml",
+  ) as Action;
+  for (const [name, command] of [
+    ["Install dependencies", ["install"]],
+    ["Run repository postinstall", ["run", "postinstall"]],
+  ] as const) {
+    for (const input of [undefined, "false", "true"]) {
+      test(`${name} respects desktop opt-in ${input ?? "default"}`, () => {
+        const step = action.runs.steps.find(
+          (candidate) => candidate.name === name,
+        );
+        if (!step) throw new Error(`Missing setup step: ${name}`);
+        runLifecycle(
+          step,
+          input ?? action.inputs["setup-fused-inference"].default,
+          [...command],
+          input === "true",
+        );
+      });
+    }
+  }
+
+  test("cloud setup skips native provisioning during its install lifecycle", () => {
+    const cloud = readYaml(
+      ".github/actions/cloud-setup-test-env/action.yml",
+    ) as Action;
+    const install = cloud.runs.steps.find(
+      (step) => step.name === "Install dependencies",
+    );
+    if (!install) throw new Error("Cloud setup has no install step");
+    runLifecycle(install, "false", ["install", "--no-save"], false);
+  });
+
+  test("desktop artifact owners enter the installer", () => {
+    for (const [workflow, job] of [
+      [".github/workflows/test.yml", "desktop-contract"],
+      [".github/workflows/electrobun-contract.yml", "flatpak-e2e"],
+    ]) {
+      const input = workspaceSetup(workflow, job).with?.[
+        "setup-fused-inference"
+      ];
+      const install = action.runs.steps.find(
+        (step) => step.name === "Install dependencies",
+      );
+      if (!install) throw new Error("Workspace setup has no install step");
+      runLifecycle(
+        install,
+        input ?? action.inputs["setup-fused-inference"].default,
+        ["install"],
+        true,
+      );
+    }
+    runLifecycle(
+      namedStep(
+        ".github/workflows/release-electrobun.yml",
+        "build",
+        "Run repository postinstall patches",
+      ),
+      "true",
+      ["run", "postinstall"],
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Closes #30485.

Generic CI dependency setup now skips desktop inference provisioning whether postinstall runs implicitly during `bun install` or through the explicit postinstall step. Desktop contract, Flatpak, and Electrobun release builds explicitly enter the installer.

The opt-in expression uses a truthy skip branch, fixing the empty-string short-circuit bug. The install step receives the same environment as explicit postinstall. Current develop already protects the separate Cloud setup action; the regression suite covers that action too. The workflow comment now describes the desktop exception accurately.

The subscription PostgreSQL smoke now waits for TCP readiness. The official PostgreSQL image starts a temporary socket-only initialization server before restarting; probing that socket let the test connect during shutdown. The failed hosted run reported PostgreSQL `57P03` before the test body. A fresh PostgreSQL 16 cluster reproduced the distinction: socket readiness succeeded while TCP correctly refused, then TCP succeeded after the final server started.

The new tests run real Bun install/postinstall subprocesses against the production installer. A deliberately unsupported probe platform detects entry before host or network mutation. Generic jobs must skip; desktop jobs must reach that boundary. Restoring the original expression or removing the install-step environment makes the tests fail.

Validated head: `f393de2491782d280d936837a6f5e871d405369f`  
Validated develop: `9322e05c91a2e645875c65bdc6d9df1e150d6b37`

- Rebased on current develop; Bun 1.3.14 install completed without tracked dependency changes.
- CI lifecycle and installer suites: 16 passed, 0 failed.
- Real PostgreSQL subscription authority suite: 3 passed, 24 assertions, with an explicit 120-second local harness timeout.
- Actionlint for changed workflows: passed.
- Standalone TypeScript check for the new contract suite: passed.
- Biome and `git diff --check`: passed.
- Root `bun run verify`: passed, 376/376 workspace tasks plus all repository audits.
- Mutation checks: both original defects produce failing regression tests.

<!-- evidence-head:f393de2491782d280d936837a6f5e871d405369f -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow environment only; no product renderer changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no product renderer changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no changed user interaction.
<!-- evidence-row:backend-logs -->
- [x] Executed lifecycle, mutation, compiler, lint and root verification results above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend execution changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real temporary Bun package lifecycle execution verified skip versus installer entry; no host provisioning performed by the test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text changed.

Fresh hosted checks on this head must complete before merge. The post-merge Develop Full run remains the integration acceptance for #30485.
