### PR TITLE
fix(ci): classify staging activation failures accurately

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -924,7 +924,7 @@ jobs:
               WHEN error ~ 'canceling statement due to statement timeout' THEN 'database_statement_timeout'
               WHEN error ~ 'Reviewed backup authority changed' THEN 'reviewed_backup_changed'
               WHEN error ~ 'Reviewed fresh-boot authority changed' THEN 'reviewed_fresh_boot_changed'
-              WHEN error ~* 'timed out|timeout' THEN 'timeout'
+              WHEN split_part(error, E'\n', 1) ~* 'timed out|timeout' THEN 'timeout'
               ELSE 'unclassified' END FROM latest_job),
             'organizationActive', (SELECT is_active FROM organization),
             'accountLifecycleState', (SELECT account_lifecycle_state FROM organization),

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -880,7 +880,8 @@ jobs:
             SELECT organization_id, user_id FROM agent_sandboxes
             WHERE agent_name = 'managed-dedicated-canary-' || :'suffix'
           ), target AS (
-            SELECT agent.id, agent.organization_id, agent.user_id
+            SELECT agent.id, agent.organization_id, agent.user_id, agent.status,
+              agent.lifecycle_job_id, agent.lifecycle_execution_generation, agent.deletion_attempt_id
             FROM canary
             JOIN personal_dedicated_upgrade_authorities AS authority
               ON authority.organization_id = canary.organization_id AND authority.user_id = canary.user_id
@@ -888,6 +889,12 @@ jobs:
               ON agent.id = authority.dedicated_agent_id
               AND agent.organization_id = authority.organization_id AND agent.user_id = authority.user_id
             WHERE (SELECT count(*) FROM canary) = 1
+          ), selected_target AS (
+            SELECT * FROM target WHERE (SELECT count(*) FROM target) = 1
+          ), organization AS (
+            SELECT org.is_active, org.account_lifecycle_state,
+              org.account_lifecycle_revision, org.account_deletion_request_id
+            FROM selected_target JOIN organizations AS org ON org.id = selected_target.organization_id
           ), latest_job AS (
             SELECT job.* FROM target
             JOIN jobs AS job ON job.agent_id = target.id::text
@@ -903,15 +910,49 @@ jobs:
             'startedAt', (SELECT started_at FROM latest_job),
             'updatedAt', (SELECT updated_at FROM latest_job),
             'attempts', (SELECT attempts FROM latest_job),
-            'errorStoredExternally', (SELECT error_storage IS NOT NULL FROM latest_job),
+            'errorStoredExternally', (SELECT error_storage = 'r2' FROM latest_job),
+            'failureKind', (SELECT CASE
+              WHEN error_storage = 'r2' THEN 'external_error'
+              WHEN error IS NULL THEN 'none'
+              WHEN error ~ 'Account lifecycle fenced provisioning job' THEN 'account_preparation_fenced'
+              WHEN error ~ 'Account lifecycle fenced provider admission' THEN 'account_provider_fenced'
+              WHEN error ~ 'Agent lifecycle resource generation is already owned' THEN 'resource_generation_owned'
+              WHEN error ~ 'Lifecycle execution generation is no longer current' THEN 'job_generation_stale'
+              WHEN error ~ 'has conflicting .* job' THEN 'conflicting_lifecycle_job'
+              WHEN error ~ 'timeout exceeded when trying to connect' THEN 'database_pool_timeout'
+              WHEN error ~ 'canceling statement due to lock timeout' THEN 'database_lock_timeout'
+              WHEN error ~ 'canceling statement due to statement timeout' THEN 'database_statement_timeout'
+              WHEN error ~ 'Reviewed backup authority changed' THEN 'reviewed_backup_changed'
+              WHEN error ~ 'Reviewed fresh-boot authority changed' THEN 'reviewed_fresh_boot_changed'
+              WHEN error ~* 'timed out|timeout' THEN 'timeout'
+              ELSE 'unclassified' END FROM latest_job),
+            'organizationActive', (SELECT is_active FROM organization),
+            'accountLifecycleState', (SELECT account_lifecycle_state FROM organization),
+            'accountLifecycleRevision', (SELECT account_lifecycle_revision::text FROM organization),
+            'accountDeletionRequested', (SELECT account_deletion_request_id IS NOT NULL FROM organization),
+            'sandboxStatus', (SELECT status FROM selected_target),
+            'sandboxDeletionRequested', (SELECT deletion_attempt_id IS NOT NULL FROM selected_target),
+            'sandboxLifecycleJobPresent', (SELECT lifecycle_job_id IS NOT NULL FROM selected_target),
+            'sandboxLifecycleJobMatches', (SELECT selected_target.lifecycle_job_id = latest_job.id FROM selected_target, latest_job),
+            'sandboxGenerationMatches', (SELECT selected_target.lifecycle_execution_generation = latest_job.execution_generation FROM selected_target, latest_job),
+            'jobQuiesced', (SELECT execution_quiesced_at IS NOT NULL FROM latest_job),
+            'jobHasLiveLease', (SELECT EXISTS (
+              SELECT 1 FROM job_execution_leases AS lease
+              WHERE lease.job_id = latest_job.id AND lease.expires_at > NOW()
+            ) FROM latest_job),
             'errorTerms', ARRAY(
               SELECT DISTINCT term[1] FROM latest_job,
-                regexp_matches(lower(error), '\m(timeout|timed|query|connection|connect|handshake|socket|pool|database|postgres|acquire|client|read|write|fetch|abort|aborted|operation|exceeded|trying|response|request|statement|health|sandbox|docker|ssh|vpn|headscale|backup|restore|revocation|lock|lease|body|headers|control|preflight|capacity|admission|fence|econnreset|etimedout|econnrefused)\M', 'g') AS term
+                regexp_matches(lower(split_part(error, E'\n', 1)), '\m(timeout|timed|query|connection|connect|handshake|socket|pool|database|postgres|acquire|client|read|write|fetch|abort|aborted|operation|exceeded|trying|response|request|statement|health|sandbox|docker|ssh|vpn|headscale|backup|restore|revocation|lock|lease|body|headers|control|preflight|capacity|admission|fence|fenced|account|lifecycle|generation|owned|current|conflicting|revision|stale|steward|kms|crypto|encryption|decryption|redis|s3|r2|tls|certificate|auth|credential|token|key|econnreset|etimedout|econnrefused)\M', 'g') AS term
               ORDER BY term[1]
+            ),
+            'stackFrames', ARRAY(
+              SELECT DISTINCT frame[1] FROM latest_job,
+                regexp_matches(error, '((?:provisioning-jobs|provisioning-account-lifecycle-fence|account-lifecycle-authority|provider-admission|eliza-sandbox|managed-eliza-config|with-timeout|agent-env-crypto|agent-tier-upgrade-target|kms-client|steward-client|api-keys)\.ts:[0-9]+(?::[0-9]+)?)', 'g') AS frame
+              ORDER BY frame[1]
             ),
             'stackModules', ARRAY(
               SELECT DISTINCT module[1] FROM latest_job,
-                regexp_matches(error, '(pg-pool/index\.js|pg/lib/client\.js|postgres/src/connection\.js|docker-ssh-client\.ts|eliza-sandbox\.ts|provisioning-jobs\.ts|managed-eliza-config\.ts|with-timeout\.ts|agent-env-crypto\.ts|agent-tier-upgrade-target\.ts)', 'g') AS module
+                regexp_matches(error, '(pg-pool/index\.js|pg/lib/client\.js|postgres/src/connection\.js|docker-ssh-client\.ts|eliza-sandbox\.ts|provisioning-jobs\.ts|managed-eliza-config\.ts|with-timeout\.ts|agent-env-crypto\.ts|agent-tier-upgrade-target\.ts|kms-client\.ts|steward-client\.ts|api-keys\.ts)', 'g') AS module
               ORDER BY module[1]
             )
           );

