### PR TITLE
fix(shared): publish connector encryption keys atomically

### DIFF
--- a/packages/scripts/vitest/default.config.ts
+++ b/packages/scripts/vitest/default.config.ts
@@ -423,6 +423,13 @@ const vitestResolveAlias: ModuleAlias[] = [
           ),
         },
         {
+          find: /^@elizaos\/core\/errors$/,
+          replacement: path.join(
+            path.dirname(elizaCoreEntry),
+            elizaCoreEntry.endsWith(".ts") ? "errors.ts" : "errors.js",
+          ),
+        },
+        {
           // Same story for the atomic-json subpath (agent's
           // app-package-modules imports it directly).
           find: /^@elizaos\/core\/atomic-json$/,

--- a/packages/shared/src/crypto/token-encryption.test.ts
+++ b/packages/shared/src/crypto/token-encryption.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Verifies persisted connector keys with real files, crypto, and concurrent
+ * Node workers. A barrier after observing a missing key forces the first-use
+ * race without replacing the key loader or filesystem writes.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  decryptTokenEnvelope,
+  type EncryptedTokenEnvelope,
+  encryptTokenPayload,
+  resolveTokenEncryptionKey,
+} from "./token-encryption.js";
+
+const directories: string[] = [];
+function freshDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "connector-key-"));
+  directories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+const workerSource = `
+import fs from "node:fs";
+import { parentPort, workerData } from "node:worker_threads";
+const { resolveTokenEncryptionKey, encryptTokenPayload } = await import(workerData.moduleUrl);
+const barrier = new Int32Array(workerData.barrier);
+let synchronized = false;
+function rendezvous(file) {
+  if (synchronized || String(file) !== workerData.keyPath) return;
+  synchronized = true;
+  Atomics.add(barrier, 0, 1);
+  Atomics.notify(barrier, 0);
+  const deadline = Date.now() + 30_000;
+  while (Atomics.load(barrier, 0) < workerData.count) {
+    if (Date.now() >= deadline) throw new Error("Concurrent key writers did not rendezvous");
+    Atomics.wait(barrier, 0, Atomics.load(barrier, 0), 100);
+  }
+}
+const exists = fs.existsSync;
+fs.existsSync = (file) => {
+  const present = exists(file);
+  if (!present) rendezvous(file);
+  return present;
+};
+const read = fs.readFileSync;
+fs.readFileSync = (...args) => {
+  try { return read(...args); }
+  catch (error) {
+    // error-policy:J2 preserve the real missing-file result after synchronization.
+    if (error.code === "ENOENT") rendezvous(args[0]);
+    throw error;
+  }
+};
+const key = resolveTokenEncryptionKey(workerData.directory, {});
+parentPort.postMessage(encryptTokenPayload("synthetic connector token", key));
+`;
+
+describe("connector key publication", () => {
+  it("keeps every concurrent first-write token decryptable after reloading the persisted key", async () => {
+    const directory = freshDirectory();
+    const count = 4;
+    const barrier = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+    const workers = Array.from(
+      { length: count },
+      () =>
+        new Worker(
+          new URL(`data:text/javascript,${encodeURIComponent(workerSource)}`),
+          {
+            workerData: {
+              moduleUrl: new URL("./token-encryption.ts", import.meta.url).href,
+              directory,
+              keyPath: path.join(directory, ".encryption-key"),
+              barrier,
+              count,
+            },
+          },
+        ),
+    );
+    try {
+      const envelopes = await Promise.all(
+        workers.map(
+          (worker) =>
+            new Promise<EncryptedTokenEnvelope>((resolve, reject) => {
+              worker.once("message", resolve);
+              worker.once("error", reject);
+              worker.once("exit", (code) => {
+                if (code !== 0) reject(new Error(`Key writer exited ${code}`));
+              });
+            }),
+        ),
+      );
+      const persistedKey = resolveTokenEncryptionKey(directory, {});
+      for (const envelope of envelopes) {
+        expect(decryptTokenEnvelope(envelope, persistedKey)).toBe(
+          "synthetic connector token",
+        );
+      }
+      expect(fs.readdirSync(directory)).toEqual([".encryption-key"]);
+      if (process.platform !== "win32") {
+        expect(
+          fs.statSync(path.join(directory, ".encryption-key")).mode & 0o777,
+        ).toBe(0o600);
+      }
+    } finally {
+      await Promise.all(workers.map((worker) => worker.terminate()));
+    }
+  }, 90_000);
+
+  it("preserves existing key bytes and decrypts tokens written with that key", () => {
+    const directory = freshDirectory();
+    const key = Buffer.alloc(32, 9);
+    const original = `${key.toString("base64")}\n`;
+    const keyPath = path.join(directory, ".encryption-key");
+    fs.writeFileSync(keyPath, original, { mode: 0o600 });
+    const envelope = encryptTokenPayload("existing token", key);
+    expect(
+      decryptTokenEnvelope(envelope, resolveTokenEncryptionKey(directory, {})),
+    ).toBe("existing token");
+    expect(fs.readFileSync(keyPath, "utf8")).toBe(original);
+  });
+
+  it("rejects malformed persisted keys without replacing their bytes", () => {
+    const directory = freshDirectory();
+    const keyPath = path.join(directory, ".encryption-key");
+    fs.writeFileSync(keyPath, "broken-key");
+    expect(() => resolveTokenEncryptionKey(directory, {})).toThrowError(
+      expect.objectContaining({ code: "TOKEN_ENCRYPTION_KEY_UNAVAILABLE" }),
+    );
+    expect(fs.readFileSync(keyPath, "utf8")).toBe("broken-key");
+  });
+
+  it("keeps configured keys authoritative without repairing an invalid key file", () => {
+    const directory = freshDirectory();
+    const keyPath = path.join(directory, ".encryption-key");
+    fs.writeFileSync(keyPath, "broken-key");
+    const key = Buffer.alloc(32, 7);
+    expect(
+      resolveTokenEncryptionKey(directory, {
+        ELIZA_TOKEN_ENCRYPTION_KEY: key.toString("hex"),
+      }),
+    ).toEqual(key);
+    expect(fs.readFileSync(keyPath, "utf8")).toBe("broken-key");
+  });
+
+  it("rejects an unreadable key target before returning usable key material", () => {
+    const directory = freshDirectory();
+    fs.mkdirSync(path.join(directory, ".encryption-key"));
+    expect(() => resolveTokenEncryptionKey(directory, {})).toThrowError(
+      expect.objectContaining({ code: "TOKEN_ENCRYPTION_KEY_UNAVAILABLE" }),
+    );
+  });
+});

