### PR TITLE
fix(core): keep own __proto__ entries in sanitized trajectory JSON

### DIFF
--- a/packages/core/src/services/trajectory-json.test.ts
+++ b/packages/core/src/services/trajectory-json.test.ts
@@ -1,7 +1,10 @@
 /** Exercises lossless trajectory JSON normalization for large prompt evidence. */
 
 import { describe, expect, it } from "vitest";
-import { sanitizeTrajectoryJsonObject } from "./trajectory-json";
+import {
+	sanitizeTrajectoryJsonObject,
+	sanitizeTrajectoryJsonValue,
+} from "./trajectory-json";
 
 describe("trajectory JSON normalization", () => {
 	it("preserves strings and collections beyond the former capture limits", () => {
@@ -13,5 +16,62 @@ describe("trajectory JSON normalization", () => {
 		const sanitized = sanitizeTrajectoryJsonObject({ prompt, messages });
 		expect(sanitized?.prompt).toBe(prompt);
 		expect(sanitized?.messages).toEqual(messages);
+	});
+});
+
+describe("trajectory JSON own-key preservation", () => {
+	// `JSON.parse` creates `__proto__` as an own data property. Rebuilding the
+	// record with `output[key] = …` invokes the prototype setter instead, which
+	// both drops the argument from the persisted trajectory and re-parents the
+	// sanitized object to caller-controlled data.
+	const rawToolCall = String.raw`{"path":"/etc/passwd","__proto__":{"approved":true}}`;
+
+	it("keeps an own __proto__ key instead of dropping it", () => {
+		const sanitized = sanitizeTrajectoryJsonValue(JSON.parse(rawToolCall)) as
+			| Record<string, unknown>
+			| undefined;
+
+		expect(Object.keys(sanitized ?? {})).toEqual(["path", "__proto__"]);
+		expect(JSON.stringify(sanitized)).toBe(rawToolCall);
+	});
+
+	it("does not re-parent the sanitized object to caller data", () => {
+		const sanitized = sanitizeTrajectoryJsonValue(JSON.parse(rawToolCall)) as
+			| Record<string, unknown>
+			| undefined;
+
+		expect(Object.getPrototypeOf(sanitized)).toBe(Object.prototype);
+		expect((sanitized as { approved?: unknown }).approved).toBeUndefined();
+		expect(({} as { approved?: unknown }).approved).toBeUndefined();
+	});
+
+	it("preserves an own __proto__ key nested inside a recorded object", () => {
+		const sanitized = sanitizeTrajectoryJsonObject(
+			JSON.parse(String.raw`{"action":{"__proto__":{"approved":true}}}`),
+		);
+
+		expect(JSON.stringify(sanitized)).toBe(
+			String.raw`{"action":{"__proto__":{"approved":true}}}`,
+		);
+	});
+
+	it("still normalizes ordinary records unchanged", () => {
+		const sanitized = sanitizeTrajectoryJsonObject({ a: 1, b: ["x"] });
+
+		expect(sanitized).toEqual({ a: 1, b: ["x"] });
+		expect(Object.getPrototypeOf(sanitized)).toBe(Object.prototype);
+	});
+
+	it("keeps an own __proto__ entry recorded through a Map", () => {
+		const sanitized = sanitizeTrajectoryJsonValue(
+			new Map<string, unknown>([
+				["path", "/etc/passwd"],
+				["__proto__", { approved: true }],
+			]),
+		) as Record<string, unknown> | undefined;
+
+		expect(Object.keys(sanitized ?? {})).toEqual(["path", "__proto__"]);
+		expect(Object.getPrototypeOf(sanitized)).toBe(Object.prototype);
+		expect((sanitized as { approved?: unknown }).approved).toBeUndefined();
 	});
 });

--- a/packages/core/src/services/trajectory-json.ts
+++ b/packages/core/src/services/trajectory-json.ts
@@ -50,6 +50,25 @@ function reserveContainer(state: SanitizationState): JsonValue | undefined {
 	return undefined;
 }
 
+/**
+ * Records one own entry on a null-prototype accumulator. A plain
+ * `output[key] = value` would invoke the `__proto__` setter for a key
+ * `JSON.parse` produced as an own data property, dropping it from the recorded
+ * trajectory and re-parenting the sanitized object to caller-controlled data.
+ */
+function defineOwnEntry(
+	target: Record<string, JsonValue>,
+	key: string,
+	value: JsonValue,
+): void {
+	Object.defineProperty(target, key, {
+		configurable: true,
+		enumerable: true,
+		value,
+		writable: true,
+	});
+}
+
 function reserveObjectKey(state: SanitizationState, key: string): boolean {
 	return reserveBytes(
 		state,
@@ -118,7 +137,7 @@ function sanitizeTrajectoryJsonValueInternal(
 		const containerMarker = reserveContainer(state);
 		if (containerMarker !== undefined) return containerMarker;
 		state.seen.add(value);
-		const output: Record<string, JsonValue> = {};
+		const output = Object.create(null) as Record<string, JsonValue>;
 		for (const [keyValue, entry] of value.entries()) {
 			const key = String(keyValue);
 			reserveObjectKey(state, key);
@@ -127,9 +146,10 @@ function sanitizeTrajectoryJsonValueInternal(
 				state,
 				depth + 1,
 			);
-			if (sanitized !== undefined) output[key] = sanitized;
+			if (sanitized !== undefined) defineOwnEntry(output, key, sanitized);
 		}
 		state.seen.delete(value);
+		Object.setPrototypeOf(output, Object.prototype);
 		return output;
 	}
 	if (value instanceof Set) {
@@ -180,7 +200,7 @@ function sanitizeTrajectoryJsonValueInternal(
 				? {}
 				: normalizedScalar(String(value), state);
 		}
-		const output: Record<string, JsonValue> = {};
+		const output = Object.create(null) as Record<string, JsonValue>;
 		for (const [key, entry] of entries) {
 			reserveObjectKey(state, key);
 			const sanitized = sanitizeTrajectoryJsonValueInternal(
@@ -188,9 +208,10 @@ function sanitizeTrajectoryJsonValueInternal(
 				state,
 				depth + 1,
 			);
-			if (sanitized !== undefined) output[key] = sanitized;
+			if (sanitized !== undefined) defineOwnEntry(output, key, sanitized);
 		}
 		state.seen.delete(value);
+		Object.setPrototypeOf(output, Object.prototype);
 		return output;
 	}
 	return normalizedScalar(String(value), state);


### PR DESCRIPTION
# Relates to

No linked issue. Found during a read-only audit of `develop` and reproduced locally before any change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Two accumulators inside one module-private walker change from a `{}` literal
to a null-prototype staging object with `Object.defineProperty`, restored to
`Object.prototype` before returning. Behaviour is identical for every input that
has no own `__proto__` key — the added test `still normalizes ordinary records
unchanged` pins that. No exported signature, schema, or serialized shape changes;
`JSON.stringify` output is unchanged for ordinary records.

# Background

## What does this PR do?

`sanitizeTrajectoryJsonValueInternal` rebuilt both the plain-object and `Map`
branches with `output[key] = sanitized` on a `{}` accumulator. `JSON.parse`
creates `__proto__` as an **own data property**, so `Object.entries` surfaces it,
the loop sanitizes it — and then the assignment invokes the `__proto__` *setter*
instead of defining an own entry.

Two things go wrong at once:

```
input own keys : [ 'path', '__proto__' ]
input JSON     : {"path":"/etc/passwd","__proto__":{"approved":true}}
output own keys: [ 'path' ]
output JSON    : {"path":"/etc/passwd"}
prototype replaced?: true
inherited leak -> out.approved: true
```

The key is **silently dropped** from the recorded value, and the sanitized
object's prototype is **replaced by the caller's own data**, so `out.approved`
reads `true` on a value the sanitizer had just declared safe. (Global
`Object.prototype` is not affected — the pollution is per-returned-object.)

This runs over model-generated planner tool arguments.
`boundStepsForPersistence` in `features/trajectories/TrajectoriesService.ts`
sanitizes `step.action`, `step.observation`, every `step.llmCalls` entry and
`step.metadata` before `stringifyTrajectoryJsonForSql` writes the row, and
`runtime/trajectory-recorder.ts` records tool stage I/O on the planner path. So a
persisted trajectory could misrepresent the arguments the model actually emitted
— including in the training-data export surface.

The fix stages both accumulators on `Object.create(null)`, defines own
properties, and restores `Object.prototype` before returning. That is the
pattern already used by `defineOwn` in `database/connector-json.ts` and the
staging object in `utils/well-formed.ts`, which solved this same class in #18081.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`defineOwnEntry` and the two accumulators in
`packages/core/src/services/trajectory-json.ts`, then the
`trajectory JSON own-key preservation` block appended to
`packages/core/src/services/trajectory-json.test.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/core test -- src/services/trajectory-json.test.ts
```

Four new cases through the exported `sanitizeTrajectoryJsonValue` /
`sanitizeTrajectoryJsonObject`: an own `__proto__` key is preserved rather than
dropped; the returned object is not re-parented and exposes no inherited member;
the same holds nested inside a recorded object; and the same holds for an entry
recorded through a `Map`. A fifth pins that ordinary records are unchanged.

Verified red before green — against unpatched source **4 fail**:

```
 × keeps an own __proto__ key instead of dropping it
 × does not re-parent the sanitized object to caller data
 × preserves an own __proto__ key nested inside a recorded object
 × keeps an own __proto__ entry recorded through a Map
 Tests  4 failed | 2 passed (6)
```

With the fix, `Tests 6 passed (6)`.

# Evidence Gate

<!-- evidence-head:07bc8da890b4fdd694cc858a152da7e32ce49fd9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; this is a module-private JSON sanitizer with no rendered component.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is the sanitizer's return value, asserted directly by the unit tests above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the before/after sanitizer output and the red/green test runs are pasted inline above and below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the changed code performs no model call. It normalizes an already-captured value; a live run would exercise nothing this diff changes, and the recorded shape is asserted deterministically by the tests.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the sanitized record is the artifact, asserted inline (`{"path":"/etc/passwd","__proto__":{"approved":true}}` round-trips intact after the fix).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Backend logs

Against the real module before the fix:

<details>
<summary>own __proto__ dropped, prototype replaced</summary>

```
input own keys : [ "path", "__proto__" ]
input JSON     : {"path":"/etc/passwd","__proto__":{"approved":true}}
output own keys: [ "path" ]
output JSON    : {"path":"/etc/passwd"}
key dropped?   : true
prototype replaced?: true
inherited leak -> out.approved: true
global Object.prototype polluted?: false
```

</details>

After the fix, same input:

<details>
<summary>key preserved, prototype intact</summary>

```
input own keys : [ "path", "__proto__" ]
output own keys: [ "path", "__proto__" ]
output JSON    : {"path":"/etc/passwd","__proto__":{"approved":true}}
key dropped?   : false
prototype replaced?: false
inherited leak -> out.approved: undefined
global Object.prototype polluted?: false
```

</details>

Sibling suites that consume this module, post-rebase:

```
bun run --cwd packages/core test -- src/services/trajectory-export.test.ts \
  src/runtime/__tests__/trajectory-recorder.test.ts
 Test Files  2 passed (2)
      Tests  58 passed (58)
```

Biome on both changed files: `Checked 2 files. No fixes applied.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface is touched by this diff.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path is touched.`

## Known gaps / failures

- **`bun run verify` was not run in full.** The owning package's focused lane
  (`trajectory-json`, plus the `trajectory-export` and `trajectory-recorder`
  suites that consume this module — 64 tests total) and the Biome gate were run
  after the final rebase. The full repository verify is a long multi-package lane
  and was not completed in this environment. The diff touches one core module and
  its colocated test; no export, schema, or serialized shape changed. Happy to
  attach a full run if a maintainer wants one before merge.
- Every `N/A` evidence row above is a non-UI, non-model code path, with the
  reason recorded inline on the row rather than left blank.
