### PR TITLE
test(ci): pin every path-gate pattern against the tracked tree

### DIFF
--- a/packages/scripts/__tests__/ci-path-gate.test.mjs
+++ b/packages/scripts/__tests__/ci-path-gate.test.mjs
@@ -4,6 +4,7 @@
  * that the centralized classifier workflow path triggers every consumer lane.
  */
 import { describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
 import { unlinkSync, writeFileSync } from "node:fs";
 import { CONFIGS, evaluate, parseGitNameStatus } from "../ci-path-gate.mjs";
 
@@ -173,4 +174,102 @@ describe("parseGitNameStatus", () => {
     );
     expect(() => parseGitNameStatus("M")).toThrow(/malformed git diff record/);
   });
+});
+
+/**
+ * A gate pattern that matches nothing on disk is silently inert: the lane it
+ * was meant to trigger simply never sees that surface. That is how
+ * `.github/workflows/classify-paths.yml` itself went unregistered above, and
+ * how `packages/app-core/scripts/docker-healthcheck.mjs` — a path that never
+ * existed in this repository — survived in the docker rule from the
+ * half-landed workflow consolidation (59ffb5ef60) until it was removed.
+ *
+ * So every pattern must resolve against the tracked tree. Patterns that
+ * deliberately anticipate a file the repo does not have yet go in the
+ * allowlist below, with the reason: naming a specific nonexistent file is a
+ * stale reference, while a conventional config glob is forward-looking.
+ */
+const PATTERNS_WITHOUT_TRACKED_MATCHES = new Map([
+  [
+    "vite.config.*",
+    "No root vite.config.* exists today; the scenario-pr toolchain rule keeps it so one added later triggers the lane without a gate edit. Root vitest.config.ts is matched by the sibling vitest.config.* pattern.",
+  ],
+]);
+
+function trackedFiles() {
+  const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  }).trim();
+  return execFileSync("git", ["ls-files", "-z"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 1 << 28,
+  })
+    .split("\0")
+    .filter(Boolean);
+}
+
+/** Mirrors ci-path-gate.mjs's own glob translation. */
+function patternToRegExp(pattern) {
+  const sentinel = "\0";
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, sentinel)
+    .replace(/\*/g, "[^/]*")
+    .replaceAll(sentinel, "[\\s\\S]*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function allPatterns() {
+  const entries = [];
+  for (const [configName, config] of Object.entries(CONFIGS)) {
+    const groups = [...(config.rules ?? [])];
+    if (config.failSafe) groups.push(config.failSafe);
+    for (const rule of groups) {
+      for (const pattern of rule.patterns ?? []) {
+        entries.push({
+          configName,
+          pattern,
+          reason: rule.reason ?? "fail-safe",
+        });
+      }
+    }
+  }
+  return entries;
+}
+
+describe("gate patterns resolve against the tracked tree", () => {
+  it("matches at least one tracked file for every pattern", () => {
+    const files = trackedFiles();
+    expect(files.length).toBeGreaterThan(1_000);
+
+    const inert = [];
+    for (const { configName, pattern, reason } of allPatterns()) {
+      if (PATTERNS_WITHOUT_TRACKED_MATCHES.has(pattern)) continue;
+      const regExp = patternToRegExp(pattern);
+      if (!files.some((file) => regExp.test(file))) {
+        inert.push(`${configName}: ${pattern} (${reason})`);
+      }
+    }
+
+    expect(inert).toEqual([]);
+  }, 120_000);
+
+  it("keeps the allowlist honest by dropping entries that start matching", () => {
+    const files = trackedFiles();
+    const known = new Set(allPatterns().map((entry) => entry.pattern));
+
+    for (const [pattern, why] of PATTERNS_WITHOUT_TRACKED_MATCHES) {
+      expect(
+        known.has(pattern),
+        `${pattern} is allowlisted but no rule uses it`,
+      ).toBe(true);
+      expect(why.length).toBeGreaterThan(20);
+      const regExp = patternToRegExp(pattern);
+      expect(
+        files.some((file) => regExp.test(file)),
+        `${pattern} now matches a tracked file; remove it from the allowlist`,
+      ).toBe(false);
+    }
+  }, 120_000);
 });

--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -274,7 +274,6 @@ export const CONFIGS = {
           "turbo.json",
           "packages/app-core/deploy/**",
           "packages/app-core/scripts/docker-ci-smoke.sh",
-          "packages/app-core/scripts/docker-healthcheck.mjs",
         ],
         reason: "Docker smoke workflow or image contract",
       },


### PR DESCRIPTION
# What

A path-gate pattern that matches nothing on disk is **silently inert**: the lane it was meant to trigger simply never sees that surface. Nothing fails, nothing warns.

