### PR TITLE
fix(ui): stop an updater snapshot discarding a typed release-notes URL

### DIFF
--- a/packages/ui/src/components/pages/ReleaseCenterView.release-notes-url.test.tsx
+++ b/packages/ui/src/components/pages/ReleaseCenterView.release-notes-url.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * The release-notes URL field is the one editable input in Release Center, and
+ * every updater refresh writes to it after awaiting the desktop bridge. These
+ * tests pin that a snapshot landing mid-edit cannot discard what the user
+ * typed, while an untouched field still follows the snapshot.
+ */
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const bridge = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock("../../bridge", () => ({
+  invokeDesktopBridgeRequest: bridge.invoke,
+  isElectrobunRuntime: () => true,
+  subscribeDesktopBridgeEvent: () => () => {},
+}));
+vi.mock("../../config/branding", () => ({
+  useBranding: () => ({ appUrl: "https://app.example/" }),
+}));
+vi.mock("../../services/app-updates/update-policy", () => ({
+  getApplicationUpdateSnapshot: vi.fn().mockResolvedValue(null),
+  mapAgentUpdateStatusToSnapshot: () => null,
+}));
+vi.mock("../../utils", () => ({ openExternalUrl: vi.fn() }));
+vi.mock("../../utils/desktop-workspace", () => ({
+  openDesktopSurfaceWindow: vi.fn(),
+}));
+vi.mock("../../state", () => ({
+  useAppSelectorShallow: (select: (state: unknown) => unknown) =>
+    select({
+      loadUpdateStatus: vi.fn().mockResolvedValue(undefined),
+      t: (key: string, options?: { defaultValue?: string }) =>
+        options?.defaultValue ?? key,
+      updateLoading: false,
+      updateStatus: null,
+    }),
+}));
+
+import { ReleaseCenterView } from "./ReleaseCenterView";
+
+const INITIAL_URL = "https://initial.example/notes";
+const CHECKED_URL = "https://from-check.example/notes";
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Render with the update check held in flight, and return the field. */
+async function renderWithPendingCheck() {
+  const pending = deferred<{ baseUrl: string; canAutoUpdate: boolean }>();
+  bridge.invoke.mockImplementation((args: { rpcMethod: string }) =>
+    args.rpcMethod === "desktopCheckForUpdates"
+      ? pending.promise
+      : Promise.resolve({ baseUrl: INITIAL_URL, canAutoUpdate: true }),
+  );
+
+  render(<ReleaseCenterView />);
+  await flush();
+  const field = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+  await waitFor(() => expect(field.value).toBe(INITIAL_URL));
+
+  const checkButton = screen
+    .getAllByRole("button")
+    .find((button) => (button.textContent ?? "").includes("Check"));
+  if (!checkButton) throw new Error("Check / Download Update button not found");
+  fireEvent.click(checkButton);
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  return {
+    field,
+    settle: async () => {
+      pending.resolve({ baseUrl: CHECKED_URL, canAutoUpdate: true });
+      await flush();
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Release Center release-notes URL", () => {
+  it("keeps a URL typed while an update check was in flight", async () => {
+    const { field, settle } = await renderWithPendingCheck();
+
+    fireEvent.change(field, {
+      target: { value: "https://typed-by-user.test/n" },
+    });
+    await settle();
+
+    // The dirty flag used to be read from the closure captured before the
+    // await, so it was still `false` here and the snapshot won.
+    expect(field.value).toBe("https://typed-by-user.test/n");
+  });
+
+  it("still adopts the checked snapshot URL when the user did not type", async () => {
+    // Liveness control: without this, the assertion above would pass just as
+    // well if the field stopped following updater snapshots altogether.
+    const { field, settle } = await renderWithPendingCheck();
+    await settle();
+    expect(field.value).toBe(CHECKED_URL);
+  });
+
+  it("does not re-run the updater refresh just because the field was edited", async () => {
+    bridge.invoke.mockResolvedValue({
+      baseUrl: INITIAL_URL,
+      canAutoUpdate: true,
+    });
+    render(<ReleaseCenterView />);
+    await flush();
+    const field = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    await waitFor(() => expect(field.value).toBe(INITIAL_URL));
+
+    const before = bridge.invoke.mock.calls.length;
+    for (const value of ["a", "ab", "abc"]) {
+      fireEvent.change(field, { target: { value } });
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    // The refresh callback used to take the dirty flag as a dependency, so the
+    // first keystroke changed its identity and re-ran the effects holding it.
+    expect(bridge.invoke.mock.calls.length).toBe(before);
+  });
+});

--- a/packages/ui/src/components/pages/ReleaseCenterView.tsx
+++ b/packages/ui/src/components/pages/ReleaseCenterView.tsx
@@ -13,7 +13,13 @@ import {
   RefreshCw,
   RotateCcw,
 } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useAgentElement } from "../../agent-surface";
 import {
   invokeDesktopBridgeRequest,
@@ -158,7 +164,18 @@ export function ReleaseCenterView() {
   const [releaseNotesUrl, setReleaseNotesUrl] = useState(
     defaultReleaseNotesUrl,
   );
-  const [releaseNotesUrlDirty, setReleaseNotesUrlDirty] = useState(false);
+  /**
+   * Has the user edited the release-notes URL, so an updater snapshot must not
+   * overwrite it?
+   *
+   * A ref rather than state, because every read happens *after* an `await` on
+   * the desktop bridge. A closure read there sees the value captured when the
+   * request was issued — always `false` if the user had not started typing yet
+   * — so editing the field while a check was in flight got overwritten by the
+   * snapshot when it landed. Nothing renders from this flag, so state bought a
+   * re-render and a stale read and nothing else.
+   */
+  const releaseNotesUrlDirtyRef = useRef(false);
 
   const refreshNativeState = useCallback(async () => {
     if (!desktopRuntime) return;
@@ -177,11 +194,16 @@ export function ReleaseCenterView() {
 
     setNativeUpdater(snapshot);
     setReleaseNotesUrl((current) =>
-      releaseNotesUrlDirty
+      releaseNotesUrlDirtyRef.current
         ? current
         : normalizeReleaseNotesUrl(snapshot?.baseUrl ?? current),
     );
-  }, [desktopRuntime, releaseNotesUrlDirty]);
+    // The dirty flag is intentionally absent from the dependencies: it is read
+    // through the ref above, so this callback keeps a stable identity while the
+    // user edits. Previously the first keystroke changed that identity and
+    // re-ran both effects below, costing one redundant bridge refresh and a
+    // listener re-subscribe.
+  }, [desktopRuntime]);
 
   useEffect(() => {
     void loadUpdateStatus();
@@ -263,7 +285,7 @@ export function ReleaseCenterView() {
       ipcChannel: "desktop:checkForUpdates",
     });
     setNativeUpdater(snapshot);
-    if (!releaseNotesUrlDirty && snapshot?.baseUrl) {
+    if (!releaseNotesUrlDirtyRef.current && snapshot?.baseUrl) {
       setReleaseNotesUrl(normalizeReleaseNotesUrl(snapshot.baseUrl));
     }
   };
@@ -459,7 +481,7 @@ export function ReleaseCenterView() {
     void runAction(
       "reset-release-url",
       async () => {
-        setReleaseNotesUrlDirty(false);
+        releaseNotesUrlDirtyRef.current = false;
         setReleaseNotesUrl(
           normalizeReleaseNotesUrl(
             nativeUpdater?.baseUrl ?? defaultReleaseNotesUrl,
@@ -635,7 +657,7 @@ export function ReleaseCenterView() {
           type="url"
           value={releaseNotesUrl}
           onValueChange={(value) => {
-            setReleaseNotesUrlDirty(true);
+            releaseNotesUrlDirtyRef.current = true;
             setReleaseNotesUrl(value);
           }}
         />


### PR DESCRIPTION
## The bug

The release-notes URL is the one editable input in Release Center, and both
updater refreshes write to it *after* awaiting the desktop bridge:

```ts
const snapshot = await invokeDesktopBridgeRequest({ ... });
setNativeUpdater(snapshot);
if (!releaseNotesUrlDirty && snapshot?.baseUrl) {
  setReleaseNotesUrl(normalizeReleaseNotesUrl(snapshot.baseUrl));
}
```

`releaseNotesUrlDirty` is the guard that is supposed to protect a user's edit.
It is read from the closure captured when the request was **issued**, so for
anyone who had not started typing yet it is still `false` when the snapshot
lands — and the edit is discarded.

`refreshNativeState` has the same stale read. It uses the functional updater
form, which protects the *value* being replaced but not the *flag* deciding
whether to replace it.

Reproduced by driving the real component with the bridge call held in flight —
click **Check / Download Update**, type, then let the snapshot arrive:

```
typed  : "https://typed-by-user.test/n"
settled: "https://from-check.example/notes"     <- edit discarded
```

## The fix

The flag becomes a ref, read at the moment of the write rather than the moment
the request was issued. Once the post-await reads go through the ref, nothing
else read the state at all — nothing renders from it — so `useState` was buying
a re-render and a stale read and nothing else, and it is gone rather than
mirrored.

That also removes a smaller cost. `refreshNativeState` took the flag as a
dependency, so the first keystroke changed its identity and re-ran the two
effects holding it: one redundant `desktopGetUpdaterState` round trip plus a
teardown and re-subscribe of both bridge listeners.

I measured this rather than assuming it, and the measurement shrank the claim:
five keystrokes produced **one** extra call, not five, because the flag only
transitions once. It is now zero.

## Relationship to #30532

Same defect class, different mechanism. There, an async handler cleared the
guard unconditionally after awaiting; here it reads a stale copy of it. In both
cases the guard was right and the *read* was wrong. I found this by looking for
the mechanism rather than the symptom — exactly three components in
`packages/ui` hold a user-is-typing flag, and checking the other two after
#30532 turned this up.

`VoiceConfigView`, the third, is clean: its `dirty` flag is only read in render
and cleared by an explicit save.

## Tests

This component had no test file; this PR adds one with three cases.

- A URL typed while a check is in flight survives the snapshot.
- **Liveness control**: an untouched field still adopts the checked snapshot
  URL. Without it, the fix could pass by making the field stop following
  snapshots altogether.
- Editing the field does not re-run the updater refresh.

**Ablation** — reverting only `ReleaseCenterView.tsx`:

```
× keeps a URL typed while an update check was in flight
  → expected 'https://from-check.example/notes' to be 'https://typed-by-user.test/n'
✓ still adopts the checked snapshot URL when the user did not type
× does not re-run the updater refresh just because the field was edited
  → expected 2 to be 1
Tests  2 failed | 1 passed (3)
```

Restored: `3 passed`. The control passing in both directions is the point of it.

`packages/ui/src/components/pages` is `1 failed | 496 passed`; the failure is
`AutomationsFeed.test.tsx` ("Unable to find a label with the text of: Workflow
name", plus a `ResizeObserver` ReferenceError), which reproduces identically on
a clean `develop` checkout and is unrelated to this change. Biome clean.
`tsc --noEmit -p packages/ui` reports 0 errors on this branch and 0 on
`develop`.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PHMA90HFW1KWS3C30JVJ0B","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T15:47:06.144Z","completed_at":"2026-09-04T15:48:01.795Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T15:47:07.367Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a62e2693e8150c441ae894afb6f52b80ec001813663a996739de5befff215ad5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"51c3346b-dca2-437c-9ec2-e9c134c1f159","object_id":"sha256:a62e2693e8150c441ae894afb6f52b80ec001813663a996739de5befff215ad5","sha256":"a62e2693e8150c441ae894afb6f52b80ec001813663a996739de5befff215ad5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Hu87z3FdmIbj9jMu00ikkeFPDfPt24bGkFhOjtcWkbBdKAEZZDabVymDf4-8LZICzSFme7dZgt7p27mjQT64Cg"}} -->
