### PR TITLE
fix(ui): keep the browser address draft across a tab-less refresh

### DIFF
--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -1042,3 +1042,81 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     }
   });
 });
+
+describe("Browser workspace address draft durability", () => {
+  // POLL_INTERVAL_MS in BrowserWorkspaceView; the background refresh is the
+  // only thing driving a workspace snapshot change here.
+  const POLL_MS = 2_500;
+
+  it("keeps an in-progress address edit when a background poll drops the selected tab", async () => {
+    vi.useFakeTimers();
+    vi.mocked(client.getBrowserWorkspace).mockResolvedValue(APPLE_WORKSPACE);
+    try {
+      render(<BrowserWorkspaceView />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const address = screen.getByTestId(
+        "browser-workspace-address-input",
+      ) as HTMLInputElement;
+      expect(address.value).toBe("https://www.apple.com/");
+
+      fireEvent.change(address, { target: { value: "docs.elizaos.ai" } });
+      expect(address.value).toBe("docs.elizaos.ai");
+
+      // The workspace endpoint blips: one poll reports no tabs at all.
+      vi.mocked(client.getBrowserWorkspace).mockResolvedValue({
+        mode: "web",
+        tabs: [],
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_MS + 100);
+      });
+
+      // The very next poll reports the same tab again.
+      vi.mocked(client.getBrowserWorkspace).mockResolvedValue(APPLE_WORKSPACE);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(POLL_MS + 100);
+      });
+
+      expect(
+        screen.getByTestId("browser-workspace-address-input"),
+      ).toHaveProperty("value", "docs.elizaos.ai");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an in-progress address edit across an unchanged background poll", async () => {
+    vi.useFakeTimers();
+    vi.mocked(client.getBrowserWorkspace).mockResolvedValue(APPLE_WORKSPACE);
+    try {
+      render(<BrowserWorkspaceView />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const address = screen.getByTestId(
+        "browser-workspace-address-input",
+      ) as HTMLInputElement;
+      fireEvent.change(address, { target: { value: "docs.elizaos.ai" } });
+      expect(address.value).toBe("docs.elizaos.ai");
+
+      // Same snapshot, three times: nothing about the workspace changed.
+      for (let i = 0; i < 3; i += 1) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(POLL_MS + 100);
+        });
+      }
+
+      expect(
+        screen.getByTestId("browser-workspace-address-input"),
+      ).toHaveProperty("value", "docs.elizaos.ai");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -793,6 +793,9 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
     () => workspace.tabs.find((tab) => tab.id === selectedTabId) ?? null,
     [selectedTabId, workspace.tabs],
   );
+  // null while a refresh omits the selected tab, which is distinct from a tab
+  // that genuinely carries an empty URL.
+  const selectedTabUrl = selectedTab?.url ?? null;
   const selectedTabSnapshot = selectedTabId
     ? (tabSnapshots[selectedTabId] ?? null)
     : null;
@@ -1211,10 +1214,17 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
         setWorkspace(snapshot);
         setLoadError(null);
         setSelectedTabId((current) =>
-          resolveBrowserWorkspaceSelection(
-            snapshot.tabs,
-            options?.preferTabId ?? current,
-          ),
+          // An empty snapshot from a background poll is transient, exactly like
+          // the failed poll handled below: retain the selection instead of
+          // resolving it to null. Clearing it here re-runs the address-bar sync
+          // as a tab switch, which drops `locationDirty` and destroys whatever
+          // the user is typing. Deliberate closes set the selection directly.
+          background && snapshot.tabs.length === 0
+            ? current
+            : resolveBrowserWorkspaceSelection(
+                snapshot.tabs,
+                options?.preferTabId ?? current,
+              ),
         );
       } catch (error) {
         if (abortController.signal.aborted) return;
@@ -2418,18 +2428,22 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
     void loadBrowserWalletState();
   }, 5_000);
 
