### PR TITLE
fix(core): make isElizaError hold across duplicate copies of the class

### DIFF
--- a/packages/cloud/api/__tests__/worker-core-stub-error-identity.test.ts
+++ b/packages/cloud/api/__tests__/worker-core-stub-error-identity.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The Worker bundle aliases `@elizaos/core` to the hand-written worker-safe
+ * mirror in `src/stubs/elizaos-core.ts` (wrangler.toml `[alias]`), but that
+ * alias is exact — `@elizaos/core/errors` keeps resolving to the real module.
+ * Both `ElizaError` classes therefore ship in one bundle, and code that throws
+ * through one while narrowing through the other used to fall through.
+ *
+ * `packages/cloud/shared/src/lib/utils/owned-bounded-fetch.ts` (subpath) and
+ * `twilio-api.ts` (barrel) are exactly that pairing, and both are in the
+ * shipped bundle.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as realCoreErrors from "@elizaos/core/errors";
+import * as workerCoreStub from "../src/stubs/elizaos-core";
+
+describe("worker core stub / real core error identity", () => {
+  const boundedBodyFailure = () =>
+    new realCoreErrors.ElizaError(
+      "REST response exceeds its bounded-body contract",
+      {
+        code: "CLOUD_REST_RESPONSE_TOO_LARGE",
+        context: { maxResponseBytes: 4 * 1024 * 1024 },
+        severity: "ephemeral",
+      },
+    );
+
+  test("the two classes really are distinct", () => {
+    expect(workerCoreStub.ElizaError).not.toBe(realCoreErrors.ElizaError);
+    expect(boundedBodyFailure() instanceof workerCoreStub.ElizaError).toBe(
+      false,
+    );
+  });
+
+  test("the stub narrows an error thrown by the real module", () => {
+    // twilio-api.ts's `if (isElizaError(cause)) throw cause;` pass-through.
+    expect(workerCoreStub.isElizaError(boundedBodyFailure())).toBe(true);
+  });
+
+  test("the real module narrows an error thrown by the stub", () => {
+    const fromStub = new workerCoreStub.ElizaError("stub failure", {
+      code: "STUB",
+    });
+    expect(realCoreErrors.isElizaError(fromStub)).toBe(true);
+  });
+
+  test("the stub does not relabel a real-module error as UNCLASSIFIED", () => {
+    const failure = boundedBodyFailure();
+    const normalized = workerCoreStub.toElizaError(failure);
+    expect(normalized).toBe(failure);
+    expect(normalized.code).toBe("CLOUD_REST_RESPONSE_TOO_LARGE");
+    expect(normalized.severity).toBe("ephemeral");
+  });
+
+  test("neither side brands unrelated values", () => {
+    expect(workerCoreStub.isElizaError(new Error("plain"))).toBe(false);
+    expect(realCoreErrors.isElizaError({ code: "X" })).toBe(false);
+  });
+});

