### PR TITLE
fix(auth): keep startup CLI credential discovery read-only

### DIFF
--- a/packages/auth/src/credentials-cli-diagnostics.test.ts
+++ b/packages/auth/src/credentials-cli-diagnostics.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Exercises deferred startup diagnostics against real temporary CLI credential
+ * files. The network boundary rejects unexpected refreshes; storage and the
+ * diagnostic path remain real so an expired external login cannot be rotated.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applySubscriptionCredentialsDeferred } from "./credentials.ts";
+
+let tempHome: string;
+let credentialsPath: string;
+let network: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-cli-diagnostic-"));
+  for (const name of ["HOME", "USERPROFILE", "ELIZA_HOME", "ELIZA_STATE_DIR"]) {
+    vi.stubEnv(name, tempHome);
+  }
+  vi.stubEnv("ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS", "");
+  credentialsPath = path.join(tempHome, ".claude", ".credentials.json");
+  await fs.mkdir(path.dirname(credentialsPath));
+  network = vi.fn(async () => {
+    throw new Error("Diagnostics must not exchange external credentials");
+  });
+  vi.stubGlobal("fetch", network);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  await fs.rm(tempHome, { recursive: true, force: true });
+});
+
+describe("external CLI startup diagnostics", () => {
+  it.each([0, Date.now() + 3_600_000])(
+    "leaves external credentials and network untouched at expiry %s",
+    async (expiresAt) => {
+      const bytes = JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fixture-access",
+          refreshToken: "fixture-refresh",
+          expiresAt,
+        },
+      });
+      await fs.writeFile(credentialsPath, bytes);
+      const before = await fs.stat(credentialsPath);
+      await Promise.all(
+        Array.from({ length: 4 }, () => applySubscriptionCredentialsDeferred()),
+      );
+      expect(network).not.toHaveBeenCalled();
+      expect(await fs.readFile(credentialsPath, "utf8")).toBe(bytes);
+      expect((await fs.stat(credentialsPath)).mtimeMs).toBe(before.mtimeMs);
+      expect(await fs.readdir(path.dirname(credentialsPath))).toEqual([
+        ".credentials.json",
+      ]);
+    },
+  );
+
+  it("honors disabled probing and keeps an absent external login unavailable", async () => {
+    const info = vi.spyOn(logger, "info");
+    await applySubscriptionCredentialsDeferred();
+    expect(info).not.toHaveBeenCalled();
+    await fs.writeFile(
+      credentialsPath,
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fixture-access",
+          refreshToken: "fixture-refresh",
+          expiresAt: 0,
+        },
+      }),
+    );
+    vi.stubEnv("ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS", "true");
+    await applySubscriptionCredentialsDeferred();
+    expect(info).not.toHaveBeenCalled();
+    expect(network).not.toHaveBeenCalled();
+  });
+});

--- a/packages/auth/src/credentials.ts
+++ b/packages/auth/src/credentials.ts
@@ -56,7 +56,6 @@ const DEFAULT_ACCOUNT_ID = "default";
 
 /** Buffer before expiry to trigger refresh (5 minutes) */
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
-const invalidClaudeCodeRefreshTokens = new Set<string>();
 
 /** Stable failure categories for callers that manage account-pool health. */
 export type AccessTokenFailureKind =
@@ -645,20 +644,10 @@ interface ClaudeCodeCredentialBlob {
   source: string;
 }
 
