### PR TITLE
fix(core): match reasoning preambles with the shared tag vocabulary in the model-JSON parser

### DIFF
--- a/packages/core/src/actions/json-model-output.test.ts
+++ b/packages/core/src/actions/json-model-output.test.ts
@@ -7,4 +7,76 @@ describe("parseJsonModelOutput", () => {
 	it("parses compact unlabeled fenced JSON scalars", () => {
 		expect(parseJsonModelOutput("```true```")).toBe(true);
 	});
+
+	describe("private-reasoning preamble", () => {
+		// A reasoning preamble is matched with the shared reasoning-tags
+		// vocabulary, not an exact lowercase `<think>` literal: models use several
+		// tag names, vary the case, and sometimes emit a dangling close tag with
+		// no open of its own (the evaluator's `None</think>` repair, #20080).
+		it.each([
+			["paired <think>", '<think>r</think>{"a":1}'],
+			[
+				"a brace inside the reasoning body",
+				'<think>maybe {a:1}?</think>{"a":1}',
+			],
+			["close-only residue with no open tag", 'None</think>{"a":1}'],
+			["<thinking>", '<thinking>r</thinking>{"a":1}'],
+			["<reasoning>", '<reasoning>r</reasoning>{"a":1}'],
+			["<analysis>", '<analysis>r</analysis>{"a":1}'],
+			["<reflection>", '<reflection>r</reflection>{"a":1}'],
+			["an upper-case tag", '<THINK>r</THINK>{"a":1}'],
+			["whitespace inside the tags", '< think >r</ think >{"a":1}'],
+			["visible prose before the block", 'Sure!\n<think>r</think>{"a":1}'],
+			[
+				"a preamble ahead of a code fence",
+				'<think>r</think>```json\n{"a":1}\n```',
+			],
+		])("strips %s", (_label, raw) => {
+			expect(parseJsonModelOutput(raw)).toEqual({ a: 1 });
+		});
+
+		it("strips a preamble ahead of an array payload", () => {
+			expect(parseJsonModelOutput("<think>r</think>[1,2]")).toEqual([1, 2]);
+		});
+
+		// The strip is anchored to the head of the candidate because reasoning
+		// markup is also ordinary string data. Stripping inside a payload would
+		// silently rewrite a value or break the parse, which is strictly worse
+		// than leaving a preamble in place.
+		it.each([
+			[
+				"a tag pair inside a string value",
+				'{"text":"<think>hi</think>"}',
+				{ text: "<think>hi</think>" },
+			],
+			[
+				"a close tag inside a string value",
+				'{"a":1,"note":"</think> x"}',
+				{ a: 1, note: "</think> x" },
+			],
+			[
+				"an open tag inside a string value",
+				'{"prompt":"use <thinking> tags"}',
+				{ prompt: "use <thinking> tags" },
+			],
+			[
+				"a close tag inside a fenced body",
+				'```json\n{"n":"</think>"}\n```',
+				{ n: "</think>" },
+			],
+			[
+				"a key named after a reasoning tag",
+				'{"analysis":"ok"}',
+				{ analysis: "ok" },
+			],
+		])("leaves %s untouched", (_label, raw, expected) => {
+			expect(parseJsonModelOutput(raw)).toEqual(expected);
+		});
+
+		it("keeps an unmatched open tag so the parse fails closed", () => {
+			// Deleting only the open tag would turn a private payload into
+			// apparently-clean output; `reasoning-tags.ts` documents the same rule.
+			expect(parseJsonModelOutput('<think>never closed {"a":1}')).toBeNull();
+		});
+	});
 });

--- a/packages/core/src/actions/json-model-output.ts
+++ b/packages/core/src/actions/json-model-output.ts
@@ -1,18 +1,58 @@
 /**
- * Lenient JSON parsing for model output. Strips a leading `<think>…</think>`
- * reasoning preamble and a ```json / ```json5 code fence, then `JSON.parse`s the
+ * Lenient JSON parsing for model output. Strips a leading private-reasoning
+ * preamble and a ```json / ```json5 code fence, then `JSON.parse`s the
  * remainder — returning `null` rather than throwing on any failure.
  * `parseJsonModelRecord` / `parseJsonModelArray` add shape guards for the common
  * object / array cases.
  */
 import { unwrapWholeCodeFence } from "../utils/code-fence.ts";
