### PR TITLE
docs(cloud): record that sensitive-request event dispatch is not wired in production

### DIFF
--- a/packages/cloud/shared/src/lib/services/sensitive-request-hosted-page-e2e.test.ts
+++ b/packages/cloud/shared/src/lib/services/sensitive-request-hosted-page-e2e.test.ts
@@ -13,9 +13,24 @@
  *   - the REAL `SensitiveRequestsService` (token mint, single-use enforcement,
  *     policy authorization, fulfillment, status machine) over an in-memory
  *     repository standing in only for Postgres;
- *   - the REAL `createSensitiveCallbackBus` wired as the service's
- *     `dispatchEvent`, so the agent's callback listener observes the actual
- *     fulfillment event — this is how the agent "sees the result land back".
+ *   - the REAL `createSensitiveCallbackBus` as the service's `dispatchEvent`,
+ *     so the agent's callback listener observes the actual fulfillment event.
+ *
+ * One caveat on that last item, so this header is not read as more than it is:
+ * the callback wiring is assembled HERE, not in production. The exported
+ * `sensitiveRequestsService` singleton is built with no deps, so its
+ * `dispatchEvent` is `undefined` and `emit` is a no-op on every
+ * `/v1/sensitive-requests` route; `sensitive-callback-bus.ts` has no
+ * production importer, and the three connector-facing event names below are
+ * translated from the service's events by this file. What the bus proves is
+ * that the service emits the right lifecycle events at the right moments and
+ * that a listener can consume them — not that a listener is subscribed in
+ * production today.
+ *
+ * The security invariants asserted here are unaffected by that: token
+ * single-use, tamper rejection, expiry, `requireAuthenticatedLink`, and
+ * redaction all live in `SensitiveRequestsService` itself and are exercised
+ * against the real service.
  *
  * The ONLY stubs are the outbound connector send (we assert the link the agent
  * would DM, not a live Telegram/Discord API call) and Postgres. Every security

--- a/packages/cloud/shared/src/lib/services/sensitive-requests.ts
+++ b/packages/cloud/shared/src/lib/services/sensitive-requests.ts
@@ -142,6 +142,22 @@ export interface SensitiveRequestsServiceDeps {
     fields: Record<string, string>;
     actor?: SensitiveRequestActor;
   }) => Promise<void>;
+  /**
+   * Optional sink for lifecycle events (`emit` below). **The exported
+   * `sensitiveRequestsService` singleton is constructed with no deps, so this
+   * is `undefined` in production and `emit` is a silent no-op** — every
+   * `/v1/sensitive-requests` route uses that singleton, so no
+   * sensitive-request event is dispatched by anything we ship today.
+   *
+   * The only caller that supplies one is
+   * `sensitive-request-hosted-page-e2e.test.ts`, which wires
+   * `createSensitiveCallbackBus` here itself; that bus module
+   * (`sensitive-callback-bus.ts`) has no production importer at all.
+   *
+   * Callers who need to observe the lifecycle must poll the request through
+   * the API. If a dispatcher was meant to be wired here, that wiring is
+   * missing rather than disabled — see the note on `emit`.
+   */
   dispatchEvent?: (params: {
     event: SensitiveRequestEvent;
     request: SensitiveRequestPublicView;
@@ -756,6 +772,12 @@ export class SensitiveRequestsService {
     });
   }
 
