### PR TITLE
fix(cloud): refuse an ambiguous restore-coordinator flag instead of reading it as off

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-backup-restore-coordinator-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-restore-coordinator-runtime.test.ts
@@ -29,6 +29,39 @@ describe("readAgentBackupRestoreCoordinatorConfig", () => {
     ).toThrow("explicit restore only");
   });
 
+  // Both refusals above are written with "1". Every value that is NOT "1" used
+  // to read as unset, so both of them vanished for a flag that plainly means
+  // ON — the operator asked for failover and got a silently-off coordinator.
+  test('refuses a flag value that means on but is not "1"', () => {
+    for (const value of ["true", "TRUE", "yes", "on", "2", " 1"]) {
+      expect(() =>
+        readAgentBackupRestoreCoordinatorConfig({
+          AGENT_BACKUP_RESTORE_FAILOVER_ENABLED: value,
+        }),
+      ).toThrow('AGENT_BACKUP_RESTORE_FAILOVER_ENABLED must be "1" or "0"');
+      expect(() =>
+        readAgentBackupRestoreCoordinatorConfig({
+          AGENT_BACKUP_RESTORE_COORDINATOR_ENABLED: value,
+          AGENT_BACKUP_RESTORE_WORKER_ID: "worker-a",
+        }),
+      ).toThrow('AGENT_BACKUP_RESTORE_COORDINATOR_ENABLED must be "1" or "0"');
+    }
+  });
+
+  // The refusal must not swallow an unambiguous "off": rejecting "0" would
+  // turn a deployment that means disabled into a boot failure.
+  test('accepts "0" and empty as off without reading a tunable', () => {
+    for (const value of ["0", ""]) {
+      expect(
+        readAgentBackupRestoreCoordinatorConfig({
+          AGENT_BACKUP_RESTORE_COORDINATOR_ENABLED: value,
+          AGENT_BACKUP_RESTORE_FAILOVER_ENABLED: value,
+          AGENT_BACKUP_RESTORE_CLAIM_MS: "not-a-number",
+        }),
+      ).toEqual({ enabled: false });
+    }
+  });
+
   test("requires an exact worker id once enabled", () => {
     for (const workerId of [undefined, "", " worker-a", "worker-a "]) {
       expect(() =>

--- a/packages/cloud/shared/src/lib/services/agent-backup-restore-coordinator-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-restore-coordinator-runtime.ts
@@ -25,6 +25,32 @@ export type AgentBackupRestoreCoordinatorConfig =
       automaticFailoverEnabled: false;
     };
 
+/**
+ * Flags are parsed as strictly as the integer tunables below: `"1"` is on,
+ * unset / empty / `"0"` is off, and any OTHER value is a configuration error
+ * rather than a silent off.
+ *
+ * A bare `=== "1"` test defeats both guarantees in this file's header, because
+ * every value that is not `"1"` reads as off — including values that plainly
+ * mean on. `AGENT_BACKUP_RESTORE_FAILOVER_ENABLED=true` was neither refused
+ * for missing its parent nor rejected as unimplemented; an operator asking for
+ * failover got a running coordinator with failover silently off.
+ * `AGENT_BACKUP_RESTORE_COORDINATOR_ENABLED=true` left the coordinator
+ * disabled while the deployment that set it believed otherwise.
+ *
+ * `"0"` is accepted as off on purpose: it is unambiguous intent, and rejecting
+ * it would turn a deployment that means "off" into a boot failure — trading
+ * this bug for a worse one. Only genuinely ambiguous values are refused.
+ */
+function readStrictFlag(env: NodeJS.ProcessEnv, name: string): boolean {
+  const raw = env[name];
+  if (raw === undefined || raw === "" || raw === "0") return false;
+  if (raw !== "1") {
+    throw new Error(`${name} must be "1" or "0" when set, or left unset`);
+  }
+  return true;
+}
+
 function readBoundedInteger(params: {
   env: NodeJS.ProcessEnv;
   name: string;
@@ -47,8 +73,8 @@ function readBoundedInteger(params: {
 export function readAgentBackupRestoreCoordinatorConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): AgentBackupRestoreCoordinatorConfig {
-  const failoverEnabled = env.AGENT_BACKUP_RESTORE_FAILOVER_ENABLED === "1";
-  if (env.AGENT_BACKUP_RESTORE_COORDINATOR_ENABLED !== "1") {
+  const failoverEnabled = readStrictFlag(env, "AGENT_BACKUP_RESTORE_FAILOVER_ENABLED");
+  if (!readStrictFlag(env, "AGENT_BACKUP_RESTORE_COORDINATOR_ENABLED")) {
     if (failoverEnabled) {
       throw new Error(
         "AGENT_BACKUP_RESTORE_FAILOVER_ENABLED requires AGENT_BACKUP_RESTORE_COORDINATOR_ENABLED=1",


### PR DESCRIPTION
# What

`agent-backup-restore-coordinator-runtime.ts` opens with a promise:

> Reading configuration while disabled is itself a hazard… a dependent flag set without its parent is an **error rather than a no-op**.

Both flags were then tested with `=== "1"`, so every value that is not `"1"` read as unset — including values that plainly mean *on*. I probed the real exported function before writing anything:

| environment | before | documented intent |
| --- | --- | --- |
| `FAILOVER_ENABLED=1` alone | throws "requires …COORDINATOR_ENABLED=1" | ✅ |
| `FAILOVER_ENABLED=true` alone | **`{enabled:false}`** | should refuse |
| `COORDINATOR_ENABLED=1` + `FAILOVER_ENABLED=1` | throws "not implemented" | ✅ |
| `COORDINATOR_ENABLED=1` + `FAILOVER_ENABLED=true` | **coordinator running, `automaticFailoverEnabled:false`** | should refuse |
| `COORDINATOR_ENABLED=true` | **`{enabled:false}`** | should refuse |

The middle row is the one that bothers me: an operator asks for a failover feature this file says is **not implemented**, and gets a running coordinator with failover silently off instead of the loud refusal the code was written to give.

Both guarantees in the header are defeated by a single-character difference in an env var, and the file is inconsistent with itself about it — `readBoundedInteger`, ten lines away, rejects `"60_000"` and `"0"` loudly rather than falling back to a default.

# The change

Parse the flags as strictly as the integer tunables beside them:

```ts
function readStrictFlag(env: NodeJS.ProcessEnv, name: string): boolean {
  const raw = env[name];
  if (raw === undefined || raw === "" || raw === "0") return false;
  if (raw !== "1") {
    throw new Error(`${name} must be "1" or "0" when set, or left unset`);
  }
  return true;
}
```

**`"0"` is accepted as off on purpose.** My first version rejected everything but `"1"` and unset, which made `COORDINATOR_ENABLED=0` throw — trading this bug for a worse one, since `0` is unambiguous intent and refusing it turns a deployment that means "off" into a boot failure. Only genuinely ambiguous values are refused now, and the comment says why so nobody tightens it later.

Both existing refusal tests use `"1"` and are untouched: behavior for well-formed values is identical.

# Mutation results

Each new case pins one direction, and neither is redundant:

| mutation | result |
| --- | --- |
| revert to the lenient `raw === "1"` | **6 pass / 1 fail** — only `refuses a flag value that means on but is not "1"` |
| re-apply my over-strict first version (reject `"0"` too) | **6 pass / 1 fail** — only `accepts "0" and empty as off` |
| unmodified | 7 pass / 0 fail |

# Blast radius

A repo-wide grep finds **no** workflow, env template, script, or config that sets either variable, so no existing deployment configuration changes behavior. The coordinator is off by default and its consumer isn't wired yet, which makes this the cheap moment to fix the parse rather than after something depends on it.

# Verification

```
bun run --cwd packages/cloud/shared typecheck   -> exit 0, 0 error TS
bunx @biomejs/biome check <both files>          -> clean
bun test agent-backup-restore-coordinator-runtime.test.ts
                                                -> 7 pass / 0 fail  (was 5)
```

# How I got here, and what I deliberately left alone

A file-level sweep for modules imported only by tests (the one that produced #30504 and #30505) flagged this module along with the other three `agent-backup-restore-v3-*` files, `shared-memory-dedicated-export.ts`, and `r2-storage-adapter.ts`.

**Those are not orphans and I'm not proposing anything about them.** Their docstrings describe a deliberately staged, disabled-first feature — *"owns neither copy selection nor failover"*, *"stops after a digest-pinned Docker container is created in the stopped, networkless quarantine"*, *"an off-by-default feature"*. That's ~3,200 lines of work-in-progress that is correctly unwired, and it reads as intentional. The only thing I'm changing is a parsing bug inside the gate itself.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NSDE9ZF20654YA1RKXK9K5","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T08:43:55.071Z","completed_at":"2026-09-04T08:46:20.268Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T08:43:55.840Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e01fb1a7499c5fa6bf32778d3d934c189703cb64e15fc1cfbd1ef5dae1e78312","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5f3d64c8-d7d1-4903-ab9d-ffff3e9685da","object_id":"sha256:e01fb1a7499c5fa6bf32778d3d934c189703cb64e15fc1cfbd1ef5dae1e78312","sha256":"e01fb1a7499c5fa6bf32778d3d934c189703cb64e15fc1cfbd1ef5dae1e78312"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"hszc29__BSc_AoRJP8wFOroRMJ8GPCrc6RPHTHKRS9SPQGv7E9LS4dAIEwMwzSpc21CvdHRVI7ccC21o2xl4Aw"}} -->
