### PR TITLE
fix(core): preserve zero trajectory timestamps

### DIFF
--- a/packages/core/src/services/trajectory-export.test.ts
+++ b/packages/core/src/services/trajectory-export.test.ts
@@ -100,6 +100,28 @@ describe("trajectory-export", () => {
 		expect(calls[1]?.callId).toBe("traj-1:step-1:call:2");
 	});
 
+	it("preserves finite zero timestamps when flattening LLM calls", () => {
+		const calls = iterateTrajectoryLlmCalls({
+			trajectoryId: "traj-zero",
+			agentId: "agent-1",
+			startTime: 200,
+			steps: [
+				{
+					stepId: "step-call-zero",
+					timestamp: 100,
+					llmCalls: [{ callId: "call-zero", timestamp: 0 }],
+				},
+				{
+					stepId: "step-zero",
+					timestamp: 0,
+					llmCalls: [{ callId: "call-fallback" }],
+				},
+			],
+		});
+
+		expect(calls.map((call) => call.timestamp)).toEqual([0, 0]);
+	});
+
 	it("rejects corrupt persisted steps instead of exporting a valid empty run", () => {
 		expect(() =>
 			summarizeTrajectoryUsage({

--- a/packages/core/src/services/trajectory-export.ts
+++ b/packages/core/src/services/trajectory-export.ts
@@ -331,8 +331,8 @@ export function iterateTrajectoryLlmCalls(
 				stepKind: step.kind,
 				callIndex,
 				timestamp:
-					toFiniteNumber(call.timestamp, Number.NaN) ||
-					toFiniteNumber(step.timestamp) ||
+					toOptionalFiniteNumber(call.timestamp) ??
+					toOptionalFiniteNumber(step.timestamp) ??
 					trajectory.startTime,
 				tags: normalizeTags(call.tags),
 				promptTokens: toFiniteNumber(call.promptTokens),


### PR DESCRIPTION
## Summary

- preserve a finite LLM-call timestamp of `0` when flattening trajectory exports
- preserve a finite parent-step timestamp of `0` when the call has no timestamp
- add regression coverage for both fallback positions

Closes #30521

## Background

`iterateTrajectoryLlmCalls` selected call, step, and trajectory timestamps with `||`. Because zero is falsy, valid epoch-zero timestamps were replaced by a later parent timestamp. The flattened value feeds the public trajectory JSON/JSONL/native export paths, changing ordering and provenance for imported or deterministic epoch-based trajectories.

The fix reuses the existing finite-number helper and uses nullish fallback, preserving zero while still rejecting missing and non-finite values.

## Sync with develop

- Base: `5463f6db84196db4f4588276bfb524c8c1453439`
- Head: `e0f0307fb104714aa13be6509ca9b5bbc6693c87`
- Targets `develop`; one signed commit.

## Testing

### Regression proof

With the new test and the production fix temporarily reverted on the current base:

```text
FAIL preserves finite zero timestamps when flattening LLM calls
1 failed
```

After the fix:

```text
bun run --cwd packages/core test -- src/services/trajectory-export.test.ts
Test Files  1 passed (1)
Tests       8 passed (8)
```

Additional gates:

```text
bun run --cwd packages/core typecheck
exit 0

bunx @biomejs/biome check packages/core/src/services/trajectory-export.ts packages/core/src/services/trajectory-export.test.ts
Checked 2 files. No fixes applied.

git diff --check
exit 0
```

The full core suite was attempted in the isolated worktree but exceeded the worker's bounded execution window and was terminated; it did not produce a completed suite result. The focused owning suite and package typecheck are green at the exact head.

## Risks

Low. The two-line runtime change only changes fallback behavior for finite zero; missing, null, and non-finite values continue to fall through. No schema, persistence, UI, cloud, auth, secret, payment, deployment, or release surface changes.

## Evidence Gate

<!-- evidence-head:e0f0307fb104714aa13be6509ca9b5bbc6693c87 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-visual trajectory export value correction.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-visual trajectory export value correction.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered user flow; focused export regression is the observable artifact.
<!-- evidence-row:backend-logs -->
- [ ] N/A - pure synchronous export helper; no service is started.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation behavior changes; only persisted trajectory export flattening.
<!-- evidence-row:domain-artifacts -->
- [ ] The regression asserts the exported flattened timestamps remain `[0, 0]` instead of being replaced by parent/start timestamps.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text surface.

## Attribution

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@5463f6db84196db4f4588276bfb524c8c1453439:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hankbobtheresearchoor]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent","skill_revision":"elizaOS/eliza@5463f6db84196db4f4588276bfb524c8c1453439:packages/skills/skills/contribute-to-eliza"} -->
