### PR TITLE
fix(ui): keep address-bar typing that races an in-flight tab operation

### DIFF
--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -1042,3 +1042,68 @@ describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () =>
     }
   });
 });
+
+describe("Browser workspace address bar during an in-flight tab operation", () => {
+  const NAVIGATED_WORKSPACE = {
+    ...EXAMPLE_WORKSPACE,
+    tabs: [{ ...EXAMPLE_WORKSPACE.tabs[0], url: "https://docs.elizaos.ai/" }],
+  };
+
+  async function renderWithPendingNavigation() {
+    const pending = deferred<{ tab: (typeof EXAMPLE_WORKSPACE)["tabs"][0] }>();
+    vi.mocked(client.getBrowserWorkspace)
+      .mockReset()
+      .mockResolvedValueOnce(EXAMPLE_WORKSPACE)
+      .mockResolvedValue(NAVIGATED_WORKSPACE);
+    vi.mocked(client.navigateBrowserWorkspaceTab)
+      .mockReset()
+      .mockImplementation(() => pending.promise);
+
+    render(<BrowserWorkspaceView />);
+    const address = (await screen.findByTestId(
+      "browser-workspace-address-input",
+    )) as HTMLInputElement;
+    await waitFor(() => expect(address.value).toBe("https://example.com/"));
+
+    fireEvent.change(address, { target: { value: "docs.elizaos.ai" } });
+    fireEvent.click(screen.getByLabelText("Go"));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    return { address, pending };
+  }
+
+  async function settle(
+    pending: Awaited<ReturnType<typeof renderWithPendingNavigation>>["pending"],
+  ) {
+    pending.resolve({ tab: NAVIGATED_WORKSPACE.tabs[0] });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("keeps what the user typed while a navigation was still in flight", async () => {
+    const { address, pending } = await renderWithPendingNavigation();
+
+    // The user changes their mind mid-load, as in a real browser.
+    fireEvent.change(address, {
+      target: { value: "typed-during-flight.test" },
+    });
+    await settle(pending);
+
+    // Completing the navigation used to write the settled URL and clear the
+    // dirty flag unconditionally, which also re-armed the sync effect and left
+    // the bar showing the tab's PREVIOUS address rather than either the typed
+    // text or the navigation target.
+    expect(address.value).toBe("typed-during-flight.test");
+  });
+
+  it("still adopts the settled URL when the user did not type", async () => {
+    // Liveness control: without this, the assertion above would pass just as
+    // well if the address bar simply stopped following navigations.
+    const { address, pending } = await renderWithPendingNavigation();
+    await settle(pending);
+    expect(address.value).toBe("https://docs.elizaos.ai/");
+  });
+});

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -741,6 +741,24 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
   const walletAddressesRef = useRef(walletAddresses);
   const walletConfigRef = useRef(walletConfig);
   const previousSelectedTabIdRef = useRef<string | null>(null);
+  /**
+   * Bumped on every user edit of the address bar.
+   *
+   * A tab operation ends by writing the settled URL into the address bar and
+   * clearing `locationDirty`. Both of those run *after* an `await`, so any text
+   * the user typed while the operation was in flight is discarded — and
+   * clearing the flag also re-arms the sync effect below, which then overwrites
+   * the field with `selectedTab.url` from workspace state. The visible result
+   * is that typing during a navigation reverts the bar to the tab's previous
+   * address. A real browser keeps what you typed while a page is still loading.
+   *
+   * Handlers snapshot this before their first `await` and skip that terminal
+   * write if the user has typed since.
+   */
+  const locationEditSeqRef = useRef(0);
+  const noteLocationEdit = useCallback(() => {
+    locationEditSeqRef.current += 1;
+  }, []);
 
   if (typeof initialBrowseUrlRef.current === "undefined") {
     const browseParam = readBrowserWorkspaceQueryParam("browse");
@@ -1372,6 +1390,9 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
       }
       const partition = resolveBrowserWorkspaceTabPartition(sectionKey);
       // Native mobile shell: the server manages no tabs (its API 503s), so the
+      // Snapshot before the first await; a later user edit invalidates the
+      // terminal address-bar write below.
+      const editSeqAtStart = locationEditSeqRef.current;
       // tab lives in client state and the isolated native surface loads the page.
       if (browserTabRenderPath === "native-mobile-webview") {
         const tab = buildLocalBrowserWorkspaceTab(
@@ -1393,8 +1414,10 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
       });
       await loadWorkspace({ preferTabId: tab.id, silent: true });
       setSelectedTabId(tab.id);
-      setLocationInput(tab.url);
-      setLocationDirty(false);
+      if (locationEditSeqRef.current === editSeqAtStart) {
+        setLocationInput(tab.url);
+        setLocationDirty(false);
+      }
     },
     [browserTabRenderPath, loadWorkspace, t],
   );
