### PR TITLE
test(cloud-shared): pin the process-isolated suite list against the tree

### DIFF
--- a/packages/cloud/shared/scripts/run-bun-tests-helpers.test.ts
+++ b/packages/cloud/shared/scripts/run-bun-tests-helpers.test.ts
@@ -501,4 +501,30 @@ describe("quarantine list stays in sync with the tree", () => {
       expect(existsSync(path.join(packageDir, suite))).toBe(true);
     }
   });
+
+  /**
+   * Same failure mode, second list. `DEFAULT_PROCESS_ISOLATED_SUITES` is only
+   * ever used to FILTER discovered files, so a renamed suite matches nothing
+   * and silently loses its process boundary. Unlike the quarantine list there
+   * is no runtime existence check for it, because a stale entry here still
+   * runs the suite — it just runs it batched with its alphabetical
+   * neighbours, where the top-level `mock.module` registrations this list
+   * exists to contain leak into them.
+   */
+  test("every DEFAULT_PROCESS_ISOLATED_SUITES entry exists (a rename must update the list, not silently batch)", () => {
+    const packageDir = path.resolve(import.meta.dir, "..");
+    for (const suite of DEFAULT_PROCESS_ISOLATED_SUITES) {
+      expect(existsSync(path.join(packageDir, suite))).toBe(true);
+    }
+  });
+
+  test("a renamed process-isolated suite stops getting its own batch", () => {
+    const stale = "src/lib/services/shared-runtime/renamed-away.test.ts";
+    const discovered = ["a.test.ts", "z.test.ts"];
+
+    const batches = buildTestBatches(discovered, [], { ordinary: 2, pglite: 1 }, [stale]);
+
+    expect(batches.some((batch) => batch.kind === "process-isolated")).toBe(false);
+    expect(batches).toEqual([{ kind: "ordinary", files: ["a.test.ts", "z.test.ts"] }]);
+  });
 });


### PR DESCRIPTION
# What

The cloud-shared test wrapper carries **two** hardcoded suite lists that are used the same way and fail the same way. Only one of them is pinned.

`DEFAULT_QUARANTINED_SUITES` is checked twice — at runtime in `run-bun-tests.mjs`:

```js
const missing = quarantinedSuites.filter((suite) => !existsSync(path.join(packageDir, suite)));
```

and here in a test whose name already states the rule:

> `every DEFAULT_QUARANTINED_SUITES entry exists (a rename must update the list, not silently skip)`

`DEFAULT_PROCESS_ISOLATED_SUITES` has neither. It is only ever used to **filter** discovered files:

```js
const processIsolatedFiles = testFiles.filter((file) =>
  DEFAULT_PROCESS_ISOLATED_SUITES.includes(file),
);
```

so a renamed suite matches nothing and quietly stops getting its own process.

# Why the boundary matters

Not cosmetic — the list's own docstring says why it exists:

> Suites whose top-level `mock.module` registrations replace broad runtime dependencies for the lifetime of the Bun process. Bun's `--isolate` keeps test globals separate but does not restore those process-wide module mocks, so these suites need a process boundary from their alphabetical neighbors.

A stale entry therefore does not just lose isolation: the suite gets batched, and the process-wide module mocks it was separated from leak into the neighbours.

That is a different failure from the quarantine list's, which is why the remedy differs — see Scope.

# The existing test looks like it covers this, and does not

`gives process-wide module-mock suites a fresh process` asserts:

```js
expect(DEFAULT_PROCESS_ISOLATED_SUITES).toContain(isolated);
```

That pins the **list**, not the tree. Rename the file and leave the list alone — the real-world mistake — and the list still contains the old literal, so it still passes.

I checked this rather than assuming it. My first mutation edited the list, which trips that `toContain` and made the gap look already-covered. Redone in the correct direction, `git mv` on the actual suite with the list untouched:

```
52 pass, 1 fail
(fail) every DEFAULT_PROCESS_ISOLATED_SUITES entry exists (a rename must update the list, not silently batch)
```

The new test is the only thing that fails.

# Scope

Two tests, one file, +26 lines: the mirrored existence check, and one documenting the consequence directly (a stale entry produces no `process-isolated` batch at all).

**No runtime check added to `run-bun-tests.mjs`, deliberately.** A stale *quarantine* entry makes the quarantined pass run nothing — a coverage hole that has to fail closed at runtime. A stale *process-isolated* entry still runs the suite, so a CI-time guard is the proportionate remedy and does not risk failing a run over a batching detail.

# Verification

- `bun test scripts/run-bun-tests-helpers.test.ts` → **53 pass / 0 fail** (was 51).
- `bun test scripts/run-bun-tests.e2e.test.ts` → **14 pass / 0 fail**.
- `biome check` clean on the changed file.

# Context

Found while auditing this package for stranded suites, given its custom runner. Discovery itself is sound — `discoverTestFiles()` walks the package root by pattern and explicitly refuses a vacuous green run — so no suite is orphaned; the gap is only in the hand-maintained list beside it.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1P8EY22794G2JT431894AW0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T13:06:52.610Z","completed_at":"2026-09-04T13:07:25.127Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T13:06:52.847Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c4ff41973a5755f088d4881044cd0e481753171cdfb5ef29f5c0a482ff088b15","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"31e2263d-1b49-4042-9660-d2543a711efd","object_id":"sha256:c4ff41973a5755f088d4881044cd0e481753171cdfb5ef29f5c0a482ff088b15","sha256":"c4ff41973a5755f088d4881044cd0e481753171cdfb5ef29f5c0a482ff088b15"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"9viFmgPg3iZvjuN55CsNAXmdEcGi7CfmtboPz-bNIiLiyY4DTdIHRHa_8-Rv8y-fHKRKF7gtzs2TEQjRic20Aw"}} -->
