### PR TITLE
test(app): pin the ui-smoke cloud API base to the local origin

### DIFF
--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -1586,6 +1586,52 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
       __ELIZA_APP_API_BASE__?: string;
     };
     host.__ELIZA_APP_API_BASE__ = window.location.origin;
+    // The renderer's direct-cloud client resolves its API base from the boot
+    // config's `cloudApiBase`, whose default is production api.eliza.app.
+    // Without an explicit loopback target, any flow that opens the cloud
+    // sign-in surface POSTs the REAL /api/auth/cli-session from a 127.0.0.1
+    // origin — production CORS-correctly refuses it, the console-diagnostics
+    // guard fails, and the lane makes a live call to production. The
+    // production resolver (client-cloud.ts resolveConfiguredDirectCloudApiBase)
+    // accepts a loopback cloudApiBase only from a loopback-rendered page, so
+    // pinning it here cannot leak outside local harnesses. Registered after
+    // spec-level injections, this merge also survives them.
+    const bootHost = window as typeof window & {
+      __ELIZAOS_APP_BOOT_CONFIG__?: Record<string, unknown>;
+    };
+    const existingBootConfig = bootHost.__ELIZAOS_APP_BOOT_CONFIG__ ?? {};
+    bootHost.__ELIZAOS_APP_BOOT_CONFIG__ = {
+      ...existingBootConfig,
+      cloudApiBase: existingBootConfig.cloudApiBase ?? window.location.origin,
+    };
+  });
+
+  // Cloud CLI-session pairing, routed at the loopback cloud base pinned above.
+  // POST creates a pending session; GET polls it. The pending stub keeps the
+  // flow inert (no authenticated token ever lands), matching what production
+  // looks like before the user acts. Specs that drive cloud login for real
+  // register their own handlers later, which take precedence over these.
+  await page.route("**/api/auth/cli-session", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessionId: "ui-smoke-cli-session" }),
+    });
+  });
+  await page.route("**/api/auth/cli-session/**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "pending" }),
+    });
   });
 
   let notesRevision = 4;


### PR DESCRIPTION
## Summary

- the ui-smoke harness seeds the renderer's API base but never its `cloudApiBase`, so flows that open the cloud sign-in surface resolve the direct-cloud client against **production** and POST the real `/api/auth/cli-session` from a `127.0.0.1` origin
- production CORS-correctly refuses the call; the console-diagnostics guard then fails the lane — and the lane makes a **live network call to the production API**
- fix: pin the boot config's `cloudApiBase` at the one shared boundary (`installDefaultAppRoutes`' document-start init script, registered after spec-level injections so the merge survives them) and answer the cli-session endpoints locally with an inert pending-session stub

## Root cause (traced in source)

`packages/ui/src/api/client-cloud.ts` `resolveConfiguredDirectCloudApiBase` resolves `getBootConfig().cloudApiBase ?? DEFAULT_DIRECT_CLOUD_BASE_URL` (`https://eliza.app`), which `resolveKnownDirectCloudApiBase` maps into the production API origin. The smoke harness injects `apiBase` only (`__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: origin }` in spec-level hosts; `__ELIZA_APP_API_BASE__` in the shared default), so the direct-cloud client targets production. The resolver deliberately accepts a **loopback** `cloudApiBase` from a loopback-rendered page — exactly the local-harness case — so pinning `cloudApiBase = window.location.origin` cannot leak outside local harnesses. The CORS middleware is behaving correctly throughout (all its unit tests pass); the harness was the gap.

## The failing job (authoritative RED)

