### PR TITLE
fix(cloud): recognize hosted Blooio account refs

### DIFF
--- a/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
@@ -20,6 +20,11 @@ import {
 } from "./managed-accounts";
 
 const ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const BLOOIO_HOSTED_GATEWAY_CREDENTIAL_SET = [
+  "ELIZA_APP_BLOOIO_API_KEY",
+  "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+  "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+] as const;
 const REPOSITORY_ROOT = spawnSync("git", ["rev-parse", "--show-toplevel"], {
   cwd: path.dirname(new URL(import.meta.url).pathname),
   encoding: "utf8",
@@ -91,6 +96,13 @@ describe("managed-account manifest invariants", () => {
         ...Object.values(provider.secretPatterns ?? {}),
       ]);
       for (const set of spec.credentialSets) {
+        // The hosted gateway is a separate shipped consumer, not an OAuth
+        // registry alternative; admit only its exact external contract here.
+        const isBlooioHostedGatewaySet =
+          spec.id === "blooio" &&
+          set.length === BLOOIO_HOSTED_GATEWAY_CREDENTIAL_SET.length &&
+          BLOOIO_HOSTED_GATEWAY_CREDENTIAL_SET.every((name) => set.includes(name));
+        if (isBlooioHostedGatewaySet) continue;
         for (const name of set) {
           expect(registryVars.has(name)).toBe(true);
         }
@@ -118,6 +130,10 @@ describe("managed-account manifest invariants", () => {
         "packages/cloud",
         "plugins",
         ":(exclude)packages/cloud/shared/src/lib/config/managed-accounts.ts",
+        ":(exclude,glob)**/*.test.*",
+        ":(exclude,glob)**/*.spec.*",
+        ":(exclude,glob)**/__tests__/**",
+        ":(exclude,glob)**/*.md",
       ],
       { cwd: REPOSITORY_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
     );
@@ -271,5 +287,65 @@ describe("managed WhatsApp 4-of-4 readiness contract", () => {
       );
       expect(JSON.stringify(report)).not.toContain(CONFIGURED);
     }
+  });
+});
+
+describe("managed Blooio readiness contracts", () => {
+  const blooio = MANAGED_ACCOUNTS.find((spec) => spec.id === "blooio");
+  if (!blooio) throw new Error("blooio managed account is missing");
+
+  it("classifies all 32 cross-namespace states without accepting split custody", () => {
+    const allNames = blooio.credentialSets.flat();
+    const combinations = 1 << allNames.length;
+    for (let mask = 0; mask < combinations; mask += 1) {
+      const env: Record<string, string> = {};
+      for (const [index, name] of allNames.entries()) {
+        if ((mask & (1 << index)) !== 0) env[name] = CONFIGURED;
+      }
+
+      const report = evaluateManagedAccount(blooio, env);
+      const hasCompleteAuthority = blooio.credentialSets.some((credentialSet) =>
+        credentialSet.every((name) => Boolean(env[name])),
+      );
+      expect(report.state).toBe(
+        hasCompleteAuthority ? "configured" : mask === 0 ? "missing" : "partial",
+      );
+      expect(report.missingEnvVars.every((name) => !env[name])).toBe(true);
+      expect(JSON.stringify(report)).not.toContain(CONFIGURED);
+    }
+  });
+
+  it("accepts the complete generic connection tuple without its optional webhook", () => {
+    const report = evaluateManagedAccount(blooio, {
+      BLOOIO_API_KEY: CONFIGURED,
+      BLOOIO_FROM_NUMBER: CONFIGURED,
+    });
+
+    expect(report.state).toBe("configured");
+    expect(report.missingEnvVars).toEqual([]);
+    expect(JSON.stringify(report)).not.toContain(CONFIGURED);
+  });
+
+  it("accepts the complete hosted gateway tuple", () => {
+    const report = evaluateManagedAccount(blooio, {
+      ELIZA_APP_BLOOIO_API_KEY: CONFIGURED,
+      ELIZA_APP_BLOOIO_PHONE_NUMBER: CONFIGURED,
+      ELIZA_APP_BLOOIO_WEBHOOK_SECRET: CONFIGURED,
+    });
+
+    expect(report.state).toBe("configured");
+    expect(report.missingEnvVars).toEqual([]);
+    expect(JSON.stringify(report)).not.toContain(CONFIGURED);
+  });
+
+  it("keeps the hosted gateway tuple partial when its webhook secret is missing", () => {
+    const report = evaluateManagedAccount(blooio, {
+      ELIZA_APP_BLOOIO_API_KEY: CONFIGURED,
+      ELIZA_APP_BLOOIO_PHONE_NUMBER: CONFIGURED,
+    });
+
+    expect(report.state).toBe("partial");
+    expect(report.missingEnvVars).toEqual(["ELIZA_APP_BLOOIO_WEBHOOK_SECRET"]);
+    expect(JSON.stringify(report)).not.toContain(CONFIGURED);
   });
 });

