### PR TITLE
fix(plugin-workflow): preserve results after slow events

### DIFF
--- a/plugins/plugin-workflow/__tests__/fixtures/smithers-worker-lifecycle-fixture.mjs
+++ b/plugins/plugin-workflow/__tests__/fixtures/smithers-worker-lifecycle-fixture.mjs
@@ -37,6 +37,9 @@ if (mode === 'ignore-termination') {
     emit({ kind: 'result', result: { runId: payload.runId, status: 'finished' } });
     process.exit(0);
   }, 100);
+} else if (mode === 'event-before-result') {
+  emit({ kind: 'event', event: { type: 'TaskStarted' } });
+  emit({ kind: 'result', result: { runId: payload.runId, status: 'finished' } });
 } else if (mode === 'oversized-stdout-line') {
   process.stdout.write('x'.repeat(Number(payload.input.outputBytes)));
 } else {

--- a/plugins/plugin-workflow/__tests__/unit/smithers-worker-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-worker-lifecycle.test.ts
@@ -43,6 +43,7 @@ async function run(
     timeoutMs?: number;
     input?: Record<string, unknown>;
     generate?: SmithersRunRequest['generate'];
+    onEvent?: SmithersRunRequest['onEvent'];
   } = {}
 ) {
   return runSmithersWorkflow({
@@ -53,6 +54,7 @@ async function run(
     input: { fixtureMode: mode, ...options.input },
     timeoutMs: options.timeoutMs ?? 20_000,
     ...(options.signal ? { signal: options.signal } : {}),
+    ...(options.onEvent ? { onEvent: options.onEvent } : {}),
     generate: options.generate ?? (async () => 'done'),
   });
 }
@@ -148,6 +150,20 @@ describe('Smithers worker lifecycle', () => {
   test('observes a closed stdin while preserving a valid terminal result', async () => {
     const result = await run('closed-input-result');
     expect(result.status).toBe('finished');
+  });
+
+  test('preserves a terminal result when durable event delivery exceeds pipe drain grace', async () => {
+    const delivered: string[] = [];
+    const result = await run('event-before-result', {
+      onEvent: async (event) => {
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+        delivered.push(event.type);
+      },
+    });
+
+    expect(result.status).toBe('finished');
+    expect(delivered).toEqual(['TaskStarted']);
+    expect(result.events.map((event) => event.type)).toEqual(['TaskStarted']);
   });
 
   test('terminates a worker whose stdout line exceeds the protocol budget', async () => {

--- a/plugins/plugin-workflow/__tests__/unit/smithers-worker-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-worker-lifecycle.test.ts
@@ -18,6 +18,7 @@ const fixturePath = fileURLToPath(
   new URL('../fixtures/smithers-worker-lifecycle-fixture.mjs', import.meta.url)
 );
 const originalBunBin = process.env.BUN_BIN;
+type UnrefTimer = ReturnType<typeof setTimeout> & { unref(): void };
 
 function workflow(): WorkflowDefinitionResponse {
   const now = new Date().toISOString();
@@ -164,6 +165,83 @@ describe('Smithers worker lifecycle', () => {
     expect(result.status).toBe('finished');
     expect(delivered).toEqual(['TaskStarted']);
     expect(result.events.map((event) => event.type)).toEqual(['TaskStarted']);
+  });
+
+  test('observes an immediate event delivery rejection before child outcome settles', async () => {
+    const deliveryError = new Error('immediate event delivery rejection');
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      if (reason === deliveryError) unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      await expect(
+        run('event-before-result', {
+          onEvent: () => Promise.reject(deliveryError),
+        })
+      ).rejects.toBe(deliveryError);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('times out when event delivery does not settle after the worker exits', async () => {
+    const startedAt = Date.now();
+    const workflowOutcome = run('event-before-result', {
+      timeoutMs: 3_000,
+      onEvent: () => new Promise(() => {}),
+    }).then(
+      (value) => ({ kind: 'result' as const, value }),
+      (error) => ({ kind: 'error' as const, error })
+    );
+    let watchdogTimer: UnrefTimer | undefined;
+    const watchdogOutcome = new Promise<{ kind: 'watchdog' }>((resolve) => {
+      const timer = setTimeout(() => resolve({ kind: 'watchdog' }), 5_000) as unknown as UnrefTimer;
+      timer.unref();
+      watchdogTimer = timer;
+    });
+    try {
+      const outcome = await Promise.race([workflowOutcome, watchdogOutcome]);
+
+      expect(outcome).toMatchObject({
+        kind: 'error',
+        error: { code: 'SMTHRS_WORKFLOW_TIMEOUT' },
+      });
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+    } finally {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
+    }
+  });
+
+  test('cancels when event delivery does not settle after the worker exits', async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 500);
+    const startedAt = Date.now();
+    const workflowOutcome = run('event-before-result', {
+      signal: controller.signal,
+      timeoutMs: 3_000,
+      onEvent: () => new Promise(() => {}),
+    });
+    let watchdogTimer: UnrefTimer | undefined;
+    const watchdogOutcome = new Promise<{ status: 'watchdog' }>((resolve) => {
+      const timer = setTimeout(
+        () => resolve({ status: 'watchdog' }),
+        2_000
+      ) as unknown as UnrefTimer;
+      timer.unref();
+      watchdogTimer = timer;
+    });
+    try {
+      const outcome = await Promise.race([workflowOutcome, watchdogOutcome]);
+
+      expect(outcome.status).toBe('cancelled');
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    } finally {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
+    }
   });
 
   test('terminates a worker whose stdout line exceeds the protocol budget', async () => {

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -655,15 +655,11 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     lineProcessingFailed = true;
     lineProcessingError = error;
   });
-  let lineProcessingTimer: NodeJS.Timeout | undefined;
-  let releaseLineProcessingTimer: (() => void) | undefined;
-  const lineProcessingDeadline = new Promise<void>((resolve) => {
-    releaseLineProcessingTimer = resolve;
-    lineProcessingTimer = setTimeout(resolve, WORKER_STDIO_DRAIN_GRACE_MS);
-  });
-  await Promise.race([observedLineProcessing, lineProcessingDeadline]);
-  if (lineProcessingTimer) clearTimeout(lineProcessingTimer);
-  releaseLineProcessingTimer?.();
+  // Protocol-owned generation is aborted as soon as the worker exits, so the
+  // remaining work here is ordered event delivery. It is part of the run
+  // contract: do not let the pipe-drain fallback skip a terminal result queued
+  // behind a slow persistence or runtime event callback.
+  await observedLineProcessing;
   if (lineProcessingFailed) throw lineProcessingError;
 
   if (outcome.processError) {

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -460,8 +460,15 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
   let stdoutBuffer = '';
   let stdoutNoise = '';
   let stdinError: Error | undefined;
-  let lineProcessing = Promise.resolve();
+  const observeLineProcessing = (processing: Promise<void>): Promise<void> => {
+    // error-policy:J5 the same rejection is re-observed and propagated after
+    // child-process settlement through observedLineProcessing below.
+    void processing.catch(() => undefined);
+    return processing;
+  };
+  let lineProcessing = observeLineProcessing(Promise.resolve());
   const protocolController = new AbortController();
+  const deliveryController = new AbortController();
 
   const protocolAbortOutcome = new Promise<{ kind: 'aborted' }>((resolve) => {
     if (protocolController.signal.aborted) {
@@ -469,6 +476,15 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
       return;
     }
     protocolController.signal.addEventListener('abort', () => resolve({ kind: 'aborted' }), {
+      once: true,
+    });
+  });
+  const deliveryAbortOutcome = new Promise<{ kind: 'aborted' }>((resolve) => {
+    if (deliveryController.signal.aborted) {
+      resolve({ kind: 'aborted' });
+      return;
+    }
+    deliveryController.signal.addEventListener('abort', () => resolve({ kind: 'aborted' }), {
       once: true,
     });
   });
@@ -547,7 +563,18 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
         payload: raw,
       };
       events.push(event);
-      await request.onEvent?.(event);
+      const deliveryOutcome = Promise.resolve(request.onEvent?.(event)).then(
+        () => ({ kind: 'delivered' as const }),
+        (error) => ({ kind: 'error' as const, error })
+      );
+      const delivery = await Promise.race([deliveryOutcome, deliveryAbortOutcome]);
+      if (delivery.kind === 'error') throw delivery.error;
+      if (delivery.kind === 'aborted' && !terminationCause) {
+        const reason = deliveryController.signal.reason;
+        if (reason === 'abort' || reason === 'timeout' || reason === 'overflow') {
+          terminationCause = reason;
+        }
+      }
     }
   };
 
@@ -560,13 +587,15 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     }
     stdoutBuffer = appended.buffer;
     worker.stdout?.pause();
-    lineProcessing = lineProcessing
-      .then(async () => {
-        for (const line of appended.lines) await consumeLine(line);
-      })
-      .finally(() => {
-        if (!terminationCause && !processExited) worker.stdout?.resume();
-      });
+    lineProcessing = observeLineProcessing(
+      lineProcessing
+        .then(async () => {
+          for (const line of appended.lines) await consumeLine(line);
+        })
+        .finally(() => {
+          if (!terminationCause && !processExited) worker.stdout?.resume();
+        })
+    );
   });
   worker.stderr?.setEncoding('utf8');
   worker.stderr?.on('data', (chunk: string) => {
@@ -580,14 +609,21 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     if (terminationCause || processExited) return;
     terminationCause = cause;
     protocolController.abort(cause);
+    deliveryController.abort(cause);
     worker.kill('SIGTERM');
     forceKillTimer = setTimeout(() => worker.kill('SIGKILL'), WORKER_TERMINATION_GRACE_MS);
     forceKillTimer.unref();
   };
-  const abort = (): void => terminate('abort');
+  const abort = (): void => {
+    if (processExited) deliveryController.abort('abort');
+    else terminate('abort');
+  };
   if (request.signal?.aborted) abort();
   else request.signal?.addEventListener('abort', abort, { once: true });
-  const timeoutTimer = setTimeout(() => terminate('timeout'), timeoutMs);
+  const timeoutTimer = setTimeout(() => {
+    if (processExited) deliveryController.abort('timeout');
+    else terminate('timeout');
+  }, timeoutMs);
 
   const outcome = await new Promise<{
     exitCode: number | null;
@@ -627,9 +663,7 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
       settle(code);
     });
   }).finally(async () => {
-    clearTimeout(timeoutTimer);
     if (forceKillTimer) clearTimeout(forceKillTimer);
-    request.signal?.removeEventListener('abort', abort);
     await unlink(payloadPath).catch((error: NodeJS.ErrnoException) => {
       // error-policy:J6 run state is already persisted; teardown reports only
       // unexpected payload cleanup failures through the worker diagnostic path.
@@ -645,7 +679,7 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     }
   }
   if (stdoutBuffer && terminationCause !== 'overflow') {
-    lineProcessing = lineProcessing.then(() => consumeLine(stdoutBuffer));
+    lineProcessing = observeLineProcessing(lineProcessing.then(() => consumeLine(stdoutBuffer)));
   }
   let lineProcessingFailed = false;
   let lineProcessingError: unknown;
@@ -660,6 +694,8 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
   // contract: do not let the pipe-drain fallback skip a terminal result queued
   // behind a slow persistence or runtime event callback.
   await observedLineProcessing;
+  clearTimeout(timeoutTimer);
+  request.signal?.removeEventListener('abort', abort);
   if (lineProcessingFailed) throw lineProcessingError;
 
   if (outcome.processError) {


### PR DESCRIPTION
## Summary

- preserve terminal results queued behind slow durable Smithers `onEvent` delivery
- keep the workflow timeout and caller cancellation armed while ordered protocol/event processing finishes after worker exit
- make event delivery abort-aware so stuck callbacks produce the typed timeout or cancellation outcome rather than hanging
- propagate immediate event-delivery rejection without an unhandled rejection
- add real child-process regressions for slow delivery, rejection, deadline, and cancellation

Closes #30518

## Root cause

`runSmithersWorkflow` serializes stdout protocol lines through `lineProcessing`, and event lines await caller-supplied `onEvent`. The original runtime raced that ordered queue against the fixed one-second `WORKER_STDIO_DRAIN_GRACE_MS`. A supported persistence/listener delay longer than that grace let result evaluation run before the following terminal-result line was consumed, producing `SMTHRS_RESULT_MISSING` for a successful worker.

Simply awaiting the queue fixed result ordering but exposed a second lifecycle defect: the workflow timeout and caller abort listener had already been disarmed, while event delivery itself was not abort-aware. A never-settling callback could therefore wedge the run permanently.

The current head keeps timeout and cancellation authority alive through ordered queue completion and races event delivery against a dedicated abort outcome. Finite slow delivery still completes before terminal-result evaluation; a stuck callback is released with `SMTHRS_WORKFLOW_TIMEOUT` or a cancelled run; callback rejection remains observable.

## Exact head / base

- Base branch: `elizaOS/eliza:develop`
- Current live `develop`: `8fea4f94c29c7712ce3caf303e3350150622d048`
- Branch merge-base: `5463f6db84196db4f4588276bfb524c8c1453439`
- Head: `hankbobtheresearchoor:fix/workflow-preserve-result-after-slow-event`
- Head SHA: `fab466c37bfe322bedb3662a8a2fdaa504d1977b`

## Verification

| Evidence | Command / source | Result |
| --- | --- | --- |
| Independent regression control on current `develop` runtime | Maintainer reproduction on `develop` `8fea4f94c29` with the PR regression tests, Bun 1.3.14 / Node 24.15.0 | **9 pass, 4 fail**: slow delivery loses the terminal result; rejection, deadline, and cancellation cases fail. |
| Independent exact-head lifecycle suite | Same maintainer reproduction with runtime from head `fab466c37bfe322bedb3662a8a2fdaa504d1977b` | **13 pass, 0 fail**, covering slow delivery, immediate rejection, stuck-delivery timeout, and stuck-delivery cancellation. |
| Focused lifecycle suite | `/Users/inference2/.bun/bin/bun test --isolate plugins/plugin-workflow/__tests__/unit/smithers-worker-lifecycle.test.ts` | **13 pass, 0 fail; 25 assertions** on the exact head. |
| Canonical package test | `/Users/inference2/.bun/bin/bun run --cwd plugins/plugin-workflow test` | **16/16 isolated test files passed** on the exact head. The isolated worktree needed the ignored generated core i18n directory linked for the run; the temporary link was removed before commit. |
| Typecheck | `/Users/inference2/.bun/bin/bun run --cwd plugins/plugin-workflow typecheck` | Passed on the exact head (`tsc --noEmit -p tsconfig.typecheck.json`); independently reproduced by the maintainer. |
| Lint | `/Users/inference2/.bun/bin/bun run --cwd plugins/plugin-workflow lint:check` | Passed on the exact head; independently reproduced by the maintainer. |
| Repository verify | `/Users/inference2/.bun/bin/bun run verify` | Reached **126/146** Turbo tasks, then stopped on pre-existing SwiftLint debt in unchanged `plugins/plugin-native-gateway/ios/Sources/GatewayPlugin/GatewayPlugin.swift` (`type_body_length`). This is not a full-root pass. |
| Guide parity | `/Users/inference2/.bun/bin/bun run check:agents-claude` | Passed; 160 tracked pairs byte-identical. |
| Patch hygiene | `git diff --check 5463f6db84196db4f4588276bfb524c8c1453439...fab466c37bfe322bedb3662a8a2fdaa504d1977b` | Passed. |
| Commit signature | GitHub commit verification API for `fab466c37bfe322bedb3662a8a2fdaa504d1977b` | Verified (`reason: valid`); key `57E1CCC9E6C07252`. |

All contributor Bun commands used `PATH=/Users/inference2/.bun/bin:$PATH` and `BUN_BIN=/Users/inference2/.bun/bin/bun` where the worker executable was relevant. Hosted checks are not currently attached to this PR. Full root validation and hosted merge requirements remain pending.

## Scope / risk

Narrow runtime lifecycle correction in `plugin-workflow`. Existing timeout, abort, pending-generation cancellation, inherited-pipe drain, spawn-failure, and protocol-overflow lifecycle tests remain green. No API, schema, migration, authentication, secret, deployment, or UI changes.

The branch is currently behind live `develop`; the validation above is exact-head evidence, not evidence for a future rebased commit.

## Attribution

- AI provider: `openai`
- Model: `gpt-5.6-sol`
- Client / agent tooling: `Hermes Agent`
- Repository contribution skill revision: `elizaOS/eliza@5463f6db84196db4f4588276bfb524c8c1453439:packages/skills/skills/contribute-to-eliza`
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent","skill_revision":"elizaOS/eliza@5463f6db84196db4f4588276bfb524c8c1453439:packages/skills/skills/contribute-to-eliza"} -->
