### PR TITLE
fix(auth): validate OpenAI Codex OAuth token responses

### DIFF
--- a/packages/auth/src/openai-codex-transport.test.ts
+++ b/packages/auth/src/openai-codex-transport.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Exercises OAuth rejection cleanup through real Node HTTP and Fetch responses.
+ * Only endpoint routing is replaced; provider bodies must be released before the
+ * caller receives failure so repeated login attempts do not retain transport resources.
+ */
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  exchangeAuthorizationCode,
+  refreshOpenAICodexToken,
+} from "./vendor/pi-oauth/openai-codex-login.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("OpenAI Codex rejected response lifecycle", () => {
+  it.each(["exchange", "refresh"] as const)(
+    "releases each rejected %s response before another attempt",
+    async (mode) => {
+      let requests = 0;
+      const server = createServer((request, response) => {
+        request.resume();
+        requests += 1;
+        response.writeHead(400, { "content-type": "text/plain" });
+        response.end("synthetic-provider-error".repeat(16_384));
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("HTTP fixture did not bind a TCP port");
+      }
+      const realFetch = globalThis.fetch;
+      const responses: Response[] = [];
+      vi.stubGlobal("fetch", async (_input: unknown, init?: RequestInit) => {
+        const response = await realFetch(
+          `http://127.0.0.1:${address.port}/oauth/token`,
+          { ...init, signal: AbortSignal.timeout(5_000) },
+        );
+        responses.push(response);
+        return response;
+      });
+
+      try {
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          if (mode === "exchange") {
+            await expect(
+              exchangeAuthorizationCode("synthetic-code", "synthetic-verifier"),
+            ).resolves.toMatchObject({ type: "failed" });
+          } else {
+            await expect(
+              refreshOpenAICodexToken("synthetic-refresh"),
+            ).rejects.toThrow("Failed to refresh OpenAI Codex token");
+          }
+          const response = responses[attempt];
+          expect(response.bodyUsed).toBe(true);
+          const reader = response.body?.getReader();
+          if (!reader) throw new Error("HTTP fixture response has no body");
+          await expect(reader.read()).resolves.toEqual({
+            done: true,
+            value: undefined,
+          });
+          reader.releaseLock();
+        }
+        expect(requests).toBe(2);
+      } finally {
+        vi.unstubAllGlobals();
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+});

--- a/packages/auth/src/vendor/pi-oauth/openai-codex-login.test.ts
+++ b/packages/auth/src/vendor/pi-oauth/openai-codex-login.test.ts
@@ -1,5 +1,11 @@
+/** Verifies OpenAI Codex OAuth exchange and refresh validation with mocked Fetch and real Response objects. */
+
+import { logger } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { refreshOpenAICodexToken } from "./openai-codex-login.ts";
+import {
+  exchangeAuthorizationCode,
+  refreshOpenAICodexToken,
+} from "./openai-codex-login.ts";
 
 /** Unsigned JWT carrying the chatgpt_account_id claim getAccountId reads. */
 function fakeAccessToken(accountId = "acct-123"): string {
@@ -14,17 +20,37 @@ function fakeAccessToken(accountId = "acct-123"): string {
 function mockTokenResponse(body: unknown, ok = true): void {
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => ({
-      ok,
-      json: async () => body,
-      text: async () => JSON.stringify(body),
-    })),
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: ok ? 200 : 400,
+          headers: { "content-type": "application/json" },
+        }),
+    ),
   );
