### PR TITLE
docs(payout): scope the broadcast-hash rule to unknown outcomes, and pin the confirmed-failure exception

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
@@ -487,6 +487,71 @@ describe("payout stale-lock recovery (#10553)", () => {
   );
 
   test(
+    "(d3) a CONFIRMED on-chain failure clears the broadcast hash and is deliberately re-queued",
+    async () => {
+      if (!pgliteReady) return;
+      const id = await seedRedemption({ status: "approved" });
+
+      // The counterpart to (d). There the confirmation THREW, so the outcome
+      // was unknown and the hash had to be kept. Here the receipt arrives and
+      // reports a revert: the outcome is KNOWN, an ERC-20 transfer that
+      // reverted moved no tokens, and retrying therefore cannot double-pay.
+      waitReceiptMock.mockImplementation(async () => ({
+        status: "reverted" as const,
+      }));
+
+      await service.processBatch();
+
+      const row = await readRedemption(id);
+      expect(row.status).toBe("approved");
+      expect(row.failure_reason).toBe("Transaction reverted");
+      expect(row.tx_hash).toBeNull();
+      // markFailed clears the hash ON PURPOSE. This is the one place the
+      // "a recorded hash is never re-broadcast" rule is relaxed, and it is
+      // relaxed only because the transaction is confirmed to have moved
+      // nothing. Keeping the hash here would strand every reverted payout.
+      expect(row.broadcast_tx_hash).toBeNull();
+      expect(Number(row.retry_count)).toBe(1);
+      expect(sendRawTxMock.mock.calls.length).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "(d4) the re-queued row is paid out by the next batch, and pays exactly once",
+    async () => {
+      if (!pgliteReady) return;
+      const id = await seedRedemption({ status: "approved" });
+
+      waitReceiptMock.mockImplementation(async () => ({
+        status: "reverted" as const,
+      }));
+      await service.processBatch();
+      expect((await readRedemption(id)).status).toBe("approved");
+
+      // Same row, next batch, healthy chain.
+      waitReceiptMock.mockImplementation(async () => ({
+        status: "success" as const,
+      }));
+      await service.processBatch();
+
+      const row = await readRedemption(id);
+      expect(row.status).toBe("completed");
+      expect(row.tx_hash).toBe(BROADCAST_HASH);
+      // Two broadcasts, one payout: the first reverted and transferred nothing.
+      // Asserting the count makes the deliberate re-broadcast explicit rather
+      // than something a reader has to infer from the status.
+      expect(sendRawTxMock.mock.calls.length).toBe(2);
+      const ledger = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM redeemable_earnings_ledger
+         WHERE redemption_id = '${id}' AND entry_type = 'redemption';`,
+      );
+      expect((ledger.rows[0] as { n: number }).n).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "(e) a FRESH 'processing' row (within LOCK_TIMEOUT) is left alone for the live worker",
     async () => {
       if (!pgliteReady) return;

--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -1061,7 +1061,25 @@ export class PayoutProcessorService {
   /**
    * Persist the broadcast transaction hash the moment a payout is broadcast,
    * before waiting for confirmation. This is the recovery signal: a `processing`
-   * row with a recorded broadcast hash must never be re-broadcast.
+   * row with a recorded broadcast hash must never be re-broadcast **while the
+   * broadcast's outcome is unknown**. `recoverStaleProcessing()` therefore only
+   * ever touches rows with `broadcast_tx_hash IS NULL`, and
+   * `handleProcessingThrow()` re-reads the hash before deciding whether a throw
+   * is safe to retry.
+   *
+   * A CONFIRMED on-chain failure is the deliberate exception, and it is not a
+   * re-broadcast of an in-flight transaction: an EVM revert and a Solana
+   * `confirmation.value.err` both mean the transaction landed and executed no
+   * transfer, so the payout provably did not happen. `markFailed` clears
+   * `broadcast_tx_hash` on purpose in that case and the row is retried with a
+   * fresh signature. Pinned by cases (d3) and (d4) of
+   * `__tests__/payout-stale-lock-recovery.test.ts`.
+   *
+   * Do not "restore" the absolute reading. Keeping the hash on a confirmed
+   * failure carries it into the next attempt, so a worker death during that
+   * attempt leaves a row `recoverStaleProcessing()` refuses to touch — stranded
+   * in `processing` forever. Routing the confirmed failure to reconciliation
+   * instead sends every reverted payout to manual review.
    */
   private async recordBroadcast(redemptionId: string, broadcastTxHash: string): Promise<void> {
     await dbWrite


### PR DESCRIPTION
# What

`recordBroadcast` states its rule absolutely:

> This is the recovery signal: a `processing` row with a recorded broadcast hash must never be re-broadcast.

Two paths break that reading on purpose, and they are right to. `executeEvmPayout` records the hash at line 812 and then, on a receipt reporting `reverted`, returns `{ success: false, retryable: true }`. `executeSolanaPayout` records the deterministic signature and does the same on `confirmation.value.err`. Both land in the batch loop's `markFailed(id, reason, true)`, which resets the row to `approved` **and** sets `broadcast_tx_hash: null` — a deliberate re-broadcast of a row that had a recorded hash.

That is safe, and the code already knows why. A reverted ERC-20 transfer and an atomically-failed Solana transaction both moved no tokens, so the payout provably did not happen. The Solana branch says so inline:

```ts
// The transaction landed but failed atomically — no SPL transfer executed,
// so it is safe to retry (markFailed clears the broadcast hash).
```

So the code is correct and the docstring over-claims. **The real invariant is about an _unknown_ broadcast outcome, not a recorded hash.** I checked that the paths which do guard the strict rule guard it properly: all three `recoverStaleProcessing()` branches gate on `isNull(broadcast_tx_hash)`, and `handleProcessingThrow()` re-reads the hash and parks the row in `processing` when it is set. Nothing needed fixing there.

This matters because the over-claim invites a specific harmful edit, and #10588's framing ("a recorded broadcast hash means recovery must never re-broadcast") makes that edit look like a bug fix. Keeping the hash on a confirmed failure carries it into the next attempt, so a worker death during *that* attempt leaves a row `recoverStaleProcessing()` refuses to touch — stranded in `processing` forever. Routing the confirmed failure to reconciliation instead sends every reverted payout to manual review.

# The change

Two things, no behavior change:

1. Scope the docstring to what it actually guards, name the confirmed-failure exception and why it is safe, and say plainly what not to "fix".
2. Add the two cases that were missing.

The suite has 13 cases and covers the **unknown** outcome well — `(d)` is "an eviction during confirm leaves it for reconciliation". Nothing covered a **confirmed** on-chain failure, which is exactly the behavior the old wording forbids. The new cases sit next to `(d)` so the pair reads as one contract:

- **(d3)** a confirmed revert clears the broadcast hash, returns the row to `approved` with `retry_count = 1`, and broadcasts exactly once
- **(d4)** the re-queued row completes on the next batch: two broadcasts, one payout, and exactly one `redemption` ledger entry

# Mutation results

Both cases are load-bearing, and they discriminate different edits:

| mutation | outcome |
| --- | --- |
| drop `broadcast_tx_hash: null` from `markFailed`'s retryable branch — the edit a literal reading of the old docstring invites | **(d3) fails** — 15 pass / 1 fail |
| make the `reverted` return `retryable: false` | **(d3) and (d4) fail** — 14 pass / 2 fail |
| unmodified | 16 pass / 0 fail |

I ran these because I nearly filed the opposite PR. My first read was that `markFailed` clearing the hash was a double-pay bug against the stated invariant. It isn't — the two post-broadcast retryable returns are both confirmed-no-transfer outcomes — so the fix belonged in the prose and the coverage, not the logic.

# Verification

```
bun run --cwd packages/cloud/shared typecheck                 -> exit 0
bunx @biomejs/biome check <both files>                        -> clean
bun test __tests__/payout-stale-lock-recovery.test.ts         -> 16 pass / 0 fail   (was 14)
all four payout suites                                        -> 34 pass / 6 skip / 0 fail
  same four suites on develop                                 -> 32 pass / 6 skip / 0 fail
```

The 6 skips are pre-existing and identical on both sides; I diffed the counts rather than assuming.

# What I did not change

`markFailed`'s hash-clearing, the two post-broadcast `retryable: true` returns, the `recoverStaleProcessing()` gates, and `handleProcessingThrow()` are all untouched — they are correct as they stand. This PR only makes the docstring agree with them and pins the exception so a future reader cannot quietly remove it.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NNZXW4JXN60A3Z7HSN6TA1","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T07:44:06.533Z","completed_at":"2026-09-04T07:47:27.530Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T07:44:07.180Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f8fec3ff8abe03ccd33d73da19295530181dead5cb572cdc589be2be57c01148","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f1a612d2-9bb0-42ed-a431-1f4c43276f39","object_id":"sha256:f8fec3ff8abe03ccd33d73da19295530181dead5cb572cdc589be2be57c01148","sha256":"f8fec3ff8abe03ccd33d73da19295530181dead5cb572cdc589be2be57c01148"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"81V7Qk84DXj2xDT3gYjxzZw1quT69tCkZsJmIP1M2uiiwWJPuuU7XWfqMRCk8bveGE59wSHwNYCQtQfhR9dRDg"}} -->
