### PR TITLE
docs(budget): correct the reserve-scaling contract and pin its sentinel

### DIFF
--- a/packages/core/src/runtime/__tests__/model-input-budget.test.ts
+++ b/packages/core/src/runtime/__tests__/model-input-budget.test.ts
@@ -194,6 +194,25 @@ describe("buildModelInputBudget", () => {
 			expect(budget.resolvedModelKey).toBe("gpt-oss-120b");
 		});
 
+		it("applies that sentinel to exactly one value, not a range", () => {
+			// The "carrying the legacy default" rule keys on strict equality with
+			// DEFAULT_INPUT_RESERVE_TOKENS. Neighbouring values are ordinary
+			// explicit overrides, so widening the sentinel to a range (or to
+			// "<= DEFAULT") would silently re-scale reserves callers pinned.
+			for (const reserveTokens of [
+				DEFAULT_INPUT_RESERVE_TOKENS - 1,
+				DEFAULT_INPUT_RESERVE_TOKENS + 1,
+			]) {
+				const budget = buildModelInputBudget({
+					messages: [userMessageOfChars(100)],
+					modelName: "gpt-oss-120b",
+					reserveTokens,
+				});
+				expect(budget.reserveTokens).toBe(reserveTokens);
+				expect(budget.dispatchThresholdTokens).toBe(131_000 - reserveTokens);
+			}
+		});
+
 		it("does NOT swap derivation in when reserveTokens===DEFAULT and lookup misses", () => {
 			// Lookup misses → no derived reserve available → the explicit
 			// default-equal must be honored. Otherwise we'd silently drop the

--- a/packages/core/src/runtime/model-input-budget.ts
+++ b/packages/core/src/runtime/model-input-budget.ts
@@ -36,11 +36,21 @@ export const DEFAULT_CONTENT_PROJECTION_AGGREGATE_TOKENS = 64_000;
  * tiny windows (≤ 50k) still get the 10k floor and large windows (≥ 200k)
  * scale up proportionally.
  *
- * **Important:** the scaled reserve only applies when (a) the model name was
- * passed AND resolved through `lookupModelContextWindow` AND (b) the caller
- * did not supply an explicit `reserveTokens`. Callers that pre-compute a
- * window-and-reserve pair keep their exact behavior — no regression for
- * existing call sites that don't pass `modelName`.
+ * **Important:** the scaled reserve applies when (a) the model name was passed
+ * AND resolved through `lookupModelContextWindow` AND (b) the caller supplied
+ * no `reserveTokens` — or supplied exactly `DEFAULT_INPUT_RESERVE_TOKENS`,
+ * which is treated as "carrying the legacy default" rather than as an
+ * override, so the planner-loop call site (which always forwards its 10k
+ * default) still gets the per-model derivation. Any other value, including
+ * `0`, is honored verbatim.
+ *
+ * That sentinel is easy to trip over: with a 1M-token window, passing
+ * `reserveTokens: 10_000` yields a 200k reserve, while `10_001` yields 10_001.
+ * To pin the flat 10k floor against a resolved model, omit `modelName` (no
+ * lookup fires) or pass `contextWindowTokens` explicitly.
+ *
+ * Callers that pre-compute a window-and-reserve pair keep their exact
+ * behavior — no regression for existing call sites that don't pass `modelName`.
  */
 export const MODEL_WINDOW_RESERVE_FRACTION = 0.2;
 


### PR DESCRIPTION
# What

The `MODEL_WINDOW_RESERVE_FRACTION` docstring states the scaled reserve applies only when:

> (a) the model name was passed AND resolved through `lookupModelContextWindow` AND **(b) the caller did not supply an explicit `reserveTokens`**

Clause (b) is wrong. It *also* applies when the caller supplies exactly `DEFAULT_INPUT_RESERVE_TOKENS` — that value is deliberately treated as "carrying the legacy default" rather than as an override, so the planner-loop call site (which always forwards its 10k default) still gets the per-model derivation.

# Why it matters

Against `claude-opus-4-8`'s **1,000,000**-token window:

| caller passes | docstring implies | code actually gives |
|---|---|---|
| `reserveTokens: 10_000` | reserve 10,000 → threshold 990,000 | **reserve 200,000 → threshold 800,000** |
| `reserveTokens: 10_001` | — | reserve 10,001 (verbatim) |

A **20× reserve** and a **190,000-token** difference in the dispatch threshold, from a value that reads like the default. The discontinuity is sharp — one token more and it's honoured verbatim.

# The behaviour is right; only the contract is stale

I checked whether the *code* was the bug and concluded it isn't:

- `buildModelInputBudget`'s inline comments explain the sentinel and give the reason (the planner-loop forwards `compactionReserveTokens`, default 10k; without the special case the explicit 10k would always beat the derivation).
- It is already tested: *"treats reserveTokens === DEFAULT as 'no override' so derivation fires (planner-loop call pattern)"*.

So this corrects only the contract a caller reads first — and says how to actually pin the flat floor: omit `modelName` (no lookup fires) or pass `contextWindowTokens` explicitly.

# The one test I added

Existing coverage pins that `10_000` triggers derivation. Nothing pinned that the sentinel is **exactly one value** — someone generalizing it to `<= DEFAULT` would silently re-scale reserves that callers had pinned. The new test asserts `DEFAULT − 1` and `DEFAULT + 1` are both honoured verbatim.

Control — widening the comparison to `rawExplicitReserve <= DEFAULT_INPUT_RESERVE_TOKENS`:

```
× applies that sentinel to exactly one value, not a range
AssertionError: expected 26200 to be 9999
```

Two pre-existing tests (explicit reserves of `5_000` and `0`) fail alongside it, which confirms that exact comparison is load-bearing in more than one place.

# What I checked and found clean

A property harness over seven groups, all passing — recording them so the ground is covered:

- no `modelName` → flat default reserve, no scaling;
- resolved `modelName`, no `reserveTokens` → `max(DEFAULT_INPUT_RESERVE_TOKENS, window × 0.20)`;
- explicit reserves `0`, `1`, `5_000`, `25_000`, `999_999` → honoured verbatim;
- `dispatchThresholdTokens === max(1, window − reserve)` across twelve model keys;
- `compactionThresholdTokens` never drifts from its alias;
- a 10,000,000 reserve against a 1,000-token window still leaves a threshold ≥ 1;
- a small window keeps the 10k floor.

# Verification

- `model-input-budget.test.ts` → **30 passed / 0 failed** (up from 29).
- Full `packages/core/src/runtime/__tests__` → **1572 passed / 0 failed**.
- `bun run --cwd packages/core typecheck` → exit 0.
- `biome check` → clean on both files, no reformatting.

Diff is 2 files, **+34/−5**. Documentation and tests only — **no behaviour change**.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NKS6CF5BXZ88T5GXZWKHAB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T07:05:28.719Z","completed_at":"2026-09-04T07:06:45.743Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T07:05:29.778Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"8dd0060b4e8936fb3ecdfebfd5956812a5724adacbaf3ff31f78d7476b61dd27","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"40c55531-bbbf-4247-a6d4-03973eac3cc0","object_id":"sha256:8dd0060b4e8936fb3ecdfebfd5956812a5724adacbaf3ff31f78d7476b61dd27","sha256":"8dd0060b4e8936fb3ecdfebfd5956812a5724adacbaf3ff31f78d7476b61dd27"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"yoeUQnNqmXTDqAHHeYg5YwTsRltFZXbamGNeRUfnvQXr29ubjIqzIkF_b-u_kcImny94GujnTdsUVmERHSwgDA"}} -->