+}
+
+function mockRawTokenResponse(body: string): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ),
+  );
+}
+
+async function exchangeMockedAuthorizationCode() {
+  return exchangeAuthorizationCode("code", "verifier");
 }
 
 describe("refreshOpenAICodexToken", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("returns rotated refresh token, accountId, and id_token from the response", async () => {
@@ -41,20 +67,194 @@ describe("refreshOpenAICodexToken", () => {
     expect(creds.expires).toBeGreaterThan(Date.now());
   });
 
-  it("keeps the current refresh token when the response omits refresh_token (RFC 6749 §6)", async () => {
-    mockTokenResponse({
-      access_token: fakeAccessToken(),
-      expires_in: 3600,
-    });
+  it.each([
+    ["omitted", { access_token: fakeAccessToken(), expires_in: 3600 }],
+    [
+      "null",
+      {
+        access_token: fakeAccessToken(),
+        refresh_token: null,
+        expires_in: 3600,
+      },
+    ],
+  ])("keeps the current refresh token when refresh_token is %s", async (_name, body) => {
+    mockTokenResponse(body);
     const creds = await refreshOpenAICodexToken("rt-old");
     expect(creds.refresh).toBe("rt-old");
     expect(creds.access).toBe(fakeAccessToken());
   });
 
-  it("fails when the response lacks an access token", async () => {
-    mockTokenResponse({ refresh_token: "rt-new", expires_in: 3600 });
+  it.each([
+    ["null", null],
+    ["empty", ""],
+  ])("accepts an %s optional id_token without returning it", async (_name, idToken) => {
+    mockTokenResponse({
+      access_token: fakeAccessToken(),
+      expires_in: 3600,
+      id_token: idToken,
+    });
+    const creds = await refreshOpenAICodexToken("rt-old");
+    expect(creds.idToken).toBeUndefined();
+  });
+
+  it.each([
+    ["non-object root", null],
+    ["missing access token", { refresh_token: "rt-new", expires_in: 3600 }],
+    ["numeric access token", { access_token: 7, expires_in: 3600 }],
+    [
+      "numeric rotated refresh token",
+      { access_token: fakeAccessToken(), refresh_token: 7, expires_in: 3600 },
+    ],
+    [
+      "blank rotated refresh token",
+      { access_token: fakeAccessToken(), refresh_token: " ", expires_in: 3600 },
+    ],
+    ["zero lifetime", { access_token: fakeAccessToken(), expires_in: 0 }],
+    ["negative lifetime", { access_token: fakeAccessToken(), expires_in: -1 }],
+    ["null lifetime", { access_token: fakeAccessToken(), expires_in: null }],
+    [
+      "overflowing lifetime",
+      { access_token: fakeAccessToken(), expires_in: 1e308 },
+    ],
+    [
+      "numeric id token",
+      { access_token: fakeAccessToken(), expires_in: 3600, id_token: 7 },
+    ],
+  ])("fails a successful response with %s", async (_name, body) => {
+    mockTokenResponse(body);
     await expect(refreshOpenAICodexToken("rt-old")).rejects.toThrow(
       /Failed to refresh OpenAI Codex token/,
     );
+  });
+
+  it("fails JSON numeric overflow before constructing credentials", async () => {
+    mockRawTokenResponse(
+      `{"access_token":${JSON.stringify(fakeAccessToken())},"expires_in":1e400}`,
+    );
+    await expect(refreshOpenAICodexToken("rt-old")).rejects.toThrow(
+      /Failed to refresh OpenAI Codex token/,
+    );
+  });
+
+  it("fails malformed successful JSON", async () => {
+    mockRawTokenResponse("{not-json");
+    await expect(refreshOpenAICodexToken("rt-old")).rejects.toThrow(
+      /Failed to refresh OpenAI Codex token/,
+    );
+  });
+
+  it("does not pass token values to diagnostics for an invalid response", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockTokenResponse({
+      refresh_token: "refresh-secret-value",
+      expires_in: 3600,
+      id_token: "identity-secret-value",
+    });
+    await expect(refreshOpenAICodexToken("rt-old")).rejects.toThrow(
+      /Failed to refresh OpenAI Codex token/,
+    );
+    const diagnosticArguments = JSON.stringify(errorSpy.mock.calls);
+    expect(diagnosticArguments).not.toContain("refresh-secret-value");
+    expect(diagnosticArguments).not.toContain("identity-secret-value");
+  });
+
+  it("does not pass a non-success response body to diagnostics", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockTokenResponse(
+      {
+        access_token: "access-secret-value",
+        refresh_token: "refresh-secret-value",
+      },
+      false,
+    );
+    await expect(refreshOpenAICodexToken("rt-old")).rejects.toThrow(
+      /Failed to refresh OpenAI Codex token/,
+    );
+    const diagnosticArguments = JSON.stringify(errorSpy.mock.calls);
+    expect(diagnosticArguments).not.toContain("access-secret-value");
+    expect(diagnosticArguments).not.toContain("refresh-secret-value");
+  });
+});
+
+describe("OpenAI Codex authorization exchange", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns complete credentials for a valid token response", async () => {
+    mockTokenResponse({
+      access_token: fakeAccessToken(),
+      refresh_token: "rt-exchange",
+      expires_in: 3600,
+      id_token: "idt-exchange",
+    });
+    const result = await exchangeMockedAuthorizationCode();
+    expect(result).toMatchObject({
+      type: "success",
+      access: fakeAccessToken(),
+      refresh: "rt-exchange",
+      idToken: "idt-exchange",
+    });
+  });
+
+  it.each([
+    ["non-object root", []],
+    ["missing access token", { refresh_token: "rt-exchange", expires_in: 3600 }],
+    ["missing refresh token", { access_token: fakeAccessToken(), expires_in: 3600 }],
+    [
+      "numeric refresh token",
+      { access_token: fakeAccessToken(), refresh_token: 7, expires_in: 3600 },
+    ],
+    [
+      "non-positive lifetime",
+      { access_token: fakeAccessToken(), refresh_token: "rt-exchange", expires_in: 0 },
+    ],
+    [
+      "overflowing lifetime",
+      {
+        access_token: fakeAccessToken(),
+        refresh_token: "rt-exchange",
+        expires_in: 1e308,
+      },
+    ],
+    [
+      "invalid id token",
+      {
+        access_token: fakeAccessToken(),
+        refresh_token: "rt-exchange",
+        expires_in: 3600,
+        id_token: {},
+      },
+    ],
+  ])("fails a successful response with %s", async (_name, body) => {
+    mockTokenResponse(body);
+    await expect(exchangeMockedAuthorizationCode()).resolves.toMatchObject({
+      type: "failed",
+    });
+  });
+
+  it("fails malformed successful JSON", async () => {
+    mockRawTokenResponse("{not-json");
+    await expect(exchangeMockedAuthorizationCode()).resolves.toMatchObject({
+      type: "failed",
+    });
+  });
+
+  it("does not pass a non-success response body to diagnostics", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockTokenResponse(
+      {
+        access_token: "access-secret-value",
+        refresh_token: "refresh-secret-value",
+      },
+      false,
+    );
+    await expect(exchangeMockedAuthorizationCode()).resolves.toMatchObject({
+      type: "failed",
+    });
+    const diagnosticArguments = JSON.stringify(errorSpy.mock.calls);
+    expect(diagnosticArguments).not.toContain("access-secret-value");
+    expect(diagnosticArguments).not.toContain("refresh-secret-value");
   });
 });

