### PR TITLE
fix(ci): report activated staging job timeout origin

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -863,6 +863,61 @@ jobs:
             "$CANARY_DIAGNOSTIC_RAW_PATH" \
             "$CANARY_DIAGNOSTIC_EVIDENCE_PATH"
 
+      - name: Diagnose activated target job origin
+        shell: bash
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
+          PGOPTIONS: -c default_transaction_read_only=on -c statement_timeout=20000
+        run: |
+          set -euo pipefail
+          PSQL_DATABASE_URL="$(bun packages/cloud/scripts/admin/libpq-connection-url.ts)"
+          echo "::add-mask::$PSQL_DATABASE_URL"
+          psql "$PSQL_DATABASE_URL" --no-psqlrc --no-align --tuples-only --quiet \
+            --set ON_ERROR_STOP=1 --set suffix="$CANARY_DIAGNOSTIC_SUFFIX" <<'SQL'
+          BEGIN READ ONLY;
+          SET LOCAL statement_timeout = '20s';
+          WITH canary AS (
+            SELECT organization_id, user_id FROM agent_sandboxes
+            WHERE agent_name = 'managed-dedicated-canary-' || :'suffix'
+          ), target AS (
+            SELECT agent.id, agent.organization_id, agent.user_id
+            FROM canary
+            JOIN personal_dedicated_upgrade_authorities AS authority
+              ON authority.organization_id = canary.organization_id AND authority.user_id = canary.user_id
+            JOIN agent_sandboxes AS agent
+              ON agent.id = authority.dedicated_agent_id
+              AND agent.organization_id = authority.organization_id AND agent.user_id = authority.user_id
+            WHERE (SELECT count(*) FROM canary) = 1
+          ), latest_job AS (
+            SELECT job.* FROM target
+            JOIN jobs AS job ON job.agent_id = target.id::text
+              AND job.organization_id = target.organization_id AND job.user_id = target.user_id
+            WHERE job.type = 'agent_provision' AND (SELECT count(*) FROM target) = 1
+            ORDER BY job.created_at DESC, job.id DESC LIMIT 1
+          )
+          SELECT json_build_object(
+            'kind', 'activated-target-job-origin',
+            'canaryCount', (SELECT count(*) FROM canary),
+            'targetCount', (SELECT count(*) FROM target),
+            'jobCount', (SELECT count(*) FROM latest_job),
+            'startedAt', (SELECT started_at FROM latest_job),
+            'updatedAt', (SELECT updated_at FROM latest_job),
+            'attempts', (SELECT attempts FROM latest_job),
+            'errorStoredExternally', (SELECT error_storage IS NOT NULL FROM latest_job),
+            'errorTerms', ARRAY(
+              SELECT DISTINCT term[1] FROM latest_job,
+                regexp_matches(lower(error), '\m(timeout|timed|query|connection|connect|handshake|socket|pool|database|postgres|acquire|client|read|write|fetch|abort|aborted|operation|exceeded|trying|response|request|statement|health|sandbox|docker|ssh|vpn|headscale|backup|restore|revocation|lock|lease|body|headers|control|preflight|capacity|admission|fence|econnreset|etimedout|econnrefused)\M', 'g') AS term
+              ORDER BY term[1]
+            ),
+            'stackModules', ARRAY(
+              SELECT DISTINCT module[1] FROM latest_job,
+                regexp_matches(error, '(pg-pool/index\.js|pg/lib/client\.js|postgres/src/connection\.js|docker-ssh-client\.ts|eliza-sandbox\.ts|provisioning-jobs\.ts|managed-eliza-config\.ts|with-timeout\.ts|agent-env-crypto\.ts|agent-tier-upgrade-target\.ts)', 'g') AS module
+              ORDER BY module[1]
+            )
+          );
+          COMMIT;
+          SQL
+
       - name: Summarize replacement cleanup reconciliation eligibility
         id: cleanup_reconciliation
         shell: bash

