### PR TITLE
fix(auth): validate Anthropic OAuth token responses

### DIFF
--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.test.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.test.ts
@@ -59,6 +59,17 @@ describe("refreshAnthropicToken", () => {
     expect(creds.access).toBe("at-new");
   });
 
+  it("keeps the current refresh token when refresh_token is null", async () => {
+    mockTokenResponse({
+      access_token: "at-new",
+      refresh_token: null,
+      expires_in: 3600,
+    });
+    const creds = await refreshAnthropicToken("rt-old");
+    expect(creds.refresh).toBe("rt-old");
+    expect(creds.access).toBe("at-new");
+  });
+
   it("throws when the response lacks an access token instead of persisting a broken blob", async () => {
     mockTokenResponse({ refresh_token: "rt-new", expires_in: 3600 });
     await expect(refreshAnthropicToken("rt-old")).rejects.toThrow(

--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.test.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.test.ts
@@ -1,5 +1,6 @@
-/** Verifies Anthropic OAuth exchange, refresh rotation, and callback state validation at the HTTP boundary. */
+/** Verifies Anthropic OAuth exchange, token-response validation, refresh rotation, and callback state validation at the HTTP boundary. */
 
+import { ElizaError } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   exchangeAnthropicAuthorizationCode,
@@ -10,12 +11,28 @@ import {
 function mockTokenResponse(body: unknown, ok = true): void {
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => ({
-      ok,
-      json: async () => body,
-      text: async () => JSON.stringify(body),
-    })),
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: ok ? 200 : 400,
+          headers: { "content-type": "application/json" },
+        }),
+    ),
   );
+}
+
+async function expectTokenError(
+  operation: Promise<unknown>,
+  code: string,
+): Promise<void> {
+  try {
+    await operation;
+    throw new Error("Expected Anthropic token operation to reject");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ElizaError);
+    if (!(error instanceof ElizaError)) throw error;
+    expect(error.code).toBe(code);
+  }
 }
 
 describe("refreshAnthropicToken", () => {
@@ -46,6 +63,61 @@ describe("refreshAnthropicToken", () => {
     mockTokenResponse({ refresh_token: "rt-new", expires_in: 3600 });
     await expect(refreshAnthropicToken("rt-old")).rejects.toThrow(
       /missing access_token/,
+    );
+  });
+
+  it.each([
+    ["non-object root", null],
+    ["numeric access token", { access_token: 7, expires_in: 3600 }],
+    ["blank access token", { access_token: "   ", expires_in: 3600 }],
+    [
+      "invalid rotated refresh token",
+      { access_token: "at-new", refresh_token: 7, expires_in: 3600 },
+    ],
+    ["zero lifetime", { access_token: "at-new", expires_in: 0 }],
+    ["negative lifetime", { access_token: "at-new", expires_in: -1 }],
+    ["null lifetime", { access_token: "at-new", expires_in: null }],
+    ["overflowing lifetime", { access_token: "at-new", expires_in: 1e308 }],
+    ["string lifetime", { access_token: "at-new", expires_in: "3600" }],
+  ])("rejects a successful response with %s", async (_name, body) => {
+    mockTokenResponse(body);
+    await expectTokenError(
+      refreshAnthropicToken("rt-old"),
+      "anthropic_oauth.token_invalid_shape",
+    );
+  });
+
+  it("wraps malformed successful JSON as a typed token response error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("{not-json", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    await expectTokenError(
+      refreshAnthropicToken("rt-old"),
+      "anthropic_oauth.token_invalid_json",
+    );
+  });
+
+  it("rejects a JSON lifetime that parses beyond the finite number range", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response('{"access_token":"at-new","expires_in":1e400}', {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+    await expectTokenError(
+      refreshAnthropicToken("rt-old"),
+      "anthropic_oauth.token_invalid_shape",
     );
   });
 
@@ -137,5 +209,56 @@ describe("Anthropic authorization exchange", () => {
     expect(creds.expires).toBe(now + 3600 * 1000);
     expect(creds.expires).not.toBe(now + 3600 * 1000 - 5 * 60 * 1000);
     vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["non-object root", []],
+    ["missing access token", { refresh_token: "rt-ex", expires_in: 3600 }],
+    [
+      "missing refresh token",
+      { access_token: "at-ex", expires_in: 3600 },
+    ],
+    [
+      "numeric access token",
+      { access_token: 7, refresh_token: "rt-ex", expires_in: 3600 },
+    ],
+    [
+      "blank refresh token",
+      { access_token: "at-ex", refresh_token: " ", expires_in: 3600 },
+    ],
+    [
+      "non-positive lifetime",
+      { access_token: "at-ex", refresh_token: "rt-ex", expires_in: -1 },
+    ],
+    [
+      "string lifetime",
+      { access_token: "at-ex", refresh_token: "rt-ex", expires_in: "3600" },
+    ],
+    [
+      "overflowing lifetime",
+      { access_token: "at-ex", refresh_token: "rt-ex", expires_in: 1e308 },
+    ],
+  ])("rejects a successful response with %s", async (_name, body) => {
+    mockTokenResponse(body);
+    await expectTokenError(
+      exchangeAnthropicAuthorizationCode("code#state-value"),
+      "anthropic_oauth.token_invalid_shape",
+    );
+  });
+
+  it("wraps malformed successful JSON with its parse cause", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{not-json", { status: 200 })),
+    );
+    try {
+      await exchangeAnthropicAuthorizationCode("code#state-value");
+      throw new Error("Expected token exchange to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      if (!(error instanceof ElizaError)) throw error;
+      expect(error.code).toBe("anthropic_oauth.token_invalid_json");
+      expect(error.cause).toBeInstanceOf(SyntaxError);
+    }
   });
 });

