### PR TITLE
fix(cloud): enforce Outreachr per-seat Stripe pricing

### DIFF
--- a/packages/cloud/shared/src/lib/services/outreachr-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/outreachr-billing.test.ts
@@ -20,6 +20,23 @@ function fixture() {
   const requests: { path: string; method: string; body: URLSearchParams }[] = [];
   let foreign = false;
   let amount = 4900;
+  let priceOverrides: Partial<Stripe.Price> = {};
+  let existingSubscription = false;
+  let existingQuantity: number | undefined;
+  const price = () => ({
+    id: "price_sol",
+    object: "price",
+    active: true,
+    currency: "usd",
+    unit_amount: amount,
+    billing_scheme: "per_unit",
+    type: "recurring",
+    transform_quantity: null,
+    recurring: { interval: "month", interval_count: 1, usage_type: "licensed" },
+    product: "prod_outreachr",
+    metadata: { outreachr_app_id: appId },
+    ...priceOverrides,
+  });
   const stripe = new Stripe("sk_test_outreachr_fixture", {
     maxNetworkRetries: 0,
     httpClient: Stripe.createFetchHttpClient(async (input, init) => {
@@ -39,25 +56,53 @@ function fixture() {
             outreachr_workspace_id: workspaceId,
           },
         };
-      else if (url.pathname === "/v1/prices/price_sol")
-        result = {
-          id: "price_sol",
-          object: "price",
-          active: true,
-          currency: "usd",
-          unit_amount: amount,
-          recurring: { interval: "month", interval_count: 1 },
-          product: "prod_outreachr",
-          metadata: { outreachr_app_id: appId },
-        };
+      else if (url.pathname === "/v1/prices/price_sol") result = price();
+      else if (url.pathname === "/v1/prices/price_astra")
+        result = { ...price(), id: "price_astra", unit_amount: 20000 };
       else if (url.pathname === "/v1/subscriptions")
-        result = { object: "list", data: [], has_more: false };
+        result = {
+          object: "list",
+          has_more: false,
+          data: existingSubscription
+            ? [
+                {
+                  id: "sub_fixture",
+                  object: "subscription",
+                  metadata: { outreachr_app_id: appId, outreachr_workspace_id: workspaceId },
+                  status: "active",
+                  created: 1_700_000_000,
+                  cancel_at_period_end: false,
+                  items: {
+                    object: "list",
+                    has_more: false,
+                    data: [
+                      {
+                        id: "si_fixture",
+                        price: price(),
+                        quantity: existingQuantity,
+                        current_period_start: 1_700_000_000,
+                        current_period_end: 1_702_592_000,
+                      },
+                    ],
+                  },
+                },
+              ]
+            : [],
+        };
       else if (url.pathname === "/v1/checkout/sessions")
         result = {
           object: "checkout.session",
           id: "cs_fixture",
           url: "https://checkout.stripe.com/c/pay/fixture",
           status: "open",
+        };
+      else if (url.pathname === "/v1/billing_portal/configurations")
+        result = { id: "bpc_fixture", object: "billing_portal.configuration" };
+      else if (url.pathname === "/v1/billing_portal/sessions")
+        result = {
+          id: "bps_fixture",
+          object: "billing_portal.session",
+          url: "https://billing.stripe.com/p/session/fixture",
         };
       else throw new Error(`Unexpected fixture request: ${url.pathname}`);
       return Response.json(result, { headers: { "request-id": "req_fixture" } });
@@ -71,6 +116,13 @@ function fixture() {
     },
     setWrongPrice: () => {
       amount = 3000;
+    },
+    setPrice: (overrides: Partial<Stripe.Price>) => {
+      priceOverrides = overrides;
+    },
+    setSubscription: (quantity: number | undefined) => {
+      existingSubscription = true;
+      existingQuantity = quantity;
     },
   };
 }
@@ -156,5 +208,105 @@ describe("Outreachr scoped Stripe billing", () => {
         signature: foreignSignature,
       }),
     ).resolves.toEqual({ eventId: "evt_fixture", workspaceId: null });
+  });
+
+  test("rejects quantity transformations before creating a per-seat checkout", async () => {
+    const f = fixture();
+    f.setPrice({ transform_quantity: { divide_by: 10, round: "up" } });
+    await expect(
+      outreachrBillingOperation(f.stripe, registration, config, {
+        action: "checkout",
+        workspaceId,
+        customerId: "cus_fixture",
+        attemptId: "33333333-3333-4333-8333-333333333333",
+        plan: "sol",
+        seats: 3,
+      }),
+    ).rejects.toMatchObject({ code: "OUTREACHR_BILLING_SCOPE" });
+    expect(f.requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
+  test("rejects transformed subscription prices instead of reporting them as per-seat plans", async () => {
+    const f = fixture();
+    f.setSubscription(3);
+    f.setPrice({ transform_quantity: { divide_by: 10, round: "up" } });
+    await expect(
+      outreachrBillingOperation(f.stripe, registration, config, {
+        action: "subscriptions",
+        workspaceId,
+        customerId: "cus_fixture",
+      }),
+    ).rejects.toMatchObject({ code: "OUTREACHR_BILLING_SCOPE" });
+  });
+
+  test("rejects unavailable or invalid subscription quantities instead of returning a seat entitlement", async () => {
+    for (const quantity of [undefined, 0, -1, 1.5, 1001]) {
+      const f = fixture();
+      f.setSubscription(quantity);
+      await expect(
+        outreachrBillingOperation(f.stripe, registration, config, {
+          action: "subscriptions",
+          workspaceId,
+          customerId: "cus_fixture",
+        }),
+      ).rejects.toMatchObject({ code: "OUTREACHR_BILLING_SCOPE" });
+    }
+  });
+
+  test("reads complete seat entitlements from an ordinary licensed per-unit subscription", async () => {
+    const f = fixture();
+    f.setSubscription(3);
+    await expect(
+      outreachrBillingOperation(f.stripe, registration, config, {
+        action: "subscriptions",
+        workspaceId,
+        customerId: "cus_fixture",
+      }),
+    ).resolves.toMatchObject({ subscriptions: [{ id: "sub_fixture", plan: "sol", seats: 3 }] });
+  });
+
+  test("rejects a transformed current plan before creating any billing portal configuration", async () => {
+    const f = fixture();
+    f.setSubscription(3);
+    f.setPrice({ transform_quantity: { divide_by: 10, round: "up" } });
+    await expect(
+      outreachrBillingOperation(f.stripe, registration, config, {
+        action: "portal",
+        workspaceId,
+        customerId: "cus_fixture",
+        attemptId: "33333333-3333-4333-8333-333333333333",
+        minimumSeats: 3,
+      }),
+    ).rejects.toMatchObject({ code: "OUTREACHR_BILLING_SCOPE" });
+    expect(f.requests.some((request) => request.method === "POST")).toBe(false);
+  });
+
+  test("retains the registered plan and seat-floor constraints in a valid portal upgrade", async () => {
+    const f = fixture();
+    f.setSubscription(3);
+    await outreachrBillingOperation(f.stripe, registration, config, {
+      action: "portal",
+      workspaceId,
+      customerId: "cus_fixture",
+      attemptId: "33333333-3333-4333-8333-333333333333",
+      minimumSeats: 3,
+      update: { subscriptionId: "sub_fixture", plan: "astra", seats: 4 },
+    });
+    const configuration = f.requests.find(
+      (request) => request.path === "/v1/billing_portal/configurations",
+    )!;
+    expect(
+      configuration.body.get(
+        "features[subscription_update][products][0][adjustable_quantity][minimum]",
+      ),
+    ).toBe("3");
+    const portal = f.requests.find((request) => request.path === "/v1/billing_portal/sessions")!;
+    expect(portal.body.get("flow_data[subscription_update_confirm][subscription]")).toBe(
+      "sub_fixture",
+    );
+    expect(portal.body.get("flow_data[subscription_update_confirm][items][0][price]")).toBe(
+      "price_astra",
+    );
+    expect(portal.body.get("flow_data[subscription_update_confirm][items][0][quantity]")).toBe("4");
   });
 });

--- a/packages/cloud/shared/src/lib/services/outreachr-billing.ts
+++ b/packages/cloud/shared/src/lib/services/outreachr-billing.ts
@@ -69,6 +69,21 @@ function assertBilling(condition: unknown, message: string): asserts condition {
   if (!condition) throw new OutreachrDelegationError(403, "OUTREACHR_BILLING_SCOPE", message);
 }
 
+function assertSeatPrice(price: Stripe.Price, chosen: "sol" | "astra", appId: string): void {
+  assertBilling(
+    price.type === "recurring" &&
+      price.billing_scheme === "per_unit" &&
+      price.transform_quantity === null &&
+      price.currency === "usd" &&
+      price.unit_amount === (chosen === "sol" ? 4900 : 20000) &&
+      price.recurring?.interval === "month" &&
+      price.recurring.interval_count === 1 &&
+      price.recurring.usage_type === "licensed" &&
+      price.metadata.outreachr_app_id === appId,
+    "Outreachr price does not match the registered per-seat plan",
+  );
+}
+
 export async function outreachrBillingOperation(
   stripe: Stripe,
   registration: OutreachrRegistration,
@@ -92,15 +107,8 @@ export async function outreachrBillingOperation(
         "Outreachr subscription prices are not configured",
       );
     const price = await stripe.prices.retrieve(id);
-    assertBilling(
-      price.active &&
-        price.currency === "usd" &&
-        price.unit_amount === (chosen === "sol" ? 4900 : 20000) &&
-        price.recurring?.interval === "month" &&
-        price.recurring.interval_count === 1 &&
-        price.metadata.outreachr_app_id === registration.appId,
-      "Outreachr price does not match the registered plan",
-    );
+    assertBilling(price.active, "Outreachr price is inactive");
+    assertSeatPrice(price, chosen, registration.appId);
     return price;
   };
   if (input.action === "event") {
@@ -188,39 +196,38 @@ export async function outreachrBillingOperation(
       subscriptions.data.every((sub) => matches(sub.metadata, input.workspaceId)),
     "Unexpected subscriptions exist for this Outreachr customer",
   );
-  if (input.action === "subscriptions") {
+  const subscriptionStates = subscriptions.data.map((sub) => {
+    const item = sub.items.data[0];
+    const known =
+      item?.price.id === config.solPrice
+        ? "sol"
+        : item?.price.id === config.astraPrice
+          ? "astra"
+          : null;
+    assertBilling(
+      sub.items.data.length === 1 && !sub.items.has_more && item && known,
+      "Subscription does not match an Outreachr plan",
+    );
+    assertSeatPrice(item.price, known, registration.appId);
+    assertBilling(
+      typeof item.quantity === "number" &&
+        Number.isSafeInteger(item.quantity) &&
+        item.quantity >= 1 &&
+        item.quantity <= 1000,
+      "Subscription does not have a valid Outreachr seat quantity",
+    );
     return {
-      subscriptions: subscriptions.data.map((sub) => {
-        const item = sub.items.data[0];
-        const known =
-          item?.price.id === config.solPrice
-            ? "sol"
-            : item?.price.id === config.astraPrice
-              ? "astra"
-              : null;
-        assertBilling(
-          sub.items.data.length === 1 &&
-            item &&
-            known &&
-            item.price.currency === "usd" &&
-            item.price.unit_amount === (known === "sol" ? 4900 : 20000) &&
-            item.price.recurring?.interval === "month" &&
-            item.price.recurring.interval_count === 1,
-          "Subscription does not match an Outreachr plan",
-        );
-        return {
-          id: sub.id,
-          status: sub.status,
-          plan: known,
-          seats: item.quantity,
-          periodStart: item.current_period_start,
-          periodEnd: item.current_period_end,
-          cancelAtPeriodEnd: sub.cancel_at_period_end,
-          created: sub.created,
-        };
-      }),
+      id: sub.id,
+      status: sub.status,
+      plan: known,
+      seats: item.quantity,
+      periodStart: item.current_period_start,
+      periodEnd: item.current_period_end,
+      cancelAtPeriodEnd: sub.cancel_at_period_end,
+      created: sub.created,
     };
-  }
+  });
+  if (input.action === "subscriptions") return { subscriptions: subscriptionStates };
   const prices = await Promise.all([priceFor("sol"), priceFor("astra")]);
   const products = new Map<string, string[]>();
   for (const price of prices) {


### PR DESCRIPTION
Outreachr accepted a Stripe price with a quantity transform even though its unit amount was $49/month. For three selected seats, Stripe could therefore bill a single transformed unit while the application treated the subscription as three paid seats. Existing subscriptions also bypassed the seat-price contract when opening the billing portal.

Validate the complete seat-price contract before checkout or portal configuration: USD, the configured monthly amount, a one-month licensed recurring interval, per-unit billing, and no quantity transform. Existing subscriptions must have exactly one known price item and an integer quantity from 1 through 1,000. Inactive prices remain readable for existing subscriptions; new checkout prices must be active.

Closes #30613. Repairs the billing validation introduced in #30607.

Validation on `894d76d861fbb9249182932e086e4e612287bc79`:

- The real Stripe SDK against a controlled HTTP service accepted the invalid transformed price before the repair. Three regression cases failed before the change and pass afterward.
- All 17 focused billing, delegation, and migration tests pass. Tests cover invalid quantities, transformed and unsupported prices, valid three-seat checkout, portal rejection before configuration mutation, and a valid four-seat upgrade. The source and tests are byte-identical to the tested repair before its rebase onto the merged feature.
- Pinned installation and final-head root verification pass: all 376 tasks and repository audits.

## Evidence Gate

<!-- evidence-head:894d76d861fbb9249182932e086e4e612287bc79 -->
<!-- evidence-row:before-screenshots -->
N/A - backend Stripe contract validation; no view changes.
<!-- evidence-row:after-screenshots -->
N/A - no view changes.
<!-- evidence-row:walkthrough-video -->
N/A - real SDK HTTP requests and persisted database results exercise the affected boundary.
<!-- evidence-row:backend-logs -->
[Final root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30615-verify-894d76d8.log), [focused tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30615-focused-source-equivalent-894d76d8.log), and [failing regression before repair](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30615-regression-before-894d76d8.log).
<!-- evidence-row:frontend-logs -->
N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
N/A - no model behavior changes.
<!-- evidence-row:domain-artifacts -->
[Synthetic Stripe price receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30615-price-receipt-894d76d8.json) records the controlled SDK boundary. No external charge, account delegation, or message was sent. Live activation of the broader Outreachr feature remains outside this validator repair and still requires its configured application bindings.
<!-- evidence-row:ocr-review -->
N/A - no visual artifacts.

Maintainer CI exception: N/A.
