### PR TITLE
fix(app-core): validate consumer usage-log lines before metering on them

### DIFF
--- a/packages/app-core/src/services/account-pool-consumer-metering.test.ts
+++ b/packages/app-core/src/services/account-pool-consumer-metering.test.ts
@@ -4,7 +4,7 @@
  * parser tests feed raw SSE bytes, auth tests inspect stripped headers, and
  * storage tests exercise the durable JSONL/totals path.
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -323,5 +323,221 @@ describe("quota and totals", () => {
       tokens: 150,
     });
     expect(summary.records).toEqual([]);
+  });
+});
+
+describe("a damaged usage-log line", () => {
+  // The log is append-only and `readUsageRecords` runs on the admission path,
+  // so a line this process did not finish writing must not be able to fail —
+  // or silently pass — the quota gate.
+
+  function usageDirPath(): string {
+    return path.join(stateDir, "account-pool", "consumer-usage");
+  }
+
+  function appendRawLine(bytes: string): void {
+    const files = readdirSync(usageDirPath());
+    if (files.length !== 1) throw new Error("expected exactly one usage file");
+    appendFileSync(path.join(usageDirPath(), files[0]), bytes);
+  }
+
+  async function seedRecord(consumerId: string, tokens: number): Promise<void> {
+    await recordAccountPoolConsumerUsage({
+      ts: 1_800_000_000_000,
+      consumerId,
+      consumerLabel: "damaged-line",
+      model: "claude-test",
+      streaming: false,
+      status: 200,
+      latencyMs: 5,
+      usage: {
+        input_tokens: tokens,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    });
+  }
+
+  it("does not fail admission, and does not fail it forever", async () => {
+    const created = createAccountPoolConsumerKey({
+      label: "truncated",
+      dailyTokenQuota: 1_000_000,
+    });
+    if (!created) throw new Error("failed to create key");
+    await seedRecord(created.consumer.id, 10);
+
+    // An append interrupted before its trailing newline.
+    appendRawLine(`{"consumerId":"${created.consumer.id}","ts":1`);
+
+    // Twice: the first call must not throw, and the row is left in place, so
+    // the second must not throw either.
+    for (const _attempt of [1, 2]) {
+      const admission = await admitAccountPoolConsumerRequest(created.consumer);
+      expect(admission).not.toHaveProperty("status", 429);
+      expect(admission).toHaveProperty("consumerId", created.consumer.id);
+    }
+  });
+
+  it("still reports every intact record in the same file", async () => {
+    const created = createAccountPoolConsumerKey({ label: "partial-ledger" });
+    if (!created) throw new Error("failed to create key");
+    await seedRecord(created.consumer.id, 10);
+    await seedRecord(created.consumer.id, 7);
+    // Truncation strands the newline too, so the damaged bytes are last.
+    appendRawLine('{"consumerId":"x","ts":1');
+
+    const summary = await queryAccountPoolConsumerUsage({});
+    // Liveness control: skipping the damaged line must not mean skipping the
+    // ledger. Without this, every assertion above would pass just as well if
+    // the reader returned nothing at all.
+    expect(summary.records).toHaveLength(2);
+    expect(summary.totals.tokens).toBe(17);
+    expect(summary.totals.requests).toBe(2);
+  });
+
+  it("loses only the damaged line's own record, not the whole file", async () => {
+    const created = createAccountPoolConsumerKey({ label: "one-line-lost" });
+    if (!created) throw new Error("failed to create key");
+    await seedRecord(created.consumer.id, 10);
+    // A complete but unparseable line, newline intact, with a good record
+    // after it.
+    appendRawLine('{"consumerId":"x","ts":1\n');
+    await seedRecord(created.consumer.id, 7);
+
+    const summary = await queryAccountPoolConsumerUsage({});
+    expect(summary.records).toHaveLength(2);
+    expect(summary.totals.tokens).toBe(17);
+  });
+
+  const NON_CONFORMING: ReadonlyArray<
+    readonly [string, Record<string, unknown>]
+  > = [
+    [
+      "no totalTokens (a `reduce` over it would make the day total NaN)",
+      {
+        ts: 1_800_000_000_001,
+        latencyMs: 1,
+        status: 200,
+        usage: {
+          input_tokens: 1,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    ],
+    [
+      "no usage object",
+      { ts: 1_800_000_000_001, totalTokens: 5, latencyMs: 1, status: 200 },
+    ],
+    [
+      "usage present but a member missing",
+      {
+        ts: 1_800_000_000_001,
+        totalTokens: 5,
+        latencyMs: 1,
+        status: 200,
+        usage: {
+          input_tokens: 1,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    ],
+    [
+      "no ts (would pass every day-window comparison)",
+      {
+        totalTokens: 5,
+        latencyMs: 1,
+        status: 200,
+        usage: {
+          input_tokens: 1,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    ],
+    [
+      "totalTokens is a string",
+      {
+        ts: 1_800_000_000_001,
+        totalTokens: "5",
+        latencyMs: 1,
+        status: 200,
+        usage: {
+          input_tokens: 1,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    ],
+  ];
+
+  for (const [label, row] of NON_CONFORMING) {
+    it(`is ignored by the usage summary: ${label}`, async () => {
+      const created = createAccountPoolConsumerKey({ label: "shapeless" });
+      if (!created) throw new Error("failed to create key");
+      await seedRecord(created.consumer.id, 10);
+      appendRawLine(
+        `${JSON.stringify({ consumerId: created.consumer.id, ...row })}\n`,
+      );
+
+      const summary = await queryAccountPoolConsumerUsage({});
+      expect(summary.records).toHaveLength(1);
+      expect(summary.totals.tokens).toBe(10);
+    });
+  }
+
+  it("cannot lift an exhausted quota", async () => {
+    const created = createAccountPoolConsumerKey({
+      label: "quota-bypass",
+      dailyTokenQuota: 100,
+    });
+    if (!created) throw new Error("failed to create key");
+    const day = new Date().toISOString().slice(0, 10);
+    await recordAccountPoolConsumerUsage({
+      consumerId: created.consumer.id,
+      consumerLabel: created.consumer.label,
+      model: "claude-test",
+      streaming: false,
+      status: 200,
+      latencyMs: 1,
+      usage: {
+        input_tokens: 500,
+        output_tokens: 500,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    });
+    expect(day).toBe(day);
+
+    // Already far over quota.
+    expect(
+      await admitAccountPoolConsumerRequest(created.consumer),
+    ).toMatchObject({ ok: false, status: 429 });
+
+    // A single record with no `totalTokens` used to turn the day total into
+    // NaN, and `NaN > quota` is `false` — the gate opened.
+    appendRawLine(
+      `${JSON.stringify({
+        consumerId: created.consumer.id,
+        ts: Date.now(),
+        latencyMs: 1,
+        status: 200,
+        usage: {
+          input_tokens: 1,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      })}\n`,
+    );
+
+    expect(
+      await admitAccountPoolConsumerRequest(created.consumer),
+    ).toMatchObject({ ok: false, status: 429 });
   });
 });

--- a/packages/app-core/src/services/account-pool-consumer-metering.ts
+++ b/packages/app-core/src/services/account-pool-consumer-metering.ts
@@ -1081,6 +1081,42 @@ export async function queryAccountPoolConsumerUsage(
   return result;
 }
 
+/**
+ * Is one parsed usage-log line a usable {@link AccountPoolConsumerUsageRecord}?
+ *
+ * Every numeric field checked here is one that {@link addRecordToBucket} or
+ * {@link recordedConsumerDayTokens} goes on to *accumulate or compare*, which
+ * is where a missing field stops being loud and starts being silently wrong.
+ * `totalTokens` is the sharpest: the day total is a `reduce` of it straight
+ * into the admission comparison, so a single record without it makes `used`
+ * `NaN`, and `NaN > quota` is `false` — the quota gate would admit a consumer
+ * that is already over its limit, permanently.
+ */
+function isUsageRecord(
+  parsed: unknown,
+): parsed is AccountPoolConsumerUsageRecord {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
+  const row = parsed as Partial<AccountPoolConsumerUsageRecord>;
+  const usage = row.usage as
+    | Partial<AccountPoolConsumerUsage>
+    | undefined
+    | null;
+  if (typeof usage !== "object" || usage === null) return false;
+  return (
+    typeof row.consumerId === "string" &&
+    Number.isFinite(row.ts) &&
+    Number.isFinite(row.totalTokens) &&
+    Number.isFinite(row.latencyMs) &&
+    Number.isFinite(row.status) &&
+    Number.isFinite(usage.input_tokens) &&
+    Number.isFinite(usage.output_tokens) &&
+    Number.isFinite(usage.cache_read_input_tokens) &&
+    Number.isFinite(usage.cache_creation_input_tokens)
+  );
+}
+
 function readUsageRecords(
   query: AccountPoolConsumerUsageQuery,
 ): AccountPoolConsumerUsageRecord[] {
@@ -1095,7 +1131,19 @@ function readUsageRecords(
     const raw = readFileSync(path.join(dir, fileName), "utf8");
     for (const line of raw.split("\n")) {
       if (!line.trim()) continue;
-      const parsed = JSON.parse(line) as AccountPoolConsumerUsageRecord;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // error-policy:J3 the log is append-only and this reader runs on the
+        // admission path, so an append interrupted before its newline must not
+        // become a permanent outage: every later call would re-read the same
+        // partial line and throw again. One unreadable line is skipped, the
+        // rest of the ledger is still counted, and the record is left in place
+        // rather than rewritten — this is an audit log, not a cache.
+        continue;
+      }
+      if (!isUsageRecord(parsed)) continue;
       if (query.consumerId && parsed.consumerId !== query.consumerId) continue;
       if (parsed.ts < start || parsed.ts >= end) continue;
       out.push(parsed);


### PR DESCRIPTION
## The bug

`readUsageRecords` parsed the append-only consumer usage log one line at a time,
with no error handling and an unvalidated cast:

```ts
const parsed = JSON.parse(line) as AccountPoolConsumerUsageRecord;
```

That reader is not a reporting-only path. It feeds `recordedConsumerDayTokens`,
whose sum lands directly in the admission gate:

```ts
const used = recordedConsumerDayTokens(consumer.id, day);
// ...
if (used + reserved + normalizedReservation > consumer.dailyTokenQuota) {
  return { ok: false, status: 429, body: anthropicQuotaError() };
}
```

Lines are written with `appendFileSync`, so a crash, a signal or a full disk
between the record and its trailing newline leaves a partial line behind. I
seeded a real record, appended one truncated line, and called the admission
function twice:

```
attempt 1: THREW SyntaxError
attempt 2: THREW SyntaxError
```

Nothing skips or repairs the line, so it is not one failed request — every
later admission decision re-reads the same bytes and throws again, in this
process and in every future one. `queryAccountPoolConsumerUsage` throws with it.

## The same cast also decides wrongly rather than loudly

`used` is a `reduce` over `record.totalTokens`. One well-formed line missing
that field makes the sum `NaN` — and `NaN > quota` is `false`. Against a
consumer already far past a 100-token quota:

```
over-quota admission BEFORE: {"ok":false,"status":429,...}
over-quota admission AFTER : {"id":"qbfxPIAqQd3VrtsV",...}     <- admitted
```

Two more shapes behave the same way: a record with no `usage` object throws a
`TypeError` out of the summary via `addRecordToBucket`, and a record with no
`ts` passes *both* halves of `parsed.ts < start || parsed.ts >= end` — since
`undefined` compares `false` either way — so it is counted into every day.

**On reachability, so the severity is not overstated:** `normalizeUsage` runs
every member through `normalizeNonNegativeInteger`, so `usageTotal` is always
finite and today's writer *cannot* emit a record without `totalTokens`; the
field and the log format also arrived in the same commit (d59e659500), so no
older schema produced one either. The quota bypass therefore needs external
modification of the state directory or a future schema change. **The truncated
line does not** — an interrupted append is enough. So the throw is why this
needs fixing, and the bypass is why the fix validates rather than merely
catching: a bare `try/catch` closes the outage and leaves the gate open.

## The fix, and why it is this shape

This module already applies the right rule to its *other* untrusted input.
`consumeEvent` guards `JSON.parse` on upstream SSE bytes:

```ts
} catch {
  // error-policy:J3 upstream SSE data is untrusted input; malformed events
  // are invalid for metering but the already-enqueued passthrough bytes are
  // still owned by the transport proxy.
  return;
}
```

A log line written by a previous process is untrusted in exactly the same sense.
This extends that existing in-file policy to the reader 900 lines away, rather
than importing an outside opinion: skip a line that cannot be parsed, and
validate the rest through `isUsageRecord`, which checks every field the
aggregation and the quota comparison go on to accumulate or compare.

## What I deliberately did not change

- **The damaged line is left on disk.** #30528 evicts an unreadable row because
  a cache row is reconstructible; this is an audit log, and repairing it by
  rewriting would destroy records. Skipping is the whole remedy.
- **No logger.** The module imports only node builtins plus `resolveStateDir`,
  and its own SSE precedent skips silently with a comment. Adding a logging
  dependency to announce a skipped line would be a bigger change than the fix.
  If you would rather surface a skipped-line count, say so and I will add it —
  it is a deliberate omission, not an oversight.
- **A truncation that strands the newline still costs the *next* record too**,
  because the following append glues onto the same line. That is inherent to
  the JSONL-plus-`appendFileSync` format, not something the reader can recover;
  a test pins the boundary explicitly so the limit is documented rather than
  assumed.
- `readTotalsFile`, `readReservationsFile` and `readKeysFile` are untouched.
  What separates them from the log reader is that all three read a *whole* file
  written through `atomicWriteJson` (temp file + `rename`), so the interrupted
  write that produces a partial JSONL line cannot produce a partial one of
  these. `readReservationsFile` and `readKeysFile` additionally check a version
  and reject a bad shape — `readReservationsFile` validates every reservation
  field by field, which is the model I followed for `isUsageRecord`.
  `readTotalsFile` does **not**: it is a bare
  `JSON.parse(readFileSync(file)) as AccountPoolConsumerUsageTotals` with no
  checks at all, so a totals file with no `byConsumer` would throw a
  `TypeError` out of `recordAccountPoolConsumerUsage`. I am leaving it out of
  this PR because its atomic write means nothing in normal operation produces
  such a file — but the asymmetry with its immediate neighbour is real, and if
  you would like it validated too, say so and I will extend this PR rather than
  open a second one against the same module.

## Tests

9 added, alongside the 10 existing ones.

- Admission survives a truncated trailing line, **twice** — the second call is
  what proves it is not permanent.
- A damaged line costs only its own record: intact records before it, and after
  it when the newline survived, are still counted.
- A table of five non-conforming shapes (no `totalTokens`, no `usage`, a
  missing `usage` member, no `ts`, a string `totalTokens`) is ignored by the
  summary.
- An exhausted quota **stays** exhausted when a `totalTokens`-less line is
  appended.
- **Liveness control**: two intact records around a damaged line still report
  `tokens: 17`, `requests: 2`. Without it, every "is ignored" assertion above
  would pass just as well if the reader returned nothing at all.

**Ablation** — reverting only the reader and re-running:

```
Tests  9 failed | 10 passed (19)
```

Restored: `19 passed`. Biome clean. `tsc -p packages/app-core` reports 22
errors, unchanged from `develop` and none in either changed file.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PEQTEJMWM4840P15WVPRNQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T14:56:35.282Z","completed_at":"2026-09-04T14:57:30.203Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T14:56:35.884Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5d7eace5d5410a85dea3ff2a83f319bb11a96ff4ceb186643f21c001ebb548d6","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c97c2bdd-f7ad-40d1-b558-89af26355fe4","object_id":"sha256:5d7eace5d5410a85dea3ff2a83f319bb11a96ff4ceb186643f21c001ebb548d6","sha256":"5d7eace5d5410a85dea3ff2a83f319bb11a96ff4ceb186643f21c001ebb548d6"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"xoTj_NbOBpnG55EffRQbKkcWqAqBtnWNVaq0db0dHpDTqaSBs60wxIxq8aeNNVuFHeSdA3jveH-_zSzZEH5BAA"}} -->