--- a/packages/scripts/__tests__/staging-activation-job-origin.test.ts
+++ b/packages/scripts/__tests__/staging-activation-job-origin.test.ts
@@ -20,23 +20,29 @@ test("reads only the bound owner's latest provision error and emits closed terms
   const db = new PGlite();
   try {
     await db.exec(`
-      CREATE TABLE agent_sandboxes (id text, agent_name text, organization_id text, user_id text);
+      CREATE TABLE agent_sandboxes (id text, agent_name text, organization_id text, user_id text,
+        status text DEFAULT 'error', lifecycle_job_id text, lifecycle_execution_generation text, deletion_attempt_id text);
+      CREATE TABLE organizations (id text, is_active boolean, account_lifecycle_state text,
+        account_lifecycle_revision bigint, account_deletion_request_id text);
+      CREATE TABLE job_execution_leases (job_id text, expires_at timestamp);
       CREATE TABLE personal_dedicated_upgrade_authorities (dedicated_agent_id text, organization_id text, user_id text);
       CREATE TABLE jobs (id text, agent_id text, organization_id text, user_id text, type text,
-        created_at timestamp, started_at timestamp, updated_at timestamp, attempts integer, error text, error_storage jsonb);
-      INSERT INTO agent_sandboxes VALUES
+        created_at timestamp, started_at timestamp, updated_at timestamp, attempts integer, error text,
+        error_storage text NOT NULL DEFAULT 'inline', execution_generation text, execution_quiesced_at timestamp);
+      INSERT INTO organizations VALUES ('owner-org', true, 'active', 1, null);
+      INSERT INTO agent_sandboxes (id, agent_name, organization_id, user_id) VALUES
         ('canary', 'managed-dedicated-canary-r33717318238a1', 'owner-org', 'owner-user'),
         ('target', 'personal', 'owner-org', 'owner-user'),
         ('foreign', 'personal', 'foreign-org', 'owner-user');
       INSERT INTO personal_dedicated_upgrade_authorities VALUES
         ('target', 'owner-org', 'owner-user'), ('foreign', 'foreign-org', 'owner-user');
-      INSERT INTO jobs VALUES
-        ('older', 'target', 'owner-org', 'owner-user', 'agent_provision', '2026-09-01', null, '2026-09-01', 1, 'Docker health timeout', null),
-        ('foreign', 'target', 'foreign-org', 'owner-user', 'agent_provision', '2026-09-05', null, '2026-09-05', 1, 'SSH timeout', null),
-        ('other-user', 'target', 'owner-org', 'other-user', 'agent_provision', '2026-09-05', null, '2026-09-05', 1, 'Headscale timeout', null);
+      INSERT INTO jobs (id, agent_id, organization_id, user_id, type, created_at, started_at, updated_at, attempts, error) VALUES
+        ('older', 'target', 'owner-org', 'owner-user', 'agent_provision', '2026-09-01', null, '2026-09-01', 1, 'Docker health timeout'),
+        ('foreign', 'target', 'foreign-org', 'owner-user', 'agent_provision', '2026-09-05', null, '2026-09-05', 1, 'SSH timeout'),
+        ('other-user', 'target', 'owner-org', 'other-user', 'agent_provision', '2026-09-05', null, '2026-09-05', 1, 'Headscale timeout');
     `);
     await db.query(
-      "INSERT INTO jobs VALUES ('current', 'target', 'owner-org', 'owner-user', 'agent_provision', '2026-09-04', '2026-09-04', '2026-09-04', 3, $1, null)",
+      "INSERT INTO jobs (id, agent_id, organization_id, user_id, type, created_at, started_at, updated_at, attempts, error) VALUES ('current', 'target', 'owner-org', 'owner-user', 'agent_provision', '2026-09-04', '2026-09-04', '2026-09-04', 3, $1)",
       [
         "timeout exceeded when trying to connect PRIVATE_CREDENTIAL https://private.example\n at /private/path/pg-pool/index.js:45:1",
       ],
@@ -49,15 +55,67 @@ test("reads only the bound owner's latest provision error and emits closed terms
       targetCount: 1,
       jobCount: 1,
       attempts: 3,
-      errorTerms: ["connect", "exceeded", "pool", "timeout", "trying"],
+      errorStoredExternally: false,
+      failureKind: "database_pool_timeout",
+      organizationActive: true,
+      accountLifecycleState: "active",
+      accountLifecycleRevision: "1",
+      accountDeletionRequested: false,
+      jobHasLiveLease: false,
+      errorTerms: ["connect", "exceeded", "timeout", "trying"],
       stackModules: ["pg-pool/index.js"],
     });
     expect(JSON.stringify(report)).not.toMatch(
       /PRIVATE|private\.example|owner-org|owner-user|foreign|other-user/,
     );
 
+    await db.query("UPDATE jobs SET error = $1 WHERE id = 'current'", [
+      "Unexpected operation failure\n at /private/provisioning-account-lifecycle-fence.ts:1:1",
+    ]);
+    const stackOnly = await db.query<{
+      json_build_object: Record<string, unknown>;
+    }>(query, ["r33717318238a1"]);
+    expect(stackOnly.rows[0].json_build_object).toMatchObject({
+      failureKind: "unclassified",
+      errorTerms: ["operation"],
+      stackFrames: ["provisioning-account-lifecycle-fence.ts:1:1"],
+    });
+
+    await db.exec(`
+      UPDATE jobs SET error = 'Account lifecycle fenced provisioning job PRIVATE_ID', execution_generation = 'generation', execution_quiesced_at = NOW() WHERE id = 'current';
+      UPDATE organizations SET is_active = false, account_lifecycle_state = 'deletion_recovery', account_lifecycle_revision = 2, account_deletion_request_id = 'PRIVATE_REQUEST';
+      UPDATE agent_sandboxes SET lifecycle_job_id = 'current', lifecycle_execution_generation = 'generation' WHERE id = 'target';
+      INSERT INTO job_execution_leases VALUES ('current', NOW() + INTERVAL '1 hour');
+    `);
+    const fenced = await db.query<{
+      json_build_object: Record<string, unknown>;
+    }>(query, ["r33717318238a1"]);
+    expect(fenced.rows[0].json_build_object).toMatchObject({
+      failureKind: "account_preparation_fenced",
+      organizationActive: false,
+      accountLifecycleState: "deletion_recovery",
+      accountLifecycleRevision: "2",
+      accountDeletionRequested: true,
+      sandboxLifecycleJobMatches: true,
+      sandboxGenerationMatches: true,
+      jobHasLiveLease: true,
+      jobQuiesced: true,
+    });
+    expect(JSON.stringify(fenced.rows)).not.toContain("PRIVATE");
+
     await db.exec(
-      "INSERT INTO agent_sandboxes VALUES ('duplicate', 'managed-dedicated-canary-r33717318238a1', 'foreign-org', 'owner-user')",
+      "UPDATE jobs SET error_storage = 'r2', error = null WHERE id = 'current'",
+    );
+    const external = await db.query<{
+      json_build_object: Record<string, unknown>;
+    }>(query, ["r33717318238a1"]);
+    expect(external.rows[0].json_build_object).toMatchObject({
+      errorStoredExternally: true,
+      failureKind: "external_error",
+    });
+
+    await db.exec(
+      "INSERT INTO agent_sandboxes (id, agent_name, organization_id, user_id) VALUES ('duplicate', 'managed-dedicated-canary-r33717318238a1', 'foreign-org', 'owner-user')",
     );
     const ambiguous = await db.query<{
       json_build_object: Record<string, unknown>;

--- a/packages/scripts/__tests__/staging-activation-job-origin.test.ts
+++ b/packages/scripts/__tests__/staging-activation-job-origin.test.ts
@@ -70,7 +70,7 @@ test("reads only the bound owner's latest provision error and emits closed terms
     );
 
     await db.query("UPDATE jobs SET error = $1 WHERE id = 'current'", [
-      "Unexpected operation failure\n at /private/provisioning-account-lifecycle-fence.ts:1:1",
+      "Unexpected operation failure\n at /private/provisioning-account-lifecycle-fence.ts:1:1\n at /private/with-timeout.ts:2:1",
     ]);
     const stackOnly = await db.query<{
       json_build_object: Record<string, unknown>;
@@ -78,7 +78,10 @@ test("reads only the bound owner's latest provision error and emits closed terms
     expect(stackOnly.rows[0].json_build_object).toMatchObject({
       failureKind: "unclassified",
       errorTerms: ["operation"],
-      stackFrames: ["provisioning-account-lifecycle-fence.ts:1:1"],
+      stackFrames: [
+        "provisioning-account-lifecycle-fence.ts:1:1",
+        "with-timeout.ts:2:1",
+      ],
     });
 
     await db.exec(`


### PR DESCRIPTION
Staging provisioning diagnostics misreported inline errors as external and mixed exception messages with stack-file names. Correct the storage discriminator, classify known failure messages, and report the selected account's lifecycle state plus sandbox/job ownership and lease facts. Output remains limited to closed categories, booleans, timestamps, counts, and allowlisted source locations. Raw errors and tenant identifiers remain private; ambiguous ownership yields unavailable target details.

Validation: the actual diagnostic SQL executes against PostgreSQL/PGlite with competing tenants, ambiguous ownership, inline and external errors, account deletion state, and lease ownership. A stack referencing `with-timeout.ts` or the account-fence module cannot turn an unrelated exception into a timeout or account restriction. After rebasing on `89b5d92840dfa462653093651d429c7236912833`, the focused diagnostic and CI setup suites passed 11 tests and 43 assertions. Actionlint, Biome, `bun install`, and root `bun run verify` passed (376/376 tasks plus repository audits).

Live staging diagnostic output will be collected through the protected workflow after merge. No deployment or activation success is claimed by this change.

Refs #30552.