--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
@@ -142,6 +142,7 @@ async function parseAnthropicTokenResponse(
   if (
     mode === "refresh" &&
     refreshToken !== undefined &&
+    refreshToken !== null &&
     !isNonBlankString(refreshToken)
   ) {
     throw invalidTokenResponse(
@@ -298,8 +299,8 @@ export async function refreshAnthropicToken(
   const data = await parseAnthropicTokenResponse(response, "refresh");
   return {
     // Anthropic rotates refresh tokens (one-time-use). Per RFC 6749 §6 a
-    // response that omits refresh_token means "keep the current one" — never
-    // persist undefined over a still-valid stored refresh token.
+    // response that omits refresh_token means "keep the current one". Treat a
+    // null optional value equivalently and never replace a valid stored token.
     refresh: data.refreshToken ?? refreshToken,
     access: data.accessToken,
     expires: data.expiresAt,

--- a/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
+++ b/packages/auth/src/vendor/pi-oauth/anthropic-login.ts
@@ -8,6 +8,7 @@
  * the UI / CLI calls once the user has copied the code.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { generatePKCE } from "./pkce.ts";
 
 const decode = (s: string): string => atob(s);
@@ -38,6 +39,121 @@ export interface AnthropicOAuthFlowHandle {
   /** Resolves with credentials once `submitCode` lands and the token exchange succeeds. */
   completion: Promise<AnthropicOAuthCredentials>;
   cancel: (reason?: string) => void;
+}
+
+type AnthropicTokenResponseMode = "exchange" | "refresh";
+
+interface ParsedAnthropicRefreshResponse {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+}
+
+interface ParsedAnthropicExchangeResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function invalidTokenResponse(
+  mode: AnthropicTokenResponseMode,
+  reason: string,
+): ElizaError {
+  return new ElizaError(
+    `Anthropic OAuth token response was invalid: ${reason}`,
+    {
+      code: "anthropic_oauth.token_invalid_shape",
+      severity: "fatal",
+      context: { mode, reason },
+    },
+  );
+}
+
+function parseAnthropicTokenResponse(
+  response: Response,
+  mode: "exchange",
+): Promise<ParsedAnthropicExchangeResponse>;
+function parseAnthropicTokenResponse(
+  response: Response,
+  mode: "refresh",
+): Promise<ParsedAnthropicRefreshResponse>;
+async function parseAnthropicTokenResponse(
+  response: Response,
+  mode: AnthropicTokenResponseMode,
+): Promise<ParsedAnthropicRefreshResponse> {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    // error-policy:J2 context-adding rethrow — malformed provider JSON cannot
+    // become a partial credential record.
+    throw new ElizaError("Anthropic OAuth token response was not JSON", {
+      code: "anthropic_oauth.token_invalid_json",
+      severity: "fatal",
+      context: { mode },
+      cause,
+    });
+  }
+
+  if (!isRecord(payload)) {
+    throw invalidTokenResponse(mode, "response root must be an object");
+  }
+
+  const accessToken = payload.access_token;
+  const refreshToken = payload.refresh_token;
+  const expiresIn = payload.expires_in;
+  if (!isNonBlankString(accessToken)) {
+    throw invalidTokenResponse(
+      mode,
+      "missing access_token or invalid access_token; expected a non-blank string",
+    );
+  }
+  if (
+    typeof expiresIn !== "number" ||
+    !Number.isFinite(expiresIn) ||
+    expiresIn <= 0
+  ) {
+    throw invalidTokenResponse(
+      mode,
+      "missing or invalid expires_in; expected a positive finite number",
+    );
+  }
+  const expiresAt = Date.now() + expiresIn * 1000;
+  if (!Number.isFinite(expiresAt)) {
+    throw invalidTokenResponse(
+      mode,
+      "invalid expires_in; absolute expiry exceeds the supported numeric range",
+    );
+  }
+  if (mode === "exchange" && !isNonBlankString(refreshToken)) {
+    throw invalidTokenResponse(
+      mode,
+      "missing or invalid refresh_token; expected a non-blank string",
+    );
+  }
+  if (
+    mode === "refresh" &&
+    refreshToken !== undefined &&
+    !isNonBlankString(refreshToken)
+  ) {
+    throw invalidTokenResponse(
+      mode,
+      "invalid refresh_token; expected a non-blank string when present",
+    );
+  }
+
+  if (isNonBlankString(refreshToken)) {
+    return { accessToken, refreshToken, expiresAt };
+  }
+  return { accessToken, expiresAt };
 }
 
 function parseAnthropicAuthorizationInput(authCode: string): {
@@ -86,15 +202,14 @@ export async function exchangeAnthropicAuthorizationCode(
     const errText = await tokenResponse.text();
     throw new Error(`Token exchange failed: ${errText}`);
   }
-  const tokenData = (await tokenResponse.json()) as {
-    refresh_token: string;
-    access_token: string;
-    expires_in: number;
-  };
+  const tokenData = await parseAnthropicTokenResponse(
+    tokenResponse,
+    "exchange",
+  );
   return {
-    refresh: tokenData.refresh_token,
-    access: tokenData.access_token,
-    expires: Date.now() + tokenData.expires_in * 1000,
+    refresh: tokenData.refreshToken,
+    access: tokenData.accessToken,
+    expires: tokenData.expiresAt,
   };
 }
 
@@ -180,22 +295,13 @@ export async function refreshAnthropicToken(
     const errText = await response.text();
     throw new Error(`Anthropic token refresh failed: ${errText}`);
   }
-  const data = (await response.json()) as {
-    refresh_token?: string;
-    access_token?: string;
-    expires_in?: number;
-  };
-  if (!data.access_token || typeof data.expires_in !== "number") {
-    throw new Error(
-      "Anthropic token refresh failed: response missing access_token/expires_in",
-    );
-  }
+  const data = await parseAnthropicTokenResponse(response, "refresh");
   return {
     // Anthropic rotates refresh tokens (one-time-use). Per RFC 6749 §6 a
     // response that omits refresh_token means "keep the current one" — never
     // persist undefined over a still-valid stored refresh token.
-    refresh: data.refresh_token ?? refreshToken,
-    access: data.access_token,
-    expires: Date.now() + data.expires_in * 1000,
+    refresh: data.refreshToken ?? refreshToken,
+    access: data.accessToken,
+    expires: data.expiresAt,
   };
 }


### PR DESCRIPTION
Closes #30563.

Validate successful Anthropic OAuth responses before credentials can be persisted. Invalid responses produce typed errors while valid exchange and refresh behavior, including null/omitted refresh-token rotation, is preserved.

Reviewed both token exchange and refresh, their callers and persistence boundary, all added tests, and the earlier null-rotation finding. The refresh response keeps the existing token when rotation is omitted or null; exchange still requires a refresh token. Malformed tokens, non-positive lifetimes, numeric overflow, and invalid JSON reject before constructing credentials.

On `3640209cf0a42539c9999046ac82f49ad5b1b6ec`, rebased onto `10adfdb85226639480c544f6522954f0d44eb1f7`, Bun 1.3.14 / Node 24.15.0:
- `bun install`: passed.
- Full auth suite: 19 files, 234 tests passed.
- Auth typecheck, lint and format checks: passed.
- Root `bun run verify`: all 376 workspace tasks and repository audits passed.

Real Response bodies cover provider parsing; no live credential exchange was needed or claimed. UI/native captures and model trajectories are N/A for this parsing-only change. No further implementation changes were needed. Hosted checks must pass at this head before merge.

<!-- evidence-head:3640209cf0a42539c9999046ac82f49ad5b1b6ec -->
