### PR TITLE
fix(evidence): report newly retired invalid queue jobs as failures

### DIFF
--- a/packages/evidence/src/queue/cli.test.ts
+++ b/packages/evidence/src/queue/cli.test.ts
@@ -1,8 +1,4 @@
-// The evidence:gpu-queue CLI as a process boundary: argv parsing, usage/error
-// exit codes, `enqueue` writing a real pending job, and `worker --once` draining
-// to honest skip records when no vision service is reachable. Drives the real
-// runQueueCli with a captured CliIo (no spawned process); the library it calls
-// is the same one exercised elsewhere.
+/** Exercises queue CLI outcomes against actual files, including invalid jobs and unavailable analyzers. */
 
 import fs from "node:fs";
 import os from "node:os";
@@ -32,6 +28,36 @@ function captureIo() {
 }
 
 describe("runQueueCli", () => {
+  it("reports newly retired invalid jobs and exits nonzero without recounting historical failures", async () => {
+    const root = newRoot();
+    const queue = new FileJobQueue(root);
+    fs.writeFileSync(
+      path.join(root, "pending", "000-invalid.json"),
+      "{not JSON",
+    );
+    const first = captureIo();
+    expect(
+      await runQueueCli(["worker", "--root", root, "--once"], first.io),
+    ).toBe(1);
+    const result = queue.readResult("000-invalid");
+    expect(result).toMatchObject({ status: "failed", id: "000-invalid" });
+    expect(result?.reason).toBeTruthy();
+    expect(first.out.join("\n")).toContain(
+      "0 completed, 1 failed, 0 skipped, 0 requeued",
+    );
+    expect(fs.existsSync(path.join(root, "done", "000-invalid.json"))).toBe(
+      true,
+    );
+    const second = captureIo();
+    expect(
+      await runQueueCli(["worker", "--root", root, "--once"], second.io),
+    ).toBe(0);
+    expect(second.out.join("\n")).toContain(
+      "0 completed, 0 failed, 0 skipped, 0 requeued",
+    );
+    expect(queue.readResult("000-invalid")).toEqual(result);
+  });
+
   it("prints usage and exits 1 on an unknown command", async () => {
     const { io, err } = captureIo();
     expect(await runQueueCli(["bogus"], io)).toBe(1);

--- a/packages/evidence/src/queue/cli.ts
+++ b/packages/evidence/src/queue/cli.ts
@@ -126,7 +126,7 @@ async function runWorkerCommand(argv: string[], io: CliIo): Promise<number> {
   io.out(
     `[gpu-queue] done: ${counts.completed} completed, ${counts.failed} failed, ${counts.skipped} skipped, ${counts.requeued} requeued`,
   );
-  return 0;
+  return counts.failed > 0 ? 1 : 0;
 }
 
 function runEnqueueCommand(argv: string[], io: CliIo): number {

--- a/packages/evidence/src/queue/file-queue.ts
+++ b/packages/evidence/src/queue/file-queue.ts
@@ -120,9 +120,10 @@ export class FileJobQueue {
    * concurrency primitive: if two workers target the same file, exactly one
    * rename succeeds and the loser's `ENOENT` makes it try the next candidate, so
    * a job is never processed twice. A file that parses invalid is moved aside
-   * with a `failed` result recorded and the claim continues past it.
+   * with a `failed` result recorded and the claim continues past it. The optional
+   * observer receives each invalid result only after this worker retires it.
    */
-  claim(): ClaimedJob | null {
+  claim(onInvalid?: (result: JobResult) => void): ClaimedJob | null {
     for (const fileName of claimOrder(fs.readdirSync(this.dir("pending")))) {
       const from = path.join(this.dir("pending"), fileName);
       const to = path.join(this.dir("processing"), fileName);
@@ -144,7 +145,8 @@ export class FileJobQueue {
           // Malformed job: record an honest failed result and retire the file so
           // the queue makes progress instead of wedging on a poison job.
           const id = fileName.replace(/\.json$/, "");
-          this.recordInvalid(id, to, error);
+          const result = this.recordInvalid(id, to, error);
+          onInvalid?.(result);
           continue;
         }
         throw error;
@@ -208,16 +210,18 @@ export class FileJobQueue {
     id: string,
     processingPath: string,
     error: QueueJobInvalidError,
-  ): void {
-    this.writeResult({
+  ): JobResult {
+    const result: JobResult = {
       schema: 1,
       id,
       analyzerId: "unknown",
       status: "failed",
       completedAt: new Date(this.now()).toISOString(),
       reason: error.message,
-    });
+    };
+    this.writeResult(result);
     const done = path.join(this.dir("done"), path.basename(processingPath));
     fs.renameSync(processingPath, done);
+    return result;
   }
 }

--- a/packages/evidence/src/queue/worker.test.ts
+++ b/packages/evidence/src/queue/worker.test.ts
@@ -16,7 +16,7 @@ import { makeOcrAnalyzer } from "../analyzers/ocr/ocr.ts";
 import type { Analyzer } from "../analyzers/types.ts";
 import { FileJobQueue } from "./file-queue.ts";
 import { DEFAULT_LIMITS, type WorkerState } from "./state.ts";
-import { processJob, runQueueWorker } from "./worker.ts";
+import { processJob, runQueueWorker, type WorkerEvent } from "./worker.ts";
 
 const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-worker-"));
 afterAll(() => fs.rmSync(scratch, { recursive: true, force: true }));
@@ -388,4 +388,69 @@ describe("queue worker cancellation cleanup", () => {
     await worker;
     expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
   });
+});
+
+describe("invalid queue job outcomes", () => {
+  it.each([false, true])(
+    "reports every invalid job and keeps processing valid work (mixed=%s)",
+    async (mixed) => {
+      const root = newRoot();
+      const queue = new FileJobQueue(root);
+      for (const [id, raw] of [
+        ["000-invalid-json", "broken"],
+        ["001-invalid-shape", "{}"],
+      ]) {
+        fs.writeFileSync(path.join(root, "pending", `${id}.json`), raw);
+      }
+      let validId: string | undefined;
+      if (mixed) {
+        validId = queue.enqueue(
+          writePng(path.join(root, "shot.png")),
+          "ocr.unlimited",
+          {
+            artifact: "shot.png",
+            kind: "screenshot",
+            analysisPath: path.join(root, "analysis.json"),
+          },
+        ).id;
+      }
+      const events: WorkerEvent[] = [];
+      const counts = await runQueueWorker({
+        queue,
+        analyzers: [unlimitedAt(undefined)],
+        stopWhenIdle: true,
+        limits: { drainAfterMs: 0 },
+        onEvent: (event) => events.push(event),
+      });
+      expect(counts).toEqual({
+        completed: 0,
+        failed: 2,
+        skipped: mixed ? 1 : 0,
+        requeued: 0,
+      });
+      for (const id of ["000-invalid-json", "001-invalid-shape"]) {
+        const result = queue.readResult(id);
+        expect(result?.status).toBe("failed");
+        expect(
+          events.filter(
+            (event) => event.type === "processed" && event.id === id,
+          ),
+        ).toEqual([
+          { type: "processed", id, action: "failed", reason: result?.reason },
+        ]);
+        expect(fs.existsSync(path.join(root, "done", `${id}.json`))).toBe(true);
+      }
+      if (validId) expect(queue.readResult(validId)?.status).toBe("skipped");
+      expect(queue.pendingCount()).toBe(0);
+      const secondEvents: WorkerEvent[] = [];
+      expect(
+        await runQueueWorker({
+          queue,
+          stopWhenIdle: true,
+          onEvent: (event) => secondEvents.push(event),
+        }),
+      ).toEqual({ completed: 0, failed: 0, skipped: 0, requeued: 0 });
+      expect(secondEvents).toEqual([{ type: "idle" }]);
+    },
+  );
 });

--- a/packages/evidence/src/queue/worker.ts
+++ b/packages/evidence/src/queue/worker.ts
@@ -252,7 +252,15 @@ export async function runQueueWorker(
   let state = createWorkerState();
 
   while (!options.signal?.aborted) {
-    const claimed = deps.queue.claim();
+    const claimed = deps.queue.claim((result) => {
+      counts.failed += 1;
+      emit({
+        type: "processed",
+        id: result.id,
+        action: "failed",
+        reason: result.reason,
+      });
+    });
     if (!claimed) {
       emit({ type: "idle" });
       // When draining, a requeued job is the only thing that could reappear; if


### PR DESCRIPTION
Malformed pending jobs were retired as failed on disk but omitted from the current worker totals, allowing the CLI to exit successfully. The worker now records and emits each newly retired invalid result once. The CLI exits with failure when the current run contains failed jobs; historical results do not affect a later run.

Closes #30576.

The change uses the existing queue state machine and durable retirement path. No new queue, scheduler, schema, or analyzer is introduced. Risk is low: only current-run outcome accounting and the corresponding CLI exit code change.

Validation: all 532 evidence tests passed, with two opt-in tests skipped; package typecheck and lint passed through root verification. The package has no standalone build. An independent reviewer reran the 22 focused real-filesystem queue tests and found no blocker. Root verification passed all 376 tasks again after rebasing onto develop at 89b5d92840dfa462653093651d429c7236912833 and running bun install. The rebased head is 1d5026b1b5f2fab680f833dca2f836d19dc49c69.

## Evidence Gate

<!-- evidence-head:1d5026b1b5f2fab680f833dca2f836d19dc49c69 -->
<!-- evidence-row:before-screenshots -->
N/A - filesystem queue and CLI behavior; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
N/A - filesystem queue and CLI behavior; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
N/A - the complete CLI outcome is captured in the transcript below.
<!-- evidence-row:backend-logs -->
<details><summary>Actual CLI drain followed by a second empty run</summary>

```text
[gpu-queue] worker draining /tmp/eliza-quality-review-20260904/queue-pr-proof at tier=gpu
[gpu-queue] failed 000-invalid — invalid queue job: not valid JSON
[gpu-queue] done: 0 completed, 1 failed, 0 skipped, 0 requeued
first exit: 1
[gpu-queue] worker draining /tmp/eliza-quality-review-20260904/queue-pr-proof at tier=gpu
[gpu-queue] done: 0 completed, 0 failed, 0 skipped, 0 requeued
second exit: 0
```

</details>
<!-- evidence-row:frontend-logs -->
N/A - no browser or frontend request path changed.
<!-- evidence-row:llm-trajectory -->
N/A - no model, action, prompt, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
The malformed pending file was retired to done before the failure was counted. Its persisted result was inspected:

```json
{
  "schema": 1,
  "id": "000-invalid",
  "analyzerId": "unknown",
  "status": "failed",
  "completedAt": "2026-09-05T01:28:04.755Z",
  "reason": "invalid queue job: not valid JSON"
}

```
<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface.

Known gaps: the two opt-in CLI test cases remain skipped in the standard package lane. The actual malformed-job CLI path was independently exercised above. Hosted checks must pass on the exact current head before merge.

Documentation: no public option or command changed. Maintainer CI exception: N/A - no exception requested.
