### PR TITLE
fix(i18n): keep keyword word boundaries when text has non-ASCII characters

### DIFF
--- a/packages/core/src/i18n/validation-keywords.test.ts
+++ b/packages/core/src/i18n/validation-keywords.test.ts
@@ -45,3 +45,35 @@ describe("collectKeywordTermMatches / findKeywordTermMatch", () => {
 		expect(findKeywordTermMatch("nope", ["a", "b"])).toBeUndefined();
 	});
 });
+
+// This module is a byte-for-byte sibling of
+// packages/shared/src/i18n/keyword-matching.ts; the same cases are pinned there.
+// Word boundaries used to hold only for pure-ASCII text: the pattern was tested
+// against the RAW input, so an NFKC-only spelling could not match it, and the
+// substring fallback that compensated dropped boundaries for any text carrying
+// a non-ASCII character — one emoji was enough.
+describe("textIncludesKeywordTerm word boundaries with non-ASCII text", () => {
+	it.each([
+		["restart the server \u{1F642}", "art"],
+		["please reschedule \u{1F642}", "schedule"],
+		["I am scanning caf\u00e9", "scan"],
+		["classified \u2705", "class"],
+	])("does not match %s against %s", (text, term) => {
+		expect(textIncludesKeywordTerm(text, term)).toBe(false);
+	});
+
+	it.each([
+		["run a scan now \u{1F642}", "scan"],
+		["\u5f00\u59cbscan\u4efb\u52a1", "scan"],
+		["\uff53\uff43\uff41\uff4e now", "scan"],
+	])("still matches %s against %s", (text, term) => {
+		expect(textIncludesKeywordTerm(text, term)).toBe(true);
+	});
+
+	it.each([
+		["scan  the   disk", "scan the disk"],
+		["scan\nthe disk", "scan the disk"],
+	])("matches a multi-word term across %j", (text, term) => {
+		expect(textIncludesKeywordTerm(text, term)).toBe(true);
+	});
+});

--- a/packages/core/src/i18n/validation-keywords.ts
+++ b/packages/core/src/i18n/validation-keywords.ts
@@ -96,19 +96,18 @@ export function textIncludesKeywordTerm(text: string, term: string): boolean {
 	}
 
 	if (usesAsciiWordBoundaries(normalizedTerm)) {
-		const pattern = new RegExp(
-			`\\b${escapePattern(normalizedTerm).replace(/\\ /g, "\\s+")}\\b`,
+		// Test the NORMALIZED text, not the raw input. Matching the raw text meant
+		// NFKC-only spellings (full-width `ｓｃａｎ`) could never satisfy the
+		// boundary pattern, and the substring fallback that compensated dropped
+		// word boundaries for ANY text containing a non-ASCII character — a single
+		// emoji was enough, so `art` matched `restart the server \u{1F642}`.
+		// Normalizing first also makes the `\s+` relaxation real: `escapePattern`
+		// never escapes a space, so the old `/\\ /` replace matched nothing and a
+		// multi-word term could not span a line break or a double space.
+		return new RegExp(
+			`\\b${escapePattern(normalizedTerm).replace(/ /g, "\\s+")}\\b`,
 			"i",
-		);
-		if (pattern.test(text)) {
-			return true;
-		}
-
-		const hasNonAsciiText = [...text].some((char) => char.charCodeAt(0) > 0x7f);
-		if (hasNonAsciiText) {
-			return normalizedText.includes(normalizedTerm);
-		}
-		return false;
+		).test(normalizedText);
 	}
 
 	return normalizedText.includes(normalizedTerm);

--- a/packages/shared/src/i18n/keyword-matching.test.ts
+++ b/packages/shared/src/i18n/keyword-matching.test.ts
@@ -57,4 +57,47 @@ describe("collectKeywordTermMatches / findKeywordTermMatch", () => {
       findKeywordTermMatch("nothing matches", ["foo", "bar"]),
     ).toBeUndefined();
   });