-function isClaudeCodeInvalidGrantError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return /\binvalid_grant\b/i.test(message);
-}
-
 /**
- * Try to read a Claude Code OAuth credential blob from its explicit local
- * file. Does NOT validate expiry — that's the caller's job (so it can decide
- * whether to refresh via the refresh token).
- *
- * Note that Claude Code's runtime keeps the live access token in memory and
- * refreshes it via the refresh token on demand — the persisted access token
- * will often be expired even though the user is actively using Claude Code.
- * That's why we always need to be ready to refresh.
+ * Read local Claude Code credential metadata for status and discovery.
+ * Persisted access tokens may be expired while the CLI refreshes its own login;
+ * callers distinguish presence from validity without exchanging the credential.
  */
 function readClaudeCodeOAuthBlob(): ClaudeCodeCredentialBlob | null {
   const parse = (
@@ -712,58 +701,6 @@ function readClaudeCodeOAuthBlob(): ClaudeCodeCredentialBlob | null {
   return null;
 }
 
-/**
- * Import a usable Anthropic OAuth access token from Claude Code's stored
- * credentials. If the persisted access token is still valid, returns it
- * directly. If it has expired, attempts to refresh via the persisted refresh
- * token. Returns null if no credentials are available, the token is expired
- * with no refresh token, or the refresh fails.
- */
-async function importClaudeCodeOAuthToken(): Promise<string | null> {
-  const blob = readClaudeCodeOAuthBlob();
-  if (!blob) return null;
-
-  const expired =
-    typeof blob.expiresAt === "number" && blob.expiresAt <= Date.now();
-
-  if (!expired) {
-    logger.info(`[auth] Imported OAuth token from Claude Code ${blob.source}`);
-    return blob.accessToken;
-  }
-
-  if (!blob.refreshToken) {
-    logger.info(
-      `[auth] Claude Code OAuth token from ${blob.source} is expired and no refresh token is available. Run "claude auth login" to refresh.`,
-    );
-    return null;
-  }
-
-  const refreshTokenCacheKey = `${blob.source}:${blob.refreshToken}`;
-  if (invalidClaudeCodeRefreshTokens.has(refreshTokenCacheKey)) {
-    return null;
-  }
-
-  try {
-    const refreshed = await refreshAnthropicToken(blob.refreshToken);
-    logger.info(`[auth] Refreshed Claude Code OAuth token from ${blob.source}`);
-    return refreshed.access;
-  } catch (err) {
-    // error-policy:J4 an optional external credential that cannot refresh is
-    // reported and marked unavailable; no healthy token is fabricated.
-    if (isClaudeCodeInvalidGrantError(err)) {
-      invalidClaudeCodeRefreshTokens.add(refreshTokenCacheKey);
-      logger.info(
-        `[auth] Claude Code OAuth refresh token from ${blob.source} is invalid or revoked. Run "claude auth login" to refresh.`,
-      );
-      return null;
-    }
-    logger.warn(
-      `[auth] Failed to refresh expired Claude Code OAuth token from ${blob.source}: ${String(err)}. Run "claude auth login" to refresh.`,
-    );
-    return null;
-  }
-}
-
 interface SubscriptionCredentialConfig {
   agents?: {
     defaults?: { subscriptionProvider?: string; model?: { primary?: string } };
@@ -786,9 +723,8 @@ function isSubscriptionCredentialApplicationDisabled(): boolean {
  *
  * Reads stored accounts from disk and derives `model.primary` for runtime
  * subscription providers (currently only `openai-codex`). Performs no network
- * I/O, so it is safe to await on the blocking boot path. The network-touching
- * Claude Code OAuth import is handled separately by
- * {@link applySubscriptionCredentialsDeferred}.
+ * I/O, so it is safe to await on the blocking boot path. Local Claude Code
+ * credential discovery is handled by {@link applySubscriptionCredentialsDeferred}.
  *
  * None of the Anthropic / Codex / Gemini / coding-plan branches mutate `config`
  * or `process.env` — they are purely informational logging. The only config
@@ -905,10 +841,9 @@ export function applySubscriptionCredentialsLocal(
  * Called at startup to make credentials available to elizaOS plugins.
  *
  * Combines the local-only model.primary derivation
- * ({@link applySubscriptionCredentialsLocal}) with the network-touching Claude
- * Code OAuth probe ({@link applySubscriptionCredentialsDeferred}). The cold-boot
- * path calls the two halves separately so the network probe can run off the
- * blocking path; other callers (API routes, hot reload) use this combined form.
+ * ({@link applySubscriptionCredentialsLocal}) with local Claude Code credential
+ * discovery ({@link applySubscriptionCredentialsDeferred}). Startup can call
+ * either phase separately; API routes and hot reload use this combined form.
  *
  * **Claude subscription tokens are NOT applied to the runtime environment.**
  * Anthropic's TOS only permits Claude subscription tokens to be used through
@@ -927,24 +862,20 @@ export async function applySubscriptionCredentials(
 }
 
 /**
- * Deferred, network-touching part of subscription credential application.
+ * Discover locally stored Claude Code credentials for startup diagnostics.
  *
- * When no stored Anthropic subscription account exists, this probes for a
- * Claude Code CLI OAuth token (which may require a network refresh) so it can
- * log that a subscription is available for coding agents. It mutates neither
- * `config` nor `process.env` — the token stays reserved for spawned Claude
- * Code CLI sessions — so it can run off the blocking boot path.
+ * The CLI owns its credential lifecycle, including refreshing expired tokens.
+ * Discovery reads its file without exchanging or importing credentials and
+ * reports presence without claiming that the provider accepted the login.
  */
 export async function applySubscriptionCredentialsDeferred(): Promise<void> {
   if (isSubscriptionCredentialApplicationDisabled()) return;
-
   if (listProviderAccounts("anthropic-subscription").length > 0) return;
 
-  const claudeImported = await importClaudeCodeOAuthToken();
-  if (claudeImported) {
+  if (readClaudeCodeOAuthBlob()) {
     logger.info(
-      "[auth] Anthropic subscription detected via Claude Code CLI — available for coding agents. " +
-        "Not applied to runtime env. Add an API key or connect Eliza Cloud for the main agent.",
+      "[auth] Detected local Claude Code CLI credentials. The CLI manages refresh. " +
+        "Add an API key or connect Eliza Cloud for the main agent.",
     );
   }
 }


### PR DESCRIPTION
Startup's informational credential probe exchanged expired Claude Code tokens even though it discarded the result. The probe now reads local credential metadata without contacting the provider and leaves refresh to the CLI. Explicit account-store refresh and inference credential resolution retain their existing behavior.

Closes #30573.

Validation on scoped commit `f0a54007dd51d15456045161c11974105049e8ce`, based on `9322e05c91a2e645875c65bdc6d9df1e150d6b37`:

- All 213 auth tests passed with one worker. The initial parallel run exposed an unchanged two-process adoption test race; the complete serial run passed.
- The new regression uses real temporary credential files and verifies unchanged bytes and timestamps, with no refresh request across concurrent probes.
- Package tests, typecheck, lint, and build passed. Root `bun run verify` passed, including all 376 Turbo tasks and the final repository audits. Bun 1.3.14 and Node 24.15.0 were used.
- Independent runtime and cloud reviewers checked refresh ownership and existing OAuth consumers and found no remaining blocker.

Screenshots, video, native captures, and live-model outputs are N/A: this changes informational startup diagnostics, with no rendered view or inference behavior change. The credential-file regression uses synthetic test credentials; no real account credentials were changed.

## Review and risk

Low risk: removes an unused external token exchange from informational startup discovery. The public startup functions remain compatible. Updated module documentation describes the read-only behavior. No deployment or database migration is required.

## Evidence Gate

<!-- evidence-head:f0a54007dd51d15456045161c11974105049e8ce -->
<!-- evidence-row:before-screenshots -->
N/A - informational backend diagnostic; no rendered view changed.
<!-- evidence-row:after-screenshots -->
N/A - informational backend diagnostic; no rendered view changed.
<!-- evidence-row:walkthrough-video -->
N/A - the observable contract is credential-file preservation and absence of network requests.
<!-- evidence-row:backend-logs -->
<details><summary>Terminal verification output</summary>

```text
Test Files  19 passed (19)
Tests       213 passed (213)
Package typecheck: exit 0
Package lint: exit 0
Package build: exit 0
Root verify: exit 0
Tasks: 376 successful, 376 total
[anti-larp] scanned 11360 test files — 0 focused, 0 orphaned skip(s)
[anti-larp] clean — no focused tests, no untracked skips.
```

</details>
<!-- evidence-row:frontend-logs -->
N/A - no browser request or UI state changes.
<!-- evidence-row:llm-trajectory -->
N/A - no model, action, prompt, or inference behavior changed.
<!-- evidence-row:domain-artifacts -->
The real-file regression verified both expired and unexpired synthetic CLI credentials: four concurrent diagnostic calls made zero network requests, preserved file bytes and modification times, and created no sibling credential files. Disabled and absent credentials remained unavailable. These are observed test assertions against temporary filesystem state, not real user account data.
<details><summary>Real temporary-file diagnostic regression</summary>

```text

 RUN  v4.1.10 /Users/shawwalters/.codex/worktrees/code-quality-cleanup-20260904/packages/auth

stdout | src/credentials-cli-diagnostics.test.ts > external CLI startup diagnostics > leaves external credentials and network untouched at expiry 0
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.

stdout | src/credentials-cli-diagnostics.test.ts > external CLI startup diagnostics > leaves external credentials and network untouched at expiry 1788574712462
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.
 Info       [auth] Detected local Claude Code CLI credentials. The CLI manages refresh. Add an API key or connect Eliza Cloud for the main agent.

 ✓ src/credentials-cli-diagnostics.test.ts > external CLI startup diagnostics > leaves external credentials and network untouched at expiry 0 397ms
 ✓ src/credentials-cli-diagnostics.test.ts > external CLI startup diagnostics > leaves external credentials and network untouched at expiry 1788574712462 186ms
 ✓ src/credentials-cli-diagnostics.test.ts > external CLI startup diagnostics > honors disabled probing and keeps an absent external login unavailable 66ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  21:18:13
   Duration  19.27s (transform 15.02s, setup 0ms, import 18.46s, tests 650ms, environment 0ms)

```

</details>

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface.



Known gaps: the initial parallel auth run hit the existing two-process credential-adoption test race. All 213 tests then passed serially; no test limits or assertions were relaxed. Hosted checks must pass on the current PR head before merge.

Maintainer CI exception: N/A - no exception requested.
