### PR TITLE
fix(app-core): retry transient embedding-model download failures

### DIFF
--- a/packages/app-core/scripts/ensure-fused-inference-install.mjs
+++ b/packages/app-core/scripts/ensure-fused-inference-install.mjs
@@ -107,11 +107,40 @@ function validateArtifactBytes(bytes, artifact) {
   }
 }
 
+// CI downloads run anonymously from shared runner egress IPs, so the host can
+// answer 429 (or reset the connection) for traffic this repository did not
+// generate. A bounded, Retry-After-aware second chance keeps the pinned
+// download robust without masking a genuinely unavailable artifact: the final
+// attempt still produces the typed HTTP error below.
+const RETRYABLE_DOWNLOAD_STATUSES = new Set([429, 502, 503, 504]);
+const DEFAULT_DOWNLOAD_ATTEMPTS = 4;
+const DEFAULT_RETRY_DELAY_MS = 10_000;
+const MAX_RETRY_DELAY_MS = 60_000;
+
+function computeRetryDelayMs(response, attempt, { retryDelayMs }) {
+  const retryAfterHeader = response?.headers?.get("retry-after");
+  const retryAfter = Number(retryAfterHeader);
+  // An absent header reads as null, and Number(null) is 0 — only a present,
+  // parseable, non-negative value overrides the fixed backoff.
+  if (
+    retryAfterHeader !== null &&
+    retryAfterHeader !== undefined &&
+    Number.isFinite(retryAfter) &&
+    retryAfter >= 0
+  ) {
+    return Math.min(retryAfter * 1_000, MAX_RETRY_DELAY_MS);
+  }
+  return Math.min(retryDelayMs * attempt, MAX_RETRY_DELAY_MS);
+}
+
 export async function ensureEmbeddingArtifact({
   env = process.env,
   repoRoot = defaultRepoRoot,
   fetchImpl = fetch,
   artifact = FUSED_EMBEDDING_ARTIFACT,
+  downloadAttempts = DEFAULT_DOWNLOAD_ATTEMPTS,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 } = {}) {
   const targetPath = resolveEmbeddingArtifactPath({ env, repoRoot });
   if (existsSync(targetPath)) {
@@ -130,12 +159,28 @@ export async function ensureEmbeddingArtifact({
   log(
     `downloading ${artifact.filename} from pinned revision ${artifact.revision}`,
   );
-  const response = await fetchImpl(url, {
+  const requestOptions = {
     headers: env.HF_TOKEN
       ? { Authorization: `Bearer ${env.HF_TOKEN}` }
       : undefined,
     redirect: "follow",
-  });
+  };
+  let response;
+  for (let attempt = 1; ; attempt++) {
+    response = await fetchImpl(url, requestOptions);
+    if (
+      response.ok ||
+      !RETRYABLE_DOWNLOAD_STATUSES.has(response.status) ||
+      attempt >= downloadAttempts
+    ) {
+      break;
+    }
+    const delay = computeRetryDelayMs(response, attempt, { retryDelayMs });
+    log(
+      `download attempt ${attempt}/${downloadAttempts} for ${artifact.filename} returned HTTP ${response.status}; retrying in ${delay}ms`,
+    );
+    await sleep(delay);
+  }
   if (!response.ok) {
     throw new Error(
       `failed to download ${artifact.filename}: HTTP ${response.status}`,

--- a/packages/app-core/scripts/ensure-fused-inference-install.test.mjs
+++ b/packages/app-core/scripts/ensure-fused-inference-install.test.mjs
@@ -239,3 +239,127 @@ test("a corrupt download is rejected without replacing the existing artifact", a
     rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+function rateLimitResponse(retryAfterSeconds) {
+  return new Response("rate limited", {
+    status: 429,
+    headers:
+      retryAfterSeconds === undefined
+        ? {}
+        : { "retry-after": String(retryAfterSeconds) },
+  });
+}
+
+test("a transient 429 download is retried and then installs", async () => {
+  const repoRoot = mkdtempSync(path.join(os.tmpdir(), "fused-install-retry-"));
+  const env = { MODELS_DIR: "models" };
+  const bytes = Buffer.from("retried embedding fixture");
+  const artifact = fixtureArtifact(bytes);
+  const requests = [];
+  const sleeps = [];
+  try {
+    const result = await ensureEmbeddingArtifact({
+      env,
+      repoRoot,
+      artifact,
+      retryDelayMs: 5,
+      async fetchImpl(url, options) {
+        requests.push({ url, options });
+        if (requests.length === 1) return rateLimitResponse();
+        return fixtureResponse(bytes);
+      },
+      async sleep(ms) {
+        sleeps.push(ms);
+      },
+    });
+
+    assert.equal(result.downloaded, true);
+    assert.equal(requests.length, 2);
+    assert.deepEqual(sleeps, [5]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("Retry-After is honored and capped", async () => {
+  const repoRoot = mkdtempSync(
+    path.join(os.tmpdir(), "fused-install-retry-after-"),
+  );
+  const env = { MODELS_DIR: "models" };
+  const artifact = fixtureArtifact(Buffer.from("fixture"));
+  const sleeps = [];
+  try {
+    await assert.rejects(
+      ensureEmbeddingArtifact({
+        env,
+        repoRoot,
+        artifact,
+        downloadAttempts: 2,
+        retryDelayMs: 10_000,
+        fetchImpl: async () => rateLimitResponse(120),
+        async sleep(ms) {
+          sleeps.push(ms);
+        },
+      }),
+      /HTTP 429/,
+    );
+    assert.deepEqual(sleeps, [60_000]);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("a persistent 429 exhausts the attempts and keeps the typed error", async () => {
+  const repoRoot = mkdtempSync(
+    path.join(os.tmpdir(), "fused-install-persistent-429-"),
+  );
+  const env = { MODELS_DIR: "models" };
+  const artifact = fixtureArtifact(Buffer.from("fixture"));
+  const requests = [];
+  try {
+    await assert.rejects(
+      ensureEmbeddingArtifact({
+        env,
+        repoRoot,
+        artifact,
+        downloadAttempts: 3,
+        retryDelayMs: 5,
+        async fetchImpl() {
+          requests.push(1);
+          return rateLimitResponse();
+        },
+        sleep: async () => {},
+      }),
+      /failed to download gte-small_fp16\.gguf: HTTP 429/,
+    );
+    assert.equal(requests.length, 3);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("a non-retryable download status is not retried", async () => {
+  const repoRoot = mkdtempSync(
+    path.join(os.tmpdir(), "fused-install-not-found-"),
+  );
+  const env = { MODELS_DIR: "models" };
+  const artifact = fixtureArtifact(Buffer.from("fixture"));
+  const requests = [];
+  try {
+    await assert.rejects(
+      ensureEmbeddingArtifact({
+        env,
+        repoRoot,
+        artifact,
+        fetchImpl: async () => {
+          requests.push(1);
+          return new Response("not found", { status: 404 });
+        },
+      }),
+      /HTTP 404/,
+    );
+    assert.equal(requests.length, 1);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# Relates to

No open issue owns this. Driver: the required `develop-full` workflow failed at the current `develop` head — run [33822968275](https://github.com/elizaOS/eliza/actions/runs/33822968275) (head `5463f6db84196db4f4588276bfb524c8c1453439`, 2026-09-04T00:43Z), job `canonical / Smoke (3)` [100870028330](https://github.com/elizaOS/eliza/actions/jobs/100870028330), step `Run ./.github/actions/setup-bun-workspace`:

```text
[ensure-fused-inference] downloading gte-small_fp16.gguf from pinned revision 208c4701ee35ad296b92918e02c03aebfaa6be6f
[ensure-fused-inference] ERROR: failed to download gte-small_fp16.gguf: HTTP 429
error: script "postinstall" exited with code 1
```

(`ci-ok`, `Complete manifest`, and `canonical / All Tests Passed` in that run are downstream aggregations of this failure. The Zero-Key failures in the same run are a separate fixture root owned by #30490 and are untouched here.)

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. — Scoped verification
      only: the package's script suite (12/12) and Biome on both changed files;
      full `bun run verify` not run (see Testing).

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Branch is a single commit cut directly from `origin/develop` @ `5463f6db8`.
- [ ] `bun run verify` passes post-sync — not run; scoped evidence in Testing.

# Risks

Low. Only the embedding-model download path inside `ensureEmbeddingArtifact` changes. The success path still makes exactly one request; a failing download now takes at most 3 extra attempts bounded by ~90 s of backoff before producing the same typed error as before (message unchanged). No dependency, workflow, or artifact-contract changes; the pinned revision, SHA-256 verification, atomic rename, and HF_TOKEN handling are untouched.

# Background

## What does this PR do?

`bun install` postinstall downloads the pinned `gte-small_fp16.gguf` (67,308,128 bytes, SHA-256-verified) from `huggingface.co` with a single `fetch` and no retry. CI sends no `HF_TOKEN` (no workflow sets it), so every full-install job downloads anonymously from shared GitHub-runner egress IPs — the host can answer `429` for traffic this repository did not generate, and one such answer fails the job's whole postinstall (observed above at the current integration head).

This adds a bounded, `Retry-After`-aware retry to that one download:

- retries only `429 / 502 / 503 / 504` (plus never more than `downloadAttempts`, default 4);
- honors a present, parseable, non-negative `Retry-After` header (capped at 60 s); otherwise backs off `retryDelayMs × attempt` (default 10 s × attempt, capped at 60 s);
- preserves the existing typed error verbatim on exhaustion — a genuinely unavailable artifact still fails loudly;
- exposes `downloadAttempts` / `retryDelayMs` / `sleep` options alongside the already-injectable `fetchImpl` so the behavior is deterministically testable without network.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

## Why are we doing this? Any context or related work?

`develop-full` has a standing zero-success streak where this HTTP 429 is one of the reproducible roots at the current head (the other, the Zero-Key fixture network removal, is owned by #30490). Rate-limit answers to anonymous shared-egress requests are transient by nature; a bounded second chance is the proportional control and does not mask a real outage. A cross-job artifact cache was considered and deliberately left out of scope — retry alone addresses the observed failure class; caching is a separate, larger workflow change if the nightly still trips after this lands.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/scripts/ensure-fused-inference-install.test.mjs` — the four new `node:test` cases at the bottom run in the package's `test:script-suites` lane (`node --test …` inside `bun run --cwd packages/app-core test`).

## Detailed testing steps

Disposable container (oven/bun:1.3.14), tree loaded from `git archive` of the branch head, no host mounts, no network:

1. `bun test packages/app-core/scripts/ensure-fused-inference-install.test.mjs` at head `133b6091592161c21d5df6d993f6987b1c58793d` → **12 pass, 0 fail** (8 pre-existing + 4 new).
2. Same command with only `ensure-fused-inference-install.mjs` reverted to `origin/develop` → **9 pass, 3 fail**: the three retry-behavior tests fail on develop's single-shot fetch (no sleep, one request), while "a non-retryable download status is not retried" passes on both — it pins preserved behavior.
3. `biome check` (pinned 2.5.8) on both changed files → clean.

The new tests cover: transient 429 then 200 succeeds with the delay recorded; `Retry-After: 120` is honored and capped at 60 s; a persistent 429 exhausts attempts (3 requests) and keeps the exact typed error; a 404 is not retried. During development the delay-assertion caught a real bug (missing `Retry-After` header read as `Number(null) === 0` instead of falling back to the fixed backoff), which is fixed and pinned by the first test.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
133b6091592161c21d5df6d993f6987b1c58793d

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - no UI surface changed; postinstall download path only.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - no UI surface changed; postinstall download path only.`
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      `N/A - not frontend-testable; the user flow is a CI postinstall step, evidenced by the failing hosted job log linked above and the deterministic suite.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      `Failing-path hosted evidence: job 100870028330 log excerpt quoted in Relates to (HTTP 429 at the current develop head). Fixed-path evidence: the deterministic suite exercises the same ensureEmbeddingArtifact code path with a stubbed transport, 12/12 green at the reviewed head in a disposable container.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      `N/A - no frontend change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      `N/A - no domain artifact surface; the change is a postinstall download retry.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend, failing path (hosted, current develop head, quoted from job 100870028330):

<details><summary>develop-full 33822968275 · canonical / Smoke (3) · setup-bun-workspace</summary>

```text
[stage-desktop-fused-lib] done. The desktop runtime resolves this automatically via
[stage-desktop-fused-lib]   <stateDir>/local-inference/lib  (resolveFusedLibraryPath default)
[stage-desktop-fused-lib] or set ELIZA_INFERENCE_LIB_DIR=/home/runner/.local/state/eliza/local-inference/lib to point at it explicitly.
[ensure-fused-inference] downloading gte-small_fp16.gguf from pinned revision 208c4701ee35ad296b92918e02c03aebfaa6be6f
[ensure-fused-inference] ERROR: failed to download gte-small_fp16.gguf: HTTP 429
error: script "postinstall" exited with code 1
##[error]Process completed with exit code 1.
```

</details>

Backend, fixed path (deterministic suite at the reviewed head, disposable container):

<details><summary>bun test packages/app-core/scripts/ensure-fused-inference-install.test.mjs @ 133b6091</summary>

```text
(pass) a normal install initializes the pinned source and ensures the fused library
(pass) CI is not an implicit escape hatch
(pass) missing Linux prerequisites are provisioned before the native build
(pass) the explicit emergency escape hatch performs no native mutations
(pass) a missing embedding artifact is downloaded and hash-verified atomically
(pass) a stale embedding artifact is replaced with verified bytes
(pass) a current embedding artifact never touches the network
(pass) a corrupt download is rejected without replacing the existing artifact
(pass) a transient 429 download is retried and then installs
(pass) Retry-After is honored and capped
(pass) a persistent 429 exhausts the attempts and keeps the typed error
(pass) a non-retryable download status is not retried

 12 pass
 0 fail
```

</details>

Frontend: `N/A - no frontend change.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface changed; this is a postinstall download path. The CI evidence gate rows above are marked accordingly.`


Compute receipt: 15638055 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: zai / glm-5.3-1m
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-review]
<!-- slop-contribution-attribution:v1 {"provider":"zai","model":"glm-5.3-1m","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PBT77239SJV66NTX1TTH39","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T14:05:28.162Z","completed_at":"2026-09-04T14:31:03.999Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T14:05:46.940Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":154129,"output_tokens":49942,"cache_creation_tokens":0,"cache_read_tokens":15433984,"total_tokens":15638055,"cost_micro_usd":"4448362","session_count":4},"trajectory_sha256":"2c0ffc9748ae0faf2bd0c9631b67baf9c14d518cbca3d7e8a05565059e055e67","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2e422a91-6d7c-4ed5-90b4-f8407c38636f","object_id":"sha256:2c0ffc9748ae0faf2bd0c9631b67baf9c14d518cbca3d7e8a05565059e055e67","sha256":"2c0ffc9748ae0faf2bd0c9631b67baf9c14d518cbca3d7e8a05565059e055e67"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAR850XHeZVEfYMatnrCiWT7P3QZHECM3R-C2VnfZ8iZQ","device_key_id":"5935e4ed75d7ef04a6827ac468d61a17e4bba8f871647762e8ff62c5e50dda49","device_signature":"LC_jmdrjru97pKemLY3lTVDmkLkG1tSSC2fJ77WlYwZduKRsJAydVASuldEBrx_UvOleroGSLM9qYSBmZ2TXAA"}} -->