--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -280,14 +280,32 @@ export class ElizaError extends Error {
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
+// Registry symbol shared with packages/core/src/errors.ts. `@elizaos/core` is
+// aliased to this file inside the Worker bundle (wrangler.toml) while
+// `@elizaos/core/errors` still resolves to the real module, so both classes
+// ship in one bundle and `instanceof` alone is false across them.
+const ELIZA_ERROR_BRAND = Symbol.for("@elizaos/core:ElizaError");
+
+Object.defineProperty(ElizaError.prototype, ELIZA_ERROR_BRAND, {
+  value: true,
+  enumerable: false,
+  writable: false,
+  configurable: false,
+});
+
 export function isElizaError(value: unknown): value is ElizaError {
-  return value instanceof ElizaError;
+  if (value instanceof ElizaError) return true;
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[ELIZA_ERROR_BRAND] === true
+  );
 }
 export function toElizaError(
   value: unknown,
   fallbackCode = "UNCLASSIFIED",
 ): ElizaError {
-  if (value instanceof ElizaError) return value;
+  if (isElizaError(value)) return value;
   if (value instanceof Error) {
     return new ElizaError(value.message, { code: fallbackCode, cause: value });
   }

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -4,7 +4,7 @@
  * helper.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ElizaError, isElizaError, toElizaError } from "./errors";
 
 describe("ElizaError", () => {
@@ -63,6 +63,69 @@ describe("ElizaError", () => {
 			expect(wrapped.code).toBe("UNCLASSIFIED");
 			expect(wrapped.message).toBe("string failure");
 			expect(wrapped.cause).toBe("string failure");
+		});
+	});
+
+	// `@elizaos/core` and `@elizaos/core/errors` are separate build entrypoints
+	// that each inline this module, and the Cloud Worker bundle additionally
+	// aliases `@elizaos/core` to a hand-written mirror. So a second, unrelated
+	// `ElizaError` constructor is a shipped configuration, not a hypothetical.
+	// `vi.resetModules()` reproduces exactly that: a fresh module instance with
+	// its own class object.
+	describe("across a second copy of this module", () => {
+		const loadFreshCopy = async () => {
+			vi.resetModules();
+			return (await import("./errors")) as typeof import("./errors");
+		};
+
+		it("still narrows an ElizaError built by the other copy", async () => {
+			const other = await loadFreshCopy();
+			const foreign = new other.ElizaError("bounded body exceeded", {
+				code: "CLOUD_REST_RESPONSE_TOO_LARGE",
+				severity: "ephemeral",
+			});
+
+			// The premise: this really is a different class object.
+			expect(other.ElizaError).not.toBe(ElizaError);
+			expect(foreign instanceof ElizaError).toBe(false);
+
+			expect(isElizaError(foreign)).toBe(true);
+			expect(other.isElizaError(new ElizaError("local", { code: "X" }))).toBe(
+				true,
+			);
+		});
+
+		it("passes a foreign ElizaError through toElizaError unchanged", async () => {
+			const other = await loadFreshCopy();
+			const foreign = new other.ElizaError("bounded body exceeded", {
+				code: "CLOUD_REST_RESPONSE_TOO_LARGE",
+				severity: "ephemeral",
+			});
+
+			// Re-wrapping would replace a precise code with UNCLASSIFIED and
+			// bury the real one on `.cause`.
+			expect(toElizaError(foreign)).toBe(foreign);
+			expect(toElizaError(foreign).code).toBe("CLOUD_REST_RESPONSE_TOO_LARGE");
+		});
+
+		it("does not brand unrelated errors or plain objects", async () => {
+			expect(isElizaError(new Error("plain"))).toBe(false);
+			expect(isElizaError({ code: "X", severity: "fatal" })).toBe(false);
+			expect(isElizaError(null)).toBe(false);
+			expect(isElizaError(undefined)).toBe(false);
+		});
+
+		it("keeps the brand off enumerable and serialized output", () => {
+			const err = new ElizaError("db query failed", { code: "DB" });
+			expect(Object.keys(err)).not.toContain(
+				"Symbol(@elizaos/core:ElizaError)",
+			);
+			expect(Object.getOwnPropertyNames(err)).toEqual(
+				expect.not.arrayContaining(["@elizaos/core:ElizaError"]),
+			);
+			expect(JSON.stringify({ ...err })).not.toContain(
+				"elizaos/core:ElizaError",
+			);
 		});
 	});
 });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -75,9 +75,48 @@ export interface ReportedError {
 	at: number;
 }
 
