### PR TITLE
fix(ci): align deployment branches and production secret bindings

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -365,13 +365,20 @@ pair only when it matches the protected `staging` GitHub Environment secret
 `TELEGRAM_IDENTITY_AUTHORITY_SHA256`, and requires both components to differ
 from production. The receipt is the lowercase SHA-256 of the framed bytes
 `elizaOS/eliza\0staging\0telegram-public-identity\0v1\0<ID>\0<lowercase-username>\n`.
+`staging-approval` is the policy-only admission checkpoint for `develop`, not a
+third runtime or a Git branch. The `staging` Environment owns staging runtime
+configuration; `production` deploys certified `main` trees. Deployment branch
+policies must allow `develop` for staging approval and `main` for production.
+
 The protected staging entry job reads the receipt directly and verifies that the
 existing Worker has both Telegram binding names before any release mutation. It
 emits only a safe staging preserve-authority result; the reusable release
-receives that result and the already-admitted public pair, never the receipt,
-bot token, or webhook secret. This keeps a repository or organization secret
-from substituting for Environment authority or crossing the reusable-workflow
-boundary. The `deploy-api` job preserves a staging binding whose GitHub source
+receives that result and the already-admitted public pair, never the receipt.
+The caller maps both Telegram credential names to literal empty strings. This
+enables GitHub to resolve the selected Environment's secrets inside the reusable
+job while keeping repository and organization values out of that boundary.
+Omitting a name prevents its Environment secret from reaching the called job.
+The `deploy-api` job preserves a staging binding whose GitHub source
 is blank, then verifies its name again after the atomic Worker deploy. For
 production, the already-approved `production` authorization job verifies the
 live bot token against the canonical public identity and the deploy hard-fails

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1027,11 +1027,10 @@ jobs:
       cancel-in-progress: false
       queue: max
     uses: ./.github/workflows/cloud-cf-release.yml
-    # Explicitly forward every caller-scope secret consumed by the reusable
-    # release except Telegram authority and runtime credentials. The entry
-    # workflow validates the protected receipt and passes only public identity
-    # plus a safe runtime-authority result; `inherit` could admit a repository
-    # or organization secret with the same name.
+    # Telegram credentials have empty caller bindings so GitHub exposes their
+    # names to the reusable job's selected Environment without forwarding a
+    # repository or organization value. Omitting the names makes even existing
+    # Environment secrets resolve blank. The authority receipt stays here.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CARTESIA_API_KEY: ${{ secrets.CARTESIA_API_KEY }}
@@ -1050,6 +1049,8 @@ jobs:
       ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
       ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
       ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: ""
+      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ""
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
       ELIZA_MOBILE_APP_AUTH_APP_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_APP_ID }}
       ELIZA_SERVICE_JWT_SECRET: ${{ secrets.ELIZA_SERVICE_JWT_SECRET }}

--- a/.github/workflows/production-railway-database-authority-audit.yml
+++ b/.github/workflows/production-railway-database-authority-audit.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      - name: Require canonical develop source
+      - name: Require canonical main source
         env:
           SOURCE_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [ "$SOURCE_REF" != "refs/heads/develop" ]; then
-            echo "::error::Production database authority audits must run from refs/heads/develop"
+          if [ "$SOURCE_REF" != "refs/heads/main" ]; then
+            echo "::error::Production database authority audits must run from refs/heads/main"
             exit 1
           fi
 
@@ -155,7 +155,7 @@ jobs:
           if ! GITHUB_TOKEN='${{ github.token }}' \
             node packages/cloud/scripts/canonical-deploy-source-guard.mjs \
             --run-sha "$GITHUB_SHA" \
