### PR TITLE
fix(cloud): fall back when a native-planner loop bound is configured to a non-count

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
@@ -50,6 +50,7 @@ import {
 import {
   getAvailableActionNames,
   parseNativePlannerDecision,
+  positiveIntSetting,
   toNativeActionParams,
   type ValidatedNativePlannerDecision,
   validateNativePlannerDecision,
@@ -552,9 +553,11 @@ export class CloudBootstrapMessageService implements IMessageService {
 
     const maxIterations =
       options?.maxNativePlannerIterations ??
-      parseInt(String(runtime.getSetting("NATIVE_PLANNER_MAX_ITERATIONS") ?? "6"));
-    const maxConsecutiveFailures = parseInt(
-      String(runtime.getSetting("NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES") ?? "2"),
+      positiveIntSetting(runtime, "NATIVE_PLANNER_MAX_ITERATIONS", 6);
+    const maxConsecutiveFailures = positiveIntSetting(
+      runtime,
+      "NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES",
+      2,
     );
     let iterationCount = 0;
     let consecutiveFailures = 0;
@@ -686,9 +689,7 @@ export class CloudBootstrapMessageService implements IMessageService {
         // PERF: Reduced from 5 to 3 retries. Each retry adds 1-4s with exponential backoff.
         // 3 balances latency (~6-12s max) vs. reliability for complex native-planner queries
         // where LLMs occasionally produce malformed JSON. Override via NATIVE_PLANNER_PARSE_RETRIES.
-        const maxParseRetries = parseInt(
-          String(runtime.getSetting("NATIVE_PLANNER_PARSE_RETRIES") ?? "2"),
-        );
+        const maxParseRetries = positiveIntSetting(runtime, "NATIVE_PLANNER_PARSE_RETRIES", 2);
         let stepResultRaw = "";
         let parsedStep: ValidatedNativePlannerDecision | null = null;
 
@@ -1112,9 +1113,7 @@ export class CloudBootstrapMessageService implements IMessageService {
       logger.info(`[LLM:nativeResponse] User Prompt:\n${summaryPrompt}`);
       logger.info("==============================================");
 
-      const maxSummaryRetries = parseInt(
-        String(runtime.getSetting("NATIVE_RESPONSE_PARSE_RETRIES") ?? "2"),
-      );
+      const maxSummaryRetries = positiveIntSetting(runtime, "NATIVE_RESPONSE_PARSE_RETRIES", 2);
       let finalOutput = "";
       let summary: Record<string, unknown> | null = null;
 

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/utils/native-planner-guards.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/utils/native-planner-guards.ts
@@ -1,6 +1,23 @@
 // Wires hosted Eliza agent native planner guards behavior for cloud runtime services.
+import type { IAgentRuntime } from "@elizaos/core";
 import { parseJSONObjectFromText } from "@elizaos/core";
 import type { ParsedNativePlannerDecision } from "../types";
+
+/**
+ * Read a setting that bounds a loop, falling back whenever the configured value
+ * is not a usable positive count.
+ *
+ * `getSetting(key) ?? "2"` only covers an ABSENT setting. A setting present but
+ * empty (`FOO=` in an env file), non-numeric, zero or negative still reaches
+ * `parseInt` and yields NaN or 0 -- and every comparison against NaN is false,
+ * so a loop bounded by it does not error, it silently does not run. Matches the
+ * guard `numberSetting` in ../providers/actions.ts already applies.
+ */
+export function positiveIntSetting(runtime: IAgentRuntime, key: string, fallback: number): number {
+  const raw = runtime.getSetting?.(key);
+  const value = typeof raw === "string" ? Number(raw) : raw;
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
 
 const BUILT_IN_RESPONSE_ACTIONS = new Set(["REPLY", "NONE"]);
 

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/utils/native-planner-settings.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/utils/native-planner-settings.test.ts
@@ -1,0 +1,49 @@
+// Exercises the numeric-setting guard that bounds the native planner's loops.
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, test } from "vitest";
+import { positiveIntSetting } from "./native-planner-guards";
+
+function runtimeWith(value: unknown): IAgentRuntime {
+  return { getSetting: () => value } as unknown as IAgentRuntime;
+}
+
+describe("positiveIntSetting", () => {
+  test("uses a configured positive integer", () => {
+    expect(positiveIntSetting(runtimeWith("5"), "K", 2)).toBe(5);
+  });
+
+  test("falls back when the setting is absent", () => {
+    expect(positiveIntSetting(runtimeWith(undefined), "K", 2)).toBe(2);
+    expect(positiveIntSetting({} as IAgentRuntime, "K", 2)).toBe(2);
+  });
+
+  // Each of these previously reached `parseInt` and produced NaN or 0. Every
+  // comparison against NaN is false, so `while (i < max)` and
+  // `for (a = 1; a <= max; a++)` do not error -- they silently never run, and a
+  // `failures >= max` cap never trips.
+  test.each([
+    ["an empty string, as an env file writes `FOO=`", ""],
+    ["whitespace", "   "],
+    ["a non-numeric word", "default"],
+    ["zero", "0"],
+    ["a negative count", "-1"],
+    ["a fractional count", "1.5"],
+    ["a null setting", null],
+    ["a boolean setting", true],
+  ])("falls back on %s", (_label, raw) => {
+    expect(positiveIntSetting(runtimeWith(raw), "K", 2)).toBe(2);
+  });
+
+  test("accepts a number-typed setting without string coercion", () => {
+    expect(positiveIntSetting(runtimeWith(7), "K", 2)).toBe(7);
+  });
+
+  test("a NaN bound would have made every loop guard false", () => {
+    // Pins the mechanism the guard exists to prevent.
+    const bad = Number.parseInt(String("" ?? "2"), 10);
+    expect(Number.isNaN(bad)).toBe(true);
+    expect(0 < bad).toBe(false);
+    expect(1 <= bad).toBe(false);
+    expect(9 >= bad).toBe(false);
+  });
+});

--- a/packages/cloud/shared/vitest.config.ts
+++ b/packages/cloud/shared/vitest.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       "src/lib/services/email.port.test.ts",
       "src/lib/services/docker-node-manager.surrogate-safe.test.ts",
       "src/lib/services/affiliate-billing-attribution.test.ts",
+      "src/lib/eliza/plugin-cloud-bootstrap/utils/native-planner-settings.test.ts",
     ],
     environment: "node",
     // PGlite's WASM worker outlives Vitest's fork shutdown grace even after


### PR DESCRIPTION
## The defect

The native planner reads its four loop bounds like this:

```ts
const maxIterations = options?.maxNativePlannerIterations ??
  parseInt(String(runtime.getSetting("NATIVE_PLANNER_MAX_ITERATIONS") ?? "6"));
const maxConsecutiveFailures = parseInt(
  String(runtime.getSetting("NATIVE_PLANNER_MAX_CONSECUTIVE_FAILURES") ?? "2"));
// ...and the same shape for NATIVE_PLANNER_PARSE_RETRIES and NATIVE_RESPONSE_PARSE_RETRIES
```

The `??` covers an **absent** setting. It does not cover a setting that is present but empty — `NATIVE_PLANNER_PARSE_RETRIES=` in an env file is an empty string, not `undefined` — nor a non-numeric value, nor `0`, nor a negative. Those reach `parseInt` and produce `NaN` or `0`.

`NaN` does not throw. Every relational comparison against it is false, so the bound does not fail loudly — **it silently disables the loop it bounds**:

| bound | site | what happens at `NaN` |
|---|---|---|
| `maxIterations` | `while (iterationCount < maxIterations)` | loop never runs — the planner does nothing at all |
| `maxParseRetries` | `for (a = 1; a <= maxParseRetries; a++)` | loop never runs — `parsedStep` stays `null` |
| `maxSummaryRetries` | summary retry loop | `summary` stays `null`, and the `else` branch replies with the canned *"I completed the requested actions, but encountered an issue generating the summary."* |
| `maxConsecutiveFailures` | `consecutiveFailures >= maxConsecutiveFailures` | cap never trips — the failure limit is gone |

I read the code after each loop rather than inferring these; the summary case is the one a user actually sees, as a plausible-looking reply rather than an error.

## This plugin already had the guard

`providers/actions.ts` in the same plugin reads its numeric settings correctly, and is used for three timeout settings:

```ts
function numberSetting(runtime: IAgentRuntime, key: string, fallback: number): number {
  const raw = runtime.getSetting?.(key) ?? env?.[key];
  const value = typeof raw === "string" ? Number(raw) : raw;
  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
}
```

The four planner sites hand-rolled the read and lost that rule. This PR adds `positiveIntSetting` to `utils/native-planner-guards.ts` — the module whose name already covers exactly this — applying the same requirement (integer and positive, else fall back), and routes all four bounds through it.

## Reachability, graded honestly

**Ordinary operation is unaffected.** An absent setting resolved to the default before this change and still does; the four defaults are unchanged. The reachable triggers are operator misconfiguration: an env var assigned empty, a placeholder word, or `0`. So this is a robustness fix rather than a bug ordinary use hits — but the failure mode it removes is the bad kind, because nothing logs and the planner degrades into silence or a canned reply.

## Tests

New `native-planner-settings.test.ts`, 12 tests: the valid and absent cases, then each rejected input (empty string, whitespace, non-numeric word, `0`, `-1`, `1.5`, `null`, a boolean), plus one that pins the mechanism itself —

```ts
const bad = Number.parseInt(String("" ?? "2"), 10);
expect(Number.isNaN(bad)).toBe(true);
expect(0 < bad).toBe(false);
expect(1 <= bad).toBe(false);
expect(9 >= bad).toBe(false);
```

The file is registered in `vitest.config.ts`'s explicit `include` list, which its own comment requires for any file importing from `"vitest"` — otherwise the changed-file coverage lane filters against `include`, matches nothing, and hard-fails with *"No test files found"*.

**Liveness control.** Replacing the guard body with the old `parseInt` idiom fails **7 of the 12** tests. The other 5 are the absent-setting and valid-value cases, which the old code also got right — so 7, not 12.

## Verification

| check | result |
|---|---|
| `packages/cloud/shared` (full suite) | 128 passed / 129 |
| `bun run typecheck` (`packages/cloud/shared`) | clean |
| `biome check` (4 touched files) | clean |

The single failure is `src/lib/services/__tests__/direct-wallet-payments.integration.test.ts` — *"confirm rejects an expired payment even with a valid real signature"* reports a quote-signature mismatch instead of expiry. Confirmed identical with my changes stashed on `develop`, and unrelated to this diff. It may be worth a separate look: it reads as though the signature check runs ahead of the expiry check, so an expired payment surfaces as tampering. I have not investigated far enough to say whether the test or the ordering is wrong, so I am only flagging it.

## How this was found

An AST scan over 12,040 non-test source files found 902 variables initialised from `Number` / `parseInt` / `parseFloat`, 456 of them used in a relational comparison, and 82 with no `Number.isFinite` / `isInteger` / `isNaN` exclusion in the enclosing function. 82 is not evidence, so the discriminator was: keep only comparisons that are guards which *reject*, where `NaN` flips them to accept and nothing downstream re-enforces.

That closed the two highest-stakes candidates as clean negatives, both worth recording as fine:

- `web-push/endpoint-validation.ts` derives its octets from a `^(\d{1,3})\.…$` match, so `Number()` can never be `NaN` and the private-range guard is sound.
- `readImageWithLimit` in `fal-` and `atlascloud-image-generation.ts` uses the `content-length` header only as a fast path — the streaming `received > MAX` loop and the `arrayBuffer` byte-length check still enforce the cap, so a `NaN` declared length loses nothing.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PMVPC73HC0JYG41Y3DEM1Y","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T16:43:33.639Z","completed_at":"2026-09-04T16:48:31.853Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T16:43:33.857Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3d2bff7cbe97e29e15bda7161cc916a1c0052b8ed6fe3430127e9def39d4de89","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5a5203a0-ccea-4edd-9023-a318131121ba","object_id":"sha256:3d2bff7cbe97e29e15bda7161cc916a1c0052b8ed6fe3430127e9def39d4de89","sha256":"3d2bff7cbe97e29e15bda7161cc916a1c0052b8ed6fe3430127e9def39d4de89"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"VEFKrioxL8R2h8hGUVnE4ilD16G-iW9EBDPWcHQWKpatIWQdd7VYqfejT5WF5LNfFuNxaTECqNFPqSO-A0LBBA"}} -->
