### PR TITLE
fix(ci): serialize prompt artifact consumer tests

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -56,6 +56,10 @@ The generated publish manifest rewrites every source-facing condition to
 compiled JavaScript and declarations in `dist/`, so the release tarball never
 publishes TypeScript source as runtime code.
 
+The repository runs this package's tests serially because they rebuild and
+temporarily remove `dist/` while checking consumer resolution. Concurrent
+workspace tests may still be importing that compiled package.
+
 ## Usage
 
 Runtime code imports the templates through `@elizaos/core`, which re-exports them and provides `composePrompt` to fill the `{{...}}` placeholders:

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -70,6 +70,7 @@
         "order": 2,
         "script": "build:package"
       },
+      "testSerial": true,
       "testLanes": [
         "server"
       ]


### PR DESCRIPTION
Develop Full run 33920498044 started the prompts package test at 21:45:45 while agent tests were still importing it. The package consumer tests remove the real workspace `dist/` directory to validate clean resolution, and the agent suites beginning during that interval failed to resolve `@elizaos/prompts`.

Mark the prompts test task serial through its existing `elizaos.scripts.testSerial` metadata and document the shared artifact constraint. The runner completes the concurrent pool before starting serialized tasks, so the package's complete build, clean-resolution, and published-consumer tests remain enabled without deleting artifacts beneath another suite.

Validation:
- Prompts package tests 25/25, typecheck, and lint passed.
- Previously affected agent consumer suites: 23/23 passed across three files.
- Task-pool tests 32/32 passed. The live server plan classifies the prompts task as serial with zero parallel tasks.
- Pinned Bun 1.3.14 and Node 24.15.0; `bun install`, root `bun run verify`, and `git diff --check` passed.
- Hosted server validation is required after merge.

UI captures and live-model trajectories: N/A. This changes test scheduling only; authored prompts and runtime code are unchanged.

Refs #30552 and #30440.
