### PR TITLE
fix(i18n): give the goals context keyword stems, and make the stem map total

### DIFF
--- a/packages/core/src/i18n/action-search-keywords.test.ts
+++ b/packages/core/src/i18n/action-search-keywords.test.ts
@@ -178,4 +178,24 @@ describe("action-search-keywords resolution edge cases", () => {
 			countActionSearchKeywordMatches(["forwarding this along"], ["forward"]),
 		).toBe(0);
 	});
+
+	it("supplies keyword terms for the goals context", () => {
+		const sources = getActionSearchKeywordSources({
+			name: "",
+			contexts: ["goals"],
+		});
+		expect(sources.map((source) => source.key)).toEqual([
+			"contextSignal.lifeops_goal.strong",
+			"action.ownerGoals.request",
+		]);
+		expect(
+			getActionSearchKeywordTerms({ name: "", contexts: ["goals"] }),
+		).toContain("goal");
+	});
+
+	it("returns no context terms for names outside the taxonomy", () => {
+		expect(
+			getActionSearchKeywordTerms({ name: "", contexts: ["not_a_context"] }),
+		).toEqual([]);
+	});
 });

--- a/packages/core/src/i18n/action-search-keywords.ts
+++ b/packages/core/src/i18n/action-search-keywords.ts
@@ -6,6 +6,7 @@
  * used as hard action availability checks.
  */
 