--- a/packages/auth/src/vendor/pi-oauth/openai-codex-login.ts
+++ b/packages/auth/src/vendor/pi-oauth/openai-codex-login.ts
@@ -46,16 +46,6 @@ export interface OAuthPrompt {
   placeholder?: string;
 }
 
-async function readOAuthFailureBody(response: Response): Promise<string> {
-  try {
-    return await response.text();
-  } catch (cause) {
-    // error-policy:J4 explicit diagnostic degrade — the non-2xx status remains
-    // authoritative when the optional response body cannot be read.
-    return `[response body unavailable: ${cause instanceof Error ? cause.message : String(cause)}]`;
-  }
-}
-
 async function createState(): Promise<string> {
   if (!isNodeLikeRuntime()) {
     throw new Error(
@@ -125,9 +115,126 @@ type TokenSuccess = {
    * account's CODEX_HOME to authenticate. */
   idToken?: string;
 };
-type TokenFailure = { type: "failed" };
+type TokenFailure = { type: "failed"; reason: string };
+type TokenResult = TokenSuccess | TokenFailure;
 
-async function exchangeAuthorizationCode(
+type TokenResponseContext =
+  | { mode: "exchange" }
+  | { mode: "refresh"; currentRefreshToken: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function failedTokenResponse(reason: string): TokenFailure {
+  return { type: "failed", reason };
+}
+
+function parseTokenResponse(
+  payload: unknown,
+  context: TokenResponseContext,
+): TokenResult {
+  if (!isRecord(payload)) {
+    return failedTokenResponse("response root must be an object");
+  }
+
+  const rawAccessToken = payload.access_token;
+  const rawRefreshToken = payload.refresh_token;
+  const rawExpiresIn = payload.expires_in;
+  const rawIdToken = payload.id_token;
+
+  if (!isNonBlankString(rawAccessToken)) {
+    return failedTokenResponse(
+      "missing or invalid access_token; expected a non-blank string",
+    );
+  }
+  if (
+    typeof rawExpiresIn !== "number" ||
+    !Number.isFinite(rawExpiresIn) ||
+    rawExpiresIn <= 0
+  ) {
+    return failedTokenResponse(
+      "missing or invalid expires_in; expected a positive finite number",
+    );
+  }
+
+  const expires = Date.now() + rawExpiresIn * 1000;
+  if (!Number.isFinite(expires)) {
+    return failedTokenResponse(
+      "invalid expires_in; absolute expiry exceeds the supported numeric range",
+    );
+  }
+
+  let refresh: string;
+  if (context.mode === "exchange") {
+    if (!isNonBlankString(rawRefreshToken)) {
+      return failedTokenResponse(
+        "missing or invalid refresh_token; expected a non-blank string",
+      );
+    }
+    refresh = rawRefreshToken;
+  } else if (rawRefreshToken === undefined || rawRefreshToken === null) {
+    refresh = context.currentRefreshToken;
+  } else if (!isNonBlankString(rawRefreshToken)) {
+    return failedTokenResponse(
+      "invalid refresh_token; expected a non-blank string when present",
+    );
+  } else {
+    refresh = rawRefreshToken;
+  }
+
+  let idToken: string | undefined;
+  if (rawIdToken !== undefined && rawIdToken !== null) {
+    if (typeof rawIdToken !== "string") {
+      return failedTokenResponse(
+        "invalid id_token; expected a string when present",
+      );
+    }
+    idToken = rawIdToken || undefined;
+  }
+
+  return {
+    type: "success",
+    access: rawAccessToken,
+    refresh,
+    expires,
+    ...(idToken ? { idToken } : {}),
+  };
+}
+
+async function readTokenResponse(
+  response: Response,
+  context: TokenResponseContext,
+): Promise<TokenResult> {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    // error-policy:J3 provider JSON is untrusted; malformed JSON becomes an
+    // explicit failed result and no partial credential record is constructed.
+    const failure = failedTokenResponse("response body was not valid JSON");
+    logger.error(
+      { mode: context.mode, reason: failure.reason },
+      "[openai-codex] Token response invalid",
+    );
+    return failure;
+  }
+
+  const result = parseTokenResponse(payload, context);
+  if (result.type === "failed") {
+    logger.error(
+      { mode: context.mode, reason: result.reason },
+      "[openai-codex] Token response invalid",
+    );
+  }
+  return result;
+}
+
+export async function exchangeAuthorizationCode(
   code: string,
   verifier: string,
   redirectUri: string = REDIRECT_URI,
@@ -144,35 +251,13 @@ async function exchangeAuthorizationCode(
     }),
   });
   if (!response.ok) {
-    const text = await readOAuthFailureBody(response);
     logger.error(
-      `[openai-codex] code->token failed: ${response.status} ${text}`,
+      { mode: "exchange", status: response.status },
+      "[openai-codex] Token request returned a non-success status",
     );
-    return { type: "failed" };
+    return failedTokenResponse("provider returned a non-success status");
   }
-  const json = (await response.json()) as {
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-    id_token?: string;
-  };
-  if (
-    !json.access_token ||
-    !json.refresh_token ||
-    typeof json.expires_in !== "number"
-  ) {
-    logger.error(
-      `[openai-codex] token response missing fields: ${JSON.stringify(json)}`,
-    );
-    return { type: "failed" };
-  }
-  return {
-    type: "success",
-    access: json.access_token,
-    refresh: json.refresh_token,
-    expires: Date.now() + json.expires_in * 1000,
-    ...(json.id_token ? { idToken: json.id_token } : {}),
-  };
+  return readTokenResponse(response, { mode: "exchange" });
 }
 
 async function refreshAccessToken(
@@ -189,41 +274,21 @@ async function refreshAccessToken(
       }),
     });
     if (!response.ok) {
-      const text = await readOAuthFailureBody(response);
       logger.error(
-        `[openai-codex] Token refresh failed: ${response.status} ${text}`,
+        { mode: "refresh", status: response.status },
+        "[openai-codex] Token request returned a non-success status",
       );
-      return { type: "failed" };
+      return failedTokenResponse("provider returned a non-success status");
     }
