### PR TITLE
fix(cloud): await Dedicated jobs and trim cold paths

### DIFF
--- a/packages/app/test/cloud-live-continuity-contract.test.ts
+++ b/packages/app/test/cloud-live-continuity-contract.test.ts
@@ -238,6 +238,8 @@ describe("forbidden Cloud agent mutations", () => {
       completedDedicatedQuoteResponseBodyCount: 0,
       parsedDedicatedQuoteResponseBodyCount: 0,
       decodedDedicatedQuoteResponseCount: 0,
+      dedicatedCutoverResponseStatus: null,
+      dedicatedCutoverResponseCode: null,
       uninspectableDedicatedQuoteResponseBodyCount: 0,
       dedicatedActivationPostRequestCount: 0,
       successfulDedicatedActivationPostResponseCount: 0,
@@ -436,6 +438,8 @@ describe("forbidden Cloud agent mutations", () => {
       uninspectableDedicatedActivationResponseBodyCount: 0,
       dedicatedActivationResponseStatus: 202,
       dedicatedActivationResponseCode: null,
+      dedicatedCutoverResponseStatus: 200,
+      dedicatedCutoverResponseCode: null,
       dedicatedCutoverPostRequestCount: 2,
       successfulDedicatedCutoverPostResponseCount: 1,
       clientErrorDedicatedCutoverPostResponseCount: 1,
@@ -493,6 +497,28 @@ describe("forbidden Cloud agent mutations", () => {
       "dedicated_quote_changed",
     );
     expect(JSON.stringify(snapshot)).not.toMatch(/private user detail|quoteId/);
+  });
+
+  it("retains only the latest bounded Dedicated cutover status and error code", async () => {
+    const audit = createCloudLiveNetworkAudit();
+    const cutover =
+      "https://api.test/api/v1/eliza/agents/private-target/upgrade-tier/cutover";
+    audit.observeRequest("POST", cutover);
+    audit.observeResponse(
+      "POST",
+      cutover,
+      409,
+      boundedJsonBody({
+        success: false,
+        code: "dedicated_not_healthy",
+        error: "private operator detail",
+      }).responseBody,
+    );
+
+    const snapshot = await audit.snapshot();
+    expect(snapshot.dedicatedCutoverResponseStatus).toBe(409);
+    expect(snapshot.dedicatedCutoverResponseCode).toBe("dedicated_not_healthy");
+    expect(JSON.stringify(snapshot)).not.toMatch(/private operator detail/);
   });
 
   it("fails closed when an approved quote is followed by another agent target", async () => {

--- a/packages/app/test/cloud-live-continuity-contract.ts
+++ b/packages/app/test/cloud-live-continuity-contract.ts
@@ -97,6 +97,8 @@ export interface CloudLiveNetworkAuditSnapshot {
   uninspectableDedicatedActivationResponseBodyCount: number;
   dedicatedActivationResponseStatus: number | null;
   dedicatedActivationResponseCode: string | null;
+  dedicatedCutoverResponseStatus: number | null;
+  dedicatedCutoverResponseCode: string | null;
   dedicatedCutoverPostRequestCount: number;
   successfulDedicatedCutoverPostResponseCount: number;
   clientErrorDedicatedCutoverPostResponseCount: number;
@@ -1437,10 +1439,12 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
         const counters = dedicatedControlPlane[dedicatedRequest];
         const sourceAgentId = dedicatedRequestSourceAgentId(rawUrl);
         const lifecycleRequest =
-          dedicatedRequest === "activation" && sourceAgentId
+          (dedicatedRequest === "activation" ||
+            dedicatedRequest === "cutover") &&
+          sourceAgentId
             ? dedicatedLifecycleRequests.find(
                 (request) =>
-                  request.phase === "activation" &&
+                  request.phase === dedicatedRequest &&
                   request.sourceAgentId === sourceAgentId &&
                   request.responseStatus === null,
               )
@@ -1584,6 +1588,13 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
           (request) =>
             request.phase === "activation" && request.responseStatus !== null,
         );
+      const latestDedicatedCutoverResponse = dedicatedLifecycleRequests
+        .slice()
+        .reverse()
+        .find(
+          (request) =>
+            request.phase === "cutover" && request.responseStatus !== null,
+        );
       const approvedTargetId =
         dedicatedApprovalBinding?.dedicatedAgentId ??
         (dedicatedApprovalBinding?.confirmationKind === "activation"
@@ -1714,6 +1725,10 @@ export function createCloudLiveNetworkAudit(): CloudLiveNetworkAudit {
           latestDedicatedActivationResponse?.responseStatus ?? null,
         dedicatedActivationResponseCode:
           latestDedicatedActivationResponse?.responseCode ?? null,
+        dedicatedCutoverResponseStatus:
+          latestDedicatedCutoverResponse?.responseStatus ?? null,
+        dedicatedCutoverResponseCode:
+          latestDedicatedCutoverResponse?.responseCode ?? null,
         dedicatedCutoverPostRequestCount: dedicatedControlPlane.cutover.request,
         successfulDedicatedCutoverPostResponseCount:
           dedicatedControlPlane.cutover.success,

--- a/packages/cloud/api/__tests__/eliza-agents-adopt-existing-dedicated.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-adopt-existing-dedicated.test.ts
@@ -265,16 +265,21 @@ function quote(agentId = PERSONAL_A) {
   );
 }
 
-function confirm(quoteId: string, agentId = PERSONAL_A) {
-  return app.request(
-    `/api/v1/eliza/agents/${encodeURIComponent(agentId)}/upgrade-tier/adopt-existing`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "adopt_existing_dedicated", quoteId }),
-    },
-    ENV,
-  );
+function confirm(
+  quoteId: string,
+  agentId = PERSONAL_A,
+  executionCtx?: unknown,
+) {
+  const path = `/api/v1/eliza/agents/${encodeURIComponent(agentId)}/upgrade-tier/adopt-existing`;
+  const init = {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "adopt_existing_dedicated", quoteId }),
+  };
+  if (executionCtx) {
+    return app.request(path, init, ENV, executionCtx as never);
+  }
+  return app.request(path, init, ENV);
 }
 
 function patchProfile(agentConfig: Record<string, unknown>) {
@@ -780,12 +785,18 @@ describe("GET/POST adopt-existing Dedicated", () => {
     ).mockResolvedValue();
     commitAckLossCountdown = 1;
     try {
-      const response = await confirm(quoteId);
+      const registered: Promise<unknown>[] = [];
+      const response = await confirm(quoteId, PERSONAL_A, {
+        waitUntil: (promise: Promise<unknown>) => registered.push(promise),
+        passThroughOnException: () => undefined,
+      });
       expect(response.status).toBe(202);
       expect(await response.json()).toMatchObject({
         success: true,
         data: { dedicatedAgentId: TARGET_A },
       });
+      expect(registered).toHaveLength(1);
+      await Promise.all(registered);
       expect(trigger).toHaveBeenCalledTimes(1);
       const [target] = await rows();
       expect(

--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -10,7 +10,15 @@
  * `requireAuthOrApiKeyWithOrg` (same pattern as eliza-agents-restore-body-guard).
  */
 
-import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 
 process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
@@ -366,7 +374,10 @@ function cutover(agentId: string, dedicatedAgentId: string) {
   );
 }
 
-async function upgrade(agentId: string) {
+async function upgrade(
+  agentId: string,
+  executionCtx?: Parameters<Hono<AppEnv>["request"]>[3],
+) {
   const quoted = await quote(agentId);
   const body = (await quoted
     .clone()
@@ -385,7 +396,40 @@ async function upgrade(agentId: string) {
       }),
     },
     ENV,
+    executionCtx,
   );
+}
+
+async function upgradeWithRetainedNudge(agentId: string, failure?: Error) {
+  const { provisioningJobService } = await import(
+    "@/lib/services/provisioning-jobs"
+  );
+  const pending = Promise.withResolvers<void>();
+  const trigger = spyOn(
+    provisioningJobService,
+    "triggerImmediate",
+  ).mockReturnValue(pending.promise);
+  const retained: Promise<unknown>[] = [];
+  const executionCtx = {
+    waitUntil: (promise: Promise<unknown>) => retained.push(promise),
+    passThroughOnException: () => undefined,
+    props: {},
+  };
+  try {
+    const response = await upgrade(agentId, executionCtx);
+    expect(response.status).toBe(202);
+    expect(trigger).toHaveBeenCalledTimes(1);
+    expect(retained).toHaveLength(1);
+    // The response is available while dispatch is unresolved. The Worker owns
+    // its completion, including failures after the durable job was committed.
+    if (failure) pending.reject(failure);
+    else pending.resolve();
+    await Promise.all(retained);
+    return response;
+  } finally {
+    pending.resolve();
+    trigger.mockRestore();
+  }
 }
 
 describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
@@ -825,7 +869,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
     expect(pgliteReady).toBe(true);
     await setOrgBalance(ORG_A, "10");
 
-    const res = await upgrade(SHARED_A);
+    const res = await upgradeWithRetainedNudge(SHARED_A);
     expect(res.status).toBe(202);
     const body = (await res.json()) as {
       success: boolean;
@@ -940,6 +984,41 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       .where(eq(jobs.agent_id, target.id));
     expect(jobRows.length).toBe(1);
     expect(body.data.jobId).toBe(jobRows[0]?.id ?? "");
+  });
+
+  test("retains a failed reactivation nudge without losing the new durable job", async () => {
+    const { dbWrite } = await import("@/db/client");
+    const { agentSandboxesRepository } = await import(
+      "@/db/repositories/agent-sandboxes"
+    );
+    const { jobs } = await import("@/db/schemas/jobs");
+    const target = (
+      await agentSandboxesRepository.listByOrganization(ORG_A)
+    ).find(
+      (agent) =>
+        (agent.agent_config as Record<string, unknown> | null)
+          ?.__agentUpgradedFrom === SHARED_A,
+    );
+    if (!target) throw new Error("The funded activation target is missing");
+    await agentSandboxesRepository.update(target.id, { status: "stopped" });
+    await dbWrite
+      .update(jobs)
+      .set({ status: "failed" })
+      .where(eq(jobs.agent_id, target.id));
+    const response = await upgradeWithRetainedNudge(
+      SHARED_A,
+      new Error("control plane unavailable"),
+    );
+    const body = (await response.json()) as {
+      data: { dedicatedAgentId: string; jobId: string };
+    };
+    expect(body.data.dedicatedAgentId).toBe(target.id);
+    const [job] = await dbWrite
+      .select()
+      .from(jobs)
+      .where(eq(jobs.id, body.data.jobId));
+    expect(job?.agent_id).toBe(target.id);
+    expect(job?.status).toBe("pending");
   });
 
   test("concurrent upgrades atomically converge on one target, one job, one credential set", async () => {
@@ -1487,7 +1566,11 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       markerObservedAtCommit = undefined;
       cutoverCoordinatorOperations.length = 0;
       const commitRefused = await cutover(PERSONAL_C, CUTOVER_TARGET);
-      expect(commitRefused.status).toBeGreaterThanOrEqual(500);
+      expect(commitRefused.status).toBe(503);
+      expect(await commitRefused.json()).toMatchObject({
+        success: false,
+        code: "shared_history_unavailable",
+      });
       const [afterCommitFailure] = await dbWrite
         .select()
         .from(agentSandboxes)

--- a/packages/cloud/api/src/discord-gateway-app.ts
+++ b/packages/cloud/api/src/discord-gateway-app.ts
@@ -1,5 +1,6 @@
 /**
- * Dependency-bounded Hono shell for authenticated managed Discord turns.
+ * Dependency-bounded Hono shell for gateway authentication and managed
+ * Discord turns.
  *
  * The Railway gateway already owns provider ingress and retries. This shell
  * preserves the Cloud request context, security headers, and internal JWT
@@ -22,7 +23,9 @@ import { runWithRequestContext } from "@/lib/runtime/request-context";
 import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import gatewayToken from "../internal/auth/token/route";
 import managedDiscordMessages from "../internal/discord/eliza-app/messages/route";
+import pendingDiscordGreetings from "../internal/discord/eliza-app/pending-greetings/route";
 
 export function createDiscordGatewayApp(): Hono<AppEnv> {
   const app = new Hono<AppEnv>({ strict: false });
@@ -78,7 +81,12 @@ export function createDiscordGatewayApp(): Hono<AppEnv> {
     ),
   );
 
+  app.route("/api/internal/auth/token", gatewayToken);
   app.route("/api/internal/discord/eliza-app/messages", managedDiscordMessages);
+  app.route(
+    "/api/internal/discord/eliza-app/pending-greetings",
+    pendingDiscordGreetings,
+  );
 
   app.notFound((c) =>
     c.json(

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -31,7 +31,7 @@ test("preserves Workerd WebSocket upgrade responses without rewrapping", () => {
   expect(
     decorateFullAppDispatchResponse(
       upgrade,
-      "11111111-1111-4111-8111-111111111111",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       12,
       8,
     ),
@@ -222,7 +222,7 @@ test("answers crypto payment confirmation preflight before shard loading", async
 });
 
 test("dispatches provider webhooks without full-app bootstrap", async () => {
-  const traceId = "11111111-1111-4111-8111-111111111111";
+  const traceId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
   const env = {
     ENVIRONMENT: "test",
     NODE_ENV: "test",
@@ -286,22 +286,36 @@ test("matches only supported provider webhook routes", () => {
   expect(isElizaAppWebhookPath("/api/eliza-app/webhook")).toBe(false);
 });
 
-test("matches only the managed Discord gateway route", () => {
+test("matches only dependency-bounded managed Discord gateway routes", () => {
+  expect(isInternalDiscordGatewayPath("/api/internal/auth/token")).toBe(true);
   expect(
     isInternalDiscordGatewayPath("/api/internal/discord/eliza-app/messages"),
+  ).toBe(true);
+  expect(
+    isInternalDiscordGatewayPath(
+      "/api/internal/discord/eliza-app/pending-greetings",
+    ),
   ).toBe(true);
   expect(
     isInternalDiscordGatewayPath("/api/internal/discord/eliza-app/messages/"),
   ).toBe(false);
   expect(
     isInternalDiscordGatewayPath(
+      "/api/internal/discord/eliza-app/pending-greetings/",
+    ),
+  ).toBe(false);
+  expect(
+    isInternalDiscordGatewayPath(
       "/api/internal/discord/eliza-app/messages/admin",
     ),
   ).toBe(false);
+  expect(isInternalDiscordGatewayPath("/api/internal/auth/token/refresh")).toBe(
+    false,
+  );
 });
 
 test("dispatches managed Discord turns without full-app bootstrap", async () => {
-  const traceId = "33333333-3333-4333-8333-333333333333";
+  const traceId = "cccccccccccccccccccccccccccccccc";
   const env = {
     ENVIRONMENT: "test",
     NODE_ENV: "test",
@@ -355,6 +369,90 @@ test("dispatches managed Discord turns without full-app bootstrap", async () => 
   );
   expect(warmResponse.headers.get("server-timing")).not.toContain(
     "discord_module_init",
+  );
+});
+
+test("dispatches proactive greeting claims without full-app bootstrap", async () => {
+  const traceId = "44444444444444444444444444444444";
+  const env = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    REDIS_RATE_LIMITING: "false",
+    CACHE_ENABLED: "false",
+    THIN_INFERENCE_ENTRY_ENABLED: "false",
+    BLOB: {},
+  } as unknown as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+
+  const response = await cloudApiWorker.fetch(
+    new Request(
+      "https://api.eliza.app/api/internal/discord/eliza-app/pending-greetings",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-eliza-trace-id": traceId,
+        },
+        body: JSON.stringify({ action: "claim" }),
+      },
+    ),
+    env,
+    executionCtx,
+  );
+
+  expect(response.status).toBe(401);
+  expect(response.headers.get("x-eliza-trace-id")).toBe(traceId);
+  expect(response.headers.get("x-eliza-discord-path")).toBe("thin");
+  expect(response.headers.get("server-timing")).toContain(
+    "discord_entry_dispatch",
+  );
+  expect(response.headers.get("server-timing")).not.toContain(
+    "full_app_dispatch",
+  );
+});
+
+test("dispatches gateway token exchange without full-app bootstrap", async () => {
+  const traceId = "55555555555555555555555555555555";
+  const env = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    REDIS_RATE_LIMITING: "false",
+    CACHE_ENABLED: "false",
+    THIN_INFERENCE_ENTRY_ENABLED: "false",
+    BLOB: {},
+  } as unknown as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+
+  const response = await cloudApiWorker.fetch(
+    new Request("https://api.eliza.app/api/internal/auth/token", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-eliza-trace-id": traceId,
+      },
+      body: JSON.stringify({
+        pod_name: "gateway-test",
+        service: "gateway-discord",
+      }),
+    }),
+    env,
+    executionCtx,
+  );
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get("x-eliza-trace-id")).toBe(traceId);
+  expect(response.headers.get("x-eliza-discord-path")).toBe("thin");
+  expect(response.headers.get("server-timing")).toContain(
+    "discord_entry_dispatch",
+  );
+  expect(response.headers.get("server-timing")).not.toContain(
+    "full_app_dispatch",
   );
 });
 
@@ -417,7 +515,7 @@ test("preserves provider authentication on the thin webhook path", async () => {
 });
 
 test("correlates and times dispatch outside full-app middleware", async () => {
-  const traceId = "22222222-2222-4222-8222-222222222222";
+  const traceId = "dddddddddddddddddddddddddddddddd";
   const env = {
     ENVIRONMENT: "test",
     NODE_ENV: "test",

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -478,11 +478,14 @@ async function dispatchWebhook(
   });
 }
 
-const INTERNAL_DISCORD_GATEWAY_PATH =
-  "/api/internal/discord/eliza-app/messages";
+const INTERNAL_DISCORD_GATEWAY_PATHS = new Set([
+  "/api/internal/auth/token",
+  "/api/internal/discord/eliza-app/messages",
+  "/api/internal/discord/eliza-app/pending-greetings",
+]);
 
 export function isInternalDiscordGatewayPath(pathname: string): boolean {
-  return pathname === INTERNAL_DISCORD_GATEWAY_PATH;
+  return INTERNAL_DISCORD_GATEWAY_PATHS.has(pathname);
 }
 
 async function getDiscordGatewayApp(): Promise<Hono<AppEnv>> {

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -511,8 +511,20 @@ async function __hono_POST(
     // for the next cron tick. Fire-and-forget; the cron is the safety net.
     if (created) {
       const triggerEnv = ctx?.env;
-      const triggerPromise =
-        provisioningJobService.triggerImmediate(triggerEnv);
+      const triggerPromise = provisioningJobService
+        .triggerImmediate(triggerEnv)
+        .catch((err) => {
+          // error-policy:J7 the durable job remains observable by the daemon;
+          // retain a failed best-effort nudge as an operational diagnostic.
+          logger.warn(
+            "[provision] provisioning triggerImmediate nudge failed",
+            {
+              agentId,
+              jobId: job.id,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          );
+        });
       let executionCtx: AppContext["executionCtx"] | undefined;
       try {
         executionCtx = ctx?.executionCtx;
@@ -526,15 +538,7 @@ async function __hono_POST(
         // the provisioning job is already persisted, so a failed immediate nudge only
         // defers execution to the next poll. Log it rather than swallow so a stuck
         // orchestrator surfaces.
-        // error-policy:J7 nudge failure only delays an already-enqueued job; logged, not fatal.
-        triggerPromise.catch((err) =>
-          logger.warn(
-            "[provision] provisioning triggerImmediate nudge failed",
-            {
-              error: err instanceof Error ? err.message : String(err),
-            },
-          ),
-        );
+        void triggerPromise;
       }
     }
 

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/adopt-existing/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/adopt-existing/route.ts
@@ -272,6 +272,7 @@ async function __hono_POST(
   request: Request,
   env: AppEnv["Bindings"],
   { params }: { params: Promise<{ agentId: string }> },
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void },
 ) {
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
@@ -402,9 +403,35 @@ async function __hono_POST(
     }
 
     if (result.jobCreated) {
-      void provisioningJobService.triggerImmediate(env).catch(() => {
-        // error-policy:J5 the durable job remains observable by the worker poll.
-      });
+      if (typeof executionCtx?.waitUntil === "function") {
+        const trigger = provisioningJobService
+          .triggerImmediate(env)
+          .catch((error) => {
+            // error-policy:J7 the durable job remains observable by the daemon;
+            // retain the failed nudge as a structured operational diagnostic.
+            logger.warn(
+              "[agent-tier-adoption] Immediate provisioning nudge failed",
+              {
+                sourceAgentId,
+                dedicatedAgentId: result.agent.id,
+                orgId: user.organization_id,
+                jobId: result.job?.id ?? null,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          });
+        executionCtx.waitUntil(trigger);
+      } else {
+        logger.warn(
+          "[agent-tier-adoption] Immediate provisioning nudge unavailable; daemon polling retained",
+          {
+            sourceAgentId,
+            dedicatedAgentId: result.agent.id,
+            orgId: user.organization_id,
+            jobId: result.job?.id ?? null,
+          },
+        );
+      }
     }
 
     logger.info("[agent-tier-adoption] Existing Dedicated target adopted", {
@@ -453,10 +480,23 @@ app.get("/", async (c) =>
     params: Promise.resolve({ agentId: c.req.param("agentId")! }),
   }),
 );
-app.post("/", async (c) =>
-  __hono_POST(c.req.raw, c.env, {
-    params: Promise.resolve({ agentId: c.req.param("agentId")! }),
-  }),
-);
+app.post("/", async (c) => {
+  let executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    // Hono test and non-Worker adapters may not expose an execution context.
+    // The durable daemon poll remains authoritative in that case.
+    executionCtx = undefined;
+  }
+  return __hono_POST(
+    c.req.raw,
+    c.env,
+    {
+      params: Promise.resolve({ agentId: c.req.param("agentId")! }),
+    },
+    executionCtx,
+  );
+});
 
 export default app;

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -33,6 +33,7 @@ import {
   personalDedicatedClientApiBase,
   personalSharedAgentId,
 } from "@/lib/services/shared-runtime/personal-shared-agent";
+import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import {
   commitSharedReminderCutover,
   releaseSharedReminderCutover,
@@ -832,6 +833,17 @@ app.post("/", async (c) => {
       }
     }
   } catch (error) {
+    // error-policy:J1 preserve the coordinator's temporary unavailable state
+    // so the client can retry the idempotent cutover within its startup deadline.
+    if (error instanceof SharedRuntimeCacheWarmingError) {
+      return rejectCutover(c, {
+        code: "shared_history_unavailable",
+        error:
+          "Shared history is temporarily unavailable. Retry Dedicated activation shortly.",
+        status: 503,
+        phase: "coordinate-shared-history",
+      });
+    }
     logger.error("[personal-dedicated-cutover] Cutover failed", {
       traceId: c.get("traceId") ?? c.get("requestId"),
       phase: "unhandled-boundary",

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -9,7 +9,7 @@ import {
   createSharedTodoCutoverSnapshot,
   type SharedTodoCutoverSnapshot,
 } from "@elizaos/shared/todo-cutover";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { z } from "zod";
 import { usersRepository } from "@/db/repositories/users";
 import { errorToResponse } from "@/lib/api/errors";
@@ -41,6 +41,7 @@ import {
   SharedReminderCutoverConflictError,
 } from "@/lib/services/shared-runtime/shared-scheduling";
 import { readSharedTodoCutoverState } from "@/lib/services/shared-runtime/shared-todos";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CORS_METHODS = "POST, OPTIONS";
@@ -49,6 +50,51 @@ const bodySchema = z.object({ dedicatedAgentId: z.string().uuid() });
 
 function json(body: unknown, status = 200): Response {
   return applyCorsHeaders(Response.json(body, { status }), CORS_METHODS);
+}
+
+interface CutoverRejection {
+  code: string;
+  error: string;
+  status: number;
+  phase: string;
+  context?: Record<string, unknown>;
+}
+
+function rejectCutover(
+  c: Context<AppEnv>,
+  rejection: CutoverRejection,
+): Response {
+  logger.warn("[personal-dedicated-cutover] Cutover rejected", {
+    traceId: c.get("traceId") ?? c.get("requestId"),
+    code: rejection.code,
+    status: rejection.status,
+    phase: rejection.phase,
+    sourceAgentId: c.req.param("agentId") ?? null,
+    ...rejection.context,
+  });
+  return json(
+    {
+      success: false,
+      code: rejection.code,
+      error: rejection.error,
+    },
+    rejection.status,
+  );
+}
+
+function errorDiagnostic(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) return { error: String(error) };
+  return {
+    errorName: error.name,
+    errorMessage: error.message,
+    errorStack: error.stack,
+    errorCause:
+      error.cause instanceof Error
+        ? { name: error.cause.name, message: error.cause.message }
+        : error.cause === undefined
+          ? undefined
+          : String(error.cause),
+  };
 }
 
 async function invalidateUserDeliveryProjections(
@@ -249,14 +295,13 @@ app.post("/", async (c) => {
     const { user } = await requireAuthOrApiKeyWithOrg(c.req.raw);
     const parsed = bodySchema.safeParse(await readJsonBody(c.req.raw));
     if (!parsed.success) {
-      return json(
-        {
-          success: false,
-          code: "invalid_dedicated_cutover",
-          error: "A valid Dedicated target id is required.",
-        },
-        400,
-      );
+      return rejectCutover(c, {
+        code: "invalid_dedicated_cutover",
+        error: "A valid Dedicated target id is required.",
+        status: 400,
+        phase: "validate-request",
+        context: { orgId: user.organization_id, userId: user.id },
+      });
     }
 
     const sourceAgentId = personalSharedAgentId({
@@ -264,22 +309,27 @@ app.post("/", async (c) => {
       organizationId: user.organization_id,
     });
     if (c.req.param("agentId") !== sourceAgentId) {
-      return json({ success: false, error: "Agent not found" }, 404);
+      return rejectCutover(c, {
+        code: "personal_source_not_found",
+        error: "Agent not found",
+        status: 404,
+        phase: "authorize-source",
+        context: { orgId: user.organization_id, userId: user.id },
+      });
     }
     const conversationNamespace = c.env.SHARED_RUNTIME_CONVERSATIONS;
     if (
       !conversationNamespace ||
       typeof conversationNamespace.getByName !== "function"
     ) {
-      return json(
-        {
-          success: false,
-          code: "shared_history_unavailable",
-          error:
-            "Shared history is temporarily unavailable. Shared remains active.",
-        },
-        503,
-      );
+      return rejectCutover(c, {
+        code: "shared_history_unavailable",
+        error:
+          "Shared history is temporarily unavailable. Shared remains active.",
+        status: 503,
+        phase: "resolve-shared-history",
+        context: { orgId: user.organization_id, userId: user.id },
+      });
     }
     if (
       await usersRepository.hasPendingPhoneTelegramPersonalAccountConvergenceTarget(
@@ -290,15 +340,14 @@ app.post("/", async (c) => {
         },
       )
     ) {
-      return json(
-        {
-          success: false,
-          code: "personal_identity_convergence_in_progress",
-          error:
-            "Personal history is still linking across channels. Try Dedicated activation again shortly.",
-        },
-        409,
-      );
+      return rejectCutover(c, {
+        code: "personal_identity_convergence_in_progress",
+        error:
+          "Personal history is still linking across channels. Try Dedicated activation again shortly.",
+        status: 409,
+        phase: "identity-convergence",
+        context: { orgId: user.organization_id, userId: user.id },
+      });
     }
     const sealToken = `personal-cutover:${sourceAgentId}:${parsed.data.dedicatedAgentId}`;
     const reminderReservationToken = `${sealToken}:reminders:${crypto.randomUUID()}`;
@@ -332,15 +381,19 @@ app.post("/", async (c) => {
       ) {
         const activeToken = dedicatedAgentTransportToken(active);
         if (!activeToken) {
-          return json(
-            {
-              success: false,
-              code: "dedicated_transport_unavailable",
-              error:
-                "Dedicated authentication is still being prepared. Shared remains active.",
+          return rejectCutover(c, {
+            code: "dedicated_transport_unavailable",
+            error:
+              "Dedicated authentication is still being prepared. Shared remains active.",
+            status: 503,
+            phase: "repair-active-transport",
+            context: {
+              orgId: user.organization_id,
+              userId: user.id,
+              dedicatedAgentId: active.id,
+              targetStatus: active.status,
             },
-            503,
-          );
+          });
         }
         try {
           await invalidateUserDeliveryProjections(c.env, user);
@@ -419,9 +472,21 @@ app.post("/", async (c) => {
               importedTodoMutations: marker.sharedTodoMutationCount,
             },
           });
-        } catch {
+        } catch (error) {
           // error-policy:J4 An old or interrupted marker is not accepted as a
           // healthy success until the full sealed import below repairs it.
+          logger.warn(
+            "[personal-dedicated-cutover] Active marker repair failed; full sealed import retained",
+            {
+              traceId: c.get("traceId") ?? c.get("requestId"),
+              phase: "repair-active-marker",
+              sourceAgentId,
+              dedicatedAgentId: active.id,
+              orgId: user.organization_id,
+              userId: user.id,
+              ...errorDiagnostic(error),
+            },
+          );
         }
       }
     }
@@ -435,15 +500,23 @@ app.post("/", async (c) => {
       target.user_id !== user.id ||
       target.status !== "running"
     ) {
-      return json(
-        {
-          success: false,
-          code: "dedicated_not_healthy",
-          error:
-            "Dedicated is not healthy yet. Shared remains active; try again when setup finishes.",
+      return rejectCutover(c, {
+        code: "dedicated_not_healthy",
+        error:
+          "Dedicated is not healthy yet. Shared remains active; try again when setup finishes.",
+        status: 409,
+        phase: "resolve-running-target",
+        context: {
+          orgId: user.organization_id,
+          userId: user.id,
+          requestedDedicatedAgentId: parsed.data.dedicatedAgentId,
+          targetResolved: Boolean(target),
+          targetIdMatches: target?.id === parsed.data.dedicatedAgentId,
+          targetOwnerMatches: target?.user_id === user.id,
+          targetStatus: target?.status ?? null,
+          targetLifecycleRevision: target?.lifecycle_revision ?? null,
         },
-        409,
-      );
+      });
     }
 
     const base = personalDedicatedAgentApiBase(
@@ -451,27 +524,35 @@ app.post("/", async (c) => {
       c.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
     );
     if (!base) {
-      return json(
-        {
-          success: false,
-          code: "dedicated_not_reachable",
-          error:
-            "Dedicated has no reachable endpoint yet. Shared remains active.",
+      return rejectCutover(c, {
+        code: "dedicated_not_reachable",
+        error:
+          "Dedicated has no reachable endpoint yet. Shared remains active.",
+        status: 409,
+        phase: "resolve-dedicated-endpoint",
+        context: {
+          orgId: user.organization_id,
+          userId: user.id,
+          dedicatedAgentId: target.id,
+          targetStatus: target.status,
         },
-        409,
-      );
+      });
     }
     const targetToken = dedicatedAgentTransportToken(target);
     if (!targetToken) {
-      return json(
-        {
-          success: false,
-          code: "dedicated_transport_unavailable",
-          error:
-            "Dedicated authentication is still being prepared. Shared remains active.",
+      return rejectCutover(c, {
+        code: "dedicated_transport_unavailable",
+        error:
+          "Dedicated authentication is still being prepared. Shared remains active.",
+        status: 503,
+        phase: "resolve-dedicated-transport",
+        context: {
+          orgId: user.organization_id,
+          userId: user.id,
+          dedicatedAgentId: target.id,
+          targetStatus: target.status,
         },
-        503,
-      );
+      });
     }
     const history = await coordinateSharedCutoverSeal(
       sourceAgentId,
@@ -497,15 +578,19 @@ app.post("/", async (c) => {
           message.role === "user" || message.role === "assistant",
       );
       if (transferableHistory.some((message) => !message.id)) {
-        return json(
-          {
-            success: false,
-            code: "shared_history_identity_missing",
-            error:
-              "Shared history could not be verified for an exact transfer. Shared remains active.",
+        return rejectCutover(c, {
+          code: "shared_history_identity_missing",
+          error:
+            "Shared history could not be verified for an exact transfer. Shared remains active.",
+          status: 503,
+          phase: "validate-shared-history",
+          context: {
+            orgId: user.organization_id,
+            userId: user.id,
+            dedicatedAgentId: target.id,
+            transferableMessageCount: transferableHistory.length,
           },
-          503,
-        );
+        });
       }
       let scheduledTasks: Awaited<
         ReturnType<typeof reserveSharedRemindersForCutover>
@@ -521,15 +606,19 @@ app.post("/", async (c) => {
       } catch (error) {
         // error-policy:J1 the cutover boundary translates an ownership conflict for retry.
         if (error instanceof SharedReminderCutoverConflictError) {
-          return json(
-            {
-              success: false,
-              code: "personal_reminder_cutover_in_progress",
-              error:
-                "Another Dedicated cutover is already moving Shared reminders.",
+          return rejectCutover(c, {
+            code: "personal_reminder_cutover_in_progress",
+            error:
+              "Another Dedicated cutover is already moving Shared reminders.",
+            status: 423,
+            phase: "reserve-shared-reminders",
+            context: {
+              orgId: user.organization_id,
+              userId: user.id,
+              dedicatedAgentId: target.id,
+              ...errorDiagnostic(error),
             },
-            423,
-          );
+          });
         }
         throw error;
       }
@@ -555,15 +644,24 @@ app.post("/", async (c) => {
           targetToken,
         );
         if (!imported.response.ok) {
-          return json(
-            {
-              success: false,
-              code: "dedicated_history_import_failed",
-              error:
-                "History, reminders, and Todos did not finish moving to Dedicated. Shared remains active.",
+          return rejectCutover(c, {
+            code: "dedicated_history_import_failed",
+            error:
+              "History, reminders, and Todos did not finish moving to Dedicated. Shared remains active.",
+            status: 503,
+            phase: "import-personal-state",
+            context: {
+              orgId: user.organization_id,
+              userId: user.id,
+              dedicatedAgentId: target.id,
+              upstreamStatus: imported.response.status,
+              importAttempt: attempt + 1,
+              messageCount: importedMessages.length,
+              scheduledTaskCount: scheduledTasks.length,
+              todoCount: todoSnapshot.todos.length,
+              todoMutationCount: todoSnapshot.mutations.length,
             },
-            503,
-          );
+          });
         }
         const receipt = imported.receipt;
         if (
@@ -575,15 +673,25 @@ app.post("/", async (c) => {
             false,
           )
         ) {
-          return json(
-            {
-              success: false,
-              code: "dedicated_history_receipt_invalid",
-              error:
-                "Dedicated did not confirm the complete history, reminder, and Todo import. Shared remains active.",
+          return rejectCutover(c, {
+            code: "dedicated_history_receipt_invalid",
+            error:
+              "Dedicated did not confirm the complete history, reminder, and Todo import. Shared remains active.",
+            status: 503,
+            phase: "verify-personal-import-receipt",
+            context: {
+              orgId: user.organization_id,
+              userId: user.id,
+              dedicatedAgentId: target.id,
+              importAttempt: attempt + 1,
+              upstreamStatus: imported.response.status,
+              receiptPresent: Boolean(receipt),
+              messageCount: importedMessages.length,
+              scheduledTaskCount: scheduledTasks.length,
+              todoCount: todoSnapshot.todos.length,
+              todoMutationCount: todoSnapshot.mutations.length,
             },
-            503,
-          );
+          });
         }
         const refreshedTasks = await reserveSharedRemindersForCutover({
           sourceAgentId,
@@ -602,15 +710,19 @@ app.post("/", async (c) => {
           break;
         }
         if (attempt >= 2) {
-          return json(
-            {
-              success: false,
-              code: "shared_personal_snapshot_unstable",
-              error:
-                "Shared personal data is still settling. Try Dedicated activation again.",
+          return rejectCutover(c, {
+            code: "shared_personal_snapshot_unstable",
+            error:
+              "Shared personal data is still settling. Try Dedicated activation again.",
+            status: 409,
+            phase: "stabilize-personal-snapshot",
+            context: {
+              orgId: user.organization_id,
+              userId: user.id,
+              dedicatedAgentId: target.id,
+              importAttempts: attempt + 1,
             },
-            409,
-          );
+          });
         }
         scheduledTasks = refreshedTasks;
         todoSnapshot = refreshedTodoSnapshot;
@@ -657,15 +769,24 @@ app.post("/", async (c) => {
           true,
         )
       ) {
-        return json(
-          {
-            success: false,
-            code: "dedicated_reminder_activation_failed",
-            error:
-              "Dedicated did not confirm the imported reminders and Todos. Retry cutover to repair them.",
+        return rejectCutover(c, {
+          code: "dedicated_reminder_activation_failed",
+          error:
+            "Dedicated did not confirm the imported reminders and Todos. Retry cutover to repair them.",
+          status: 503,
+          phase: "activate-dedicated-personal-state",
+          context: {
+            orgId: user.organization_id,
+            userId: user.id,
+            dedicatedAgentId: target.id,
+            upstreamStatus: activation.response.status,
+            receiptPresent: Boolean(activation.receipt),
+            messageCount: importedMessages.length,
+            scheduledTaskCount: scheduledTasks.length,
+            todoCount: todoSnapshot.todos.length,
+            todoMutationCount: todoSnapshot.mutations.length,
           },
-          503,
-        );
+        });
       }
       await commitSharedReminderCutover({
         sourceAgentId,
@@ -711,6 +832,12 @@ app.post("/", async (c) => {
       }
     }
   } catch (error) {
+    logger.error("[personal-dedicated-cutover] Cutover failed", {
+      traceId: c.get("traceId") ?? c.get("requestId"),
+      phase: "unhandled-boundary",
+      sourceAgentId: c.req.param("agentId") ?? null,
+      ...errorDiagnostic(error),
+    });
     return applyCorsHeaders(errorToResponse(error), CORS_METHODS);
   }
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/route.ts
@@ -36,7 +36,7 @@
  *    re-arms, for stopped/sleeping/dead-job targets) durable state.
  */
 
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { z } from "zod";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -84,6 +84,35 @@ type AgentRow = NonNullable<
 type AuthedUser = Awaited<
   ReturnType<typeof requireAuthOrApiKeyWithOrg>
 >["user"];
+
+type ProvisioningExecutionContext = Pick<
+  Context<AppEnv>["executionCtx"],
+  "waitUntil"
+>;
+
+async function retainProvisioningNudge(
+  env: AppEnv["Bindings"],
+  executionCtx: ProvisioningExecutionContext | undefined,
+  context: {
+    sharedAgentId: string;
+    dedicatedAgentId: string;
+    orgId: string;
+    jobId: string;
+  },
+): Promise<void> {
+  const trigger = provisioningJobService
+    .triggerImmediate(env)
+    .catch((error) => {
+      // error-policy:J7 the committed job remains owned by the daemon; retain
+      // the failed latency nudge as an operational diagnostic at this boundary.
+      logger.warn("[agent-upgrade-tier] Immediate provisioning nudge failed", {
+        ...context,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  if (executionCtx) executionCtx.waitUntil(trigger);
+  else await trigger;
+}
 
 interface UpgradeSource {
   id: string;
@@ -269,6 +298,7 @@ async function respondToLiveTarget(
   user: AuthedUser,
   env: AppEnv["Bindings"],
   confirmedQuoteId: string,
+  executionCtx: ProvisioningExecutionContext | undefined,
 ): Promise<Response> {
   logger.info("[agent-upgrade-tier] Reattaching to in-flight upgrade", {
     sharedAgentId,
@@ -342,9 +372,11 @@ async function respondToLiveTarget(
     agentName: target.agent_name ?? target.id,
   });
   if (reattach.created) {
-    void provisioningJobService.triggerImmediate(env).catch(() => {
-      // error-policy:J5 fire-and-forget nudge; the job is persisted and the
-      // provisioning cron is the safety net (failure logged in the service).
+    await retainProvisioningNudge(env, executionCtx, {
+      sharedAgentId,
+      dedicatedAgentId: target.id,
+      orgId: user.organization_id,
+      jobId: reattach.job.id,
     });
   }
   return json(
@@ -391,6 +423,7 @@ async function __hono_GET(
       data: await dedicatedQuote(source, user, existingTarget),
     });
   } catch (error) {
+    // error-policy:J1 translate authentication and quote failures at HTTP.
     return applyCorsHeaders(errorToResponse(error), CORS_METHODS);
   }
 }
@@ -399,6 +432,7 @@ async function __hono_POST(
   request: Request,
   env: AppEnv["Bindings"],
   { params }: { params: Promise<{ agentId: string }> },
+  executionCtx: ProvisioningExecutionContext | undefined,
 ) {
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
@@ -411,6 +445,7 @@ async function __hono_POST(
     const sourceError = invalidUpgradeSource(source);
     if (sourceError) return sourceError;
 
+    // error-policy:J3 malformed JSON is an explicitly invalid confirmation.
     const confirmation = ActivationBody.safeParse(
       await request.json().catch(() => null),
     );
@@ -438,6 +473,7 @@ async function __hono_POST(
         user,
         env,
         confirmation.data.quoteId,
+        executionCtx,
       );
     }
 
@@ -522,6 +558,8 @@ async function __hono_POST(
         ),
       });
     } catch (error) {
+      // error-policy:J1 translate known activation refusals; propagate others
+      // to the outer HTTP error boundary.
       if (error instanceof AgentQuotaExceededError) {
         logger.warn("[agent-upgrade-tier] Upgrade blocked: org quota", {
           sharedAgentId: source.id,
@@ -575,14 +613,17 @@ async function __hono_POST(
         user,
         env,
         confirmation.data.quoteId,
+        executionCtx,
       );
     }
     const dedicated = result.agent;
     const job = result.job;
 
-    void provisioningJobService.triggerImmediate(env).catch(() => {
-      // error-policy:J5 fire-and-forget nudge; the job is persisted and the
-      // provisioning cron is the safety net (failure logged in the service).
+    await retainProvisioningNudge(env, executionCtx, {
+      sharedAgentId: source.id,
+      dedicatedAgentId: dedicated.id,
+      orgId: user.organization_id,
+      jobId: job.id,
     });
 
     logger.info("[agent-upgrade-tier] Upgrade started", {
@@ -615,6 +656,7 @@ async function __hono_POST(
       202,
     );
   } catch (error) {
+    // error-policy:J1 preserve the structured HTTP failure contract.
     return applyCorsHeaders(errorToResponse(error), CORS_METHODS);
   }
 }
@@ -626,9 +668,22 @@ __hono_app.get("/", async (c) =>
     params: Promise.resolve({ agentId: c.req.param("agentId")! }),
   }),
 );
-__hono_app.post("/", async (c) =>
-  __hono_POST(c.req.raw, c.env, {
-    params: Promise.resolve({ agentId: c.req.param("agentId")! }),
-  }),
-);
+__hono_app.post("/", async (c) => {
+  let executionCtx: ProvisioningExecutionContext | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    // error-policy:J4 non-Worker Hono adapters lack this context; the route
+    // awaits the nudge before returning instead of leaving work unobserved.
+    executionCtx = undefined;
+  }
+  return __hono_POST(
+    c.req.raw,
+    c.env,
+    {
+      params: Promise.resolve({ agentId: c.req.param("agentId")! }),
+    },
+    executionCtx,
+  );
+});
 export default __hono_app;

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -543,6 +543,8 @@ describe("resolveInferenceAuthContext", () => {
     };
     const waited: Promise<unknown>[] = [];
     const cacheRead = spyOn(cache, "getWithOutcome");
+    const errorSpy = spyOn(logger, "error").mockImplementation(() => undefined);
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => undefined);
     try {
       const result = await resolveInferenceAuthContext(reqWithApiKey(), {
         cacheOnly: true,
@@ -555,9 +557,34 @@ describe("resolveInferenceAuthContext", () => {
         reason: "credential_invalid",
       });
       expect(cacheRead).toHaveBeenCalledTimes(1);
+      const denialLogs = errorSpy.mock.calls.filter(
+        ([message]) => message === "[InferenceAuth] account standing denied inference",
+      );
+      expect(denialLogs).toHaveLength(1);
+      expect(denialLogs[0]).toEqual([
+        "[InferenceAuth] account standing denied inference",
+        expect.objectContaining({
+          status: 401,
+          reason: "credential_invalid",
+          cacheRead: "miss",
+          source: "authoritative",
+        }),
+      ]);
+      const authTraces = infoSpy.mock.calls
+        .filter(([message]) => message === "[InferenceAuth] trace")
+        .map(([, context]) => context);
+      expect(authTraces).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ cacheRead: "not_run", authoritative: "error" }),
+          expect.objectContaining({ cacheRead: "miss", authoritative: "rejected" }),
+        ]),
+      );
+      expect(authTraces).not.toContainEqual(expect.objectContaining({ cacheRead: "unavailable" }));
       await Promise.all(waited);
     } finally {
       cacheRead.mockRestore();
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
     }
   });
 
@@ -568,24 +595,54 @@ describe("resolveInferenceAuthContext", () => {
       return true;
     };
     const waited: Promise<unknown>[] = [];
+    const cacheRead = spyOn(cache, "getWithOutcome");
+    const errorSpy = spyOn(logger, "error").mockImplementation(() => undefined);
 
-    const cold = await resolveInferenceAuthContext(reqWithApiKey(), {
-      cacheOnly: true,
-      executionCtx: { waitUntil: (promise) => waited.push(promise) },
-    });
-    expect(cold).toEqual({
-      kind: "suspended",
-      userId: "user-1",
-      reason: "moderation_blocked",
-    });
-    await Promise.all(waited);
-    expect(moderationCalls).toBe(1);
+    try {
+      const cold = await resolveInferenceAuthContext(reqWithApiKey(), {
+        cacheOnly: true,
+        executionCtx: { waitUntil: (promise) => waited.push(promise) },
+      });
+      expect(cold).toEqual({
+        kind: "suspended",
+        userId: "user-1",
+        reason: "moderation_blocked",
+      });
+      await Promise.all(waited);
+      expect(moderationCalls).toBe(1);
+      expect(cacheRead).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls).toEqual([
+        [
+          "[InferenceAuth] account standing denied inference",
+          expect.objectContaining({
+            status: 403,
+            reason: "moderation_blocked",
+            cacheRead: "miss",
+            source: "authoritative",
+          }),
+        ],
+      ]);
 
-    const retry = await resolveInferenceAuthContext(reqWithApiKey(), {
-      cacheOnly: true,
-    });
-    expect(retry).toEqual({ kind: "suspended", reason: "moderation_blocked" });
-    expect(moderationCalls).toBe(1);
+      const retry = await resolveInferenceAuthContext(reqWithApiKey(), {
+        cacheOnly: true,
+      });
+      expect(retry).toEqual({ kind: "suspended", reason: "moderation_blocked" });
+      expect(moderationCalls).toBe(1);
+      expect(cacheRead).toHaveBeenCalledTimes(2);
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(errorSpy).toHaveBeenLastCalledWith(
+        "[InferenceAuth] account standing denied inference",
+        expect.objectContaining({
+          status: 403,
+          reason: "moderation_blocked",
+          cacheRead: "rejected",
+          source: "cache",
+        }),
+      );
+    } finally {
+      cacheRead.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 
   test("inline continuation deadline returns warming after one cache read", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -181,6 +181,9 @@ interface ApiKeyHydration {
 
 const apiKeyHydrations = new Map<string, ApiKeyHydration>();
 const SKIP_CACHE_PROJECTION_WRITE = Symbol("skip-cache-projection-write");
+// A cold request owns the canonical denial log after consuming its nested
+// authoritative continuation; the hydration phase still emits its trace.
+const SUPPRESS_STANDING_DENIAL_LOG = Symbol("suppress-standing-denial-log");
 const AUTH_CONTEXT_REFRESH_AFTER_MS = 30_000;
 const DEFAULT_HYDRATION_DEADLINE_MS = 10_000;
 const DEFAULT_INLINE_CONTINUATION_DEADLINE_MS = 2_500;
@@ -390,12 +393,14 @@ function getOrCreateApiKeyHydration(
   // projection barrier, including its standalone strong credential check.
   const hydrationOptions: ResolveInferenceAuthOptions & {
     [SKIP_CACHE_PROJECTION_WRITE]: true;
+    [SUPPRESS_STANDING_DENIAL_LOG]: true;
   } = {
     traceId: options.traceId,
     cacheOnly: false,
     forceAuthoritative: true,
     deferStrongCredentialCheck: true,
     [SKIP_CACHE_PROJECTION_WRITE]: true,
+    [SUPPRESS_STANDING_DENIAL_LOG]: true,
     onAuthoritativeRejection: (reason) => {
       authoritativeRejectionReason = reason;
     },
@@ -650,6 +655,15 @@ export async function resolveInferenceAuthContext(
     source: InferenceStandingDecisionSource;
   }): void => {
     standingDenialLogged = true;
+    if (
+      (
+        options as ResolveInferenceAuthOptions & {
+          [SUPPRESS_STANDING_DENIAL_LOG]?: true;
+        }
+      )[SUPPRESS_STANDING_DENIAL_LOG]
+    ) {
+      return;
+    }
     const reason =
       typeof params.reason === "string" && /^[a-z0-9_:-]{1,64}$/.test(params.reason)
         ? params.reason
@@ -837,7 +851,7 @@ export async function resolveInferenceAuthContext(
           ? { kind: "suspended", reason: cached.reason }
           : { kind: "rejected", status: cached.status, reason: cached.reason };
       }
-    } else {
+    } else if (!cacheAvailable) {
       trace.cacheRead = "unavailable";
     }
 

--- a/packages/cloud/shared/src/lib/services/personal-dedicated-delivery.ts
+++ b/packages/cloud/shared/src/lib/services/personal-dedicated-delivery.ts
@@ -9,6 +9,7 @@
 
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
 import type { AppEnv } from "../../types/cloud-worker-env";
+import { logger } from "../utils/logger";
 import { checkAgentCreditGate } from "./agent-billing-gate";
 import { provisioningJobService } from "./provisioning-jobs";
 import { checkProvisioningWorkerHealth } from "./provisioning-worker-health";
@@ -116,7 +117,18 @@ export async function preparePersonalDedicatedDelivery(
 
   // The durable job is already committed. This kick only avoids waiting for
   // the periodic poller and observes its own transport failures internally.
-  executionCtx.waitUntil(provisioningJobService.triggerImmediate(env));
+  const trigger = provisioningJobService.triggerImmediate(env).catch((error) => {
+    // error-policy:J7 the durable lifecycle job remains observable by the
+    // daemon; retain a failed best-effort nudge as an operational diagnostic.
+    logger.warn("[personal-dedicated-delivery] Immediate provisioning nudge failed", {
+      agentId: target.id,
+      organizationId: identity.organizationId,
+      userId: identity.userId,
+      jobId: result.job.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+  executionCtx.waitUntil(trigger);
   return {
     state: "starting",
     action: target.status === "sleeping" ? "wake" : "resume",

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-trigger-immediate.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-trigger-immediate.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The provisioning nudge contract treats an HTTP rejection as a failed
+ * dispatch and never calls the retired Worker no-op. Durable job processing
+ * remains owned by the provisioning daemon.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { ProvisioningJobService } from "./provisioning-jobs";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function directEnv() {
+  return {
+    CONTAINER_CONTROL_PLANE_URL: "https://control-plane.example.test",
+    CONTAINER_CONTROL_PLANE_TOKEN: "control-plane-token",
+    DATABASE_URL: "postgres://worker-db.example.test/eliza",
+  };
+}
+
+describe("ProvisioningJobService.triggerImmediate", () => {
+  test("rejects when the only configured nudge endpoint returns non-success", async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 401 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(new ProvisioningJobService().triggerImmediate(directEnv())).rejects.toMatchObject({
+      code: "PROVISIONING_IMMEDIATE_TRIGGER_REJECTED",
+      context: { target: "control-plane", status: 401 },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not call the retired Worker no-op without a direct nudge", async () => {
+    const fetchMock = mock(async () => new Response(null, { status: 204 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(new ProvisioningJobService().triggerImmediate({})).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -3744,21 +3744,16 @@ export class ProvisioningJobService {
   }
 
   /**
-   * Best-effort kick of the provisioning worker without waiting for the
-   * next cron tick. Fire-and-forget — the cron is the safety net.
-   *
-   * The cron endpoint is idempotent (FOR UPDATE SKIP LOCKED) so calling
-   * it concurrently with the scheduled invocation is safe.
+   * Best-effort kick of the provisioning worker without waiting for its next
+   * daemon poll. Callers running inside a Worker must register this promise
+   * with `waitUntil`; the durable job and daemon poll remain authoritative.
    */
   async triggerImmediate(env?: {
-    CRON_SECRET?: string;
     CONTAINER_CONTROL_PLANE_TOKEN?: string;
     CONTAINER_CONTROL_PLANE_URL?: string;
     CONTAINER_SIDECAR_URL?: string;
     DATABASE_URL?: string;
     HETZNER_CONTAINER_CONTROL_PLANE_URL?: string;
-    NEXT_PUBLIC_API_URL?: string;
-    NEXT_PUBLIC_APP_URL?: string;
   }): Promise<void> {
     const controlPlaneBaseUrl =
       env?.CONTAINER_CONTROL_PLANE_URL ??
@@ -3776,7 +3771,7 @@ export class ProvisioningJobService {
         const target = new URL(controlPlaneBaseUrl);
         target.pathname = "/api/v1/cron/process-provisioning-jobs";
         target.search = "?limit=5";
-        await fetch(target, {
+        const response = await fetch(target, {
           method: "POST",
           headers: {
             "x-container-control-plane-token": controlPlaneToken,
@@ -3785,34 +3780,22 @@ export class ProvisioningJobService {
           },
           signal: AbortSignal.timeout(120_000),
         });
+        if (!response.ok) {
+          throw new ElizaError("The provisioning control plane rejected the immediate nudge", {
+            code: "PROVISIONING_IMMEDIATE_TRIGGER_REJECTED",
+            context: {
+              target: "control-plane",
+              status: response.status,
+            },
+          });
+        }
         return;
       } catch (err) {
         logger.debug("[provisioning-jobs] direct triggerImmediate failed", {
           error: jobErrorText(err),
         });
+        throw err;
       }
-    }
-
-    const cronSecret = env?.CRON_SECRET ?? process.env.CRON_SECRET;
-    const baseUrl =
-      env?.NEXT_PUBLIC_API_URL ??
-      env?.NEXT_PUBLIC_APP_URL ??
-      process.env.NEXT_PUBLIC_API_URL ??
-      process.env.NEXT_PUBLIC_APP_URL;
-    if (!cronSecret || !baseUrl) return;
-    try {
-      await fetch(`${baseUrl}/api/v1/cron/process-provisioning-jobs?limit=5`, {
-        method: "POST",
-        headers: {
-          "x-cron-secret": cronSecret,
-          "user-agent": "agent-provision-trigger/1.0",
-        },
-        signal: AbortSignal.timeout(3_000),
-      });
-    } catch (err) {
-      logger.debug("[provisioning-jobs] triggerImmediate fire-and-forget failed", {
-        error: jobErrorText(err),
-      });
     }
   }
 

--- a/packages/ui/src/api/client-cloud-personal-shared.test.ts
+++ b/packages/ui/src/api/client-cloud-personal-shared.test.ts
@@ -455,9 +455,68 @@ describe("ensurePersonalDedicatedEliza", () => {
     );
   });
 
+  it.each([undefined, "", { invalid: true }])(
+    "rejects an accepted activation with invalid job identity %j before cutover",
+    async (jobId) => {
+      const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
+      const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+      const unexpectedRequests: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/eliza/personal")) {
+            return jsonResponse(200, {
+              success: true,
+              data: {
+                identity: {
+                  id: personalElizaId,
+                  displayName: "Eliza",
+                  runtime: "shared",
+                },
+              },
+            });
+          }
+          if (url.endsWith("/upgrade-tier") && init?.method === "GET") {
+            return jsonResponse(200, {
+              success: true,
+              data: {
+                quoteId: "a".repeat(64),
+                canActivate: true,
+                activation: { state: "available" },
+              },
+            });
+          }
+          if (url.endsWith("/upgrade-tier") && init?.method === "POST") {
+            return jsonResponse(202, {
+              success: true,
+              data: { dedicatedAgentId, jobId },
+            });
+          }
+          unexpectedRequests.push(url);
+          return jsonResponse(500, {
+            error: "unexpected request after invalid activation",
+          });
+        }),
+      );
+      await expect(
+        new ElizaClient().ensurePersonalDedicatedEliza({
+          cloudApiBase: "https://api.eliza.app",
+          authToken: "steward-token",
+          timeoutMs: 1_000,
+        }),
+      ).rejects.toMatchObject({
+        code: "CLOUD_DEDICATED_PROVISION_JOB_INVALID",
+        context: { phase: "activation", field: "jobId" },
+      });
+      expect(unexpectedRequests).toEqual([]);
+    },
+  );
+
   it("does not retry cutover from HTTP status alone without a retryable response code", async () => {
     const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
     const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+    const jobId = "10000000-0000-4000-8000-000000000020";
     let cutoverAttempts = 0;
     vi.stubGlobal(
       "fetch",
@@ -488,7 +547,13 @@ describe("ensurePersonalDedicatedEliza", () => {
         if (url.endsWith("/upgrade-tier") && init?.method === "POST") {
           return jsonResponse(202, {
             success: true,
-            data: { dedicatedAgentId },
+            data: { dedicatedAgentId, jobId },
+          });
+        }
+        if (url.endsWith(`/api/v1/jobs/${jobId}`)) {
+          return jsonResponse(200, {
+            success: true,
+            data: { id: jobId, status: "completed" },
           });
         }
         if (url.endsWith("/upgrade-tier/cutover")) {
@@ -1571,6 +1636,7 @@ describe("ensurePersonalDedicatedEliza", () => {
     async (targetStatus) => {
       const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
       const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+      const jobId = "10000000-0000-4000-8000-000000000020";
       let activationPosts = 0;
       const fetchMock = vi.fn(
         async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1605,7 +1671,7 @@ describe("ensurePersonalDedicatedEliza", () => {
             activationPosts += 1;
             return jsonResponse(202, {
               success: true,
-              data: { dedicatedAgentId },
+              data: { dedicatedAgentId, jobId },
             });
           }
           if (
@@ -1616,6 +1682,12 @@ describe("ensurePersonalDedicatedEliza", () => {
               success: false,
               code: "dedicated_adoption_unavailable",
               error: "Agent not found",
+            });
+          }
+          if (url.endsWith(`/api/v1/jobs/${jobId}`)) {
+            return jsonResponse(200, {
+              success: true,
+              data: { id: jobId, status: "completed" },
             });
           }
           if (url.endsWith("/upgrade-tier/cutover")) {
@@ -1839,14 +1911,21 @@ describe("ensurePersonalDedicatedEliza", () => {
     expect(cutoverPosts).toBe(1);
   });
 
-  it.each(["request", "body"] as const)(
-    "aborts a hung boundary cutover %s at exactly 720000ms without late work",
-    async (stalledPhase) => {
+  it.each([
+    ["cutover", "request"],
+    ["cutover", "body"],
+    ["job", "request"],
+    ["job", "body"],
+  ] as const)(
+    "aborts a hung boundary %s %s at exactly 720000ms without late work",
+    async (stalledBoundary, stalledPhase) => {
       vi.useFakeTimers();
       vi.setSystemTime(0);
       const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
       const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+      const jobId = "10000000-0000-4000-8000-000000000020";
       let cutoverPosts = 0;
+      let boundaryRequests = 0;
       let releaseLateRequest: ((response: Response) => void) | undefined;
       let releaseLateBody: ((body: string) => void) | undefined;
       const onProgress = vi.fn();
@@ -1872,30 +1951,49 @@ describe("ensurePersonalDedicatedEliza", () => {
               data: {
                 quoteId: "3".repeat(64),
                 canActivate: true,
-                activation: {
-                  state: "in_progress",
-                  dedicatedAgentId,
-                  status: "provisioning",
-                },
+                activation:
+                  stalledBoundary === "job"
+                    ? { state: "available" }
+                    : {
+                        state: "in_progress",
+                        dedicatedAgentId,
+                        status: "provisioning",
+                      },
               },
             });
           }
           if (url.endsWith("/upgrade-tier") && init?.method === "POST") {
+            if (stalledBoundary === "job") {
+              return jsonResponse(202, {
+                success: true,
+                data: { dedicatedAgentId, jobId },
+              });
+            }
             throw new Error("activation POST must not replay");
           }
-          if (url.endsWith("/upgrade-tier/cutover")) {
-            cutoverPosts += 1;
-            if (cutoverPosts === 2) {
+          if (url.endsWith("/upgrade-tier/cutover")) cutoverPosts += 1;
+          if (
+            url.endsWith("/upgrade-tier/cutover") ||
+            url.endsWith(`/api/v1/jobs/${jobId}`)
+          ) {
+            boundaryRequests += 1;
+            if (boundaryRequests === 2) {
               if (stalledPhase === "request") {
                 return await new Promise<Response>((resolve) => {
                   releaseLateRequest = resolve;
                 });
               }
-              const headersOnly = jsonResponse(409, {
-                success: false,
-                code: "dedicated_not_healthy",
-                error: "Dedicated is still provisioning",
-              });
+              const headersOnly =
+                stalledBoundary === "job"
+                  ? jsonResponse(200, {
+                      success: true,
+                      data: { id: jobId, status: "in_progress" },
+                    })
+                  : jsonResponse(409, {
+                      success: false,
+                      code: "dedicated_not_healthy",
+                      error: "Dedicated is still provisioning",
+                    });
               vi.spyOn(headersOnly, "text").mockImplementation(
                 async () =>
                   await new Promise<string>((resolve) => {
@@ -1904,11 +2002,16 @@ describe("ensurePersonalDedicatedEliza", () => {
               );
               return headersOnly;
             }
-            return jsonResponse(409, {
-              success: false,
-              code: "dedicated_not_healthy",
-              error: "Dedicated is still provisioning",
-            });
+            return stalledBoundary === "job"
+              ? jsonResponse(200, {
+                  success: true,
+                  data: { id: jobId, status: "in_progress" },
+                })
+              : jsonResponse(409, {
+                  success: false,
+                  code: "dedicated_not_healthy",
+                  error: "Dedicated is still provisioning",
+                });
           }
           return jsonResponse(500, { error: "unexpected route" });
         }),
@@ -1931,7 +2034,8 @@ describe("ensurePersonalDedicatedEliza", () => {
 
       await vi.advanceTimersByTimeAsync(719_999);
       expect(outcome).toBeUndefined();
-      expect(cutoverPosts).toBe(2);
+      expect(boundaryRequests).toBe(2);
+      expect(cutoverPosts).toBe(stalledBoundary === "cutover" ? 2 : 0);
       const progressCountAtBoundaryRequest = onProgress.mock.calls.length;
 
       await vi.advanceTimersByTimeAsync(1);
@@ -1945,19 +2049,26 @@ describe("ensurePersonalDedicatedEliza", () => {
         name: "TimeoutError",
       });
       expect(Date.now()).toBe(720_000);
-      expect(cutoverPosts).toBe(2);
+      expect(boundaryRequests).toBe(2);
       expect(onProgress).toHaveBeenCalledTimes(progressCountAtBoundaryRequest);
 
-      const lateResponse = jsonResponse(409, {
-        success: false,
-        error: "late Dedicated response",
-      });
+      const lateResponse =
+        stalledBoundary === "job"
+          ? jsonResponse(200, {
+              success: true,
+              data: { id: jobId, status: "completed" },
+            })
+          : jsonResponse(409, {
+              success: false,
+              error: "late Dedicated response",
+            });
       releaseLateRequest?.(lateResponse);
       releaseLateBody?.(await lateResponse.text());
       await Promise.resolve();
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(30_000);
-      expect(cutoverPosts).toBe(2);
+      expect(boundaryRequests).toBe(2);
+      expect(cutoverPosts).toBe(stalledBoundary === "cutover" ? 2 : 0);
       expect(onProgress).toHaveBeenCalledTimes(progressCountAtBoundaryRequest);
       expect(vi.getTimerCount()).toBe(0);
     },
@@ -2041,6 +2152,7 @@ describe("ensurePersonalDedicatedEliza", () => {
     vi.setSystemTime(0);
     const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
     const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+    const jobId = "10000000-0000-4000-8000-000000000020";
     const onProgress = vi.fn();
     let activationPosts = 0;
     let cutoverPosts = 0;
@@ -2090,7 +2202,7 @@ describe("ensurePersonalDedicatedEliza", () => {
             1_000,
             jsonResponse(202, {
               success: true,
-              data: { dedicatedAgentId },
+              data: { dedicatedAgentId, jobId },
             }),
           );
         }
@@ -2102,6 +2214,15 @@ describe("ensurePersonalDedicatedEliza", () => {
             success: false,
             code: "dedicated_adoption_unavailable",
           });
+        }
+        if (url.endsWith(`/api/v1/jobs/${jobId}`)) {
+          return await delayResponse(
+            1_000,
+            jsonResponse(200, {
+              success: true,
+              data: { id: jobId, status: "completed" },
+            }),
+          );
         }
         if (url.endsWith("/upgrade-tier/cutover")) {
           cutoverPosts += 1;

--- a/packages/ui/src/api/client-cloud-personal-shared.test.ts
+++ b/packages/ui/src/api/client-cloud-personal-shared.test.ts
@@ -344,8 +344,10 @@ describe("ensurePersonalDedicatedEliza", () => {
   it("creates one fresh Dedicated target without entering adoption and completes cutover", async () => {
     const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
     const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+    const jobId = "10000000-0000-4000-8000-000000000020";
     const dedicatedBase = `https://${dedicatedAgentId}.cloud.eliza.app`;
     let cutoverAttempts = 0;
+    const events: string[] = [];
     const fetchMock = vi.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
@@ -372,20 +374,34 @@ describe("ensurePersonalDedicatedEliza", () => {
           });
         }
         if (url.endsWith("/upgrade-tier") && init?.method === "POST") {
+          events.push("activation");
           expect(JSON.parse(String(init.body))).toEqual({
             action: "activate_dedicated",
             quoteId: "a".repeat(64),
           });
           return jsonResponse(202, {
             success: true,
-            data: { dedicatedAgentId },
+            data: { dedicatedAgentId, jobId },
+          });
+        }
+        if (url.endsWith(`/api/v1/jobs/${jobId}`)) {
+          events.push("job");
+          return jsonResponse(200, {
+            success: true,
+            data: { id: jobId, status: "completed" },
           });
         }
         if (url.endsWith("/upgrade-tier/cutover")) {
+          events.push("cutover");
           cutoverAttempts += 1;
           if (cutoverAttempts <= 3) {
             return jsonResponse([409, 423, 503][cutoverAttempts - 1] ?? 409, {
               success: false,
+              code: [
+                "dedicated_not_healthy",
+                "personal_reminder_cutover_in_progress",
+                "dedicated_history_import_failed",
+              ][cutoverAttempts - 1],
               error: "Dedicated is still provisioning",
             });
           }
@@ -423,6 +439,7 @@ describe("ensurePersonalDedicatedEliza", () => {
       runtime: "dedicated",
     });
     expect(cutoverAttempts).toBe(4);
+    expect(events.slice(0, 3)).toEqual(["activation", "job", "cutover"]);
     expect(
       fetchMock.mock.calls.filter(([url]) =>
         String(url).endsWith("/upgrade-tier/adopt-existing"),
@@ -436,6 +453,68 @@ describe("ensurePersonalDedicatedEliza", () => {
       "ready",
       "Connected to your Dedicated agent",
     );
+  });
+
+  it("does not retry cutover from HTTP status alone without a retryable response code", async () => {
+    const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
+    const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+    let cutoverAttempts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/eliza/personal")) {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              identity: {
+                id: personalElizaId,
+                displayName: "Eliza",
+                runtime: "shared",
+              },
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier") && init?.method === "GET") {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              quoteId: "a".repeat(64),
+              canActivate: true,
+              activation: { state: "available" },
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier") && init?.method === "POST") {
+          return jsonResponse(202, {
+            success: true,
+            data: { dedicatedAgentId },
+          });
+        }
+        if (url.endsWith("/upgrade-tier/cutover")) {
+          cutoverAttempts += 1;
+          return jsonResponse(409, {
+            success: false,
+            code: "dedicated_history_receipt_invalid",
+            error: "Dedicated history receipt is invalid.",
+          });
+        }
+        return jsonResponse(500, { error: `Unexpected URL ${url}` });
+      }),
+    );
+
+    await expect(
+      new ElizaClient().ensurePersonalDedicatedEliza({
+        cloudApiBase: "https://api.eliza.app",
+        authToken: "steward-token",
+        pollIntervalMs: 0,
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      data: { code: "dedicated_history_receipt_invalid" },
+    });
+    expect(cutoverAttempts).toBe(1);
   });
 
   it("adopts the selected existing Dedicated row after the create contract redirects it", async () => {
@@ -581,6 +660,239 @@ describe("ensurePersonalDedicatedEliza", () => {
       { url: "<personal>/upgrade-tier/adopt-existing", method: "POST" },
       { url: "<personal>/upgrade-tier/cutover", method: "POST" },
     ]);
+  });
+
+  it("polls an adopted target's provisioning job to completion before cutover", async () => {
+    const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
+    const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+    const jobId = "10000000-0000-4000-8000-000000000020";
+    const events: string[] = [];
+    let jobReads = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/eliza/personal")) {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              identity: {
+                id: personalElizaId,
+                displayName: "Eliza",
+                runtime: "shared",
+              },
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier") && init?.method === "GET") {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              quoteId: "a".repeat(64),
+              canActivate: true,
+              activation: { state: "available" },
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier") && init?.method === "POST") {
+          return jsonResponse(409, {
+            success: false,
+            code: "dedicated_adoption_selection_required",
+          });
+        }
+        if (
+          url.endsWith("/upgrade-tier/adopt-existing") &&
+          init?.method === "GET"
+        ) {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              quoteId: "b".repeat(64),
+              dedicatedAgentId,
+              adoptionState: "available",
+              status: "error",
+              startsCompute: true,
+              hourlyRateUsd: 0.01,
+              dailyRateUsd: 0.24,
+              minimumBalanceUsd: 0.72,
+              minimumRunwayDays: 3,
+              balanceUsd: 115.54,
+              deficitUsd: 0,
+              stateDisposition: "verified_backup_present",
+              canAdopt: true,
+              requiresCatalogRestore: false,
+              requiresConfirmation: true,
+              action: "adopt_existing_dedicated",
+            },
+          });
+        }
+        if (
+          url.endsWith("/upgrade-tier/adopt-existing") &&
+          init?.method === "POST"
+        ) {
+          events.push("adoption");
+          return jsonResponse(202, {
+            success: true,
+            data: {
+              dedicatedAgentId,
+              jobId,
+              status: "pending",
+              runtime: "dedicated_pending_cutover",
+            },
+          });
+        }
+        if (url.endsWith(`/api/v1/jobs/${jobId}`)) {
+          jobReads += 1;
+          events.push(`job:${jobReads}`);
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              id: jobId,
+              status: jobReads === 1 ? "pending" : "completed",
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier/cutover")) {
+          events.push("cutover");
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              personalElizaId,
+              activeAgentId: dedicatedAgentId,
+              runtime: "dedicated",
+              apiBase: `https://${dedicatedAgentId}.cloud.eliza.app`,
+              importedMessages: 0,
+            },
+          });
+        }
+        return jsonResponse(500, { error: `Unexpected URL ${url}` });
+      }),
+    );
+
+    await expect(
+      new ElizaClient().ensurePersonalDedicatedEliza({
+        cloudApiBase: "https://api.eliza.app",
+        authToken: "steward-token",
+        pollIntervalMs: 0,
+        timeoutMs: 1_000,
+        requestDedicatedAdoptionConfirmation: async (quote) => ({
+          action: "adopt_existing_dedicated",
+          quoteId: quote.quoteId,
+        }),
+      }),
+    ).resolves.toMatchObject({ activeAgentId: dedicatedAgentId });
+    expect(events).toEqual(["adoption", "job:1", "job:2", "cutover"]);
+  });
+
+  it("surfaces an adopted target's terminal provisioning error without cutover", async () => {
+    const personalElizaId = "personal:3b9e517b-5c33-5c5f-a6f9-f78c764dc41b";
+    const dedicatedAgentId = "00000000-0000-4000-8000-000000000020";
+    const jobId = "10000000-0000-4000-8000-000000000020";
+    let cutoverPosts = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/eliza/personal")) {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              identity: {
+                id: personalElizaId,
+                displayName: "Eliza",
+                runtime: "shared",
+              },
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier") && init?.method === "GET") {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              quoteId: "a".repeat(64),
+              canActivate: true,
+              activation: { state: "available" },
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier") && init?.method === "POST") {
+          return jsonResponse(409, {
+            success: false,
+            code: "dedicated_adoption_selection_required",
+          });
+        }
+        if (
+          url.endsWith("/upgrade-tier/adopt-existing") &&
+          init?.method === "GET"
+        ) {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              quoteId: "b".repeat(64),
+              dedicatedAgentId,
+              adoptionState: "available",
+              status: "error",
+              startsCompute: true,
+              hourlyRateUsd: 0.01,
+              dailyRateUsd: 0.24,
+              minimumBalanceUsd: 0.72,
+              minimumRunwayDays: 3,
+              balanceUsd: 115.54,
+              deficitUsd: 0,
+              stateDisposition: "verified_backup_present",
+              canAdopt: true,
+              requiresCatalogRestore: false,
+              requiresConfirmation: true,
+              action: "adopt_existing_dedicated",
+            },
+          });
+        }
+        if (
+          url.endsWith("/upgrade-tier/adopt-existing") &&
+          init?.method === "POST"
+        ) {
+          return jsonResponse(202, {
+            success: true,
+            data: {
+              dedicatedAgentId,
+              jobId,
+              status: "pending",
+              runtime: "dedicated_pending_cutover",
+            },
+          });
+        }
+        if (url.endsWith(`/api/v1/jobs/${jobId}`)) {
+          return jsonResponse(200, {
+            success: true,
+            data: {
+              id: jobId,
+              status: "failed",
+              error: "No healthy capacity is available.",
+            },
+          });
+        }
+        if (url.endsWith("/upgrade-tier/cutover")) cutoverPosts += 1;
+        return jsonResponse(500, { error: `Unexpected URL ${url}` });
+      }),
+    );
+
+    await expect(
+      new ElizaClient().ensurePersonalDedicatedEliza({
+        cloudApiBase: "https://api.eliza.app",
+        authToken: "steward-token",
+        pollIntervalMs: 0,
+        timeoutMs: 1_000,
+        requestDedicatedAdoptionConfirmation: async (quote) => ({
+          action: "adopt_existing_dedicated",
+          quoteId: quote.quoteId,
+        }),
+      }),
+    ).rejects.toMatchObject({
+      code: "CLOUD_DEDICATED_PROVISION_JOB_FAILED",
+      message:
+        "Your Dedicated agent failed to start: No healthy capacity is available.",
+    });
+    expect(cutoverPosts).toBe(0);
   });
 
   it("returns the current adoption quote without POSTing when visible confirmation is unavailable", async () => {
@@ -853,8 +1165,20 @@ describe("ensurePersonalDedicatedEliza", () => {
               created: false,
               data: {
                 dedicatedAgentId,
+                jobId: "10000000-0000-4000-8000-000000000020",
                 runtime: "dedicated_pending_cutover",
                 status: "queued",
+              },
+            });
+          }
+          if (
+            url.endsWith("/api/v1/jobs/10000000-0000-4000-8000-000000000020")
+          ) {
+            return jsonResponse(200, {
+              success: true,
+              data: {
+                id: "10000000-0000-4000-8000-000000000020",
+                status: "completed",
               },
             });
           }
@@ -992,8 +1316,20 @@ describe("ensurePersonalDedicatedEliza", () => {
               created: false,
               data: {
                 dedicatedAgentId,
+                jobId: "10000000-0000-4000-8000-000000000020",
                 runtime: "dedicated_pending_cutover",
                 status: "queued",
+              },
+            });
+          }
+          if (
+            url.endsWith("/api/v1/jobs/10000000-0000-4000-8000-000000000020")
+          ) {
+            return jsonResponse(200, {
+              success: true,
+              data: {
+                id: "10000000-0000-4000-8000-000000000020",
+                status: "completed",
               },
             });
           }
@@ -1183,14 +1519,14 @@ describe("ensurePersonalDedicatedEliza", () => {
                 [409, 423, 503][cutoverAttempts - 1] ?? 409,
                 {
                   success: false,
+                  code: [
+                    "dedicated_not_healthy",
+                    "personal_reminder_cutover_in_progress",
+                    "dedicated_history_import_failed",
+                  ][cutoverAttempts - 1],
                   error: "Dedicated is still provisioning",
                 },
               );
-              if (cutoverAttempts === 1) {
-                vi.spyOn(response, "text").mockRejectedValue(
-                  new Error("409 response body unavailable"),
-                );
-              }
               return response;
             }
             return jsonResponse(200, {
@@ -1464,6 +1800,7 @@ describe("ensurePersonalDedicatedEliza", () => {
           cutoverPosts += 1;
           const headersOnly = jsonResponse(409, {
             success: false,
+            code: "dedicated_not_healthy",
             error: "Dedicated is still provisioning",
           });
           vi.spyOn(headersOnly, "text").mockImplementation(
@@ -1503,7 +1840,7 @@ describe("ensurePersonalDedicatedEliza", () => {
   });
 
   it.each(["request", "body"] as const)(
-    "aborts a hung boundary cutover %s at exactly 360000ms without late work",
+    "aborts a hung boundary cutover %s at exactly 720000ms without late work",
     async (stalledPhase) => {
       vi.useFakeTimers();
       vi.setSystemTime(0);
@@ -1556,6 +1893,7 @@ describe("ensurePersonalDedicatedEliza", () => {
               }
               const headersOnly = jsonResponse(409, {
                 success: false,
+                code: "dedicated_not_healthy",
                 error: "Dedicated is still provisioning",
               });
               vi.spyOn(headersOnly, "text").mockImplementation(
@@ -1568,6 +1906,7 @@ describe("ensurePersonalDedicatedEliza", () => {
             }
             return jsonResponse(409, {
               success: false,
+              code: "dedicated_not_healthy",
               error: "Dedicated is still provisioning",
             });
           }
@@ -1581,7 +1920,7 @@ describe("ensurePersonalDedicatedEliza", () => {
           cloudApiBase: "https://api.eliza.app",
           authToken: "steward-token",
           onProgress,
-          pollIntervalMs: 359_999,
+          pollIntervalMs: 719_999,
         })
         .then(() => {
           outcome = "resolved";
@@ -1590,7 +1929,7 @@ describe("ensurePersonalDedicatedEliza", () => {
           outcome = error instanceof Error ? error : new Error(String(error));
         });
 
-      await vi.advanceTimersByTimeAsync(359_999);
+      await vi.advanceTimersByTimeAsync(719_999);
       expect(outcome).toBeUndefined();
       expect(cutoverPosts).toBe(2);
       const progressCountAtBoundaryRequest = onProgress.mock.calls.length;
@@ -1605,7 +1944,7 @@ describe("ensurePersonalDedicatedEliza", () => {
         message: "The startup deadline elapsed",
         name: "TimeoutError",
       });
-      expect(Date.now()).toBe(360_000);
+      expect(Date.now()).toBe(720_000);
       expect(cutoverPosts).toBe(2);
       expect(onProgress).toHaveBeenCalledTimes(progressCountAtBoundaryRequest);
 
@@ -1633,8 +1972,8 @@ describe("ensurePersonalDedicatedEliza", () => {
     vi.spyOn(Date, "now").mockImplementation(() => {
       nowReadCount += 1;
       if (nowReadCount === 1) return 0;
-      if (nowReadCount <= 11) return 359_999;
-      return 360_000;
+      if (nowReadCount <= 11) return 719_999;
+      return 720_000;
     });
     vi.stubGlobal(
       "fetch",
@@ -1673,6 +2012,7 @@ describe("ensurePersonalDedicatedEliza", () => {
           cutoverPosts += 1;
           return jsonResponse(409, {
             success: false,
+            code: "dedicated_not_healthy",
             error: "Dedicated is still provisioning",
           });
         }
@@ -1767,6 +2107,7 @@ describe("ensurePersonalDedicatedEliza", () => {
           cutoverPosts += 1;
           return jsonResponse(409, {
             success: false,
+            code: "dedicated_not_healthy",
             error: "Dedicated is still provisioning",
           });
         }
@@ -1789,7 +2130,7 @@ describe("ensurePersonalDedicatedEliza", () => {
         outcome = error instanceof Error ? error : new Error(String(error));
       });
 
-    await vi.advanceTimersByTimeAsync(359_999);
+    await vi.advanceTimersByTimeAsync(719_999);
     expect(outcome).toBeUndefined();
     expect(activationPosts).toBe(1);
     expect(cutoverPosts).toBeGreaterThan(0);
@@ -1798,7 +2139,7 @@ describe("ensurePersonalDedicatedEliza", () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await attempt;
-    expect(Date.now()).toBe(360_000);
+    expect(Date.now()).toBe(720_000);
     expect(outcome).toBeInstanceOf(Error);
     expect((outcome as Error).message).toContain(
       "did not become ready before the signed-in startup deadline",
@@ -1823,8 +2164,8 @@ describe("ensurePersonalDedicatedEliza", () => {
     vi.spyOn(Date, "now").mockImplementation(() => {
       nowReadCount += 1;
       if (nowReadCount === 1) return 0;
-      if (nowReadCount <= 11) return 359_999;
-      return 360_000;
+      if (nowReadCount <= 11) return 719_999;
+      return 720_000;
     });
     capacitorHttpRequestMock.mockImplementation(
       async ({ method, url }: { method: string; url: string }) => {
@@ -1894,9 +2235,9 @@ describe("ensurePersonalDedicatedEliza", () => {
       if (nowReadCount === 1) return 0;
       if (nowReadCount === 2) {
         controller.abort(abortReason);
-        return 359_999;
+        return 719_999;
       }
-      return 360_000;
+      return 720_000;
     });
     vi.stubGlobal(
       "fetch",

--- a/packages/ui/src/api/client-cloud-provision-wait-copy.test.ts
+++ b/packages/ui/src/api/client-cloud-provision-wait-copy.test.ts
@@ -51,7 +51,7 @@ describe("describeProvisioningWait", () => {
 
   it("advances to reassurance copy past the typical-wait threshold", () => {
     expect(describeProvisioningWait("in_progress", 25_000)).toContain(
-      "usually takes under a minute",
+      "cold start can take several minutes",
     );
     expect(describeProvisioningWait("queued", 25_000)).toContain(
       "Waiting for a sandbox slot",
@@ -66,6 +66,9 @@ describe("describeProvisioningWait", () => {
     );
     expect(describeProvisioningWait("in_progress", 61_000)).toContain(
       "about 60s in",
+    );
+    expect(describeProvisioningWait("in_progress", 61_000)).toContain(
+      "Cold starts can take several minutes",
     );
     expect(describeProvisioningWait("in_progress", 95_000)).toContain(
       "about 90s in",

--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -109,7 +109,7 @@ describe("waitForCloudAgentRunning — typed non-transient failures", () => {
     expect(wake.agentId).toBe("agent-1");
     expect(wake.message).toMatch(/HTTP 402/);
     expect(wake.message).toMatch(/about 30s/);
-    // Never fell through to the six-minute poll.
+    // Never fell through to the bounded cold-start poll.
     expect(client.getCloudCompatAgent).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3911,15 +3911,15 @@ export function describeProvisioningWait(
     // chat turn per unique status text, so a per-tick counter would spam a
     // new bubble every poll. A 30s step still visibly advances a long wait.
     const bucket = Math.floor(elapsedMs / 30_000) * 30;
-    return `Still working — about ${bucket}s in. Almost there…`;
+    return `Still working — about ${bucket}s in. Cold starts can take several minutes…`;
   }
   const active =
     normalizeCloudJobStatus(status) === "processing" ||
     normalizeCloudJobStatus(status) === "retrying";
   if (elapsedMs >= PROVISION_WAIT_REASSURE_MS) {
     return active
-      ? "Starting your agent — this usually takes under a minute…"
-      : "Waiting for a sandbox slot — this usually takes under a minute…";
+      ? "Starting your agent — a cold start can take several minutes…"
+      : "Waiting for a sandbox slot — this can take several minutes…";
   }
   return active
     ? "Starting your agent…"
@@ -3927,11 +3927,12 @@ export function describeProvisioningWait(
 }
 
 // Dedicated cold-boot wait defaults. A dedicated container cold-starts in
-// ~5 minutes (#8621, measured live 2026-06-19); the generic 202-retry budget in
+// ~5 minutes (#8621, measured live 2026-06-19), while the full supported image
+// pull plus health budget can approach 11 minutes. The generic retry budget in
 // client-base is only ~60 s, so the connect flow must wait on the control plane
 // instead of letting the first chat call exhaust that budget and error.
 const CLOUD_AGENT_WAKE_POLL_INTERVAL_MS = 5_000;
-const CLOUD_AGENT_WAKE_TIMEOUT_MS = 6 * 60_000;
+const CLOUD_AGENT_WAKE_TIMEOUT_MS = 12 * 60_000;
 const CLOUD_AGENT_FAILED_STATUSES = new Set([
   "error",
   "failed",
@@ -3944,7 +3945,7 @@ const CLOUD_AGENT_FAILED_STATUSES = new Set([
  * expiry (401/403), credit exhaustion (402), a deleted agent row (404), a
  * conflicting lifecycle operation (409), and a worker/capacity outage (503).
  * Continuing to poll cannot cure any of them — it only hides the real failure
- * behind the six-minute timeout (#18463). Transport failures without an HTTP
+ * behind the bounded startup timeout (#18463). Transport failures without an HTTP
  * status and explicit 408/429/500/502/504 churn stay transient: those are the
  * control plane asking for another attempt (a rate-limited or timed-out poll
  * tick says nothing about the wake itself), so the bounded poll remains the
@@ -4670,6 +4671,25 @@ export type DedicatedAdoptionConfirmationRequester = (
 const DEDICATED_ADOPTION_SELECTION_REQUIRED =
   "dedicated_adoption_selection_required";
 const DEDICATED_ADOPTION_QUOTE_CHANGED = "dedicated_adoption_quote_changed";
+const PERSONAL_DEDICATED_RETRYABLE_CUTOVER_CODES = new Set([
+  "shared_history_unavailable",
+  "personal_identity_convergence_in_progress",
+  "dedicated_not_healthy",
+  "dedicated_not_reachable",
+  "dedicated_transport_unavailable",
+  "personal_reminder_cutover_in_progress",
+  "dedicated_history_import_failed",
+  "shared_personal_snapshot_unstable",
+  "dedicated_reminder_activation_failed",
+]);
+const PERSONAL_DEDICATED_TRANSIENT_JOB_HTTP_STATUSES = new Set([
+  408, 429, 500, 502, 503, 504,
+]);
+
+interface PersonalDedicatedAdoptionTarget {
+  dedicatedAgentId: string;
+  jobId?: string;
+}
 
 function finiteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -4769,7 +4789,7 @@ async function adoptSelectedPersonalDedicatedEliza(
   upgradeUrl: string,
   options: EnsurePersonalDedicatedElizaOptions,
   deadline: number,
-): Promise<string | null> {
+): Promise<PersonalDedicatedAdoptionTarget | null> {
   const adoptionUrl = `${upgradeUrl}/adopt-existing`;
   const fetchCurrentQuote = async () => {
     throwIfDedicatedStartupDeadlineElapsed(deadline, options.signal);
@@ -4900,11 +4920,13 @@ async function adoptSelectedPersonalDedicatedEliza(
     }
     const adoption = recordOrNull(adoptionRoot?.data);
     const adoptedTargetId = firstString(adoption?.dedicatedAgentId);
+    const jobId = firstString(adoption?.jobId);
     if (
       !adoptionResponse.ok ||
       adoptionRoot?.success !== true ||
       !adoptedTargetId ||
-      adoption?.runtime !== "dedicated_pending_cutover"
+      adoption?.runtime !== "dedicated_pending_cutover" ||
+      (adoptionResponse.status === 202 && !jobId)
     ) {
       throw dedicatedAdoptionError({
         message: directCloudResponseErrorMessage(
@@ -4926,7 +4948,103 @@ async function adoptSelectedPersonalDedicatedEliza(
         },
       );
     }
-    return adoptedTargetId;
+    return {
+      dedicatedAgentId: adoptedTargetId,
+      ...(jobId ? { jobId } : {}),
+    };
+  }
+}
+
+function personalDedicatedCutoverCode(error: unknown): string | null {
+  if (!error || typeof error !== "object" || !("data" in error)) return null;
+  return (
+    directCloudErrorMetadata((error as { data?: unknown }).data).code ?? null
+  );
+}
+
+async function waitForPersonalDedicatedProvisionJob(
+  cloudApiBase: string,
+  authToken: string,
+  target: Required<PersonalDedicatedAdoptionTarget>,
+  options: EnsurePersonalDedicatedElizaOptions,
+  deadline: number,
+): Promise<void> {
+  const jobUrl = `${cloudApiBase}/api/v1/jobs/${encodeURIComponent(target.jobId)}`;
+  const intervalMs =
+    options.pollIntervalMs ?? CLOUD_AGENT_WAKE_POLL_INTERVAL_MS;
+  const startedAt = Date.now();
+  for (;;) {
+    throwIfDedicatedStartupDeadlineElapsed(deadline, options.signal);
+    const response = await directCloudJsonResponse<unknown>(jobUrl, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+      ...(options.signal ? { signal: options.signal } : {}),
+    });
+    throwIfDedicatedStartupDeadlineElapsed(deadline, options.signal);
+    const root = recordOrNull(response.data);
+    const job = recordOrNull(root?.data);
+    const jobId = firstString(job?.id);
+    const status = firstString(job?.status);
+    if (!response.ok || root?.success !== true) {
+      if (PERSONAL_DEDICATED_TRANSIENT_JOB_HTTP_STATUSES.has(response.status)) {
+        await abortableDelay(
+          Math.min(intervalMs, deadline - Date.now()),
+          options.signal,
+        );
+        continue;
+      }
+      throw Object.assign(
+        new Error(
+          directCloudResponseErrorMessage(response.status, response.data),
+        ),
+        { status: response.status, data: response.data, url: jobUrl },
+      );
+    }
+    if (jobId !== target.jobId || !status) {
+      throw new ElizaError(
+        "Eliza Cloud returned an invalid Dedicated provisioning job.",
+        {
+          code: "CLOUD_DEDICATED_PROVISION_JOB_INVALID",
+          context: { phase: "provision-job", field: "data" },
+        },
+      );
+    }
+    if (status === "completed") return;
+    if (status === "failed") {
+      const error = firstString(job?.error);
+      throw new ElizaError(
+        error
+          ? `Your Dedicated agent failed to start: ${error}`
+          : "Your Dedicated agent failed to start. Check its status in Eliza Cloud and try again.",
+        {
+          code: "CLOUD_DEDICATED_PROVISION_JOB_FAILED",
+          context: {
+            phase: "provision-job",
+            agentId: target.dedicatedAgentId,
+            jobId: target.jobId,
+          },
+        },
+      );
+    }
+    if (status !== "pending" && status !== "in_progress") {
+      throw new ElizaError(
+        "Eliza Cloud returned an unknown Dedicated provisioning job status.",
+        {
+          code: "CLOUD_DEDICATED_PROVISION_JOB_STATUS_UNKNOWN",
+          context: { phase: "provision-job", field: "status", status },
+        },
+      );
+    }
+    options.onProgress?.(
+      "starting",
+      describeProvisioningWait(status, Date.now() - startedAt),
+    );
+    await abortableDelay(
+      Math.min(intervalMs, deadline - Date.now()),
+      options.signal,
+    );
   }
 }
 
@@ -4989,6 +5107,7 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
   let quotedTargetId: string | null = null;
   let activationPostRequired = false;
   let dedicatedAgentId: string | null = null;
+  let provisioningJobId: string | null = null;
   if (activationState === "in_progress") {
     const existingTargetId = firstString(quoteActivation?.dedicatedAgentId);
     const existingTargetStatus = firstString(quoteActivation?.status);
@@ -5016,13 +5135,13 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
       // row without carrying its reviewed restore authority into the new job.
       // A 404 here means there is no selection receipt, so the ordinary
       // quote-bound activation path remains valid for that account.
-      const adoptedTargetId = await adoptSelectedPersonalDedicatedEliza(
+      const adoptedTarget = await adoptSelectedPersonalDedicatedEliza(
         upgradeUrl,
         options,
         deadline,
       );
-      if (adoptedTargetId) {
-        if (adoptedTargetId !== existingTargetId) {
+      if (adoptedTarget) {
+        if (adoptedTarget.dedicatedAgentId !== existingTargetId) {
           throw new ElizaError(
             "Eliza Cloud resumed a different Dedicated target than the quoted activation.",
             {
@@ -5031,7 +5150,8 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
             },
           );
         }
-        dedicatedAgentId = adoptedTargetId;
+        dedicatedAgentId = adoptedTarget.dedicatedAgentId;
+        provisioningJobId = adoptedTarget.jobId ?? null;
       } else {
         activationPostRequired = true;
       }
@@ -5074,6 +5194,7 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
     const activationRoot = recordOrNull(activationResponse.data);
     const activation = recordOrNull(activationRoot?.data);
     let activatedTargetId = firstString(activation?.dedicatedAgentId);
+    const activatedJobId = firstString(activation?.jobId);
     const activationCode = directCloudErrorMetadata(
       activationResponse.data,
     ).code;
@@ -5082,12 +5203,14 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
       activationRoot?.success === false &&
       activationCode === DEDICATED_ADOPTION_SELECTION_REQUIRED;
     if (adoptionRequired) {
-      activatedTargetId = await adoptSelectedPersonalDedicatedEliza(
+      const adoptedTarget = await adoptSelectedPersonalDedicatedEliza(
         upgradeUrl,
         options,
         deadline,
       );
-      if (!activatedTargetId) {
+      activatedTargetId = adoptedTarget?.dedicatedAgentId ?? null;
+      provisioningJobId = adoptedTarget?.jobId ?? null;
+      if (!adoptedTarget) {
         throw new ElizaError(
           "Eliza Cloud required an existing-row adoption but no selected target was available.",
           {
@@ -5126,10 +5249,21 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
       );
     }
     dedicatedAgentId = activatedTargetId;
+    if (activatedJobId) provisioningJobId = activatedJobId;
   }
   if (!dedicatedAgentId) {
     throw new Error(
       "Eliza Cloud did not resolve a Dedicated activation target.",
+    );
+  }
+
+  if (provisioningJobId) {
+    await waitForPersonalDedicatedProvisionJob(
+      cloudApiBase,
+      options.authToken,
+      { dedicatedAgentId, jobId: provisioningJobId },
+      options,
+      deadline,
     );
   }
 
@@ -5163,11 +5297,10 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
     } catch (error) {
       options.signal?.throwIfAborted();
       if (Date.now() >= deadline) throw error;
-      const status =
-        error && typeof error === "object" && "status" in error
-          ? (error as { status?: unknown }).status
-          : null;
-      if (status !== 409 && status !== 423 && status !== 503) throw error;
+      const code = personalDedicatedCutoverCode(error);
+      if (!code || !PERSONAL_DEDICATED_RETRYABLE_CUTOVER_CODES.has(code)) {
+        throw error;
+      }
       options.onProgress?.(
         "starting",
         "Your Dedicated agent is still starting…",

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -5249,7 +5249,20 @@ async function ensurePersonalDedicatedElizaWithinDeadline(
       );
     }
     dedicatedAgentId = activatedTargetId;
-    if (activatedJobId) provisioningJobId = activatedJobId;
+    if (
+      !adoptionRequired &&
+      activationResponse.status === 202 &&
+      !activatedJobId
+    ) {
+      throw new ElizaError(
+        "Eliza Cloud accepted Dedicated activation without a provisioning job.",
+        {
+          code: "CLOUD_DEDICATED_PROVISION_JOB_INVALID",
+          context: { phase: "activation", field: "jobId" },
+        },
+      );
+    }
+    if (!adoptionRequired && activatedJobId) provisioningJobId = activatedJobId;
   }
   if (!dedicatedAgentId) {
     throw new Error(

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -2870,7 +2870,7 @@ describe("bounded cloud sign-in wait (#19255)", () => {
 
     // The OAuth-only deadline must not govern this already-authenticated
     // Personal/Dedicated activation. Its own client contract owns the longer
-    // six-minute bound.
+    // bounded cold-start window.
     await act(async () => vi.advanceTimersByTimeAsync(90_000));
     expect(signalA?.aborted).toBe(false);
     expect(turn("first-run:cloud-login-waiting")?.text).not.toContain(


### PR DESCRIPTION
Dedicated activation now waits for its provisioning job before cutting over to the new backend. Fresh activation requires a nonempty job ID, adoption retains its own job identity, and terminal failures stop the transition with an actionable error. Pending work and response-body reads share an absolute deadline.

Worker provisioning nudges are retained through `executionCtx.waitUntil`; hosts without that context await the work. Shared history that is still warming returns a retryable `503 shared_history_unavailable`. Exact auth-token and pending-greetings bootstrap routes avoid unrelated initialization. Privacy-safe cutover diagnostics retain the latest machine code and status.

Relates to #30559. The independent staging Stripe catalog gap remains tracked in #30565.

## Verification

Reviewed head: `e18109441162fc68334f772cbb3d60e4153201a2`, rebased on `aba2fffd930f5ec256fe61cebc67457be9e69708` with a clean install. Final root verification passed all 376 tasks and all repository audits. [The exact-head hosted run passed all five checks](https://github.com/elizaOS/eliza/actions/runs/33942168176).

- Focused cutover API: 19 tests / 188 assertions; UI client: 64 tests; authorization/nudge: 54 tests / 181 assertions; adoption integration: 29 tests / 203 assertions; continuity: 31 tests. Removing the nudge-retention repair makes its regression fail.
- App scripts: 948 passed, 2 skipped. The shared host required a 120-second test harness limit for four unchanged timing-sensitive cases; production deadlines were not changed for that run.
- `audit:app`: 219 passed, 216 captures inspected by the audit, no computed broken or needs-work verdicts. Affected desktop/mobile rest and hover captures were reviewed.
- Startup renderer fixtures: all four viewport/entry cases passed. The final comparison rebuilt and ran the two mobile/desktop cases on both the base and final head; both revisions passed those cases. [Comparison receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-renderer-comparison.json).

## Reviewed renderer evidence

These captures use the real renderer with scripted HTTP and assistant fixtures. The visible JSON assistant response is fixture output. They prove the UI flow and preserve the existing layout; they do not establish deployed provisioning or live model success.

| View | Before (`aba2fffd`) | After (`e1810944`) | Final walkthrough |
| --- | --- | --- | --- |
| Mobile | ![Before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-before-mobile-aba2fffd.jpg) | ![After mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-final-head-mobile-e1810944.jpg) | [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-final-head-mobile-e1810944.mp4) |
| Desktop | ![Before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-before-desktop-aba2fffd.jpg) | ![After desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-final-head-desktop-e1810944.jpg) | [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-final-head-desktop-e1810944.mp4) |

[Final renderer console and network receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30567-final-renderer-console-network.json) retains every console event and API request method/path/status from the two final traces. Both viewports reached `ready`; neither recorded a console error. Query strings, request bodies, and headers are excluded from this public diagnostic receipt. Backend and live-model logs are not applicable to the scripted renderer run and remain required for deployed acceptance below.

## Deployed acceptance

The canonical Cloudflare staging workflow accepts `develop`, so deployed acceptance follows the merge. Deploy the exact merged revision with the coordinated worker rollout, run the renderer-enabled frontend receipt, inspect structured Cloudflare logs, and repeat direct-Cerebras versus gateway latency certification. Keep #30559 open until that proof is attached. The read-only personal Cloud check available during this review returned 401; no provisioning job was created from it. #30600 also repairs worker-before-renderer deployment ordering and must be coordinated with this staging run.