@@ -1413,6 +1436,9 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
 
   const navigateSelectedBrowserWorkspaceTab = useCallback(
     async (rawUrl: string) => {
+      // Snapshot before the first await; a later user edit invalidates the
+      // terminal address-bar write below.
+      const editSeqAtStart = locationEditSeqRef.current;
       if (selectedTab && isInternalBrowserWorkspaceTab(selectedTab)) {
         throw new Error(
           t("browserworkspace.InternalTabUrlManaged", {
@@ -1469,8 +1495,10 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
         tag?.loadURL(tab.url);
       }
       await loadWorkspace({ preferTabId: tab.id, silent: true });
-      setLocationInput(tab.url);
-      setLocationDirty(false);
+      if (locationEditSeqRef.current === editSeqAtStart) {
+        setLocationInput(tab.url);
+        setLocationDirty(false);
+      }
     },
     [
       armBrowserWorkspaceIframeFocusReturn,
@@ -2703,11 +2731,13 @@ function BrowserWorkspaceForAuthority(): React.JSX.Element {
         agentDescription="The browser address bar for the active tab"
         getValue={() => locationInput}
         onFill={(value) => {
+          noteLocationEdit();
           setLocationInput(value);
           setLocationDirty(true);
         }}
         value={locationInput}
         onChange={(event) => {
+          noteLocationEdit();
           setLocationInput(event.target.value);
           setLocationDirty(true);
         }}


### PR DESCRIPTION
## The failing job

`canonical / Smoke (6)` fails on the current `develop` head — run
[33822968275](https://github.com/elizaOS/eliza/actions/runs/33822968275) at
`5463f6db84`, job
[100870028378](https://github.com/elizaOS/eliza/actions/jobs/100870028378),
step *Deterministic end-to-end smoke*. It is the one failing job in that run
that no open PR claims: Smoke (3) is the HTTP 429 (#30527), Smoke lanes covers
cartesia (#30529), `route-provider-selection` (#30395) and migrate-database
(#30531), the four Zero-Key jobs are #30490, and the rest are downstream
aggregations.

```
1) [dashboard-desktop-landscape] › browser-workspace.spec.ts:82 ›
   browser workspace can create, navigate, switch, and close tabs

  Error: expect(locator).toHaveValue(expected) failed
  Expected: "docs.elizaos.ai"
  Received: "https://example.com/"

  276 |
  277 |   await addressInput.fill("docs.elizaos.ai");
> 278 |   await expect(addressInput).toHaveValue("docs.elizaos.ai");
```

The spec waits for the address bar to settle on the selected tab's URL, fills
the field, and finds it back at that tab's **previous** address — 34 locator
resolutions, so it never recovers. It passes on `desktop-webkit` and fails on
`dashboard-desktop-landscape`: a timing difference, not a deterministic break.

## Why it happens

`locationDirty` is what stops the sync effect from overwriting what the user is
typing. The tab handlers end like this, after two awaits:

```ts
await loadWorkspace({ preferTabId: tab.id, silent: true });
setLocationInput(tab.url);
setLocationDirty(false);
```

Both writes are unconditional, so text typed while the operation was in flight
is overwritten. Worse, clearing the flag **re-arms** the sync effect, which
then writes `selectedTab?.url` from workspace state over the top — which is why
the value CI sees is the tab's previous URL rather than either the typed text
or the navigation target.

I reproduced it against the real component with the client call held in flight:

```
user typed  : "typed-during-flight.test"
after settle: "https://example.com/"        <- CI's exact value
```

My first hypothesis was wrong, for the record: I expected a background workspace
refresh to be the clobberer. It is not — typed text survives a background
reload, because that path does respect `locationDirty`. Only the terminal write
at the end of a tab operation clears it.

## The fix

Every user edit bumps a `locationEditSeqRef`. The two handlers that write the
address bar *after* awaiting snapshot it before their first `await` and skip
that terminal write if the user has typed since.

A real browser does not erase what you are typing when a page finishes loading,
so I read this as a product bug rather than a flaky test — the spec asserts the
right thing.

**Scope.** Only `navigateSelectedBrowserWorkspaceTab` and
`openNewBrowserWorkspaceTab`, the two paths that write the bar after an await.
The synchronous native-mobile branches cannot interleave with typing, and the
close-all reset is a deliberate response to an explicit user action; both are
left alone.

## Tests

Two added, driving the real component with `navigateBrowserWorkspaceTab` held
in flight.

- Typing during the in-flight window survives the navigation settling.
- **Liveness control**: with no typing, the settled URL is still adopted.
  Without it, the fix could pass by making the address bar stop following
  navigations altogether.

That control initially failed, and it was my fixture rather than the component:
the mock had `navigateBrowserWorkspaceTab` returning `docs.elizaos.ai` while
`getBrowserWorkspace` still returned `example.com`, so the workspace the effect
mirrors disagreed with the navigation. Made the mock self-consistent, as a real
server would be.

**Ablation** — reverting only `BrowserWorkspaceView.tsx`:

```
× keeps what the user typed while a navigation was still in flight
  → expected 'https://docs.elizaos.ai/' to be 'typed-during-flight.test'
Tests  1 failed | 31 passed (32)
```

Restored: `32 passed`. Biome clean. `tsc --noEmit -p packages/ui` reports 0
errors on this branch and 0 on `develop`.

I have not re-run the full Playwright smoke lane locally (14.6 min in CI); the
component-level reproduction above is byte-identical to the value CI reported,
and the lane will confirm on this PR.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PGQ3Z54Y79SH5YNCV2GADF","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T15:31:09.413Z","completed_at":"2026-09-04T15:32:04.727Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T15:31:09.980Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d6ef9aa8a79f6f3b05c7906256f23b0ae8eeca2478e4f8eba90539d9050499dd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"4380b886-eac2-407e-99c1-de5f3ee64819","object_id":"sha256:d6ef9aa8a79f6f3b05c7906256f23b0ae8eeca2478e4f8eba90539d9050499dd","sha256":"d6ef9aa8a79f6f3b05c7906256f23b0ae8eeca2478e4f8eba90539d9050499dd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"0lLIvm3i84a7Z4gSvu5kb4RSE_hXKnhXObBATf-5tzcYcHxHKCCtG-Jdxia2w1XuDLQmxdijBx1KeV5ABErNAQ"}} -->
