### PR TITLE
fix(cloud): run Cartesia synthesis tests under the bun lane runner

### DIFF
--- a/packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts
@@ -14,8 +14,13 @@ import {
   synthesizeCartesiaWav,
 } from "../cartesia-synthesis";
 
+// The cloud unit lane runs this file under `bun test`, whose vitest-compat `vi`
+// implements neither `stubGlobal` nor `unstubAllGlobals` — those calls failed
+// every stubbing test at setup and the whole file at teardown. Only `fetch` is
+// stubbed here, so assign it directly and restore it after each test.
+const realFetch = globalThis.fetch;
 afterEach(() => {
-  vi.unstubAllGlobals();
+  globalThis.fetch = realFetch;
 });
 
 /** In-memory Cartesia socket: on the generation request, replay frames+done. */
@@ -266,7 +271,7 @@ describe("makeWorkersCartesiaWebSocketFactory", () => {
         webSocket: upstreamSocket,
       });
     });
-    vi.stubGlobal("fetch", fetchImpl);
+    globalThis.fetch = fetchImpl as unknown as typeof fetch;
     const beforeProviderDispatch = vi.fn(async () => {
       events.push("callback:start");
       await Promise.resolve();
@@ -292,7 +297,7 @@ describe("makeWorkersCartesiaWebSocketFactory", () => {
 
   it("does not attempt the upgrade when the dispatch callback rejects", async () => {
     const fetchImpl = vi.fn(async () => new Response(null));
-    vi.stubGlobal("fetch", fetchImpl);
+    globalThis.fetch = fetchImpl as unknown as typeof fetch;
     const beforeProviderDispatch = vi.fn(async () => {
       throw new Error("dispatch marker unavailable");
     });


### PR DESCRIPTION
## Summary
`canonical / Smoke lanes: Cloud tests` on develop head `5463f6db8` fails deterministically: every test in `packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts` (12/12 red) with `TypeError: vi.unstubAllGlobals is not a function` at teardown, plus two tests failing earlier at `vi.stubGlobal` (Develop Full run 33822968275, job 100870028372). #30362 introduced those calls; the cloud unit lane runs the file under plain `bun test` via `packages/scripts/test-cloud-run.mjs`, and bun's vitest-compat `vi` (pinned 1.3.14, still true on 1.4.0) implements neither `stubGlobal` nor `unstubAllGlobals`. This PR replaces them with the established cloud test idiom — direct `globalThis.fetch` assignment with the repo-standard `as unknown as typeof fetch` cast (as in `agent-bridge-runtime-routing.test.ts`, `chat-completions-passthrough-streaming.test.ts`, `dedicated-agent-proxy.test.ts`) and an `afterEach` restore of the captured original. No assertion or test semantic changes.

## Regression
- **Red (develop `5463f6db8`, disposable container `oven/bun:1.3.14`, `bun install --frozen-lockfile --ignore-scripts`):** `bun test packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts` → `0 pass / 12 fail`, `TypeError: vi.unstubAllGlobals is not a function ... cartesia-synthesis.test.ts:18:6` — byte-matching the hosted lane failure.
- **Green (this PR, same container, only this file changed):** same command → `12 pass / 0 fail, 32 expect() calls`.

## Evidence Gate

<!-- evidence-head:0bd9b6bd70d52dfbe3c3d08fff9cdd3cd1a829ca -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side test-lane repair; no UI surface touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side test-lane repair; no UI surface touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend-testable change; the proof is the red→green test run below.
<!-- evidence-row:backend-logs -->
- [x] Red at develop head `5463f6db8` in container (oven/bun:1.3.14):
  ```
  TypeError: vi.unstubAllGlobals is not a function. (In 'vi.unstubAllGlobals()', 'vi.unstubAllGlobals' is undefined)
        at <anonymous> (/work/packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts:18:6)
   0 pass
  12 fail
  ```
  Green at this PR head `0bd9b6bd70d52dfbe3c3d08fff9cdd3cd1a829ca` in the same container:
  ```
   12 pass
   0 fail
   32 expect() calls
  Ran 12 tests across 1 file. [1338ms]
  ```
  Hosted lane failure being repaired: Develop Full run 33822968275, job `canonical / Smoke lanes: Cloud tests` (job id 100870028372), identical TypeError at `cartesia-synthesis.test.ts:18:6`.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path; test infrastructure only.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, or prompt path touched.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifact; test-lane repair only.
<!-- evidence-row:ocr-review -->
- [x] N/A - no UI capture involved.

## Verification
- `bun test packages/cloud/api/v1/voice/tts/__tests__/cartesia-synthesis.test.ts` — 12/12 green in disposable container (bun 1.3.14, frozen lockfile, ignore-scripts, generated i18n keywords).
- `cd packages/cloud/api && bun run typecheck` — `tsc --noEmit` and `check:router-contract` pass. (`check:worker-bundle` needs built workspace dists that a `--ignore-scripts` container does not produce; CI runs it after build. My diff touches only a test file, outside the worker bundle graph.)
- `bunx @biomejs/biome check` on the changed file — clean.

## Remaining develop-lane failures (not this PR, decomposition at 5463f6db8)
- `route-provider-selection.test.ts` expects `Server-Timing` on 4xx — owned by open #30395.
- `migrate-database.diagnostic.test.ts` 0295 child path times out at its 60 s `spawnSync` cap — separate investigation, not reproduced here.
- `canonical / Smoke (3)` — external HTTP 429 on `gte-small_fp16.gguf` (known external root).
- Zero-Key diagnostics slice — owned by open #30490.

## Known gaps / failures
- `bun run verify` not run in full locally (shared machine); owning-workspace `tsc --noEmit`, biome, and the focused suite verified in container as above.


Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: z.ai / glm-5.3
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza
Attribution status: self-reported
— [workflow-health]
<!-- slop-contribution-attribution:v1 {"provider":"z.ai","model":"glm-5.3","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PA9GPQ4NPNVSEQA848F982","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T13:38:52.247Z","completed_at":"2026-09-04T15:32:26.272Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T13:38:54.146Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"341975e1c4fe56d29158d9257c464acadb2acf20af79127ac2255d2919eb651b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"76307de5-f0d1-4754-94e1-75513c69a6f4","object_id":"sha256:341975e1c4fe56d29158d9257c464acadb2acf20af79127ac2255d2919eb651b","sha256":"341975e1c4fe56d29158d9257c464acadb2acf20af79127ac2255d2919eb651b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAR850XHeZVEfYMatnrCiWT7P3QZHECM3R-C2VnfZ8iZQ","device_key_id":"5935e4ed75d7ef04a6827ac468d61a17e4bba8f871647762e8ff62c5e50dda49","device_signature":"RslEFM9z2OyUNfOsXu1jaUha08b9lP2_jb2BFqELD4tfShIeM44levLFAu1wSyUhCyFpJfH4YqQduTkPt1q1BA"}} -->
