### PR TITLE
docs(cloud): name the real post-debit balance-hint writer, and delete the lower-only one

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/container-billing-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/container-billing-numeric.test.ts
@@ -15,7 +15,7 @@
  *                       running total.
  *   - `credit_balance` → the returned `newBalance` becomes `NaN` and is shown
  *                        verbatim: the low-balance email renders `$NaN`, and
- *                        `lowerOrgBalanceHint`/logs record a garbage figure.
+ *                        the cached balance hint and logs record a garbage figure.
  *
  * A real corrupt NUMERIC cannot be stored in PGlite/Postgres (they reject it),
  * so the healthy-path regression coverage lives in the PGlite-backed

--- a/packages/cloud/shared/src/db/repositories/container-billing-numeric.ts
+++ b/packages/cloud/shared/src/db/repositories/container-billing-numeric.ts
@@ -17,8 +17,8 @@
  *                       undiagnosable at the point it matters.
  *   - `credit_balance` → the returned `newBalance` becomes `NaN` and is
  *                        surfaced verbatim to the caller: the low-balance email
- *                        renders `$NaN`, `lowerOrgBalanceHint`/logs record a
- *                        garbage balance — a fabricated (nonsense) money figure
+ *                        renders `$NaN`, and the cached balance hint and logs
+ *                        record a garbage balance — a fabricated money figure
  *                        shown to the user instead of a fail-closed error.
  *
  * Failing closed here surfaces the corruption with a field-named error BEFORE

--- a/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-cache.ts
@@ -557,9 +557,12 @@ export async function writeOrgBalanceHint(
   };
   // Physical lifetime is orgBalanceStale (5m): the hint must survive past the
   // orgBalance freshness window so getGateBalanceUsd can serve it stale-while-
