### PR TITLE
docs: make two source references resolve to the file they name

### DIFF
--- a/packages/cloud/services/headscale/README.md
+++ b/packages/cloud/services/headscale/README.md
@@ -16,7 +16,7 @@ deploys to `/etc/headscale/acl.hujson`.
 
 | Tag | Used by | Reach |
 |---|---|---|
-| `tag:agent` | Internal agent containers (set in [`headscale-integration.ts`](../../shared/src/lib/services/headscale-integration.ts:57)) | Internal services only — must NOT reach customer tunnels. |
+| `tag:agent` | Internal agent containers (set in [`headscale-integration.ts`](../../shared/src/lib/services/headscale-integration.ts#L262)) | Internal services only — must NOT reach customer tunnels. |
 | `tag:eliza-tunnel` | Customer tunnel sessions minted by [`auth-key/route.ts`](../../api/v1/apis/tunnels/tailscale/auth-key/route.ts) | The reverse proxy and the customer's own node. Cross-customer routing is enforced by the proxy lookup layer. |
 | `tag:eliza-proxy` | The public reverse proxy node and the control plane's own `cp-<env>-router` | Customer tunnel HTTPS endpoints, plus the agent fleet on the container port only (`tag:agent:2138`) for bridge and health traffic. |
 

--- a/plugins/plugin-agent-orchestrator/docs/orchestrator-dashboard-task-widget-secrets-design.md
+++ b/plugins/plugin-agent-orchestrator/docs/orchestrator-dashboard-task-widget-secrets-design.md
@@ -17,7 +17,7 @@ goal hook calls out, in priority order:
    actually work and be tested**, with no secret material echoed to chat.
 
 Scope is intentionally narrow. The existing
-[`OrchestratorWorkbench.tsx`](../src/OrchestratorWorkbench.tsx) (4142 LOC) is
+[`OrchestratorWorkbench.tsx`](../../plugin-task-coordinator/src/OrchestratorWorkbench.tsx) (4142 LOC) is
 mature — rail, inspector, action bar, timeline, operator drawer, plan editor.
 We do not redesign it. We add a thin glance strip, fix the gaps, and lock
 behavior in tests.


### PR DESCRIPTION
## What

Two documentation links do not resolve. Each is fixed to the target the
repository itself already proves is correct.

| File | Was | Now |
|---|---|---|
| `plugins/plugin-agent-orchestrator/docs/orchestrator-dashboard-task-widget-secrets-design.md` | `../src/OrchestratorWorkbench.tsx` | `../../plugin-task-coordinator/src/OrchestratorWorkbench.tsx` |
| `packages/cloud/services/headscale/README.md` | `...headscale-integration.ts:57` | `...headscale-integration.ts#L262` |

## Why each target is the right one

**Orchestrator design doc.** `plugin-agent-orchestrator` ships no `.tsx` file at
all, so `../src/OrchestratorWorkbench.tsx` cannot resolve. The component lives in
`plugin-task-coordinator`, and three other places in the tree already cite it
that way:

- `plugins/plugin-agent-orchestrator/docs/orchestrator-dashboard-task-widget-secrets-assessment.md:52` — the sibling doc in the same directory
- `packages/core/src/messaging/interactions/README.md:196`
- `plugins/plugin-agent-orchestrator/docs/SUBAGENT_FLOW_AND_PARITY.md:58`

**Headscale README.** A `:line` suffix is not a GitHub fragment, so
`headscale-integration.ts:57` resolves to nothing; the convention used elsewhere
in this repository is `#L<n>` (e.g. `packages/cloud/shared/docs/billing-contract-matrix.md`).
Line 57 had *also* drifted onto an unrelated `HEADSCALE_REGISTRATION_TIMEOUT_TOO_SHORT`
error block, so rewriting `:57` to `#L57` would have produced a link that resolves
to the wrong place. The README's claim is that `tag:agent` is *set* there, and it
is set at `aclTags: ["tag:agent"]` — line 262 — so the anchor is retargeted to the
line the sentence actually describes.

## What I deliberately did not change

- **The `(4142 LOC)` figure** in the design doc. That file is a dated
  (2026-06-05) design record and the number was true when written; the component
  is 1038 lines today. Making a link resolve is a correction; rewriting a dated
  document's historical claims is churn.
- **Five broken `CHANGELOG.md` links** (`packages/core` → `./docs/PIPELINE_HOOKS.md`,
  `packages/cloud/shared` → three `./docs/*.md`). Those targets exist nowhere in
  the tree, so there is no correct target to point at, and `packages/core` does not
  publish its CHANGELOG (`files: ["registry-entry.json", "dist"]`), so there is no
  reader-facing impact either.
- **Three `plugin-local-inference` links** into `native/llama.cpp/...`. Those
  resolve once the submodule is initialized; they only appear broken in a
  checkout that has not run `ensure-llama-cpp-submodule.mjs`.

## How I found them, and the gap that let them through

I validated every explicit-relative markdown link in the tracked tree (511 links
across 903 files) against `git ls-files`. Nine did not resolve; the breakdown
above accounts for all nine.

The root guide states that documentation changes must pass "guide parity and
link/path validation". The parity half exists (`bun run check:agents-claude`, which
I re-ran — still clean). I could not find a repo-wide validator for **relative
markdown links**, which is why both of these survived. I have not added one here:
a new repository-wide gate is a scope decision for maintainers, not something to
bundle into a two-line docs fix. Happy to open that separately if it is wanted —
it would need to exclude uninitialized submodule paths, Docusaurus absolute site
routes under `packages/docs/`, and CHANGELOG history.

## Verification

- Both new targets resolve against the tracked tree.
- Re-ran the link validation: 9 broken → 7, the delta being exactly these two, with
  no other link changed.
- `CLAUDE.md`/`AGENTS.md` byte-parity: clean.
- Docs-only. No code, script, test, or gate is touched.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PSTBMYE838ZKTV9MRVBRCA","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T18:10:12.766Z","completed_at":"2026-09-04T18:12:40.935Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T18:10:13.470Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6ef6c5779f43caf0c83170c5b61a51cc736e7ccfad8902d5fb27e44127f33e53","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"06cc16b0-ad30-4ed1-b2aa-88660e33d354","object_id":"sha256:6ef6c5779f43caf0c83170c5b61a51cc736e7ccfad8902d5fb27e44127f33e53","sha256":"6ef6c5779f43caf0c83170c5b61a51cc736e7ccfad8902d5fb27e44127f33e53"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"wd-MeHXQDU0biRA58sqbg-MVjBtATReNBMFaISiGbv6vljcFogFCUPW6wVMDeognR7tINFRZcDWcpwCiC3h0DA"}} -->
