### PR TITLE
ci(release): make the packaged macOS smoke failure reachable and visible

### DIFF
--- a/.github/workflows/release-electrobun.yml
+++ b/.github/workflows/release-electrobun.yml
@@ -1448,7 +1448,13 @@ jobs:
             exit 1
           fi
 
+      # Advisory unlike the Linux and Windows packaged smokes, which fail the
+      # job. Keep the id so the diagnostics upload below can key off this
+      # step's own outcome: continue-on-error means a smoke failure never makes
+      # failure() true, so a condition on failure() alone can never collect the
+      # evidence for the failure it was written for.
       - name: Smoke test packaged macOS app
+        id: macos-packaged-smoke
         if: matrix.platform.os == 'macos' && steps.build-electrobun-app.outputs.fallback != 'true'
         continue-on-error: true
         env:
@@ -1573,8 +1579,22 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Report advisory macOS smoke failure
+        if: >-
+          steps.macos-packaged-smoke.outcome == 'failure' &&
+          matrix.platform.os == 'macos'
+        run: |
+          echo "::warning title=Packaged macOS smoke failed::The packaged macOS app smoke test failed. This step is advisory (continue-on-error), so the release job stays green — see the uploaded macOS smoke diagnostics artifact."
+          {
+            echo "### Packaged macOS smoke: FAILED (advisory)"
+            echo
+            echo "\`bun run test:desktop:packaged\` failed on macOS. The step is \`continue-on-error: true\`, so this did not fail the release job."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload macOS smoke diagnostics
-        if: failure() && matrix.platform.os == 'macos'
+        if: >-
+          (failure() || steps.macos-packaged-smoke.outcome == 'failure') &&
+          matrix.platform.os == 'macos'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: electrobun-${{ matrix.platform.artifact-name }}-smoke-diagnostics

--- a/packages/scripts/__tests__/release-electrobun-macos-smoke-diagnostics.test.ts
+++ b/packages/scripts/__tests__/release-electrobun-macos-smoke-diagnostics.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The packaged macOS smoke step is advisory (`continue-on-error: true`) while
+ * the Linux and Windows packaged smokes fail the job. That asymmetry made the
+ * macOS diagnostics upload unreachable for the only failure it exists to
+ * capture: `continue-on-error` keeps `failure()` false, so a condition on
+ * `failure()` alone could fire only when some *other* step failed.
+ *
+ * These pin the wiring, not the gating decision: if the smoke test is ever made
+ * to fail the job, `failure()` covers it and these assertions still hold.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const workflow = Bun.YAML.parse(
+  readFileSync(
+    join(repoRoot, ".github", "workflows", "release-electrobun.yml"),
+    "utf8",
+  ),
+) as {
+  jobs: Record<
+    string,
+    {
+      steps?: {
+        name?: string;
+        id?: string;
+        if?: string;
+        "continue-on-error"?: unknown;
+      }[];
+    }
+  >;
+};
+
+const steps = Object.values(workflow.jobs).flatMap((job) => job.steps ?? []);
+const byName = (name: string) => {
+  const step = steps.find((candidate) => candidate.name === name);
+  if (!step)
+    throw new Error(`step "${name}" is missing from release-electrobun.yml`);
+  return step;
+};
+
+const SMOKE_ID = "macos-packaged-smoke";
+const smoke = byName("Smoke test packaged macOS app");
+const upload = byName("Upload macOS smoke diagnostics");
+
+describe("packaged macOS smoke diagnostics stay reachable", () => {
+  test("the smoke step keeps a referable id", () => {
+    expect(smoke.id).toBe(SMOKE_ID);
+  });
+
+  test("the diagnostics upload keys off the smoke step's own outcome", () => {
+    const condition = String(upload.if ?? "").replace(/\s+/g, " ");
+    expect(condition).toContain(`steps.${SMOKE_ID}.outcome == 'failure'`);
+  });
+
+  test("an advisory smoke failure is reported rather than silent", () => {
+    const report = byName("Report advisory macOS smoke failure");
+    expect(String(report.if ?? "").replace(/\s+/g, " ")).toContain(
+      `steps.${SMOKE_ID}.outcome == 'failure'`,
+    );
+  });
+
+  test("the Linux and Windows packaged smokes still fail the job", () => {
+    for (const name of [
+      "Smoke test packaged Linux desktop",
+      "Smoke test packaged Windows app",
+    ]) {
+      expect(byName(name)["continue-on-error"], name).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
# What

`release-electrobun.yml` collects diagnostics for a failure it has made impossible to observe.

The packaged macOS smoke step (line 1451) is `continue-on-error: true`. Sixty lines later, **"Upload macOS smoke diagnostics"** is gated on:

```yaml
if: failure() && matrix.platform.os == 'macos'
```

and uploads `${{ runner.temp }}/eliza-smoke-diagnostics/**` — exactly the `SMOKE_DIAGNOSTICS_DIR` that the smoke step writes. But `continue-on-error` keeps `failure()` false, so **that upload can never fire when the smoke test fails**. It can only fire when some *other* step in the job fails — the one case where those diagnostics are least relevant.

So today, if the packaged macOS app fails to launch during a release: the job is green, no warning appears, and the artifact written specifically to explain it is discarded with the runner.

# The asymmetry that produced it

The other three packaged smokes fail the job:

| step | line | `continue-on-error` |
|---|---|---|
| Smoke test packaged Linux desktop | 924 | — |
| Smoke test packaged Windows app | 1137 | — |
| **Smoke test packaged macOS app** | **1451** | **`true`** |

There's no comment explaining the macOS exception, and the step immediately before it fails closed on a missing `Developer ID Application` signature.

# What this changes — and what it deliberately doesn't

**I did not change the gating.** Whether the macOS smoke *should* fail the release like the other two is your call: I can't assess macOS runner flakiness from here, and dropping `continue-on-error` could start breaking releases for reasons that have nothing to do with this bug. If it is meant to gate, that's a one-line follow-up; if it's meant to stay advisory, it should at least be audible.

Three changes, all wiring:

1. The smoke step gets `id: macos-packaged-smoke`, plus a comment recording that it is advisory unlike Linux/Windows and why the id is load-bearing.
2. The diagnostics upload now also fires on that step's own outcome:
   ```yaml
   if: >-
     (failure() || steps.macos-packaged-smoke.outcome == 'failure') &&
     matrix.platform.os == 'macos'
   ```
   Keeping `failure()` means this stays correct if the smoke is ever promoted to a hard gate.
3. A new step emits a `::warning::` annotation and a `$GITHUB_STEP_SUMMARY` line when the advisory smoke fails, so a green release run still shows what happened.

# Verification

- `Bun.YAML.parse` on the edited workflow: parses, 6 jobs. The three touched steps resolve to the intended conditions, including the explicit `matrix.platform.os == 'macos'` guard on the new reporting step.
- `packages/scripts/__tests__/release-electrobun-macos-smoke-diagnostics.test.ts` pins the wiring. Against **unmodified `develop`** it fails 3 of 4 — missing id, upload not keyed off the outcome, no advisory report. Against this branch: **4 pass**.
- The 4th assertion (Linux and Windows smokes still fail the job) passes on both, which is the point: it guards the asymmetry from being "fixed" in the wrong direction.
- `bunx @biomejs/biome check` clean on the new test.

The test pins wiring, not policy — if you later make the macOS smoke fail the job, `failure()` covers the upload and every assertion still holds.

# Context

Found by sweeping workflows for fail-open shapes after #30516. Two clean negatives worth recording: the verification-shaped `|| true` uses are all fine (`deploy-gateway-webhook.yml:623` is a curl inside a retry loop whose status is checked afterward with an explicit `exit 1`; the rest are `docker system prune` and `git checkout` cleanup), and the only other gate-shaped `continue-on-error` steps are disk reclamation.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1P3RGBHQH0PPH9WR3E06JJV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T11:44:43.378Z","completed_at":"2026-09-04T11:46:36.245Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T11:44:44.021Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"96b3e0c4aacfdda1e8e01d6e6662401ba7f4a6c54134b280d6e70a29da14e0b1","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5f75dd89-a90a-4587-a946-ef887e4e7e06","object_id":"sha256:96b3e0c4aacfdda1e8e01d6e6662401ba7f4a6c54134b280d6e70a29da14e0b1","sha256":"96b3e0c4aacfdda1e8e01d6e6662401ba7f4a6c54134b280d6e70a29da14e0b1"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"zg4Yy1-p80akNYDk6IIYCdDSgbJYVSl7lsCbVfKkwURy8JI47itkshDk9uSG8wnNOapRBoH6hCXvQmkg5WZvBg"}} -->
