### PR TITLE
fix(auth): validate Codex device-login credential files

### DIFF
--- a/packages/auth/src/codex-device.test.ts
+++ b/packages/auth/src/codex-device.test.ts
@@ -75,6 +75,18 @@ function accessToken(exp: number): string {
   return `header.${Buffer.from(JSON.stringify({ exp })).toString("base64url")}.signature`;
 }
 
+async function deviceLoginFromAuthJson(authJson: unknown) {
+  const child = mockChild();
+  const start = startCodexDeviceLogin();
+  const codexHome = spawnedCodexHome();
+  child.process.emit("spawn");
+  emitPrompt(child);
+  const flow = await start;
+  writeFileSync(path.join(codexHome, "auth.json"), JSON.stringify(authJson));
+  child.process.emit("close", 0, null);
+  return { credentials: flow.credentials, codexHome };
+}
+
 afterEach(() => {
   for (const temporaryHome of temporaryHomes) {
     if (existsSync(temporaryHome)) {
@@ -319,6 +331,110 @@ describe("startCodexDeviceLogin", () => {
     await expect(flow.credentials).rejects.toMatchObject({
       code: "codex_device.process_failed",
       context: { exitCode: null, signal: "SIGTERM" },
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["non-object root", null],
+    ["non-object token block", { tokens: [] }],
+    [
+      "numeric access token",
+      { tokens: { access_token: 7, refresh_token: "refresh" } },
+    ],
+    [
+      "blank access token",
+      { tokens: { access_token: " ", refresh_token: "refresh" } },
+    ],
+    [
+      "numeric refresh token",
+      {
+        tokens: {
+          access_token: accessToken(2_000_000_000),
+          refresh_token: 7,
+        },
+      },
+    ],
+    [
+      "blank refresh token",
+      {
+        tokens: {
+          access_token: accessToken(2_000_000_000),
+          refresh_token: " ",
+        },
+      },
+    ],
+    [
+      "numeric ID token",
+      {
+        tokens: {
+          access_token: accessToken(2_000_000_000),
+          refresh_token: "refresh",
+          id_token: 7,
+        },
+      },
+    ],
+  ])("rejects auth.json with a %s", async (_name, authJson) => {
+    const { credentials, codexHome } = await deviceLoginFromAuthJson(authJson);
+    await expect(credentials).rejects.toMatchObject({
+      code: "codex_device.credentials_invalid",
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["overflowing", 1e308],
+  ])("rejects an access token with a %s exp claim", async (_name, exp) => {
+    const { credentials, codexHome } = await deviceLoginFromAuthJson({
+      tokens: {
+        access_token: accessToken(exp),
+        refresh_token: "refresh",
+      },
+    });
+    await expect(credentials).rejects.toMatchObject({
+      code: "codex_device.invalid_access_token",
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["null", null],
+    ["empty", ""],
+  ])("omits an %s optional ID token", async (_name, idToken) => {
+    const { credentials, codexHome } = await deviceLoginFromAuthJson({
+      tokens: {
+        access_token: accessToken(2_000_000_000),
+        refresh_token: "refresh",
+        id_token: idToken,
+      },
+    });
+    await expect(credentials).resolves.toEqual({
+      access: accessToken(2_000_000_000),
+      refresh: "refresh",
+      expires: 2_000_000_000_000,
+    });
+    expect(existsSync(codexHome)).toBe(false);
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a whitespace-only ID token for compatibility", async () => {
+    const { credentials, codexHome } = await deviceLoginFromAuthJson({
+      tokens: {
+        access_token: accessToken(2_000_000_000),
+        refresh_token: "refresh",
+        id_token: " ",
+      },
+    });
+    await expect(credentials).resolves.toEqual({
+      access: accessToken(2_000_000_000),
+      refresh: "refresh",
+      expires: 2_000_000_000_000,
+      idToken: " ",
     });
     expect(existsSync(codexHome)).toBe(false);
     expect(rmSyncMock).toHaveBeenCalledTimes(1);

--- a/packages/auth/src/codex-device.ts
+++ b/packages/auth/src/codex-device.ts
@@ -65,15 +65,31 @@ export function codexDeviceLoginUsesShell(
   return platform === "win32";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function expiryFromJwt(token: string): number {
   try {
-    const payload = JSON.parse(
+    const payload: unknown = JSON.parse(
       Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8"),
-    ) as { exp?: unknown };
-    if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) {
-      throw new Error("Codex access token has no finite exp claim");
+    );
+    if (!isRecord(payload)) {
+      throw new Error("Codex access token payload must be an object");
     }
-    return payload.exp * 1000;
+    const exp = payload.exp;
+    if (typeof exp !== "number" || !Number.isFinite(exp) || exp <= 0) {
+      throw new Error("Codex access token has no positive finite exp claim");
+    }
+    const expires = exp * 1000;
+    if (!Number.isFinite(expires) || expires <= 0) {
+      throw new Error("Codex access token expiry exceeds the numeric range");
+    }
+    return expires;
   } catch (cause) {
     // error-policy:J2 context-adding rethrow — fabricating an expiry can make an
     // invalid token look healthy and delay required reauthentication.
@@ -231,26 +247,33 @@ export function startCodexDeviceLogin(): Promise<CodexDeviceFlow> {
       }
       let parsedCredentials: OAuthCredentials;
       try {
-        const parsed = JSON.parse(
+        const parsed: unknown = JSON.parse(
           readFileSync(path.join(codexHome, "auth.json"), "utf8"),
-        ) as {
-          tokens?: {
-            access_token?: string;
-            refresh_token?: string;
-            id_token?: string;
-          };
-        };
-        const access = parsed.tokens?.access_token;
-        const refresh = parsed.tokens?.refresh_token;
-        if (!access || !refresh)
-          throw new Error("Codex device login returned no tokens");
+        );
+        if (!isRecord(parsed) || !isRecord(parsed.tokens)) {
+          throw new Error("Codex device login returned no token object");
+        }
+        const access = parsed.tokens.access_token;
+        const refresh = parsed.tokens.refresh_token;
+        const rawIdToken = parsed.tokens.id_token;
+        if (!isNonBlankString(access) || !isNonBlankString(refresh)) {
+          throw new Error(
+            "Codex device login returned invalid access or refresh tokens",
+          );
+        }
+        if (
+          rawIdToken !== undefined &&
+          rawIdToken !== null &&
+          typeof rawIdToken !== "string"
+        ) {
+          throw new Error("Codex device login returned an invalid ID token");
+        }
+        const idToken = rawIdToken || undefined;
         parsedCredentials = {
           access,
           refresh,
           expires: expiryFromJwt(access),
-          ...(parsed.tokens?.id_token
-            ? { idToken: parsed.tokens.id_token }
-            : {}),
+          ...(idToken ? { idToken } : {}),
         };
       } catch (cause) {
         // error-policy:J2 context-adding translation — credential-file and JWT


### PR DESCRIPTION
Closes #30588.

Reject malformed Codex device-login credential files before constructing a login result. Access and refresh tokens must be nonblank strings; supplied ID tokens must be strings; explicit expiry must be positive and finite, including conversion to milliseconds. Existing valid optional-ID-token behavior is preserved.

Independent review traced the credential file reader, device-flow completion, and persisted credential consumers. Real temporary-file tests exercise successful and rejected inputs through the device login boundary.

Validation after rebase onto `f567055f1c3656590369e6f9c416c253a773f283`, using Bun 1.3.14 and Node 24.15.0:
- `bun install`: passed.
- Full auth suite: 19 files, 226 tests passed.
- Auth typecheck, lint, and format checks: passed.
- Root `bun run verify`: 376/376 workspace tasks and all repository audits passed.

<!-- evidence-head:bf1cae56b96d2295d4cd5e45c60e4ba0e84ff348 -->
UI screenshots/video, frontend logs, native capture, and model trajectories are N/A: this change only validates a local credential file. Hosted checks must pass at the final head before merge.