+import type { FirstPartyAgentContext } from "../types/contexts.ts";
 import { VALIDATION_KEYWORD_DOCS } from "./generated/validation-keyword-data.ts";
 import {
 	collectKeywordTermMatches,
@@ -26,7 +27,16 @@ export type ActionSearchKeywordSource = {
 	terms: string[];
 };
 
-const CONTEXT_KEYWORD_STEMS: Record<string, readonly string[]> = {
+/**
+ * Keyword stems consulted for each first-party agent context.
+ *
+ * Total over `FirstPartyAgentContext` on purpose: a context added to the
+ * taxonomy without stems here contributes no keywords at all, which is silent
+ * at runtime. Keeping the record total turns that into a build error.
+ */
+type ContextKeywordStems = Record<FirstPartyAgentContext, readonly string[]>;
+
+const CONTEXT_KEYWORD_STEMS: ContextKeywordStems = {
 	admin: ["contextSignal.admin"],
 	agent_internal: ["contextSignal.agent_internal"],
 	automation: [
@@ -51,6 +61,7 @@ const CONTEXT_KEYWORD_STEMS: Record<string, readonly string[]> = {
 	finance: ["contextSignal.finance"],
 	game: ["contextSignal.game"],
 	general: ["contextSignal.general"],
+	goals: ["contextSignal.lifeops_goal", "action.ownerGoals"],
 	health: ["contextSignal.health"],
 	knowledge: ["contextSignal.knowledge"],
 	messaging: [
@@ -107,6 +118,19 @@ export function actionNameToKeywordStem(actionName: string): string {
 	return [words[0], ...words.slice(1).map(capitalizeAscii)].join("");
 }
 
+/**
+ * Stems for a context name. Contexts are an open union (`AgentContext`), so a
+ * name outside the first-party taxonomy can reach this lookup even though the
+ * record above is total over the first-party ones.
+ */
+function stemsForContext(context: string): readonly string[] {
+	return (
+		(CONTEXT_KEYWORD_STEMS as Record<string, readonly string[] | undefined>)[
+			context
+		] ?? []
+	);
+}
+
 export function getActionSearchKeywordSources(input: {
 	name: string;
 	contexts?: unknown;
@@ -119,7 +143,7 @@ export function getActionSearchKeywordSources(input: {
 	}
 
 	for (const context of normalizeStringArray(input.contexts)) {
-		for (const stem of CONTEXT_KEYWORD_STEMS[context] ?? []) {
+		for (const stem of stemsForContext(context)) {
 			stems.add(stem);
 		}
 	}


### PR DESCRIPTION
# What

The `goals` context produces **zero** keyword terms.

`CONTEXT_KEYWORD_STEMS` in `packages/core/src/i18n/action-search-keywords.ts` is typed `Record<string, readonly string[]>`, so a first-party context simply missing from the map is invisible. Diffing the map's keys against the `FirstPartyAgentContext` union: **41 contexts, 40 map keys, one missing — `goals`.**

It is not a vestigial name. `goals` has a full `ContextDefinition` in `runtime/default-contexts.ts` (`parent: "tasks"`, label "Goals", ADMIN role gate, described as "Long-horizon owner outcomes and aspirations"), and appears in `context-normalization.ts`, `pluginManagerService.ts` and `direct-action-heuristics.ts`.

The consequence, measured:

| context | sources | terms |
|---|---|---|
| `todos` | 3 | 181 |
| `productivity` | 3 | 190 |
| **`goals`** | **0** | **0** |

`goals` and `todos` are declared side by side as subcontexts of `tasks`. One of them contributes nothing to retrieval.

# The change

**1. Map `goals` to goal vocabulary that already exists.** No new terms authored:

- `contextSignal.lifeops_goal.strong` — `goal, goals, aspiration, life goal, achieve, aim, target, ambition, milestone, objective, dream, bucket list, resolution, i want to, working toward, strive, vision, purpose, intention`
- `action.ownerGoals.request` — the goal-action vocabulary

Referencing a differently-named signal is the established pattern in this map: `browser` already pulls `contextSignal.web_search`, `email` pulls `contextSignal.gmail`.

Result: **0 → 260 terms.**

**2. Make the map total, so this cannot recur.** Typed over `FirstPartyAgentContext` through a `ContextKeywordStems` alias. A context added to the taxonomy without stems is now a build error rather than a silent zero.

`AgentContext` is an open union (`FirstPartyAgentContext | (string & {})`), so lookups go through a small `stemsForContext` accessor that casts to a partial record. Runtime behaviour for unknown names is unchanged, and there is a test pinning that an unknown context still returns no terms.

# Control

Removing only the `goals` line:

```
src/i18n/action-search-keywords.ts(39,7): error TS2741: Property 'goals' is missing
in type '{ admin: ...; ... 28 more ...; world: string[]; }'
but required in type 'ContextKeywordStems'.
```

The guard names the missing context directly. With the line present, `packages/core` typecheck exits 0.

For this class a compile-time guard is strictly stronger than a test, which is why I typed the record rather than asserting over it.

# A note on the diff

My first attempt annotated the const inline. That pushed the declaration past biome's line width, biome broke after the `=`, and all 40 map entries reindented — a 159-line diff for a one-line change. The type alias keeps the declaration short and the diff at **+46/−2**. (develop's copy of this file is biome-clean, so that churn was mine, not pre-existing.)

# Also found, deliberately not changed

`contextSignal.send_admin_message.strong` / `.weak` in `shared.keywords.json` are fully authored across all seven locales and read by **nothing** — not the lexicon, not this map. I looked for a consumer that should be using them; the nearest candidate, `providers/escalation-trigger.ts`, is condition-driven rather than keyword-driven. Deleting staged vocabulary or inventing a feature to consume it both seemed presumptuous, so I am flagging it rather than touching it. Happy to follow up either way if you say which.

# Verification

- `bunx vitest run packages/core/src/i18n packages/shared/src/i18n packages/agent/src/actions` → **581 passed / 0 failed** across 40 files.
- `bun run --cwd packages/core typecheck` → exit 0.
- `bunx @biomejs/biome check` → clean on both changed files, no reformatting.

# Relation to #30495

Same file, complementary halves of one failure mode. #30495 guards the **values** (every stem resolves to keyword data; it found `contextSignal.messaging` dangling); this guards the **keys** (every context has stems). They touch the `CONTEXT_KEYWORD_STEMS` declaration line, so whichever lands second needs a one-line rebase. Either order works — say the word and I will rebase this onto whichever you prefer.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NE7VWQ02MEDWH0MH0JS2YH","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T05:28:38.040Z","completed_at":"2026-09-04T05:30:01.074Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T05:28:38.802Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ffb8290124cc84ed2b47f1f0335cbe4a1ecead462ede7a3ed3fb971cb0367c5d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"70a47964-dd3e-482c-8a4a-73ca2357021d","object_id":"sha256:ffb8290124cc84ed2b47f1f0335cbe4a1ecead462ede7a3ed3fb971cb0367c5d","sha256":"ffb8290124cc84ed2b47f1f0335cbe4a1ecead462ede7a3ed3fb971cb0367c5d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"zp9PT7_JHGQqzEddlWcdLh9w1Z5PQXJibSYKMWQxjLzq8fhQun-9SMtM57D5-Zn1BeAGIJsbdmEd5Olb_hrnDw"}} -->
