### PR TITLE
fix(plugins): correct action contexts that no classifier can produce

### DIFF
--- a/plugins/plugin-anthropic-proxy/src/actions/proxy-status.action.ts
+++ b/plugins/plugin-anthropic-proxy/src/actions/proxy-status.action.ts
@@ -19,7 +19,7 @@ export const proxyStatusAction: Action = {
     "and (in shared mode) reachability of the upstream proxy.",
   descriptionCompressed:
     "anthropic-proxy-status: mode, url, listening, requests, token expiry, upstream check",
-  contexts: ["debug", "operations"],
+  contexts: ["system", "settings"],
   validate: async () => true,
   handler: async (runtime: IAgentRuntime): Promise<ActionResult> => {
     const service = runtime.getService<AnthropicProxyService>(ANTHROPIC_PROXY_SERVICE_NAME);

--- a/plugins/plugin-personal-assistant/src/actions/agreement-knowledge.ts
+++ b/plugins/plugin-personal-assistant/src/actions/agreement-knowledge.ts
@@ -71,7 +71,7 @@ export const ownerAgreementKnowledgeAction: Action = {
   routingHint:
     "parenting or coparenting agreement knowledge, reviewed obligations, pins, or guest access preview -> OWNER_AGREEMENT_KNOWLEDGE",
   tags: ["domain:family", "capability:read", "capability:write"],
-  contexts: ["family", "docs", "contacts"],
+  contexts: ["family", "documents", "contacts"],
   roleGate: { minRole: "OWNER" },
   validate: hasLifeOpsAccess,
   parameters: [

--- a/plugins/plugin-personal-assistant/src/actions/document.ts
+++ b/plugins/plugin-personal-assistant/src/actions/document.ts
@@ -854,7 +854,7 @@ export const ownerDocumentsAction: Action & {
     "OWNER_DOCUMENTS signature|approval|deadline|upload_asset|collect_id|close_request|guarantee_class",
   routingHint:
     'owner document signature/approval/upload/portal/ID-form ("get signed", "send approval", "upload deck", "track NDA deadline", "close doc") -> OWNER_DOCUMENTS; approval queue resolution -> RESOLVE_REQUEST',
-  contexts: ["docs", "tasks", "calendar", "contacts"],
+  contexts: ["documents", "tasks", "calendar", "contacts"],
   roleGate: { minRole: "OWNER" },
   suppressPostActionContinuation: true,
   validate: async (runtime, message) => hasLifeOpsAccess(runtime, message),

--- a/plugins/plugin-personal-assistant/src/lifeops/household-operations/action.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household-operations/action.ts
@@ -191,7 +191,7 @@ export function createHouseholdOperationsAction(
       "household vendors|maintenance|seasonal opportunities|child sizes|CPEM|weekly brief; drafts only",
     routingHint:
       "vendor/service history, due home work, seasonal registration, child clothing size, household responsibility non-use, or weekly family brief -> HOUSEHOLD_OPERATIONS",
-    contexts: ["general", "calendar", "tasks", "finances", "documents"],
+    contexts: ["general", "calendar", "tasks", "finance", "documents"],
     roleGate: { minRole: "OWNER" },
     suppressPostActionContinuation: true,
     toolSchemaStrict: false,


### PR DESCRIPTION
# What

Action eligibility is an exact-string overlap between an action's declared `contexts` and the routing contexts active for the turn (`hasActionContext` → `routingContextsOverlap`), and turns are classified only into **registered** context definitions. A declared name that nothing registers can never overlap.

`plugin-notes` already documents this failure mode from experience, in its own words:

> Stage 1 classifies a turn into registered CONTEXTS, not actions: a context the taxonomy lacks is a request Stage 1 cannot name, however well the action itself advertises. Without this entry, "what notes do i have?" classified [wrongly] … the read then honestly reported an absence from the wrong store.

Its fix was to register the context. This PR fixes four actions that hit the same trap without one.

# How I found it

Validated every `contexts: [...]` literal in the repo (12,839 source files) against `FirstPartyAgentContext`. 28 names are not first-party, across ~100 sites — which is a sweep result, not a bug report, so I triaged rather than filing it.

The discriminator: **exactly one plugin in the whole repo registers `ContextDefinition`s — `plugin-notes`.** So every other non-first-party name is registered nowhere. Narrowing to the class that is unconditionally wrong — actions where *every* declared context is unregistered, leaving no routable context at all — gives exactly two sites, one of which is a declared test fixture (`fixture-remote-plugin`) that I excluded.

# The changes

**1. `PROXY_STATUS` had no routable context at all** — `["debug", "operations"]`, neither registered.

Replacement chosen from precedent, not taste: core's own status actions use `["admin","settings"]`, `["secrets","settings"]`, `["automation","agent_internal"]`, and every sibling plugin status action pairs its custom tag with at least one first-party context. `PROXY_STATUS` reports mode, bound URL, listening state and token expiry → **`["system", "settings"]`**, which maps the author's "debug"/"operations" intent onto contexts that exist.

**2. Three near-miss names** where the intended registered context plainly exists, each sitting in an array whose every other member was already first-party:

| file | was | now |
|---|---|---|
| `lifeops/household-operations/action.ts` | `finances` | `finance` |
| `actions/agreement-knowledge.ts` | `docs` | `documents` |
| `actions/document.ts` | `docs` | `documents` |

I specifically checked the risk that a `@elizaos/plugin-finances` package might define `finances`: it registers no context, and its own scenario declares `contexts: ["finance"]` singular.

# What I deliberately did not change

The other 22 non-first-party names (`apps`, `cloud`, `inbox`, `briefing`, `family`, …). Those are plausibly deliberate domain tags, and renaming them would be guessing at intent rather than correcting a demonstrable error. `agreement-knowledge.ts` still carries `family` for that reason.

# Scope of the impact, stated honestly

`shouldIncludeByContext` returns `true` when the active context set is empty, so these actions are not invisible in *every* situation — only whenever routing contexts are actually active, which is the case routing exists to serve.

# The systemic gap

Nothing validates `action.contexts` against the registry, which is why these drifted silently. `ContextRegistry` already warns `Context ${id} references unknown context ${context}` for definitions, so the precedent exists — but the roster (`DEFAULT_CONTEXT_DEFINITIONS`) is not exported from the package index, so a plugin can't assert against it today either.

I did not add a guard here because both plausible options — exporting the roster, or warning at registration — expand core's public surface or risk noisy warnings around plugin load order. Happy to do either if you tell me which you'd prefer.

# Verification

- `biome check` → clean on all four changed files.
- `plugin-anthropic-proxy` typecheck → exit 0; `proxy-status.action.test.ts` → **4 pass / 0 fail**. Its wider suite has 2 failures that reproduce identically on `develop` (proxy config parsing, unrelated).
- `plugin-personal-assistant` typecheck reports 186 errors — **byte-identical to `develop`'s 186**; I diffed the sorted error lists. Its two touched-file tests also fail on `develop`, from a missing `@elizaos/plugin-finances` workspace module.

Diff is 4 files, **+4/−4**.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NEX19XQNSMGEXJTZ9JRZ55","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T05:40:11.709Z","completed_at":"2026-09-04T05:41:28.497Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T05:40:12.375Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b73a42f696f4cacd6e50f6642a83689eb5f2d27e0a2ff29756c976cb2d4678da","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"164f1c3a-405d-4351-a080-b58368356913","object_id":"sha256:b73a42f696f4cacd6e50f6642a83689eb5f2d27e0a2ff29756c976cb2d4678da","sha256":"b73a42f696f4cacd6e50f6642a83689eb5f2d27e0a2ff29756c976cb2d4678da"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"pTAOrdMP7Dh8QOwywOa5GfnI-QFpbJ3RdtKBtwQMimu_ucwvFHvsM5a6HoFLQXaKNIsWd_FHa-yILGp9EHixAA"}} -->