--- a/packages/scripts/__tests__/staging-activation-job-origin.test.ts
+++ b/packages/scripts/__tests__/staging-activation-job-origin.test.ts
@@ -1,0 +1,82 @@
+/** Exercises the protected diagnostic SQL against PostgreSQL with competing tenant records. */
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { PGlite } from "@electric-sql/pglite";
+
+const workflow = Bun.YAML.parse(
+  readFileSync(
+    new URL("../../../.github/workflows/live-smoke.yml", import.meta.url),
+    "utf8",
+  ),
+) as { jobs: Record<string, { steps: { name?: string; run?: string }[] }> };
+const step = workflow.jobs["dedicated-diagnostic"].steps.find(
+  (candidate) => candidate.name === "Diagnose activated target job origin",
+);
+const source = step?.run?.match(/WITH canary AS \([\s\S]+?(?=COMMIT;)/)?.[0];
+if (!source) throw new Error("Missing hosted activation origin query");
+const query = source.replace(":'suffix'", "$1");
+
+test("reads only the bound owner's latest provision error and emits closed terms", async () => {
+  const db = new PGlite();
+  try {
+    await db.exec(`
+      CREATE TABLE agent_sandboxes (id text, agent_name text, organization_id text, user_id text);
+      CREATE TABLE personal_dedicated_upgrade_authorities (dedicated_agent_id text, organization_id text, user_id text);
+      CREATE TABLE jobs (id text, agent_id text, organization_id text, user_id text, type text,
+        created_at timestamp, started_at timestamp, updated_at timestamp, attempts integer, error text, error_storage jsonb);
+      INSERT INTO agent_sandboxes VALUES
+        ('canary', 'managed-dedicated-canary-r33717318238a1', 'owner-org', 'owner-user'),
+        ('target', 'personal', 'owner-org', 'owner-user'),
+        ('foreign', 'personal', 'foreign-org', 'owner-user');
+      INSERT INTO personal_dedicated_upgrade_authorities VALUES
+        ('target', 'owner-org', 'owner-user'), ('foreign', 'foreign-org', 'owner-user');
+      INSERT INTO jobs VALUES
+        ('older', 'target', 'owner-org', 'owner-user', 'agent_provision', '2026-09-01', null, '2026-09-01', 1, 'Docker health timeout', null),
+        ('foreign', 'target', 'foreign-org', 'owner-user', 'agent_provision', '2026-09-05', null, '2026-09-05', 1, 'SSH timeout', null),
+        ('other-user', 'target', 'owner-org', 'other-user', 'agent_provision', '2026-09-05', null, '2026-09-05', 1, 'Headscale timeout', null);
+    `);
+    await db.query(
+      "INSERT INTO jobs VALUES ('current', 'target', 'owner-org', 'owner-user', 'agent_provision', '2026-09-04', '2026-09-04', '2026-09-04', 3, $1, null)",
+      [
+        "timeout exceeded when trying to connect PRIVATE_CREDENTIAL https://private.example\n at /private/path/pg-pool/index.js:45:1",
+      ],
+    );
+    const result = await db.query<{
+      json_build_object: Record<string, unknown>;
+    }>(query, ["r33717318238a1"]);
+    const report = result.rows[0].json_build_object;
+    expect(report).toMatchObject({
+      targetCount: 1,
+      jobCount: 1,
+      attempts: 3,
+      errorTerms: ["connect", "exceeded", "pool", "timeout", "trying"],
+      stackModules: ["pg-pool/index.js"],
+    });
+    expect(JSON.stringify(report)).not.toMatch(
+      /PRIVATE|private\.example|owner-org|owner-user|foreign|other-user/,
+    );
+
+    await db.exec(
+      "INSERT INTO agent_sandboxes VALUES ('duplicate', 'managed-dedicated-canary-r33717318238a1', 'foreign-org', 'owner-user')",
+    );
+    const ambiguous = await db.query<{
+      json_build_object: Record<string, unknown>;
+    }>(query, ["r33717318238a1"]);
+    expect(ambiguous.rows[0].json_build_object).toMatchObject({
+      canaryCount: 2,
+      targetCount: 0,
+      jobCount: 0,
+      errorTerms: [],
+    });
+    const missing = await db.query<{
+      json_build_object: Record<string, unknown>;
+    }>(query, ["missing"]);
+    expect(missing.rows[0].json_build_object).toMatchObject({
+      canaryCount: 0,
+      targetCount: 0,
+      jobCount: 0,
+    });
+  } finally {
+    await db.close();
+  }
+});


### PR DESCRIPTION
The activated staging agent's provisioning failures are persisted in `jobs.error`, while the worker journal omits ordinary job failures. The existing coarse diagnostic reports only `timeout`, so the journal classifier alone cannot locate this failure.

Add a read-only query to the existing staging diagnostic. It resolves the exact canary owner, follows that owner's Dedicated activation receipt, and reads only the latest provisioning job belonging to the same organization and user. Its output contains counts, timestamps, attempts, storage presence, and allowlisted error terms and source module names. No raw error, identifier, address, credential, or user content is emitted. Missing or ambiguous ownership produces explicit zero target/job counts.

Validation: the actual SQL passes PostgreSQL/PGlite execution with competing organizations, competing users, older jobs, missing targets, duplicate canaries, and private error text. Focused diagnostics pass 9/9; Biome, actionlint, and diff checks pass; `bun install` and root `bun run verify` pass (376/376 tasks). Live output remains to be collected through the protected staging workflow after merge.

Refs #30552.
