### PR TITLE
ci: drop dead test-path references and pin them against disk

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -459,8 +459,9 @@ jobs:
   # (packages/app/test/ui-smoke/.pr-deny-list.json). That makes any NEW spec land
   # on the PR path by default; the only way to exclude one is to record it in the
   # deny-list with a category and a reason. The spec set is emitted by
-  # packages/app/scripts/ui-smoke-pr-specs.mjs and the wiring is enforced by
-  # packages/app/test/ui-smoke-coverage.test.ts.
+  # packages/app/scripts/ui-smoke-pr-specs.mjs. The test that enforced this
+  # wiring was removed with the other non-behavioral suites in #28109, so the
+  # deny-list contract is currently documented here rather than asserted.
   app-browser-auto-discovered:
     name: Zero-Key app browser auto-discovered specs
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -586,9 +586,6 @@ jobs:
       - name: UI dynamic view interaction coverage
         run: bun run --cwd packages/ui test -- src/App.navigate-view-wiring.test.tsx src/app-navigate-view.test.ts src/components/shell/__tests__/shell-assistant-flow.test.tsx src/components/views/DynamicViewLoader.test.tsx src/hooks/useAvailableViews.test.tsx src/hooks/useDesktopTabs.test.tsx src/state/startup-phase-hydrate.view-interact.test.ts
 
-      - name: App route + ui-smoke spec coverage gates
-        run: bun run --cwd packages/app test -- test/route-coverage.test.ts test/ui-smoke-coverage.test.ts test/view-interaction-coverage.test.ts
-
   zero-key-browser:
     name: Zero-Key app browser
     needs: changes
@@ -710,7 +707,7 @@ jobs:
         run: bun run --cwd packages/cloud/routing build
 
       - name: Electrobun window and dynamic-view coverage
-        run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts src/application-menu.test.ts
+        run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/surface-windows.test.ts src/application-menu.test.ts
 
       - name: View management action coverage
         run: bun run --cwd plugins/plugin-app-control test -- src/actions/views-management.test.ts