--- a/packages/cloud/shared/src/lib/config/managed-accounts.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.ts
@@ -4,8 +4,9 @@
  * Each entry names a provider account the platform operates, the
  * secret-manager reference names (env vars) that prove it is provisioned,
  * and whether the program currently requires it. OAuth application entries
- * derive their credential sets from the canonical OAuth provider registry so
- * this manifest can never drift from the env vars the runtime actually reads.
+ * derive their generic credential sets from the canonical OAuth provider
+ * registry. A provider may also declare a complete consumer-specific
+ * alternative when a shipped runtime uses a separate namespace.
  *
  * Verification reports configured/partial/missing/deferred status only —
  * never credential values — so its output is safe for CI logs and issues.
@@ -46,18 +47,20 @@ export interface ManagedAccountSpec {
 }
 
 /**
- * Derive a manifest entry from the OAuth provider registry so credential sets
- * stay identical to what the OAuth routes read at runtime. Secrets-storage
- * providers contribute their secret patterns; env-var providers contribute
- * their envVars/envVarAlternatives. Secret patterns whose credential field the
- * registry marks optional (e.g. a webhook secret) are excluded so a
- * runtime-valid account is never reported partial.
+ * Derive a manifest entry from the OAuth provider registry so its generic
+ * credential sets stay identical to what the OAuth routes read at runtime.
+ * Secrets-storage providers contribute their secret patterns; env-var
+ * providers contribute their envVars/envVarAlternatives. Secret patterns whose
+ * credential field the registry marks optional (e.g. a webhook secret) are
+ * excluded so a runtime-valid account is never reported partial. Complete
+ * credential sets for a separate shipped consumer may be appended explicitly.
  */
 function fromOAuthRegistry(
   registryId: string,
   category: ManagedAccountCategory,
   consoleUrl: string,
   requirement: ManagedAccountRequirement,
+  additionalCredentialSets: readonly (readonly string[])[] = [],
 ): ManagedAccountSpec {
   const provider = OAUTH_PROVIDERS[registryId];
   if (!provider) {
@@ -81,7 +84,7 @@ function fromOAuthRegistry(
     name: provider.name,
     category,
     console: consoleUrl,
-    credentialSets,
+    credentialSets: [...credentialSets, ...additionalCredentialSets],
     requirement,
   };
 }
@@ -203,9 +206,13 @@ export const MANAGED_ACCOUNTS: readonly ManagedAccountSpec[] = [
   fromOAuthRegistry("twilio", "social_communications", "https://console.twilio.com", {
     kind: "optional",
   }),
-  fromOAuthRegistry("blooio", "social_communications", "https://blooio.com", {
-    kind: "optional",
-  }),
+  fromOAuthRegistry("blooio", "social_communications", "https://blooio.com", { kind: "optional" }, [
+    [
+      "ELIZA_APP_BLOOIO_API_KEY",
+      "ELIZA_APP_BLOOIO_PHONE_NUMBER",
+      "ELIZA_APP_BLOOIO_WEBHOOK_SECRET",
+    ],
+  ]),
   {
     id: "telegram",
     name: "Telegram",
@@ -331,8 +338,12 @@ export function evaluateManagedAccount(
     set.filter((name) => !isConfiguredValue(env, name)),
   );
   const bestIndex = missingPerSet
-    .map((missing, index) => ({ missing, index }))
-    .sort((a, b) => a.missing.length - b.missing.length)[0].index;
+    .map((missing, index) => ({
+      missing,
+      index,
+      present: spec.credentialSets[index].length - missing.length,
+    }))
+    .sort((a, b) => a.missing.length - b.missing.length || b.present - a.present)[0].index;
   const missingEnvVars = missingPerSet[bestIndex];
 
   if (missingEnvVars.length === 0) {
@@ -341,7 +352,9 @@ export function evaluateManagedAccount(
   if (spec.requirement.kind === "deferred") {
     return { ...base, state: "deferred", missingEnvVars };
   }
-  const anyPresent = missingEnvVars.length < spec.credentialSets[bestIndex].length;
+  const anyPresent = missingPerSet.some(
+    (missing, index) => missing.length < spec.credentialSets[index].length,
+  );
   return { ...base, state: anyPresent ? "partial" : "missing", missingEnvVars };
 }
 


### PR DESCRIPTION
## Summary

- recognize the complete hosted-gateway Blooio names-only credential tuple as an alternative to the generic connection tuple
- make diagnostic alternative selection presence-aware on ties and report `partial` when any alternative has a configured name
- cover all 32 Blooio cross-namespace states and preserve value-free reports

This changes only the managed-account diagnostic contract. It does not change provider registry behavior, provider configuration, credentials, gateway routing, deployment, database, control-plane, sandbox, or production state.

## Exact-head validation

- Final source parent: `develop` at `a29276ac4d7156489f7a133954e31b451c43008d`
- Final reviewed/merged head: `7881a7fe4aced11c70c508089a4b4f33bb8b6b73`
- Merge commit: `9612ff217a00465f63f1854b53ebcd65e2461dcd` (target head at merge: `2016d245a5e7147757526d637327a480539a96f3`)
- `mise x -- bun run verify` — PASS, 376/376 tasks plus trailing audits
- focused managed-account suite — 23 passed, 0 failed, 853 assertions
- cloud/shared typecheck — PASS
- Biome + diff check — PASS
- independent final-head security and Bugbot/adversarial reviews on `7881a7fe4aced11c70c508089a4b4f33bb8b6b73` — PASS, no P0–P3 findings
- final-head hosted [run 33978870488](https://github.com/elizaOS/eliza/actions/runs/33978870488) — 5/5 PASS, including All Tests Passed
- final-head evidence-contract verification — PASS
- timing note: the maintainer merge preceded completion of the final-head hosted run; final-head CI and independent reviews completed and were recorded post-merge
- maintainer lalalune rebased, reran the 23-test/853-assertion package gates plus full verify 376/376, and merged the patch

## Evidence boundaries

- Browser/network: N/A — no customer-facing flow changed
- Cloudflare/Railway/gateway: N/A — no runtime or configuration mutation
- Database/control plane/sandbox: N/A — no access or lifecycle change
- Provider receipt: N/A — no provider-side action
- Credential handling: names only; no values read, emitted, or changed

Closes #30510
Part of #25025
Part of #19910

<!-- evidence-head:7881a7fe4aced11c70c508089a4b4f33bb8b6b73 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - names-only configuration evaluator change; no rendered UI exists before the patch.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - names-only configuration evaluator change; no rendered UI exists after the patch.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no customer-facing interaction or visual workflow is changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed request or runtime service path is changed; behavior is proven by deterministic source tests.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser runtime path is changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, agent, or inference behavior is changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no provider, database, credential, identity, or environment resource is mutated; this patch only classifies names-only contracts.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface or screenshot text is changed.