### PR TITLE
test(cloud): name the timeout when the admin-migrate child is killed

### DIFF
--- a/packages/cloud/scripts/admin/migrate-database.diagnostic.test.ts
+++ b/packages/cloud/scripts/admin/migrate-database.diagnostic.test.ts
@@ -33,17 +33,59 @@ interface JournalEntry {
   breakpoints: boolean;
 }
 
-function runAdminScript(args: string[], environment: NodeJS.ProcessEnv) {
-  return spawnSync(
+/**
+ * Wall-clock cap on one child run of the admin script.
+ *
+ * The `0295` case below drives a real destination migration and takes ~25 s
+ * locally, so this is roughly 2.5x headroom — thin enough that a loaded CI
+ * runner has hit it.
+ */
+const ADMIN_SCRIPT_TIMEOUT_MS = 60_000;
+
+/**
+ * Run the admin script once, failing loudly if the child did not exit on its
+ * own terms.
+ *
+ * Without this guard a `timeout` kill is the least legible failure this file
+ * can produce. `spawnSync` reports it as `status: null`, `signal: "SIGTERM"`,
+ * `error: ETIMEDOUT` — and with **empty** `stdout`/`stderr`, because the
+ * buffers die with the child. Every assertion here is of the form
+ * `expect(result.status, output).toBe(1)`, so the run surfaces as
+ *
+ *     expected null to be 1
+ *
+ * with a blank custom message, naming neither the timeout nor the cap. The one
+ * fact worth knowing is the one that gets dropped. Following the existing
+ * repo idiom for spawned children (`run-with-deadline.test.mjs` reports
+ * `status`/`signal`/`error` together; `provider-latency-report.test.ts`
+ * asserts `result.error` is undefined), classify that case up front.
+ */
+function runAdminScript(
+  args: string[],
+  environment: NodeJS.ProcessEnv,
+  timeoutMs: number = ADMIN_SCRIPT_TIMEOUT_MS,
+) {
+  const result = spawnSync(
     process.execPath,
     ["--conditions=eliza-source", scriptPath, ...args],
     {
       cwd: repositoryRoot,
       env: environment,
       encoding: "utf8",
-      timeout: 60_000,
+      timeout: timeoutMs,
     },
   );
+  if (result.error || result.signal !== null) {
+    throw new Error(
+      `admin script did not exit on its own: status=${String(result.status)} ` +
+        `signal=${String(result.signal)} error=${String(result.error)}. ` +
+        `The ${timeoutMs}ms spawnSync cap kills the child and discards its ` +
+        `output, so stdout/stderr below are expected to be empty.\n` +
+        `--- stdout ---\n${result.stdout ?? ""}\n` +
+        `--- stderr ---\n${result.stderr ?? ""}`,
+    );
+  }
+  return result;
 }
 
 async function seedLegacyPhoneJsonFailure(
@@ -240,5 +282,25 @@ describe("migrate-database fatal diagnostics", () => {
     });
     expect(JSON.stringify(diagnostic)).not.toContain(secretMessage);
     expect(Object.keys(diagnostic).sort()).toEqual(["code", "stage"]);
+  });
+
+  test("names the timeout when the child is killed instead of exiting", () => {
+    // Same code path as every case above, with a cap the child cannot meet, so
+    // this is the real kill rather than a synthetic result object. ~200ms.
+    let message = "";
+    try {
+      runAdminScript([], process.env, 200);
+      throw new Error("expected the harness to reject a killed child");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    // The three facts a CI log needs and `expect(status).toBe(1)` throws away.
+    expect(message).toContain("did not exit on its own");
+    expect(message).toContain("signal=SIGTERM");
+    expect(message).toContain("200ms spawnSync cap");
+    // And it must say why the output it prints is blank, so an empty tail does
+    // not read as "the script produced nothing".
+    expect(message).toContain("discards its output");
   });
 });


### PR DESCRIPTION
## Why

#30529's description enumerated the remaining `develop-full` failures and left
one without an owner:

> `migrate-database.diagnostic.test.ts` 0295 child path times out at its 60 s
> `spawnSync` cap — separate investigation, not reproduced here.

That phrasing is the symptom this PR addresses. Characterising the red run
required a separate investigation *before it could even be attributed*, because
of how the failure presents.

