### PR TITLE
fix(core): use the shared SSRF denylist for MCP remote hosts

### DIFF
--- a/packages/core/src/security/mcp-server-config.test.ts
+++ b/packages/core/src/security/mcp-server-config.test.ts
@@ -430,4 +430,31 @@ describe("validateMcpServerConfig", () => {
 			).toBeNull();
 		});
 	});
+
+	// The remote-host denylist used to be a second, smaller copy of the shared
+	// SSRF one. It had drifted: `.internal` was missing, so cloud-internal names
+	// reached the resolver and were rejected only if DNS happened to fail or to
+	// answer with a private address. These now short-circuit on the denylist,
+	// before any lookup, like every other case in this suite.
+	describe.each(["http", "streamable-http", "sse"])(
+		"%s remote host denylist",
+		(type) => {
+			test.each([
+				["localhost"],
+				["metadata.google.internal"],
+				["app.localhost"],
+				["printer.local"],
+				["foo.internal"],
+				["bar.ec2.internal"],
+				["node-1.compute.internal"],
+			])("blocks %s", async (host) => {
+				expect(
+					await validateMcpServerConfig({
+						type,
+						url: `https://${host}/mcp`,
+					}),
+				).toBe(`URL host "${host}" is blocked for security reasons`);
+			});
+		},
+	);
 });

--- a/packages/core/src/security/mcp-server-config.ts
+++ b/packages/core/src/security/mcp-server-config.ts
@@ -5,7 +5,11 @@
 
 import { lookup as dnsLookup } from "node:dns/promises";
 import net from "node:net";
-import { isPrivateIpAddress, normalizeHostLike } from "../network/ssrf.ts";
+import {
+	isBlockedHostname,
+	isPrivateIpAddress,
+	normalizeHostLike,
+} from "../network/ssrf.ts";
 import {
 	BLOCKED_SPAWN_ENV_KEYS,
 	BLOCKED_SPAWN_ENV_PREFIXES,
@@ -137,10 +141,6 @@ const BLOCKED_DENO_FLAGS = new Set([
 	"--no-prompt",
 ]);
 const BLOCKED_DENO_FLAG_PREFIXES = ["--unstable"] as const;
-const BLOCKED_MCP_REMOTE_HOST_LITERALS = new Set([
-	"localhost",
-	"metadata.google.internal",
-]);
 
 function blockedMcpEnvPrefix(upperKey: string): string | null {
 	for (const prefix of BLOCKED_SPAWN_ENV_PREFIXES) {
@@ -255,11 +255,12 @@ async function resolveMcpRemoteUrlRejection(
 	const hostname = normalizeHostLike(parsed.hostname);
 	if (!hostname) return "URL hostname is required";
 
-	if (
-		BLOCKED_MCP_REMOTE_HOST_LITERALS.has(hostname) ||
-		hostname.endsWith(".localhost") ||
-		hostname.endsWith(".local")
-	) {
+	// Defer to the shared SSRF denylist rather than keeping a second copy here.
+	// The local copy had already drifted: it covered `localhost`,
+	// `metadata.google.internal`, `.localhost` and `.local`, but not `.internal`
+	// — so `*.ec2.internal` and `*.compute.internal` reached the resolver and
+	// were rejected only if DNS happened to fail or to return a private address.
+	if (isBlockedHostname(hostname)) {
 		return `URL host "${hostname}" is blocked for security reasons`;
 	}
 


### PR DESCRIPTION
# What

`resolveMcpRemoteUrlRejection` keeps its own copy of the blocked-host policy:

```ts
const BLOCKED_MCP_REMOTE_HOST_LITERALS = new Set(["localhost", "metadata.google.internal"]);
...
if (
  BLOCKED_MCP_REMOTE_HOST_LITERALS.has(hostname) ||
  hostname.endsWith(".localhost") ||
  hostname.endsWith(".local")
) { ... }
```

`isBlockedHostname` in `network/ssrf.ts` holds the same policy **plus `.internal`**. Two copies of one rule, and they have already drifted.

# Severity: drift and depth, not a bypass

I want to be precise about this, because "SSRF denylist" invites over-reading.

`*.ec2.internal` and `*.compute.internal` were **still rejected** — either the lookup fails, or it answers with a private address and `isPrivateIpAddress` catches it. I could not construct a case that got through. So this is defense-in-depth plus duplicate removal, which is why it's a normal PR rather than a private report.

What *is* observable is that those hosts reached the resolver, where every other blocked host short-circuits on the denylist. The control run shows it directly — the `.internal` cases take **7–10ms** against **~1ms** for the denylist cases. That's the DNS attempt.

# Evidence

A differential harness over the two functions, before the change:

| host | `isBlockedHostname` | MCP guard |
|---|---|---|
| `localhost` | blocked | blocked |
| `metadata.google.internal` | blocked | blocked |
| `app.localhost` | blocked | blocked |
| `printer.local` | blocked | blocked |
| **`foo.internal`** | **blocked** | **fell through to DNS** |
| **`bar.ec2.internal`** | **blocked** | **fell through to DNS** |
| **`node-1.compute.internal`** | **blocked** | **fell through to DNS** |
| `example.com` | allowed | accepted |

# The change

Delete the duplicate set and the inline suffix checks; call `isBlockedHostname`. The comment records which entry had drifted, so the next reader knows why the local copy is gone rather than re-adding one.

# Tests

A `describe.each` over `http`, `streamable-http` and `sse` asserting the denylist message for `localhost`, `metadata.google.internal`, `app.localhost`, `printer.local`, `foo.internal`, `bar.ec2.internal`, `node-1.compute.internal` — 21 cases, all short-circuiting before DNS as this suite's header promises.

**Control, both ways.** Reverting only the production file and keeping the tests: **exactly the 9 `.internal` cases fail**, and the other 12 stay green — so the probes aren't vacuous.

| | on `develop` | with the fix |
|---|---|---|
| `mcp-server-config.test.ts` | **9 failed** / 73 passed | 82 passed |
| `packages/core/src/security/` | — | **700 passed** |

`biome check` clean. `bun run --cwd packages/core typecheck` exit 0, 0 errors.

# Note

While reading this file I also looked hard at `network/ssrf.ts` itself and found nothing to report: `isPrivateIpAddress` already normalizes IPv4-mapped IPv6, strips scope ids, and explicitly classifies the `inet_aton` encodings (`0177.0.0.1`, `0x7f.0.0.1`, `2130706433`, `127.1`) with a comment naming that bypass class. That part is in good shape.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1N9E5VX0A1BPBPR6A7R5QWE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T04:04:41.982Z","completed_at":"2026-09-04T04:05:45.835Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T04:04:42.543Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a607b963b7cc566bece0e19145ee44be3aea1b7e6ef8f5cc98e72eb97c2b3920","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"308365e0-03d5-4746-a330-39346577356a","object_id":"sha256:a607b963b7cc566bece0e19145ee44be3aea1b7e6ef8f5cc98e72eb97c2b3920","sha256":"a607b963b7cc566bece0e19145ee44be3aea1b7e6ef8f5cc98e72eb97c2b3920"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"OMS1ScIMtPDPmNnHGAmoK1bm9vNiCFfPdtX2Xx2pf6rcuuiMmK2RTugaq6U3UF8yxmOmtuCf1Eh4kj3K0WYdAA"}} -->
