### PR TITLE
fix(i18n): back the messaging context signal with keyword data

### DIFF
--- a/packages/core/src/i18n/action-search-keywords.test.ts
+++ b/packages/core/src/i18n/action-search-keywords.test.ts
@@ -5,10 +5,12 @@
 import { describe, expect, it } from "vitest";
 import {
 	actionNameToKeywordStem,
+	CONTEXT_KEYWORD_STEMS,
 	countActionSearchKeywordMatches,
 	getActionSearchKeywordSources,
 	getActionSearchKeywordTerms,
 } from "./action-search-keywords.js";
+import { VALIDATION_KEYWORD_DOCS } from "./generated/validation-keyword-data.ts";
 
 describe("action-search-keywords", () => {
 	it("converts action names to camelCase keyword stems", () => {
@@ -177,5 +179,29 @@ describe("action-search-keywords resolution edge cases", () => {
 		expect(
 			countActionSearchKeywordMatches(["forwarding this along"], ["forward"]),
 		).toBe(0);
+	});
+
+	it("resolves every context keyword stem to backing keyword data", () => {
+		const resolveStem = (stem: string): unknown => {
+			let node: unknown = VALIDATION_KEYWORD_DOCS;
+			for (const segment of stem.split(".")) {
+				if (typeof node !== "object" || node === null) {
+					return undefined;
+				}
+				node = (node as Record<string, unknown>)[segment];
+			}
+			return node;
+		};
+
+		const unresolved: string[] = [];
+		for (const [context, stems] of Object.entries(CONTEXT_KEYWORD_STEMS)) {
+			for (const stem of stems) {
+				if (resolveStem(stem) === undefined) {
+					unresolved.push(`${context} -> ${stem}`);
+				}
+			}
+		}
+
+		expect(unresolved).toEqual([]);
 	});
 });

--- a/packages/core/src/i18n/action-search-keywords.ts
+++ b/packages/core/src/i18n/action-search-keywords.ts
@@ -26,7 +26,13 @@ export type ActionSearchKeywordSource = {
 	terms: string[];
 };
 
-const CONTEXT_KEYWORD_STEMS: Record<string, readonly string[]> = {
+/**
+ * Keyword stems consulted for each declared agent context.
+ *
+ * Exported so tests can assert every stem still resolves to keyword data;
+ * a stem with no backing entry silently contributes nothing at runtime.
+ */
+export const CONTEXT_KEYWORD_STEMS: Record<string, readonly string[]> = {
 	admin: ["contextSignal.admin"],
 	agent_internal: ["contextSignal.agent_internal"],
 	automation: [

--- a/packages/shared/src/i18n/keywords/context-search.keywords.json
+++ b/packages/shared/src/i18n/keywords/context-search.keywords.json
@@ -364,6 +364,29 @@
       "vi": ["ký ức", "ky uc", "nhớ", "nho", "ghi nhớ", "ghi nho"],
       "zh-CN": ["记忆", "记住", "回忆", "长期记忆"]
     },
+    "contextSignal.messaging.strong": {
+      "base": [
+        "message",
+        "messages",
+        "chat",
+        "conversation",
+        "dm",
+        "direct message"
+      ],
+      "es": [
+        "mensaje",
+        "mensajes",
+        "chat",
+        "conversación",
+        "conversacion",
+        "dm"
+      ],
+      "ko": ["메시지", "메세지", "대화", "쪽지", "디엠", "dm"],
+      "pt": ["mensagem", "mensagens", "chat", "conversa", "dm"],
+      "tl": ["mensahe", "mga mensahe", "usapan", "dm"],
+      "vi": ["tin nhắn", "tin nhan", "nhắn tin", "cuộc trò chuyện", "dm"],
+      "zh-CN": ["消息", "私信", "对话"]
+    },
     "contextSignal.payments.strong": {
       "base": [
         "payment",


### PR DESCRIPTION
# What

`CONTEXT_KEYWORD_STEMS.messaging` in `packages/core/src/i18n/action-search-keywords.ts` lists five stems. One of them, `contextSignal.messaging`, has no keyword entry anywhere in `packages/shared/src/i18n/keywords/*.keywords.json`, so it resolves to nothing and the `messaging` context quietly degrades to its four siblings.

I found this with a resolver over the merged data rather than by reading the file: extract every stem string in `CONTEXT_KEYWORD_STEMS` and look each one up in `VALIDATION_KEYWORD_DOCS`. **52 stems referenced, exactly one dead.**

`messaging` is not a vestigial name. It is declared in `packages/core/src/types/contexts.ts` and used by `features/autonomy/action.ts`, `features/advanced-capabilities/actions/room.ts` (`ROOM_CONTEXTS`), `features/basic-capabilities/providers/recentMessages.ts` and `providers/entities.ts`. And of the 38 `contextSignal.<name>.strong` entries in `context-search.keywords.json`, all 37 other contexts have one — `messaging` alone does not.

# Not a security issue

The module header is explicit that these helpers "deliberately support retrieval/ranking only. They must not be used as hard action availability checks." A missing signal degrades ranking; it cannot open a gate. That is why this is a public PR.

# The change

Two parts.

**1. Back the reference.** Added `contextSignal.messaging.strong` to `context-search.keywords.json`. I chose to add the data rather than delete the reference: dropping it would enshrine the gap in the one context whose name is the domain itself.

Every existing entry in that file carries all seven locales and none are base-only, so authoring one honestly means writing seven locales. Rather than invent translations, **every term is one already attested in a sibling entry** — `contextSignal.send_message.strong`, `contextSignal.read_messages.strong`, `contextSignal.social.strong` and `contextSignal.phone.strong`.

**2. A permanent guard.** A test that walks every stem in `CONTEXT_KEYWORD_STEMS`, resolves it against `VALIDATION_KEYWORD_DOCS`, and asserts the unresolved list is empty — reporting `context -> stem` pairs on failure, so the next dead reference names itself. This is the part I actually care about; the data fix alone would leave the same trap open for the next context added.

That guard needed `CONTEXT_KEYWORD_STEMS` exported. It is documented in place as exported for exactly that assertion.

# Control, both directions

With the data entry reverted and everything else in place:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+   "messaging -> contextSignal.messaging",
Tests  1 failed | 15 passed (16)
```

With the entry present, 16/16. One failure, exactly the stem claimed — that is the whole assertion, reproduced in both directions.

# What this does and does not change

Honest numbers, because they are small. For `contexts: ["messaging"]`, sources go **8 → 9** and the deduped term set **254 → 257**. Only three terms are genuinely new — `메세지`, `mga mensahe`, `tin nhan` — precisely *because* I restricted myself to attested vocabulary; the rest already arrived via the sibling stems.

So: this fixes the dangling reference and stops it recurring. It **does not** broaden messaging vocabulary — there is a good case for terms like "inbox", "thread" or "messaging" itself, and for locale forms not already in this file, but I am not the right author for translations I would have to invent. If you want that coverage, the entry is now there to extend.

# Verification

- `bunx vitest run packages/core/src/i18n packages/shared/src/i18n` → **39 passed / 0 failed** across 5 files (up from 38).
- `bun run --cwd packages/core typecheck` → exit 0, 0 TS errors. Same for `packages/shared`.
- `bunx @biomejs/biome check` → clean on all three changed files, no unrelated reformatting.
- Regenerated the gitignored keyword modules with `packages/shared/scripts/generate-keywords.mjs` so codegen output matches the JSON.

Diff is 3 files, +56/−1.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NDRCFR9MZ7WYERPTNSXKA4","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T05:20:10.744Z","completed_at":"2026-09-04T05:21:54.398Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T05:20:11.437Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"95781cb4a683bbc1572568c4267f4c209a2a19501d40722ca3e7c7158c898ef3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d13c7788-73a9-4d5f-aeb3-4e95910da042","object_id":"sha256:95781cb4a683bbc1572568c4267f4c209a2a19501d40722ca3e7c7158c898ef3","sha256":"95781cb4a683bbc1572568c4267f4c209a2a19501d40722ca3e7c7158c898ef3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"jTeqZWRuSQqI7LObX_pu9Gxcs9aeAKnM0Mdtz5kdc4-79SI65xDuDs_P0FEHU7ya2w4Ajq39YSF0hc6UJDRYAQ"}} -->
