### PR TITLE
fix(app): stop main.tsx re-implementing url-trust-policy's IPC check

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -120,6 +120,7 @@ import {
 } from "@elizaos/ui/first-run/first-run-action-channel";
 import {
   IOS_LOCAL_AGENT_IPC_BASE,
+  isMobileLocalAgentIpcUrl,
   MOBILE_LOCAL_AGENT_API_BASE,
   MOBILE_RUNTIME_MODE_STORAGE_KEY,
   normalizeMobileRuntimeMode,
@@ -258,7 +259,9 @@ import {
 } from "./runtime-chooser-override";
 import {
   isElizaCloudSharedHost,
+  isLoopbackApiHost,
   isTrustedCloudOnlyApiBaseUrl,
+  isTrustedPrivateHttpHost,
 } from "./url-trust-policy";
 
 declare const __ELIZA_BUILD_VARIANT__: string | undefined;
@@ -2925,34 +2928,6 @@ function isPopoutWindow(): boolean {
   return getWindowUrlSearchParams().has("popout");
 }
 
-function isTrustedPrivateHttpHost(host: string): boolean {
-  return (
-    host === "0.0.0.0" ||
-    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    /^169\.254\.\d{1,3}\.\d{1,3}$/.test(host) ||
-    host === "local" ||
-    host === "internal" ||
-    host === "lan" ||
-    host === "ts.net" ||
-    host.endsWith(".local") ||
-    host.endsWith(".lan") ||
-    host.endsWith(".internal") ||
-    host.endsWith(".ts.net")
-  );
-}
-
-function isLoopbackApiHost(host: string): boolean {
-  return (
-    host === "localhost" ||
-    host === "127.0.0.1" ||
-    host === "[::1]" ||
-    host === "::1"
-  );
-}
-
 /**
  * Dedicated Cloud agents serve their runtime on the canonical managed-agent
  * hostname family. The shared classifier also recognizes legacy agent hosts
@@ -2967,7 +2942,11 @@ function isNativeIosStoreBuild(): boolean {
 }
 
 function isIosLocalAgentIpcUrl(parsed: URL): boolean {
-  return parsed.protocol === "eliza-local-agent:" && parsed.hostname === "ipc";
+  // Delegates to the shared predicate rather than re-testing protocol+hostname:
+  // Chromium WebView parses a non-special URL's authority as path data, so
+  // `eliza-local-agent://ipc/api/status` arrives with an EMPTY hostname and the
+  // inline check silently failed there. `url-trust-policy.ts` already delegates.
+  return isMobileLocalAgentIpcUrl(parsed);
 }
 
 function isPrivateOrLoopbackApiHost(host: string): boolean {


### PR DESCRIPTION
## The defect

`packages/app/src/main.tsx` **already imports** from `./url-trust-policy`, yet keeps private copies of four functions that module owns: `isTrustedPrivateHttpHost`, `isLoopbackApiHost`, `isPrivateOrLoopbackApiHost`, `isIosLocalAgentIpcUrl`.

Three copies are still byte-identical. The fourth has drifted:

```ts
// main.tsx
return parsed.protocol === "eliza-local-agent:" && parsed.hostname === "ipc";

// url-trust-policy.ts
return isMobileLocalAgentIpcUrl(parsed);
```

The shared predicate is broader, and its own comment records why:

> Chromium WebView treats non-special URL authorities as path data:
> `eliza-local-agent://ipc/api/status` → pathname `//ipc/api/status`.

In that parse the **hostname is empty**, so the inline check — which tests hostname only — returns `false` where the policy module returns `true`.

## Consequence

Both call sites are the same shape, in `isTrustedApiBaseUrl` and `isTrustedDeepLinkApiBaseUrl`:

```ts
if (isIosLocalAgentIpcUrl(parsed)) return canUseIosLocalAgentIpc();
if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
```

A `false` from the first line falls straight through to the protocol guard and returns `false`, so **the on-device agent's own API base is treated as untrusted**. It fails closed: this refuses a legitimate URL rather than accepting a hostile one, which is why this is a functionality fix and not a security report.

**A limit worth stating plainly:** Node's URL parser reports `hostname === "ipc"` for every one of these inputs, so I could not reproduce the divergence in this environment. The evidence is the shared helper's documented behaviour and its own test, `mobile-runtime-mode.test.ts:130`, which asserts the `//ipc` pathname shape via a `URL` object.

## The change

- `isIosLocalAgentIpcUrl` delegates to `isMobileLocalAgentIpcUrl` — the same thing `url-trust-policy.ts` does. `main.tsx` already imports that module, so this adds one named import.
- `isTrustedPrivateHttpHost` and `isLoopbackApiHost` are imported from `./url-trust-policy` instead of redefined.
- `isPrivateOrLoopbackApiHost` is **left alone**: it is private in `url-trust-policy` too, and exporting it would widen that module's API for a change that does not need it. Flagging it so the remaining duplicate is visible.

Net **+8 / −29**.

**Delegation is not more permissive in a harmful direction.** The shared predicate additionally accepts the string fast path and the `//ipc` pathname shape; `eliza-local-agent://ipcevil/x` is still rejected on all three branches (hostname mismatch, pathname does not start with `//ipc/`, no string-prefix match) — already pinned by `attachment-url.test.ts:70`.

## On not adding a test

Deliberately none. `main.tsx` is the composition root and these helpers are not exported, so any test would have to re-assert the shared predicate — which this repo's own `CLAUDE.md` names as a test to avoid ("do not add tests whose material assertions… restate the implementation"). The delegation inherits `mobile-runtime-mode.test.ts`'s coverage, including the WebView pathname case, and the two imported functions are covered by `test/url-trust-policy.test.ts`.

## Verification

| check | result |
|---|---|
| `bun run typecheck` (`packages/app`) | exit 0 |
| `bun run test` (`packages/app`) | 945 pass, 2 skip, 3 fail |
| `biome check src/main.tsx` | clean |

The 3 failures are pre-existing — identical with my changes stashed on `develop`: the Playwright colocated-vitest contract, audit-projects worker propagation, and a `host-agent` pinned-Node delay test (my local Node is 22 against the repo's pinned 24).

## How this was found

The previous two fires each turned up a drifted duplicate helper by accident, so I made it a scan: same-named function declarations of ≥6 lines appearing in more than one file, bodies comment-stripped and whitespace-normalised, compared by token-multiset similarity, keeping only pairs that are **near-identical but not identical** — an exact duplicate cannot have drifted, and a dissimilar one is coincidental name reuse.

That yields 2943 duplicated names across 23140 pairs, 3424 of them near-identical-but-different — far too many to act on, so the discriminator was drift inside a **security decision**, where a small divergence means one copy accepts what the other rejects.

Worth recording that the top such candidate is **clean**: `embeddedIpv4ForPolicy` is duplicated between `packages/core/src/network/ssrf.ts` and `packages/cloud/shared/src/lib/security/outbound-url.ts` at 99.8% similarity, but the only differences are tab-vs-space indentation and comment wording. The NAT64, 6to4 and Teredo branches are identical, so the SSRF copies agree.

---

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PQ5QVBG0SJGB3WCKVD8320","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T17:23:59.979Z","completed_at":"2026-09-04T17:29:08.327Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T17:24:00.283Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"40523ace25ab7dfc78af07704ab7795673650a173c22b4c2e47bc9fde089f837","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b88bb64c-8d8e-4928-a350-ece8e7c97fbd","object_id":"sha256:40523ace25ab7dfc78af07704ab7795673650a173c22b4c2e47bc9fde089f837","sha256":"40523ace25ab7dfc78af07704ab7795673650a173c22b4c2e47bc9fde089f837"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"lt5i8LUvMJUUa4lxXvgGXlw_y3sa8sHJyt7vxpI1LqPjtFU9jjxUHO62I_2AHC3yQd8p8EfgDcnUT9CuYq5zAg"}} -->
