### PR TITLE
fix(ci): avoid desktop model downloads in Cloud jobs

### DIFF
--- a/.github/actions/cloud-setup-test-env/action.yml
+++ b/.github/actions/cloud-setup-test-env/action.yml
@@ -94,6 +94,10 @@ runs:
     - name: Install dependencies
       shell: bash
       working-directory: packages/cloud/shared
+      env:
+        # Cloud tests use remote or fixture inference; desktop model setup is
+        # covered by the desktop/device lanes and must not gate this install.
+        ELIZA_SKIP_FUSED_INFERENCE_SETUP: "1"
       run: |
         for attempt in 1 2 3; do
           if [ "$attempt" -eq 3 ]; then

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -3301,6 +3301,10 @@ jobs:
 
       - name: Setup workspace dependencies
         uses: ./.github/actions/setup-bun-workspace
+        env:
+          # This browser proves deployed Cloud inference, so installing a
+          # local desktop model adds an unrelated network dependency.
+          ELIZA_SKIP_FUSED_INFERENCE_SETUP: "1"
         with:
           bun-version: "1.3.14"
           install-command: bun install --frozen-lockfile


### PR DESCRIPTION
Cloud unit setup in Develop Full run 33926260898 failed before tests started because root postinstall downloaded the desktop embedding model and received HTTP 429 on every attempt. Cloud tests and the deployed staging renderer use fixture or remote inference, so that download is unrelated to their acceptance path.

Pass the existing explicit fused-inference setup opt-out during Cloud test dependency installation and deployed-renderer workspace setup. Dependency installation, linked workspace builds, browser tests, deployment authority, and desktop/device installer coverage retain their existing gates.

Validation: pinned Bun 1.3.14 and Node 24.15.0; `bun install` and `bun run verify` passed; installer behavior tests 8/8 and Cloud workflow tests 11/11 passed; Actionlint and `git diff --check` passed. Hosted Cloud setup and release verification remain required after merge.

UI screenshots and model trajectories: N/A for this CI setup change. Hosted setup logs are the applicable evidence.

Refs #30552 and #30440.
