### PR TITLE
fix(cloud): enforce response contracts and total request deadlines

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -728,6 +728,7 @@
         "@electric-sql/pglite-socket": "0.1.6",
         "@elevenlabs/elevenlabs-js": "^2.45.0",
         "@elizaos/cloud-sdk": "workspace:*",
+        "@elizaos/cloud-services-common": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-cloud-apps": "workspace:*",
         "@elizaos/plugin-doordash": "workspace:*",

--- a/packages/cloud/sdk/README.md
+++ b/packages/cloud/sdk/README.md
@@ -145,3 +145,9 @@ throw `CloudApiError`; they never become an invented `{ success: true }` DTO.
 HEAD and HTTP 204/205 responses resolve to `undefined`, as these protocols have
 no response body. Use `requestRaw` (or a generated `Raw` method) for text,
 binary, streaming, or status-sensitive responses.
+
+`pollJob` and `waitForCliLogin` enforce a total timeout through every request,
+response-body read and polling interval. Their timeout and interval options
+accept integers from 0 through 2,147,483,647 milliseconds; zero timeout expires
+immediately. Login cancellation also interrupts an in-flight request or wait.
+Direct `getJob` and `pollCliLogin` calls accept optional `timeoutMs` and `signal`.

--- a/packages/cloud/sdk/README.md
+++ b/packages/cloud/sdk/README.md
@@ -135,3 +135,13 @@ Build and publish:
 bun run build
 npm publish --access public
 ```
+
+## Parsed responses
+
+`request` and typed endpoint methods accept `application/json` and application
+media types ending in `+json`, preserving objects, arrays and JSON primitives.
+Successful HTML/text, malformed JSON and unexpectedly empty JSON responses
+throw `CloudApiError`; they never become an invented `{ success: true }` DTO.
+HEAD and HTTP 204/205 responses resolve to `undefined`, as these protocols have
+no response body. Use `requestRaw` (or a generated `Raw` method) for text,
+binary, streaming, or status-sensitive responses.

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -11,6 +11,7 @@
 
 import { isCliLoginSessionId } from "./cli-login.js";
 import { CloudApiClient, CloudApiError, ElizaCloudHttpClient } from "./http.js";
+import { pollUntil } from "./poll.js";
 import { ElizaCloudPublicRoutesClient } from "./public-routes.js";
 import type {
   CreateRedemptionRequest,
@@ -411,11 +412,14 @@ export class ElizaCloudClient {
     });
   }
 
-  pollCliLogin(sessionId: string): Promise<CliLoginPollResponse> {
+  pollCliLogin(
+    sessionId: string,
+    options?: Pick<CloudRequestOptions, "signal" | "timeoutMs">,
+  ): Promise<CliLoginPollResponse> {
     return this.request<CliLoginPollResponse>(
       "GET",
       `/api/auth/cli-session/${encodePathParam(sessionId)}`,
-      { skipAuth: true },
+      { ...options, skipAuth: true },
     );
   }
 
@@ -441,25 +445,22 @@ export class ElizaCloudClient {
       signal?: AbortSignal;
     } = {},
   ): Promise<CliLoginPollResponse> {
-    const timeoutMs = options.timeoutMs ?? 300_000;
-    const intervalMs = options.intervalMs ?? 2_000;
-    const deadline = Date.now() + timeoutMs;
-
-    while (Date.now() < deadline) {
-      if (options.signal?.aborted) {
-        throw new Error("Eliza Cloud sign-in was cancelled");
-      }
-      const result = await this.pollCliLogin(sessionId);
-      if (result.status === "authenticated") {
-        return result;
-      }
-      if (result.status === "expired" || result.status === "error") {
-        throw new Error(result.error ?? `Eliza Cloud sign-in ${result.status}`);
-      }
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-
-    throw new Error("Timed out waiting for Eliza Cloud sign-in");
+    return pollUntil({
+      read: (requestOptions) => this.pollCliLogin(sessionId, requestOptions),
+      isComplete: (result) => {
+        if (result.status === "expired" || result.status === "error") {
+          throw new Error(
+            result.error ?? `Eliza Cloud sign-in ${result.status}`,
+          );
+        }
+        return result.status === "authenticated";
+      },
+      timeoutMs: options.timeoutMs ?? 300_000,
+      intervalMs: options.intervalMs ?? 2_000,
+      signal: options.signal,
+      timeoutMessage: "Timed out waiting for Eliza Cloud sign-in",
+      cancellationMessage: "Eliza Cloud sign-in was cancelled",
+    });
   }
 
   pairWithToken(token: string, origin: string): Promise<AuthPairResponse> {
@@ -1518,27 +1519,29 @@ export class ElizaCloudClient {
     );
   }
 
-  getJob(jobId: string): Promise<JobStatus> {
-    return this.request("GET", `/api/v1/jobs/${encodePathParam(jobId)}`);
+  getJob(
+    jobId: string,
+    options?: Pick<CloudRequestOptions, "signal" | "timeoutMs">,
+  ): Promise<JobStatus> {
+    return this.request(
+      "GET",
+      `/api/v1/jobs/${encodePathParam(jobId)}`,
+      options,
+    );
   }
 
   async pollJob(
     jobId: string,
     options: { timeoutMs?: number; intervalMs?: number } = {},
-  ) {
-    const timeoutMs = options.timeoutMs ?? 120_000;
-    const intervalMs = options.intervalMs ?? 2_000;
-    const deadline = Date.now() + timeoutMs;
-
-    while (Date.now() < deadline) {
-      const job = await this.getJob(jobId);
-      if (job.status === "completed" || job.status === "failed") {
-        return job;
-      }
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-
-    throw new Error(`Timed out waiting for Eliza Cloud job ${jobId}`);
+  ): Promise<JobStatus> {
+    return pollUntil({
+      read: (requestOptions) => this.getJob(jobId, requestOptions),
+      isComplete: (job) =>
+        job.status === "completed" || job.status === "failed",
+      timeoutMs: options.timeoutMs ?? 120_000,
+      intervalMs: options.intervalMs ?? 2_000,
+      timeoutMessage: `Timed out waiting for Eliza Cloud job ${jobId}`,
+    });
   }
 
   getUser(): Promise<UserProfileResponse> {

--- a/packages/cloud/sdk/src/http-server.test.ts
+++ b/packages/cloud/sdk/src/http-server.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Exercises parsed SDK response contracts over real localhost HTTP, including
+ * public account access and raw/bodyless protocol behavior without fetch mocks.
+ */
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ElizaCloudClient } from "./client.js";
+import { ElizaCloudHttpClient } from "./http.js";
+
+let baseUrl: string;
+const server = createServer((req, res) => {
+  const path = req.url ?? "/";
+  const send = (body: string, contentType?: string): void => {
+    if (contentType) res.setHeader("content-type", contentType);
+    res.end(body);
+  };
+  if (path === "/api/v1/user") return send("<h1>Maintenance</h1>", "text/html");
+  if (path === "/missing-type") return send('{"id":"real"}');
+  if (path === "/wrong-type") return send('{"id":"real"}', "text/plain");
+  if (path === "/empty") return send("", "application/json");
+  if (path === "/malformed") return send("{broken", "application/json");
+  if (path === "/raw") return send("complete server text", "text/plain");
+  if (path === "/bodyless/204" || path === "/bodyless/205") {
+    res.statusCode = Number(path.split("/")[2]);
+    return res.end();
+  }
+  if (req.method === "HEAD") return res.end();
+  const value = new URL(path, "http://localhost").searchParams.get("value");
+  send(value ?? '{"id":"real"}', "Application/Problem+JSON; charset=utf-8");
+});
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing HTTP port");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
+  });
+});
+
+describe("real HTTP parsed response contracts", () => {
+  it("fails the public account request on an HTML maintenance page", async () => {
+    await expect(
+      new ElizaCloudClient({ baseUrl }).getUser(),
+    ).rejects.toMatchObject({
+      name: "CloudApiError",
+      statusCode: 200,
+      errorBody: { code: "unexpected_response_content_type" },
+    });
+  });
+  it.each(["/missing-type", "/wrong-type"])(
+    "rejects mislabeled data at %s",
+    async (path) => {
+      await expect(
+        new ElizaCloudHttpClient({ baseUrl }).get(path),
+      ).rejects.toMatchObject({
+        errorBody: { code: "unexpected_response_content_type" },
+      });
+    },
+  );
+  it.each([
+    ["/empty", "empty_response_body"],
+    ["/malformed", "malformed_json_response"],
+  ])("rejects unusable JSON at %s", async (path, code) => {
+    await expect(
+      new ElizaCloudHttpClient({ baseUrl }).get(path),
+    ).rejects.toMatchObject({ errorBody: { code } });
+  });
+  it.each(
+    ["hello", "", null, false, 0, [1, "two"], { id: "real" }].map((value) => [
+      value,
+    ]),
+  )("preserves JSON value %# with a structured media type", async (value) => {
+    const path = `/json?value=${encodeURIComponent(JSON.stringify(value))}`;
+    await expect(
+      new ElizaCloudHttpClient({ baseUrl }).get(path),
+    ).resolves.toEqual(value);
+  });
+  it.each([204, 205])("returns absence for HTTP %s", async (status) => {
+    await expect(
+      new ElizaCloudHttpClient({ baseUrl }).get(`/bodyless/${status}`),
+    ).resolves.toBeUndefined();
+  });
+  it("returns absence for HEAD and preserves text through raw access", async () => {
+    const client = new ElizaCloudHttpClient({ baseUrl });
+    await expect(client.request("HEAD", "/head")).resolves.toBeUndefined();
+    const response = await client.requestRaw("GET", "/raw");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("complete server text");
+  });
+});

--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -306,7 +306,7 @@ describe("ElizaCloudHttpClient errors", () => {
     ).rejects.toMatchObject({ name: "CloudApiError", statusCode: 500 });
   });
 
-  it("accepts a 2xx text/plain body as a success without JSON parsing", async () => {
+  it("rejects a 2xx text/plain body when a parsed response was requested", async () => {
     const client = new ElizaCloudHttpClient({
       baseUrl: "https://cloud.test",
       fetchImpl: asFetch(
@@ -318,8 +318,9 @@ describe("ElizaCloudHttpClient errors", () => {
       ),
     });
 
-    await expect(client.request("GET", "/api/ping")).resolves.toEqual({
-      success: true,
+    await expect(client.request("GET", "/api/ping")).rejects.toMatchObject({
+      name: "CloudApiError",
+      errorBody: { code: "unexpected_response_content_type" },
     });
   });
 });

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -252,6 +252,18 @@ async function readBoundedResponseText(
   }
 }
 
+function hasJsonContentType(response: Response): boolean {
+  const mediaType = response.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  return (
+    mediaType === "application/json" ||
+    /^application\/[\w.+-]+\+json$/.test(mediaType ?? "")
+  );
+}
+
 async function parseResponseBody(
   response: Response,
   signal: AbortSignal | undefined,
@@ -259,8 +271,7 @@ async function parseResponseBody(
   const text = await readBoundedResponseText(response, signal);
   if (!text) return undefined;
 
-  const contentType = response.headers.get("content-type") ?? "";
-  if (!contentType.includes("application/json")) {
+  if (!hasJsonContentType(response)) {
     return text;
   }
 
@@ -680,17 +691,33 @@ export class ElizaCloudHttpClient {
           : new CloudApiError(response.status, errorBody);
       }
 
-      // A 2xx that promised JSON but delivered unparseable bytes is a broken
-      // response, not a success — surface it instead of fabricating one.
+      if (
+        method === "HEAD" ||
+        response.status === 204 ||
+        response.status === 205
+      ) {
+        return undefined as TResponse;
+      }
+      if (!hasJsonContentType(response)) {
+        throw new CloudApiError(response.status, {
+          success: false,
+          code: "unexpected_response_content_type",
+          error: `HTTP ${response.status}: expected a JSON response; use requestRaw for text or binary responses`,
+        });
+      }
+      if (body === undefined) {
+        throw new CloudApiError(response.status, {
+          success: false,
+          code: "empty_response_body",
+          error: `HTTP ${response.status}: expected a JSON response body`,
+        });
+      }
       if (isMalformedJsonBody(body)) {
         throw new CloudApiError(response.status, {
           success: false,
+          code: "malformed_json_response",
           error: `HTTP ${response.status}: malformed JSON response body: ${body.text}`,
         });
-      }
-
-      if (body === undefined || typeof body === "string") {
-        return { success: true } as TResponse;
       }
 
       return body as TResponse;

--- a/packages/cloud/sdk/src/poll-server.test.ts
+++ b/packages/cloud/sdk/src/poll-server.test.ts
@@ -1,0 +1,147 @@
+/** Verifies total SDK polling deadlines and cancellation with real localhost HTTP. */
+import { createServer } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ElizaCloudClient } from "./client.js";
+
+let baseUrl: string;
+const requests = new Map<string, number>();
+const server = createServer((req, res) => {
+  const id = req.url?.split("/").at(-1) ?? "";
+  const count = (requests.get(id) ?? 0) + 1;
+  requests.set(id, count);
+  if (id.startsWith("headers")) return;
+  res.setHeader("content-type", "application/json");
+  if (id.startsWith("body")) {
+    res.write('{"status":');
+    return;
+  }
+  const login = req.url?.startsWith("/api/auth/");
+  const status =
+    id.startsWith("complete") && count > 1
+      ? login
+        ? "authenticated"
+        : "completed"
+      : id.startsWith("fail")
+        ? login
+          ? "expired"
+          : "failed"
+        : "pending";
+  res.end(
+    JSON.stringify({
+      id,
+      status,
+      ...(status === "completed" ? { result: { complete: "result" } } : {}),
+      ...(status === "authenticated"
+        ? { apiKey: "local-fixture-key", userId: "user" }
+        : {}),
+    }),
+  );
+});
+beforeAll(async () => {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing HTTP port");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
+  });
+});
+
+for (const mode of ["job", "login"] as const) {
+  describe(`real HTTP ${mode} polling`, () => {
+    const poll = (
+      id: string,
+      options: { timeoutMs?: number; intervalMs?: number },
+    ) => {
+      const client = new ElizaCloudClient({ baseUrl });
+      return mode === "job"
+        ? client.pollJob(id, options)
+        : client.waitForCliLogin(id, options);
+    };
+    it.each(["headers", "body", "pending"])(
+      "bounds %s stalls and long intervals by the total timeout",
+      async (phase) => {
+        const id = `${phase}-${mode}`;
+        const started = performance.now();
+        await expect(
+          poll(id, { timeoutMs: 80, intervalMs: 2_000 }),
+        ).rejects.toThrow("Timed out waiting for Eliza Cloud");
+        expect(performance.now() - started).toBeLessThan(800);
+        expect(requests.get(id)).toBe(1);
+      },
+    );
+    it("preserves terminal results through repeated requests", async () => {
+      const result = await poll(`complete-${mode}`, {
+        timeoutMs: 2_000,
+        intervalMs: 1,
+      });
+      if (mode === "job")
+        expect(result).toMatchObject({
+          status: "completed",
+          result: { complete: "result" },
+        });
+      else
+        expect(result).toMatchObject({
+          status: "authenticated",
+          apiKey: "local-fixture-key",
+        });
+    });
+    it("preserves failed or expired terminal outcomes", async () => {
+      if (mode === "job")
+        await expect(poll("fail-job", {})).resolves.toMatchObject({
+          status: "failed",
+        });
+      else
+        await expect(poll("fail-login", {})).rejects.toThrow("sign-in expired");
+    });
+    it.each([-1, NaN, Infinity, 0.5, 2_147_483_648])(
+      "rejects invalid timer options before sending HTTP",
+      async (value) => {
+        await expect(
+          poll(`invalid-${mode}`, { timeoutMs: value }),
+        ).rejects.toBeInstanceOf(RangeError);
+        await expect(
+          poll(`invalid-${mode}`, { intervalMs: value }),
+        ).rejects.toBeInstanceOf(RangeError);
+        expect(requests.has(`invalid-${mode}`)).toBe(false);
+      },
+    );
+    it("expires a zero timeout before sending HTTP", async () => {
+      await expect(poll(`zero-${mode}`, { timeoutMs: 0 })).rejects.toThrow(
+        "Timed out",
+      );
+      expect(requests.has(`zero-${mode}`)).toBe(false);
+    });
+  });
+}
+
+describe("login cancellation", () => {
+  it.each(["headers", "body", "pending"])(
+    "interrupts %s with the existing cancellation message",
+    async (phase) => {
+      const controller = new AbortController();
+      const reason = new Error("caller stopped");
+      const timer = setTimeout(() => controller.abort(reason), 80);
+      const started = performance.now();
+      try {
+        await expect(
+          new ElizaCloudClient({ baseUrl }).waitForCliLogin(`${phase}-cancel`, {
+            signal: controller.signal,
+            timeoutMs: 2_000,
+            intervalMs: 2_000,
+          }),
+        ).rejects.toMatchObject({
+          message: "Eliza Cloud sign-in was cancelled",
+          cause: reason,
+        });
+        expect(performance.now() - started).toBeLessThan(800);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  );
+});

--- a/packages/cloud/sdk/src/poll.ts
+++ b/packages/cloud/sdk/src/poll.ts
@@ -1,0 +1,76 @@
+/** Owns the total SDK polling budget across requests, response bodies and waits. */
+
+interface PollOptions<T> {
+  read(options: { timeoutMs: number; signal?: AbortSignal }): Promise<T>;
+  isComplete(value: T): boolean;
+  timeoutMs: number;
+  intervalMs: number;
+  timeoutMessage: string;
+  signal?: AbortSignal;
+  cancellationMessage?: string;
+}
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function validateDelay(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > MAX_TIMER_DELAY_MS) {
+    throw new RangeError(
+      `${name} must be an integer between 0 and ${MAX_TIMER_DELAY_MS} milliseconds`,
+    );
+  }
+}
+
+function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const finish = (): void => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener("abort", finish, { once: true });
+  });
+}
+
+export async function pollUntil<T>(options: PollOptions<T>): Promise<T> {
+  validateDelay("timeoutMs", options.timeoutMs);
+  validateDelay("intervalMs", options.intervalMs);
+  const deadline = performance.now() + options.timeoutMs;
+  const checkCancellation = (): void => {
+    if (options.signal?.aborted) {
+      if (options.cancellationMessage) {
+        throw new Error(options.cancellationMessage, {
+          cause: options.signal.reason,
+        });
+      }
+      options.signal.throwIfAborted();
+    }
+  };
+  for (;;) {
+    checkCancellation();
+    const remaining = Math.ceil(deadline - performance.now());
+    if (remaining <= 0) throw new Error(options.timeoutMessage);
+    let result: T;
+    try {
+      result = await options.read({
+        timeoutMs: remaining,
+        signal: options.signal,
+      });
+    } catch (error) {
+      // error-policy:J2 Add polling context to deadline/cancellation failures; preserve other transport failures.
+      checkCancellation();
+      if (performance.now() >= deadline) {
+        throw new Error(options.timeoutMessage, { cause: error });
+      }
+      throw error;
+    }
+    checkCancellation();
+    if (performance.now() >= deadline) throw new Error(options.timeoutMessage);
+    if (options.isComplete(result)) return result;
+    await wait(
+      Math.min(options.intervalMs, Math.ceil(deadline - performance.now())),
+      options.signal,
+    );
+  }
+}

--- a/packages/cloud/services/_common/AGENTS.md
+++ b/packages/cloud/services/_common/AGENTS.md
@@ -30,6 +30,9 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   LINK-code recognition and user-facing confirmation results.
 - `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token
   response validation plus shared refresh and jittered retry timing.