-            --canonical-ref refs/heads/develop \
+            --canonical-ref refs/heads/main \
             > "$evidence_dir/freshness.stdout" \
             2> "$evidence_dir/freshness.stderr"; then
             echo "::error::Production database audit source is no longer canonical"

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -510,14 +510,14 @@ describe("homepage deployment workflow", () => {
     expect(callerSecrets).not.toBe("inherit");
     expect(callerSecrets).toBeTypeOf("object");
     const callerSecretMap = callerSecrets as Record<string, string>;
-    expect(Object.keys(callerSecretMap).sort()).toEqual(expectedCallerSecrets);
+    expect(Object.keys(callerSecretMap).sort()).toEqual(
+      [...expectedCallerSecrets, ...reusableEnvironmentSecrets].sort(),
+    );
     expect(
       Object.keys(
         parsedReleaseWorkflow.on?.workflow_call?.secrets ?? {},
       ).sort(),
-    ).toEqual(
-      [...expectedCallerSecrets, ...reusableEnvironmentSecrets].sort(),
-    );
+    ).toEqual([...expectedCallerSecrets, ...reusableEnvironmentSecrets].sort());
     for (const name of expectedCallerSecrets) {
       expect(callerSecretMap[name], name).toBe(
         githubExpression(`secrets.${name}`),
@@ -527,13 +527,16 @@ describe("homepage deployment workflow", () => {
         name,
       ).toEqual({ required: false });
     }
-    for (const name of environmentOnlySecrets) {
-      expect(callerSecretMap).not.toHaveProperty(name);
-    }
+    expect(callerSecretMap).not.toHaveProperty(
+      "TELEGRAM_IDENTITY_AUTHORITY_SHA256",
+    );
     expect(parsedReleaseWorkflow.on?.workflow_call?.secrets).not.toHaveProperty(
       "TELEGRAM_IDENTITY_AUTHORITY_SHA256",
     );
     for (const name of reusableEnvironmentSecrets) {
+      // GitHub requires the caller binding to expose the selected Environment
+      // secret in the called job. An empty literal cannot forward repo values.
+      expect(callerSecretMap[name], name).toBe("");
       expect(
         parsedReleaseWorkflow.on?.workflow_call?.secrets?.[name],
         name,

--- a/packages/scripts/__tests__/production-railway-database-authority-audit-workflow.test.ts
+++ b/packages/scripts/__tests__/production-railway-database-authority-audit-workflow.test.ts
@@ -1,5 +1,6 @@
 /** Guards the protected, read-only production Railway database authority audit. */
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 const workflowSource = readFileSync(
@@ -38,11 +39,8 @@ function step(name: string): WorkflowStep {
 }
 
 describe("production Railway database authority audit workflow", () => {
-  test("uses only the protected production environment and canonical develop source", () => {
+  test("uses only the protected production environment and canonical main source", () => {
     expect(job?.environment).toBe("production");
-    expect(step("Require canonical develop source").run).toContain(
-      '"refs/heads/develop"',
-    );
     const config = step("Validate protected audit configuration");
     expect(config.env?.HAS_DATABASE_URL).toContain("secrets.DATABASE_URL");
     expect(config.env?.HAS_RAILWAY_TOKEN).toContain("secrets.RAILWAY_TOKEN");
@@ -56,6 +54,25 @@ describe("production Railway database authority audit workflow", () => {
     expect(config.run).not.toContain(
       "RAILWAY_ENVIRONMENT_ID \\\n            RAILWAY_POSTGRES_SERVICE_ID; do",
     );
+  });
+
+  test.each([
+    ["refs/heads/main", 0],
+    ["refs/heads/develop", 1],
+    ["refs/heads/fix/deployment", 1],
+    ["refs/tags/main", 1],
+    ["", 1],
+  ])("admits production audit source %s with exit %i", (sourceRef, status) => {
+    const guard = step("Require canonical main source").run;
+    if (!guard) throw new Error("Missing production source guard");
+    const result = spawnSync("bash", ["-c", guard], {
+      env: { PATH: process.env.PATH, SOURCE_REF: sourceRef },
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(status);
+    if (status !== 0) {
+      expect(result.stdout).toContain("must run from refs/heads/main");
+    }
   });
 
   test("discovers one private Postgres target and never publishes its identity", () => {
@@ -92,7 +109,7 @@ describe("production Railway database authority audit workflow", () => {
     expect(audit.run).toContain(
       ["GITHUB_TOKEN='$", "{{ github.token }}'"].join(""),
     );
-    expect(audit.run).toContain("--canonical-ref refs/heads/develop");
+    expect(audit.run).toContain("--canonical-ref refs/heads/main");
     expect(audit.run).toContain("env -u GITHUB_STEP_SUMMARY");
     expect(audit.run?.indexOf("audit-production-railway")).toBeLessThan(
       audit.run?.indexOf("canonical-deploy-source-guard.mjs") ?? -1,


### PR DESCRIPTION
Production Cloud CF run [33711875349](https://github.com/elizaOS/eliza/actions/runs/33711875349) validated the production Telegram credentials in its authorization job, then failed because the reusable API deploy saw those same Environment-owned credentials as blank. The caller omitted both names from its explicit reusable-secret map.

Bind the two names to literal empty caller values so the selected Environment can supply them inside the called job. Repository and organization credentials cannot substitute through these entries; receipt authority, live identity attestation, missing-value rejection, and atomic Worker deployment remain enforced. Align both production database audit source checks with main, exercising the actual shell admission for main, develop, feature refs, tags, and empty input. Update the existing workflow boundary regression and document `develop` → staging admission/staging and certified `main` → production.

Validation at `98475f193b285d035d8ae1b78101c557c94a3ee1` on `develop` base `d04078cd890ea25dff7297434c7c447cdc399d38`:
- Pinned Bun 1.3.14 and Node 24.15.0; `bun install` passed.
- `bun run verify`: 376/376 tasks passed, exit 0.
- Deployment workflow, environment, secret, admission, and certification tests: 113 passed, 0 failed.
- Actionlint 1.7.12, Biome, Markdown link validation, and `git diff --check` passed.
- Live GitHub policy readback: `staging-approval` accepts branch `develop`; `production` accepts branch `main`. No runtime secret values or reviewer settings were changed.
- Hosted staging and production release/readback remain required after merge and will be recorded in the issue.

UI screenshots/video and model trajectories: N/A for this workflow-only change. Hosted release receipts, deployment logs, and API/Pages provenance are the applicable acceptance evidence.

Refs #30552.
