### PR TITLE
test(agent): make the identity-module consumer boundary actually assertable

### DIFF
--- a/packages/agent/src/runtime/runtime-installation-id.test.ts
+++ b/packages/agent/src/runtime/runtime-installation-id.test.ts
@@ -224,19 +224,49 @@ describe("runtime installation identity", () => {
       path.join(root, "package.json"),
       JSON.stringify({ name: "identity-sibling-consumer", type: "module" }),
     );
+    // The fixture must be able to resolve the package at all, or "the deep
+    // subpath threw" proves nothing: every resolution failure would look like
+    // an enforced boundary. Import the public `./runtime` subpath first and
+    // require it to succeed, then require the blocked one to fail. Asserting
+    // the OUTCOME rather than an error message keeps this off Bun's
+    // resolver wording, which differs between releases.
     const script = [
-      'const specifier = "@elizaos/agent/runtime/runtime-installation-id";',
+      'const control = await import("@elizaos/agent/runtime");',
+      'if (Object.keys(control).length === 0) { console.error("control subpath resolved but exported nothing"); process.exit(8); }',
+      "let blocked = false;",
       "try {",
-      "  const loaded = await import(specifier);",
-      '  if ("__createRuntimeInstallationIdLoaderForTests" in loaded) process.exit(7);',
-      "} catch (error) {",
-      '  const expected = error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED" || String(error).includes("Cannot find module");',
-      "  if (!expected) throw error;",
+      '  await import("@elizaos/agent/runtime/runtime-installation-id");',
+      "} catch {",
+      "  blocked = true;",
       "}",
+      'if (!blocked) { console.error("blocked subpath was importable by a sibling consumer"); process.exit(7); }',
     ].join("\n");
     await expect(
       execFileAsync("bun", ["--eval", script], { cwd: root }),
     ).resolves.toMatchObject({ stderr: "" });
+  });
+
+  /**
+   * The consumer probe above can only prove the subpath stays unreachable. It
+   * cannot inspect a module it is forbidden to load, so the "no test controls
+   * escape" half is asserted here against the real module surface — by NAME
+   * SHAPE, not one hardcoded identifier. The previous probe looked for
+   * `__createRuntimeInstallationIdLoaderForTests`, which never existed in any
+   * implementation, so its leak branch was unreachable from the day it landed.
+   */
+  it("exports no test-only controls from the identity module", async () => {
+    const surface = await import("./runtime-installation-id.ts");
+    const testOnly = Object.keys(surface).filter(
+      (name) =>
+        name.startsWith("__") ||
+        /ForTests?$/.test(name) ||
+        name.toLowerCase().includes("fortest"),
+    );
+
+    expect(testOnly).toEqual([]);
+    // Guard the guard: the surface must be non-empty, or the filter above
+    // would pass on an empty module.
+    expect(Object.keys(surface).length).toBeGreaterThan(0);
   });
 
   it("accepts a trusted pre-existing state directory", async () => {


### PR DESCRIPTION
# What

`does not expose test controls to a real Bun sibling consumer` cannot detect the leak it exists to prevent, and separately fails outright on a newer Bun.

## 1. The leak branch has never been reachable

The probe imports the blocked subpath and then checks the loaded namespace:

```js
if ("__createRuntimeInstallationIdLoaderForTests" in loaded) process.exit(7);
```

**That symbol has never existed in any implementation.** `git log -S '__createRuntimeInstallationIdLoaderForTests' --all -- packages/agent` returns exactly one commit — `861f05be2d`, the commit that added this probe. The module exports four things, and none of them is a test control:

```
RuntimeInstallationIdentityUnsupportedError
RuntimeInstallationIdentityRecoveryError
loadOrCreateRuntimeInstallationId
constructWithRuntimeInstallationIdentity
```

It is unreachable twice over. `packages/agent/package.json` carries an explicit

```json
"./runtime/runtime-installation-id": null
```

which overrides the `./runtime/*` wildcard and blocks the subpath — so the `import()` throws and the namespace check never runs at all.

## 2. What was left is a Bun-version string match, and it already fails

With `exit(7)` unreachable, pass/fail is decided entirely by:

```js
error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED" || String(error).includes("Cannot find module")
```

`"Cannot find module"` is Bun's **stderr banner** wording, not the error's own string. On Bun 1.4.0 the caught error stringifies as `ResolveMessage: Cannot find package …` with code `ERR_MODULE_NOT_FOUND`. Both arms are false, `if (!expected) throw error` rethrows, stderr is non-empty, and the test fails:

```
× does not expose test controls to a real Bun sibling consumer
Caused by: Error: Command failed: bun --eval …
error: Cannot find module '@elizaos/agent/runtime/runtime-installation-id'
```

This repo pins `packageManager: bun@1.3.14` and CI installs 1.3.14, **so CI is green today** — this is what the next Bun bump lands on. My local 1.4.0 is what surfaced it.

## 3. Nothing proved the fixture was live

That same predicate accepts *any* error whose text contains `"Cannot find module"` — which is exactly what an unresolvable package produces. So a fixture whose symlink does not resolve is indistinguishable from an enforced boundary: the test passes either way, without ever exercising the exports block.

# The change

**Consumer probe — assert outcomes, not resolver wording.** Import the public `./runtime` subpath first and require it to *succeed*, then require the blocked subpath to *fail*. The control is what makes the second half mean anything, and neither depends on a message string that differs between Bun releases.

**Surface check — match by name shape, not one identifier.** The consumer probe cannot inspect a module it is forbidden to load, so "no test controls escape" is asserted against the real module surface, filtering `__`-prefixed and `/ForTests?$/` names, plus a non-empty-surface assertion so the filter cannot pass vacuously on an empty module.

I verified the boundary is genuinely enforced before rewriting around it — against a real sibling fixture, the deep path is blocked while `@elizaos/agent/runtime` imports fine with 226 exports.

# Verification

| mutation | result |
| --- | --- |
| reintroduce exactly `__createRuntimeInstallationIdLoaderForTests` on the module | **fails** the new surface test (`expected [ Array(1) ] to deeply equal []`) |
| point the fixture symlink at a nonexistent path | **fails** the new probe (exit 1, stderr non-empty) |
| unmodified tree | 15 pass / 1 skipped, up from **13 pass / 1 failed** / 1 skipped |

The first row is the one that matters: the original probe would **not** have caught it, structurally — the blocked import throws before `in loaded` is evaluated.

With `optional-plugins.test.ts` alongside: 24 pass / 1 skipped. `biome check` clean. One test file, +36/−6, no production code touched.

# Context

Found while auditing generator/committed-artifact drift in this package. `gen-optional-plugin-imports.ts` itself is fine — regeneration is a no-op diff, and corrupting a single `import()` specifier while leaving its key intact is caught by its drift test. This turned up as an unrelated failure in the same run.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PA8WEZNKEYS3N98ZXQSP12","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T13:38:31.519Z","completed_at":"2026-09-04T13:39:31.952Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T13:38:32.397Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a5dfcc2dda6348f882225253d6717153c7f33a8154230ac2f07f8b434327142c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"481d7d76-9e9c-41a0-bd60-ea943b0d89ab","object_id":"sha256:a5dfcc2dda6348f882225253d6717153c7f33a8154230ac2f07f8b434327142c","sha256":"a5dfcc2dda6348f882225253d6717153c7f33a8154230ac2f07f8b434327142c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"rYTWrIuBhCNg43rVkX2aAfV4WYDVeuK77haGDx_KeDUd7_ZYphXbiqxDPGp5IS0Sx7IWoGP-QYc9MjDO42lDCw"}} -->