## The failure is the least legible one this file can produce

Each case spawns the real admin script under a 60 s cap. When `spawnSync` kills
a child on `timeout` it returns:

```
status: null
signal: "SIGTERM"
error : ETIMEDOUT spawnSync ... ETIMEDOUT
stdout: ""      <- buffers die with the child
stderr: ""
```

Every assertion in the file has the form `expect(result.status, output).toBe(1)`,
so the run reports:

```
expected null to be 1 -- output was: ""
```

The custom message the author deliberately attached is **empty**, because it is
built from the dead child's buffers. The report names neither the timeout nor
the cap, and the blank output tail reads as *"the script printed nothing"*
rather than *"the script was killed"* — which points an investigation at the
migration logic instead of at the clock.

## What this changes

Only the classification. `runAdminScript` now detects a child that did not exit
on its own terms and fails with the three facts a CI log needs:

```
admin script did not exit on its own: status=null signal=SIGTERM
error=Error: spawnSync ... ETIMEDOUT. The 60000ms spawnSync cap kills the child
and discards its output, so stdout/stderr below are expected to be empty.
```

This follows the existing repo idiom rather than inventing one —
`packages/scripts/run-with-deadline.test.mjs:659` reports `status`, `signal` and
`error` together in its failure message, and
`packages/core/scripts/provider-latency-report.test.ts:43` asserts
`result.error` is undefined.

## What I deliberately did not change

- **The cap stays at 60 s.** The file passes locally — 5 tests in 26.5 s, with
  the `0295` case alone at ~25.6 s, nearly all of it the spawned child. So 60 s
  is roughly **2.5x headroom**: thin for a loaded runner, which fits an
  intermittent CI timeout. But the test is not wrong, and raising the number
  silently would mask the ~25 s runtime rather than report it. Choosing a new
  cap is a CI-budget decision that belongs to you, so I made it a named constant
  and an injectable parameter — it is now a one-line change if you want it, and
  I am happy to make it here.
- **The other 27 files.** 46 test files spawn a child with a `timeout`; 18
  reference `ETIMEDOUT` / `.signal` / `result.error`, and 28 do not, so a
  timeout in any of them surfaces the same way. I scoped this to the one file
  that is actually red rather than editing all of them. Happy to follow up if
  you want the pattern applied more broadly.

  (Worth flagging that my first pass at that count was wrong — a loose
  `/\.error\b/` matched unrelated domain fields like `job.error` in
  `managed-dedicated-canary-diagnostic.test.ts`. The numbers above come from a
  tightened predicate, spot-checked against the files it claims.)
- **The migration itself.** Nothing about what the child does, or how long it
  takes, is touched.

## Tests

One added. It drives the *same* code path with a cap the child cannot meet, so
it exercises a real `SIGTERM` kill rather than a synthetic result object, and
completes in ~200 ms instead of waiting out a 60 s timeout. It asserts the three
facts that `expect(status).toBe(1)` discards, plus the sentence explaining why
the printed output is blank — so an empty tail is never mistaken for silence
from the script.

**Ablation** — reverting the guard and re-running just that test:

```
Expected to contain: "did not exit on its own"
Received: "expected the harness to reject a killed child"
```

Restored: `6 pass, 0 fail` for the whole file. Biome clean.
`tsc --noEmit -p packages/cloud` reports 1 error on this branch and 1 on
`develop` — baseline unchanged, and not in this file.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PG37QZ6PBFJQB2KRYDSZVD","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T15:20:17.920Z","completed_at":"2026-09-04T15:21:16.203Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T15:20:18.534Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fa1041edf373a701ce2def87740e65c9da718f0c56d62f47d87d15006761c0da","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"3e3a1ffc-e79b-4646-84c5-7322f9168bc1","object_id":"sha256:fa1041edf373a701ce2def87740e65c9da718f0c56d62f47d87d15006761c0da","sha256":"fa1041edf373a701ce2def87740e65c9da718f0c56d62f47d87d15006761c0da"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"M_zQoph7sXdIo0_riM-BogEjJEM0JzWJexkiYg_73rN2jnfHwUeGrUDCv7ofiwzzIG0S53z9ogKcjB0pQ0lxBQ"}} -->