+  // The header invariant above ("cat" must not match "category") held only
+  // while the text was pure ASCII. The boundary pattern was tested against the
+  // RAW text, so an NFKC-only spelling could not match it, and the substring
+  // fallback that compensated abandoned word boundaries for any text
+  // containing a non-ASCII character — one emoji was enough.
+  it.each([
+    ["restart the server \u{1F642}", "art"],
+    ["please reschedule \u{1F642}", "schedule"],
+    ["I am scanning caf\u00e9", "scan"],
+    ["classified \u2705", "class"],
+  ])("keeps word boundaries in %s", (text, term) => {
+    expect(textIncludesKeywordTerm(text, term)).toBe(false);
+  });
+
+  // The same words without the trailing non-ASCII character already behaved,
+  // which is what made the regression invisible.
+  it.each([
+    ["restart the server", "art"],
+    ["please reschedule", "schedule"],
+    ["I am scanning", "scan"],
+    ["classified", "class"],
+  ])("kept word boundaries in pure-ASCII %s all along", (text, term) => {
+    expect(textIncludesKeywordTerm(text, term)).toBe(false);
+  });
+
+  it.each([
+    ["run a scan now", "scan"],
+    ["run a scan now \u{1F642}", "scan"],
+    ["\u5f00\u59cbscan\u4efb\u52a1", "scan"],
+    ["\uff53\uff43\uff41\uff4e now", "scan"],
+    ["SCAN THIS", "scan"],
+  ])("still matches %s", (text, term) => {
+    expect(textIncludesKeywordTerm(text, term)).toBe(true);
+  });
+
+  // `escapePattern` never escapes a space, so the old `/\\ /` replace was
+  // inert and a multi-word term could not span a double space or a newline.
+  it.each([
+    ["scan  the   disk", "scan the disk"],
+    ["scan\nthe disk", "scan the disk"],
+  ])("matches a multi-word term across %j", (text, term) => {
+    expect(textIncludesKeywordTerm(text, term)).toBe(true);
+  });
 });

--- a/packages/shared/src/i18n/keyword-matching.ts
+++ b/packages/shared/src/i18n/keyword-matching.ts
@@ -91,19 +91,18 @@ export function textIncludesKeywordTerm(text: string, term: string): boolean {
   }
 
   if (usesAsciiWordBoundaries(normalizedTerm)) {
-    const pattern = new RegExp(
-      `\\b${escapePattern(normalizedTerm).replace(/\\ /g, "\\s+")}\\b`,
+    // Test the NORMALIZED text, not the raw input. Matching the raw text meant
+    // NFKC-only spellings (full-width `ｓｃａｎ`) could never satisfy the
+    // boundary pattern, and the substring fallback that compensated dropped
+    // word boundaries for ANY text containing a non-ASCII character — a single
+    // emoji was enough, so `art` matched `restart the server \u{1F642}`.
+    // Normalizing first also makes the `\s+` relaxation real: `escapePattern`
+    // never escapes a space, so the old `/\\ /` replace matched nothing and a
+    // multi-word term could not span a line break or a double space.
+    return new RegExp(
+      `\\b${escapePattern(normalizedTerm).replace(/ /g, "\\s+")}\\b`,
       "i",
-    );
-    if (pattern.test(text)) {
-      return true;
-    }
-
-    const hasNonAsciiText = [...text].some((char) => char.charCodeAt(0) > 0x7f);
-    if (hasNonAsciiText) {
-      return normalizedText.includes(normalizedTerm);
-    }
-    return false;
+    ).test(normalizedText);
   }
 
   return normalizedText.includes(normalizedTerm);


### PR DESCRIPTION
# One emoji turns every ASCII keyword into a substring match

```js
textIncludesKeywordTerm("restart the server",    "art")  // false
textIncludesKeywordTerm("restart the server 🙂", "art")  // true   ← same words
textIncludesKeywordTerm("please reschedule 🙂",  "schedule")  // true
textIncludesKeywordTerm("I am scanning café",    "scan")      // true
textIncludesKeywordTerm("classified ✅",          "class")     // true
```

`keyword-matching.test.ts`'s own header states the invariant this breaks:

