### PR TITLE
fix(agent): enforce file quota before snapshot restore

### DIFF
--- a/packages/agent/src/services/virtual-filesystem-persistence.test.ts
+++ b/packages/agent/src/services/virtual-filesystem-persistence.test.ts
@@ -41,6 +41,38 @@ async function names(root: string) {
   return (await fsp.readdir(root)).sort();
 }
 
+describe("snapshot restore quotas", () => {
+  it("rejects a file exceeding the current limit before changing live or saved state", async () => {
+    const initial = new VirtualFilesystemService({
+      stateDir,
+      projectId,
+      maxFileBytes: 16,
+    });
+    await initial.writeFile("nested/state.txt", "0123456789");
+    const oversized = await initial.createSnapshot();
+    await initial.writeFile("nested/state.txt", "ok");
+    const valid = await initial.createSnapshot();
+    await initial.writeFile("nested/state.txt", "now");
+    const limited = new VirtualFilesystemService({
+      stateDir,
+      projectId,
+      maxFileBytes: 4,
+    });
+    const before = await names(limited.projectRoot);
+    const snapshots = await limited.listSnapshots();
+
+    await expect(limited.rollback(oversized.id)).rejects.toMatchObject({
+      code: "QUOTA_EXCEEDED",
+    });
+    expect(await service().readFile("nested/state.txt")).toBe("now");
+    expect(await names(limited.projectRoot)).toEqual(before);
+    expect(await limited.listSnapshots()).toEqual(snapshots);
+
+    await limited.rollback(valid.id);
+    expect(await service().readFile("nested/state.txt")).toBe("ok");
+  });
+});
+
 describe("saved VFS metadata", () => {
   it("distinguishes absence from an actual metadata read failure", async () => {
     const { vfs, snapshot, metadata } = await savedWorkspace();

--- a/packages/agent/src/services/virtual-filesystem.ts
+++ b/packages/agent/src/services/virtual-filesystem.ts
@@ -516,7 +516,7 @@ export class VirtualFilesystemService {
     snapshot: VirtualFilesystemSnapshot,
     root: string,
   ): Promise<void> {
-    const stats = await this.measureTree(root);
+    const stats = await this.measureTree(root, true);
     if (
       stats.bytes !== snapshot.filesBytes ||
       stats.fileCount !== snapshot.fileCount


### PR DESCRIPTION
Closes #30596. Follow-up to #30592.

Restoring a saved workspace bypassed the current per-file quota: a snapshot containing a 10-byte file could be restored after the service limit was reduced to 4 bytes, even though writing that file directly was rejected. Snapshot validation now applies the existing per-file check before rollback changes the live workspace or its recovery metadata.

The real filesystem regression creates both oversized and valid snapshots, lowers the limit, verifies the oversized restore is rejected without changing live bytes, metadata or saved snapshots, then restores the valid snapshot successfully.

Validated head: `441f15e1c89c11a10803c3ea2a19ba25bb722219`; base `aba2fffd930f5ec256fe61cebc67457be9e69708`.

- Real VFS, persistence, shell, Git and workbench-route suites: 71 passed across five files.
- Pinned Bun 1.3.14 / Node 24.15.0 install completed.
- Root `bun run verify`: 376/376 workspace tasks and every repository audit passed, including owning typecheck and lint.
- Biome and git diff checks passed.

<!-- evidence-head:441f15e1c89c11a10803c3ea2a19ba25bb722219 -->
<!-- evidence-row:before-screenshots -->
N/A - filesystem restore contract; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
N/A - no renderer change.
<!-- evidence-row:walkthrough-video -->
N/A - the real filesystem readback below owns acceptance.
<!-- evidence-row:backend-logs -->
```text
Original implementation, real temporary workspace:
  direct write of 10 bytes under maxFileBytes=4: QUOTA_EXCEEDED
  restore of the same 10-byte file: accepted (defect)
Repaired implementation:
  oversized snapshot: QUOTA_EXCEEDED before mutation
  current bytes, recovery metadata and snapshot collection: unchanged
  valid snapshot restore: saved bytes restored
Five focused suites: 71 passed, 0 failed
```
<!-- evidence-row:frontend-logs -->
N/A - no browser execution changed.
<!-- evidence-row:llm-trajectory -->
N/A - no model, prompt or action-result transformation changed.
<!-- evidence-row:domain-artifacts -->
The regression inspects real files and snapshot metadata before rejection and after a valid restore. A separate probe reproduced the original behavior before the repair.
<!-- evidence-row:ocr-review -->
N/A - no visual surface changed.
