### PR TITLE
fix(test): remove network from verification fixture

### DIFF
--- a/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/app-verification.integration.test.ts
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterAll, describe, expect } from "vitest";
@@ -20,6 +21,7 @@ import { itIf } from "../../../../../packages/app-core/test/helpers/conditional-
 import { AppVerificationService } from "../app-verification.js";
 
 const execFileAsync = promisify(execFile);
+const TYPESCRIPT_CLI = fileURLToPath(import.meta.resolve("typescript/bin/tsc"));
 
 async function commandAvailable(
 	file: string,
@@ -101,11 +103,10 @@ function writeMinimalTsProject(workdir: string, source: string): void {
 				version: "0.0.0",
 				private: true,
 				scripts: {
-					// typecheck: invoke the locally-resolvable tsc via npx. If typescript
-					// is not installed locally, npx will download it on the fly — slow
-					// but acceptable for this single-file integration check.
-					typecheck:
-						"npx --yes -p typescript@5.6.2 tsc --noEmit -p tsconfig.json",
+					// Exercise the real child-process boundary with the repository's pinned
+					// compiler. Temp fixtures cannot resolve it themselves, and downloading
+					// TypeScript through npx makes this deterministic test network-bound.
+					typecheck: `${JSON.stringify(process.execPath)} ${JSON.stringify(TYPESCRIPT_CLI)} --noEmit -p tsconfig.json`,
 					lint: `node ${JSON.stringify(lintShim).slice(1, -1)}`,
 					test: `node ${JSON.stringify(testShim).slice(1, -1)}`,
 					build: `node ${JSON.stringify(buildShim).slice(1, -1)}`,


### PR DESCRIPTION
## Summary
- resolve the repository-pinned TypeScript compiler once
- execute that compiler inside each temporary verification fixture
- preserve the real npm-script and child-process boundary without downloading from the public registry

## Root cause
The temp project ran `npx --yes -p typescript@5.6.2 tsc`. Because the fixture lives outside the repository, npx downloaded TypeScript on every cold runner. Two consecutive Develop Full jobs exceeded the 120-second test timeout while the orphaned compiler later completed successfully; the next identical fixture passed after npm cache warming.

## Evidence
- run 33821458523: timeout at 120006ms; child later passed at 143066ms; warmed fixture 27733ms
- run 33819285065: timeout at 120106ms; child later passed at 177794ms; warmed fixture 62714ms
- exact focused suite after fix: 25/25 passed in 13.31s before rebase and 20.28s after rebase
- full plugin suite: 2025/2025 passed
- plugin typecheck, lint, and build passed
- full uncached `bun run verify`: 376/376 tasks plus all audits passed in 7m12s

Closes #30487