### PR TITLE
fix(core): make the ```json5 code-fence branch reachable in model-output parsers

### DIFF
--- a/packages/core/src/utils/json-llm.test.ts
+++ b/packages/core/src/utils/json-llm.test.ts
@@ -35,6 +35,22 @@ describe("extractAndParseJSONObjectFromText", () => {
 		).toEqual({ ok: true });
 	});
 
+	it("extracts JSON from a ```json5 fenced block", () => {
+		// The helper parses with JSON5, so a model is free to label the fence
+		// `json5`. The info string is not anchored, so a `json`-first alternation
+		// matched only the first four characters and left the "5" at the head of
+		// the capture, which JSON5.parse then rejected.
+		expect(
+			extractAndParseJSONObjectFromText("```json5\n{ ok: true, }\n```"),
+		).toEqual({ ok: true });
+	});
+
+	it("extracts JSON from a ```JSON5 fenced block with CRLF line endings", () => {
+		expect(
+			extractAndParseJSONObjectFromText("```JSON5\r\n[1, 2, 3]\r\n```"),
+		).toEqual([1, 2, 3]);
+	});
+
 	it("accepts JSON5 leniency (unquoted keys, single quotes, trailing comma)", () => {
 		expect(extractAndParseJSONObjectFromText("{ a: 1, b: 'two', }")).toEqual({
 			a: 1,

--- a/packages/core/src/utils/json-llm.ts
+++ b/packages/core/src/utils/json-llm.ts
@@ -8,7 +8,11 @@
 
 import JSON5 from "json5";
 
-const jsonBlockPattern = /```(?:json|json5)?\s*\r?\n?([\s\S]*?)\r?\n?```/i;
+// WHY the alternation lists json5 before json: the info string is not followed
+// by an anchor, so `json` matches the first four characters of a ```json5 fence
+// and the overall match still succeeds -- leaving the stray "5" at the head of
+// the capture. Longest alternative first is what makes the json5 branch reachable.
+const jsonBlockPattern = /```(?:json5|json)?\s*\r?\n?([\s\S]*?)\r?\n?```/i;
 
 /**
  * Extract and parse JSON from text using JSON5 for LLM output tolerance.

--- a/packages/ui/stories/src/eliza-core-browser-shim.ts
+++ b/packages/ui/stories/src/eliza-core-browser-shim.ts
@@ -147,8 +147,10 @@ export const logger = {
   child: () => logger,
 };
 
+// Alternation is longest-first: nothing anchors the end of the info string, so a
+// leading `json` would match inside ```json5 and strand the "5" in the capture.
 const MODEL_CODE_FENCE_PATTERN =
-  /^\s*```(?:json|json5)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
+  /^\s*```(?:json5|json)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
 
 function stripModelWrappers(raw: string): string {
   let candidate = raw.trim();

--- a/plugins/plugin-calendar/src/internal/detail.ts
+++ b/plugins/plugin-calendar/src/internal/detail.ts
@@ -85,8 +85,10 @@ export function detailArray(
   return Array.isArray(value) ? value : undefined;
 }
 
+// Alternation is longest-first: nothing anchors the end of the info string, so a
+// leading `json` would match inside ```json5 and strand the "5" in the capture.
 const MODEL_CODE_FENCE_PATTERN =
-  /^\s*```(?:json|json5)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
+  /^\s*```(?:json5|json)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
 
 function stripModelWrappers(raw: string): string {
   let candidate = raw.trim();

--- a/plugins/plugin-inbox/src/inbox/priority-scoring.test.ts
+++ b/plugins/plugin-inbox/src/inbox/priority-scoring.test.ts
@@ -89,4 +89,30 @@ describe("scoreInboxMessages", () => {
       expect.objectContaining({ count: 1, modelId: "test-model" }),
     );
   });
+
+  it("scores a model response wrapped in a ```json5 code fence", async () => {
+    // The fence info string is not anchored, so a `json`-first alternation
+    // matched the first four characters of `json5` and left the stray "5" at
+    // the head of the stripped candidate, failing the whole batch. The body is
+    // strict JSON because the downstream parser is `JSON.parse`; only the fence
+    // label is under test.
+    const reportError = vi.fn();
+    const runtime = {
+      useModel: vi.fn(
+        async () =>
+          '```json5\n{"scores":[{"score":80,"category":"important","flags":[]}]}\n```',
+      ),
+      reportError,
+    } as unknown as IAgentRuntime;
+
+    const result = await scoreInboxMessages(runtime, [message("fenced")], {
+      model: "test-model",
+      concurrency: 1,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({ score: 80, category: "important" }),
+    ]);
+    expect(reportError).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/plugin-inbox/src/inbox/priority-scoring.ts
+++ b/plugins/plugin-inbox/src/inbox/priority-scoring.ts
@@ -177,8 +177,10 @@ function buildPrompt(
   return lines.join("\n");
 }
 
+// Alternation is longest-first: nothing anchors the end of the info string, so a
+// leading `json` would match inside ```json5 and strand the "5" in the capture.
 const STRUCTURED_CODE_FENCE_PATTERN =
-  /^\s*```(?:json|json|json5)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
+  /^\s*```(?:json5|json)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
 
 function stripModelWrapper(raw: string): string {
   let candidate = raw.trim();

--- a/plugins/plugin-inbox/src/inbox/triage-classifier.ts
+++ b/plugins/plugin-inbox/src/inbox/triage-classifier.ts
@@ -236,8 +236,10 @@ export function buildTriagePrompt(
 
 // Legacy JSON fallback: strip a surrounding markdown code fence from older
 // model output, e.g. ```json\n[...]\n``` or ```\n[...]\n```.
+// Alternation is longest-first: nothing anchors the end of the info string, so a
+// leading `json` would match inside ```json5 and strand the "5" in the capture.
 const TRIAGE_CODE_FENCE_PATTERN =
-  /^\s*```(?:json|json5)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
+  /^\s*```(?:json5|json)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i;
 
 // Parse a legacy JSON array returned by older classifier prompts. We tolerate
 // code fences and leading <think> blocks, but we do NOT regex-slice an array


### PR DESCRIPTION
## The defect

Five markdown code-fence regexes in the model-output parsing path spell the info string `(?:json|json5)?`:

| file | pattern |
|---|---|
| `packages/core/src/utils/json-llm.ts:11` | ``` /```(?:json\|json5)?\s*\r?\n?([\s\S]*?)\r?\n?```/i ``` |
| `plugins/plugin-calendar/src/internal/detail.ts:89` | anchored variant |
| `plugins/plugin-inbox/src/inbox/triage-classifier.ts:240` | anchored variant |
| `plugins/plugin-inbox/src/inbox/priority-scoring.ts:181` | anchored variant, plus a duplicated `json\|json` alternative |
| `packages/ui/stories/src/eliza-core-browser-shim.ts:151` | anchored variant |

Nothing anchors the end of that alternation group — what follows is `\s*\r?\n?`, all of which can match empty. So on a ` ```json5 ` fence the engine takes the `json` branch, matches only the first four characters, and the **overall match still succeeds**. There is no backtracking pressure to ever reach the longer branch. The stray `5` lands at the head of capture group 1, which is exactly the text handed to the parser:

```
'```json5\n{"a":1}\n```'   ->  capture: '5\n{"a":1}'     (then parse fails)
'```json\n{"a":1}\n```'    ->  capture: '{"a":1}'        (fine)
'```\n{"a":1}\n```'        ->  capture: '{"a":1}'        (fine)
'```JSON5\r\n[1]\r\n```'   ->  capture: '5\r\n[1]'       (then parse fails)
```

All five sites read `match[1]`, so the stray character reaches the parser at every one. The `json5` label these parsers advertise has never worked; `json` and bare fences are unaffected. This is why the duplicated `json|json` in `priority-scoring` went unnoticed — nothing downstream of that alternative was reachable either way.

## Reachability

The blast radius differs by site because of what the caller does next:

- `extractAndParseJSONObjectFromText` throws `Failed to parse invalid JSON` — the whole structured model output is lost.
- `scoreInboxMessages` returns `null` for the batch, so callers fall back to the heuristic scorer; the LLM scores are silently discarded.
- `triage-classifier` raises `InboxTriageClassificationError`.
- `plugin-calendar`'s `stripModelWrappers` yields a candidate that fails to parse downstream.

The trigger is ordinary operation: a model labelling its fence `json5` rather than `json`. That is a label these modules explicitly declare support for — `json-llm.ts` imports `JSON5` precisely so JSON5-flavoured output is accepted.

## The repo already has the contract

`packages/core/src/utils/code-fence.ts` — `unwrapWholeCodeFence`, core's canonical fence stripper — sorts its accepted languages longest-first before matching:

```ts
const acceptedLanguage = [...languages]
  .sort((left, right) => right.length - left.length)
  .find((language) => lowerValue.startsWith(language.toLowerCase(), 3));
```

and it is called as `unwrapWholeCodeFence(candidate, ["json", "json5"])`. So the correct handling is already established in core; the five hand-rolled regex copies drifted from it. This PR restores that ordering at each copy and removes the duplicated alternative.

## The change

Each alternation becomes `(?:json5|json)?`, with a comment at the site recording why the order is load-bearing. No behaviour changes for ` ```json `, ` ```JSON `, bare ` ``` `, or an unrecognised info string — verified against each.

## Tests

Pinned at the two exported entry points; the other three sites' strippers are module-private, so the identical one-token change there rides on the same reasoning rather than a separate test.

- `packages/core/src/utils/json-llm.test.ts` — a ` ```json5 ` fence with a JSON5 body, and a ` ```JSON5 ` fence with CRLF line endings.
- `plugins/plugin-inbox/src/inbox/priority-scoring.test.ts` — `scoreInboxMessages` given a ` ```json5 `-fenced response.

**Liveness control.** Each patched regex was reverted in turn and the new tests do fail: core `2 failed | 8 passed`, plugin-inbox `1 failed | 2 passed`. Restored, both green.

One correction worth recording: my first version of the plugin test put JSON5 *syntax* (unquoted keys) inside the fence and failed even with the fix — `parseJsonModelRecord` parses with strict `JSON.parse`, so the body was failing for a reason unrelated to the fence. The body is now strict JSON so that only the fence label is under test, and the test comment says so.

## Verification

| check | result |
|---|---|
| `packages/core` `src/utils` + `src/actions` | 1025 passed / 1026 |
| `plugins/plugin-calendar` (full) | 713 passed, 4 skipped |
| `plugins/plugin-inbox` (full) | 239 passed, 2 skipped |
| `tsc --noEmit` — core, ui, plugin-inbox, plugin-calendar | 0 errors each |
| `biome check` — all 7 touched files | clean |

The single core failure is pre-existing and unrelated: `src/utils/project-registry.test.ts` asserts `resolve("/tmp/a")` and receives `/private/tmp/a` — macOS's `/tmp` symlink. Confirmed identical with this branch stashed on `develop`, and this diff does not touch that file.

## How this was found

A scan of 70,592 regex literals across 22,328 tracked source files for prefix-shadowed alternation members (a shorter alternative preceding a longer one sharing its prefix) returned 598 pairs — almost all harmless, because backtracking reaches the longer branch whenever the pattern constrains what follows the group (`\.(ts|tsx)$`, `\b(local|locally)\b`, `(lon|longitude)\s*[:=]` are all fine). Filtering to groups at an *unconstrained* tail, where the short branch can win and its capture is consumed, left 20; the five fence patterns are the ones whose capture is actually read rather than tested as a boolean.

## Not done here

Consolidating the five copies onto `unwrapWholeCodeFence` would be the better end state, but they are not interchangeable as written: the helper only unwraps a whole-value fence, whereas core's `jsonBlockPattern` is unanchored and locates a fence embedded in surrounding prose. Happy to follow up separately if a maintainer wants the consolidation.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PK56J979GQ4YHR2H3BN40S","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T16:13:47.978Z","completed_at":"2026-09-04T16:19:21.227Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T16:13:48.375Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"112245975871711cd74b82fd45359ad8a3efa37f1817caf3ca3e784888f86a9e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"e1cfe993-74a5-42b3-a0ae-8ba96d7fcfcc","object_id":"sha256:112245975871711cd74b82fd45359ad8a3efa37f1817caf3ca3e784888f86a9e","sha256":"112245975871711cd74b82fd45359ad8a3efa37f1817caf3ca3e784888f86a9e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"Srv5I1eVlfaUeJBOUkZ78xmnmbaMkIV-XtkmYj4xAoPqR5ge9KDGub0dXLvikYFrFFOOKF_wzn7JmARZeF7PBQ"}} -->