-  // revalidate. `balanceAt` is the freshness clock the reader checks; the debit
-  // settler (lowerOrgBalanceHint) and top-ups (invalidateOrgBalanceHint) still
-  // keep the served value correct on writes.
+  // revalidate. `balanceAt` is the freshness clock the reader checks; the served
+  // value is kept correct by the two writers that follow an authoritative
+  // mutation — the debit settler republishes the committed balance and revision
+  // (republishOrgBalanceHint), and every other credit mutation evicts the entry
+  // (CacheInvalidation.onCreditMutation, plus invalidateOrgBalanceHint on a
+  // failed or refused debit).
   const outcome = await cache.setWithOutcome(
     CacheKeys.inference.orgBalance(orgId),
     hint,
@@ -579,33 +582,19 @@ export async function invalidateOrgBalanceHint(orgId: string): Promise<void> {
 }
 
 /**
- * Write the org-balance gate hint ONLY when it lowers the cached value. Used by
- * the debit settler: a debit can only reduce a balance, so an out-of-order
- * concurrent debit must never raise the cached gate value (which would
- * over-admit the optimistic path). A fresh authoritative read still uses
- * `writeOrgBalanceHint` (it is the source of truth); top-ups invalidate the hint.
- */
-export async function lowerOrgBalanceHint(
-  orgId: string,
-  balanceUsd: number,
-  balanceAt: number,
-): Promise<void> {
-  const existing = await readOrgBalanceHint(orgId);
-  if (!existing) return;
-  if (existing.balanceUsd <= balanceUsd) return;
-  await writeOrgBalanceHint(orgId, balanceUsd, balanceAt, existing.balanceRevision);
-}
-
-/**
  * Publish one authoritative post-debit balance snapshot with a single cache
  * write and no cache readback.
  *
- * Unlike {@link lowerOrgBalanceHint}, this seeds an entry after the committed
- * debit's invalidation deletes the old hint, preventing the next Worker turn
- * from failing closed on an avoidable cache miss. The projection is not the
- * monetary authority: Worker provider dispatch is serialized by the
- * revision-aware InferenceAdmissionGate Durable Object. Non-Worker paths use
- * the atomic DB-ledger admission or reserve credits synchronously; the legacy
+ * This is an unconditional write, and it has to be: it seeds an entry after the
+ * committed debit's invalidation has already deleted the old hint, preventing
+ * the next Worker turn from failing closed on an avoidable cache miss. A
+ * lower-only writer cannot do that job — with no entry present there is
+ * nothing to lower.
+ *
+ * The projection is not the monetary authority: Worker provider dispatch is
+ * serialized by the revision-aware InferenceAdmissionGate Durable Object.
+ * Non-Worker paths use the atomic DB-ledger admission or reserve credits
+ * synchronously; the legacy
  * KV lane cannot dispatch from this projection. A delayed projection write can
  * therefore be stale, but it cannot authorize spend by itself; the next Durable
  * Object admission applies only a newer revision and accounts for active holds.

--- a/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
+++ b/packages/cloud/shared/src/lib/services/inference-balance-republish.ts
@@ -31,8 +31,9 @@ import { republishOrgBalanceHint } from "./inference-auth-cache";
  * not a slow read. Every settled turn therefore armed a guaranteed failure for
  * the following turn (observed on staging as a strict 200/503 alternation).
  *
- * `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no
- * entry exists, so after the delete it is always a no-op.
+ * A lower-only writer cannot repair this: it would bail when no entry exists,
+ * so after the delete it is always a no-op. That is why this republishes
+ * unconditionally rather than clamping to the cached value.
  *
  * The debit statement returns both the committed balance and trigger-advanced
  * revision. Passing that atomic result here avoids a post-debit primary read

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.test.ts
@@ -657,7 +657,7 @@ describe("sweepStalePendingInferenceCharges", () => {
   });
 });
 
-describe("#9899 hardening: backstop durability, lower-only hint, claim atomicity", () => {
+describe("#9899 hardening: backstop durability, hint republication, claim atomicity", () => {
   test("writePendingInferenceCharge reports true when the backstop persists", async () => {
     const input = chargeInput();
     const ok = await writePendingInferenceCharge(input, Date.now());

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -97,18 +97,7 @@ export function isPendingInferenceCharge(value: unknown): value is PendingInfere
   );
 }
 
-/**
- * Read the gate balance for an org, stale-while-revalidate. Serves the KV hint
- * whenever one exists; if it is older than the `orgBalance` freshness window it
- * is still returned immediately and an authoritative refresh is scheduled in the
- * background. Only a full miss (no hint within the physical `orgBalanceStale`
- * lifetime) blocks on the authoritative read. This keeps the human-paced first
- * call of each turn off the ~200-500ms balance re-read that a hard 15s TTL
- * forced, without widening the over-admit window: every optimistic charge still
- * lands in the durable pending-charge ledger, the debit settler lowers the hint
- * after each settle, and top-ups invalidate it — so a drained org is corrected
- * on its first settle exactly as before, not after the stale window.
- */
+/** Options for {@link getGateBalanceHint} and {@link getGateBalanceUsd}. */
 export interface GateBalanceReadOptions {
   /**
    * Worker lifetime hook for stale/full-miss revalidation. Supplying this keeps
@@ -193,6 +182,21 @@ export function scheduleOrgBalanceHintHydration(
   );
 }
 
+/**
+ * Read the gate balance for an org, stale-while-revalidate. Serves the KV hint
+ * whenever one exists; if it is older than the `orgBalance` freshness window it
+ * is still returned immediately and an authoritative refresh is scheduled in the
+ * background. Only a full miss (no hint within the physical `orgBalanceStale`
+ * lifetime) blocks on the authoritative read — or, under `cacheOnly`, fails
+ * closed with {@link InferenceBalanceCacheWarmingError}. This keeps the
+ * human-paced first call of each turn off the ~200-500ms balance re-read that a
+ * hard 15s TTL forced, without widening the over-admit window: every optimistic
+ * charge still lands in the durable pending-charge ledger, each settle
+ * republishes the committed balance and revision over the hint
+ * (`republishOrgBalanceHintAfterDebit`), and every other credit mutation evicts
+ * it — so a drained org is corrected on its first settle exactly as before, not
+ * after the stale window.
+ */
 export async function getGateBalanceHint(
   organizationId: string,
   options: GateBalanceReadOptions = {},


### PR DESCRIPTION
# What

`lowerOrgBalanceHint` in `packages/cloud/shared/src/lib/services/inference-auth-cache.ts` has **zero call sites** — no production caller, no test. Four doc comments still describe it as the live post-debit gate-hint writer.

That claim isn't just stale, it's the opposite of a bug you already fixed. `inference-balance-republish.ts:34` spells it out:

> `lowerOrgBalanceHint` cannot repair this: it is lower-only and bails when no entry exists, so after the delete it is always a no-op.

And the fast-path test file, at the regression it pins, calls it "the **old** lower-only repair":

```
// REGRESSION (staging 2026-08-05): every settled turn left the gate hint
// ABSENT, because the committed debit's `onCreditMutation` deletes it and the
// old lower-only repair bails when no entry exists.
```

So the function survived the fix that superseded it, and the surrounding prose kept pointing at it.

# The four doc sites

| where | said | actually |
|---|---|---|
| `inference-billing-fast-path.ts` — gate-balance docstring | "the debit settler **lowers** the hint after each settle, and top-ups invalidate it" | the settler **republishes** the committed balance and revision (`republishOrgBalanceHintAfterDebit`); every other credit mutation **evicts** the entry |
| `inference-auth-cache.ts` — inside `writeOrgBalanceHint` | "the debit settler (`lowerOrgBalanceHint`) and top-ups (`invalidateOrgBalanceHint`)" | both halves wrong: top-ups evict via `CacheInvalidation.onCreditMutation`; `invalidateOrgBalanceHint` is only reached on a **failed or refused** debit |
| `inference-auth-cache.ts` — `republishOrgBalanceHint` | "Unlike `{@link lowerOrgBalanceHint}`…" | reworded to state the property directly, so it survives the deletion |
| `container-billing-numeric.ts` + its test | "`lowerOrgBalanceHint`/logs record a garbage figure" | dangling name; now "the cached balance hint and logs" — I deliberately did **not** substitute `republishOrgBalanceHint`, because container billing doesn't go through the inference settler and I'd only be trading one wrong symbol for another |

I also moved the gate-balance stale-while-revalidate docstring off `GateBalanceReadOptions` and onto `getGateBalanceHint`. It describes the read, not the options bag — hovering the interface currently shows a paragraph about the ~200-500ms balance re-read. While moving it I added the one branch it omitted: under `cacheOnly` a full miss fails closed with `InferenceBalanceCacheWarmingError` instead of blocking on the authoritative read.

The verified call chain, for the record: `creditsService.deductCredits` → `CacheInvalidation.onCreditMutation` (deletes `CacheKeys.inference.orgBalance`) → `debitInferenceCost` → `republishOrgBalanceHintAfterDebit` → `republishOrgBalanceHint` (unconditional `writeOrgBalanceHint`).

# I added no test, and here is why

That was my first instinct, and mutation testing talked me out of it.

I wrote a candidate: settle a debit whose committed balance is **higher** than the cached hint (a top-up lands mid-request), then assert the hint reflects the authoritative value — the one case every existing settle assertion happens to miss, since they all lower. Then I checked whether it actually discriminates:

| mutation to `republishOrgBalanceHint` | existing suite | my candidate test |
|---|---|---|
| lower-only (bail when absent, skip when not lower) | **6 fail** | fail |
| clamp to `min(cached, new)` | **1 fail** | **pass** |

It passed under the clamp because the mocked `deductCredits` deletes the hint first — exactly as production does — so there is never a cached value to clamp against. The test proved nothing the suite didn't already prove, so I dropped it rather than ship coverage theatre. `republish issues one direct authoritative write without a cache read` (line 692) already pins the raising case directly, `2 → 9`, which no lower-only or clamping writer can pass.

The one thing I renamed in a test is a title that named the removed mechanism: `#9899 hardening: backstop durability, lower-only hint, claim atomicity` → `…, hint republication, …`.

# Verification

- `bun run --cwd packages/cloud/shared typecheck` → **exit 0**, 0 `error TS`
- `bunx @biomejs/biome check` → clean on all six touched files
- `bun test inference-billing-fast-path.test.ts --isolate` → **42 pass / 0 fail**
- `inference-billing-invalidation-logged` 1 pass · `inference-billing-cache-failure` 2 pass · `invalidation-credit-hint` 2 pass · `container-billing-numeric` 8 pass — all 0 fail
- `grep -rn lowerOrgBalanceHint` across the repo → no hits remain

Net **−6 lines**. No behavior change: the only executable code removed is a function nothing calls.

# What I did not change

I left `republishOrgBalanceHint`'s unconditional-write semantics, the `balanceAt`-before-query ordering in `refreshOrgBalanceHint`, and the documented KV residuals in the sweep exactly as they are. All three are deliberate and correctly described where they live; this PR only makes the *other* comments agree with them.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NN1ZK6DTWNKX6VDN4TXSHY","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T07:27:45.254Z","completed_at":"2026-09-04T07:31:32.660Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T07:27:46.016Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c96511109a32b15508a5ac687134382a60ec81259cba32a8dacaf0b5b86f79ad","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"66293207-db99-4ccc-825a-cfa787a38a03","object_id":"sha256:c96511109a32b15508a5ac687134382a60ec81259cba32a8dacaf0b5b86f79ad","sha256":"c96511109a32b15508a5ac687134382a60ec81259cba32a8dacaf0b5b86f79ad"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"3aOCUcDabK9mbY5Ea3p9HPnsGPjmRHw7aAJgFxbum312vYh3En51zXwjM_SaKqxnITuegh8EapMWwrft_2A-DQ"}} -->
