### PR TITLE
test(registry): gate the committed first-party artifacts against generator drift

### DIFF
--- a/packages/registry/src/first-party/generate-drift.test.ts
+++ b/packages/registry/src/first-party/generate-drift.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Drift gate for the committed first-party registry artifacts.
+ *
+ * `generate:first-party:check` has always been able to detect this, but its
+ * doc comment calls it "the CI drift gate" and nothing ran it — the script was
+ * referenced only by its own package.json definition. Two of the five
+ * artifacts had no other guard: a stale `generated.json` (the canonical
+ * first-party registry) or `curated-app-definitions.json` could merge with a
+ * green build. The three derived maps were covered only incidentally, by
+ * consistency assertions in other packages.
+ *
+ * This runs the shipped generator and compares its bytes to what is committed,
+ * so the whole set is gated from inside the registry package's own suite.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename } from "node:path";
+import { describe, expect, it } from "vitest";
+import { firstPartyArtifacts } from "./generate.ts";
+
+const { artifacts } = firstPartyArtifacts();
+
+describe("first-party generated artifacts", () => {
+  it("emits all five committed artifacts", () => {
+    expect(artifacts.map(([path]) => basename(path))).toEqual([
+      "generated.json",
+      "curated-app-definitions.json",
+      "channel-plugin-map.json",
+      "provider-plugin-map.json",
+      "short-id-plugin-map.json",
+    ]);
+  });
+
+  it.each(
+    artifacts.map(([path, expected]) => [basename(path), path, expected]),
+  )("%s is byte-identical to a fresh generation", (name, path, expected) => {
+    expect(
+      existsSync(path) && statSync(path).isFile(),
+      `${name} is missing`,
+    ).toBe(true);
+    // Compared as bytes, not parsed JSON: the committed files must also
+    // satisfy `format:check`, which key order and array wrapping affect.
+    expect(
+      readFileSync(path, "utf-8"),
+      `${name} is stale — run \`bun run --cwd packages/registry generate:first-party\` and commit the result`,
+    ).toBe(expected);
+  });
+});

--- a/packages/registry/src/first-party/generate.ts
+++ b/packages/registry/src/first-party/generate.ts
@@ -266,16 +266,34 @@ export function generateFirstPartyRegistry(): {
   };
 }
 
