### PR TITLE
registry: add @rh4cpu/plugin-rh4 (community plugin)

### DIFF
--- a/packages/registry/entries/third-party/rh4cpu__plugin-rh4.json
+++ b/packages/registry/entries/third-party/rh4cpu__plugin-rh4.json
@@ -1,0 +1,16 @@
+{
+  "package": "@rh4cpu/plugin-rh4",
+  "repository": "github:giupy997/chipc",
+  "kind": "plugin",
+  "directory": "eliza/plugin-rh4",
+  "description": "Give an agent a real processor: mint, power and read RH-4 chips \u2014 gate-level 8-bit CPUs (2,368 NAND gates) executing on-chain on Robinhood Chain. Each tick engraves one byte of the agent's choosing in the event log: a tamper-proof logbook. Every transaction is simulated before signing; read-only without a key.",
+  "homepage": "https://rh4cpu.tech",
+  "version": "0.1.1",
+  "tags": [
+    "blockchain",
+    "evm",
+    "onchain-cpu",
+    "mining",
+    "robinhood-chain"
+  ]
+}

--- a/packages/registry/entries/third-party/rh4cpu__plugin-rh4.json
+++ b/packages/registry/entries/third-party/rh4cpu__plugin-rh4.json
@@ -5,7 +5,7 @@
   "directory": "eliza/plugin-rh4",
   "description": "Give an agent a real processor: mint, power and read RH-4 chips \u2014 gate-level 8-bit CPUs (2,368 NAND gates) executing on-chain on Robinhood Chain. Each tick engraves one byte of the agent's choosing in the event log: a tamper-proof logbook. Every transaction is simulated before signing; read-only without a key.",
   "homepage": "https://rh4cpu.tech",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "tags": [
     "blockchain",
     "evm",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -507,7 +507,7 @@
         "repo": "@rh4cpu/plugin-rh4",
         "v0": null,
         "v1": null,
-        "v2": "0.1.1"
+        "v2": "0.1.2"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -490,6 +490,51 @@
         "maxPlayers": null
       }
     },
+    "@rh4cpu/plugin-rh4": {
+      "git": {
+        "repo": "giupy997/chipc",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@rh4cpu/plugin-rh4",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Give an agent a real processor: mint, power and read RH-4 chips — gate-level 8-bit CPUs (2,368 NAND gates) executing on-chain on Robinhood Chain. Each tick engraves one byte of the agent's choosing in the event log: a tamper-proof logbook. Every transaction is simulated before signing; read-only without a key.",
+      "homepage": "https://rh4cpu.tech",
+      "topics": [
+        "blockchain",
+        "evm",
+        "onchain-cpu",
+        "mining",
+        "robinhood-chain"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": "eliza/plugin-rh4"
+    },
     "@seekdaseek/plugin-agentfeed": {
       "git": {
         "repo": "seekdaseek/plugin-agentfeed",


### PR DESCRIPTION
## What

Adds the **RH-4 chips** community plugin to the registry: agents can mint, power and read real gate-level 8-bit CPUs — 2,368 NAND gates executing on-chain on Robinhood Chain (chain id 4663). Each paid clock cycle engraves one byte of the agent's choosing into the chain's event log, giving the agent a tamper-proof logbook nobody — the agent included — can rewrite.

- **npm**: [`@rh4cpu/plugin-rh4`](https://www.npmjs.com/package/@rh4cpu/plugin-rh4) v0.1.1
- **Source**: [`giupy997/chipc`](https://github.com/giupy997/chipc), directory `eliza/plugin-rh4`
- **Docs**: [README](https://github.com/giupy997/chipc/tree/main/eliza/plugin-rh4) · [integrator guide](https://github.com/giupy997/chipc/blob/main/INTEGRATION.md) · https://rh4cpu.tech

## Plugin surface

- 3 actions — `MINT_RH4_CHIP` (chip NFT + fixed-supply token in one tx), `TICK_RH4_CHIP` (one paid cycle: byte engraved, reward earned from the chip's mining reserve), `READ_RH4_CHIP` (free state read by id or ticker)
- 1 provider — `RH4_CHIP_STATE`: keeps the agent aware of its own machine

## Safety notes for review

- Every transaction is **simulated (`eth_call`) before signing** — a taken ticker or a lost cycle costs nothing
- **Read-only without a key**: write actions self-disable via `validate()` unless `RH4_PRIVATE_KEY` is set; docs insist on a dedicated low-value key
- All contracts verified on Blockscout (exact match); chip tokens have no mint function, reserves leave the factory only through public `tick()` rewards
- Tested against `@elizaos/core` 1.7.2 with a live `AgentRuntime` (registration, settings resolution, actions, provider) plus live-chain reads and mint/tick `eth_call` simulations against the production factory

## Checklist

- [x] Entry validated (`validate-cli`) — 50 third-party entries pass
- [x] `generated-registry.json` regenerated with `src/generate.ts` (no hand edits)
- [x] Package published to npm under own scope, `elizaos` keyword for runtime auto-discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)