### PR TITLE
fix(cloud): stop service-cache shadowing the canonical CacheKeys with unversioned keys

### DIFF
--- a/packages/cloud/shared/src/lib/cache/service-cache.ts
+++ b/packages/cloud/shared/src/lib/cache/service-cache.ts
@@ -1,56 +1,17 @@
 /**
  * Service-level caching utilities.
  * Provides consistent caching patterns for frequently accessed data.
+ *
+ * Cache keys and TTLs live in `./keys` (`CacheKeys` / `CacheTTL`) and are NOT
+ * redefined here. This module used to export its own `CacheKeys`, which
+ * shadowed that canonical one from the same directory while building
+ * unversioned keys (`org:<id>:credits` against the canonical
+ * `org:<id>:credits:v1`) — so an import that picked the wrong `CacheKeys`
+ * wrote entries `CacheInvalidation` would never evict.
  */
 
 import { logger } from "../utils/logger";
 import { cache } from "./client";
-
-/**
- * Cache TTL configurations for different data types (in seconds).
- */
-export const CACHE_TTL = {
-  USER_PROFILE: 3600, // 1 hour
-  CHARACTER_LIST: 900, // 15 minutes
-  MODEL_PRICING: 86400, // 1 day
-  ORGANIZATION_SETTINGS: 3600, // 1 hour
-  API_KEY: 1800, // 30 minutes
-  CREDIT_BALANCE: 300, // 5 minutes
-  CONTAINER_STATUS: 60, // 1 minute
-  AGENT_STATUS: 120, // 2 minutes
-  STATISTICS: 300, // 5 minutes
-} as const;
-
-/**
- * Stale time configurations (time before background refresh) (in seconds).
- */
-export const CACHE_STALE_TIME = {
-  USER_PROFILE: 1800, // 30 minutes
-  CHARACTER_LIST: 450, // 7.5 minutes
-  MODEL_PRICING: 43200, // 12 hours
-  ORGANIZATION_SETTINGS: 1800, // 30 minutes
-  API_KEY: 900, // 15 minutes
-  CREDIT_BALANCE: 150, // 2.5 minutes
-  CONTAINER_STATUS: 30, // 30 seconds
-  AGENT_STATUS: 60, // 1 minute
-  STATISTICS: 150, // 2.5 minutes
-} as const;
-
-/**
- * Cache key builders for consistent key naming.
- */
-export const CacheKeys = {
-  userProfile: (userId: string) => `user:${userId}:profile`,
-  organizationSettings: (orgId: string) => `org:${orgId}:settings`,
-  characterList: (orgId: string) => `org:${orgId}:characters`,
-  character: (characterId: string) => `character:${characterId}`,
-  modelPricing: (provider?: string) => (provider ? `pricing:${provider}` : "pricing:all"),
-  apiKey: (keyId: string) => `apikey:${keyId}`,
-  creditBalance: (orgId: string) => `org:${orgId}:credits`,
-  containerStatus: (containerId: string) => `container:${containerId}:status`,
-  agentStatus: (agentId: string) => `agent:${agentId}:status`,
-  statistics: (orgId: string, type: string) => `stats:${orgId}:${type}`,
-} as const;
 
 /**
  * Generic caching wrapper for service methods.


### PR DESCRIPTION
# What

`packages/cloud/shared/src/lib/cache/` contained **two** `export const CacheKeys` — the canonical one in `keys.ts`, and a second in `service-cache.ts`. Same name, same directory, different keys:

| concept | `keys.ts` (canonical, 63 importers) | `service-cache.ts` (1 importer — its own test) |
| --- | --- | --- |
| org credits | `org:<id>:credits:v1` | `org:<id>:credits` |
| org settings/data | `org:<id>:data:v1` | `org:<id>:settings` |
| TTL for credits | `CacheTTL.org.credits = 60` | `CACHE_TTL.CREDIT_BALANCE = 300` |

The canonical builders are versioned; these were not. `CacheInvalidation.onCreditMutation` deletes `CacheKeys.org.credits(orgId)` — the `:v1` key — so anything that wrote through the other `CacheKeys` would leave an entry **no invalidation path ever evicts**, with no version suffix to roll forward with either.

Nothing was reaching for it yet, which is the good moment to remove it. Two same-named exports in one directory is a wrong-import away from a silent stale-cache bug, and autocomplete does not distinguish them.

# The change

Removed `CacheKeys`, `CACHE_TTL`, and `CACHE_STALE_TIME` from `service-cache.ts` (−46 lines) and recorded in the module header that keys and TTLs live in `./keys` and are deliberately not redefined there.

Confirming they were unreferenced:

- the module's only importer is `service-cache.invalidate.test.ts`, which imports exactly `CacheInvalidationError`, `invalidateCache`, `invalidateCachePattern`, `invalidateCacheBatch`
- `CACHE_STALE_TIME` — zero references repo-wide
- the `CACHE_TTL` matches elsewhere are unrelated private constants in `connection-cache.ts` and `credit-packs-cache.ts`, not imports of this export

After the change, `grep "export const CacheKeys"` across `packages/cloud` returns exactly one hit.

# What I left alone, and why

**The `#13417` fail-closed invalidation helpers and their test are untouched.** `invalidateCache` / `invalidateCachePattern` / `invalidateCacheBatch` are deliberate security hardening — `delConfirmed`/`delPatternConfirmed`, `error-policy:J1` annotations, a docstring explaining that a swallowed delete keeps a revoked API key serving until TTL. This module surfaced in a sweep for modules imported only by tests, and the naive reading of that signal would have been to delete the file; that would have thrown away live-intent security work.

I also left `withCache`, `withStaleWhileRevalidate`, and `withBatchCache`. They are unreferenced too, but they shadow nothing, so removing them would widen the diff without addressing a hazard. If you'd rather this PR take the whole unused surface, say so and I'll extend it.

# Verification

```
bun run --cwd packages/cloud/shared typecheck   -> exit 0, 0 error TS
bunx @biomejs/biome check service-cache.ts      -> clean
bun test src/lib/cache/                         -> 70 pass / 0 fail (13 files)
  same directory on develop                     -> 70 pass / 0 fail (13 files)
```

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NTJJB81ZKQ14Y5KRSD9WSC","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T09:04:11.625Z","completed_at":"2026-09-04T09:05:47.194Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T09:04:12.437Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"bb1ebfd5e1edacff76fe6035bdad0fb386163badc8f0124cbc94817b8807153d","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"be44f30e-80c5-4d37-af5a-1ee6b06e8171","object_id":"sha256:bb1ebfd5e1edacff76fe6035bdad0fb386163badc8f0124cbc94817b8807153d","sha256":"bb1ebfd5e1edacff76fe6035bdad0fb386163badc8f0124cbc94817b8807153d"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"E-AfZf-u2wR7qNMo5JVgEiU5oAI2PdrfDWtUT-REpRyOaBe4Wbe2AZkg0IVMFSGFL9_NpQM9B0lREZ20TTYJAg"}} -->
