### PR TITLE
fix(cloud): forward the shared turn degraded flag through the REST adapter

### DIFF
--- a/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
+++ b/packages/cloud/e2e/tests/shared-to-dedicated-upgrade.spec.ts
@@ -141,7 +141,7 @@ test.describe("shared→dedicated tier upgrade", () => {
       expect(
         firstTurn.json.degraded,
         `first shared turn must use the configured mock model: ${JSON.stringify(firstTurn.json)}`,
-      ).not.toBe(true);
+      ).toBe(false);
       const secondTurn = await sendTurn(SECOND, "personal-upgrade-2");
       expect(
         secondTurn.status,
@@ -150,7 +150,7 @@ test.describe("shared→dedicated tier upgrade", () => {
       expect(
         secondTurn.json.degraded,
         `second shared turn must use the configured mock model: ${JSON.stringify(secondTurn.json)}`,
-      ).not.toBe(true);
+      ).toBe(false);
       const sharedHistory = await retrySharedRuntimeWarming(() =>
         c<{ messages?: Array<{ role: string; text: string }> }>(
           "GET",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -421,6 +421,77 @@ describe("shared-rest-adapter — messages", () => {
     );
   });
 
+  test("POST forwards the bridge degraded flag so REST callers can see a fallback turn", async () => {
+    // The no-shared-model branch is the only producer of `degraded: true`
+    // (run-shared-agent-turn.ts). Dropping it here left REST clients unable to
+    // distinguish a real answer from the "temporarily unavailable" placeholder,
+    // because that placeholder is delivered as an ordinary 200 with reply text.
+    coordinateSharedBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "degraded",
+      result: {
+        text: "Nova is temporarily unavailable (no shared model configured).",
+        degraded: true,
+      },
+    });
+    const out = await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "2+2?",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+    );
+    expect(out).toEqual({
+      text: "Nova is temporarily unavailable (no shared model configured).",
+      agentName: "Eliza",
+      degraded: true,
+    });
+  });
+
+  test("POST forwards a healthy turn's degraded:false rather than omitting it", async () => {
+    // `false` must survive as `false`. Emitting the field only when true would
+    // make "healthy" and "field dropped" indistinguishable to a caller, which
+    // is the exact ambiguity this flag exists to remove.
+    coordinateSharedBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "healthy",
+      result: { text: "four", degraded: false },
+    });
+    const out = await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "2+2?",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+    );
+    expect(out).toEqual({ text: "four", agentName: "Eliza", degraded: false });
+    expect(Object.hasOwn(out, "degraded")).toBe(true);
+  });
+
+  test("POST omits degraded when the bridge did not report it", async () => {
+    // Absence is forwarded as absence, never coerced to false: a bridge that
+    // stops sending the flag is a contract change, not a healthy turn.
+    for (const degraded of [undefined, "true", 1, null]) {
+      coordinateSharedBridge.mockResolvedValueOnce({
+        jsonrpc: "2.0",
+        id: "unreported",
+        result: { text: "four", ...(degraded === undefined ? {} : { degraded }) },
+      });
+      const out = await sharedRestMessageSend(
+        SHARED_AGENT,
+        AGENT,
+        "2+2?",
+        "Eliza",
+        EXECUTION_CTX,
+        NAMESPACE,
+      );
+      expect(out).toEqual({ text: "four", agentName: "Eliza" });
+      expect(Object.hasOwn(out, "degraded")).toBe(false);
+    }
+  });
+
   test("POST rejects impossible provider timing from the untrusted bridge", async () => {
     const warn = spyOn(logger, "warn").mockImplementation(() => undefined);
     const impossibleReceipts = [

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -583,6 +583,7 @@ export async function sharedRestMessageSend(
 ): Promise<{
   text: string;
   agentName: string;
+  degraded?: boolean;
   timing?: SharedProviderTimingReceipt;
   mediaUrls?: string[];
 }> {
@@ -622,6 +623,7 @@ export async function sharedRestMessageSend(
   }
   const result = (response.result ?? {}) as {
     text?: unknown;
+    degraded?: unknown;
     timing?: unknown;
     actionResults?: unknown;
   };
@@ -645,6 +647,10 @@ export async function sharedRestMessageSend(
   return {
     text: replyText,
     agentName: agentName || "Eliza",
+    // The bridge always sends a boolean (`degraded` is required on the shared
+    // turn result), so absence means the bridge shape changed rather than that
+    // the turn was healthy — forward only what it actually reported.
+    ...(typeof result.degraded === "boolean" ? { degraded: result.degraded } : {}),
     ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
     ...(timing ? { timing } : {}),
   };


### PR DESCRIPTION
# What

`sharedRestMessageSend` drops the shared turn's `degraded` flag, so the guard added in #30482 and merged into `develop` can never fail.

That spec asserts:

```ts
expect(firstTurn.json.degraded, `... must use the configured mock model ...`).not.toBe(true);
```

but the endpoint it calls — `/api/v1/eliza/agents/:agentId/api/conversations/:conversationId/messages` — never returns the field:

```ts
// shared-rest-adapter.ts:645
return {
  text: replyText,
  agentName: agentName || "Eliza",
  ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
  ...(timing ? { timing } : {}),
};
```

`messages/route.ts` assigns `result` once and returns `Response.json(result)` verbatim, so `json.degraded` is permanently `undefined` and `expect(undefined).not.toBe(true)` passes — including on exactly the no-model turn the assertion exists to catch. Raised on #30482 after it merged; this is the follow-up I offered there.

The flag isn't missing upstream. `degraded: boolean` is **required** on the shared turn result (`run-shared-agent-turn.ts:231`, `:260`), set `true` only in the two `!modelId` branches (`:1144`, `:1379`), and both other response shapes already carry it — `shared-runtime-chat.ts:1482` and `eliza-sandbox.ts:5366`. The REST adapter is the one path that drops it, and it's the path this E2E reads.

# The change

Forward what the bridge reported:

```ts
// The bridge always sends a boolean (`degraded` is required on the shared
// turn result), so absence means the bridge shape changed rather than that
// the turn was healthy — forward only what it actually reported.
...(typeof result.degraded === "boolean" ? { degraded: result.degraded } : {}),
```

plus `degraded?: boolean` on the declared return type and `degraded?: unknown` on the bridge-result cast. Six lines in one function; no other production behaviour changes.

## Why not `degraded: result.degraded === true`

That was my first instinct and it's wrong twice. It reports a healthy `false` when the bridge sent nothing at all, collapsing "healthy" and "the bridge shape changed" into one value — which is the exact ambiguity this flag exists to remove. And it breaks three existing `toEqual` assertions that pin the returned object exactly. Absence is forwarded as absence.

## The spec assertion, tightened

`.not.toBe(true)` → `.toBe(false)`, both turns. `not.toBe(true)` cannot distinguish "field absent" from "turn healthy", which is precisely how this went unnoticed. `toBe(false)` fails when the turn is degraded *and* when the field stops being emitted.

# Evidence

`bun test shared-rest-adapter.test.ts shared-rest-adapter.error-policy.test.ts` → **41 pass / 0 fail** (up from 38).
`bun test 'v1/eliza/.../messages/route.test.ts'` → **1 pass / 0 fail**.
`bun run --cwd packages/cloud/shared typecheck` and `--cwd packages/cloud/e2e typecheck` → clean.
`bunx @biomejs/biome check` on the three touched files → no findings.

Mutation-tested the forwarding line against the three new tests:

| mutant | result |
|---|---|
| drop the forwarding spread entirely | **2 fail** |
| forward on `result.degraded !== undefined` | **1 fail** |
| forward only when `result.degraded === true` | **1 fail** |
| unconditional `degraded: result.degraded === true` | **3 fail** |

All four killed. The fourth's third failure is a pre-existing test, which is the direct evidence for the conservative form above.

The three new tests cover: `degraded: true` forwarded alongside the placeholder reply text; `degraded: false` surviving as `false` with `Object.hasOwn(out, "degraded") === true`; and a missing or non-boolean value (`undefined`, `"true"`, `1`, `null`) leaving the key absent rather than coerced.

# Note

I can't run the Playwright E2E itself here — it needs the deployed worker and a live shared runtime. The unit tests pin the adapter contract the spec depends on; the spec change is the one-token tightening above.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1MXC2CRVY6XBZYV12FSY00T","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T00:33:49.976Z","completed_at":"2026-09-04T00:34:45.818Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T00:33:50.656Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"676bade886eb420360b9173db6ad29dc425d838277103217bb66ca1b89f02a4d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1d52da06-52cc-440d-896a-4cb2b85c5667","object_id":"sha256:676bade886eb420360b9173db6ad29dc425d838277103217bb66ca1b89f02a4d","sha256":"676bade886eb420360b9173db6ad29dc425d838277103217bb66ca1b89f02a4d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"HVdiwKQcpHukFqnTDimqaRqvr10OYDkDqSnIN6DyRwBF1ZkqeyvqI_6wdXzaPqbsDGwmVGlPWVoxVFpJQXS3BA"}} -->