-    const json = (await response.json()) as {
-      access_token?: string;
-      refresh_token?: string;
-      expires_in?: number;
-      id_token?: string;
-    };
-    if (!json.access_token || typeof json.expires_in !== "number") {
-      logger.error(
-        `[openai-codex] Token refresh response missing fields: ${JSON.stringify(
-          json,
-        )}`,
-      );
-      return { type: "failed" };
-    }
-    return {
-      type: "success",
-      access: json.access_token,
-      // RFC 6749 §6: a refresh response that omits refresh_token means
-      // "keep the current one". Failing here would discard a successful
-      // refresh and strand the account on an already-consumed token.
-      refresh: json.refresh_token ?? refreshToken,
-      expires: Date.now() + json.expires_in * 1000,
-      ...(json.id_token ? { idToken: json.id_token } : {}),
-    };
+    return readTokenResponse(response, {
+      mode: "refresh",
+      currentRefreshToken: refreshToken,
+    });
   } catch (error) {
     // error-policy:J1 provider boundary translation — refresh transport and
     // parse failures become the explicit failed token outcome.
     logger.error(`[openai-codex] Token refresh error: ${String(error)}`);
-    return { type: "failed" };
+    return failedTokenResponse("token refresh request failed");
   }
 }
 

--- a/packages/auth/src/vendor/pi-oauth/openai-codex-login.ts
+++ b/packages/auth/src/vendor/pi-oauth/openai-codex-login.ts
@@ -134,6 +134,20 @@ function failedTokenResponse(reason: string): TokenFailure {
   return { type: "failed", reason };
 }
 
