### PR TITLE
fix(app-core): reject malformed Anthropic usage response shapes

### DIFF
--- a/packages/agent/src/api/accounts-routes.test.ts
+++ b/packages/agent/src/api/accounts-routes.test.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { LINKED_ACCOUNT_PROVIDER_IDS } from "@elizaos/core";
+import { ElizaError, LINKED_ACCOUNT_PROVIDER_IDS } from "@elizaos/core";
 import { codingProviderDescriptorForProvider } from "@elizaos/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -736,6 +736,50 @@ describe("accounts routes", () => {
       },
     });
   });
+
+  it.each(["anthropic_usage.invalid_shape", "anthropic_usage.invalid_json"])(
+    "does not fall back to a healthy inline probe after malformed subscription usage (%s)",
+    async (code) => {
+      const existing = {
+        ...linkedAccount,
+        providerId: "anthropic-subscription",
+        health: "rate-limited",
+        healthDetail: { until: Date.now() + 60_000 },
+        usage: { refreshedAt: 100, sessionPct: 91, weeklyPct: 72 },
+      };
+      fakes.poolAccounts = [existing];
+      fakes.pool.refreshUsage.mockRejectedValueOnce(
+        new ElizaError('Anthropic usage response field "limits" was invalid', {
+          code,
+          severity: "fatal",
+        }),
+      );
+      const fetchMock = vi.fn(async () =>
+        Promise.resolve(new Response("{}", { status: 200 })),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      try {
+        const refreshed = makeContext(
+          "POST",
+          "/api/accounts/anthropic-subscription/account-1/refresh-usage",
+        );
+
+        await handleAccountsRoutes(refreshed.ctx);
+
+        expect(refreshed.errorCalls).toEqual([
+          {
+            message: 'Anthropic usage response field "limits" was invalid',
+            status: 502,
+          },
+        ]);
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(fakes.pool.upsert).not.toHaveBeenCalled();
+        expect(fakes.poolAccounts).toEqual([existing]);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    },
+  );
 
   it("starts and controls OAuth flows and validates the status stream", async () => {
     const started = makeContext(

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -1656,8 +1656,9 @@ async function handleRefreshUsage(
   // Drive the canonical `pollAnthropicUsage` / `pollCodexUsage` through
   // the pool — same singleton used by the runtime, so health flips and
   // usage snapshots are consistent across UI and inference paths. Falls
-  // back to an inline 1-token probe only if the pool throws (network
-  // failure to the provider's usage endpoint, etc.).
+  // back to an inline 1-token probe for transport failures. Invalid provider
+  // data is terminal because a successful model probe cannot reconstruct the
+  // missing usage fields or safely replace the existing snapshot.
   try {
     await pool.refreshUsage(accountId, accessToken, {
       providerId,
@@ -1673,6 +1674,16 @@ async function handleRefreshUsage(
       return true;
     }
   } catch (err) {
+    if (
+      err instanceof ElizaError &&
+      (err.code === "anthropic_usage.invalid_shape" ||
+        err.code === "anthropic_usage.invalid_json")
+    ) {
+      // error-policy:J1 translate malformed upstream data at the HTTP boundary
+      // without running a fallback that could fabricate a healthy usage state.
+      error(res, err.message, 502);
+      return true;
+    }
     logger.debug(`[accounts] pool.refreshUsage failed: ${String(err)}`);
   }
 

--- a/packages/app-core/src/services/account-pool.test.ts
+++ b/packages/app-core/src/services/account-pool.test.ts
@@ -272,6 +272,44 @@ describe("AccountPool provider-scoped account resolution", () => {
     expect(profileUrls).toHaveLength(0);
   });
 
+  it("does not replace account health or usage when Anthropic returns a malformed payload", async () => {
+    const writeAccount = vi.fn(async () => {});
+    const existing = account("anthropic-subscription", {
+      id: "malformed-usage",
+      email: "known@example.com",
+      health: "rate-limited",
+      healthDetail: { until: Date.now() + 60_000 },
+      usage: {
+        refreshedAt: 100,
+        sessionPct: 91,
+        weeklyPct: 72,
+        resetsAt: 1_900_000_000_000,
+      },
+    });
+    const pool = new AccountPool({
+      readAccounts: () => ({
+        "anthropic-subscription:malformed-usage": existing,
+      }),
+      writeAccount,
+    });
+
+    await expect(
+      pool.refreshUsage("malformed-usage", "token", {
+        providerId: "anthropic-subscription",
+        fetch: (async () =>
+          new Response(
+            JSON.stringify({
+              five_hour: 7,
+              seven_day: [],
+              limits: { kind: "weekly_all" },
+            }),
+            { status: 200 },
+          )) as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "anthropic_usage.invalid_shape" });
+    expect(writeAccount).not.toHaveBeenCalled();
+  });
+
   it("selects among multiple accounts for the same provider by priority", async () => {
     const accounts = {
       "openai-codex:personal": account("openai-codex", {

--- a/packages/app-core/src/services/account-usage.test.ts
+++ b/packages/app-core/src/services/account-usage.test.ts
@@ -345,6 +345,112 @@ describe("pollAnthropicUsage", () => {
     expect(typeof snap.refreshedAt).toBe("number");
   });
 
+  it.each([
+    ["null root", null],
+    ["array root", []],
+    ["numeric five_hour window", { five_hour: 7 }],
+    ["array seven_day window", { seven_day: [] }],
+    ["object limits collection", { limits: { kind: "weekly_all" } }],
+    ["non-object limits entry", { limits: [null] }],
+    [
+      "non-object limit scope",
+      { limits: [{ kind: "weekly_scoped", scope: "all-models" }] },
+    ],
+    [
+      "non-object scoped model",
+      {
+        limits: [
+          {
+            kind: "weekly_scoped",
+            scope: { model: "Fable" },
+          },
+        ],
+      },
+    ],
+  ])("rejects a malformed Anthropic usage %s", async (_name, payload) => {
+    stubFetch(jsonResponse(payload));
+
+    await expect(pollAnthropicUsage("malformed-token")).rejects.toMatchObject({
+      code: "anthropic_usage.invalid_shape",
+    });
+  });
+
+  it.each([
+    {
+      name: "session window",
+      payload: { five_hour: null, seven_day: { utilization: 42 } },
+      expected: { weeklyPct: 42 },
+    },
+    {
+      name: "weekly window",
+      payload: { five_hour: { utilization: 27 }, seven_day: null },
+      expected: { sessionPct: 27 },
+    },
+    {
+      name: "limits collection",
+      payload: {
+        five_hour: { utilization: 13 },
+        seven_day: { utilization: 61 },
+        limits: null,
+      },
+      expected: { sessionPct: 13, weeklyPct: 61 },
+    },
+  ])(
+    "retains available usage when the $name is null",
+    async ({ payload, expected }) => {
+      stubFetch(jsonResponse(payload));
+
+      const { refreshedAt, ...usage } =
+        await pollAnthropicUsage("nullable-token");
+
+      expect(usage).toEqual(expected);
+      expect(refreshedAt).toBeGreaterThan(0);
+    },
+  );
+
+  it("keeps aggregate and named model usage when another model scope is null", async () => {
+    stubFetch(
+      jsonResponse({
+        limits: [
+          {
+            kind: "weekly_scoped",
+            group: "weekly",
+            percent: 80,
+            scope: { model: null },
+          },
+          { kind: "weekly_all", group: "weekly", percent: 32 },
+          {
+            kind: "weekly_scoped",
+            group: "weekly",
+            percent: 40,
+            scope: { model: { display_name: "Fable" } },
+          },
+        ],
+      }),
+    );
+
+    const { refreshedAt, ...usage } = await pollAnthropicUsage(
+      "nullable-model-token",
+    );
+
+    expect(usage).toEqual({
+      weeklyPct: 32,
+      weeklyModelBuckets: { Fable: { pct: 40 } },
+    });
+    expect(refreshedAt).toBeGreaterThan(0);
+  });
+
+  it("rejects malformed Anthropic usage JSON with a typed decoding error", async () => {
+    stubFetch(new Response("{", { status: 200 }));
+
+    await expect(
+      pollAnthropicUsage("malformed-json-token"),
+    ).rejects.toMatchObject({
+      code: "anthropic_usage.invalid_json",
+      cause: expect.any(SyntaxError),
+    });
+  });
+
   it("passes through an epoch-MILLISECONDS reset timestamp unchanged", async () => {
     const ms = 1_700_000_000_000; // already > 1e12
     stubFetch(jsonResponse({ seven_day: { resets_at: ms } }));

--- a/packages/app-core/src/services/account-usage.ts
+++ b/packages/app-core/src/services/account-usage.ts
@@ -16,7 +16,7 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fetchCodexUsage } from "@elizaos/auth/codex-usage";
-import { resolveStateDir } from "@elizaos/core";
+import { ElizaError, resolveStateDir } from "@elizaos/core";
 import type { LinkedAccountUsage } from "@elizaos/shared/contracts/service-routing";
 
 /**
@@ -65,30 +65,117 @@ function normalizeResetTimestamp(value: unknown): number | undefined {
 }
 
 interface AnthropicUsageWindow {
-  utilization?: number;
-  resets_at?: string | number;
+  utilization?: unknown;
+  resets_at?: unknown;
 }
 
 interface AnthropicUsageLimitScope {
-  model?: { display_name?: string };
+  model?: { display_name?: unknown };
 }
 
 interface AnthropicUsageLimit {
-  kind?: string;
-  group?: string;
-  percent?: number;
-  resets_at?: string | number;
-  scope?: AnthropicUsageLimitScope;
+  kind?: unknown;
+  group?: unknown;
+  percent?: unknown;
+  resets_at?: unknown;
+  scope?: AnthropicUsageLimitScope | null;
 }
 
 interface AnthropicUsagePayload {
-  five_hour_utilization?: number;
-  five_hour_resets_at?: string | number;
-  seven_day_utilization?: number;
-  seven_day_resets_at?: string | number;
+  five_hour_utilization?: unknown;
+  five_hour_resets_at?: unknown;
+  seven_day_utilization?: unknown;
+  seven_day_resets_at?: unknown;
   five_hour?: AnthropicUsageWindow;
   seven_day?: AnthropicUsageWindow;
   limits?: AnthropicUsageLimit[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function invalidAnthropicUsageShape(field: string): never {
+  throw new ElizaError(
+    `Anthropic usage response field "${field}" was invalid`,
+    {
+      code: "anthropic_usage.invalid_shape",
+      severity: "fatal",
+      context: { field },
+    },
+  );
+}
+
+function parseOptionalRecord(
+  value: unknown,
+  field: string,
+): Record<string, unknown> | undefined {
+  // Providers use null for unavailable optional windows and model scopes.
+  if (value === undefined || value === null) return undefined;
+  return isRecord(value) ? value : invalidAnthropicUsageShape(field);
+}
+
+function parseNullableRecord(
+  value: unknown,
+  field: string,
+): Record<string, unknown> | null | undefined {
+  if (value === null) return null;
+  return parseOptionalRecord(value, field);
+}
+
+function parseAnthropicUsageWindow(
+  value: unknown,
+  field: string,
+): AnthropicUsageWindow | undefined {
+  const record = parseOptionalRecord(value, field);
+  if (record === undefined) return undefined;
+  return {
+    utilization: record.utilization,
+    resets_at: record.resets_at,
+  };
+}
+
+function parseAnthropicUsageLimits(
+  value: unknown,
+): AnthropicUsageLimit[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) return invalidAnthropicUsageShape("limits");
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) return invalidAnthropicUsageShape(`limits[${index}]`);
+    const scope = parseNullableRecord(entry.scope, `limits[${index}].scope`);
+    const model = parseOptionalRecord(
+      scope?.model,
+      `limits[${index}].scope.model`,
+    );
+    return {
+      kind: entry.kind,
+      group: entry.group,
+      percent: entry.percent,
+      resets_at: entry.resets_at,
+      scope:
+        scope === undefined || scope === null
+          ? scope
+          : {
+              model:
+                model === undefined
+                  ? undefined
+                  : { display_name: model.display_name },
+            },
+    };
+  });
+}
+
+function parseAnthropicUsagePayload(value: unknown): AnthropicUsagePayload {
+  if (!isRecord(value)) return invalidAnthropicUsageShape("root");
+  return {
+    five_hour_utilization: value.five_hour_utilization,
+    five_hour_resets_at: value.five_hour_resets_at,
+    seven_day_utilization: value.seven_day_utilization,
+    seven_day_resets_at: value.seven_day_resets_at,
+    five_hour: parseAnthropicUsageWindow(value.five_hour, "five_hour"),
+    seven_day: parseAnthropicUsageWindow(value.seven_day, "seven_day"),
+    limits: parseAnthropicUsageLimits(value.limits),
+  };
 }
 
 /**
@@ -118,7 +205,19 @@ export async function pollAnthropicUsage(
   if (!res.ok) {
     throw new Error(`Anthropic usage probe failed: HTTP ${res.status}`);
   }
-  const payload = (await res.json()) as AnthropicUsagePayload;
+  let rawPayload: unknown;
+  try {
+    rawPayload = await res.json();
+  } catch (cause) {
+    // error-policy:J2 preserve the provider JSON decoding failure as a typed
+    // boundary error so callers cannot mistake it for missing optional data.
+    throw new ElizaError("Anthropic usage response was not JSON", {
+      code: "anthropic_usage.invalid_json",
+      severity: "fatal",
+      cause,
+    });
+  }
+  const payload = parseAnthropicUsagePayload(rawPayload);
 
   const fiveHour = payload.five_hour;
   const sevenDay = payload.seven_day;
@@ -151,7 +250,9 @@ export async function pollAnthropicUsage(
       const pct = utilizationToPct(limit.percent, false);
       if (pct === undefined) continue;
       const resetsAt = normalizeResetTimestamp(limit.resets_at);
-      const modelName = limit.scope?.model?.display_name?.trim();
+      const displayName = limit.scope?.model?.display_name;
+      const modelName =
+        typeof displayName === "string" ? displayName.trim() : undefined;
       if (modelName) {
         weeklyModelBuckets[modelName] = {
           pct,


### PR DESCRIPTION
Anthropic account usage now rejects malformed response objects with an explicit unavailable result instead of presenting invalid data as valid quota information. Optional windows, limits, and model scopes still accept `null` as absent, preserving other valid buckets and the previously supported API behavior.

Fixes #30550. Targets `develop`; rebased and installed with Bun 1.3.14 and Node 24.15.0.

Review found that the stricter parser also rejected legitimate nullable optional fields. Four regressions failed on the original implementation and pass with the compatibility repair. Both malformed JSON and invalid response shapes reach the accounts route's explicit failure response.

Validation for `37aa4722c4ec7a71007715ce5fd9e12176d4417f`:

- Usage parser/account-pool focused tests: 81 passed. Accounts-route focused tests: 18 passed.
- Full app-core suite: 4,477 passed, 25 skipped; script suites: 74 Node and 21 Bun tests passed.
- Full agent runner completed all 757 files. Six files initially failed because workspace build artifacts or the test-only optimized-prompt integrity key were absent. After supplying those prerequisites, all six complete files passed: inbox mute, CORS preflight, Android plugins, deferred watchdog, provider vault boot, and wallet cache lifecycle. These files are unchanged from the base; no assertions or timeouts were weakened.
- Final app-core and agent typecheck/lint passed, with no lint rewrites.
- Root `bun run verify`: all 376 workspace tasks and repository audits passed.

Evidence is deterministic parser, service, and route coverage. No live Anthropic credential was used, and no end-to-end provider availability claim is made. Screenshots, video, and model trajectories are N/A: this changes account-usage validation and its error translation, not a rendered view, model request, or prompt.