--- a/packages/shared/src/crypto/token-encryption.ts
+++ b/packages/shared/src/crypto/token-encryption.ts
@@ -18,6 +18,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { ElizaError } from "@elizaos/core/errors";
 
 const KEY_ENV_VAR = "ELIZA_TOKEN_ENCRYPTION_KEY";
 const KEY_FILENAME = ".encryption-key";
@@ -53,17 +54,66 @@ function decodeKeyMaterial(raw: string): Buffer {
 
 function loadOrCreateKeyFile(credentialsDir: string): Buffer {
   const filePath = path.join(credentialsDir, KEY_FILENAME);
-  if (fs.existsSync(filePath)) {
-    const raw = fs.readFileSync(filePath, "utf8");
-    return decodeKeyMaterial(raw);
+  try {
+    return decodeKeyMaterial(fs.readFileSync(filePath, "utf8"));
+  } catch (cause) {
+    // error-policy:J3 only an absent key permits creation; invalid existing
+    // material must never be replaced with a key that cannot decrypt tokens.
+    if (
+      !(cause instanceof Error && "code" in cause && cause.code === "ENOENT")
+    ) {
+      throw new ElizaError(
+        "Unable to read the persisted connector encryption key",
+        {
+          code: "TOKEN_ENCRYPTION_KEY_UNAVAILABLE",
+          cause,
+          context: { credentialsDir },
+        },
+      );
+    }
   }
-  fs.mkdirSync(credentialsDir, { recursive: true, mode: 0o700 });
-  const key = crypto.randomBytes(KEY_BYTES);
-  fs.writeFileSync(filePath, key.toString("base64"), {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  return key;
+  try {
+    return publishKeyFile(credentialsDir, filePath);
+  } catch (cause) {
+    // error-policy:J2 retain the filesystem failure and identify the key store.
+    throw new ElizaError("Unable to publish the connector encryption key", {
+      code: "TOKEN_ENCRYPTION_KEY_UNAVAILABLE",
+      cause,
+      context: { credentialsDir },
+    });
+  }
+}
+
+function publishKeyFile(credentialsDir: string, filePath: string): Buffer {
+  const temporaryPath = `${filePath}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.mkdirSync(credentialsDir, { recursive: true, mode: 0o700 });
+    const key = crypto.randomBytes(KEY_BYTES);
+    const descriptor = fs.openSync(temporaryPath, "wx", 0o600);
+    try {
+      fs.writeFileSync(descriptor, key.toString("base64"), "utf8");
+      fs.fsyncSync(descriptor);
+    } finally {
+      fs.closeSync(descriptor);
+    }
+    try {
+      // Publish a complete key atomically without replacing another writer's
+      // winner. Opening the final path with wx exposes a partially written key;
+      // renaming over it can strand tokens already encrypted by another host.
+      fs.linkSync(temporaryPath, filePath);
+      return key;
+    } catch (cause) {
+      // error-policy:J3 a publication collision means another complete key won.
+      if (
+        !(cause instanceof Error && "code" in cause && cause.code === "EEXIST")
+      ) {
+        throw cause;
+      }
+      return decodeKeyMaterial(fs.readFileSync(filePath, "utf8"));
+    }
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
 }
 
 /**


### PR DESCRIPTION
Concurrent first use of the connector token store could publish different encryption keys to the same credentials directory. Four successful writers left only one token recoverable after reloading the final key. This affected the canonical implementation introduced by #30560 and its former duplicated implementations.

Publish a fully written, fsynced private temporary key through an atomic non-overwriting hard link. A competing initializer reads the complete winning key. Existing keys are preserved, and malformed or unreadable key material raises `TOKEN_ENCRYPTION_KEY_UNAVAILABLE`. The connector token format and configured environment-key authority remain compatible. The shared Vitest resolver now recognizes the canonical core errors subpath used by the typed failure.

Closes #30611.

Validation on `632e0178aa68baece0eb54e2b2af8c3cadeec1ab`:
- A deterministic real-filesystem worker race failed before the repair: four writes succeeded, but only one token decrypted with the persisted key. The same regression now preserves all four tokens.
- All five key-store tests pass, including existing key compatibility, environment authority, malformed material, and an unreadable target.
- The complete shared package suite passes: 2,852 tests in 225 files. Finance and health connector compatibility suites each pass all 13 tests.
- Pinned installation, shared build, and root verification pass, including all 376 tasks and repository audits.

## Evidence Gate

<!-- evidence-head:632e0178aa68baece0eb54e2b2af8c3cadeec1ab -->
<!-- evidence-row:before-screenshots -->
N/A - filesystem encryption behavior; no rendered view changes.
<!-- evidence-row:after-screenshots -->
N/A - no rendered view changes.
<!-- evidence-row:walkthrough-video -->
N/A - real worker and filesystem results directly exercise the changed contract.
<!-- evidence-row:backend-logs -->
[Root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30612-30611-verify-632e0178.log), [full shared suite](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30612-30611-shared-632e0178.log), and the concurrency regression [before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30612-30611-race-before-632e0178.log) / [after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30612-30611-race-after-632e0178.log).
<!-- evidence-row:frontend-logs -->
N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
N/A - no model behavior or provider dispatch changes.
<!-- evidence-row:domain-artifacts -->
[Synthetic race receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30612-30611-race-receipt-632e0178.json). Four real Node workers use a shared temporary credentials directory and synthetic token bytes. After publication, a freshly loaded persisted key decrypts every successful writer's token. Existing key bytes and 0600 permissions are checked. No user credentials are used.
<!-- evidence-row:ocr-review -->
N/A - no visual artifacts.

Maintainer CI exception: N/A.