+async function releaseRejectedResponse(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // error-policy:J6 response teardown is best-effort; the provider's HTTP
+    // failure remains authoritative and neither body nor transport errors may
+    // expose credentials through diagnostics.
+    logger.warn(
+      { status: response.status },
+      "[openai-codex] Could not release rejected token response",
+    );
+  }
+}
+
 function parseTokenResponse(
   payload: unknown,
   context: TokenResponseContext,
@@ -251,6 +265,7 @@ export async function exchangeAuthorizationCode(
     }),
   });
   if (!response.ok) {
+    await releaseRejectedResponse(response);
     logger.error(
       { mode: "exchange", status: response.status },
       "[openai-codex] Token request returned a non-success status",
@@ -274,6 +289,7 @@ async function refreshAccessToken(
       }),
     });
     if (!response.ok) {
+      await releaseRejectedResponse(response);
       logger.error(
         { mode: "refresh", status: response.status },
         "[openai-codex] Token request returned a non-success status",


### PR DESCRIPTION
Closes #30581.

Validate OpenAI Codex OAuth token responses before constructing credentials. Preserve refresh-token rotation and compatible optional ID-token behavior, reject invalid JSON and malformed token fields, and keep token values out of diagnostics. Rejected HTTP responses are canceled before returning failure so repeated exchange and refresh attempts release their transport resources.

## Validation

Reviewed the token parser, its callers, response cleanup, and the existing findings. The validation is useful: malformed successful responses must not become persisted credentials, and diagnostics must exclude token values.

I repaired the response lifecycle regression from my earlier review. Both authorization exchange and refresh now cancel rejected response bodies before returning failure, without logging their contents. The new `packages/auth/src/openai-codex-transport.test.ts` runs real Node HTTP/Fetch exchanges with a finite 384 KiB response; both cases fail on the original implementation and pass after the repair. Each path performs two attempts and verifies that every response body is released.

Validation with Node 24.15.0 and Bun 1.3.14:

- Full auth suite: 20 files, 241 tests passed.
- Auth typecheck, lint, and format checks: passed.
- Root `bun run verify`: 376/376 workspace tasks and repository audits passed.
- `bun install` completed; working tree clean after committing the repair.

Reviewed head: `8ec579e9e51b0a48de98618cfabd2c8c92ca33a4`.
Rebase/validation base: `2fd687670a5` (the subsequent APNs-only base change does not touch this contract).

The HTTP fixture uses synthetic credentials and a real transport. This is transport and credential parsing evidence; no live provider login or user account mutation is claimed. No rendered UI or model behavior changes.


## Evidence

<!-- evidence-head:8ec579e9e51b0a48de98618cfabd2c8c92ca33a4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - No rendered UI change.

<!-- evidence-row:after-screenshots -->
- [x] N/A - No rendered UI change.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - No interactive UI or native transport behavior changes.

<!-- evidence-row:backend-logs -->
- [x] Executed local HTTP fixture and command results are documented above.

<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend path changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - No model, prompt, provider inference, or action behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] Real temporary credential-response bodies were inspected by the HTTP tests; no user credentials or account state were changed.

<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered UI change.