-/** Narrowing helper: true when `value` is an {@link ElizaError}. */
+/**
+ * Cross-copy brand for {@link isElizaError}.
+ *
+ * `instanceof` alone is not sufficient here: the class reaches a running
+ * process through more than one module instance, so two `ElizaError`
+ * constructors can coexist and `instanceof` is false across them. Two of those
+ * splits ship today:
+ *
+ * - `@elizaos/core` and `@elizaos/core/errors` are separate build entrypoints,
+ *   and each inlines its own copy of this module — so a value thrown by a
+ *   subpath importer fails `instanceof` in a barrel importer, in plain Node.
+ * - the Cloud Worker bundle aliases `@elizaos/core` to a hand-written
+ *   worker-safe mirror (`packages/cloud/api/src/stubs/elizaos-core.ts`) while
+ *   `@elizaos/core/errors` still resolves here, putting both classes in one
+ *   bundle.
+ *
+ * A registry symbol is shared by identity across every copy that uses the same
+ * key, so branding the prototype makes the narrowing hold across all of them.
+ * It is defined on the prototype (not as a field) so it is non-enumerable and
+ * inherited by subclasses: `JSON.stringify`, `Object.keys` and structural
+ * equality are unaffected.
+ */
+const ELIZA_ERROR_BRAND = Symbol.for("@elizaos/core:ElizaError");
+
+Object.defineProperty(ElizaError.prototype, ELIZA_ERROR_BRAND, {
+	value: true,
+	enumerable: false,
+	writable: false,
+	configurable: false,
+});
+
+/**
+ * Narrowing helper: true when `value` is an {@link ElizaError}, including one
+ * built by a different copy of this module (see {@link ELIZA_ERROR_BRAND}).
+ */
 export function isElizaError(value: unknown): value is ElizaError {
-	return value instanceof ElizaError;
+	if (value instanceof ElizaError) return true;
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		(value as Record<symbol, unknown>)[ELIZA_ERROR_BRAND] === true
+	);
 }
 
 /**
@@ -90,7 +129,7 @@ export function toElizaError(
 	value: unknown,
 	fallbackCode = "UNCLASSIFIED",
 ): ElizaError {
-	if (value instanceof ElizaError) return value;
+	if (isElizaError(value)) return value;
 	if (value instanceof Error) {
 		return new ElizaError(value.message, { code: fallbackCode, cause: value });
 	}


### PR DESCRIPTION
# The bug

`isElizaError` is `value instanceof ElizaError`. That is only sound while exactly one `ElizaError` constructor exists in the process. Two splits ship today, so it isn't.

**1. `@elizaos/core` and `@elizaos/core/errors` are different classes, in plain Node.** `build.ts` lists `src/errors.ts` as its own entrypoint alongside `src/index.node.ts`, and the barrel re-exports `./errors`, so each emitted bundle inlines its own copy. Against the built `dist`:

```
node barrel   -> same class as ./errors subpath = false
browser barrel-> same class as ./errors subpath = false
edge barrel   -> same class as ./errors subpath = false
```

**2. The Cloud Worker bundle carries two of them.** `packages/cloud/api/wrangler.toml:34` aliases `"@elizaos/core"` to the hand-written worker-safe mirror `src/stubs/elizaos-core.ts`. That alias is exact, so `@elizaos/core/errors` escapes it and keeps resolving to the real module. The shipped bundle's sourcemap (`.wrangler-dry-run/index.js.map`, worker `eliza-cloud-api-prod`) lists both:

```
../src/stubs/elizaos-core.ts
../../../core/src/errors.ts
```

# Why it matters: a paid Twilio call is misclassified

`packages/cloud/shared/src/lib/utils/owned-bounded-fetch.ts:9` imports `ElizaError` from **`@elizaos/core/errors`** and throws `INVALID_CLOUD_REST_BOUNDS` and `CLOUD_REST_RESPONSE_TOO_LARGE` (`severity: "ephemeral"`).

`packages/cloud/shared/src/lib/utils/twilio-api.ts:7` imports `isElizaError` from **`@elizaos/core`**, and awaits `twilioFetch` → `ownedBoundedFetch` inside the `try` at line 119:

```ts
} catch (cause) {
  if (isElizaError(cause)) throw cause;
  // error-policy:J2 transport failure after dispatch cannot prove whether
  // Twilio accepted the paid operation.
  throw new ElizaError("Twilio request acceptance is uncertain", {
    code: "TWILIO_SUBMISSION_UNCERTAIN", ..., severity: "fatal",
  });
}
```

The pass-through misses. Reproduced end to end against `dist`:

```
isElizaError(cause) = false            <-- twilio-api.ts:121 pass-through
toElizaError keeps code?  UNCLASSIFIED   (expected CLOUD_REST_RESPONSE_TOO_LARGE)
double-wrapped: true
```

So a deterministic, client-side bounds failure — where we know exactly what happened — is relabeled *"Twilio request acceptance is uncertain"*, `fatal`. That is the one classification that means "we may have been charged and cannot tell." Both `owned-bounded-fetch.ts` and `twilio-api.ts` are in the shipped worker bundle; I checked.

`toElizaError` has the same shape and loses the precise `code` to `UNCLASSIFIED`, burying the real one on `.cause`.

# Why no test catches it

`vitest.config.ts` aliases `@elizaos/core` and its subpaths to source, so every suite resolves a single module instance. The split is structurally unobservable from the existing harness — which is why the new tests construct a second copy explicitly.

# The fix

Brand the prototype with a **registry** symbol, which is shared by identity across every copy that uses the same key:

```ts
const ELIZA_ERROR_BRAND = Symbol.for("@elizaos/core:ElizaError");

Object.defineProperty(ElizaError.prototype, ELIZA_ERROR_BRAND, {
  value: true, enumerable: false, writable: false, configurable: false,
});

export function isElizaError(value: unknown): value is ElizaError {
  if (value instanceof ElizaError) return true;
  return (
    typeof value === "object" && value !== null &&
    (value as Record<symbol, unknown>)[ELIZA_ERROR_BRAND] === true
  );
}
```

`instanceof` stays the fast path. `toElizaError` now calls `isElizaError` instead of a bare `instanceof`.

It is on the **prototype**, not a class field, so it is non-enumerable and inherited by subclasses: `JSON.stringify`, `Object.keys`, `{...err}` and structural equality are all unaffected (asserted). The same change is mirrored into `src/stubs/elizaos-core.ts`, which already documents itself as mirroring `packages/core/src/errors.ts`.

This also covers the general duplicate-copy case (two `@elizaos/core` versions in one dependency tree), not just the two splits above.

# Evidence

New tests, **with the control run both ways** — reverting only the two production files and keeping the tests:

| suite | on `develop` | with the fix |
|---|---|---|
| `packages/core/src/errors.test.ts` | **2 failed** / 9 passed | 11 passed |
| `packages/cloud/api/__tests__/worker-core-stub-error-identity.test.ts` | **3 failed** / 2 passed | 5 passed |

The premise assertions (`other.ElizaError !== ElizaError`, `foreign instanceof ElizaError === false`) and the negative cases (plain `Error`, plain object, `null`) stay green in *both* directions, so the probes are not vacuous. The core test uses `vi.resetModules()` to get a genuinely separate module instance; the cloud test crosses the real stub against the real module — the exact production pairing.

Regression sweep:

- `bunx vitest run` over the core + agent `ElizaError` suites — **88 passed**. One unrelated suite fails to collect (`Failed to resolve entry for package "@elizaos/plugin-sql"`); it fails identically on `develop`, so it is pre-existing and not from this change.
- `bun test` cloud/shared `twilio-api`, `steward-sync-default-provisioning`, `owned-bounded-fetch`, `cloud-bound-helpers` — **35 tests, 0 fail**.
- `bun test` cloud/api stub consumers (`onboarding-coordinator-transport`, voice `revoke-and-metering`, `mint-consent-route`) — **34 tests, 0 fail**.
- `bun run --cwd packages/core typecheck` and `--cwd packages/cloud/api typecheck` — exit 0, 0 TS errors.
- `biome check` clean on all four files.

# Not in this PR

While confirming the above I noticed `dist/node/errors.js` carries a module-scope `createRequire(import.meta.url)` preamble even though `src/errors.ts` has no imports at all, and `__require` is declared but never used. Per the comments in `build.ts`, that preamble is exactly what workerd rejects at import time, and `./errors` has no `workerd` condition. It is not reachable today — the worker bundle resolves the subpath to source, not to `dist` — so I left it alone rather than widen this diff into build config. Happy to file it separately if you want it.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1N69F5Q6A8Y1P9TDVDM8FAW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T03:09:41.943Z","completed_at":"2026-09-04T03:11:07.752Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T03:09:42.558Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3e31f7049c2a9ae8fdee5e3895d3b678ce714501f6c396f665e561d7d8c97e30","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"bb052fde-b57f-4ebd-b331-5d491e645379","object_id":"sha256:3e31f7049c2a9ae8fdee5e3895d3b678ce714501f6c396f665e561d7d8c97e30","sha256":"3e31f7049c2a9ae8fdee5e3895d3b678ce714501f6c396f665e561d7d8c97e30"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"ctoor8HlShzN7YdWWctMg2BCwHDbeb417Ha7VUcmPSjZXFP_qkapKI5kJDBOeQjLzu4Lbd6xgjMZnxH5UBUTBQ"}} -->
