### PR TITLE
test(app): collect the unit tests stranded by directory-wide vitest excludes

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "format:check": "bunx @biomejs/biome format src scripts",
     "clean": "node ../scripts/rm-path-recursive.mjs dist .turbo",
     "typecheck": "node ../app-core/scripts/write-homepage-release-data.mjs && tsc --noEmit -p tsconfig.typecheck.json",
-    "test": "bun test scripts vite/calendar-optimize-deps.test.ts && vitest run --config vitest.config.ts",
+    "test": "bun test scripts vite/calendar-optimize-deps.test.ts vite.config.test.ts && vitest run --config vitest.config.ts",
     "trace:startup": "node scripts/capture-startup-trace.mjs",
     "perf:startup-budget": "node scripts/check-startup-budget.mjs",
     "measure:login-transfer": "node scripts/measure-anonymous-login-transfer.mjs",

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -18,8 +18,11 @@ const unitExcludes = [
   "**/*.e2e.test.{ts,tsx}",
   "**/*.e2e.spec.{ts,tsx}",
   "**/*.spec.{ts,tsx}",
-  "test/ui-smoke/**",
-  "test/electrobun-packaged/**",
+  // These two directories are playwright suites, and the `**/*.spec.{ts,tsx}`
+  // and `**/*.e2e.spec.{ts,tsx}` patterns above already keep every one of their
+  // 168 specs out of vitest. Excluding the directories wholesale also swept up
+  // the handful of plain `*.test.ts` unit files that live beside them, which
+  // launch no browser and were running in no lane at all.
   // Script-level tests use Bun or Node test APIs and run through the package's
   // dedicated `bun test` phase, outside Vitest's jsdom transform.
   "scripts/**/*.test.{ts,tsx,mjs}",


### PR DESCRIPTION
# What

Four unit-test files in `packages/app` run in no lane. Three are excluded from vitest by directory; the fourth is a 523-line `bun:test` file the bun phase never reaches.

The clearest case is `test/ui-smoke/voice-live-trajectory.test.ts`. `scripts/playwright-test-match.test.mjs` calls it a **"colocated Vitest contract"** and asserts Playwright must *not* collect it:

```js
expect(output).not.toContain("voice-live-trajectory.test.ts");
```

So the repo designates it a vitest test, deliberately keeps Playwright away from it — and `vitest.config.ts` excludes `test/ui-smoke/**`, so vitest never sees it either.

# Cause 1 — directory excludes that are broader than their purpose

```js
"test/ui-smoke/**",
"test/electrobun-packaged/**",
```

Those directories are Playwright suites, and the `**/*.spec.{ts,tsx}` and `**/*.e2e.spec.{ts,tsx}` patterns immediately above them already exclude **all 168** of their specs. The directory entries add nothing for keeping Playwright specs out — they only sweep up the three plain `*.test.ts` unit files living beside them:

| file | what it is |
|---|---|
| `test/ui-smoke/voice-live-trajectory.test.ts` | "Exercises live-voice trajectory correlation" |
| `test/electrobun-packaged/packaged-revision.test.ts` | "Exercises stale-binary rejection for packaged desktop evidence" |
| `test/electrobun-packaged/packaged-test-contracts.test.ts` | "Deterministic unit coverage … no native process, compositor, or renderer is launched" |

All three are pure unit tests. Together they run in **770 ms**.

Removing the two directory entries collects **exactly** those three — vitest goes from 125 to 128 files, **zero `.spec.` files are collected**, and nothing previously collected is lost.

# Cause 2 — a root-level bun test file the path list misses

```json
"test": "bun test scripts vite/calendar-optimize-deps.test.ts && vitest run --config vitest.config.ts"
```

The bun phase names paths explicitly. `vite.config.test.ts` sits at the package root — not under `scripts`, and not the file inside `vite/` — so its **21 assertions never ran**. Adding it to that list is the whole fix.

# Verification

- vitest collection: **125 → 128 files**, exactly the three named above; `.spec.` files collected: **0**; files lost: **0**.
- Those three: **12 tests passing** in 770 ms.
- bun phase: **950 → 971 tests** (945 → 966 passing) — the 21 recovered assertions.
- Failure lists diffed **sorted**, before vs after: **identical**. Three pre-existing failures remain, all from one environmental cause — the machine I ran on has Node 22.22.3 and those suites require Node 24+ (`host-agent`, `playwright-test-match`, `playwright-audit-projects` all fail with "Node.js 24+ is required"). I did not touch them, and I can't confirm from here that they're green on a Node 24 runner — CI will say.
- `bun run --cwd packages/app typecheck` → exit 0, **0 errors**.
- `bunx @biomejs/biome check` clean on both changed files.

# Scope

I didn't add a guard against this recurring. The systematic check is `bunx vitest list` diffed against the test files on disk, which is how these turned up; if that's worth pinning as a test, it's a better fit as its own change than bolted onto this one.

# Context

Found by extending that same check across the vitest packages. `packages/core` (14 uncollected) and `packages/ui` (12) both came back clean — `core`'s are all `.live`/`.real`/`.cerebras` opt-in suites, and `ui`'s are the `scripts/` gate tests plus two files under its documented `**/__e2e__/**` exclusion.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1P0PYW3S5PSVRRKHP1PWEX1","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T10:51:26.979Z","completed_at":"2026-09-04T10:55:24.837Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T10:51:27.984Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"87d7548f0a7f0babb09fcd58c583485867bd5bed297dd1708f98491abb6a28a3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9c8f88dc-da96-4fd5-becb-5ccad51e299d","object_id":"sha256:87d7548f0a7f0babb09fcd58c583485867bd5bed297dd1708f98491abb6a28a3","sha256":"87d7548f0a7f0babb09fcd58c583485867bd5bed297dd1708f98491abb6a28a3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"C_aPdpATFju96liR1BtqQvccvIPKR01c0sOVWCL4Zags-mfvRjCC8wGFEVFvVXzJ8JLXpCAQouVU0FgnkJ9yDA"}} -->
