### PR TITLE
fix(ci): classify staging provisioning worker timeouts

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -535,7 +535,74 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Validate provision diagnostic contract
-        run: bun test packages/cloud/scripts/admin/managed-dedicated-provision-diagnostic.test.ts
+        run: >-
+          bun test
+          packages/cloud/scripts/admin/managed-dedicated-provision-diagnostic.test.ts
+          packages/scripts/__tests__/staging-worker-journal-diagnostic.test.ts
+
+      - name: Classify recent provisioning worker failures
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+          username: deploy
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+          command_timeout: 2m
+          script: |
+            set -euo pipefail
+            sudo journalctl -u eliza-provisioning-worker.service --since '2 hours ago' -o json --no-pager | python3 -c '
+            import collections, json, re, sys
+            patterns = {
+                "sandbox_health_timeout": r"Sandbox health check timed out",
+                "sandbox_creation_timeout": r"Sandbox creation failed:.*(?:timed out|timeout)",
+                "database_provision_failed": r"Database provisioning failed:",
+                "environment_decryption_failed": r"Environment decryption failed:",
+                "ssh_command_timeout": r"\[docker-ssh\] Command timed out",
+                "ssh_connect_timeout": r"(?:SSH|connection|connect).*timed out",
+                "docker_health_timeout": r"Docker health check timed out",
+                "tailnet_health_timeout": r"Tailnet health check timed out",
+                "vpn_registration_timeout": r"VPN registration timeout",
+                "registration_unresolved": r"Headscale registration did not reach an exact observable completion",
+                "job_watchdog_timeout": r"Execution timed out; retaining ownership until quiescent",
+                "image_pull_failed": r"Image pull failed",
+                "image_pull_completed": r"Image pulled successfully",
+                "docker_capacity_unavailable": r"No (?:reachable )?Docker capacity",
+                "container_daemon_unavailable": r"Cannot connect to the Docker daemon|docker_daemon_unavailable",
+                "container_created": r"\[docker-sandbox\] Created container",
+                "provision_failed": r"agent_provision failed",
+                "provision_completed": r"agent_provision completed",
+                "runtime_module_resolution": r"Cannot find (?:package|module)|ERR_MODULE_NOT_FOUND",
+                "runtime_out_of_memory": r"heap out of memory|Out of memory|OOMKilled",
+                "runtime_database_unavailable": r"database.*(?:unavailable|connection refused|timeout)",
+                "remote_command_timeout": r"remote_command_timeout",
+                "unclassified_timeout": r"timed out|timeout|ETIMEDOUT",
+            }
+            patterns = {key: re.compile(value, re.I) for key, value in patterns.items()}
+            counts = collections.Counter()
+            durations = collections.Counter()
+            functions = collections.Counter()
+            allowed_functions = (
+                "executeJob", "provision", "create", "checkHealthDetailed", "checkHealth",
+                "ensureDatabase", "mintAgentToken", "ensureImage", "prepareRuntime",
+                "withTimeout", "fetch", "exec", "connect", "ensureAgentDatabase",
+            )
+            records = 0
+            for line in sys.stdin:
+                entry = json.loads(line)
+                message = entry["MESSAGE"]
+                if not isinstance(message, str):
+                    raise ValueError("Journal message is not text")
+                records += 1
+                for key, pattern in patterns.items():
+                    if pattern.search(message):
+                        counts[key] += 1
+                if patterns["unclassified_timeout"].search(message):
+                    for value in re.findall(r"timed out after ([0-9]{1,8})ms", message):
+                        durations[value] += 1
+                    for name in allowed_functions:
+                        if re.search(r"\bat (?:[A-Za-z0-9_]+\.)?" + name + r"\s*\(", message):
+                            functions[name] += 1
+            print(json.dumps({"schemaVersion": 1, "scope": "staging-worker-two-hours", "records": records, "signals": dict(counts), "timeoutDurationsMs": dict(durations), "timeoutFunctions": dict(functions)}, sort_keys=True))
+            '
 
       - name: Classify exact canary journal by suffix
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2

