### PR TITLE
fix(agent): stop a damaged tool-cache row from failing the tool call

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache/cache.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.test.ts
@@ -733,3 +733,99 @@ describe("ToolCallCache", () => {
     expect(desc.cacheable).toBe(false);
   });
 });
+
+describe("ToolCallCache over a damaged disk tier", () => {
+  const descriptor: CacheableToolDescriptor = {
+    name: "web_search",
+    version: "1",
+    ttlMs: 1_000,
+    cacheable: true,
+  };
+  const args = { q: "hello" };
+
+  function poison(bytes: string): string {
+    const file = path.join(
+      tempRoot,
+      buildCacheKey(descriptor.name, args).slice(0, 2),
+      `${buildCacheKey(descriptor.name, args)}.json`,
+    );
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, bytes, "utf8");
+    return file;
+  }
+
+  it("runs the tool instead of failing the call when the row is truncated", async () => {
+    poison('{"key":"abc","output":{"a":1');
+    const cache = makeCache(() => 0);
+    let calls = 0;
+
+    // The lookup happens synchronously before the executor, so a throw from the
+    // disk tier does not degrade to a miss — it means the tool never runs.
+    const output = await cache.run(descriptor, args, async () => {
+      calls += 1;
+      return "fresh";
+    });
+
+    expect(output).toBe("fresh");
+    expect(calls).toBe(1);
+  });
+
+  it("self-heals the poisoned key rather than failing it on every later call", async () => {
+    const file = poison("{oops");
+    const cache = makeCache(() => 0);
+    let calls = 0;
+    const run = () =>
+      cache.run(descriptor, args, async () => {
+        calls += 1;
+        return "fresh";
+      });
+
+    expect(await run()).toBe("fresh");
+    expect(await run()).toBe("fresh");
+
+    // Second call was a hit, so the bad row was replaced, not merely skipped.
+    expect(calls).toBe(1);
+    expect(existsSync(file)).toBe(true);
+    expect(JSON.parse(readFileSync(file, "utf8")).output).toBe("fresh");
+  });
+
+  it("keeps a successful tool result when the disk write fails", async () => {
+    // Occupy the row path with a directory so the publish cannot succeed. The
+    // write happens in `run`'s `.then`, i.e. after the tool already returned,
+    // so a raised fs error would throw away a result the caller had earned.
+    const key = buildCacheKey(descriptor.name, args);
+    const file = path.join(tempRoot, key.slice(0, 2), `${key}.json`);
+    mkdirSync(file, { recursive: true });
+    writeFileSync(path.join(file, "occupied"), "x", "utf8");
+    const cache = makeCache(() => 0);
+
+    await expect(
+      cache.run(descriptor, args, async () => "fresh"),
+    ).resolves.toBe("fresh");
+  });
+
+  it("does not serve a row that carries no expiry as if it never expires", async () => {
+    const key = buildCacheKey(descriptor.name, args);
+    poison(
+      JSON.stringify({
+        key,
+        toolName: descriptor.name,
+        toolVersion: descriptor.version,
+        cachedAt: 0,
+        output: "STALE",
+      }),
+    );
+    // A clock far past any plausible TTL: nothing written by this cache could
+    // still be live here.
+    const cache = makeCache(() => 1e15);
+    let calls = 0;
+
+    const output = await cache.run(descriptor, args, async () => {
+      calls += 1;
+      return "fresh";
+    });
+
+    expect(output).toBe("fresh");
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/agent/src/runtime/tool-call-cache/disk-store.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/disk-store.test.ts
@@ -11,6 +11,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -97,22 +98,16 @@ describe("DiskStore.read", () => {
     expect(store.read(KEY_AB)).toEqual(written);
   });
 
-  it("returns undefined when the stored key does not match the lookup key", () => {
+  it("returns undefined and evicts when the stored key does not match the lookup key", () => {
     const store = storeWith();
     store.write(entry(KEY_AB, { output: "kept" }));
     const file = fileFor(tempRoot, KEY_AB);
     const parsed = JSON.parse(readFileSync(file, "utf8")) as ToolCacheEntry;
     writeFileSync(file, JSON.stringify({ ...parsed, key: KEY_CD }), "utf8");
     expect(store.read(KEY_AB)).toBeUndefined();
-    expect(existsSync(file)).toBe(true);
-  });
-
-  it("throws when the on-disk row is not JSON", () => {
-    const store = storeWith();
-    const file = fileFor(tempRoot, KEY_AB);
-    mkdirSync(path.dirname(file), { recursive: true });
-    writeFileSync(file, "not-json{", "utf8");
-    expect(() => store.read(KEY_AB)).toThrow();
+    // Previously the row was declined but left in place, so the mismatch was
+    // re-detected on every future lookup and the key could never repopulate.
+    expect(existsSync(file)).toBe(false);
   });
 
   it("does not alias the on-disk row through the returned object", () => {
@@ -130,6 +125,138 @@ describe("DiskStore.read", () => {
     (first.output as { n: number }).n = 99;
     expect(store.read(KEY_AB)).toEqual(entry(KEY_AB, { output: { n: 1 } }));
   });
+
+  // --- rows this process did not write -------------------------------------
+  // A row on disk may be truncated by a crash, left by an older layout, or
+  // edited in the state directory. Each case must read as a miss AND evict the
+  // file: the read path is called synchronously before the tool executor, so a
+  // throw here fails the tool call outright, and a row it merely declines
+  // without removing keeps failing that key on every future call.
+
+  function writeRaw(key: string, bytes: string): string {
+    const file = fileFor(tempRoot, key);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, bytes, "utf8");
+    return file;
+  }
+
+  const MALFORMED: ReadonlyArray<readonly [string, string]> = [
+    [
+      "truncated mid-object (an interrupted write)",
+      '{"key":"x","output":{"a":1',
+    ],
+    ["empty file", ""],
+    ["not JSON at all", "<html>nope</html>"],
+    ["valid JSON but null", "null"],
+    ["valid JSON but an array", "[]"],
+    ["valid JSON but a bare number", "123"],
+  ];
+
+  for (const [label, bytes] of MALFORMED) {
+    it(`reads as a miss and evicts the file: ${label}`, () => {
+      const file = writeRaw(KEY_AB, bytes);
+      const store = storeWith();
+      expect(() => store.read(KEY_AB)).not.toThrow();
+      expect(store.read(KEY_AB)).toBeUndefined();
+      expect(existsSync(file)).toBe(false);
+    });
+  }
+
+  const NONCONFORMING: ReadonlyArray<
+    readonly [string, Record<string, unknown>]
+  > = [
+    [
+      "no expiresAt (would compare `undefined <= now` and never expire)",
+      { toolName: "web_search", toolVersion: "1", cachedAt: 1, output: 1 },
+    ],
+    [
+      "expiresAt is a string",
+      {
+        toolName: "web_search",
+        toolVersion: "1",
+        cachedAt: 1,
+        expiresAt: "2000",
+        output: 1,
+      },
+    ],
+    [
+      "expiresAt is NaN",
+      {
+        toolName: "web_search",
+        toolVersion: "1",
+        cachedAt: 1,
+        expiresAt: Number.NaN,
+        output: 1,
+      },
+    ],
+    [
+      "no cachedAt",
+      { toolName: "web_search", toolVersion: "1", expiresAt: 2, output: 1 },
+    ],
+    [
+      "no toolVersion (version invalidation could not fire)",
+      { toolName: "web_search", cachedAt: 1, expiresAt: 2, output: 1 },
+    ],
+    [
+      "toolVersion is a number",
+      {
+        toolName: "web_search",
+        toolVersion: 1,
+        cachedAt: 1,
+        expiresAt: 2,
+        output: 1,
+      },
+    ],
+    ["no toolName", { toolVersion: "1", cachedAt: 1, expiresAt: 2, output: 1 }],
+    [
+      "no output at all",
+      { toolName: "web_search", toolVersion: "1", cachedAt: 1, expiresAt: 2 },
+    ],
+  ];
+
+  for (const [label, row] of NONCONFORMING) {
+    it(`reads as a miss and evicts the file: ${label}`, () => {
+      const file = writeRaw(KEY_AB, JSON.stringify({ key: KEY_AB, ...row }));
+      const store = storeWith();
+      expect(store.read(KEY_AB)).toBeUndefined();
+      expect(existsSync(file)).toBe(false);
+    });
+  }
+
+  it("reads as a miss when the row path is not a regular file", () => {
+    // `readFileSync` raises EISDIR here and the eviction that follows cannot
+    // remove a directory with a non-recursive `rmSync`, so both the read and
+    // its own repair step have to absorb a failure.
+    const file = fileFor(tempRoot, KEY_AB);
+    mkdirSync(file, { recursive: true });
+    writeFileSync(path.join(file, "occupied"), "x", "utf8");
+    const store = storeWith();
+    expect(() => store.read(KEY_AB)).not.toThrow();
+    expect(store.read(KEY_AB)).toBeUndefined();
+  });
+
+  // Liveness control for the two tables above. Without it every "reads as a
+  // miss" assertion would still pass if the validator rejected everything.
+  const FALSY_OUTPUTS: ReadonlyArray<
+    readonly [string, ToolCacheEntry["output"]]
+  > = [
+    ["null", null],
+    ["zero", 0],
+    ["false", false],
+    ["empty string", ""],
+    ["empty array", []],
+    ["empty object", {}],
+  ];
+
+  for (const [label, output] of FALSY_OUTPUTS) {
+    it(`still serves a conforming row whose output is ${label}`, () => {
+      const store = storeWith();
+      const written = entry(KEY_AB, { output });
+      store.write(written);
+      expect(store.read(KEY_AB)).toEqual(written);
+      expect(existsSync(fileFor(tempRoot, KEY_AB))).toBe(true);
+    });
+  }
 });
 
 describe("DiskStore.write", () => {
@@ -289,6 +416,37 @@ describe("DiskStore.write", () => {
     expect(store.read(KEY_AB)?.output).toBe(false);
     store.write(entry(KEY_AB, { output: ["x", { y: 1 }] }));
     expect(store.read(KEY_AB)?.output).toEqual(["x", { y: 1 }]);
+  });
+
+  // Writes publish atomically so a crash cannot leave the truncated row the
+  // read path above has to defend against.
+  it("leaves no temp file behind after a successful write", () => {
+    const store = storeWith();
+    store.write(entry(KEY_AB));
+    const dir = path.dirname(fileFor(tempRoot, KEY_AB));
+    expect(readdirSync(dir)).toEqual([`${KEY_AB}.json`]);
+  });
+
+  it("swallows a publish failure and cleans up its temp file", () => {
+    const store = storeWith();
+    // Make the destination un-renameable-onto in a way that survives on both
+    // Linux and macOS: a directory sitting where the row file belongs. The
+    // serialisation and temp write both succeed, so this exercises exactly the
+    // window a crash would land in — after the bytes exist, before they are
+    // published — and nothing may be left behind in it.
+    const file = fileFor(tempRoot, KEY_AB);
+    mkdirSync(file, { recursive: true });
+    writeFileSync(path.join(file, "occupied"), "x", "utf8");
+
+    // `write` runs inside `ToolCallCache.run`'s `.then`, after the tool has
+    // already produced a result, so a raised fs error would discard a
+    // successful tool call. Failing to cache must stay invisible to the caller.
+    expect(() => store.write(entry(KEY_AB))).not.toThrow();
+
+    const dir = path.dirname(file);
+    expect(readdirSync(dir).filter((name) => name.endsWith(".tmp"))).toEqual(
+      [],
+    );
   });
 });
 

--- a/packages/agent/src/runtime/tool-call-cache/disk-store.ts
+++ b/packages/agent/src/runtime/tool-call-cache/disk-store.ts
@@ -8,19 +8,84 @@
  * Reads/writes synchronously to keep the wrapping flow simple. Tool calls
  * already cross network or shell boundaries, so a small fs touch is in the
  * noise. Writes go through the privacy redactor before serialisation.
+ *
+ * Nothing on disk is trusted. A row is data this process did not produce: an
+ * earlier version wrote it, a crash truncated it, or something else edited the
+ * state directory. So {@link DiskStore.read} validates the parsed row against
+ * {@link ToolCacheEntry} instead of casting to it, and treats every failure as
+ * a miss that also evicts the offending file. Two properties fall out of that:
+ *
+ *   - The cache can never fail a tool call. `ToolCallCache.run` calls `read`
+ *     on the synchronous path before the executor, so a throw here does not
+ *     degrade to a miss — it propagates to the caller and the tool never runs
+ *     at all (error-policy:J7 — "the cache is optional degradation, not the
+ *     tool call"). A malformed row used to throw `SyntaxError` out of `run`.
+ *   - A bad row cannot poison a key forever. Since the read path never
+ *     rewrote or removed the file it rejected, the same key threw on every
+ *     later call, in this process and every future one, until someone deleted
+ *     the state directory by hand. Eviction makes the next call a clean miss
+ *     that repopulates the row.
+ *
+ * Writes are atomic (temp file in the same directory, then `rename`) because
+ * the read path's robustness is not a licence to produce partial rows: a
+ * `writeFileSync` interrupted by a crash, a signal or a full disk left exactly
+ * the truncated JSON described above.
+ *
+ * For the same reason neither `read` nor `write` throws. Both sit on the tool
+ * call's own path — `write` runs in `run`'s `.then`, where a raised `ENOSPC`
+ * or `EACCES` rejects a call whose tool had *already succeeded* and discards
+ * its result. Populating or evicting a cache row is best-effort by nature, so
+ * an fs failure is logged and swallowed. Only the tool's own error belongs to
+ * the caller.
  */
 
+import { randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
+import { logger } from "@elizaos/core";
+
 import { isRedactionDegraded } from "./redact.ts";
 import type { PrivacyRedactor, ToolCacheEntry } from "./types.ts";
+
+/**
+ * Does a parsed disk row conform to {@link ToolCacheEntry} and belong to `key`?
+ *
+ * Every scalar field the read path or `ToolCallCache.getByKey` goes on to
+ * *compare* is checked here, because a missing or wrongly-typed one does not
+ * fail loudly — it fails as a silently wrong decision. The motivating case is
+ * `expiresAt`: `getByKey` tests `candidate.expiresAt <= this.now()`, and when
+ * the field is absent that comparison is `undefined <= now`, which is `false`.
+ * The row reads as not-yet-expired at every clock value, so a TTL-less entry
+ * was served forever and the tool it caches never ran again.
+ *
+ * `output` is checked for presence only, not shape. It is legitimately `null`,
+ * `0` or `false`, so presence must be `in` rather than a truthiness test, and
+ * validating the payload itself would mean a deep walk of untrusted data that
+ * `isRedactionDegraded` here and `shouldCache` in `ToolCallCache.run` already
+ * perform on the way out.
+ */
+function isStoredEntry(parsed: unknown, key: string): parsed is ToolCacheEntry {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
+  const row = parsed as Partial<ToolCacheEntry>;
+  return (
+    row.key === key &&
+    typeof row.toolName === "string" &&
+    typeof row.toolVersion === "string" &&
+    Number.isFinite(row.cachedAt) &&
+    Number.isFinite(row.expiresAt) &&
+    "output" in row
+  );
+}
 
 export class DiskStore {
   constructor(
@@ -32,33 +97,77 @@ export class DiskStore {
     return path.join(this.root, key.slice(0, 2), `${key}.json`);
   }
 
+  /**
+   * Remove a row, absorbing any fs failure.
+   *
+   * Eviction is a repair step on a path that must not throw, and the thing
+   * being repaired is by definition an unexpected file — including one that is
+   * not a regular file at all, which `delete`'s non-recursive `rmSync` refuses.
+   */
+  private evict(key: string): void {
+    try {
+      this.delete(key);
+    } catch (error) {
+      logger.warn(
+        { key, error },
+        "[DiskStore] could not evict an unreadable cache row",
+      );
+    }
+  }
+
   read(key: string): ToolCacheEntry | undefined {
     const file = this.pathFor(key);
     if (!existsSync(file)) return undefined;
-    const raw = readFileSync(file, "utf8");
-    const parsed = JSON.parse(raw) as ToolCacheEntry;
-    if (parsed.key !== key) return undefined;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(file, "utf8"));
+    } catch {
+      // Truncated, empty, unreadable or non-JSON row: a miss, and drop it so
+      // the next call repopulates instead of failing again.
+      this.evict(key);
+      return undefined;
+    }
+    if (!isStoredEntry(parsed, key)) {
+      this.evict(key);
+      return undefined;
+    }
     return parsed;
   }
 
   write(entry: ToolCacheEntry): void {
     const file = this.pathFor(entry.key);
-    const dir = path.dirname(file);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-
     const output = this.redact(entry.output);
     // A truncated or cyclic walk must not persist as a successful disk hit.
     // Evict any existing row so a later degraded rewrite cannot leave the
     // previous successful value to be served by a fresh process.
     if (isRedactionDegraded(output)) {
-      this.delete(entry.key);
+      this.evict(entry.key);
       return;
     }
     const sanitized: ToolCacheEntry = {
       ...entry,
       output: output as ToolCacheEntry["output"],
     };
-    writeFileSync(file, JSON.stringify(sanitized), "utf8");
+    // Atomic publish: a reader either sees the previous row or this one, never
+    // a half-written one. Same directory, so `rename` stays on one filesystem.
+    const temp = `${file}.${randomUUID()}.tmp`;
+    try {
+      const dir = path.dirname(file);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      writeFileSync(temp, JSON.stringify(sanitized), "utf8");
+      renameSync(temp, file);
+    } catch (error) {
+      try {
+        if (existsSync(temp)) rmSync(temp, { force: true });
+      } catch {
+        // Nothing further to do; the temp name is unique so a leftover cannot
+        // be mistaken for a row.
+      }
+      logger.warn(
+        { key: entry.key, toolName: entry.toolName, error },
+        "[DiskStore] could not persist a cache row; continuing uncached",
+      );
+    }
   }
 
   delete(key: string): void {


### PR DESCRIPTION
## The bug

`DiskStore.read` trusted its own state directory:

```ts
const raw = readFileSync(file, "utf8");
const parsed = JSON.parse(raw) as ToolCacheEntry;
if (parsed.key !== key) return undefined;
return parsed;
```

No error handling, and an unvalidated cast on bytes this process did not write.

`ToolCallCache.run` calls that synchronously, *before* the executor:

```ts
const hit = this.getByKey(descriptor, cacheKey);   // -> disk.read(key)
if (hit && shouldCache(hit.output)) return hit.output;
```

So a malformed row does not degrade to a cache miss. It throws out of `run`
and **the tool never runs at all**. That contradicts the contract stated a few
lines away in `keyFor`, on the sibling failure path:

> error-policy:J7 the cache is optional degradation, not the tool call

I confirmed it by writing a truncated row and calling `run`:

| on-disk bytes | result | executor calls |
|---|---|---|
| `{"key":"…","toolName":"web_search"` | throws `SyntaxError` | **0** |
| `null` | throws `TypeError: Cannot read properties of null (reading 'key')` | **0** |

And it is permanent. The read path never rewrote or removed the row it
rejected, so the same key fails on every later call — in this process and in
every future one — until someone deletes the state directory by hand:

```
attempt 1: threw SyntaxError
attempt 2: threw SyntaxError
poisoned file still present: true
```

This needs no attacker. `write` called `writeFileSync` straight onto the live
path, with no temp-and-rename, so a crash, a signal or a full disk mid-write
leaves exactly that partial file.

## A quieter consequence of the same cast

`getByKey` tests `candidate.expiresAt <= this.now()`. When the field is absent
that is `undefined <= now`, which is `false` — so the row reads as *not yet
expired at every clock value*. A row carrying no expiry is served forever and
the tool it caches never runs again. With a 1 s TTL and `now() = 1e15`:

```
served: "STALE"   executor calls: 0
```

I checked two adjacent shapes that looked equally suspect and they are fine —
a string `expiresAt` coerces and does expire, and a row with no `output` field
misses — so this is the one field where absence is silently wrong rather than
loud.

## The fix

- **`read` validates instead of casting.** A new `isStoredEntry` type guard
  checks every field the read path or `getByKey` goes on to *compare*. Any
  failure — unparseable, unreadable, non-object, or non-conforming — is a miss
  that **also evicts the file**, so the key self-heals on the next call.
- **`write` publishes atomically** through a uniquely-named temp file plus
  `rename`, so a crash cannot produce the partial row in the first place.
- **Neither method throws.** Two holes I found while auditing my own patch:
  - If `<key>.json` is a *directory*, `readFileSync` raises `EISDIR` and the
    eviction's non-recursive `rmSync` then throws too. Eviction is now
    best-effort.
  - `disk.write` runs inside `run`'s `.then`, **after the tool has already
    returned**, so a raised `ENOSPC`/`EACCES` rejects a promise whose tool
    succeeded and discards the result. `write` now logs and continues uncached.

`output` presence is checked with `in`, not truthiness, because `null`, `0` and
`false` are all valid `ToolOutput` values.

## What I deliberately did not change

- **`output` shape is not validated.** That would mean a deep walk of untrusted
  data, which `isRedactionDegraded` here and `shouldCache` in `run` already
  perform on the way out. Presence only.
- **The two traversals in `key.ts` and `bounded-walk.ts` stay separate.** The
  header comment explains why at length; nothing here needs them merged.
- **`invalidate(toolName, argHash)` does not verify that the entry's `toolName`
  matches** before deleting by hash, so `invalidate("a", hashOfB)` drops B's
  row. Both callers pass a hash they just derived from that same descriptor, so
  it is unreachable today — noting it rather than widening the diff.

## Tests

21 added, and the pinning tests updated.

- `disk-store.test.ts`: two tables — 6 malformed-bytes cases (truncated, empty,
  non-JSON, `null`, `[]`, bare number) and 8 non-conforming-shape cases — each
  asserting **miss *and* eviction**; the not-a-regular-file case; a swallowed
  publish failure leaving no temp residue.
- `cache.test.ts`: the tool runs instead of the call failing; the key self-heals
  so a second call is a hit; a no-expiry row is not served; a successful tool
  result survives a failed disk write.
- **Liveness control**: a conforming row whose `output` is `null`, `0`, `false`,
  `""`, `[]` or `{}` is still served. Without it, every "reads as a miss"
  assertion above would pass just as well if the validator rejected everything.

Two existing tests pinned the old behaviour — `throws when the on-disk row is
not JSON`, and a key-mismatch case asserting `existsSync(file)` stays `true`.
Both come from d2cdce0d56 *"test(agent): cover disk-store (#25621)"*, a coverage
commit, with no stated rationale; they recorded what the code did rather than a
designed contract, and they contradict error-policy:J7. Updated in place rather
than dropped, so the contract change is visible in the diff.

**Ablation** — reverting only `disk-store.ts` to `develop` and re-running:

```
Tests  21 failed | 220 passed (241)
```

Restored: `241 passed`. `biome check` clean; `tsc --noEmit -p packages/agent`
clean.

The wider `packages/agent/src/runtime` suite has 14 pre-existing red files on
`develop` locally (cloud-config, vault, wallet, plugin-resolver). None of them
reference `ToolCallCache` or `DiskStore`, `DiskStore` has no consumers outside
this directory, and I reproduced one of them (`plugin-resolver-preflight`) on a
clean `develop` checkout — so they are unrelated to this change rather than
something it introduced.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PBWNFM8KYX7B0FQ3JFGHEV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T14:06:48.309Z","completed_at":"2026-09-04T14:18:09.773Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T14:06:48.534Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5d9db2582a418a00b975bac9ceada410d217be307148e8298655d208e6e7888e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9e0a6430-cdf7-487d-bdf1-a6af985d6f3d","object_id":"sha256:5d9db2582a418a00b975bac9ceada410d217be307148e8298655d208e6e7888e","sha256":"5d9db2582a418a00b975bac9ceada410d217be307148e8298655d208e6e7888e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"o9mh0_gJMLaVg-nnWmj7QQcKo6vu2gnRGzX1GOJpDDEnc_U7kglvUQdD_qDujJKVSrb-q9VJ0zUcV-stYNlnBw"}} -->
