### PR TITLE
fix(auth): reject malformed Claude CLI OAuth metadata

### DIFF
--- a/packages/auth/src/credentials-claude-cli-boundary.test.ts
+++ b/packages/auth/src/credentials-claude-cli-boundary.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Exercises Claude Code credential-file parsing through the public subscription
+ * status and deferred-detection entry points with real temporary files.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { logger, resetSubscriptionAuthProviders } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { refreshAnthropicToken } from "./anthropic";
+import {
+  applySubscriptionCredentialsDeferred,
+  getSubscriptionStatus,
+} from "./credentials";
+
+vi.mock("./anthropic.ts", () => ({
+  refreshAnthropicToken: vi.fn(),
+}));
+
+const tempHomes: string[] = [];
+
+function useClaudeCredentialRaw(raw: string): void {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-claude-auth-"));
+  tempHomes.push(home);
+  fs.mkdirSync(path.join(home, ".claude"));
+  fs.writeFileSync(path.join(home, ".claude", ".credentials.json"), raw, {
+    mode: 0o600,
+  });
+  vi.stubEnv("HOME", home);
+  vi.stubEnv("USERPROFILE", home);
+  vi.stubEnv("ELIZA_HOME", home);
+  vi.stubEnv("ELIZA_STATE_DIR", home);
+  vi.stubEnv("ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS", "0");
+}
+
+function useClaudeCredentialDocument(document: unknown): void {
+  useClaudeCredentialRaw(JSON.stringify(document));
+}
+
+function useClaudeCredentialFixture(
+  claudeAiOauth: Record<string, unknown>,
+): void {
+  useClaudeCredentialDocument({ claudeAiOauth });
+}
+
+function anthropicStatusRows() {
+  return getSubscriptionStatus().filter(
+    (row) => row.provider === "anthropic-subscription" && row.configured,
+  );
+}
+
+describe("Claude Code credential boundary", () => {
+  beforeEach(() => {
+    resetSubscriptionAuthProviders();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    resetSubscriptionAuthProviders();
+    for (const home of tempHomes.splice(0)) {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["null document", null],
+    ["array document", []],
+    ["array OAuth payload", { claudeAiOauth: [] }],
+  ])("rejects a malformed %s", async (_case, document) => {
+    useClaudeCredentialDocument(document);
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+
+    expect(anthropicStatusRows()).toEqual([]);
+    await applySubscriptionCredentialsDeferred();
+
+    expect(refreshAnthropicToken).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing access token", {}],
+    ["numeric access token", { accessToken: 42 }],
+    ["empty access token", { accessToken: "" }],
+    ["whitespace access token", { accessToken: "   " }],
+    ["string expiry", { accessToken: "access", expiresAt: "not-a-timestamp" }],
+    ["negative expiry", { accessToken: "access", expiresAt: -1 }],
+    ["object expiry", { accessToken: "access", expiresAt: {} }],
+    [
+      "numeric refresh token",
+      { accessToken: "access", refreshToken: 42, expiresAt: Date.now() - 1 },
+    ],
+    [
+      "shadowed snake_case access token",
+      {
+        accessToken: "access",
+        access_token: 42,
+        expiresAt: Date.now() + 60_000,
+      },
+    ],
+    [
+      "shadowed snake_case refresh token",
+      {
+        accessToken: "access",
+        refreshToken: "refresh",
+        refresh_token: 42,
+        expiresAt: Date.now() + 60_000,
+      },
+    ],
+    [
+      "shadowed snake_case expiry",
+      {
+        accessToken: "access",
+        expiresAt: Date.now() + 60_000,
+        expires_at: "bad",
+      },
+    ],
+  ])("rejects a blob with a malformed %s", async (_case, oauth) => {
+    useClaudeCredentialFixture(oauth);
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+
+    expect(anthropicStatusRows()).toEqual([]);
+    await applySubscriptionCredentialsDeferred();
+
+    expect(refreshAnthropicToken).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it("rejects an overflowing JSON expiry", async () => {
+    useClaudeCredentialRaw(
+      '{"claudeAiOauth":{"accessToken":"access","expiresAt":1e400}}',
+    );
+    const info = vi.spyOn(logger, "info").mockImplementation(() => undefined);
+
+    expect(anthropicStatusRows()).toEqual([]);
+    await applySubscriptionCredentialsDeferred();
+
+    expect(refreshAnthropicToken).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it("preserves a future camelCase expiry", async () => {
+    const expiresAt = Date.now() + 60_000;
+    useClaudeCredentialFixture({
+      accessToken: "access",
+      refreshToken: "refresh",
+      expiresAt,
+    });
+
+    expect(anthropicStatusRows()).toMatchObject([
+      { valid: true, expiresAt, source: "claude-code-cli" },
+    ]);
+    const beforeDiscovery = anthropicStatusRows();
+    await applySubscriptionCredentialsDeferred();
+    expect(refreshAnthropicToken).not.toHaveBeenCalled();
+    expect(anthropicStatusRows()).toEqual(beforeDiscovery);
+  });
+
+  it("keeps an absent expiry as an explicit unknown expiry", async () => {
+    useClaudeCredentialFixture({ accessToken: "access" });
+
+    expect(anthropicStatusRows()).toMatchObject([
+      { valid: true, expiresAt: null, source: "claude-code-cli" },
+    ]);
+    const beforeDiscovery = anthropicStatusRows();
+    await applySubscriptionCredentialsDeferred();
+    expect(refreshAnthropicToken).not.toHaveBeenCalled();
+    expect(anthropicStatusRows()).toEqual(beforeDiscovery);
+  });
+
+  it("accepts explicit null refresh and expiry fields", async () => {
+    useClaudeCredentialFixture({
+      accessToken: "access",
+      refreshToken: null,
+      expiresAt: null,
+    });
+
+    expect(anthropicStatusRows()).toMatchObject([
+      { valid: true, expiresAt: null, source: "claude-code-cli" },
+    ]);
+    const beforeDiscovery = anthropicStatusRows();
+    await applySubscriptionCredentialsDeferred();
+    expect(refreshAnthropicToken).not.toHaveBeenCalled();
+    expect(anthropicStatusRows()).toEqual(beforeDiscovery);
+  });
+
+  it("reports an expired snake_case credential without refreshing it", async () => {
+    const expiresAt = Date.now() - 60_000;
+    useClaudeCredentialFixture({
+      access_token: "access",
+      refresh_token: "refresh",
+      expires_at: expiresAt,
+    });
+    expect(anthropicStatusRows()).toMatchObject([
+      { valid: false, expiresAt, source: "claude-code-cli" },
+    ]);
+    const beforeDiscovery = anthropicStatusRows();
+    await applySubscriptionCredentialsDeferred();
+
+    expect(refreshAnthropicToken).not.toHaveBeenCalled();
+    expect(anthropicStatusRows()).toEqual(beforeDiscovery);
+  });
+});

--- a/packages/auth/src/credentials.ts
+++ b/packages/auth/src/credentials.ts
@@ -644,8 +644,12 @@ interface ClaudeCodeCredentialBlob {
   source: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
- * Read local Claude Code credential metadata for status and discovery.
+ * Read and validate local Claude Code credential metadata for status and discovery.
  * Persisted access tokens may be expired while the CLI refreshes its own login;
  * callers distinguish presence from validity without exchanging the credential.
  */
@@ -655,24 +659,57 @@ function readClaudeCodeOAuthBlob(): ClaudeCodeCredentialBlob | null {
     source: string,
   ): ClaudeCodeCredentialBlob | null => {
     try {
-      const parsed = JSON.parse(raw) as {
-        claudeAiOauth?: {
-          accessToken?: string;
-          access_token?: string;
-          refreshToken?: string;
-          refresh_token?: string;
-          expiresAt?: number;
-          expires_at?: number;
-        };
-      };
+      const parsed: unknown = JSON.parse(raw);
+      if (!isRecord(parsed)) return null;
       const oauth = parsed.claudeAiOauth;
-      if (!oauth) return null;
+      if (!isRecord(oauth)) return null;
+      const accessTokenFields = [oauth.accessToken, oauth.access_token].filter(
+        (value) => value !== undefined,
+      );
+      if (
+        accessTokenFields.length === 0 ||
+        accessTokenFields.some(
+          (value) => typeof value !== "string" || !value.trim(),
+        )
+      ) {
+        return null;
+      }
       const accessToken = oauth.accessToken ?? oauth.access_token;
-      if (typeof accessToken !== "string" || !accessToken.trim()) return null;
+      if (typeof accessToken !== "string") return null;
+      const refreshTokenFields = [
+        oauth.refreshToken,
+        oauth.refresh_token,
+      ].filter((value) => value !== undefined);
+      if (
+        refreshTokenFields.some(
+          (value) => value !== null && typeof value !== "string",
+        )
+      ) {
+        return null;
+      }
+      const refreshTokenValue =
+        oauth.refreshToken ?? oauth.refresh_token ?? null;
+      const refreshToken =
+        typeof refreshTokenValue === "string" ? refreshTokenValue : null;
+      const expiresAtFields = [oauth.expiresAt, oauth.expires_at].filter(
+        (value) => value !== undefined,
+      );
+      if (
+        expiresAtFields.some(
+          (value) =>
+            value !== null &&
+            (typeof value !== "number" || !Number.isFinite(value) || value < 0),
+        )
+      ) {
+        return null;
+      }
+      const expiresAtValue = oauth.expiresAt ?? oauth.expires_at ?? null;
+      const expiresAt =
+        typeof expiresAtValue === "number" ? expiresAtValue : null;
       return {
         accessToken: accessToken.trim(),
-        refreshToken: oauth.refreshToken ?? oauth.refresh_token ?? null,
-        expiresAt: oauth.expiresAt ?? oauth.expires_at ?? null,
+        refreshToken,
+        expiresAt,
         source,
       };
     } catch {


### PR DESCRIPTION
Closes #30548.

Validate Claude CLI credential metadata before reporting it as a configured subscription. Malformed token, refresh-token, or expiry fields—including shadowed camelCase/snake_case values—are rejected; valid metadata preserves the CLI's read-only discovery contract.

Rebased onto `9612ff217a00465f63f1854b53ebcd65e2461dcd` and resolved the conflict with the merged read-only CLI discovery change. Replaced obsolete refresh/log assertions with public status checks: expired credentials remain expired and discovery never refreshes them.

Validation on `7577bd43a79eb1ce9ea6a18dd62e88a7863706d9`, Bun 1.3.14 / Node 24.15.0:
- Real temporary credential files exercise public status and deferred discovery entry points.
- Restoring the previous parser makes eight boundary tests fail; the repaired parser passes.
- Full auth suite: 260 tests in 21 files passed.
- Auth typecheck, lint and format checks passed.
- Root `bun run verify`: all 376 workspace tasks and repository audits passed on the final revision.
- `bun install` passed after the final rebase.

UI/native captures and model trajectories are N/A: this change validates local metadata and deliberately performs no credential exchange.

<!-- evidence-head:7577bd43a79eb1ce9ea6a18dd62e88a7863706d9 -->