+- `src/bounded-fetch.ts` (`./bounded-fetch`) — Web-standard REST transport
+  owning deadlines, bounded decoded response reads and cancellation cleanup.
+  Cloud shared and gateway adapters supply limits and public error factories.
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram

--- a/packages/cloud/services/_common/CLAUDE.md
+++ b/packages/cloud/services/_common/CLAUDE.md
@@ -30,6 +30,9 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   LINK-code recognition and user-facing confirmation results.
 - `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token
   response validation plus shared refresh and jittered retry timing.
+- `src/bounded-fetch.ts` (`./bounded-fetch`) — Web-standard REST transport
+  owning deadlines, bounded decoded response reads and cancellation cleanup.
+  Cloud shared and gateway adapters supply limits and public error factories.
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram

--- a/packages/cloud/services/_common/package.json
+++ b/packages/cloud/services/_common/package.json
@@ -16,7 +16,8 @@
     "./personal-shared-failure": "./src/personal-shared-failure.ts",
     "./response-attempts": "./src/response-attempts.ts",
     "./telegram-connector": "./src/telegram-connector.ts",
-    "./telegram-delivery": "./src/telegram-delivery.ts"
+    "./telegram-delivery": "./src/telegram-delivery.ts",
+    "./bounded-fetch": "./src/bounded-fetch.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/cloud/services/_common/src/bounded-fetch.ts
+++ b/packages/cloud/services/_common/src/bounded-fetch.ts
@@ -1,0 +1,185 @@
+/**
+ * Owns a cloud REST hop through its deadline, bounded body read and cleanup.
+ * Only arrived bytes are retained; adapters supply limits and error factories
+ * so Worker and sidecar callers share transport behavior without sharing policy.
+ */
+
+export interface BoundedFetchOptions {
+  timeoutMs: number;
+  maxResponseBytes: number;
+  maxResponseChunks?: number;
+  fetchImpl?: typeof fetch;
+  invalidBoundsError(): Error;
+  responseTooLargeError(context: Record<string, unknown>): Error;
+  timeoutMessage: string;
+  cancellationMessage: string;
+}
+
+function releaseNoThrow(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    reader.releaseLock();
+  } catch {
+    // error-policy:J6 Releasing a terminal response stream is teardown-only.
+  }
+}
+
+function cancelBodyDetached(
+  body: ReadableStream<Uint8Array> | null,
+  reason: unknown,
+): void {
+  if (!body) return;
+  try {
+    void body
+      .cancel(reason)
+      // error-policy:J6 The selected boundary failure is already observed by the caller.
+      .catch(() => undefined);
+  } catch {
+    // error-policy:J6 A synchronous cancellation failure is teardown-only.
+  }
+}
+
+function cancelReaderDetached(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason: unknown,
+): void {
+  try {
+    // Hostile cancellation must not delay the selected error. Keep reader
+    // ownership until cancellation finishes before releasing its lock.
+    void reader
+      .cancel(reason)
+      // error-policy:J6 The selected boundary failure is already observed by the caller.
+      .catch(() => undefined)
+      .finally(() => releaseNoThrow(reader));
+  } catch {
+    // error-policy:J6 A synchronous cancellation failure is teardown-only.
+    releaseNoThrow(reader);
+  }
+}
+
+/** Returns a fully buffered response detached from the transport deadline. */
+export async function boundedFetch(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  options: BoundedFetchOptions,
+): Promise<Response> {
+  const { timeoutMs, maxResponseBytes, maxResponseChunks } = options;
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > 2_147_483_647 ||
+    !Number.isSafeInteger(maxResponseBytes) ||
+    maxResponseBytes < 0 ||
+    (maxResponseChunks !== undefined &&
+      (!Number.isSafeInteger(maxResponseChunks) || maxResponseChunks < 1))
+  ) {
+    throw options.invalidBoundsError();
+  }
+  const callerSignal =
+    init?.signal ?? (input instanceof Request ? input.signal : undefined);
+  const cancellationReason = (): unknown =>
+    callerSignal?.reason ??
+    new DOMException(options.cancellationMessage, "AbortError");
+  if (callerSignal?.aborted) throw cancellationReason();
+  const controller = new AbortController();
+  let rejectAbort!: (reason: unknown) => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  const abort = (reason: unknown): void => {
+    if (controller.signal.aborted) return;
+    // Select provenance before the transport rejects with its own AbortError.
+    rejectAbort(reason);
+    controller.abort(reason);
+  };
+  const onCallerAbort = (): void => abort(cancellationReason());
+  callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+  const timer = setTimeout(
+    () => abort(new DOMException(options.timeoutMessage, "TimeoutError")),
+    timeoutMs,
+  );
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let response: Response | undefined;
+  try {
+    const pending = (options.fetchImpl ?? fetch)(input, {
+      ...init,
+      signal: controller.signal,
+    });
+    void pending.then(
+      (lateResponse) => {
+        if (controller.signal.aborted)
+          cancelBodyDetached(lateResponse.body, controller.signal.reason);
+      },
+      () => {
+        // error-policy:J5 The same fetch rejection is observed by the race below.
+      },
+    );
+    response = await Promise.race([pending, aborted]);
+    controller.signal.throwIfAborted();
+    const rawLength = response.headers.get("content-length");
+    if (
+      rawLength !== null &&
+      (!/^\d+$/.test(rawLength) || Number(rawLength) > maxResponseBytes)
+    ) {
+      throw options.responseTooLargeError({
+        contentLength: rawLength,
+        maxResponseBytes,
+      });
+    }
+    if (!response.body) return response;
+    reader = response.body.getReader();
+    const retainedChunks: Uint8Array[] = [];
+    let receivedBytes = 0;
+    let chunks = 0;
+    for (;;) {
+      const next = await Promise.race([reader.read(), aborted]);
+      controller.signal.throwIfAborted();
+      if (next.done) break;
+      chunks += 1;
+      receivedBytes += next.value.byteLength;
+      if (
+        receivedBytes > maxResponseBytes ||
+        (maxResponseChunks !== undefined && chunks > maxResponseChunks)
+      ) {
+        throw options.responseTooLargeError({
+          receivedBytes,
+          maxResponseBytes,
+          ...(maxResponseChunks !== undefined
+            ? { chunks, maxResponseChunks }
+            : {}),
+        });
+      }
+      if (next.value.byteLength > 0) retainedChunks.push(next.value);
+    }
+    releaseNoThrow(reader);
+    reader = undefined;
+    const retained = new Uint8Array(receivedBytes);
+    let offset = 0;
+    for (const chunk of retainedChunks) {
+      retained.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    const headers = new Headers(response.headers);
+    // Fetch body reads yield decoded bytes. Rebuilt responses describe those
+    // bytes, independent of the origin's compression and transfer framing.
+    headers.delete("content-encoding");
+    headers.delete("transfer-encoding");
+    headers.set("content-length", String(receivedBytes));
+    const bodyless =
+      response.status === 204 ||
+      response.status === 205 ||
+      response.status === 304;
+    return new Response(bodyless ? null : retained, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  } catch (error) {
+    // error-policy:J2 Preserve the selected transport or boundary error through teardown.
+    if (reader) cancelReaderDetached(reader, error);
+    else if (response) cancelBodyDetached(response.body, error);
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    callerSignal?.removeEventListener("abort", onCallerAbort);
+  }
+}

--- a/packages/cloud/services/_common/tests/bounded-fetch.test.ts
+++ b/packages/cloud/services/_common/tests/bounded-fetch.test.ts
@@ -1,0 +1,108 @@
+/** Exercises shared bounded transport cleanup with real adversarial streams and cancellation signals. */
+import { describe, expect, it } from "bun:test";
+import { getEventListeners } from "node:events";
+import { type BoundedFetchOptions, boundedFetch } from "../src/bounded-fetch";
+
+const options: BoundedFetchOptions = {
+  timeoutMs: 50,
+  maxResponseBytes: 64,
+  timeoutMessage: "Deadline expired",
+  cancellationMessage: "Cancelled",
+  invalidBoundsError: () => new RangeError("Invalid bounds"),
+  responseTooLargeError: (context) =>
+    Object.assign(new Error("Too large"), { context }),
+};
+function transport(
+  implementation: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>,
+): typeof fetch {
+  return Object.assign(implementation, { preconnect: fetch.preconnect });
+}
+
+describe("boundedFetch resource ownership", () => {
+  it("cancels a late response from a transport that ignores abort", async () => {
+    let respond!: (response: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      respond = resolve;
+    });
+    let cancelled = false;
+    await expect(
+      boundedFetch("http://local.test", undefined, {
+        ...options,
+        fetchImpl: transport(() => pending),
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    respond(
+      new Response(
+        new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+        }),
+      ),
+    );
+    await Promise.resolve();
+    expect(cancelled).toBe(true);
+  });
+  it("does not await hostile stream cancellation and removes the caller listener", async () => {
+    const controller = new AbortController();
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        return new Promise(() => {});
+      },
+      cancel() {
+        return new Promise(() => {});
+      },
+    });
+    const started = performance.now();
+    await expect(
+      boundedFetch(
+        "http://local.test",
+        { signal: controller.signal },
+        { ...options, fetchImpl: transport(async () => new Response(body)) },
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(performance.now() - started).toBeLessThan(800);
+    expect(getEventListeners(controller.signal, "abort")).toHaveLength(0);
+  });
+  it("honors a Request signal without dispatching when it is already cancelled", async () => {
+    const controller = new AbortController();
+    const reason = new Error("stopped");
+    controller.abort(reason);
+    const request = new Request("http://local.test", {
+      signal: controller.signal,
+    });
+    let dispatched = false;
+    await expect(
+      boundedFetch(request, undefined, {
+        ...options,
+        fetchImpl: transport(async () => {
+          dispatched = true;
+          return new Response();
+        }),
+      }),
+    ).rejects.toBe(reason);
+    expect(dispatched).toBe(false);
+  });
+  it("rejects excessive empty chunks without silently discarding stream content", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array());
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    await expect(
+      boundedFetch("http://local.test", undefined, {
+        ...options,
+        maxResponseChunks: 2,
+        fetchImpl: transport(async () => new Response(body)),
+      }),
+    ).rejects.toMatchObject({ context: { chunks: 3, maxResponseChunks: 2 } });
+    expect(cancelled).toBe(true);
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/blooio.fetch.test.ts
@@ -28,7 +28,7 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
     const start = Date.now();
     await expect(
       blooioFetch("https://api.blooio.com/v4/messages", undefined, 100),
-    ).rejects.toThrow(/aborted/i);
+    ).rejects.toMatchObject({ name: "TimeoutError" });
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
@@ -55,7 +55,7 @@ describe("blooioFetch — bounded Blooio hops fail closed and compose caller sig
         },
         100,
       ),
-    ).rejects.toThrow(/aborted/i);
+    ).rejects.toMatchObject({ name: "TimeoutError" });
     expect(Date.now() - start).toBeLessThan(5_000);
     expect(controller.signal.aborted).toBe(false);
   });

--- a/packages/cloud/services/gateway-webhook/src/adapters/bounded-fetch-http.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/bounded-fetch-http.test.ts
@@ -1,0 +1,161 @@
+/** Exercises all bounded cloud REST adapters against real local HTTP and compressed response bytes. */
+
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
+import { gzipSync } from "node:zlib";
+import { boundedProviderFetch } from "@elizaos/cloud-shared/lib/utils/bounded-provider-fetch";
+import { ownedBoundedFetch } from "@elizaos/cloud-shared/lib/utils/owned-bounded-fetch";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  boundedGatewayFetch,
+  GatewayProviderFetchError,
+} from "./bounded-fetch";
+
+let baseUrl: string;
+const payload = JSON.stringify({ complete: "response ".repeat(100) });
+const compressed = gzipSync(payload);
+const connections = new Set<Socket>();
+const server = createServer((req, res) => {
+  if (req.url === "/headers") return;
+  if (req.url === "/empty") {
+    res.writeHead(204).end();
+    return;
+  }
+  res.setHeader("content-type", "application/json");
+  if (req.url === "/body") {
+    res.write('{"complete":');
+    return;
+  }
+  if (req.url === "/gzip") {
+    res.setHeader("content-encoding", "gzip");
+    res.setHeader("content-length", compressed.length);
+    res.end(compressed);
+    return;
+  }
+  if (req.url === "/declared") {
+    res.setHeader("content-length", "1000");
+    res.flushHeaders();
+    return;
+  }
+  res.write(payload);
+  res.end();
+});
+server.on("connection", (socket) => {
+  connections.add(socket);
+  socket.on("close", () => connections.delete(socket));
+});
+beforeAll(async () => {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing local HTTP address");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+    for (const socket of connections) socket.destroy();
+    server.closeAllConnections();
+  });
+});
+
+type Adapter = (
+  path: string,
+  timeoutMs?: number,
+  maxResponseBytes?: number,
+  signal?: AbortSignal,
+) => Promise<Response>;
+const adapters: { name: string; run: Adapter; sizeCode: string }[] = [
+  {
+    name: "owned",
+    run: (path, timeoutMs = 2_000, maxResponseBytes = 4_096, signal) =>
+      ownedBoundedFetch(
+        `${baseUrl}${path}`,
+        { signal },
+        { timeoutMs, maxResponseBytes },
+      ),
+    sizeCode: "CLOUD_REST_RESPONSE_TOO_LARGE",
+  },
+  {
+    name: "provider",
+    run: (path, timeoutMs = 2_000, maxResponseBytes = 4_096, signal) =>
+      boundedProviderFetch(
+        `${baseUrl}${path}`,
+        { signal },
+        { timeoutMs, maxResponseBytes, provider: "twilio" },
+      ),
+    sizeCode: "PROVIDER_RESPONSE_TOO_LARGE",
+  },
+  {
+    name: "gateway",
+    run: (path, timeoutMs = 2_000, maxResponseBytes = 4_096, signal) =>
+      boundedGatewayFetch(
+        fetch,
+        `${baseUrl}${path}`,
+        { signal },
+        timeoutMs,
+        maxResponseBytes,
+      ),
+    sizeCode: "GATEWAY_RESPONSE_TOO_LARGE",
+  },
+];
+for (const { name, run, sizeCode } of adapters) {
+  describe(`${name} real HTTP transport`, () => {
+    it.each(["/gzip", "/json"])(
+      "returns complete decoded bytes and matching headers for %s",
+      async (path) => {
+        const response = await run(path);
+        expect(await response.text()).toBe(payload);
+        expect(response.headers.get("content-encoding")).toBeNull();
+        expect(response.headers.get("transfer-encoding")).toBeNull();
+        expect(response.headers.get("content-length")).toBe(
+          String(Buffer.byteLength(payload)),
+        );
+      },
+    );
+    it("retains a bodyless protocol response", async () => {
+      const response = await run("/empty");
+      expect(response.status).toBe(204);
+      expect(response.body).toBeNull();
+      expect(await response.text()).toBe("");
+    });
+    it.each(["/declared", "/json", "/gzip"])(
+      "rejects the complete response above its byte budget at %s",
+      async (path) => {
+        await expect(run(path, 2_000, 100)).rejects.toMatchObject({
+          code: sizeCode,
+        });
+      },
+    );
+    it.each(["/headers", "/body"])(
+      "retains the selected timeout through a %s stall",
+      async (path) => {
+        const started = performance.now();
+        await expect(run(path, 60)).rejects.toMatchObject({
+          name: "TimeoutError",
+        });
+        expect(performance.now() - started).toBeLessThan(800);
+      },
+    );
+    it("retains caller cancellation through a response-body stall", async () => {
+      const controller = new AbortController();
+      const reason = new Error("caller cancelled");
+      const timer = setTimeout(() => controller.abort(reason), 60);
+      try {
+        await expect(
+          run("/body", 2_000, 4_096, controller.signal),
+        ).rejects.toBe(reason);
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+  });
+}
+it("keeps the gateway public error class and provider context", async () => {
+  await expect(adapters[2].run("/json", 2_000, 1)).rejects.toBeInstanceOf(
+    GatewayProviderFetchError,
+  );
+  await expect(adapters[1].run("/json", 2_000, 1)).rejects.toMatchObject({
+    context: { provider: "twilio", maxResponseBytes: 1 },
+  });
+});

--- a/packages/cloud/services/gateway-webhook/src/adapters/bounded-fetch.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/bounded-fetch.ts
@@ -1,8 +1,5 @@
-/**
- * Owns gateway provider deadlines across transport and bounded response-body consumption.
- */
-
-const MAX_TIMER_MS = 2_147_483_647;
+/** Maps gateway provider bounds and public error identity to the shared REST transport. */
+import { boundedFetch } from "@elizaos/cloud-services-common/bounded-fetch";
 
 export class GatewayProviderFetchError extends Error {
   override readonly name = "GatewayProviderFetchError";
@@ -17,47 +14,6 @@ export class GatewayProviderFetchError extends Error {
   }
 }
 
-function cancelBodyDetached(
-  body: ReadableStream<Uint8Array> | null,
-  reason: unknown,
-): void {
-  if (!body) return;
-  try {
-    // error-policy:J6 The request has already failed; cancellation is detached
-    // so a hostile stream cannot replace or delay the boundary error.
-    void body.cancel(reason).catch(() => undefined);
-  } catch {
-    // error-policy:J6 A synchronous cancellation failure cannot replace the
-    // already-selected request failure.
-  }
-}
-
-function cancelReaderDetached(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  reason: unknown,
-): void {
-  const release = (): void => {
-    try {
-      reader.releaseLock();
-    } catch {
-      // error-policy:J6 Releasing a failed response stream is teardown-only.
-    }
-  };
-  try {
-    // Keep ownership until cancellation settles. Releasing first can race an
-    // in-flight cancel, while awaiting it would let a hostile stream defeat the
-    // request deadline.
-    void reader
-      .cancel(reason)
-      // error-policy:J6 The request failure is already observed by the caller.
-      .catch(() => undefined)
-      .finally(release);
-  } catch {
-    // error-policy:J6 A synchronous cancellation failure is teardown-only.
-    release();
-  }
-}
-
 export async function boundedGatewayFetch(
   fetchImpl: typeof fetch,
   input: RequestInfo | URL,
@@ -65,108 +21,23 @@ export async function boundedGatewayFetch(
   timeoutMs: number,
   maxResponseBytes: number,
 ): Promise<Response> {
-  if (
-    !Number.isSafeInteger(timeoutMs) ||
-    timeoutMs <= 0 ||
-    timeoutMs > MAX_TIMER_MS ||
-    !Number.isSafeInteger(maxResponseBytes) ||
-    maxResponseBytes < 0
-  ) {
-    throw new GatewayProviderFetchError(
-      "INVALID_GATEWAY_TIMEOUT",
-      "Gateway provider bounds must be timer-safe positive integers",
-      { timeoutMs, maxResponseBytes },
-    );
-  }
-
-  if (init?.signal?.aborted) {
-    throw (
-      init.signal.reason ??
-      new DOMException("Provider request cancelled", "AbortError")
-    );
-  }
-
-  const controller = new AbortController();
-  let rejectAbort!: (reason: unknown) => void;
-  const abortPromise = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject;
-  });
-  const abort = (reason: unknown): void => {
-    if (controller.signal.aborted) return;
-    controller.abort(reason);
-    rejectAbort(reason);
-  };
-  const onCallerAbort = (): void =>
-    abort(
-      init?.signal?.reason ??
-        new DOMException("Provider request cancelled", "AbortError"),
-    );
-  init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
-  const timer = setTimeout(
-    () =>
-      abort(
-        new DOMException("Provider request deadline expired", "TimeoutError"),
-      ),
+  return boundedFetch(input, init, {
     timeoutMs,
-  );
-
-  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
-  try {
-    const response = await Promise.race([
-      fetchImpl(input, { ...init, signal: controller.signal }),
-      abortPromise,
-    ]);
-    const rawLength = response.headers.get("content-length");
-    if (rawLength !== null) {
-      if (!/^\d+$/.test(rawLength) || Number(rawLength) > maxResponseBytes) {
-        const error = new GatewayProviderFetchError(
-          "GATEWAY_RESPONSE_TOO_LARGE",
-          "Gateway provider response exceeds the byte limit",
-          { maxResponseBytes, contentLength: rawLength },
-        );
-        cancelBodyDetached(response.body, error);
-        throw error;
-      }
-    }
-    if (!response.body) return response;
-
-    reader = response.body.getReader();
-    const chunks: Uint8Array[] = [];
-    let receivedBytes = 0;
-    while (true) {
-      const next = await Promise.race([reader.read(), abortPromise]);
-      if (next.done) break;
-      receivedBytes += next.value.byteLength;
-      if (receivedBytes > maxResponseBytes) {
-        const error = new GatewayProviderFetchError(
-          "GATEWAY_RESPONSE_TOO_LARGE",
-          "Gateway provider response exceeds the byte limit",
-          { maxResponseBytes, receivedBytes },
-        );
-        cancelReaderDetached(reader, error);
-        reader = undefined;
-        throw error;
-      }
-      chunks.push(next.value);
-    }
-    const body = new Uint8Array(receivedBytes);
-    let offset = 0;
-    for (const chunk of chunks) {
-      body.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    return new Response(body.buffer, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    });
-  } finally {
-    clearTimeout(timer);
-    init?.signal?.removeEventListener("abort", onCallerAbort);
-    if (controller.signal.aborted && reader) {
-      cancelReaderDetached(reader, controller.signal.reason);
-      reader = undefined;
-    }
-    reader?.releaseLock();
-  }
+    maxResponseBytes,
+    fetchImpl,
+    timeoutMessage: "Provider request deadline expired",
+    cancellationMessage: "Provider request cancelled",
+    invalidBoundsError: () =>
+      new GatewayProviderFetchError(
+        "INVALID_GATEWAY_TIMEOUT",
+        "Gateway provider bounds must be timer-safe positive integers",
+        { timeoutMs, maxResponseBytes },
+      ),
+    responseTooLargeError: (context) =>
+      new GatewayProviderFetchError(
+        "GATEWAY_RESPONSE_TOO_LARGE",
+        "Gateway provider response exceeds the byte limit",
+        context,
+      ),
+  });
 }

--- a/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/whatsapp.fetch.test.ts
@@ -34,7 +34,7 @@ describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller
         undefined,
         100,
       ),
-    ).rejects.toThrow(/aborted/i);
+    ).rejects.toMatchObject({ name: "TimeoutError" });
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
@@ -61,7 +61,7 @@ describe("whatsappFetch — bounded WhatsApp hops fail closed and compose caller
         },
         100,
       ),
-    ).rejects.toThrow(/aborted/i);
+    ).rejects.toMatchObject({ name: "TimeoutError" });
     expect(Date.now() - start).toBeLessThan(5_000);
     expect(controller.signal.aborted).toBe(false);
   });

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -55,6 +55,7 @@
     "@electric-sql/pglite-socket": "0.1.6",
     "@elevenlabs/elevenlabs-js": "^2.45.0",
     "@elizaos/cloud-sdk": "workspace:*",
+    "@elizaos/cloud-services-common": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-cloud-apps": "workspace:*",
     "@elizaos/plugin-doordash": "workspace:*",

--- a/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
+++ b/packages/cloud/shared/src/lib/utils/bounded-provider-fetch.ts
@@ -1,55 +1,6 @@
-/**
- * Owns per-hop deadlines and response-byte ceilings for outbound calls to
- * third-party messaging providers made from cloud-shared services.
- *
- * Callers supply the hop's timeout and byte ceiling; the helper composes any
- * caller abort signal with its own deadline (whichever fires first cancels),
- * reads the response body under that same deadline, and rejects with a typed
- * `ElizaError` rather than handing back a partially consumed stream. The
- * returned `Response` is re-materialized from the fully buffered body, so a
- * caller may read it normally after the bound has been proven.
- */
-
-import { ElizaError } from "@elizaos/core";
-
-const MAX_TIMER_MS = 2_147_483_647;
-
-function cancelBodyDetached(body: ReadableStream<Uint8Array> | null, reason: unknown): void {
-  if (!body) return;
-  try {
-    // error-policy:J6 The request has already failed; cancellation is detached
-    // so a hostile stream cannot replace or delay the boundary error.
-    void body.cancel(reason).catch(() => undefined);
-  } catch {
-    // error-policy:J6 A synchronous cancellation failure is teardown-only.
-  }
-}
-
-function cancelReaderDetached(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  reason: unknown,
-): void {
-  const release = (): void => {
-    try {
-      reader.releaseLock();
-    } catch {
-      // error-policy:J6 Releasing a failed response stream is teardown-only.
-    }
-  };
-  try {
-    // Keep ownership until cancellation settles. Releasing first can race an
-    // in-flight cancel, while awaiting it would let a hostile stream defeat
-    // the request deadline.
-    void reader
-      .cancel(reason)
-      // error-policy:J6 The request failure is already observed by the caller.
-      .catch(() => undefined)
-      .finally(release);
-  } catch {
-    // error-policy:J6 A synchronous cancellation failure is teardown-only.
-    release();
-  }
-}
+/** Maps cloud messaging provider bounds and typed failures to the shared REST transport. */
+import { boundedFetch } from "@elizaos/cloud-services-common/bounded-fetch";
+import { ElizaError } from "@elizaos/core/errors";
 
 export interface BoundedProviderFetchOptions {
   /** Provider name used in error context, e.g. "twilio". */
@@ -62,95 +13,23 @@ export interface BoundedProviderFetchOptions {
 export async function boundedProviderFetch(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
-  { provider, timeoutMs, maxResponseBytes, fetchImpl = fetch }: BoundedProviderFetchOptions,
+  { provider, timeoutMs, maxResponseBytes, fetchImpl }: BoundedProviderFetchOptions,
 ): Promise<Response> {
-  if (
-    !Number.isSafeInteger(timeoutMs) ||
-    timeoutMs <= 0 ||
-    timeoutMs > MAX_TIMER_MS ||
-    !Number.isSafeInteger(maxResponseBytes) ||
-    maxResponseBytes < 0
-  ) {
-    throw new ElizaError("Provider request bounds must be timer-safe positive integers", {
-      code: "INVALID_PROVIDER_REQUEST_BOUNDS",
-      context: { provider, timeoutMs, maxResponseBytes },
-    });
-  }
-  if (init?.signal?.aborted) {
-    throw init.signal.reason ?? new DOMException("Provider request cancelled", "AbortError");
-  }
-
-  const controller = new AbortController();
-  let rejectAbort!: (reason: unknown) => void;
-  const abortPromise = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject;
-  });
-  const abort = (reason: unknown): void => {
-    if (controller.signal.aborted) return;
-    controller.abort(reason);
-    rejectAbort(reason);
-  };
-  const onCallerAbort = (): void =>
-    abort(init?.signal?.reason ?? new DOMException("Provider request cancelled", "AbortError"));
-  init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
-  const timer = setTimeout(
-    () => abort(new DOMException("Provider request deadline expired", "TimeoutError")),
+  return boundedFetch(input, init, {
     timeoutMs,
-  );
-
-  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
-  try {
-    const response = await Promise.race([
-      fetchImpl(input, { ...init, signal: controller.signal }),
-      abortPromise,
-    ]);
-    const rawLength = response.headers.get("content-length");
-    if (rawLength !== null && (!/^\d+$/.test(rawLength) || Number(rawLength) > maxResponseBytes)) {
-      const error = new ElizaError("Provider response exceeds the allowed byte limit", {
+    maxResponseBytes,
+    fetchImpl,
+    timeoutMessage: "Provider request deadline expired",
+    cancellationMessage: "Provider request cancelled",
+    invalidBoundsError: () =>
+      new ElizaError("Provider request bounds must be timer-safe positive integers", {
+        code: "INVALID_PROVIDER_REQUEST_BOUNDS",
+        context: { provider, timeoutMs, maxResponseBytes },
+      }),
+    responseTooLargeError: (context) =>
+      new ElizaError("Provider response exceeds the allowed byte limit", {
         code: "PROVIDER_RESPONSE_TOO_LARGE",
-        context: { provider, maxResponseBytes, contentLength: rawLength },
-      });
-      cancelBodyDetached(response.body, error);
-      throw error;
-    }
-    if (!response.body) return response;
-
-    reader = response.body.getReader();
-    const chunks: Uint8Array[] = [];
-    let receivedBytes = 0;
-    while (true) {
-      const next = await Promise.race([reader.read(), abortPromise]);
-      if (next.done) break;
-      receivedBytes += next.value.byteLength;
-      if (receivedBytes > maxResponseBytes) {
-        const error = new ElizaError("Provider response exceeds the allowed byte limit", {
-          code: "PROVIDER_RESPONSE_TOO_LARGE",
-          context: { provider, maxResponseBytes, receivedBytes },
-        });
-        cancelReaderDetached(reader, error);
-        reader = undefined;
-        throw error;
-      }
-      chunks.push(next.value);
-    }
-    const body = new Uint8Array(receivedBytes);
-    let offset = 0;
-    for (const chunk of chunks) {
-      body.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    return new Response(body.buffer, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    });
-  } finally {
-    clearTimeout(timer);
-    init?.signal?.removeEventListener("abort", onCallerAbort);
-    if (controller.signal.aborted && reader) {
-      cancelReaderDetached(reader, controller.signal.reason);
-      reader = undefined;
-    }
-    reader?.releaseLock();
-  }
+        context: { provider, ...context },
+      }),
+  });
 }

--- a/packages/cloud/shared/src/lib/utils/owned-bounded-fetch.ts
+++ b/packages/cloud/shared/src/lib/utils/owned-bounded-fetch.ts
@@ -6,9 +6,9 @@
  * a hostile response without being pre-reserved by every ordinary one.
  */
 
+import { boundedFetch } from "@elizaos/cloud-services-common/bounded-fetch";
 import { ElizaError } from "@elizaos/core/errors";
 
-const MAX_TIMER_MS = 2_147_483_647;
 // The largest legitimate shared-utils reply is a Cloudflare paged listing
 // (`/zones/<id>/dns_records?per_page=200`), on the order of a hundred kilobytes;
 // Twilio, Blooio, and Twitter hops return single-resource JSON. Four MiB is the
@@ -23,56 +23,6 @@ export interface OwnedBoundedFetchOptions {
   maxResponseChunks?: number;
 }
 
-function releaseNoThrow(reader: ReadableStreamDefaultReader<Uint8Array>): void {
-  try {
-    reader.releaseLock();
-  } catch {
-    // error-policy:J6 Releasing a terminal response stream is teardown-only.
-  }
-}
-
-function cancelBodyDetached(body: ReadableStream<Uint8Array> | null, reason: unknown): void {
-  if (!body) return;
-  try {
-    // error-policy:J6 The primary boundary failure already belongs to the caller.
-    void body.cancel(reason).catch(() => undefined);
-  } catch {
-    // error-policy:J6 A synchronous cancellation failure is teardown-only.
-  }
-}
-
-function cancelReaderDetached(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  reason: unknown,
-): void {
-  try {
-    // Retain ownership until cancellation settles, but never let a hostile
-    // cancellation promise delay or replace the selected boundary failure.
-    void reader
-      .cancel(reason)
-      // error-policy:J6 The primary boundary failure already belongs to the caller.
-      .catch(() => undefined)
-      .finally(() => releaseNoThrow(reader));
-  } catch {
-    // error-policy:J6 A synchronous cancellation failure is teardown-only.
-    releaseNoThrow(reader);
-  }
-}
-
-function sizeError(context: Record<string, unknown>): ElizaError {
-  return new ElizaError("REST response exceeds its bounded-body contract", {
-    code: "CLOUD_REST_RESPONSE_TOO_LARGE",
-    context,
-    severity: "ephemeral",
-  });
-}
-
-/**
- * Fetch and fully buffer a response under one clearable deadline.
- *
- * The returned Response is detached from the network stream, so callers may
- * parse it after this function has cleared its timer and caller listener.
- */
 export async function ownedBoundedFetch(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
@@ -80,128 +30,22 @@ export async function ownedBoundedFetch(
 ): Promise<Response> {
   const maxResponseBytes = options.maxResponseBytes ?? DEFAULT_REST_RESPONSE_MAX_BYTES;
   const maxResponseChunks = options.maxResponseChunks ?? DEFAULT_REST_RESPONSE_MAX_CHUNKS;
-  if (
-    !Number.isSafeInteger(options.timeoutMs) ||
-    options.timeoutMs <= 0 ||
-    options.timeoutMs > MAX_TIMER_MS ||
-    !Number.isSafeInteger(maxResponseBytes) ||
-    maxResponseBytes < 0 ||
-    !Number.isSafeInteger(maxResponseChunks) ||
-    maxResponseChunks < 1
-  ) {
-    throw new ElizaError("REST hop bounds must be timer-safe integers", {
-      code: "INVALID_CLOUD_REST_BOUNDS",
-      context: {
-        timeoutMs: options.timeoutMs,
-        maxResponseBytes,
-        maxResponseChunks,
-      },
-    });
-  }
-
-  if (init?.signal?.aborted) {
-    throw init.signal.reason ?? new DOMException("REST request cancelled", "AbortError");
-  }
-
-  const controller = new AbortController();
-  let rejectAbort!: (reason: unknown) => void;
-  const abortPromise = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject;
+  return boundedFetch(input, init, {
+    timeoutMs: options.timeoutMs,
+    maxResponseBytes,
+    maxResponseChunks,
+    timeoutMessage: "REST request deadline expired",
+    cancellationMessage: "REST request cancelled",
+    invalidBoundsError: () =>
+      new ElizaError("REST hop bounds must be timer-safe integers", {
+        code: "INVALID_CLOUD_REST_BOUNDS",
+        context: { timeoutMs: options.timeoutMs, maxResponseBytes, maxResponseChunks },
+      }),
+    responseTooLargeError: (context) =>
+      new ElizaError("REST response exceeds its bounded-body contract", {
+        code: "CLOUD_REST_RESPONSE_TOO_LARGE",
+        context,
+        severity: "ephemeral",
+      }),
   });
-  const abort = (reason: unknown): void => {
-    if (controller.signal.aborted) return;
-    // Select provenance before aborting the transport: a stream may reject its
-    // pending read synchronously with a generic AbortError.
-    rejectAbort(reason);
-    controller.abort(reason);
-  };
-  const onCallerAbort = (): void =>
-    abort(init?.signal?.reason ?? new DOMException("REST request cancelled", "AbortError"));
-  init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
-  const timer = setTimeout(
-    () => abort(new DOMException("REST request deadline expired", "TimeoutError")),
-    options.timeoutMs,
-  );
-
-  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
-  try {
-    const response = await Promise.race([
-      fetch(input, { ...init, signal: controller.signal }),
-      abortPromise,
-    ]);
-    const rawLength = response.headers.get("content-length");
-    if (rawLength !== null && (!/^\d+$/.test(rawLength) || Number(rawLength) > maxResponseBytes)) {
-      const error = sizeError({
-        contentLength: rawLength,
-        maxResponseBytes,
-      });
-      cancelBodyDetached(response.body, error);
-      throw error;
-    }
-    if (!response.body) return response;
-
-    reader = response.body.getReader();
-    // Retain only what actually arrived: a 2 KiB JSON reply must not reserve
-    // the whole byte ceiling inside a memory-capped Worker isolate.
-    const retainedChunks: Uint8Array[] = [];
-    let receivedBytes = 0;
-    let chunks = 0;
-    while (true) {
-      const next = await Promise.race([reader.read(), abortPromise]);
-      if (next.done) break;
-      chunks += 1;
-      if (chunks > maxResponseChunks) {
-        const error = sizeError({
-          chunks,
-          maxResponseBytes,
-          maxResponseChunks,
-          receivedBytes,
-        });
-        cancelReaderDetached(reader, error);
-        reader = undefined;
-        throw error;
-      }
-      if (next.value.byteLength === 0) continue;
-      receivedBytes += next.value.byteLength;
-      if (receivedBytes > maxResponseBytes) {
-        const error = sizeError({
-          chunks,
-          maxResponseBytes,
-          maxResponseChunks,
-          receivedBytes,
-        });
-        cancelReaderDetached(reader, error);
-        reader = undefined;
-        throw error;
-      }
-      retainedChunks.push(next.value);
-    }
-
-    releaseNoThrow(reader);
-    reader = undefined;
-    const headers = new Headers(response.headers);
-    // Fetch exposes decoded body bytes; the detached response must not retain
-    // transport framing that describes the encoded network representation.
-    headers.delete("content-encoding");
-    headers.set("content-length", String(receivedBytes));
-    const retained = new Uint8Array(receivedBytes);
-    let offset = 0;
-    for (const chunk of retainedChunks) {
-      retained.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    return new Response(retained, {
-      headers,
-      status: response.status,
-      statusText: response.statusText,
-    });
-  } finally {
-    clearTimeout(timer);
-    init?.signal?.removeEventListener("abort", onCallerAbort);
-    if (controller.signal.aborted && reader) {
-      cancelReaderDetached(reader, controller.signal.reason);
-      reader = undefined;
-    }
-    if (reader) releaseNoThrow(reader);
-  }
 }

--- a/plugins/plugin-elizacloud/__tests__/cloud-api-client-contract.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-api-client-contract.test.ts
@@ -240,11 +240,13 @@ describe("error handling", () => {
     expect(err.message).toContain("503");
   });
 
-  it("returns {success: true} for non-JSON 200 response", async () => {
+  it("rejects non-JSON 200 responses instead of inventing a DTO", async () => {
     setTextResponse(200, "OK");
     const client = new CloudApiClient(baseUrl);
-    const result = await client.get<{ success: boolean }>("/health");
-    expect(result.success).toBe(true);
+    await expect(client.get("/health")).rejects.toMatchObject({
+      name: "CloudApiError",
+      errorBody: { code: "unexpected_response_content_type" },
+    });
   });
 
   it("throws CloudApiError for 403 quota exceeded", async () => {


### PR DESCRIPTION
The Cloud SDK could cast a successful non-JSON response to the requested object type, and polling deadlines stopped at request dispatch instead of covering headers, body reads and the next interval. Parsed SDK calls now reject invalid payloads, preserve valid JSON primitives, and enforce a total monotonic deadline through every polling operation. Raw-response calls retain raw access; HEAD, 204 and 205 remain bodyless.

Three cloud REST adapters now use one bounded Fetch lifecycle for deadlines, body reads, cancellation and decoded response framing. Each adapter retains its error identity, context and existing limits. This removes duplicated lifecycle code without introducing a blanket chunk limit.

Closes #30574, #30575 and #30577.

Compatibility: successful parsed calls returning non-JSON or malformed JSON now reject instead of masquerading as the caller's requested data. JSON vendor media types are accepted. The SDK README documents this correction. The dependency and package export for the shared transport are explicit in the manifest and lockfile.

Validation:

- Scoped suites: SDK 165 passed, common 59, gateway 496, shared transport 27; relevant package typecheck, lint and builds passed. The consuming plugin passed 631 Vitest cases, 21 Bun contracts and five built-package imports.
- Full cloud-shared lane: 342 batches across 1,168 files, with 12,391 tests passed, 201 skipped and none failed. Earlier attempts encountered host contention or missing build output; the final complete run passed with stable prerequisites.
- Real boundaries: 68 Node HTTP cases and four installed-workerd cases passed. An independent reviewer also ran 40 SDK HTTP and 28 adapter HTTP cases with no blocker.
- Rebase verification: all changed cloud files are identical after rebase. On the final head, 67 of 68 HTTP cases passed concurrently; an 80 ms deadline expired before the server observed dispatch in one case. Its complete 25-test polling file passed on serial rerun without changing deadlines or assertions. All four Worker cases passed again.
- Root gate: the first scoped run passed all 376 tasks. The final rebased run also passed all 376 tasks and every repository audit, including the scan of 11,367 tests (zero focused tests or untracked skips).

Complete [validation record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30597-cloud-validation-5ac21104.json).

Review follow-up: the two cloud-shared wrapper files run in the normal Bun lane; their five cases passed in the complete package run. The supplemental Vitest config is for suites requiring Vitest-only APIs. The null-body status branch is reachable in Bun 1.3.14: its native Fetch exposes a stream for 204/205/304, whereas Node 24 and workerd return null. The canonical helper normalizes those Bun responses to null bodies; the existing real HTTP wrapper tests cover 204. An additional real-server check produced:

```json
{"runtime":"Bun 1.3.14","status":204,"rawBodyIsNull":false,"normalizedBodyIsNull":true,"passed":true}
{"runtime":"Bun 1.3.14","status":205,"rawBodyIsNull":false,"normalizedBodyIsNull":true,"passed":true}
{"runtime":"Bun 1.3.14","status":304,"rawBodyIsNull":false,"normalizedBodyIsNull":true,"passed":true}
```

## Evidence Gate

<!-- evidence-head:5ac211041636cce843332474c652b6ba198df68d -->
<!-- evidence-row:before-screenshots -->
N/A - SDK and server HTTP contracts; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
N/A - SDK and server HTTP contracts; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
N/A - the real HTTP/readback contract is captured below.
<!-- evidence-row:backend-logs -->
[Final-head polling rerun](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30597-cloud-poll-5ac21104.log).

```text
Command: ['node', 'node_modules/vitest/vitest.mjs', 'run', 'packages/cloud/services/gateway-webhook/src/adapters/bounded-fetch-http.test.ts', 'packages/cloud/sdk/src/http-server.test.ts', 'packages/cloud/sdk/src/poll-server.test.ts']

 RUN  v4.1.10 /Users/shawwalters/.codex/worktrees/code-quality-cleanup-20260904


 Test Files  3 passed (3)
      Tests  68 passed (68)
   Start at  21:59:28
   Duration  1.33s (transform 842ms, setup 0ms, import 1.00s, tests 1.53s, environment 0ms)


