### PR TITLE
fix(cloud): stop a mistyped numeric env var from silently disabling a limit

### DIFF
--- a/packages/cloud/shared/src/db/repositories/anonymous-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/anonymous-sessions.ts
@@ -6,6 +6,7 @@
 
 import { ElizaError } from "@elizaos/core";
 import { and, eq, gt, gte, lt, sql } from "drizzle-orm";
+import { envInt } from "../../lib/env-int";
 import { mutateRowCount } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
 import { type AnonymousSession, anonymousSessions, userIdentities } from "../schemas";
@@ -222,7 +223,7 @@ export class AnonymousSessionsRepository {
    * @throws Error if session not found.
    */
   async incrementHourlyCount(sessionId: string): Promise<AnonymousHourlyRateLimitResult> {
-    const hourlyLimit = Number.parseInt(process.env.ANON_HOURLY_LIMIT || "10", 10);
+    const hourlyLimit = envInt(process.env.ANON_HOURLY_LIMIT, 10);
     const now = new Date();
     const oneHourAgo = new Date(now.getTime() - HOUR_MS);
 

--- a/packages/cloud/shared/src/lib/eliza/plugin-mcp/cache/schema-cache.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-mcp/cache/schema-cache.ts
@@ -14,6 +14,7 @@
 import { logger } from "@elizaos/core";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { createHash } from "crypto";
+import { envInt } from "../../../env-int";
 import type { CachedServerSchema, McpServerConfig } from "../types";
 
 const CACHE_KEY_PREFIX = "mcp:schema:v1";
@@ -65,7 +66,7 @@ export class McpSchemaCache {
     const enabled = process.env.MCP_SCHEMA_CACHE_ENABLED === "true";
     const url = process.env.MCP_CACHE_REDIS_URL;
     const token = process.env.MCP_CACHE_REDIS_TOKEN;
-    this.ttl = parseInt(process.env.MCP_SCHEMA_CACHE_TTL || String(DEFAULT_TTL), 10);
+    this.ttl = envInt(process.env.MCP_SCHEMA_CACHE_TTL, DEFAULT_TTL);
 
     if (!enabled) {
       logger.debug("[McpSchemaCache] Disabled");

--- a/packages/cloud/shared/src/lib/env-int.ts
+++ b/packages/cloud/shared/src/lib/env-int.ts
@@ -1,0 +1,26 @@
+/**
+ * Strict integer parsing for environment-supplied numeric settings.
+ *
+ * `parseInt` accepts a numeric prefix, so `parseInt("25000junk", 10)` is 25000
+ * and `parseInt("abc", 10)` is `NaN`. Neither outcome is safe for a budget, a
+ * quota, or a threshold: the first silently becomes a different value than the
+ * operator wrote, and the second poisons every subsequent comparison, because
+ * every relational test against `NaN` is false. A limit that is `NaN` does not
+ * fail loudly — it stops applying.
+ *
+ * Callers therefore share one parse that fails closed to the caller's fallback
+ * for anything non-canonical. This module holds no configuration of its own so
+ * that repositories, services, and caches can depend on the parse without
+ * depending on a particular subsystem's config module.
+ */
+
+/**
+ * Parse a canonical non-negative integer, falling back for empty, unset, or
+ * non-canonical input. Values keeping a `+` sign prefix are accepted; anything
+ * with trailing characters, a decimal point, or a leading `-` uses `fallback`.
+ */
+export function envInt(raw: string | undefined, fallback: number): number {
+  const trimmed = raw?.trim() ?? "";
+  if (trimmed === "") return fallback;
+  return /^\+?\d+$/.test(trimmed) ? Number(trimmed) : fallback;
+}

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -19,6 +19,7 @@ import {
 import { CacheInvalidation } from "../cache/invalidation";
 import { invalidateOrganizationCache } from "../cache/organizations-cache";
 import { canSendLowCreditsEmail, markLowCreditsEmailSent } from "../email/utils/rate-limiter";
+import { envInt } from "../env-int";
 import { calculateCost, getProviderFromModel } from "../pricing";
 import { PROVIDER_DEFAULT_MAX_RETRIES, PROVIDER_MAX_BACKOFF_DELAY_MS } from "../providers/_http";
 import { getRequestTaskDefer } from "../runtime/request-context";
@@ -1064,7 +1065,7 @@ export class CreditsService {
       return;
     }
 
-    const threshold = parseInt(process.env.LOW_CREDITS_THRESHOLD || "1000", 10);
+    const threshold = envInt(process.env.LOW_CREDITS_THRESHOLD, 1000);
     const status = classifyCreditBalance(newBalance, threshold);
     if (!status) {
       return;
@@ -1091,7 +1092,7 @@ export class CreditsService {
     currentBalance: number,
   ): Promise<void> {
     try {
-      const threshold = parseInt(process.env.LOW_CREDITS_THRESHOLD || "1000", 10);
+      const threshold = envInt(process.env.LOW_CREDITS_THRESHOLD, 1000);
 
       if (currentBalance <= 0 || currentBalance > threshold) {
         return;

--- a/packages/cloud/shared/src/lib/services/proxy/config.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/config.ts
@@ -6,19 +6,11 @@
  * resolve under Cloud Workers via `getCloudAwareEnv()` (per-request `c.env`).
  */
 
+import { envInt } from "../../env-int";
 import { getCloudAwareEnv } from "../../runtime/cloud-bindings";
 
-/**
- * Strict integer env parse: rejects trailing garbage (parseInt("25junk") is
- * 25) and sign-prefix confusion, so a corrupted or hostile env value can never
- * silently become a different budget than intended. Empty/unset uses the
- * fallback; anything else non-canonical fails closed to the fallback.
- */
-export function envInt(raw: string | undefined, fallback: number): number {
-  const trimmed = raw?.trim() ?? "";
-  if (trimmed === "") return fallback;
-  return /^\+?\d+$/.test(trimmed) ? Number(trimmed) : fallback;
-}
+// Re-exported so existing importers of the proxy config keep one import site.
+export { envInt };
 
 export function getProxyConfig() {
   const e = getCloudAwareEnv();


### PR DESCRIPTION
## The bug

Four numeric settings in `cloud/shared` are parsed like this:

```ts
parseInt(process.env.X || "<default>", 10)
```

The `||` runs on the **string**, so it only covers *unset* and *empty*. Once the
variable is set to anything non-numeric the fallback is skipped and `parseInt`
returns `NaN`. Every relational comparison against `NaN` is false, so the value
never fails loudly — the check it feeds just stops applying.

The safe sibling shape, `Number(process.env.X) || default`, does not have this
problem, because there the `||` runs on the parsed number and `NaN` is falsy.
Both shapes appear in this package; only the first is wrong.

## What actually breaks

Measured by evaluating the old and new expressions, not by reasoning about them.

**`ANON_HOURLY_LIMIT=ten` disables the anonymous rate limit.**

| expression | value |
|---|---|
| `hourlyLimit` | `NaN` |
| `updated.hourly_message_count > hourlyLimit` (11 > NaN) | `false` — never limited |
| `remaining: hourlyLimit - count` | `NaN` — returned to the caller |

**`LOW_CREDITS_THRESHOLD=ten` breaks the two reads in *opposite* directions.**

| site | expression | effect |
|---|---|---|
| `notifyLowCredits` | `currentBalance > NaN` → `false` | early return skipped → low-credit email sent at **any** balance |
| `classifyCreditBalance` | `newBalance <= NaN` → `false` | returns `null` → low-credit webhook **never** fires |

**`MCP_SCHEMA_CACHE_TTL=ten`** yields a `NaN` TTL (and logs `TTL: NaNs`).

## The fix

This package already owns the correct parse. `envInt` fails closed to the
caller's fallback for anything non-canonical, and its own header states the
reason: `parseInt("25junk")` is `25`, so a corrupted value must never silently
become a different budget than the operator wrote.

It lived inside `services/proxy/config.ts`. A DB repository, a credits service,
and an MCP cache should not import a proxy config module to get a number parsed,
so `envInt` moves to `lib/env-int.ts` and `proxy/config.ts` re-exports it —
**no proxy call site changes**, and its existing test still resolves it through
`./config`.

## Behavior change worth flagging

Beyond the `NaN` fix, values with trailing garbage (`"20junk"`) or a leading `-`
now fall back instead of parsing to a partial or negative number. That is
`envInt`'s documented contract and the safer reading for a quota or threshold,
but it is a real change, so it belongs here rather than being discovered in
review.

## Scope I deliberately did not take

`envInt` is duplicated **six** times across the repo with three different
signatures (some take the raw string, some take the variable name):
`app-core/scripts/copy-runtime-node-modules.ts`,
`app-core/test/helpers/stochastic-test.ts`, `plugin-codex-cli/src/codex-backend.ts`,
`plugin-local-inference/src/services/memory-monitor.ts`,
`plugin-sql/src/pg/manager.ts`, and this one. Converging them is a cross-package
change with its own layering decisions and is not attempted here. Happy to follow
up if that is wanted.

## Verification

- `bun run typecheck` from `packages/cloud/shared` — exit 0. (Used the package's
  own script; a hand-rolled `tsc -p` in this tree does not reproduce the real gate.)
- `bunx biome check` run from the package directory — clean.
- **172 tests pass** across every test file touching credits, anonymous sessions,
  and the schema cache (`organization-credits`, `anonymous-sessions`,
  `auth-anonymous.retry-after`, the nine `credits-*` / `app-credits-*` suites,
  `app-credits-monetization-write-through`, `social-media.credits`).
- `envInt`'s own suite still passes: `bun test src/lib/services/proxy/config.test.ts`
  → 5 pass, resolving the function through the re-export.

**No new test.** `envInt`'s contract — including the `"25000junk"` case — is
already pinned by `config.test.ts`, which runs under the `bun test` lane. A
second test asserting the same helper would only restate it, and the repository
guide rules that out. (I first suspected that suite was stranded because it is
absent from the `vitest.config.ts` include allowlist; registering it failed,
because that allowlist is for files importing `vitest` and this one imports
`bun:test`. The registration was reverted — the suite was never unenforced.)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eliza]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1PT7NH9EW4QFYRBHYCVFA64","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-04T18:17:28.873Z","completed_at":"2026-09-04T18:21:09.998Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-04T18:17:29.164Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"9873b6f5d166dd1f8c979b762248f35422ffaae1097d800a1da64208ca1b6b5b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5d64b45d-fdb5-49d7-8d83-d6356f6118ab","object_id":"sha256:9873b6f5d166dd1f8c979b762248f35422ffaae1097d800a1da64208ca1b6b5b","sha256":"9873b6f5d166dd1f8c979b762248f35422ffaae1097d800a1da64208ca1b6b5b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ4VxwVlmo7xGW8oMjbriZDR7aUEdM8QzYm7EPu2IZ-k","device_key_id":"faebfacd1bd138c8d1c79df0405497e5a829d7f8df26b875f53140cb964cf089","device_signature":"YlXjwz8i_daRjLSGTPMhpvgUVc7FwuO-kz8sPRj0hkOMNPIMPomfKNmQMvEhNX8WRKp5Lm0icIe1DEx1O76aAg"}} -->
