### PR TITLE
test(core): stop project-registry fixtures depending on machine-global /tmp paths

### DIFF
--- a/packages/core/src/utils/project-registry.test.ts
+++ b/packages/core/src/utils/project-registry.test.ts
@@ -14,7 +14,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import os from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	getActiveProject,
@@ -40,6 +40,24 @@ describe("project-registry", () => {
 		rmSync(stateDir, { recursive: true, force: true });
 	});
 
+	/**
+	 * A canonical, guaranteed-absent path under this test's own temp dir, for
+	 * fixtures that flow through `canonicalizeLocalPath`.
+	 *
+	 * WHY not a `/tmp/<leaf>` literal: `canonicalizeLocalPath` realpaths a path
+	 * that exists and falls back to `resolve()` only when it does not, and
+	 * `resolve()` is not the canonical spelling when an ancestor is a symlink
+	 * (`/tmp` -> `/private/tmp` on macOS, `/var` -> `/private/var`). So
+	 * `upsertProject({ localPath: "/tmp/a" })` stores `/tmp/a` or
+	 * `/private/tmp/a` depending on whether something unrelated on the machine
+	 * happens to occupy `/tmp/a` — a unit test must not depend on that. Rooting
+	 * fixtures at `realpathSync(stateDir)` and never creating the leaf makes the
+	 * stored canonical form equal to the fixture path itself on every OS,
+	 * including Windows.
+	 */
+	const fixturePath = (leaf: string): string =>
+		join(realpathSync(stateDir), leaf);
+
 	it("returns null when no registry and no legacy config exists", () => {
 		expect(readProjectRegistry(env)).toBeNull();
 		expect(getActiveProject(env)).toBeNull();
@@ -47,14 +65,18 @@ describe("project-registry", () => {
 
 	it("upserts a project keyed by localPath, preserving id/createdAt on re-upsert", () => {
 		const first = upsertProject(
-			{ name: "repo-a", localPath: "/tmp/repo-a" },
+			{ name: "repo-a", localPath: fixturePath("repo-a") },
 			env,
 		);
 		expect(first.id).toBeTruthy();
 		expect(first.createdAt).toBe(first.lastOpenedAt);
 
 		const second = upsertProject(
-			{ name: "repo-a-renamed", localPath: "/tmp/repo-a", repoUrl: "git@x:a" },
+			{
+				name: "repo-a-renamed",
+				localPath: fixturePath("repo-a"),
+				repoUrl: "git@x:a",
+			},
 			env,
 		);
 		expect(second.id).toBe(first.id);
@@ -67,13 +89,13 @@ describe("project-registry", () => {
 	});
 
 	it("adds a distinct project for a distinct localPath", () => {
-		upsertProject({ name: "a", localPath: "/tmp/a" }, env);
-		upsertProject({ name: "b", localPath: "/tmp/b" }, env);
+		upsertProject({ name: "a", localPath: fixturePath("a") }, env);
+		upsertProject({ name: "b", localPath: fixturePath("b") }, env);
 		expect(readProjectRegistry(env)?.projects).toHaveLength(2);
 	});
 
 	it("setActiveProject marks active and stamps lastOpenedAt; unknown id is a no-op returning null", () => {
-		const p = upsertProject({ name: "a", localPath: "/tmp/a" }, env);
+		const p = upsertProject({ name: "a", localPath: fixturePath("a") }, env);
 		expect(getActiveProject(env)).toBeNull();
 
 		const active = setActiveProject(p.id, env);
@@ -86,12 +108,12 @@ describe("project-registry", () => {
 	});
 
 	it("getProjectById returns the record or null", () => {
-		const p = upsertProject({ name: "a", localPath: "/tmp/a" }, env);
-		// upsert canonicalizes localPath to an absolute path (resolve → realpath);
-		// for a non-existent dir that is `resolve("/tmp/a")` — `/tmp/a` on POSIX,
-		// `<drive>:\tmp\a` on Windows. Assert the platform-canonical form, not the
-		// bare POSIX spelling, so the round-trip holds on every OS.
-		expect(getProjectById(p.id, env)?.localPath).toBe(resolve("/tmp/a"));
+		// The leaf is never created, so this exercises canonicalizeLocalPath's
+		// realpath-failure fallback: the stored value is `resolve(localPath)`,
+		// which for an already-canonical absolute path is the path itself.
+		const localPath = fixturePath("a");
+		const p = upsertProject({ name: "a", localPath }, env);
+		expect(getProjectById(p.id, env)?.localPath).toBe(localPath);
 		expect(getProjectById("nope", env)).toBeNull();
 	});
 
@@ -110,20 +132,18 @@ describe("project-registry", () => {
 	});
 
 	it("synthesizes an in-memory active project from legacy workspace-folder.json WITHOUT writing projects.json", () => {
-		writeWorkspaceFolderConfig(
-			{ path: "/tmp/legacy-folder", bookmark: "bm" },
-			env,
-		);
+		const legacyPath = fixturePath("legacy-folder");
+		writeWorkspaceFolderConfig({ path: legacyPath, bookmark: "bm" }, env);
 
 		const reg = readProjectRegistry(env);
 		expect(reg?.projects).toHaveLength(1);
-		expect(reg?.projects[0]?.localPath).toBe("/tmp/legacy-folder");
+		expect(reg?.projects[0]?.localPath).toBe(legacyPath);
 		expect(reg?.projects[0]?.bookmark).toBe("bm");
 		expect(reg?.activeProjectId).toBe(reg?.projects[0]?.id);
 		const projectId = reg?.projects[0]?.id;
 		expect(readProjectRegistry(env)?.projects[0]?.id).toBe(projectId);
 		expect(readProjectRegistry(env)?.activeProjectId).toBe(projectId);
-		expect(getActiveProject(env)?.localPath).toBe("/tmp/legacy-folder");
+		expect(getActiveProject(env)?.localPath).toBe(legacyPath);
 		expect(getActiveProject(env)?.id).toBe(projectId);
 
 		// No projects.json was written by the read.
@@ -135,10 +155,8 @@ describe("project-registry", () => {
 	});
 
 	it("synthesized legacy project keeps a stable id across reads and across the first real upsert", () => {
-		writeWorkspaceFolderConfig(
-			{ path: "/tmp/legacy-folder", bookmark: null },
-			env,
-		);
+		const legacyPath = fixturePath("legacy-folder");
+		writeWorkspaceFolderConfig({ path: legacyPath, bookmark: null }, env);
 
 		// The synthesized registry is re-minted per read; the id must not change,
 		// or a task bound during the migration window could never resolve its
@@ -152,25 +170,27 @@ describe("project-registry", () => {
 		// so bindings minted during the migration window survive the switch to
 		// projects.json.
 		const persisted = upsertProject(
-			{ name: "legacy-folder", localPath: "/tmp/legacy-folder" },
+			{ name: "legacy-folder", localPath: legacyPath },
 			env,
 		);
 		expect(persisted.id).toBe(first);
-		// The upsert persists the canonical (resolve'd) localPath, which differs
-		// from the bare POSIX spelling on Windows (`<drive>:\tmp\legacy-folder`).
-		expect(getProjectById(persisted.id, env)?.localPath).toBe(
-			resolve("/tmp/legacy-folder"),
-		);
+		// The upsert persists the canonical localPath. The leaf is never created,
+		// so canonicalizeLocalPath falls back to `resolve(localPath)`, which for
+		// an already-canonical absolute path is the path itself.
+		expect(getProjectById(persisted.id, env)?.localPath).toBe(legacyPath);
 	});
 
 	it("persists and preserves worldId across re-upsert", () => {
 		const first = upsertProject(
-			{ name: "a", localPath: "/tmp/world-a", worldId: "w-123" },
+			{ name: "a", localPath: fixturePath("world-a"), worldId: "w-123" },
 			env,
 		);
 		expect(first.worldId).toBe("w-123");
 		// A re-upsert that omits worldId keeps the stored one, not undefined.
-		const second = upsertProject({ name: "a", localPath: "/tmp/world-a" }, env);
+		const second = upsertProject(
+			{ name: "a", localPath: fixturePath("world-a") },
+			env,
+		);
 		expect(second.worldId).toBe("w-123");
 		expect(getProjectById(first.id, env)?.worldId).toBe("w-123");
 	});
@@ -209,7 +229,7 @@ describe("project-registry", () => {
 			"utf8",
 		);
 		expect(() =>
-			upsertProject({ name: "a", localPath: "/tmp/a" }, env),
+			upsertProject({ name: "a", localPath: fixturePath("a") }, env),
 		).toThrow(/refusing to overwrite/);
 		// The v2 file is untouched.
 		const onDisk = JSON.parse(readFileSync(projectRegistryPath(env), "utf8"));
@@ -226,7 +246,7 @@ describe("project-registry", () => {
 					{
 						id: "p1",
 						name: "a",
-						localPath: "/tmp/a",
+						localPath: fixturePath("a"),
 						createdAt: "2026-01-01T00:00:00.000Z",
 						lastOpenedAt: "2026-01-01T00:00:00.000Z",
 					},


### PR DESCRIPTION
## The defect

`packages/core/src/utils/project-registry.test.ts` uses hardcoded `/tmp/<leaf>` literals as `localPath` fixtures — `/tmp/a`, `/tmp/b`, `/tmp/repo-a`, `/tmp/world-a`, `/tmp/legacy-folder`. Those paths are machine-global, and `canonicalizeLocalPath` treats them differently depending on whether they exist:

```ts
function canonicalizeLocalPath(localPath: string): string {
  const abs = resolve(localPath);
  try {
    return realpathSync(abs);      // path EXISTS -> canonical spelling
  } catch {
    return abs;                    // path ABSENT  -> resolve() spelling
  }
}
```

`resolve()` is not the canonical spelling when an ancestor is a symlink, and on macOS `/tmp` **is** a symlink to `/private/tmp`. So the value the registry stores for `/tmp/a` is `/tmp/a` when nothing occupies that path and `/private/tmp/a` when something does. Two assertions compared the stored value against `resolve("/tmp/...")` and are therefore only correct while the machine happens to have those paths free.

This is not hypothetical — it is how I found it. An unrelated stray file sitting at `/tmp/a` on my machine is enough:

```
AssertionError: expected '/private/tmp/a' to be '/tmp/a'
  project-registry.test.ts:94   expect(getProjectById(p.id, env)?.localPath).toBe(resolve("/tmp/a"))
```

Adding a directory at `/tmp/legacy-folder` fails a second test the same way (line 161). Measured on the unpatched file with a file at `/tmp/a` and directories at `/tmp/{b,repo-a,world-a,legacy-folder}`: **2 failed | 11 passed**.

## No production bug behind it

I checked, because the second failure sits in a test whose name is about id stability across the legacy migration. It is only the *spelling* assertion that fails — `expect(persisted.id).toBe(first)` **passes** under the hostile state. `upsertProject` canonicalizes both sides of its match:

```ts
canonicalizeLocalPath(p.localPath) === localPath
```

so the id minted by `legacyProjectId` from the raw `workspace-folder.json` path survives the first real upsert even when the raw and canonical spellings differ. The migration invariant documented on `legacyProjectId` holds. This PR is test-only.

## The fix

The correct pattern was already in this file. Its symlink test builds a real directory with `mkdtempSync` and asserts against `realpath`; only the `/tmp` literals had drifted from that. So:

```ts
const fixturePath = (leaf: string): string => join(realpathSync(stateDir), leaf);
```

`stateDir` is the test's own `mkdtemp` directory, so `realpathSync(stateDir)` is canonical; the leaf is never created, so `canonicalizeLocalPath` takes its `resolve()` fallback, and `resolve()` of an already-canonical absolute path is the identity. The stored value equals the fixture path **by construction**, on every OS.

Every fixture that reaches `canonicalizeLocalPath` now routes through it (9 sites, 6 leaves), and `resolve` is no longer imported.

Worth noting what the old comments got wrong: they reasoned carefully about Windows drive letters (`` `<drive>:\tmp\a` ``) but not about symlinked ancestors, which is the actual reason `resolve()` is not the canonical form. The new fixture is correct on Windows for a stronger reason — `join(realpathSync(tempdir), leaf)` is already absolute and canonical there too, so `resolve()` is the identity.

## Verification

**Control.** Recreated the same hostile state against the patched file:

| | unpatched | patched |
|---|---|---|
| file at `/tmp/a`, dirs at `/tmp/{b,repo-a,world-a,legacy-folder}` | 2 failed \| 11 passed | **13 passed** |

I created only the four paths that were absent, left the pre-existing `/tmp/a` alone, and removed exactly the four afterwards.

| check | result |
|---|---|
| `packages/core` `src/utils` | 62 files, 879 tests, all passed (878/879 before) |
| `tsc --noEmit` `packages/core` | 0 errors |
| `biome check` (touched file) | clean |

## A correction worth recording

My first reading of this failure blamed the macOS `/tmp` symlink directly. That was wrong, and probing killed it: `realpathSync` throws `ENOENT` for a missing leaf — `/tmp/nope/deeper`, `/etc/a`, and `/Users/.../nope` all threw — so on a machine where `/tmp/a` is genuinely absent, the fallback fires and the test passes. `existsSync("/tmp/a")` returned `true`: a stray unrelated file was occupying it. The mechanism is machine state, and the symlink only decides *what* the wrong answer looks like. Which is exactly why the fixture should never have pointed outside the test's own sandbox.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PKQHS2C2XPRJP2GKN7DQPG","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T16:23:49.282Z","completed_at":"2026-09-04T16:26:35.484Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T16:23:49.498Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d1718f6f67e1cf82f1d7ebb5131754222925921cc1464122e5aa2bce585d607a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"6ab55a60-0352-462e-946b-4de6a5826670","object_id":"sha256:d1718f6f67e1cf82f1d7ebb5131754222925921cc1464122e5aa2bce585d607a","sha256":"d1718f6f67e1cf82f1d7ebb5131754222925921cc1464122e5aa2bce585d607a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"9Wej7hvMGcwn1mbmm2Sg4Dh1J6XStYayhCvWQXPaZy7ORrXhpF7LDIKtXBYAn0FfV95bqjO-FLcov-c1RXrCCw"}} -->