Command exit: 0
```
<!-- evidence-row:frontend-logs -->
N/A - no browser page flow changed. Node HTTP tests use real servers for late headers, stalled/chunked bodies, caller cancellation and JSON contracts.
<!-- evidence-row:llm-trajectory -->
N/A - no model inference, prompt, provider or action-result construction changed.
<!-- evidence-row:domain-artifacts -->
[Final-head Worker readback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-11/30597-cloud-worker-5ac21104.json).

Actual installed workerd, using the cloud API compatibility date, handled gzip decoding, a bodyless response, an oversize rejection and a stalled body deadline. The API Worker production dry-run also bundled successfully. No production deployment was performed.

```json
{
  "runtime": "workerd (installed Miniflare)",
  "decoded": {
    "status": 200,
    "body": "{\"complete\":\"worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response worker-response \"}",
    "encoding": null,
    "length": "1615"
  },
  "empty": {
    "status": 204,
    "body": "",
    "encoding": null,
    "length": null
  },
  "oversize": {
    "error": "too-large",
    "name": "Error"
  },
  "stalled": {
    "error": "Worker deadline expired",
    "name": "TimeoutError"
  }
}
```
<!-- evidence-row:ocr-review -->
N/A - no visual surface changed.

Known gaps: real-time deadline tests are sensitive to heavy host contention, as recorded above. Opt-in SDK integration tests requiring external credentials remain skipped. All changed HTTP contracts were exercised locally with real servers and the installed Worker runtime. Hosted checks must pass on the current head before merge. Maintainer CI exception: N/A.
