### PR TITLE
fix(ui): migrate re-export declarations and make the migrate checks fail closed

### DIFF
--- a/packages/app-core/src/browser.ts
+++ b/packages/app-core/src/browser.ts
@@ -16,6 +16,7 @@ export {
   registerOverlayApp,
   resolveAppBranding,
 } from "@elizaos/shared";
+export { Spinner, StatusBadge } from "@elizaos/ui";
 export {
   type AppRunSummary,
   type AppSessionJsonValue,
@@ -23,6 +24,7 @@ export {
 } from "@elizaos/ui/api";
 export * from "@elizaos/ui/browser";
 export { ErrorBoundary } from "@elizaos/ui/browser";
+export { Button } from "@elizaos/ui/button";
 export {
   SurfaceCard,
   SurfaceEmptyState,
@@ -38,10 +40,7 @@ export {
   toneForViewerAttachment,
 } from "@elizaos/ui/components/apps/extensions/surface.helpers";
 export { PagePanel } from "@elizaos/ui/components/composites/page-panel";
-export { Button } from "@elizaos/ui/components/ui/button";
-export { Input } from "@elizaos/ui/components/ui/input";
-export { Spinner } from "@elizaos/ui/components/ui/spinner";
-export { StatusBadge } from "@elizaos/ui/components/ui/status-badge";
+export { Input } from "@elizaos/ui/input";
 export {
   type IosRuntimeConfig,
   resolveIosRuntimeConfig,

--- a/packages/app-core/src/ui-compat.ts
+++ b/packages/app-core/src/ui-compat.ts
@@ -23,7 +23,9 @@ export type {
   AppRunSummary,
   AppSessionJsonValue,
 } from "@elizaos/shared/contracts/apps";
+export { Spinner, StatusBadge } from "@elizaos/ui";
 export { client } from "@elizaos/ui/api";
+export { Button } from "@elizaos/ui/button";
 export type { SurfaceTone } from "@elizaos/ui/components/apps/extensions/surface";
 export {
   SurfaceCard,
@@ -39,10 +41,7 @@ export {
   toneForViewerAttachment,
 } from "@elizaos/ui/components/apps/extensions/surface.helpers";
 export { PagePanel } from "@elizaos/ui/components/composites/page-panel";
-export { Button } from "@elizaos/ui/components/ui/button";
-export { Input } from "@elizaos/ui/components/ui/input";
-export { Spinner } from "@elizaos/ui/components/ui/spinner";
-export { StatusBadge } from "@elizaos/ui/components/ui/status-badge";
+export { Input } from "@elizaos/ui/input";
 // app-store only pulls React + an erased type (same weight as useApp), so it
 // stays light enough for the Node API process — re-export the selector hooks so
 // app plugins can subscribe to AppContext slices instead of the whole value.

--- a/packages/ui/scripts/migrate-canonical-imports.mjs
+++ b/packages/ui/scripts/migrate-canonical-imports.mjs
@@ -60,15 +60,23 @@ export function migrateImports(file, source) {
   );
   const replacements = [];
   for (const statement of sourceFile.statements) {
-    if (!ts.isImportDeclaration(statement)) continue;
-    const moduleName = statement.moduleSpecifier.text;
+    // `export { X } from "…"` carries the same module specifier as an import
+    // and was previously invisible here, so a re-export could keep a legacy
+    // deep specifier alive through a migration that reported nothing to do.
+    const specifier = ts.isImportDeclaration(statement)
+      ? statement.moduleSpecifier
+      : ts.isExportDeclaration(statement)
+        ? statement.moduleSpecifier
+        : undefined;
+    if (!specifier || !ts.isStringLiteral(specifier)) continue;
+    const moduleName = specifier.text;
     const pluginPublicSubpath =
       file.startsWith(path.join(repoRoot, "plugins")) &&
       /^@elizaos\/ui\/(button|card|input|dropdown-menu)$/.test(moduleName);
     if (!moduleName.startsWith(prefix) && !pluginPublicSubpath) continue;
     replacements.push({
-      end: statement.moduleSpecifier.getEnd() - 1,
-      start: statement.moduleSpecifier.getStart() + 1,
+      end: specifier.getEnd() - 1,
+      start: specifier.getStart() + 1,
       value: destination(moduleName, file),
     });
   }
@@ -131,4 +139,8 @@ if (
   process.stdout.write(
     `${write ? "Migrated" : "Would migrate"} ${changed.length} files${rebuildFromHead ? " from HEAD" : ""}\n${changed.join("\n")}\n`,
   );
+  // `:check` (no --write) is the gate half of this script: exit non-zero when
+  // work is pending so it can actually fail a build, matching format:check and
+  // generate:first-party:check. Writing runs still report and exit 0.
+  if (!write && changed.length > 0) process.exitCode = 1;
 }

--- a/packages/ui/scripts/migrate-canonical-imports.test.mjs
+++ b/packages/ui/scripts/migrate-canonical-imports.test.mjs
@@ -36,6 +36,30 @@ const compatibilityModules = {
   );
 });
 
+test("the migration rewrites re-export declarations, not just imports", () => {
+  const source = [
+    'export { Button } from "@elizaos/ui/components/ui/button";',
+    'export { CompactCardSkeleton } from "@elizaos/ui/components/ui/skeleton-layouts";',
+    'export * from "@elizaos/ui/components/ui/spinner";',
+    "",
+  ].join("\n");
+
+  assert.equal(
+    migrateImports("fixture.ts", source),
+    [
+      'export { Button } from "@elizaos/ui/button";',
+      'export { CompactCardSkeleton } from "@elizaos/ui";',
+      'export * from "@elizaos/ui";',
+      "",
+    ].join("\n"),
+  );
+});
+
+test("the migration leaves export declarations without a module specifier alone", () => {
+  const source = "const Button = 1;\nexport { Button };\n";
+  assert.equal(migrateImports("fixture.ts", source), source);
+});
+
 test("the migration preserves dedicated public atom exports", () => {
   assert.equal(
     destination("@elizaos/ui/components/ui/button"),

--- a/packages/ui/scripts/migrate-raw-controls.mjs
+++ b/packages/ui/scripts/migrate-raw-controls.mjs
@@ -141,4 +141,8 @@ if (
   process.stdout.write(
     `${write ? "Migrated" : "Would migrate"} ${changed.length} files\n${changed.join("\n")}\n`,
   );
+  // `:check` (no --write) is the gate half of this script: exit non-zero when
+  // work is pending so it can actually fail a build, matching format:check and
+  // generate:first-party:check. Writing runs still report and exit 0.
+  if (!write && changed.length > 0) process.exitCode = 1;
 }

--- a/packages/ui/scripts/migrate-raw-tables.mjs
+++ b/packages/ui/scripts/migrate-raw-tables.mjs
@@ -132,4 +132,8 @@ if (
   process.stdout.write(
     `${write ? "Migrated" : "Would migrate"} ${changed.length} files${rebuildFromHead ? " from HEAD" : ""}\n${changed.join("\n")}\n`,
   );
+  // `:check` (no --write) is the gate half of this script: exit non-zero when
+  // work is pending so it can actually fail a build, matching format:check and
+  // generate:first-party:check. Writing runs still report and exit 0.
+  if (!write && changed.length > 0) process.exitCode = 1;
 }

--- a/plugins/plugin-notes/src/views/__e2e__/ui-shim.ts
+++ b/plugins/plugin-notes/src/views/__e2e__/ui-shim.ts
@@ -1,3 +1,2 @@
 /** Focused barrel exports used by the Notes presentation in this preview. */
-export { Button } from "@elizaos/ui/button";
-export { CompactCardSkeleton } from "@elizaos/ui/components/ui/skeleton-layouts";
+export { Button, CompactCardSkeleton } from "@elizaos/ui";

--- a/plugins/plugin-notes/src/views/__e2e__/view-header-shim.tsx
+++ b/plugins/plugin-notes/src/views/__e2e__/view-header-shim.tsx
@@ -4,8 +4,8 @@
  * deliberately avoids; production Notes continues to import the real header.
  */
 
+import { Button } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
-import { Button } from "@elizaos/ui/button";
 import { ArrowLeft } from "lucide-react";
 import type { ReactNode } from "react";
 


### PR DESCRIPTION
# What

`packages/ui/scripts/migrate-canonical-imports.test.mjs:12` asserts the repo has no pending canonical-import migrations:

```js
assert.match(output, /^Would migrate 0 files/m);
```

**That assertion is currently failing on `develop`.** A violation landed in #29150 (2026-08-26) and has sat there since, because nothing runs the file: `packages/ui/vitest.config.ts` includes `__tests__/**`, `src/**` and `test/**/*.test.mjs`, but **not `scripts/**`**, and no npm script references it either.

Fixing the violation turned up the more interesting half.

# The migrator was blind to re-exports

Two files in the *same directory* import the same module. Only one was ever flagged:

```ts
// view-header-shim.tsx:8   → flagged
import { Button } from "@elizaos/ui/button";

// ui-shim.ts:2             → invisible
export { Button } from "@elizaos/ui/button";
export { CompactCardSkeleton } from "@elizaos/ui/components/ui/skeleton-layouts";
```

`migrateImports` walked only `ts.isImportDeclaration`. An `export … from` declaration carries the same `moduleSpecifier`, so a re-export could keep a legacy deep specifier alive through a migration that reported nothing to do — including `@elizaos/ui/components/ui/skeleton-layouts`, which is exactly what this script exists to rewrite.

Teaching it about `ts.isExportDeclaration` took pending migrations from **1 to 4**: the blind spot was hiding three of four, two of them in `packages/app-core`.

# `:check` couldn't fail

None of `migrate-canonical-imports.mjs`, `migrate-raw-tables.mjs`, `migrate-raw-controls.mjs` ever exits non-zero. All three `:check` scripts report pending work and exit 0, so they could not gate a build even if something ran them — while `format:check` and `generate:first-party:check` in this repo do fail closed. They now set `exitCode = 1` when work is pending; `--write` runs still exit 0.

# The change

- `migrateImports` accepts export declarations with a string-literal specifier (declarations without one — `export { Button };` — are left alone, and there's a test pinning that).
- The three `:check` variants fail closed.
- The four pending files are migrated, which turns the red assertion green.

Two things I deliberately did **not** do:

- **I didn't wire the `scripts/` tests into a suite.** I measured them first: 10 files, **97 passing / 1 failing on `develop`** (the failure being exactly the drift assertion above), ~95 s total with `design-contract-graph.test.ts` alone at 52 s. They're `node:test` files, so adding them to the vitest `include` isn't the right wiring, and the runtime is a real cost. That's a maintainer's call — here's the data.
- **`Spinner` and `StatusBadge` in `browser.ts` / `ui-compat.ts` move from `@elizaos/ui/components/ui/*` to the `@elizaos/ui` barrel**, because neither has a dedicated public subpath (`Button`/`Input` do, and go to the *narrower* `@elizaos/ui/button` / `/input`). That's the script's own policy, but those two files carry comments about staying light, so flag it if the barrel widening is unwelcome there.

One note for anyone running the script: its output doesn't satisfy the format gate on its own — rewriting specifiers leaves imports unsorted and `organizeImports` flags every touched file, so it's a two-step operation (`--write`, then `biome check --write`).

# Verification

- `packages/ui/scripts` tests: **97 pass / 1 fail → 101 pass / 0 fail**.
- The new re-export test **fails when the migrator change is reverted** (`not ok 3`), so it isn't vacuous.
- `migrate:canonical-imports:check` → exit 1 with pending work, exit 0 once migrated. `raw-tables` / `raw-controls` → 0 pending, exit 0.
- `packages/app-core` typecheck: **22 errors before and after**, identical file set, none in either changed file. `plugin-notes`: 1 error, also identical (both pre-existing on `develop`).
- `bunx @biomejs/biome check` clean on all 7 changed files.

# Context

Found by sweeping for package.json scripts nothing invokes. That sweep alone is low-signal — 166 of 1961 scripts, mostly legitimate operator tools — so I narrowed it to *verification* scripts, which are pointless unless something automates them.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1NYHXQX72YN1C06CZBQ8BY1","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T10:13:44.830Z","completed_at":"2026-09-04T10:25:09.145Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T10:13:45.555Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4beb6ef81ce19f3fbace592e57bb35a0a958b3c4235ad001b4403ad44cff36e8","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"33afa4ff-c6c6-4637-9ece-641023142070","object_id":"sha256:4beb6ef81ce19f3fbace592e57bb35a0a958b3c4235ad001b4403ad44cff36e8","sha256":"4beb6ef81ce19f3fbace592e57bb35a0a958b3c4235ad001b4403ad44cff36e8"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"sUEI6vEYGeb62EauhYtcBKU48Dt6oiPpclqioSxeKirirF0bOC2BthTfNe_9KcsGGkMcPl3qIR6K0txTahXYAw"}} -->