+import {
+	findNextCloseTag,
+	findNextOpenTag,
+	REASONING_TAG_NAMES,
+} from "../utils/reasoning-tags.ts";
+
+const REASONING_TAG_ALTERNATION = REASONING_TAG_NAMES.join("|");
+
+/** A payload opener: a JSON value start, or a code fence introducing one. */
+const PAYLOAD_OPENER_RE = /[`{[]/;
+
+/**
+ * Drop a private-reasoning preamble, matching reasoning tags the way the rest
+ * of the codebase does (all of `REASONING_TAG_NAMES`, case-insensitively, with
+ * the whitespace tolerance of `reasoning-tags.ts`) instead of an exact
+ * lowercase `<think>` literal.
+ *
+ * Both branches are deliberately ANCHORED to the head of the candidate,
+ * because reasoning markup is also ordinary string data: `{"text":"</think>"}`
+ * and a fenced body containing a close tag are valid payloads, and stripping
+ * inside them would silently rewrite a value or break the parse. Only text
+ * that cannot be payload is removed.
+ */
+function stripReasoningPreamble(candidate: string): string {
+	// The candidate OPENS with a reasoning tag, so nothing up to its close can
+	// be payload. First close only, matching the previous `indexOf` semantics.
+	const open = findNextOpenTag(candidate, 0, REASONING_TAG_ALTERNATION);
+	if (open?.start === 0) {
+		const close = findNextCloseTag(
+			candidate,
+			open.end,
+			REASONING_TAG_ALTERNATION,
+		);
+		return close ? candidate.slice(close.end).trim() : candidate;
+	}
+	// Close-only residue: a dangling close tag left by an earlier stripping pass
+	// (the evaluator's `None</think>` repair, #20080). Only when no payload
+	// opener precedes it — otherwise the close tag is inside the payload.
+	const close = findNextCloseTag(candidate, 0, REASONING_TAG_ALTERNATION);
+	if (close && !PAYLOAD_OPENER_RE.test(candidate.slice(0, close.start))) {
+		return candidate.slice(close.end).trim();
+	}
+	return candidate;
+}
 
 function stripModelWrappers(raw: string): string {
-	let candidate = raw.trim();
-	const thinkEnd = candidate.indexOf("</think>");
-	if (candidate.startsWith("<think>") && thinkEnd !== -1) {
-		candidate = candidate.slice(thinkEnd + "</think>".length).trim();
-	}
+	let candidate = stripReasoningPreamble(raw.trim());
 	candidate = (
 		unwrapWholeCodeFence(candidate, ["json", "json5"]) ?? candidate
 	).trim();


### PR DESCRIPTION
## The defect

`stripModelWrappers` in `packages/core/src/actions/json-model-output.ts` recognised a private-reasoning preamble like this:

```ts
const thinkEnd = candidate.indexOf("</think>");
if (candidate.startsWith("<think>") && thinkEnd !== -1) { … }
```

An exact lowercase `<think>` at position 0. But the codebase already has a canonical vocabulary for this in `packages/core/src/utils/reasoning-tags.ts`:

```ts
export const REASONING_TAG_NAMES = [
  "think", "thinking", "analysis", "reasoning", "reflection", "thought", "antthinking",
] as const;
```

matched case-insensitively, tolerant of whitespace inside the tag (`< thinking >`), with a documented repair for a **close-only residue** left by an earlier stripping pass — the evaluator's `None</think>`, referenced from `planner-loop.ts` and `evaluator.ts` as #20080.

The parser knew none of that. Measured against 20 realistic inputs it handled **12**. The 8 it missed:

| input | result on `develop` |
|---|---|
| `None</think>{"a":1}` | preamble reaches `JSON.parse` |
| `<thinking>r</thinking>{"a":1}` | preamble reaches `JSON.parse` |
| `<reasoning>r</reasoning>{"a":1}` | preamble reaches `JSON.parse` |
| `<analysis>r</analysis>{"a":1}` | preamble reaches `JSON.parse` |
| `<reflection>r</reflection>{"a":1}` | preamble reaches `JSON.parse` |
| `<THINK>r</THINK>{"a":1}` | preamble reaches `JSON.parse` |
| `< think >r</ think >{"a":1}` | preamble reaches `JSON.parse` |
| `Sure!\n<think>r</think>{"a":1}` | preamble reaches `JSON.parse` |

In every one `parseJsonModelOutput` returns `null` and the entire model output is discarded as unparseable. `parseJsonModelRecord` / `parseJsonModelArray` inherit it, and so do the callers that funnel through them (`plugin-inbox`'s triage classifier and priority scorer, `plugin-calendar`'s detail parser).

## Why the obvious fix is wrong

The tempting change is to call `stripReasoningBlocks`. **Don't** — and this is the part that makes the narrow original defensible. Reasoning markup is also ordinary string data. Run real payloads through that helper:

| payload | `stripReasoningBlocks` |
|---|---|
| `{"text":"<think>hi</think>"}` | `{"text":""}` — **value silently rewritten** |
| `{"a":1,"note":"</think> x"}` | **parse fails** |
| `{"prompt":"use <thinking> tags"}` | **parse fails** |

Corrupting a value is strictly worse than leaving a preamble in place, and `stripReasoningBlocks` is right for its own job — user-visible egress text, where the goal is to remove markup wherever it appears. A JSON parser has the opposite constraint.

## The fix

Both branches stay **anchored to the head of the candidate**, so nothing inside a payload can be touched:

1. **A reasoning tag opens the candidate.** Then nothing up to its close can be payload — slice through the first close after it. First-close semantics, exactly matching the previous `indexOf` behaviour.
2. **Close-only residue.** Strip through the first close tag only when no payload opener — `` ` ``, `{`, `[` — precedes it. A close tag inside a JSON string or a fenced body therefore always has an opener before it and is never touched.

Matching goes through `findNextOpenTag` / `findNextCloseTag`, so it inherits the canonical tag vocabulary and the deliberately non-quadratic scan those functions document.

An unmatched open tag is still preserved so the parse fails closed — same rule `reasoning-tags.ts` gives for `stripReasoningPrefixes`, and for the same reason: deleting only the open tag would turn a private payload into apparently-clean output.

## Results

**12/20 → 20/20**, no regression on any of the 12 that already passed:

| group | cases | before | after |
|---|---|---|---|
| preambles that should be stripped | 12 | 4 | 12 |
| payloads that must be left alone | 5 | 5 | 5 |
| fenced / array / fail-closed | 3 | 3 | 3 |

The five payload-safety cases are the ones the anchoring exists for, and they pass identically before and after.

**Liveness control.** Reverting only the source file fails exactly 8 of the 19 tests — the same 8 the baseline measurement predicted.

**Performance.** `reasoning-tags.ts` records that a maintainer benchmarked a regex form of this scan going quadratic on malformed residue, so I checked the property survives: 16,000 malformed `<think ` candidates (112,007 chars) parse in under 0.1 ms; a 500,000-char close-only prefix in 0.5 ms.

| check | result |
|---|---|
| `packages/core` `src/actions` + `src/utils` + `src/services/message` | 1817 passed / 1818 |
| `tsc --noEmit` `packages/core` | 0 errors |
| `plugins/plugin-inbox` (full) | 238 passed, 2 skipped |
| `plugins/plugin-calendar` (full) | 713 passed, 4 skipped |
| `biome check` | clean |

The single failure is `src/utils/project-registry.test.ts`, the machine-state fixture defect fixed by #30537 and not on this branch.

## Not done here — five sibling copies

The same `startsWith("<think>")` + `indexOf("</think>")` idiom appears in five more places:

- `packages/cloud/api/src/stubs/elizaos-core.ts:1048`
- `packages/ui/stories/src/eliza-core-browser-shim.ts:155`
- `plugins/plugin-calendar/src/internal/detail.ts:93`
- `plugins/plugin-inbox/src/inbox/triage-classifier.ts:253`
- `plugins/plugin-inbox/src/inbox/priority-scoring.ts:188`

I fixed only core's, deliberately. The three plugin copies run their local strip and then call `parseJsonModelRecord`, which runs core's — so for the JSON path this one change repairs them downstream, and it is the high-leverage edit. The other two are deliberate mirrors of core; I looked for a drift-check test enforcing that mirroring and found none, which is itself worth a maintainer's attention. Happy to follow up on any subset if you'd like them converged.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PMACGX9TPT205F8NZKJ0WB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T16:34:06.493Z","completed_at":"2026-09-04T16:39:17.143Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T16:34:07.119Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cef3a6ffb69b2cecb873a7db97b1e64159f4944a95fc2ec556d969fcb18d96ad","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2ccc02b2-27ec-48e7-a951-666fc2262c4b","object_id":"sha256:cef3a6ffb69b2cecb873a7db97b1e64159f4944a95fc2ec556d969fcb18d96ad","sha256":"cef3a6ffb69b2cecb873a7db97b1e64159f4944a95fc2ec556d969fcb18d96ad"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"lWHbInIA1ZW29TNl7z3n6eO1FqfgMTeoJqtoDnlh7xkPce6JBvc5zlX_XPT4RSO0eNhxLVS6L7QCafVSYzQjAA"}} -->