This file already carries a test for one instance of that — the "classifier self-registration regression" block exists because `.github/workflows/classify-paths.yml` itself went unregistered in every `CONFIGS` rule during the workflow consolidation, so a classifier-only diff returned every lane `false`.

The same consolidation left a second one:

```js
"packages/app-core/scripts/docker-healthcheck.mjs",
```

That path has **no history in this repository**. `git log --all --diff-filter=ADR` on it returns nothing — it was never restored because it never existed. It was added by `59ffb5ef60`, titled *"restore scripts deleted by half-landed workflow consolidation; reconcile gates with surviving workflows"*, and `ci-path-gate.mjs` is the only file in the repo that mentions the name. The real container healthchecks are inline `HEALTHCHECK` directives in `packages/app-core/deploy/Dockerfile.ci` and `Dockerfile.cloud-agent`.

# The deletion changes no routing

I checked this with `evaluate()` rather than by reading patterns, because the docker rule's second group already covers the whole directory:

| changed file | docker lane | matched via |
| --- | --- | --- |
| `packages/app-core/scripts/docker-healthcheck.mjs` | **triggers** | `packages/app-core/**` |
| `packages/app-core/scripts/docker-entrypoint.sh` | **triggers** | `packages/app-core/**` |
| `packages/app-core/scripts/docker-ci-smoke.sh` | **triggers** | own pattern + `packages/app-core/**` |
| `packages/app-core/deploy/Dockerfile.ci` | **triggers** | `packages/app-core/deploy/**` + `packages/app-core/**` |
| `docs/README.md` | no-op | — |

So even a file created at that exact name would still trigger the lane. The last row is there to show the lane is not trivially always-on.

# The guard

The new tests assert that every pattern in every `CONFIGS` rule — plus `failSafe` — matches at least one tracked file, using a verbatim copy of the script's own `globToRegExp` so the test asks exactly the question the gate asks.

I swept all four configs this way: **2 of 111 patterns matched nothing**. The second is scenario-pr's root `vite.config.*`, and I deliberately kept it. The rule I used, which is written into the allowlist:

> naming a specific nonexistent **file** is a stale reference; a conventional config **glob** is forward-looking.

No root `vite.config.*` exists today, but the sibling `vitest.config.*` in the same rule matches the real root `vitest.config.ts`, so nothing is uncovered, and a root vite config added later should trigger the lane without a gate edit. It is allowlisted with that reason rather than silently tolerated.

A second test keeps the allowlist honest: it fails if an allowlisted pattern starts matching a tracked file (so the entry gets removed) or stops being used by any rule (so the allowlist cannot outlive its pattern).

# Verification

**Proven against the unfixed tree.** Restoring the deleted pattern fails the new test, naming it exactly:

```
+   "docker: packages/app-core/scripts/docker-healthcheck.mjs (Docker smoke workflow or image contract)",
```

- `bun test packages/scripts/__tests__/ci-path-gate.test.mjs` → **13 pass / 0 fail** (was 11).
- Sibling suites `ci-classifier-dedup-contract` + `ci-android-aab-workflow` → **9 pass / 0 fail**.
- `node --check packages/scripts/ci-path-gate.mjs` → clean.
- `biome check` on the test file is clean; `ci-path-gate.mjs` reports the same **4 pre-existing warnings** as develop (I did not touch them).

# Scope

One dead pattern removed and a contract test added. No lane routing, output wiring, or workflow file changes.

While I was here I also checked the rest of the CI wiring and found it sound, so there is nothing else in this PR: every `steps.<id>` reference resolves to a declared step id (104 references), every `needs.<job>.outputs.<name>` resolves once reusable-workflow calls are followed into the callee's `on.workflow_call.outputs` (160 references), all 11 `workflow_call` output values resolve to real job outputs, and all 10 `classify-paths` outputs have at least one reader.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1P7NAJMXPJX0X4G8GXXC692","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T12:52:53.460Z","completed_at":"2026-09-04T12:54:00.371Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T12:52:53.677Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1b0774b5367ec033ecb84db82294e751a3ae59d44c086bb30fd68ec4120efe3c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"86438b94-a0c7-43ad-b4c1-335c3b4c5d75","object_id":"sha256:1b0774b5367ec033ecb84db82294e751a3ae59d44c086bb30fd68ec4120efe3c","sha256":"1b0774b5367ec033ecb84db82294e751a3ae59d44c086bb30fd68ec4120efe3c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"V-Oo0GNPNJmRo6U5mp6rLSSvMaoGSfwPm0QSNUE64aQyKAvzqsxCQPynNvCIao72I4Bw8OG9j1HV99vUxECZDw"}} -->