+  /**
+   * Fan a lifecycle event out to `dispatchEvent`. Returns immediately when no
+   * dispatcher was injected — which is the case for the exported singleton,
+   * and therefore for every route. Kept optional deliberately: the service
+   * must not require an event sink to mint, authorize or fulfil a request.
+   */
   private async emit(event: SensitiveRequestEvent, request: DbSensitiveRequest): Promise<void> {
     if (!this.dispatchEvent) return;
     await this.dispatchEvent({


### PR DESCRIPTION
# What

`sensitive-requests.ts:768` exports the service the routes actually use:

```ts
export const sensitiveRequestsService = new SensitiveRequestsService();
```

No deps. So `dispatchEvent` is `undefined`, and `emit` is:

```ts
private async emit(event, request) {
  if (!this.dispatchEvent) return;   // ← always, for the singleton
```

All five `/v1/sensitive-requests` routes (`create`, `submit`, `cancel`, `expire`, `[id]`) import that singleton, so **no sensitive-request lifecycle event is dispatched by anything shipped today**. `sensitive-callback-bus.ts` — 130 lines implementing `publish`/`subscribe`/`waitFor` for those events — has no production importer, and no production code anywhere emits or even names `SensitiveRequestSubmitted`, `SensitiveRequestExpired`, or `SensitiveRequestCanceled`.

# Why it's worth writing down

The E2E test header reads as though it does. Under *"This drives the REAL code, stitched together the way production wires it"* it lists:

> the REAL `createSensitiveCallbackBus` wired as the service's `dispatchEvent`, so the agent's callback listener observes the actual fulfillment event — **this is how the agent "sees the result land back"**

The bus is wired by the test itself, and the three connector-facing event names are translated from the service's own events by that same file. On the path the header calls *"the most security-sensitive path we ship"*, that sentence is the kind of thing someone stops reading at.

**To be clear about scope: the security invariants that file asserts are unaffected.** Token single-use, tamper rejection, expiry, `requireAuthenticatedLink` blocking anonymous submits, and redaction all live in `SensitiveRequestsService` and are genuinely exercised against the real service. What the bus proves is that the service emits the right lifecycle events at the right moments and that a listener *can* consume them — not that one is subscribed in production. That distinction is the whole change.

I'm treating this as a correctness/coverage gap rather than a vulnerability, which is why it's here and not a private report: the missing piece is a workflow notification, with no confidentiality, integrity, or authorization impact, and nothing above describes an exploit.

# The change

Documentation only, +40/−3 across two files:

1. On `dispatchEvent` and `emit`: the exported singleton has no dispatcher, so dispatch is a no-op on every route; the bus has no production importer; callers needing the lifecycle must poll the API.
2. In the E2E header: keep the bus in the list, then say plainly that the wiring is assembled by the test, and that the security assertions don't depend on it.

# What I deliberately did not do

- **Not wired a dispatcher.** I don't know the intended production target — the connector dispatch registry, a queue, something else — and wiring an event sink into a security path on speculation is exactly the change I'd ask another contributor not to make. If a dispatcher was meant to be here, this is a gap to close and the target is yours to name.
- **Not deleted `sensitive-callback-bus.ts`.** Unlike the orphans in #30504, this one is plausibly load-bearing for wiring that hasn't landed yet, and the E2E test is a real consumer of its behavior. Removing it would presume the answer to the question above.
- **Not added a test pinning the current no-op.** Pinning behavior I suspect is a gap would make the gap harder to close, not easier.

# How I found it

A file-level sweep for modules imported *only* by tests across `packages/cloud` — 73 hits, which self-validates by rediscovering both files from #30504. Most are test-only by design (stubs, fixtures, `push-schema-for-tests`, admin CLI scripts invoked from `package.json` rather than imported); 25 sit on production paths, and I verified this one by hand rather than trusting the sweep.

# Verification

```
bun run --cwd packages/cloud/shared typecheck   -> exit 0, 0 error TS
bunx @biomejs/biome check <both files>          -> clean
bun test sensitive-request-hosted-page-e2e.test.ts sensitive-requests.test.ts
                                                -> 13 pass / 3 skip / 0 fail
```

The 3 skips are the pre-existing live-harness cases that need real deployed cloud credentials.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NRXFJ4G5Z47RDTQZP6E7FB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T08:35:12.068Z","completed_at":"2026-09-04T08:36:49.135Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T08:35:12.968Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"030f6da87de38bd174c8e4958b1d301055ecc4b14174d2498340e7535538c74e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b9d8991f-f1f1-48dd-b1d3-8c3d61f423c4","object_id":"sha256:030f6da87de38bd174c8e4958b1d301055ecc4b14174d2498340e7535538c74e","sha256":"030f6da87de38bd174c8e4958b1d301055ecc4b14174d2498340e7535538c74e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"16i8POHCzPTwnSXiBNurHCNEjYQWPnSDZNatOnVZp4XfEDftQO3309AUF6hOHFpQ0SWwYZQje5KosYKxzdVnAA"}} -->