> ASCII word-boundary matching (so "cat" doesn't match "category") ... a loose match here fires the wrong action.

And it does fire actions: `findKeywordTermMatch` routes **mute / unmute / follow** in `advanced-capabilities/actions/room.ts:225-227` and role-intent detection in `role.ts:212`; `collectKeywordTermMatches` scores action-search relevance. In chat text an emoji or an accented name is ordinary, not exotic.

# Root cause

The boundary pattern is built from the **normalized** term but tested against the **raw** text:

```ts
const pattern = new RegExp(`\\b${escapePattern(normalizedTerm)…}\\b`, "i");
if (pattern.test(text)) return true;                    // ← raw text

const hasNonAsciiText = [...text].some((c) => c.charCodeAt(0) > 0x7f);
if (hasNonAsciiText) return normalizedText.includes(normalizedTerm);  // ← boundaries gone
```

Because the pattern never sees normalized text, an NFKC-only spelling (full-width `ｓｃａｎ`) can't satisfy it — which is exactly what the substring fallback was compensating for. The compensation is far broader than the problem.

# Fix

Test the **normalized** text. That keeps the NFKC and CJK-embedded matches the fallback existed for, so the fallback is deleted rather than patched.

I checked that with a differential harness over 12 cases before writing it:

| text | term | before | after | wanted |
|---|---|---|---|---|
| `restart the server 🙂` | `art` | ✅ match | ❌ | must not |
| `please reschedule 🙂` | `schedule` | ✅ match | ❌ | must not |
| `I am scanning café` | `scan` | ✅ match | ❌ | must not |
| `classified ✅` | `class` | ✅ match | ❌ | must not |
| `run a scan now 🙂` | `scan` | ✅ | ✅ | must match |
| `开始scan任务` | `scan` | ✅ | ✅ | must match |
| `ｓｃａｎ now` | `scan` | ✅ | ✅ | must match (NFKC) |
| `SCAN THIS` | `scan` | ✅ | ✅ | must match |
| `scan  the   disk` | `scan the disk` | ❌ | ✅ | must match |

# A second bug the harness exposed

That last row: `escapePattern` escapes `[.*+?^${}()|[\]\\]`, which **does not include a space**, so the old `.replace(/\ /g, "\s+")` was looking for a backslash-space that never exists. The relaxation was inert, and a multi-word term could not span a double space or a line break. Normalizing the text fixes it; I also corrected the replace to `/ /g` so the author's intent survives if normalization ever changes.

# Both copies

This module is duplicated byte-for-byte at `packages/core/src/i18n/validation-keywords.ts`. Fixed identically in both, with cases pinned in both suites and a comment in the core copy pointing at its sibling. (Deduplicating them is a bigger change than this fix warrants.)

# Evidence

**Control:** reverting only the two production files and keeping the tests fails **exactly 12 cases** (6 per copy); the other 20 — including every "still matches" positive — stay green, so the probes are neither vacuous nor over-tightened.

| | on `develop` | with the fix |
|---|---|---|
| the two keyword suites | **12 failed** / 20 passed | 32 passed |
| `shared/i18n` + `core/i18n` + `advanced-capabilities` | — | **819 passed** (55 files) |

`biome check` clean. `packages/core` and `packages/shared` typecheck both exit 0, 0 errors.

Two of my own slips were caught by those checks rather than shipped: a duplicate import (TS2300 — and the `develop` control confirmed `shared` typechecks clean, so it was mine), and a `/[^\x00-\x7f]/` in a test that biome rejected under `noControlCharactersInRegex`, replaced with explicit literal cases.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NB90RFVHD0FA18RG1BX1CF","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T04:36:50.063Z","completed_at":"2026-09-04T04:37:59.211Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T04:36:50.731Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"203c3a302e8d64ab777722a4d3e1792b73086ae18e5c57e38aa46af69502a77f","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2fb0f025-cfaf-4c64-bf15-761902c9b4b2","object_id":"sha256:203c3a302e8d64ab777722a4d3e1792b73086ae18e5c57e38aa46af69502a77f","sha256":"203c3a302e8d64ab777722a4d3e1792b73086ae18e5c57e38aa46af69502a77f"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"XATf7dcxZnlq2ZtT0Xtg9Hfl4IKcTuXxvZneTx1rtAWuyjfhlWr-Urd1cNRElmiBkghqF5fj18AhI-TMNe0yDg"}} -->