+  // `selectedTabId` is what the user picked; `selectedTab` resolves that against
+  // the latest snapshot and is null for as long as a refresh omits the tab.
+  // Keying the switch off the selection keeps a transient snapshot from reading
+  // as a tab change, which would clear `locationDirty` and discard an in-flight
+  // address edit; the sync below only runs against a tab that actually resolved.
   useEffect(() => {
-    const currentSelectedId = selectedTab?.id ?? null;
-    if (currentSelectedId !== previousSelectedTabIdRef.current) {
-      previousSelectedTabIdRef.current = currentSelectedId;
-      setLocationInput(selectedTab?.url ?? "");
+    if (selectedTabId !== previousSelectedTabIdRef.current) {
+      previousSelectedTabIdRef.current = selectedTabId;
+      setLocationInput(selectedTabUrl ?? "");
       setLocationDirty(false);
       return;
     }
-    if (!locationDirty) {
-      setLocationInput(selectedTab?.url ?? "");
+    if (selectedTabUrl !== null && !locationDirty) {
+      setLocationInput(selectedTabUrl);
     }
-  }, [locationDirty, selectedTab?.id, selectedTab?.url]);
+  }, [locationDirty, selectedTabId, selectedTabUrl]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Problem

Typing in the browser workspace address bar is silently discarded when a
background workspace poll returns a snapshot that does not contain the selected
tab. The field reverts to the committed URL and the edit is gone.

The polling loop runs every 2.5s while the view is visible, so this needs no
user action to trigger — it lands on whatever the user happens to be typing.

## Cause

Two independent places both have to hold for the draft to survive, and neither
does:

1. `loadWorkspace` re-resolves the selection against every snapshot:

   ```ts
   setSelectedTabId((current) =>
     resolveBrowserWorkspaceSelection(snapshot.tabs, options?.preferTabId ?? current),
   );
   ```

   `resolveBrowserWorkspaceSelection([], "tab-apple")` returns `null`, so an
   empty background snapshot clears the user's selection. The `catch` immediately
   below already treats a transient background result as non-authoritative
   (`error-policy:J4 poll — retain the last successful workspace on a transient
   background failure`); an empty success was not getting that treatment.

2. The address-bar sync tested for a tab switch using `selectedTab?.id`:

   ```ts
   const currentSelectedId = selectedTab?.id ?? null;
   if (currentSelectedId !== previousSelectedTabIdRef.current) {
     previousSelectedTabIdRef.current = currentSelectedId;
     setLocationInput(selectedTab?.url ?? "");
     setLocationDirty(false);   // <- the draft dies here
     return;
   }
   ```

   `selectedTab` is derived from the latest snapshot, so it is `null` for as long
   as a refresh omits the tab. A transient snapshot therefore reads as a
   deliberate tab switch and clears `locationDirty`.

Fixing either alone is not enough: keep the selection and `selectedTab` is still
null; fix the sync and the selection has already been nulled underneath it. I
verified both halves separately before landing them together.

## Fix

- `loadWorkspace`: an empty snapshot from a **background** poll retains the
  current selection rather than resolving it to null. Foreground loads and the
  explicit close paths (which set the selection directly) are untouched, so a
  genuinely closed tab still clears normally.
- The sync now keys on `selectedTabId` — the user's selection — and only syncs
  from a tab that actually resolved.

## Tests

Two tests in `BrowserWorkspaceView.chrome.test.tsx`, one of which is a
deliberate control:

| test | before | after |
| --- | --- | --- |
| unchanged poll repeated 3x keeps the draft | passes | passes |
| poll drops the tab for one tick, then restores it | **fails** | passes |

The control matters: it shows an ordinary refresh was never the problem, so the
failing test is pinned to the transient-snapshot path specifically and is not
just green-because-vacuous.

Mutation check — reverting only `BrowserWorkspaceView.tsx` and keeping both
tests:

```
× keeps an in-progress address edit when a background poll drops the selected tab
  Expected: "docs.elizaos.ai"
  Received: "https://www.apple.com/"
  Tests  1 failed | 1 passed | 30 skipped (32)
```

## Verification

```
npx vitest run src/components/pages/BrowserWorkspaceView   ->  36 passed (2 files)
npx biome check src/components/pages/BrowserWorkspaceView.tsx  ->  clean
npx tsc --noEmit -p tsconfig.json                          ->  clean
```

## Note on scope

`canonical / Smoke (6)` is currently red on `develop` with the same shape —
`browser-workspace.spec.ts:278` fills `docs.elizaos.ai` and reads back the
previously committed `https://example.com/`. That is what led me here. I have
**not** proven the two are the same instance; I could not reproduce the E2E
environment's snapshot timing, so I am not claiming this closes that job. The
bug fixed here is reproducible on its own terms and is a real data-loss path
regardless of whether it is also the Smoke (6) cause.
