### PR TITLE
test(cloud): make the crypto-payment expiry test independent of the machine timezone

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -1767,8 +1767,14 @@ describe.skipIf(!process.env.DATABASE_URL || !SUPPORTS_VITEST_MOCK_API)(
     test("confirm rejects an expired payment even with a valid real signature", async () => {
       await resetTable();
       const { proofAccount, payment, signature } = await createSignedBscPayment();
+      // `crypto_payments.expires_at` is `timestamp` WITHOUT time zone, and the
+      // service writes it as a JS Date, which Drizzle stores and reads back as
+      // UTC wall-clock. Plain `now()` is a timestamptz: casting it into a naive
+      // column applies the session TimeZone, so on a non-UTC machine the stored
+      // value is offset and this row can land in the FUTURE. `AT TIME ZONE
+      // 'UTC'` produces the same UTC wall-clock the reader assumes.
       await dbWrite.execute(
-        `UPDATE crypto_payments SET expires_at = now() - interval '1 hour' WHERE id = '${payment.id}'`,
+        `UPDATE crypto_payments SET expires_at = (now() AT TIME ZONE 'UTC') - interval '1 hour' WHERE id = '${payment.id}'`,
       );
       const meta = payment.metadata as Record<string, unknown>;
       const hash = `0x${"98".repeat(32)}`;


### PR DESCRIPTION
## The symptom

`direct-wallet-payments.integration.test.ts` → *"confirm rejects an expired payment even with a valid real signature"* fails on `develop`, but only on some machines:

```
AssertionError: expected [Function] to throw error matching /Payment has expired/
  but got 'Quote signature mismatch — payment may have been tampered with.'
```

## Two hypotheses, both wrong

**First:** the test's raw `UPDATE` invalidates a quote signature that covers `expiresAt`, so tamper detection fires first. Reading `confirmPayment` killed the ordering half of that — the expiry check runs **before** the signature check:

```ts
if (observedPayment.expires_at < new Date() && !params.allowExpired) throw new Error("Payment has expired");   // 1867
…
if (!sigOk) throw new Error("Quote signature mismatch — payment may have been tampered with.");                 // 1897
```

So the real question was why the expiry check didn't fire at all.

**Second:** `expires_at` is a string, so the comparison is NaN-false. No — Drizzle's `timestamp()` defaults to `mode: "date"` and returns a `Date`.

## What the probe showed

I stopped theorising and instrumented the branch:

```
[PROBE] expires_at= 2026-09-04T17:52:54.875Z  now= 2026-09-04T16:52:54.877Z  isPast= false
```

The row written as **one hour in the past** reads back **one hour in the future**.

## Root cause

`crypto_payments.expires_at` is `timestamp` **without** time zone (migration `0001_certain_stellaris.sql`), and the Drizzle schema declares `timestamp()` to match — so there is no schema mismatch, and I checked for one before going further.

The mismatch is between two ways of *writing* that column:

- **The service** writes a JS `Date` — `new Date(now.getTime() + PAYMENT_EXPIRATION_MS)`. Drizzle stores and reads that back as UTC wall-clock, consistently.
- **The test** writes `now()`, which is a `timestamptz`. Casting it into a naive column applies the **session TimeZone**, storing *local* wall-clock — which the reader then interprets as UTC.

The stored value is therefore shifted by the session's UTC offset. Probing PGlite directly (it adopts the process `TZ` as its session TimeZone):

| `TZ` | pg session | stored `now() - 1 hour` | vs real UTC now |
|---|---|---|---|
| `UTC` | `Etc/GMT0` | `15:57:41` | 1 h in the past |
| `Europe/Berlin` | `Etc/GMT-1` | `16:57:42.092` | **1 ms** in the past |
| `Asia/Tokyo` | `Etc/GMT-9` | `2026-09-05 00:57:42` | **8 h in the future** |

The test only holds while the offset is under one hour. At Tokyo the row is not expired, so `confirmPayment` runs past the expiry gate and fails later on the quote signature — which the raw `UPDATE` also invalidated, since the signature covers `expiresAt`. That is the error the assertion actually sees. Negative offsets make the row *more* expired, which is why `America/Los_Angeles` passes.

**Production is unaffected.** Only this raw-SQL `now()` mixes the two conventions. The file's other `now()` writes target `crypto_sweep_outbox` columns declared `timestamptz`, where it is correct.

## The fix

`(now() AT TIME ZONE 'UTC') - interval '1 hour'` produces the UTC wall-clock the naive column's reader assumes, with a comment recording the convention. Kept the file's existing raw-SQL style rather than introducing the query builder for one line.

## Verification

Same test, four zones, before and after:

| `TZ` | develop | patched |
|---|---|---|
| `UTC` | pass | pass |
| `Europe/Berlin` | pass (by 1 ms) | pass |
| `America/Los_Angeles` | pass | pass |
| `Asia/Tokyo` | **fail** | pass |

Full file **42/42**, up from 41/42. `packages/cloud/shared` typecheck clean; `biome check` clean.

## A retraction, and one latent sibling

I wrote a scan to find the same mistake elsewhere and then **threw its count away**: it keyed on column name, but column names are not unique across tables, so `expires_at` was excluded for appearing as `timestamptz` in other schemas — the scan missed the very line I was fixing. Not reporting a number I can't stand behind.

Checking its one hit table-aware: `account-deletion-lifecycle-authority.test.ts:157` writes `admission_token_expires_at` (also a naive `timestamp`) with `now() + interval '1 day'`. Same pattern, but a day of slack absorbs any real-world offset, so it is latent rather than failing. Left alone; flagging it in case you'd like it made consistent.

Separately, and stated only as an observation: migration `0001` declares `created_at` / `updated_at` as `timestamp DEFAULT now()`, which carries the same offset skew on a non-UTC **database** session. The security-relevant field here — `expires_at` — is written explicitly by the service and is correct, so I have not proposed a migration.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PNFNPQC7JS0K6H3GGZSR9T","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T16:54:28.311Z","completed_at":"2026-09-04T16:59:32.652Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T16:54:29.023Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"49a194973202835c8bd4be8222f31050a25bb86a38ce64f5d56dd87022634c34","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"8a8fb326-1f48-4171-aba2-18de40eb917e","object_id":"sha256:49a194973202835c8bd4be8222f31050a25bb86a38ce64f5d56dd87022634c34","sha256":"49a194973202835c8bd4be8222f31050a25bb86a38ce64f5d56dd87022634c34"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"EVpU9CKKJ2A0uJUYHRYYx43jDxS1M-s9O6V379KHlMpxYYPtlCG2ZPq9-D4uWBgVzizUA43NSYaMYsf4uD1PDA"}} -->
