### PR TITLE
test(credits): pin auto-top-up disabling when a clawback recovers nothing

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -1372,6 +1372,61 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
   );
 
   test(
+    "disables auto top-up even when a drained org recovers nothing",
+    async () => {
+      if (!pgliteReady) return;
+      // The boundary the test above does not reach. There the org still had $50
+      // to claw back, so the org row was updated for its balance anyway. Here
+      // the balance is already 0: `applied_amount` is 0 and `credit_balance`
+      // does not move, so the only reason to touch the org row is the
+      // auto-top-up flag. This is also the worst case for the invariant --
+      // auto top-up fires on a LOW balance, so an org at 0 with the flag left
+      // on charges the refunded card again immediately.
+      await seedOrg("0");
+      await dbWrite.execute(
+        `UPDATE organizations SET auto_top_up_enabled = true WHERE id = '${ORG_ID}';`,
+      );
+
+      const r = await creditsService.clawbackCredits({
+        organizationId: ORG_ID,
+        amount: 100,
+        description: "refund clawback on a drained org",
+        stripePaymentIntentId: "stripe:refund:ch_drained:10000",
+        metadata: { payment_intent_id: "pi_drained" },
+      });
+
+      expect(r.appliedAmount).toBeCloseTo(0, 6);
+      expect(r.shortfallAmount).toBeCloseTo(100, 6);
+      expect(r.newBalance).toBeCloseTo(0, 6);
+      expect(r.alreadyProcessed).toBe(false);
+      expect(await getBalance()).toBeCloseTo(0, 6);
+
+      const settings = await dbWrite.execute(
+        `SELECT auto_top_up_enabled FROM organizations WHERE id = '${ORG_ID}';`,
+      );
+      expect((settings.rows[0] as { auto_top_up_enabled: boolean }).auto_top_up_enabled).toBe(
+        false,
+      );
+
+      // A zero-value clawback row is still written, so the unrecoverable
+      // amount is auditable rather than absent.
+      expect(await countByType("clawback")).toBe(1);
+      const clawbackRow = await dbWrite.execute(
+        `SELECT amount, metadata FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'clawback';`,
+      );
+      const row = clawbackRow.rows[0] as {
+        amount: string;
+        metadata: Record<string, unknown>;
+      };
+      expect(Number(row.amount)).toBeCloseTo(0, 6);
+      expect(Number(row.metadata.applied_clawback_usd)).toBeCloseTo(0, 6);
+      expect(Number(row.metadata.requested_clawback_usd)).toBeCloseTo(100, 6);
+      expect(Number(row.metadata.unrecovered_clawback_usd)).toBeCloseTo(100, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "is idempotent on the stripePaymentIntentId key (no double claw on re-delivery)",
     async () => {
       if (!pgliteReady) return;

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -1333,6 +1333,14 @@ export class CreditsService {
             auto_top_up_enabled = false,
             updated_at = NOW()
           FROM candidate
+          -- Gated on the insert ONLY, deliberately: a fully drained org has
+          -- applied_amount = 0 and new_balance = current_balance, so this
+          -- UPDATE changes nothing but the flag -- and that is exactly the case
+          -- that most needs it, because auto top-up fires on a LOW balance. Do
+          -- not add an applied_amount > 0 guard to skip a no-op balance write;
+          -- it would leave the flag on for the org with nothing left to
+          -- recover. Pinned by "disables auto top-up even when a drained org
+          -- recovers nothing" in __tests__/credits-reconcile.test.ts.
           WHERE o.id = candidate.id
             AND EXISTS (SELECT 1 FROM inserted)
           RETURNING o.credit_balance AS new_balance


### PR DESCRIPTION
# What

`clawbackCredits` carries a money invariant in a comment:

> A Stripe refund/dispute must never look like fresh usage and automatically charge the saved card again.

The `updated` CTE enforces it by setting `auto_top_up_enabled = false` in the same statement as the clawback. That UPDATE is gated on the clawback insert **alone** — not on `applied_amount > 0` — and the difference only shows up at one boundary that nothing tests.

When an org is already at $0, `applied_amount` is 0 and `new_balance` equals `current_balance`, so the balance write is a no-op and the *only* effect of the UPDATE is the flag. That is also the worst case for the invariant: auto top-up fires on a **low** balance, so an org left at $0 with the flag still on charges the just-refunded card again immediately.

The nearest existing case, `floors the balance at zero and records unrecovered shortfall metadata`, seeds `$50` against a `$100` clawback. It asserts the flag, but the org row is written for its balance anyway, so it cannot distinguish "the UPDATE ran" from "the UPDATE ran because the balance changed".

# The change

No behavior change — one test and one comment.

**The test.** I probed the boundary against PGlite before writing anything, and the code is already correct: balance `0`, clawback `100` → `applied 0`, `shortfall 100`, `auto_top_up_enabled false`, plus a zero-amount clawback row carrying `requested_clawback_usd: 100` / `unrecovered_clawback_usd: 100`. So this pins working behavior rather than fixing a bug. It also asserts the zero-value ledger row, since that is what makes an unrecoverable refund auditable instead of absent.

**The comment**, at the gate, saying why it must stay gated on the insert alone and naming the test that pins it.

# Why this test and not just a comment

Per the mutation table, it discriminates a real and attractive edit — "don't write the org row when the balance doesn't move":

```diff
           WHERE o.id = candidate.id
             AND EXISTS (SELECT 1 FROM inserted)
+            AND candidate.applied_amount > 0
```

| suite | unmodified | with that guard |
| --- | --- | --- |
| `credits-reconcile.test.ts` on `develop` (37 cases) | 37 pass | **37 pass** — undetected |
| with this PR (38 cases) | 38 pass | **37 pass / 1 fail** |

That edit reads as a harmless optimisation, passes every existing test, and silently re-opens the exact hazard the comment names. That is what earns the case a place; I dropped a candidate test in a recent PR precisely because it survived every mutation the suite already caught.

# Verification

```
bun run --cwd packages/cloud/shared typecheck        -> exit 0
bunx @biomejs/biome check <both files>               -> clean
bun test __tests__/credits-reconcile.test.ts         -> 38 pass / 0 fail
  same file on develop                               -> 37 pass / 0 fail
```

One note for anyone editing near this: backticks inside the `sql` tagged template terminate the literal. My first draft of the comment quoted `applied_amount > 0` in backticks and broke both `tsc` and biome; the committed version uses no backticks.

# What I did not change

The gate itself, `candidate`'s `requested_amount > 0` filter, the `ON CONFLICT DO NOTHING` idempotency, and the "an operator/user can explicitly re-enable it" behavior on a replayed webhook are all untouched and, as far as I can tell, correct as they stand.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NPMEGZF5WQX3NVXYRY91WZ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T07:55:18.943Z","completed_at":"2026-09-04T07:56:17.708Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T07:55:19.957Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"71c93a52bdc3f1719a45eaac63235c936da320958cf9460623915ecb8c49cafd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0d9fd92b-c5b4-46c0-b966-ebbf8947c932","object_id":"sha256:71c93a52bdc3f1719a45eaac63235c936da320958cf9460623915ecb8c49cafd","sha256":"71c93a52bdc3f1719a45eaac63235c936da320958cf9460623915ecb8c49cafd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"N51XNrfHNx-Jn1Y6ai0wORMm5Zw7FoR8jHwDJ8pJSFWooP_9J9eNhJHobTTYgLh01tQKEwmgiCyAlVew6rqbDw"}} -->
