### PR TITLE
fix(plugin-sql): give the migrator one type normalizer so the diff and generator agree

### DIFF
--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/diff-calculator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/diff-calculator.ts
@@ -15,55 +15,7 @@ import type {
   SchemaSnapshot,
   SchemaUniqueConstraint,
 } from "../types";
-
-/**
- * Normalize SQL types for comparison
- * Handles equivalent type variations between introspected DB and schema definitions
- */
-function normalizeType(type: string | undefined): string {
-  if (!type) return "";
-
-  const normalized = type.toLowerCase().trim();
-
-  // Handle timestamp variations
-  if (normalized === "timestamp without time zone" || normalized === "timestamp with time zone") {
-    return "timestamp";
-  }
-
-  // Handle serial vs integer with identity
-  // serial is essentially integer with auto-increment
-  if (normalized === "serial") {
-    return "integer";
-  }
-  if (normalized === "bigserial") {
-    return "bigint";
-  }
-  if (normalized === "smallserial") {
-    return "smallint";
-  }
-
-  // Handle numeric/decimal equivalence
-  if (normalized.startsWith("numeric") || normalized.startsWith("decimal")) {
-    // Extract precision and scale if present
-    const match = normalized.match(/\((\d+)(?:,\s*(\d+))?\)/);
-    if (match) {
-      return `numeric(${match[1]}${match[2] ? `,${match[2]}` : ""})`;
-    }
-    return "numeric";
-  }
-
-  // Handle varchar/character varying
-  if (normalized.startsWith("character varying")) {
-    return normalized.replace("character varying", "varchar");
-  }
-
-  // Handle text array variations
-  if (normalized === "text[]" || normalized === "_text") {
-    return "text[]";
-  }
-
-  return normalized;
-}
+import { normalizeType } from "./type-normalization";
 
 /**
  * Helper function to compare two index definitions

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
@@ -20,6 +20,7 @@ import type {
   SchemaUniqueConstraint,
 } from "../types";
 import type { SchemaDiff } from "./diff-calculator";
+import { normalizeType } from "./type-normalization";
 
 /**
  * Data loss detection result
@@ -121,59 +122,6 @@ export function checkForDataLoss(diff: SchemaDiff): DataLossCheck {
   }
 
   return result;
-}
-
-/**
- * Normalize SQL types for comparison
- * Handles equivalent type variations between introspected DB and schema definitions
- */
-function normalizeType(type: string | undefined): string {
-  if (!type) return "";
-
-  const normalized = type.toLowerCase().trim();
-
-  // Handle timestamp variations - all are equivalent
-  if (
-    normalized === "timestamp without time zone" ||
-    normalized === "timestamp with time zone" ||
-    normalized === "timestamptz"
-  ) {
-    return "timestamp";
-  }
-
-  // Handle serial vs integer with identity
-  // serial is essentially integer with auto-increment
-  if (normalized === "serial") {
-    return "integer";
-  }
-  if (normalized === "bigserial") {
-    return "bigint";
-  }
-  if (normalized === "smallserial") {
-    return "smallint";
-  }
-
-  // Handle numeric/decimal equivalence
-  if (normalized.startsWith("numeric") || normalized.startsWith("decimal")) {
-    // Extract precision and scale if present
-    const match = normalized.match(/\((\d+)(?:,\s*(\d+))?\)/);
-    if (match) {
-      return `numeric(${match[1]}${match[2] ? `,${match[2]}` : ""})`;
-    }
-    return "numeric";
-  }
-
-  // Handle varchar/character varying
-  if (normalized.startsWith("character varying")) {
-    return normalized.replace("character varying", "varchar");
-  }
-
-  // Handle text array variations
-  if (normalized === "text[]" || normalized === "_text") {
-    return "text[]";
-  }
-
-  return normalized;
 }
 
 /**
@@ -681,12 +629,15 @@ function checkIfNeedsUsingClause(fromType: string, toType: string): boolean {
   // normalize to "varchar" so the pairs below (e.g. varchar→uuid) match.
   // Without this, an ALTER COLUMN id TYPE uuid is emitted without a USING
   // clause and Postgres rejects it ("cannot be cast automatically").
-  const normalizeType = (t: string) => {
+  // Named `baseType` rather than `normalizeType`: this strips the length/precision
+  // suffix to get a bare type name for the pair lookups below, which is a
+  // different job from the module-level `normalizeType` imported above.
+  const baseType = (t: string) => {
     const base = t.split("(")[0].toLowerCase().trim();
     return base === "character varying" ? "varchar" : base;
   };
-  const fromBase = normalizeType(fromType);
-  const toBase = normalizeType(toType);
+  const fromBase = baseType(fromType);
+  const toBase = baseType(toType);
 
   // Text/varchar to JSONB always needs USING
   if (

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/type-normalization.test.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/type-normalization.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Pins the migrator's single type normalizer.
+ *
+ * `diff-calculator` asks "did this column's type change?" and `sql-generator`
+ * asks "is that change destructive?". Both answers are derived by normalizing
+ * the two type strings, so the two sides must normalize identically or the
+ * migrator contradicts itself. These cases previously lived only in
+ * `type-normalization.real.test.ts`, which the default vitest lane excludes
+ * (`**\/*.real.test.ts`), and which asserted only that the migration did not
+ * throw -- never that a second run would find nothing left to do.
+ */
+import { describe, expect, it } from "vitest";
+import { normalizeType } from "./type-normalization";
+
+describe("normalizeType", () => {
+  it("returns an empty string for a missing type", () => {
+    expect(normalizeType(undefined)).toBe("");
+    expect(normalizeType("")).toBe("");
+  });
+
+  it.each([
+    "timestamp",
+    "timestamptz",
+    "timestamp with time zone",
+    "timestamp without time zone",
+    "TIMESTAMPTZ",
+    "  timestamp with time zone  ",
+  ])("collapses %j to a single timestamp spelling", (input) => {
+    expect(normalizeType(input)).toBe("timestamp");
+  });
+
+  it("treats every pair of timestamp spellings as unchanged", () => {
+    // The regression this guards: `diff-calculator` lacked the `timestamptz`
+    // alias, so it reported a change that `sql-generator` then saw as a no-op,
+    // re-emitting the same ALTER on every migration run.
+    const spellings = [
+      "timestamp",
+      "timestamptz",
+      "timestamp with time zone",
+      "timestamp without time zone",
+    ];
+    for (const from of spellings) {
+      for (const to of spellings) {
+        expect(normalizeType(from)).toBe(normalizeType(to));
+      }
+    }
+  });
+
+  it.each([
+    ["serial", "integer"],
+    ["bigserial", "bigint"],
+    ["smallserial", "smallint"],
+  ])("maps %j to %j", (input, expected) => {
+    expect(normalizeType(input)).toBe(expected);
+  });
+
+  it("canonicalizes numeric and decimal, preserving precision and scale", () => {
+    expect(normalizeType("decimal(10, 2)")).toBe("numeric(10,2)");
+    expect(normalizeType("numeric(10,2)")).toBe("numeric(10,2)");
+    expect(normalizeType("numeric(8)")).toBe("numeric(8)");
+    expect(normalizeType("decimal")).toBe("numeric");
+  });
+
+  it("rewrites character varying to varchar, keeping the length", () => {
+    expect(normalizeType("character varying")).toBe("varchar");
+    expect(normalizeType("character varying(255)")).toBe("varchar(255)");
+  });
+
+  it("collapses the two text-array spellings", () => {
+    expect(normalizeType("text[]")).toBe("text[]");
+    expect(normalizeType("_text")).toBe("text[]");
+  });
+
+  it("passes an unrecognised type through, lower-cased and trimmed", () => {
+    expect(normalizeType("  JSONB ")).toBe("jsonb");
+  });
+});

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/type-normalization.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/type-normalization.ts
@@ -1,0 +1,66 @@
+/**
+ * Canonical SQL type normalization for the runtime migrator.
+ *
+ * WHY this is one module: `diff-calculator` decides whether a column's type
+ * CHANGED, and `sql-generator` decides whether that change is DESTRUCTIVE.
+ * Both answers come from normalizing the two type strings, so if the two sides
+ * normalize differently the migrator contradicts itself -- the diff reports a
+ * change the generator then treats as a no-op, and the same ALTER is re-emitted
+ * on every run. They previously kept private copies of this function and had
+ * already drifted: `diff-calculator`'s copy was missing the `timestamptz`
+ * alias, so `timestamp with time zone` vs `timestamptz` compared as different
+ * there and identical here.
+ */
+
+/**
+ * Normalize SQL types for comparison
+ * Handles equivalent type variations between introspected DB and schema definitions
+ */
+export function normalizeType(type: string | undefined): string {
+  if (!type) return "";
+
+  const normalized = type.toLowerCase().trim();
+
+  // Handle timestamp variations - all are equivalent
+  if (
+    normalized === "timestamp without time zone" ||
+    normalized === "timestamp with time zone" ||
+    normalized === "timestamptz"
+  ) {
+    return "timestamp";
+  }
+
+  // Handle serial vs integer with identity
+  // serial is essentially integer with auto-increment
+  if (normalized === "serial") {
+    return "integer";
+  }
+  if (normalized === "bigserial") {
+    return "bigint";
+  }
+  if (normalized === "smallserial") {
+    return "smallint";
+  }
+
+  // Handle numeric/decimal equivalence
+  if (normalized.startsWith("numeric") || normalized.startsWith("decimal")) {
+    // Extract precision and scale if present
+    const match = normalized.match(/\((\d+)(?:,\s*(\d+))?\)/);
+    if (match) {
+      return `numeric(${match[1]}${match[2] ? `,${match[2]}` : ""})`;
+    }
+    return "numeric";
+  }
+
+  // Handle varchar/character varying
+  if (normalized.startsWith("character varying")) {
+    return normalized.replace("character varying", "varchar");
+  }
+
+  // Handle text array variations
+  if (normalized === "text[]" || normalized === "_text") {
+    return "text[]";
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
## The defect

`diff-calculator.ts` and `sql-generator.ts` each kept a **private copy** of `normalizeType`, and the copies had drifted. Extracting both and diffing them, they are identical except for one branch — `sql-generator` lists three timestamp spellings, `diff-calculator` lists only the two long ones and is missing the `timestamptz` alias:

| input | `diff-calculator` | `sql-generator` |
|---|---|---|
| `timestamptz` | **`"timestamptz"`** | `"timestamp"` |
| `timestamp with time zone` | `"timestamp"` | `"timestamp"` |
| `timestamp without time zone` | `"timestamp"` | `"timestamp"` |

That matters because **the two functions answer different halves of one decision**. `diff-calculator.ts:350`:

```ts
const typeChanged = normalizeType(prevCol.type) !== normalizeType(currCol.type);
```

pushes the column into `diff.columns.modified`, which drives `generateAlterColumnSQL`. `sql-generator` then asks `checkIfTypeChangeIsDestructive`, which normalizes the same pair with *its* copy.

So for a column introspected as `timestamp with time zone` against a schema spelling it `timestamptz`, the diff reports a change and the generator considers the two types identical — an `ALTER` that changes nothing, **re-emitted on every migration run**. Running both copies verbatim over the four spelling pairs:

```
prev (from DB)                curr (from schema)          diffCalc changed?  sqlGen equal?
timestamp with time zone      timestamptz                 true               true    <-- spurious
timestamptz                   timestamp                   true               true    <-- spurious
timestamp without time zone   timestamp                   false              true
timestamptz                   timestamp with time zone    true               true    <-- spurious
```

The diff never converges for such a column.

## Why taking `sql-generator`'s variant loses nothing

This was the part worth checking rather than assuming. Collapsing `timestamptz` into `"timestamp"` looks like it would stop a genuine `timestamp` → `timestamptz` migration from being detected. It doesn't, because `diff-calculator` **already** collapses `timestamp without time zone` and `timestamp with time zone` to the same value — a real with/without-timezone change is already not detected there. Only the short alias slipped through, and only when the schema happened to spell it `timestamptz`. That is an incomplete alias list, not a designed capability.

**The alternative I rejected:** keeping tz and non-tz distinct in a shared normalizer would be the semantically tighter choice, but `checkIfTypeChangeIsDestructive` returns `true` for any pair absent from `safeConversions`, and that table has:

```ts
timestamp: ["timestamp"], // Simplified since normalization handles variations
```

So distinguishing them would reclassify real timestamp changes as destructive and require extending that table. That is a semantics decision for maintainers, not something to smuggle into a de-duplication fix. Happy to do it as a follow-up if you'd like the tighter behaviour.

## The change

- `normalizeType` moves to a new `type-normalization.ts` with a comment recording *why* it must be one function — the two callers answer halves of one decision, so divergence makes the migrator contradict itself.
- Both files import it; both private copies deleted. **Net −97 lines.**
- A local `normalizeType` arrow inside `checkIfNeedsUsingClause` is renamed `baseType`. It strips the precision suffix to get a bare type name for the pair lookups, which is a different job, and it would otherwise shadow the new import. Block-scoped, so behaviour is unchanged.

## Tests

The existing coverage is `type-normalization.real.test.ts`, and it would not have caught this for two reasons:

1. The default vitest lane **excludes** it — `exclude: [..., "**/*.real.test.ts", ...]`.
2. Its `timestamptz` case asserts only that `SELECT COUNT(*)` succeeds after migrating. It never checks that a **second** run finds nothing left to do, which is precisely the symptom.

Added 15 unit tests in the running lane covering the timestamp spellings (including an all-pairs-equal check), serial/bigserial/smallserial, numeric/decimal precision, `character varying` with and without a length, both text-array spellings, and pass-through of an unrecognised type.

**Liveness control.** Reverting the shared normalizer to the drifted `diff-calculator` variant fails exactly 3 of the 15 — the two `timestamptz` spellings and the all-pairs-equal case.

| check | result |
|---|---|
| `bun run typecheck` (`plugin-sql`) | exit 0 |
| `vitest run runtime-migrator` | 15 passed |
| `biome check` (4 touched files) | clean |

## How this was found

Looking for something else entirely — a scan for `String.replace` with a **string literal** pattern, which replaces only the first occurrence, in sanitizing contexts. That vein came up empty: 4270 `.replace()` calls, 337 with a string-literal pattern, 7 in a sanitize/normalize/strip context, and all 7 are clean (`parsePgTimestampWithoutTimezoneUtc` replaces the single space in a PG timestamp; `parseCudaCompute` has already stripped the `sm_` prefix so one underscore remains; the Reddit helper strips a `t3_` fullname prefix and base36 ids cannot contain an underscore; the rest are fixtures).

What the scan did surface was `normalizeType` appearing twice in the same directory, which was worth more than the thing I was looking for.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PPHARXF8S4VYX1Z2TWRENN","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T17:12:51.230Z","completed_at":"2026-09-04T17:17:45.637Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T17:12:51.803Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2fe1d58877c56de30af71279b5a6a995cc1585374df73b1ab3738eb6af843ccd","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"aca9bb71-51f0-4ba4-ba34-56edf373ae44","object_id":"sha256:2fe1d58877c56de30af71279b5a6a995cc1585374df73b1ab3738eb6af843ccd","sha256":"2fe1d58877c56de30af71279b5a6a995cc1585374df73b1ab3738eb6af843ccd"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"I8rEt0HJYG6UaKomtz78X6muCFdtGqKggzc1mWwIU3wOgzo8EUlGovgKTyoTj59sNCI7QymbBgqo8ZkduSvQCQ"}} -->