--- a/packages/scripts/__tests__/workflow-test-path-references.test.ts
+++ b/packages/scripts/__tests__/workflow-test-path-references.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Every test file a workflow names by path must exist.
+ *
+ * Both runners fail open on a path that no longer resolves: `bun test` skips a
+ * missing file silently, and vitest treats a positional argument as a filter,
+ * so a stale name prints "No test files found" and exits 0. A step can
+ * therefore keep passing while testing nothing. #28109 removed three suites and
+ * left "App route + ui-smoke spec coverage gates" naming all three, plus two
+ * dead filters in the Electrobun step.
+ *
+ * Only `run:` command text is inspected — comments are prose, and glob
+ * fragments are not paths.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const workflowDir = join(repoRoot, ".github", "workflows");
+const TEST_PATH =
+  /[A-Za-z0-9_][A-Za-z0-9_./-]*\.(?:test|spec)\.(?:tsx|mjs|cjs|ts|js)/g;
+
+/** Package roots a `--cwd`/`working-directory` step could resolve against. */
+const packageRoots = (() => {
+  const roots = [""];
+  const workspaces = (
+    JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+      workspaces?: string[];
+    }
+  ).workspaces;
+  for (const pattern of workspaces ?? []) {
+    if (!pattern.endsWith("/*")) {
+      roots.push(pattern);
+      continue;
+    }
+    const base = pattern.slice(0, -2);
+    if (!existsSync(join(repoRoot, base))) continue;
+    for (const entry of readdirSync(join(repoRoot, base))) {
+      roots.push(`${base}/${entry}`);
+    }
+  }
+  return roots;
+})();
+
+function resolves(candidate: string): boolean {
+  return packageRoots.some((root) =>
+    existsSync(join(repoRoot, root, candidate)),
+  );
+}
+
+const references: { workflow: string; path: string }[] = [];
+for (const file of readdirSync(workflowDir).sort()) {
+  if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+  for (const line of readFileSync(join(workflowDir, file), "utf8").split(
+    "\n",
+  )) {
+    // Skip YAML comments: prose may name a suite without invoking it.
+    if (/^\s*#/.test(line)) continue;
+    for (const match of line.matchAll(TEST_PATH)) {
+      if (match[0].includes("*")) continue;
+      references.push({ workflow: file, path: match[0] });
+    }
+  }
+}
+
+describe("workflow test-path references", () => {
+  test("finds references to check", () => {
+    expect(references.length).toBeGreaterThan(0);
+  });
+
+  test("every named test file exists", () => {
+    const dangling = references
+      .filter((reference) => !resolves(reference.path))
+      .map((reference) => `${reference.workflow}: ${reference.path}`);
+    expect(
+      [...new Set(dangling)],
+      "these workflow steps name test files that no longer exist; bun skips them silently and vitest treats them as filters matching nothing, so the step passes while testing less than it claims",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
# What

Five workflow steps name test files that no longer exist. Both runners fail open on a stale path, so the steps keep passing while testing less than they claim:

- **`bun test`** skips a missing path silently and exits 0.
- **vitest** treats a positional argument as a *filter*, so a stale name prints `No test files found, exiting with code 0`.

All five names were deleted by **#28109** (2026-08-24, "test: remove non-behavioral suites") — the same commit that left the stale `packages/homepage` entry fixed in #30515.

# `test.yml:590` — "App route + ui-smoke spec coverage gates" tests nothing

```
bun run --cwd packages/app test -- test/route-coverage.test.ts test/ui-smoke-coverage.test.ts test/view-interaction-coverage.test.ts
```

All three were deleted in #28109. I ran the exact command: the vitest half reports

```
No test files found, exiting with code 0
filter: test/route-coverage.test.ts, test/ui-smoke-coverage.test.ts, test/view-interaction-coverage.test.ts
```

Because the extra args append to the end of `packages/app`'s `test` script (`bun test scripts … && vitest run …`), the step's only remaining effect is re-running that package's bun scripts suite — **950 tests, ~33 s** — which the client lane already covers, since `packages/app` declares `testLanes: ["client"]` and `test:client` runs the same `test` script.

So the step is a redundant re-run plus a no-op gate. Removed. **No coverage is lost**: the work it still did is exactly what `test:client` does.

# `test.yml:713` — Electrobun step silently runs 4 of 6

`src/dynamic-view-rpc-schema.test.ts` and `src/dynamic-views/host.test.ts` are gone. Measured, the step runs **4 files / 76 tests**. That package's `test` script carries `--passWithNoTests`, so the dead filters can never complain. Dropped the two names; the four surviving ones are unchanged.

# `scenario-pr.yml:463` — a comment asserting a guarantee that no longer exists

The comment said the ui-smoke deny-list wiring "is enforced by `packages/app/test/ui-smoke-coverage.test.ts`". That file went in #28109, and nothing covers `ui-smoke-pr-specs.mjs` today. Reworded to say the enforcement was removed rather than implying it still runs — I did not try to restore it, which is a separate decision.

# The guard

`packages/scripts/__tests__/workflow-test-path-references.test.ts` asserts every test path named in a workflow `run:` command resolves, against the repo root or any workspace package root (steps use `--cwd`/`working-directory`).

Run against **unmodified `develop`**, it fails with exactly the five:

```
+   "test.yml: test/route-coverage.test.ts",
+   "test.yml: test/ui-smoke-coverage.test.ts",
+   "test.yml: test/view-interaction-coverage.test.ts",
+   "test.yml: src/dynamic-view-rpc-schema.test.ts",
+   "test.yml: src/dynamic-views/host.test.ts",
```

Against this branch: **2 pass, 0 fail.**

It deliberately skips YAML comments and any token containing `*` — comments are prose (`scenario-pr.yml` names a suite while describing it), and a glob is not a path. It lives in `packages/scripts/__tests__`, so `bun run test:scripts` picks it up.

# Verification

- Both workflows still parse — `Bun.YAML.parse`: `test.yml` 21 jobs, `scenario-pr.yml` 18 jobs.
- Electrobun step after the edit: 4 files, **76 tests passing**.
- Guard: fails on `develop` with the five names, passes here.
- `bunx @biomejs/biome check` clean on the new test.

# Context

Found by extending the enumerated-path-list sweep from #30513/#30515 to CI. Two clean negatives on the way: `packages/elizaresearch` names 2 files and has exactly 2, and `plugins/plugin-local-inference` names 6 under `native/` plus a directory — its seventh, `voice_duet_sweep.test.mjs`, is covered because `vitest.config.ts:123` includes it explicitly.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1P3BJV4BGF8YGRZQW6FT3YS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T11:37:39.940Z","completed_at":"2026-09-04T11:39:57.906Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T11:37:40.761Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d39aa556300c8bdf9b2488a5a657f6733c1d45214a14d338503845bae9da0bb7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"805e6947-acb2-4c02-bcd3-f4a2f3db9abf","object_id":"sha256:d39aa556300c8bdf9b2488a5a657f6733c1d45214a14d338503845bae9da0bb7","sha256":"d39aa556300c8bdf9b2488a5a657f6733c1d45214a14d338503845bae9da0bb7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"FxC1nLwrlL5WR23bUJRgdMMmfD5KHBrXgyFOBeHiCDI5RXfs3C5hCl66Q6vfsBs1kNV7Qkos3TUaM8Xkwos1BQ"}} -->