+/**
+ * Every committed artifact paired with the exact bytes the generator would
+ * write for it right now, biome-formatted so the comparison matches what
+ * `format:check` expects. `main` and the drift test both consume this, so the
+ * gate and the generator cannot disagree about what "up to date" means.
+ */
+export function firstPartyArtifacts(): {
+  artifacts: [string, string][];
+  entryCount: number;
+  curatedCount: number;
+} {
+  const next = generateFirstPartyRegistry();
+  return {
+    artifacts: [
+      [GENERATED_PATH, biomeFormatJson(next.full, GENERATED_PATH)],
+      [CURATED_DEFS_PATH, biomeFormatJson(next.curated, CURATED_DEFS_PATH)],
+      [CHANNEL_MAP_PATH, biomeFormatJson(next.channels, CHANNEL_MAP_PATH)],
+      [PROVIDER_MAP_PATH, biomeFormatJson(next.providers, PROVIDER_MAP_PATH)],
+      [SHORTID_MAP_PATH, biomeFormatJson(next.shortIds, SHORTID_MAP_PATH)],
+    ],
+    entryCount: JSON.parse(next.full).entries.length,
+    curatedCount: JSON.parse(next.curated).length,
+  };
+}
+
 function main(): void {
   const check = process.argv.includes("--check");
-  const next = generateFirstPartyRegistry();
-  const artifacts: [string, string][] = [
-    [GENERATED_PATH, biomeFormatJson(next.full, GENERATED_PATH)],
-    [CURATED_DEFS_PATH, biomeFormatJson(next.curated, CURATED_DEFS_PATH)],
-    [CHANNEL_MAP_PATH, biomeFormatJson(next.channels, CHANNEL_MAP_PATH)],
-    [PROVIDER_MAP_PATH, biomeFormatJson(next.providers, PROVIDER_MAP_PATH)],
-    [SHORTID_MAP_PATH, biomeFormatJson(next.shortIds, SHORTID_MAP_PATH)],
-  ];
+  const { artifacts, entryCount, curatedCount } = firstPartyArtifacts();
   if (check) {
     for (const [path, expected] of artifacts) {
       const current =
@@ -293,10 +311,8 @@ function main(): void {
     return;
   }
   for (const [path, content] of artifacts) writeFileSync(path, content);
-  const count = JSON.parse(next.full).entries.length;
-  const curatedCount = JSON.parse(next.curated).length;
   console.log(
-    `[registry/generate] wrote ${count} entries + ${curatedCount} curated-app definitions`,
+    `[registry/generate] wrote ${entryCount} entries + ${curatedCount} curated-app definitions`,
   );
 }
 


### PR DESCRIPTION
# What

`packages/registry` ships a drift gate that nothing runs.

`generate:first-party:check` re-generates the five committed first-party artifacts and exits 1 on any difference. Its own doc comment calls it the CI drift gate:

```
 *   bun run --cwd packages/registry generate:first-party --check   # CI drift gate
```

Its only occurrence anywhere in the repo is its own definition in `packages/registry/package.json:49`. No workflow, task, or test invokes it.

That matters because **two of the five artifacts have no other guard at all**. I measured it rather than assuming it — mutating each artifact in turn and running every test that reads one:

| artifact | caught by an existing baseline-green test? |
|---|---|
| `generated.json` (204 KB, the canonical first-party registry) | **no** |
| `curated-app-definitions.json` | **no** |
| `channel-plugin-map.json` | yes — `packages/app-core/…/channel-plugin-map.test.ts` |
| `provider-plugin-map.json` | yes — the registry suite |
| `short-id-plugin-map.json` | yes — the registry suite |

So a stale `generated.json` merges with a green build today.

Two notes on how that table was built, because my first pass got it wrong:

- My first mutation deleted a channel from `channel-plugin-map.json`. The registry suite stayed 53/53 green and `--check` exited 1, which looked conclusive — but the app-core test *does* catch it. I redid this as a per-artifact matrix, and switched from deletions to **value** edits, since a deletion can trip an unrelated sortedness/non-emptiness assertion and overstate coverage.
- `packages/app-core/src/runtime/eliza.test.ts` ("no tests") and `plugins/plugin-google-genai/__tests__/config.test.ts` (1 fail) are **already red on `develop`**. They "fail" under every mutation, so I discounted them entirely; the table counts only tests that are green at baseline.

`generate.test.ts` doesn't close this either — it unit-tests the collector functions against synthetic entry lists and never compares a committed artifact to a regeneration.

# The change

One extraction plus one test.

`main()` built the expected bytes inline, so a test had to either duplicate that logic (including the `biomeFormatJson` pass, which is load-bearing — see the comment at `generate.ts:40`) or shell out. Instead `firstPartyArtifacts()` is now exported and `main()` consumes it, so the generator, the `--check` gate, and the new test all compute "what should be committed" through one code path and cannot disagree.

`generate-drift.test.ts` then compares each committed artifact to a fresh generation, **as bytes** — not parsed JSON, since the committed files must also satisfy `format:check`, which key order and array wrapping affect.

# The gate is not vacuous

Perturbing one value in each artifact, with the new test in place:

| mutated artifact | registry suite |
|---|---|
| `generated.json` | 1 failed / 58 passed |
| `curated-app-definitions.json` | 1 failed / 58 passed |
| `channel-plugin-map.json` | 1 failed / 58 passed |
| `provider-plugin-map.json` | 2 failed / 57 passed |
| `short-id-plugin-map.json` | 2 failed / 57 passed |
| *(clean tree)* | **59 passed** |

Every artifact is now caught; the two rows with 2 failures are the ones that also trip their own existing tests.

# Verification

- `bun run --cwd packages/registry test` → **59 passed** (was 53; +1 manifest assertion, +5 per-artifact).
- `bun run --cwd packages/registry typecheck` → exit 0, 0 `error TS`.
- `bunx @biomejs/biome check` on both files → clean.
- `bun run --cwd packages/registry generate:first-party` (the **write** path, not `--check`) → leaves the tree unchanged and still prints `wrote 84 entries + 4 curated-app definitions`, so the extraction didn't disturb it.
- `generate:first-party:check` still passes on a clean tree.

# Scope

I left `generate:first-party:check` in place — it's the right thing to run by hand after editing the registry, and it now shares its comparison logic with the test rather than duplicating it. Wiring it into a workflow as well would be redundant with this test, so I didn't.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NXFS53BJJPR1GFZP4KXPKR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T09:55:06.019Z","completed_at":"2026-09-04T09:57:39.390Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T09:55:07.214Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"eb688767215d1b3e20bcfece10deadd398ede4131659091d06b11b76a9a625b2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"370acef8-7188-4306-baa1-2ada29d916b6","object_id":"sha256:eb688767215d1b3e20bcfece10deadd398ede4131659091d06b11b76a9a625b2","sha256":"eb688767215d1b3e20bcfece10deadd398ede4131659091d06b11b76a9a625b2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"bVkNO28R6bbfkZRZHwBpN3eT2-cQxQ_ykKRRzGgpxBNTOJmG8mjc1r46cmsMoFPqk_oRVnhBFH1ZqJShr_nTCQ"}} -->