--- a/packages/scripts/__tests__/staging-worker-journal-diagnostic.test.ts
+++ b/packages/scripts/__tests__/staging-worker-journal-diagnostic.test.ts
@@ -1,0 +1,65 @@
+/** Exercises the hosted journal classifier with private log records and invalid input. */
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const workflow = Bun.YAML.parse(
+  readFileSync(
+    new URL("../../../.github/workflows/live-smoke.yml", import.meta.url),
+    "utf8",
+  ),
+) as {
+  jobs: Record<
+    string,
+    { steps: { name?: string; with?: { script?: string } }[] }
+  >;
+};
+const script = workflow.jobs["dedicated-diagnostic"].steps.find(
+  (step) => step.name === "Classify recent provisioning worker failures",
+)?.with?.script;
+if (!script) throw new Error("Missing hosted journal classifier");
+const python = script.split("python3 -c '\n")[1]?.replace(/'\s*$/, "");
+if (!python) throw new Error("Missing executable Python classifier");
+
+function classify(input: string) {
+  return spawnSync("python3", ["-c", python], { input, encoding: "utf8" });
+}
+
+test("identifies timeout phase without emitting private journal content", () => {
+  const messages = [
+    "[docker-sandbox] Image pulled successfully on private-node.example",
+    "Sandbox creation failed: [docker-ssh] Command timed out after 60000ms: PRIVATE_CREDENTIAL\n    at DockerSSHClient.exec (/private/path.ts:1:2)",
+    "Sandbox health check timed out\n    at ElizaSandboxService.provision (/private/other.ts:9:1)",
+    "user prompt: PRIVATE_USER_TEXT",
+  ];
+  const result = classify(
+    messages
+      .map((MESSAGE) => JSON.stringify({ MESSAGE, _HOSTNAME: "private-host" }))
+      .join("\n"),
+  );
+  expect(result.status).toBe(0);
+  const report = JSON.parse(result.stdout);
+  expect(report.signals.sandbox_creation_timeout).toBe(1);
+  expect(report.signals.sandbox_health_timeout).toBe(1);
+  expect(report.signals.ssh_command_timeout).toBe(1);
+  expect(report.timeoutDurationsMs["60000"]).toBe(1);
+  expect(report.timeoutFunctions).toEqual({ exec: 1, provision: 1 });
+  expect(result.stdout).not.toMatch(
+    /PRIVATE|private[-/.]|credential|user prompt/i,
+  );
+});
+
+test("distinguishes empty journal from an unreadable journal", () => {
+  const empty = classify("");
+  expect(empty.status).toBe(0);
+  expect(JSON.parse(empty.stdout)).toMatchObject({ records: 0, signals: {} });
+  for (const input of [
+    "invalid json",
+    JSON.stringify({ MESSAGE: ["PRIVATE_TEXT"] }),
+  ]) {
+    const invalid = classify(input);
+    expect(invalid.status).not.toBe(0);
+    expect(invalid.stdout).toBe("");
+    expect(invalid.stderr).not.toContain("PRIVATE_TEXT");
+  }
+});


### PR DESCRIPTION
The staging renderer reaches an activated Dedicated target whose provisioning jobs fail with a generic timeout. The existing canary diagnostic cannot distinguish that failure from image, SSH, runtime-health, and execution-watchdog failures elsewhere in the staging worker.

Extend the existing read-only staging diagnostic with an on-host journal classifier. It emits only closed signal names, numeric timeout durations, and allowlisted stack-function names. Raw journal messages, credentials, hostnames, agent identifiers, and user content remain on the host. No provisioning, cleanup, restart, or deployment action is added.

Validation: the actual embedded Python classifier passes mixed private-record, empty-journal, and malformed-input tests; focused diagnostics pass 8/8; Biome, actionlint, and diff checks pass; `bun install` and root `bun run verify` pass (376/376 tasks). The protected hosted diagnostic will provide the live timeout evidence after merge.

Refs #30552.
