### PR TITLE
docs(pricing): say cacheWrite is a full rate, and pin it with a test

### DIFF
--- a/packages/core/src/features/trajectories/pricing.test.ts
+++ b/packages/core/src/features/trajectories/pricing.test.ts
@@ -312,7 +312,7 @@ describe("computeCallCostUsd", () => {
 		expect(cost).toBeCloseTo(18.0, 6);
 	});
 
-	it("applies cache-read discount and cache-write surcharge for Anthropic", () => {
+	it("bills cache-read and cache-write portions at their own full rates", () => {
 		// claude-haiku-4-5: input $1.00, output $5.00, cacheRead $0.10,
 		//                   cacheWrite $1.25 (per 1M).
 		// 1000 prompt = 200 fresh + 700 cacheRead + 100 cacheWrite
@@ -329,6 +329,20 @@ describe("computeCallCostUsd", () => {
 			totalTokens: 1050,
 		});
 		expect(cost).toBeCloseTo(0.000645, 9);
+	});
+
+	it("bills a cache-creation token once, not at input plus cacheWrite", () => {
+		// cacheWrite is a full rate (1.25x input for Anthropic), not an extra
+		// charge added to the input rate. Isolate the cache-write term: all
+		// prompt tokens are cache-creation, so every other term is 0.
+		const cost = computeCallCostUsd("claude-haiku-4-5", {
+			promptTokens: 1_000_000,
+			completionTokens: 0,
+			cacheCreationInputTokens: 1_000_000,
+			totalTokens: 1_000_000,
+		});
+		// 1M * $1.25/M = $1.25. Billing input as well would give $2.25.
+		expect(cost).toBeCloseTo(1.25, 9);
 	});
 
 	it("falls back to the input rate when cacheRead is 0 (Cerebras gpt-oss)", () => {

--- a/packages/core/src/features/trajectories/pricing.ts
+++ b/packages/core/src/features/trajectories/pricing.ts
@@ -610,10 +610,18 @@ export function lookupModelPrice(
  * `logger.warn` is invoked once per call. Callers in hot paths can pass
  * `logger: undefined` to suppress noise.
  *
- * Cache-read tokens are billed at the cacheRead rate when set, otherwise
- * the regular input rate. Cache-creation tokens are billed at cacheWrite
- * (Anthropic's surcharge) on top of the regular input portion that paid
- * for them. Non-cached input is billed at the input rate.
+ * `promptTokens` is treated as INCLUSIVE of the cache counts: the non-cached
+ * portion is `promptTokens - cacheRead - cacheWrite`, clamped at 0.
+ *
+ * Each portion is then billed exactly once:
+ * - non-cached input at `input`;
+ * - cache-read tokens at `cacheRead`, or at `input` when `cacheRead` is 0 or
+ *   unset (a provider with no separate cache-read price bills them as input);
+ * - cache-creation tokens at `cacheWrite`, or at `input` under the same rule.
+ *
+ * `cacheWrite` is a FULL rate, not a surcharge added to `input` — Anthropic's
+ * cache-write entries are 1.25x their input rate, so billing a cache-creation
+ * token at both `input` and `cacheWrite` would overcharge it by 1.8x.
  */
 export function computeCallCostUsd(
 	modelName: string | undefined,


### PR DESCRIPTION
# What

`computeCallCostUsd`'s docstring describes a billing model the code does not implement — and the code is the one that's right.

> Cache-creation tokens are billed at cacheWrite **(Anthropic's surcharge) on top of the regular input portion that paid for them.**

The code does the opposite:

```ts
const nonCachedInput = Math.max(0, totalPrompt - cacheRead - cacheWrite);
const inputCost      = (nonCachedInput / 1_000_000) * price.input;
const cacheWriteCost = (cacheWrite / 1_000_000) * cacheWriteRate;
```

Cache-creation tokens are **removed** from the input portion and billed once, at `cacheWrite`. Since `cacheWrite` is `1.25 × input` for every Anthropic entry, the prose describes a **2.25×** charge where the code bills **1.25×**.

That matters because the prose is what a future reader would "fix" the code against. Doing so overcharges every cache-creation token by **1.8×**.

The same misnomer had already reached a test name — `applies cache-read discount and cache-write **surcharge** for Anthropic` — even though that test's body correctly bills 100 cache-write tokens once at $1.25/M.

# The convention, from this repo's own evidence

I checked rather than assumed:

- All 7 Anthropic entries store `cacheWrite = 1.25 × input` (e.g. `claude-opus-4-8`: input 5.0, cacheWrite 6.25). It's a **full rate**, not an increment.
- The rate-card test already comments `cacheRead = 0.1x input, cacheWrite = 1.25x`.
- An existing cost test spells out `1000 prompt = 200 fresh + 700 cacheRead + 100 cacheWrite`, which settles the other half: **`promptTokens` is inclusive of the cache counts.**

So the arithmetic is correct and already covered. Only the description is wrong.

# The change

**No behaviour change.** Docs and tests only.

1. Rewrite the docstring to state what the code does — `promptTokens` is inclusive, the non-cached portion is the remainder clamped at 0, each portion is billed exactly once, a `0`/unset cache rate means bill at `input` — and name the hazard.
2. Rename the test to `bills cache-read and cache-write portions at their own full rates`.
3. Add one assertion that **isolates** the cache-write term, instead of leaving the property implied by a four-term total: make all 1M prompt tokens cache-creation, so every other term is 0 and the expected cost is exactly $1.25.

# Control

Reverted the implementation to the model the old prose describes (`nonCachedInput = promptTokens - cacheRead`, leaving cache-write also billed as input):

```
AssertionError: expected 2.25 to be close to 1.25
Tests  2 failed | 44 passed (46)
```

The new isolated assertion names the 1.8× overcharge directly. With the change reverted, 46/46 pass.

# What I checked and found clean

While auditing this file I ran two other properties over it — both pass, noting them so the ground is covered:

- **Every one of the 20 price-table keys round-trips through `lookupModelPrice`.** It resolves unknown names by substring with longest-key-wins, so a key resolving to a *different* key would silently mis-price a model. None does.
- **The `rate > 0 ? rate : input` fallback is safe.** It treats `0` as "unset", which would overcharge if any entry had a genuine zero rate. The distribution is clean: `cacheWrite` is either `1.25 × input` (7 Anthropic entries) or exactly `0` (13 others), where `0` correctly means "no separate cache-write price, bill as ordinary input".

# Verification

- `bunx vitest run packages/core/src/features/trajectories/pricing.test.ts` → **46 passed / 0 failed** (up from 45).
- `bun run --cwd packages/core typecheck` → exit 0.
- `biome check` → clean on both files, no reformatting.

Diff is 2 files, **+27/−5**.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NHJH0EG08N64W50VBHFF34","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T06:26:53.070Z","completed_at":"2026-09-04T06:28:12.538Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T06:26:53.429Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"33aff7650a91f889c08367b853532ab3bc012a214b49d552bbe52281153a9d50","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"303f45cf-e628-486c-a6ff-c072d5457591","object_id":"sha256:33aff7650a91f889c08367b853532ab3bc012a214b49d552bbe52281153a9d50","sha256":"33aff7650a91f889c08367b853532ab3bc012a214b49d552bbe52281153a9d50"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"xsg29aMdSnUHqe8NpJ3Xi2T0bhZqxkFfmGf8-Ktu3Fm4JQxbIZJjF97e-Z4hacgDSv-9elgtWW8t4DRQxifUAg"}} -->