`Develop Full` run [33822968275](https://github.com/elizaOS/eliza/actions/runs/33822968275) at `5463f6db8`, jobs [100870074365](https://github.com/elizaOS/eliza/actions/runs/33822968275/job/100870074365) (`tests / Zero-Key diagnostics`) and [100870075817](https://github.com/elizaOS/eliza/actions/runs/33822968275/job/100870075817) (`scenarios / Zero-Key app browser auto-discovered specs`):

```
1) [chromium] › test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts:254:3 ›
   walkthrough capture smoke › captures the first stable walkthrough states

  Error: expected no browser console.error/pageerror/requestfailed diagnostics; actual=[
    "console.error: Access to fetch at 'https://api.eliza.app/api/auth/cli-session' from origin
     'http://127.0.0.1:34333' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header...",
    "requestfailed: POST https://api.eliza.app/api/auth/cli-session net::ERR_FAILED",
    "console.error: Failed to load resource: net::ERR_FAILED"
  ]
```

## Disclosure: the trigger is timing-dependent

A single-spec run of `walkthrough-capture-smoke` at `5463f6db8` in a disposable container **passes** (8.5 s) — the async pairing call does not land inside the capture window on an unloaded runner; the CI failure occurs in the full auto-discovered lane (~57 specs) where the runner is slower. That is disclosed rather than hidden: the fix targets the harness **invariant** (a smoke lane must never call the production cloud API from a loopback origin), which is wrong on every run whether or not the console guard happens to catch it. Independent of the flake, every current lane run makes a real production API call from CI.

## Verification (disposable container, node:24-bookworm-slim, exact head)

- tree loaded via `git archive` + synthetic repo (the build shells out to `git ls-files`), `bun install --frozen-lockfile --ignore-scripts`, repo codegen, chromium via `npx playwright install --with-deps`; renderer build capped at `--max-old-space-size=4096` (the uncapped build aborts 134 under the container memory limit)
- single-spec develop baseline: `1 passed` (the timing-dependence disclosure above)
- **at this PR's head** (fix applied, nothing else changed): `walkthrough-capture-smoke` **passes** (8.2 s), plus the three cloud-touching neighbors for stub-interference: `cloud-login-callsite-popup` desktop + mobile **pass**, `auth-pairing-real` (real app-core stack) **passes**, `cli-auth-completion` 2 skipped (pre-existing environment gates) — **4 passed / 2 skipped / 0 failed**
- biome: the in-container `bunx biome@2.5.8` check disagrees with the committed formatting at a **pre-existing** line (`local-inference/voice-models/preferences` route, ~L3646) — verified by stashing this diff and re-running: the develop baseline fails identically, and this PR's hunks are outside the formatter's diff. CI's formatter is the authority.

## Scope / risk

One file, test-harness only: `packages/app/test/ui-smoke/helpers.ts`. No renderer/runtime code changes. The `cloudApiBase` merge preserves any spec-set keys (adds only if absent). Spec-registered `cli-session` handlers take precedence over the defaults (Playwright last-registration wins), so specs driving cloud login deliberately are unaffected — confirmed by the green cloud-login/pairing specs above.

## Evidence

| Row | Status | Detail |
| --- | --- | --- |
| Before screenshots | N/A - test-harness change; before state is the CI job log quoted above |
| After screenshots | N/A - test-harness change; after state is the green run output quoted above |
| Walkthrough video | N/A - no UI change |
| Backend logs | CI job logs 100870074365 / 100870075817 (linked above) |
| Frontend logs | container run logs quoted above |
| Real-LLM trajectory | N/A - no model-path change |
| Domain artifacts | container run transcripts (4 passed / 2 skipped / 0 failed) quoted above |


Compute receipt: 14922926 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: z.ai / glm-5.3
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza
Attribution status: self-reported
— [workflow-health]
<!-- slop-contribution-attribution:v1 {"provider":"z.ai","model":"glm-5.3","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1QZV13MDHFHQQ2RMKC3Z3DG","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-05T05:14:40.628Z","completed_at":"2026-09-05T05:37:20.522Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-05T05:14:52.346Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":32930,"output_tokens":17484,"cache_creation_tokens":0,"cache_read_tokens":14872512,"total_tokens":14922926,"cost_micro_usd":"3989884","session_count":2},"trajectory_sha256":"5d1b6a1ba410c3357b8bd3b40c2c0de70703ac082816ee9128e3c3b8060c06cf","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"31c5f997-a7a1-4251-b79f-198fb4f833c1","object_id":"sha256:5d1b6a1ba410c3357b8bd3b40c2c0de70703ac082816ee9128e3c3b8060c06cf","sha256":"5d1b6a1ba410c3357b8bd3b40c2c0de70703ac082816ee9128e3c3b8060c06cf"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAR850XHeZVEfYMatnrCiWT7P3QZHECM3R-C2VnfZ8iZQ","device_key_id":"5935e4ed75d7ef04a6827ac468d61a17e4bba8f871647762e8ff62c5e50dda49","device_signature":"VXwJogvXMD5RuEsuCg0JO3H5YcFURiPeFPMl4R96W0sBGDiwKCJ8GEJi7yR4mjWljzl2_xLHkqfuImY2yXSuCw"}} -->
