### PR TITLE
fix(cloud-sdk): harden successful response contracts

### DIFF
--- a/packages/cloud/sdk/README.md
+++ b/packages/cloud/sdk/README.md
@@ -103,6 +103,28 @@ binary, and text routes return `Response` from the primary generated method;
 mixed routes such as chat completions keep the JSON method and use `Raw` when
 the request asks for streaming.
 
+Parsed `request()` calls require an explicit JSON media type
+(`application/json` or a structured `+json` type) and preserve every JSON
+value, including primitives and `null`. Successful text, missing media types,
+malformed JSON, and unexpectedly empty data responses throw `CloudApiError`;
+use `requestRaw()` for text or binary bodies. `HEAD`, `204`, and `205`
+responses are the deliberate bodyless exceptions and resolve to `undefined`.
+The generic `get`, `post`, `put`, `patch`, `delete`, and
+`postUnauthenticated` helpers preserve this behavior. Use `requestData` when
+a caller requires JSON data even on a successful status.
+Generated endpoints that deliberately return either JSON or `204` expose the
+same `T | undefined` result, while data-required helpers reject a bodyless
+response instead of hiding it behind their DTO type.
+Older SDK releases could replace successful text or empty bodies with an
+invented `{ success: true }` object; callers relying on that fallback must use
+an explicit bodyless status or return a JSON response instead.
+
+`pollJob` and `waitForCliLogin` enforce a total timeout through every request,
+response-body read, and polling interval. Their timeout and interval options
+accept integers from 0 through 2,147,483,647 milliseconds; zero timeout expires
+immediately. Login cancellation also interrupts an in-flight request or wait.
+Direct `getJob` and `pollCliLogin` calls accept optional `timeoutMs` and `signal`.
+
 Refresh and verify route coverage after adding or changing API routes:
 
 ```bash
@@ -135,19 +157,3 @@ Build and publish:
 bun run build
 npm publish --access public
 ```
-
-## Parsed responses
-
-`request` and typed endpoint methods accept `application/json` and application
-media types ending in `+json`, preserving objects, arrays and JSON primitives.
-Successful HTML/text, malformed JSON and unexpectedly empty JSON responses
-throw `CloudApiError`; they never become an invented `{ success: true }` DTO.
-HEAD and HTTP 204/205 responses resolve to `undefined`, as these protocols have
-no response body. Use `requestRaw` (or a generated `Raw` method) for text,
-binary, streaming, or status-sensitive responses.
-
-`pollJob` and `waitForCliLogin` enforce a total timeout through every request,
-response-body read and polling interval. Their timeout and interval options
-accept integers from 0 through 2,147,483,647 milliseconds; zero timeout expires
-immediately. Login cancellation also interrupts an in-flight request or wait.
-Direct `getJob` and `pollCliLogin` calls accept optional `timeoutMs` and `signal`.

--- a/packages/cloud/sdk/scripts/generate-public-routes.mjs
+++ b/packages/cloud/sdk/scripts/generate-public-routes.mjs
@@ -77,6 +77,14 @@ function pathParamTypeLine(endpoint) {
   return `  ${quote(endpoint.key)}: { ${fields} };`;
 }
 
+const JSON_OR_EMPTY_ROUTES = new Set([
+  "DELETE /api/v1/apis/storage/objects/_",
+  "GET /api/v1/advertising/conversions/track",
+  "GET /api/v1/marketing/inventory/serve",
+  "GET /api/v1/remote/sessions/{id}/commands",
+  "POST /api/v1/twilio/voice/status",
+]);
+
 function responseModeFor(method, route, source) {
   if (
     route === "/api/v1/apis/storage/objects/_" &&
@@ -84,12 +92,22 @@ function responseModeFor(method, route, source) {
   )
     return "binary";
   if (route.endsWith("/tts")) return "binary";
+  if (
+    method === "GET" &&
+    route === "/api/v1/apps/{id}/frontend/preview/{[...path]}"
+  )
+    return "binary";
+  if (method === "GET" && route === "/api/v1/hosted-frontend/serve/{[...path]}")
+    return "binary";
   if (source.includes('"Content-Type": "text/html')) return "text";
+  if (/\bc\.text\s*\(/.test(source)) return "text";
   if (route.includes("/stream") || route.endsWith("/logs/stream"))
     return "stream";
   if (route.endsWith("/terminal") && method === "GET") return "stream";
   if (source.includes("text/event-stream") || source.includes("SSE_HEADERS"))
     return "mixed";
+  if (method === "HEAD" || JSON_OR_EMPTY_ROUTES.has(`${method} ${route}`))
+    return "json-or-empty";
   return "json";
 }
 
@@ -133,6 +151,15 @@ function routeMethod(endpoint) {
       `    ${optionsArg}`,
       "  ): Promise<Response> {",
       `    return this.callRaw(${quote(endpoint.key)}, options);`,
+      "  }",
+    ].join("\n");
+  }
+  if (endpoint.responseMode === "json-or-empty") {
+    return [
+      `  ${endpoint.methodName}<TResponse = unknown>(`,
+      `    ${optionsArg}`,
+      "  ): Promise<CloudResponse<TResponse>> {",
+      `    return this.callBodyless<${quote(endpoint.key)}, TResponse>(${quote(endpoint.key)}, options);`,
       "  }",
     ].join("\n");
   }
@@ -209,7 +236,7 @@ const source = `/* eslint-disable @typescript-eslint/no-explicit-any */
 // The exported PublicRoute* names are retained for backward compatibility.
 // Do not edit by hand.
 
-import type { CloudRequestOptions, HttpMethod } from "./types.js";
+import type { CloudRequestOptions, CloudResponse, HttpMethod } from "./types.js";
 
 export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
 ${endpoints.map(endpointLine).join("\n")}
@@ -256,6 +283,11 @@ export type PublicRouteCallOptions<TKey extends PublicRouteKey> =
 
 interface ElizaCloudPublicRouteTransport {
   request<TResponse>(
+    method: HttpMethod,
+    path: string,
+    options?: CloudRequestOptions
+  ): Promise<CloudResponse<TResponse>>;
+  requestData?<TResponse>(
     method: HttpMethod,
     path: string,
     options?: CloudRequestOptions
@@ -336,6 +368,25 @@ export class ElizaCloudPublicRoutesClient {
     key: TKey,
     options?: PublicRouteCallOptions<TKey>
   ): Promise<TResponse> {
+    const endpoint = ELIZA_CLOUD_PUBLIC_ENDPOINTS[key];
+    const method = endpoint.method as HttpMethod;
+    const path = buildPublicRoutePath(key, options);
+    const requestOptions = toRequestOptions(options);
+    if (this.client.requestData) {
+      return this.client.requestData<TResponse>(method, path, requestOptions);
+    }
+    return this.client.request<TResponse>(method, path, requestOptions).then((response) => {
+      if (response === undefined) {
+        throw new Error(\`Expected a data response for \${key}\`);
+      }
+      return response;
+    });
+  }
+
+  private callBodyless<TKey extends PublicRouteKey, TResponse = unknown>(
+    key: TKey,
+    options?: PublicRouteCallOptions<TKey>
+  ): Promise<CloudResponse<TResponse>> {
     const endpoint = ELIZA_CLOUD_PUBLIC_ENDPOINTS[key];
     return this.client.request<TResponse>(
       endpoint.method as HttpMethod,

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -54,6 +54,7 @@ import {
   type CliLoginStartOptions,
   type CliLoginStartResponse,
   type CloudRequestOptions,
+  type CloudResponse,
   type ContainerCredentialsResponse,
   type ContainerGetResponse,
   type ContainerHealthResponse,
@@ -330,7 +331,23 @@ export class ElizaCloudClient {
       defaultHeaders: options.defaultHeaders,
       fetchImpl: options.fetchImpl,
     });
-    this.routes = new ElizaCloudPublicRoutesClient(this);
+    this.routes = new ElizaCloudPublicRoutesClient({
+      request: <TResponse>(
+        method: HttpMethod,
+        path: string,
+        requestOptions?: CloudRequestOptions,
+      ) => this.http.request<TResponse>(method, path, requestOptions),
+      requestData: <TResponse>(
+        method: HttpMethod,
+        path: string,
+        requestOptions?: CloudRequestOptions,
+      ) => this.http.requestData<TResponse>(method, path, requestOptions),
+      requestRaw: (
+        method: HttpMethod,
+        path: string,
+        requestOptions?: CloudRequestOptions,
+      ) => this.http.requestRaw(method, path, requestOptions),
+    });
   }
 
   setApiKey(apiKey: string | undefined): void {
@@ -347,7 +364,7 @@ export class ElizaCloudClient {
     method: HttpMethod,
     path: string,
     options?: CloudRequestOptions,
-  ): Promise<TResponse> {
+  ): Promise<CloudResponse<TResponse>> {
     return this.http.request<TResponse>(method, path, options);
   }
 
@@ -359,11 +376,19 @@ export class ElizaCloudClient {
     return this.http.requestRaw(method, path, options);
   }
 
+  private requestData<TResponse>(
+    method: HttpMethod,
+    path: string,
+    options?: CloudRequestOptions,
+  ): Promise<TResponse> {
+    return this.http.requestData<TResponse>(method, path, options);
+  }
+
   callEndpoint<TResponse>(
     method: HttpMethod,
     pathTemplate: string,
     options: EndpointCallOptions = {},
-  ): Promise<TResponse> {
+  ): Promise<CloudResponse<TResponse>> {
     const { pathParams, ...requestOptions } = options;
     return this.request<TResponse>(
       method,
@@ -373,7 +398,7 @@ export class ElizaCloudClient {
   }
 
   getOpenApiSpec(options: CloudRequestOptions = {}): Promise<OpenApiSpec> {
-    return this.request<OpenApiSpec>("GET", "/api/openapi.json", options);
+    return this.requestData<OpenApiSpec>("GET", "/api/openapi.json", options);
   }
 
   startCliLogin(
@@ -387,7 +412,7 @@ export class ElizaCloudClient {
       ? `?returnTo=${encodeURIComponent(options.returnTo)}`
       : "";
 
-    return this.request<{
+    return this.requestData<{
       sessionId: string;
       status?: string;
       expiresAt?: string;
@@ -416,7 +441,7 @@ export class ElizaCloudClient {
     sessionId: string,
     options?: Pick<CloudRequestOptions, "signal" | "timeoutMs">,
   ): Promise<CliLoginPollResponse> {
-    return this.request<CliLoginPollResponse>(
+    return this.requestData<CliLoginPollResponse>(
       "GET",
       `/api/auth/cli-session/${encodePathParam(sessionId)}`,
       { ...options, skipAuth: true },
@@ -464,7 +489,7 @@ export class ElizaCloudClient {
   }
 
   pairWithToken(token: string, origin: string): Promise<AuthPairResponse> {
-    return this.request<AuthPairResponse>("POST", "/api/auth/pair", {
+    return this.requestData<AuthPairResponse>("POST", "/api/auth/pair", {
       json: { token },
       headers: { Origin: origin },
       skipAuth: true,
@@ -472,34 +497,37 @@ export class ElizaCloudClient {
   }
 
   listModels(): Promise<ModelListResponse> {
-    return this.v1.get<ModelListResponse>("/models", { skipAuth: true });
+    return this.v1.requestData<ModelListResponse>("GET", "/models", {
+      skipAuth: true,
+    });
   }
 
   getSubscriptionPlans(): Promise<SubscriptionPlansResponse> {
-    return this.v1.get<SubscriptionPlansResponse>("/subscriptions/plans", {
-      skipAuth: true,
-    });
+    return this.v1.requestData<SubscriptionPlansResponse>(
+      "GET",
+      "/subscriptions/plans",
+      { skipAuth: true },
+    );
   }
 
   createResponse(
     request: ResponsesCreateRequest,
     options: InferenceCallOptions = {},
   ): Promise<ResponsesCreateResponse> {
-    return this.v1.post<ResponsesCreateResponse>(
-      "/responses",
-      request,
-      inferenceRequestOptions(options),
-    );
+    return this.v1.requestData<ResponsesCreateResponse>("POST", "/responses", {
+      ...inferenceRequestOptions(options),
+      json: request,
+    });
   }
 
   createChatCompletion(
     request: ChatCompletionRequest,
     options: InferenceCallOptions = {},
   ): Promise<ChatCompletionResponse> {
-    return this.v1.post<ChatCompletionResponse>(
+    return this.v1.requestData<ChatCompletionResponse>(
+      "POST",
       "/chat/completions",
-      request,
-      inferenceRequestOptions(options),
+      { ...inferenceRequestOptions(options), json: request },
     );
   }
 
@@ -507,21 +535,20 @@ export class ElizaCloudClient {
     request: EmbeddingsRequest,
     options: InferenceCallOptions = {},
   ): Promise<EmbeddingsResponse> {
-    return this.v1.post<EmbeddingsResponse>(
-      "/embeddings",
-      request,
-      inferenceRequestOptions(options),
-    );
+    return this.v1.requestData<EmbeddingsResponse>("POST", "/embeddings", {
+      ...inferenceRequestOptions(options),
+      json: request,
+    });
   }
 
   generateImage(
     request: GenerateImageRequest,
     options: InferenceCallOptions = {},
   ): Promise<GenerateImageResponse> {
-    return this.v1.post<GenerateImageResponse>(
+    return this.v1.requestData<GenerateImageResponse>(
+      "POST",
       "/generate-image",
-      request,
-      inferenceRequestOptions(options),
+      { ...inferenceRequestOptions(options), json: request },
     );
   }
 
@@ -543,7 +570,7 @@ export class ElizaCloudClient {
     if (request.languageCode !== undefined) {
       form.append("languageCode", request.languageCode);
     }
-    return this.v1.request<VoiceSttResponse>("POST", "/voice/stt", {
+    return this.v1.requestData<VoiceSttResponse>("POST", "/voice/stt", {
       ...inferenceRequestOptions(options),
       body: form,
     });
@@ -552,7 +579,7 @@ export class ElizaCloudClient {
   getCreditsBalance(
     options: { fresh?: boolean } = {},
   ): Promise<CreditBalanceResponse> {
-    return this.request<CreditBalanceResponse>(
+    return this.requestData<CreditBalanceResponse>(
       "GET",
       "/api/v1/credits/balance",
       {
@@ -563,7 +590,7 @@ export class ElizaCloudClient {
   }
 
   getCreditsSummary(): Promise<CreditSummaryResponse> {
-    return this.request<CreditSummaryResponse>(
+    return this.requestData<CreditSummaryResponse>(
       "GET",
       "/api/v1/credits/summary",
     );
@@ -572,7 +599,7 @@ export class ElizaCloudClient {
   createCreditsCheckout(
     request: CreateCreditsCheckoutRequest,
   ): Promise<CreateCreditsCheckoutResponse> {
-    return this.request<CreateCreditsCheckoutResponse>(
+    return this.requestData<CreateCreditsCheckoutResponse>(
       "POST",
       "/api/v1/credits/checkout",
       {
@@ -582,7 +609,7 @@ export class ElizaCloudClient {
   }
 
   getAppCreditsBalance(appId: string): Promise<AppCreditsBalanceResponse> {
-    return this.request<AppCreditsBalanceResponse>(
+    return this.requestData<AppCreditsBalanceResponse>(
       "GET",
       "/api/v1/app-credits/balance",
       {
@@ -594,7 +621,7 @@ export class ElizaCloudClient {
   createAppCreditsCheckout(
     request: CreateAppCreditsCheckoutRequest,
   ): Promise<CreateAppCreditsCheckoutResponse> {
-    return this.request<CreateAppCreditsCheckoutResponse>(
+    return this.requestData<CreateAppCreditsCheckoutResponse>(
       "POST",
       "/api/v1/app-credits/checkout",
       {
@@ -606,7 +633,7 @@ export class ElizaCloudClient {
   verifyAppCreditsCheckout(
     sessionId: string,
   ): Promise<VerifyAppCreditsCheckoutResponse> {
-    return this.request<VerifyAppCreditsCheckoutResponse>(
+    return this.requestData<VerifyAppCreditsCheckoutResponse>(
       "GET",
       "/api/v1/app-credits/verify",
       {
@@ -616,7 +643,7 @@ export class ElizaCloudClient {
   }
 
   getX402Supported(): Promise<X402SupportedResponse> {
-    return this.request<X402SupportedResponse>("GET", "/api/v1/x402", {
+    return this.requestData<X402SupportedResponse>("GET", "/api/v1/x402", {
       skipAuth: true,
     });
   }
@@ -624,7 +651,7 @@ export class ElizaCloudClient {
   verifyX402Payment(
     request: X402FacilitatorPaymentRequest,
   ): Promise<X402VerifyResponse> {
-    return this.request<X402VerifyResponse>("POST", "/api/v1/x402/verify", {
+    return this.requestData<X402VerifyResponse>("POST", "/api/v1/x402/verify", {
       json: request,
       skipAuth: true,
     });
@@ -633,7 +660,7 @@ export class ElizaCloudClient {
   settleX402Payment(
     request: X402FacilitatorPaymentRequest,
   ): Promise<X402SettleResponse> {
-    return this.request<X402SettleResponse>("POST", "/api/v1/x402/settle", {
+    return this.requestData<X402SettleResponse>("POST", "/api/v1/x402/settle", {
       json: request,
       skipAuth: true,
     });
@@ -642,7 +669,7 @@ export class ElizaCloudClient {
   createX402PaymentRequest(
     request: CreateX402PaymentRequest,
   ): Promise<CreateX402PaymentRequestResponse> {
-    return this.request<CreateX402PaymentRequestResponse>(
+    return this.requestData<CreateX402PaymentRequestResponse>(
       "POST",
       "/api/v1/x402/requests",
       {
@@ -652,14 +679,14 @@ export class ElizaCloudClient {
   }
 
   listX402PaymentRequests(): Promise<ListX402PaymentRequestsResponse> {
-    return this.request<ListX402PaymentRequestsResponse>(
+    return this.requestData<ListX402PaymentRequestsResponse>(
       "GET",
       "/api/v1/x402/requests",
     );
   }
 
   getX402PaymentRequest(id: string): Promise<GetX402PaymentRequestResponse> {
-    return this.request<GetX402PaymentRequestResponse>(
+    return this.requestData<GetX402PaymentRequestResponse>(
       "GET",
       `/api/v1/x402/requests/${encodePathParam(id)}`,
       { skipAuth: true },
@@ -670,7 +697,7 @@ export class ElizaCloudClient {
     id: string,
     paymentPayload: JsonObject,
   ): Promise<SettleX402PaymentRequestResponse> {
-    return this.request<SettleX402PaymentRequestResponse>(
+    return this.requestData<SettleX402PaymentRequestResponse>(
       "POST",
       `/api/v1/x402/requests/${encodePathParam(id)}/settle`,
       { json: { paymentPayload }, skipAuth: true },
@@ -681,7 +708,7 @@ export class ElizaCloudClient {
     appId: string,
     request: CreateAppChargeRequest,
   ): Promise<CreateAppChargeResponse> {
-    return this.request<CreateAppChargeResponse>(
+    return this.requestData<CreateAppChargeResponse>(
       "POST",
       `/api/v1/apps/${encodePathParam(appId)}/charges`,
       { json: request },
@@ -692,7 +719,7 @@ export class ElizaCloudClient {
     appId: string,
     options: { limit?: number } = {},
   ): Promise<ListAppChargesResponse> {
-    return this.request<ListAppChargesResponse>(
+    return this.requestData<ListAppChargesResponse>(
       "GET",
       `/api/v1/apps/${encodePathParam(appId)}/charges`,
       {
@@ -703,7 +730,7 @@ export class ElizaCloudClient {
   }
 
   getAppCharge(appId: string, chargeId: string): Promise<GetAppChargeResponse> {
-    return this.request<GetAppChargeResponse>(
+    return this.requestData<GetAppChargeResponse>(
       "GET",
       `/api/v1/apps/${encodePathParam(appId)}/charges/${encodePathParam(chargeId)}`,
       { skipAuth: true },
@@ -715,7 +742,7 @@ export class ElizaCloudClient {
     chargeId: string,
     request: CreateAppChargeCheckoutRequest,
   ): Promise<CreateAppChargeCheckoutResponse> {
-    return this.request<CreateAppChargeCheckoutResponse>(
+    return this.requestData<CreateAppChargeCheckoutResponse>(
       "POST",
       `/api/v1/apps/${encodePathParam(appId)}/charges/${encodePathParam(chargeId)}/checkout`,
       { json: request },
@@ -723,29 +750,37 @@ export class ElizaCloudClient {
   }
 
   getAffiliateCode(): Promise<AffiliateCodeResponse> {
-    return this.request<AffiliateCodeResponse>("GET", "/api/v1/affiliates");
+    return this.requestData<AffiliateCodeResponse>("GET", "/api/v1/affiliates");
   }
 
   createAffiliateCode(
     request: UpsertAffiliateCodeRequest,
   ): Promise<AffiliateCodeResponse> {
-    return this.request<AffiliateCodeResponse>("POST", "/api/v1/affiliates", {
-      json: request,
-    });
+    return this.requestData<AffiliateCodeResponse>(
+      "POST",
+      "/api/v1/affiliates",
+      {
+        json: request,
+      },
+    );
   }
 
   updateAffiliateCode(
     request: UpsertAffiliateCodeRequest,
   ): Promise<AffiliateCodeResponse> {
-    return this.request<AffiliateCodeResponse>("PUT", "/api/v1/affiliates", {
-      json: request,
-    });
+    return this.requestData<AffiliateCodeResponse>(
+      "PUT",
+      "/api/v1/affiliates",
+      {
+        json: request,
+      },
+    );
   }
 
   linkAffiliateCode(
     request: LinkAffiliateRequest,
   ): Promise<LinkAffiliateResponse> {
-    return this.request<LinkAffiliateResponse>(
+    return this.requestData<LinkAffiliateResponse>(
       "POST",
       "/api/v1/affiliates/link",
       {
@@ -758,7 +793,7 @@ export class ElizaCloudClient {
     appId: string,
     options: { days?: number } = {},
   ): Promise<AppEarningsResponse> {
-    return this.request<AppEarningsResponse>(
+    return this.requestData<AppEarningsResponse>(
       "GET",
       `/api/v1/apps/${encodePathParam(appId)}/earnings`,
       {
@@ -771,7 +806,7 @@ export class ElizaCloudClient {
     appId: string,
     options: { limit?: number; offset?: number; type?: string } = {},
   ): Promise<AppEarningsHistoryResponse> {
-    return this.request<AppEarningsHistoryResponse>(
+    return this.requestData<AppEarningsHistoryResponse>(
       "GET",
       `/api/v1/apps/${encodePathParam(appId)}/earnings/history`,
       { query: options },
@@ -782,7 +817,7 @@ export class ElizaCloudClient {
     appId: string,
     request: WithdrawAppEarningsRequest,
   ): Promise<WithdrawAppEarningsResponse> {
-    return this.request<WithdrawAppEarningsResponse>(
+    return this.requestData<WithdrawAppEarningsResponse>(
       "POST",
       `/api/v1/apps/${encodePathParam(appId)}/earnings/withdraw`,
       { json: request },
@@ -790,7 +825,7 @@ export class ElizaCloudClient {
   }
 
   getRedemptionBalance(): Promise<RedemptionBalanceResponse> {
-    return this.request<RedemptionBalanceResponse>(
+    return this.requestData<RedemptionBalanceResponse>(
       "GET",
       "/api/v1/redemptions/balance",
     );
@@ -812,7 +847,7 @@ export class ElizaCloudClient {
       typeof requestOrNetwork === "string"
         ? { network: requestOrNetwork, pointsAmount }
         : requestOrNetwork;
-    return this.request<RedemptionQuoteResponse>(
+    return this.requestData<RedemptionQuoteResponse>(
       "GET",
       "/api/v1/redemptions/quote",
       {
@@ -825,7 +860,7 @@ export class ElizaCloudClient {
   }
 
   getRedemptionStatus(): Promise<RedemptionStatusResponse> {
-    return this.request<RedemptionStatusResponse>(
+    return this.requestData<RedemptionStatusResponse>(
       "GET",
       "/api/v1/redemptions/status",
       {
@@ -837,7 +872,7 @@ export class ElizaCloudClient {
   createRedemption(
     request: CreateRedemptionRequest,
   ): Promise<CreateRedemptionResponse> {
-    return this.request<CreateRedemptionResponse>(
+    return this.requestData<CreateRedemptionResponse>(
       "POST",
       "/api/v1/redemptions",
       {
@@ -849,9 +884,14 @@ export class ElizaCloudClient {
   listRedemptions(
     options: { limit?: number } = {},
   ): Promise<ListRedemptionsResponse> {
-    return this.request<ListRedemptionsResponse>("GET", "/api/v1/redemptions", {
-      query: options.limit === undefined ? undefined : { limit: options.limit },
-    });
+    return this.requestData<ListRedemptionsResponse>(
+      "GET",
+      "/api/v1/redemptions",
+      {
+        query:
+          options.limit === undefined ? undefined : { limit: options.limit },
+      },
+    );
   }
 
   // ─── Apps (Eliza Cloud Apps product) ──────────────────────────────────────
@@ -945,7 +985,7 @@ export class ElizaCloudClient {
     appId: string,
     input: DeployAppFrontendInput,
   ): Promise<DeployAppFrontendResponse> {
-    return this.request<DeployAppFrontendResponse>(
+    return this.requestData<DeployAppFrontendResponse>(
       "POST",
       `/api/v1/apps/${encodeURIComponent(appId)}/frontend`,
       { json: input },
@@ -956,7 +996,7 @@ export class ElizaCloudClient {
   listAppFrontendDeployments(
     appId: string,
   ): Promise<ListAppFrontendDeploymentsResponse> {
-    return this.request<ListAppFrontendDeploymentsResponse>(
+    return this.requestData<ListAppFrontendDeploymentsResponse>(
       "GET",
       `/api/v1/apps/${encodeURIComponent(appId)}/frontend`,
     );
@@ -970,7 +1010,7 @@ export class ElizaCloudClient {
     appId: string,
     deploymentId: string,
   ): Promise<ActivateAppFrontendResponse> {
-    return this.request<ActivateAppFrontendResponse>(
+    return this.requestData<ActivateAppFrontendResponse>(
       "POST",
       `/api/v1/apps/${encodeURIComponent(appId)}/frontend/${encodeURIComponent(deploymentId)}/activate`,
     );
@@ -1051,7 +1091,7 @@ export class ElizaCloudClient {
   }
 
   listContainers(): Promise<ContainerListResponse> {
-    return this.request<ContainerListResponse>("GET", "/api/v1/containers");
+    return this.requestData<ContainerListResponse>("GET", "/api/v1/containers");
   }
 
   /**
@@ -1059,7 +1099,7 @@ export class ElizaCloudClient {
    * from serving ads on its surface (SSP, #10687).
    */
   createAdSlot(input: CreateAdSlotInput): Promise<CreateAdSlotResponse> {
-    return this.request<CreateAdSlotResponse>(
+    return this.requestData<CreateAdSlotResponse>(
       "POST",
       "/api/v1/marketing/inventory",
       {
@@ -1070,7 +1110,7 @@ export class ElizaCloudClient {
 
   /** `GET /api/v1/marketing/inventory` — list the org's ad slots. */
   listAdSlots(): Promise<ListAdSlotsResponse> {
-    return this.request<ListAdSlotsResponse>(
+    return this.requestData<ListAdSlotsResponse>(
       "GET",
       "/api/v1/marketing/inventory",
     );
@@ -1080,7 +1120,7 @@ export class ElizaCloudClient {
   getAdCampaignDayparting(
     campaignId: string,
   ): Promise<CampaignDaypartingResponse> {
-    return this.request<CampaignDaypartingResponse>(
+    return this.requestData<CampaignDaypartingResponse>(
       "GET",
       `/api/v1/advertising/campaigns/${encodeURIComponent(campaignId)}/dayparting`,
     );
@@ -1091,7 +1131,7 @@ export class ElizaCloudClient {
     campaignId: string,
     input: UpdateCampaignDaypartingInput,
   ): Promise<CampaignDaypartingResponse> {
-    return this.request<CampaignDaypartingResponse>(
+    return this.requestData<CampaignDaypartingResponse>(
       "PUT",
       `/api/v1/advertising/campaigns/${encodeURIComponent(campaignId)}/dayparting`,
       { json: input },
@@ -1103,7 +1143,7 @@ export class ElizaCloudClient {
     campaignId: string,
     input: DuplicateAdCampaignInput = {},
   ): Promise<DuplicateAdCampaignResponse> {
-    return this.request<DuplicateAdCampaignResponse>(
+    return this.requestData<DuplicateAdCampaignResponse>(
       "POST",
       `/api/v1/advertising/campaigns/${encodeURIComponent(campaignId)}/duplicate`,
       { json: input },
@@ -1114,7 +1154,7 @@ export class ElizaCloudClient {
   getAdCampaignAttribution(
     campaignId: string,
   ): Promise<AdCampaignAttributionResponse> {
-    return this.request<AdCampaignAttributionResponse>(
+    return this.requestData<AdCampaignAttributionResponse>(
       "GET",
       `/api/v1/advertising/campaigns/${encodePathParam(campaignId)}/attribution`,
     );
@@ -1130,7 +1170,7 @@ export class ElizaCloudClient {
     if (options.startDate) query.set("startDate", options.startDate);
     if (options.endDate) query.set("endDate", options.endDate);
     const suffix = query.size > 0 ? `?${query.toString()}` : "";
-    return this.request<CampaignPerformanceReportResponse>(
+    return this.requestData<CampaignPerformanceReportResponse>(
       "GET",
       `/api/v1/advertising/campaigns/${encodePathParam(campaignId)}/report${suffix}`,
     );
@@ -1141,7 +1181,7 @@ export class ElizaCloudClient {
     campaignId: string,
     input: CreateCampaignReportShareInput = {},
   ): Promise<CreateCampaignReportShareResponse> {
-    return this.request<CreateCampaignReportShareResponse>(
+    return this.requestData<CreateCampaignReportShareResponse>(
       "POST",
       `/api/v1/advertising/campaigns/${encodePathParam(campaignId)}/report/share`,
       { json: input },
@@ -1153,7 +1193,7 @@ export class ElizaCloudClient {
     campaignId: string,
     shareId: string,
   ): Promise<RevokeCampaignReportShareResponse> {
-    return this.request<RevokeCampaignReportShareResponse>(
+    return this.requestData<RevokeCampaignReportShareResponse>(
       "DELETE",
       `/api/v1/advertising/campaigns/${encodePathParam(campaignId)}/report/share/${encodePathParam(shareId)}`,
     );
@@ -1163,7 +1203,7 @@ export class ElizaCloudClient {
   createInfluencerProfile(
     input: CreateInfluencerProfileInput,
   ): Promise<CreateInfluencerProfileResponse> {
-    return this.request<CreateInfluencerProfileResponse>(
+    return this.requestData<CreateInfluencerProfileResponse>(
       "POST",
       "/api/v1/marketing/influencers",
       {
@@ -1175,7 +1215,7 @@ export class ElizaCloudClient {
   /** `GET /api/v1/marketing/influencers` — browse active influencer profiles. */
   listInfluencers(niche?: string): Promise<ListInfluencersResponse> {
     const q = niche ? `?niche=${encodeURIComponent(niche)}` : "";
-    return this.request<ListInfluencersResponse>(
+    return this.requestData<ListInfluencersResponse>(
       "GET",
       `/api/v1/marketing/influencers${q}`,
     );
@@ -1183,7 +1223,7 @@ export class ElizaCloudClient {
 
   /** `POST /api/v1/marketing/influencers/bookings` — fund an escrowed influencer booking (#10687). */
   createBooking(input: CreateBookingInput): Promise<CreateBookingResponse> {
-    return this.request<CreateBookingResponse>(
+    return this.requestData<CreateBookingResponse>(
       "POST",
       "/api/v1/marketing/influencers/bookings",
       {
@@ -1196,7 +1236,7 @@ export class ElizaCloudClient {
   createPressRelease(
     input: CreatePressReleaseInput,
   ): Promise<CreatePressReleaseResponse> {
-    return this.request<CreatePressReleaseResponse>(
+    return this.requestData<CreatePressReleaseResponse>(
       "POST",
       "/api/v1/marketing/pr",
       { json: input },
@@ -1205,7 +1245,7 @@ export class ElizaCloudClient {
 
   /** `GET /api/v1/marketing/pr` — list the org's press release drafts and submissions. */
   listPressReleases(): Promise<ListPressReleasesResponse> {
-    return this.request<ListPressReleasesResponse>(
+    return this.requestData<ListPressReleasesResponse>(
       "GET",
       "/api/v1/marketing/pr",
     );
@@ -1213,7 +1253,7 @@ export class ElizaCloudClient {
 
   /** `GET /api/v1/marketing/pr/:releaseId` — read one press release. */
   getPressRelease(releaseId: string): Promise<GetPressReleaseResponse> {
-    return this.request<GetPressReleaseResponse>(
+    return this.requestData<GetPressReleaseResponse>(
       "GET",
       `/api/v1/marketing/pr/${encodePathParam(releaseId)}`,
     );
@@ -1224,7 +1264,7 @@ export class ElizaCloudClient {
     releaseId: string,
     input: UpdatePressReleaseInput,
   ): Promise<UpdatePressReleaseResponse> {
-    return this.request<UpdatePressReleaseResponse>(
+    return this.requestData<UpdatePressReleaseResponse>(
       "PATCH",
       `/api/v1/marketing/pr/${encodePathParam(releaseId)}`,
       { json: input },
@@ -1236,7 +1276,7 @@ export class ElizaCloudClient {
     releaseId: string,
     input: SubmitPressReleaseInput = {},
   ): Promise<SubmitPressReleaseResponse> {
-    return this.request<SubmitPressReleaseResponse>(
+    return this.requestData<SubmitPressReleaseResponse>(
       "POST",
       `/api/v1/marketing/pr/${encodePathParam(releaseId)}/submit`,
       { json: input },
@@ -1245,7 +1285,7 @@ export class ElizaCloudClient {
 
   /** `POST /api/v1/marketing/pr/:releaseId/cancel` — cancel a draft or ready press release. */
   cancelPressRelease(releaseId: string): Promise<UpdatePressReleaseResponse> {
-    return this.request<UpdatePressReleaseResponse>(
+    return this.requestData<UpdatePressReleaseResponse>(
       "POST",
       `/api/v1/marketing/pr/${encodePathParam(releaseId)}/cancel`,
     );
@@ -1253,7 +1293,7 @@ export class ElizaCloudClient {
 
   /** `GET /api/v1/marketing/pr/:releaseId/coverage` — list tracked coverage for a release. */
   listPressCoverage(releaseId: string): Promise<ListPressCoverageResponse> {
-    return this.request<ListPressCoverageResponse>(
+    return this.requestData<ListPressCoverageResponse>(
       "GET",
       `/api/v1/marketing/pr/${encodePathParam(releaseId)}/coverage`,
     );
@@ -1261,7 +1301,7 @@ export class ElizaCloudClient {
 
   /** `GET /api/v1/apps/:id/backup` — export a secret-free app config snapshot (#10204). */
   exportAppBackup(appId: string): Promise<ExportAppBackupResponse> {
-    return this.request<ExportAppBackupResponse>(
+    return this.requestData<ExportAppBackupResponse>(
       "GET",
       `/api/v1/apps/${appId}/backup`,
     );
@@ -1272,7 +1312,7 @@ export class ElizaCloudClient {
     backup: AppBackupSnapshot,
     name?: string,
   ): Promise<RestoreAppBackupResponse> {
-    return this.request<RestoreAppBackupResponse>(
+    return this.requestData<RestoreAppBackupResponse>(
       "POST",
       "/api/v1/apps/backup/restore",
       {
@@ -1284,13 +1324,17 @@ export class ElizaCloudClient {
   createContainer(
     request: CreateContainerRequest,
   ): Promise<CreateContainerResponse> {
-    return this.request<CreateContainerResponse>("POST", "/api/v1/containers", {
-      json: request,
-    });
+    return this.requestData<CreateContainerResponse>(
+      "POST",
+      "/api/v1/containers",
+      {
+        json: request,
+      },
+    );
   }
 
   getContainer(containerId: string): Promise<ContainerGetResponse> {
-    return this.request<ContainerGetResponse>(
+    return this.requestData<ContainerGetResponse>(
       "GET",
       `/api/v1/containers/${encodePathParam(containerId)}`,
     );
@@ -1300,7 +1344,7 @@ export class ElizaCloudClient {
     containerId: string,
     request: UpdateContainerRequest,
   ): Promise<ContainerGetResponse> {
-    return this.request<ContainerGetResponse>(
+    return this.requestData<ContainerGetResponse>(
       "PATCH",
       `/api/v1/containers/${encodePathParam(containerId)}`,
       { json: request },
@@ -1310,21 +1354,21 @@ export class ElizaCloudClient {
   deleteContainer(
     containerId: string,
   ): Promise<{ success: boolean; message?: string }> {
-    return this.request(
+    return this.requestData(
       "DELETE",
       `/api/v1/containers/${encodePathParam(containerId)}`,
     );
   }
 
   getContainerHealth(containerId: string): Promise<ContainerHealthResponse> {
-    return this.request<ContainerHealthResponse>(
+    return this.requestData<ContainerHealthResponse>(
       "GET",
       `/api/v1/containers/${encodePathParam(containerId)}/health`,
     );
   }
 
   getContainerMetrics(containerId: string): Promise<Record<string, unknown>> {
-    return this.request(
+    return this.requestData(
       "GET",
       `/api/v1/containers/${encodePathParam(containerId)}/metrics`,
     );
@@ -1355,14 +1399,14 @@ export class ElizaCloudClient {
   getContainerDeployments(
     containerId: string,
   ): Promise<Record<string, unknown>> {
-    return this.request(
+    return this.requestData(
       "GET",
       `/api/v1/containers/${encodePathParam(containerId)}/deployments`,
     );
   }
 
   getContainerQuota(): Promise<ContainerQuotaResponse> {
-    return this.request<ContainerQuotaResponse>(
+    return this.requestData<ContainerQuotaResponse>(
       "GET",
       "/api/v1/containers/quota",
     );
@@ -1371,7 +1415,7 @@ export class ElizaCloudClient {
   createContainerCredentials(
     request: Record<string, unknown> = {},
   ): Promise<ContainerCredentialsResponse> {
-    return this.request<ContainerCredentialsResponse>(
+    return this.requestData<ContainerCredentialsResponse>(
       "POST",
       "/api/v1/containers/credentials",
       {
@@ -1381,17 +1425,21 @@ export class ElizaCloudClient {
   }
 
   listAgents(): Promise<AgentListResponse> {
-    return this.request<AgentListResponse>("GET", "/api/v1/eliza/agents");
+    return this.requestData<AgentListResponse>("GET", "/api/v1/eliza/agents");
   }
 
   createAgent(request: CreateAgentRequest): Promise<CreateAgentResponse> {
-    return this.request<CreateAgentResponse>("POST", "/api/v1/eliza/agents", {
-      json: request,
-    });
+    return this.requestData<CreateAgentResponse>(
+      "POST",
+      "/api/v1/eliza/agents",
+      {
+        json: request,
+      },
+    );
   }
 
   getAgent(agentId: string): Promise<AgentResponse> {
-    return this.request<AgentResponse>(
+    return this.requestData<AgentResponse>(
       "GET",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}`,
     );
@@ -1401,7 +1449,7 @@ export class ElizaCloudClient {
     agentId: string,
     request: Partial<CreateAgentRequest>,
   ): Promise<AgentResponse> {
-    return this.request<AgentResponse>(
+    return this.requestData<AgentResponse>(
       "PATCH",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}`,
       { json: request },
@@ -1409,28 +1457,28 @@ export class ElizaCloudClient {
   }
 
   deleteAgent(agentId: string): Promise<AgentLifecycleResponse> {
-    return this.request(
+    return this.requestData(
       "DELETE",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}`,
     );
   }
 
   provisionAgent(agentId: string): Promise<AgentLifecycleResponse> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}/provision`,
     );
   }
 
   suspendAgent(agentId: string): Promise<AgentLifecycleResponse> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}/suspend`,
     );
   }
 
   resumeAgent(agentId: string): Promise<AgentLifecycleResponse> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}/resume`,
     );
@@ -1441,7 +1489,7 @@ export class ElizaCloudClient {
     snapshotType: SnapshotType = "manual",
     metadata?: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}/snapshot`,
       {
@@ -1451,7 +1499,7 @@ export class ElizaCloudClient {
   }
 
   listAgentBackups(agentId: string): Promise<SnapshotListResponse> {
-    return this.request(
+    return this.requestData(
       "GET",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}/backups`,
     );
@@ -1461,7 +1509,7 @@ export class ElizaCloudClient {
     agentId: string,
     backupId?: string,
   ): Promise<Record<string, unknown>> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}/restore`,
       {
@@ -1471,7 +1519,9 @@ export class ElizaCloudClient {
   }
 
   getAgentPairingToken(agentId: string): Promise<PairingTokenResponse> {
-    return this.request<PairingTokenResponse | { data: PairingTokenResponse }>(
+    return this.requestData<
+      PairingTokenResponse | { data: PairingTokenResponse }
+    >(
       "POST",
       `/api/v1/eliza/agents/${encodePathParam(agentId)}/pairing-token`,
     ).then((response) => ("data" in response ? response.data : response));
@@ -1481,9 +1531,10 @@ export class ElizaCloudClient {
     runtimeAgentId: string;
     agentName?: string;
   }): Promise<RegisterGatewayRelaySessionResponse> {
-    return this.v1.post<RegisterGatewayRelaySessionResponse>(
+    return this.v1.requestData<RegisterGatewayRelaySessionResponse>(
+      "POST",
       "/eliza/gateway-relay/sessions",
-      request,
+      { json: request },
     );
   }
 
@@ -1491,7 +1542,8 @@ export class ElizaCloudClient {
     sessionId: string,
     timeoutMs?: number,
   ): Promise<PollGatewayRelayResponse> {
-    return this.v1.get<PollGatewayRelayResponse>(
+    return this.v1.requestData<PollGatewayRelayResponse>(
+      "GET",
       `/eliza/gateway-relay/sessions/${encodePathParam(sessionId)}/next`,
       { query: timeoutMs === undefined ? undefined : { timeoutMs } },
     );
@@ -1502,19 +1554,18 @@ export class ElizaCloudClient {
     requestId: string,
     response: GatewayRelayResponse,
   ): Promise<{ success: boolean }> {
-    return this.v1.post(
+    return this.v1.requestData(
+      "POST",
       `/eliza/gateway-relay/sessions/${encodePathParam(sessionId)}/responses`,
-      {
-        requestId,
-        response,
-      },
+      { json: { requestId, response } },
     );
   }
 
   disconnectGatewayRelaySession(
     sessionId: string,
   ): Promise<{ success: boolean }> {
-    return this.v1.delete(
+    return this.v1.requestData(
+      "DELETE",
       `/eliza/gateway-relay/sessions/${encodePathParam(sessionId)}`,
     );
   }
@@ -1523,7 +1574,7 @@ export class ElizaCloudClient {
     jobId: string,
     options?: Pick<CloudRequestOptions, "signal" | "timeoutMs">,
   ): Promise<JobStatus> {
-    return this.request(
+    return this.requestData(
       "GET",
       `/api/v1/jobs/${encodePathParam(jobId)}`,
       options,
@@ -1545,23 +1596,23 @@ export class ElizaCloudClient {
   }
 
   getUser(): Promise<UserProfileResponse> {
-    return this.request("GET", "/api/v1/user");
+    return this.requestData("GET", "/api/v1/user");
   }
 
   updateUser(request: Record<string, unknown>): Promise<UserProfileResponse> {
-    return this.request("PATCH", "/api/v1/user", { json: request });
+    return this.requestData("PATCH", "/api/v1/user", { json: request });
   }
 
   listApiKeys(): Promise<ApiKeyListResponse> {
-    return this.request("GET", "/api/v1/api-keys");
+    return this.requestData("GET", "/api/v1/api-keys");
   }
 
   createApiKey(request: ApiKeyCreateRequest): Promise<ApiKeyCreateResponse> {
-    return this.request("POST", "/api/v1/api-keys", { json: request });
+    return this.requestData("POST", "/api/v1/api-keys", { json: request });
   }
 
   updateApiKey(apiKeyId: string, request: Partial<ApiKeyCreateRequest>) {
-    return this.request(
+    return this.requestData(
       "PATCH",
       `/api/v1/api-keys/${encodePathParam(apiKeyId)}`,
       {
@@ -1573,14 +1624,14 @@ export class ElizaCloudClient {
   deleteApiKey(
     apiKeyId: string,
   ): Promise<{ success?: boolean; message?: string }> {
-    return this.request(
+    return this.requestData(
       "DELETE",
       `/api/v1/api-keys/${encodePathParam(apiKeyId)}`,
     );
   }
 
   regenerateApiKey(apiKeyId: string): Promise<ApiKeyCreateResponse> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/api-keys/${encodePathParam(apiKeyId)}/regenerate`,
     );
@@ -1593,7 +1644,7 @@ export class ElizaCloudClient {
    * `unknown` here to avoid drift.
    */
   listWorkflows(agentId: string): Promise<unknown> {
-    return this.request(
+    return this.requestData(
       "GET",
       `/api/v1/agents/${encodePathParam(agentId)}/workflows`,
     );
@@ -1603,7 +1654,7 @@ export class ElizaCloudClient {
     agentId: string,
     body: Record<string, unknown>,
   ): Promise<unknown> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/agents/${encodePathParam(agentId)}/workflows`,
       {
@@ -1613,7 +1664,7 @@ export class ElizaCloudClient {
   }
 
   getWorkflow(agentId: string, workflowId: string): Promise<unknown> {
-    return this.request(
+    return this.requestData(
       "GET",
       `/api/v1/agents/${encodePathParam(agentId)}/workflows/${encodePathParam(workflowId)}`,
     );
@@ -1624,7 +1675,7 @@ export class ElizaCloudClient {
     workflowId: string,
     body: Record<string, unknown>,
   ): Promise<unknown> {
-    return this.request(
+    return this.requestData(
       "PUT",
       `/api/v1/agents/${encodePathParam(agentId)}/workflows/${encodePathParam(workflowId)}`,
       { json: body },
@@ -1632,7 +1683,7 @@ export class ElizaCloudClient {
   }
 
   deleteWorkflow(agentId: string, workflowId: string): Promise<unknown> {
-    return this.request(
+    return this.requestData(
       "DELETE",
       `/api/v1/agents/${encodePathParam(agentId)}/workflows/${encodePathParam(workflowId)}`,
     );
@@ -1643,7 +1694,7 @@ export class ElizaCloudClient {
     workflowId: string,
     body: Record<string, unknown> = {},
   ): Promise<unknown> {
-    return this.request(
+    return this.requestData(
       "POST",
       `/api/v1/agents/${encodePathParam(agentId)}/workflows/${encodePathParam(workflowId)}/run`,
       { json: body },
@@ -1651,7 +1702,7 @@ export class ElizaCloudClient {
   }
 
   getWorkflowExecution(agentId: string, executionId: string): Promise<unknown> {
-    return this.request(
+    return this.requestData(
       "GET",
       `/api/v1/agents/${encodePathParam(agentId)}/workflows/executions/${encodePathParam(executionId)}`,
     );

--- a/packages/cloud/sdk/src/http-server.test.ts
+++ b/packages/cloud/sdk/src/http-server.test.ts
@@ -5,7 +5,7 @@
 import { createServer } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { ElizaCloudClient } from "./client.js";
-import { ElizaCloudHttpClient } from "./http.js";
+import { CloudApiClient, ElizaCloudHttpClient } from "./http.js";
 
 let baseUrl: string;
 const server = createServer((req, res) => {
@@ -86,6 +86,30 @@ describe("real HTTP parsed response contracts", () => {
       new ElizaCloudHttpClient({ baseUrl }).get(`/bodyless/${status}`),
     ).resolves.toBeUndefined();
   });
+  it.each([204, 205])(
+    "preserves successful bodyless mutations with HTTP %s",
+    async (status) => {
+      const client = new CloudApiClient(baseUrl);
+      const path = `/bodyless/${status}`;
+      await expect(
+        client.post(path, { value: "updated" }),
+      ).resolves.toBeUndefined();
+      await expect(
+        client.put(path, { value: "updated" }),
+      ).resolves.toBeUndefined();
+      await expect(
+        client.patch(path, { value: "updated" }),
+      ).resolves.toBeUndefined();
+      await expect(client.delete(path)).resolves.toBeUndefined();
+      await expect(
+        client.postUnauthenticated(path, { value: "updated" }),
+      ).resolves.toBeUndefined();
+      await expect(client.requestData("DELETE", path)).rejects.toMatchObject({
+        statusCode: status,
+        errorBody: { code: "empty_response_body" },
+      });
+    },
+  );
   it("returns absence for HEAD and preserves text through raw access", async () => {
     const client = new ElizaCloudHttpClient({ baseUrl });
     await expect(client.request("HEAD", "/head")).resolves.toBeUndefined();

--- a/packages/cloud/sdk/src/http-success-response.integration.test.ts
+++ b/packages/cloud/sdk/src/http-success-response.integration.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Exercises successful SDK response decoding through a real localhost HTTP
+ * server, including media-type enforcement, every JSON value kind, explicit
+ * bodyless protocols, and the raw-response escape hatch.
+ */
+
+import { once } from "node:events";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { CloudApiError, ElizaCloudClient } from "./index.js";
+
+let server: Server | undefined;
+let origin = "";
+
+function sendJson(
+  response: ServerResponse,
+  value: unknown,
+  contentType = "application/json",
+): void {
+  response.writeHead(200, { "content-type": contentType });
+  response.end(JSON.stringify(value));
+}
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
+    switch (pathname) {
+      case "/api/v1/user":
+        response.writeHead(200, { "content-type": "text/html" });
+        response.end("<html>maintenance</html>");
+        return;
+      case "/missing-content-type":
+        response.writeHead(200);
+        response.end('{"success":true}');
+        return;
+      case "/wrong-content-type":
+        response.writeHead(200, { "content-type": "text/plain" });
+        response.end('{"success":true}');
+        return;
+      case "/wildcard-type":
+        response.writeHead(200, { "content-type": "*/problem+json" });
+        response.end('{"success":true}');
+        return;
+      case "/wildcard-subtype":
+        response.writeHead(200, { "content-type": "application/*+json" });
+        response.end('{"success":true}');
+        return;
+      case "/empty-json":
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end();
+        return;
+      case "/malformed-json":
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{not-json");
+        return;
+      case "/invalid-utf8":
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(Uint8Array.from([0x22, 0xc3, 0x28, 0x22]));
+        return;
+      case "/json-object":
+        sendJson(response, { success: true });
+        return;
+      case "/json-array":
+        sendJson(response, [1, "two", false, null]);
+        return;
+      case "/json-string":
+        sendJson(response, "ready");
+        return;
+      case "/json-number":
+        sendJson(response, 42);
+        return;
+      case "/json-boolean":
+        sendJson(response, false);
+        return;
+      case "/json-null":
+        sendJson(response, null);
+        return;
+      case "/structured-json":
+        sendJson(
+          response,
+          { type: "https://example.test/problem", status: 200 },
+          "application/problem+json; charset=utf-8",
+        );
+        return;
+      case "/no-content":
+        response.writeHead(204);
+        response.end();
+        return;
+      case "/reset-content":
+        response.writeHead(205);
+        response.end();
+        return;
+      case "/head":
+        response.writeHead(200, {
+          "content-length": "128",
+          "content-type": "text/plain",
+        });
+        response.end();
+        return;
+      case "/raw-text":
+        response.writeHead(200, { "content-type": "text/plain" });
+        response.end("plain SDK response");
+        return;
+      case "/api/v1/apps-ingress/ask":
+        response.writeHead(200, {
+          "content-type": "text/plain; charset=UTF-8",
+        });
+        response.end("ok");
+        return;
+      case "/api/v1/marketing/inventory/serve":
+        response.writeHead(204);
+        response.end();
+        return;
+      case "/api/v1/apps/app_1/frontend/preview/index.html":
+        response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        response.end("<main>preview</main>");
+        return;
+      case "/api/v1/hosted-frontend/serve/logo.png":
+        response.writeHead(200, { "content-type": "image/png" });
+        response.end(Uint8Array.from([0x89, 0x50, 0x4e, 0x47]));
+        return;
+      default:
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end('{"success":false,"error":"not found"}');
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("localhost SDK test server did not bind a TCP address");
+  }
+  origin = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  if (!server) return;
+  server.close();
+  await once(server, "close");
+});
+
+function client(): ElizaCloudClient {
+  return new ElizaCloudClient({
+    baseUrl: origin,
+    apiBaseUrl: `${origin}/api/v1`,
+  });
+}
+
+describe("successful Cloud SDK response decoding", () => {
+  it("rejects an HTML maintenance response through getUser", async () => {
+    await expect(client().getUser()).rejects.toMatchObject({
+      name: "CloudApiError",
+      statusCode: 200,
+      errorBody: {
+        success: false,
+        code: "unexpected_response_content_type",
+      },
+    });
+  });
+
+  it.each([
+    "/missing-content-type",
+    "/wrong-content-type",
+    "/wildcard-type",
+    "/wildcard-subtype",
+  ])(
+    "rejects JSON-looking data without a JSON media type at %s",
+    async (path) => {
+      await expect(client().request("GET", path)).rejects.toMatchObject({
+        name: "CloudApiError",
+        statusCode: 200,
+        errorBody: {
+          success: false,
+          code: "unexpected_response_content_type",
+        },
+      });
+    },
+  );
+
+  it("rejects an unexpectedly empty JSON data response", async () => {
+    await expect(client().request("GET", "/empty-json")).rejects.toMatchObject({
+      name: "CloudApiError",
+      statusCode: 200,
+      errorBody: {
+        success: false,
+        code: "empty_response_body",
+      },
+    });
+  });
+
+  it("rejects malformed JSON through the real transport", async () => {
+    await expect(
+      client().request("GET", "/malformed-json"),
+    ).rejects.toMatchObject({
+      name: "CloudApiError",
+      statusCode: 200,
+    });
+  });
+
+  it("rejects malformed UTF-8 instead of substituting JSON string data", async () => {
+    try {
+      await client().request("GET", "/invalid-utf8");
+      expect.unreachable("invalid UTF-8 must reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CloudApiError);
+      if (!(error instanceof CloudApiError)) throw error;
+      expect(error).toMatchObject({
+        statusCode: 200,
+        errorBody: {
+          success: false,
+          code: "invalid_response_encoding",
+        },
+      });
+      expect(error.cause).toBeInstanceOf(TypeError);
+    }
+  });
+
+  it.each([
+    ["object", "/json-object", { success: true }],
+    ["array", "/json-array", [1, "two", false, null]],
+    ["string", "/json-string", "ready"],
+    ["number", "/json-number", 42],
+    ["boolean", "/json-boolean", false],
+    ["null", "/json-null", null],
+  ])("preserves a JSON %s value", async (_kind, path, expected) => {
+    await expect(client().request("GET", path)).resolves.toEqual(expected);
+  });
+
+  it("accepts a structured +json media type", async () => {
+    await expect(client().request("GET", "/structured-json")).resolves.toEqual({
+      type: "https://example.test/problem",
+      status: 200,
+    });
+  });
+
+  it.each([
+    ["GET", "/no-content"],
+    ["GET", "/reset-content"],
+    ["HEAD", "/head"],
+  ] as const)("returns undefined for bodyless %s %s", async (method, path) => {
+    await expect(client().request(method, path)).resolves.toBeUndefined();
+  });
+
+  it("keeps successful text available through requestRaw", async () => {
+    const response = await client().requestRaw("GET", "/raw-text");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/plain");
+    await expect(response.text()).resolves.toBe("plain SDK response");
+  });
+
+  it("uses the generated raw surface for a declared text route", async () => {
+    const response = await client().routes.getApiV1AppsIngressAsk({
+      query: { domain: "app.example.test" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; charset=UTF-8",
+    );
+    await expect(response.text()).resolves.toBe("ok");
+  });
+
+  it("preserves a legitimate 204 from a generated JSON-or-empty method", async () => {
+    await expect(
+      client().routes.getApiV1MarketingInventoryServe(),
+    ).resolves.toBeUndefined();
+  });
+
+  it("uses the generated raw surface for frontend preview assets", async () => {
+    const response =
+      await client().routes.getApiV1AppsByIdFrontendPreviewByPath({
+        pathParams: { id: "app_1", "[...path]": "index.html" },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    await expect(response.text()).resolves.toBe("<main>preview</main>");
+  });
+
+  it("uses the generated raw surface for public hosted assets", async () => {
+    const response = await client().routes.getApiV1HostedFrontendServeByPath({
+      pathParams: { "[...path]": "logo.png" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      Uint8Array.from([0x89, 0x50, 0x4e, 0x47]),
+    );
+  });
+});

--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -306,7 +306,7 @@ describe("ElizaCloudHttpClient errors", () => {
     ).rejects.toMatchObject({ name: "CloudApiError", statusCode: 500 });
   });
 
-  it("rejects a 2xx text/plain body when a parsed response was requested", async () => {
+  it("rejects a 2xx text/plain body instead of fabricating JSON success", async () => {
     const client = new ElizaCloudHttpClient({
       baseUrl: "https://cloud.test",
       fetchImpl: asFetch(
@@ -320,7 +320,11 @@ describe("ElizaCloudHttpClient errors", () => {
 
     await expect(client.request("GET", "/api/ping")).rejects.toMatchObject({
       name: "CloudApiError",
-      errorBody: { code: "unexpected_response_content_type" },
+      statusCode: 200,
+      errorBody: {
+        success: false,
+        code: "unexpected_response_content_type",
+      },
     });
   });
 });

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -11,6 +11,7 @@
 import {
   type CloudApiErrorBody,
   type CloudRequestOptions,
+  type CloudResponse,
   DEFAULT_ELIZA_CLOUD_API_BASE_URL,
   type ElizaCloudClientOptions,
   type HttpMethod,
@@ -82,19 +83,15 @@ function resolveUrl(
   return appendQuery(url, query).toString();
 }
 
-/**
- * A body the server labelled `application/json` but that failed to parse. The
- * raw text is retained so error responses can still surface it in their message;
- * on a 2xx response `request()` promotes this to a thrown failure rather than
- * fabricating a success — a malformed JSON body is a broken response, not data.
- */
-const malformedJsonBodyBrand = Symbol("MalformedJsonBody");
-
-interface MalformedJsonBody {
-  readonly [malformedJsonBodyBrand]: true;
-  readonly kind: "malformed-json";
-  readonly text: string;
-}
+type ParsedResponseBody =
+  | { readonly kind: "empty" }
+  | { readonly kind: "json"; readonly value: unknown }
+  | {
+      readonly kind: "text";
+      readonly text: string;
+      readonly contentType: string | null;
+    }
+  | { readonly kind: "malformed-json"; readonly text: string };
 
 const MAX_RESPONSE_BODY_BYTES = 8 * 1024 * 1024;
 const MAX_RESPONSE_BODY_CHUNKS = 8_192;
@@ -106,13 +103,49 @@ interface RequestDeadline {
   close(): void;
 }
 
-function isMalformedJsonBody(value: unknown): value is MalformedJsonBody {
+const MEDIA_TYPE_RESTRICTED_NAME =
+  /^[0-9a-z](?:[!#$&+.^_0-9a-z-]{0,125}[0-9a-z])?$/;
+
+function isJsonMediaType(contentType: string | null): boolean {
+  if (contentType === null) return false;
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  if (!mediaType) return false;
+
+  const slashIndex = mediaType.indexOf("/");
+  if (slashIndex <= 0 || slashIndex !== mediaType.lastIndexOf("/")) {
+    return false;
+  }
+  const type = mediaType.slice(0, slashIndex);
+  const subtype = mediaType.slice(slashIndex + 1);
+  if (
+    !MEDIA_TYPE_RESTRICTED_NAME.test(type) ||
+    !MEDIA_TYPE_RESTRICTED_NAME.test(subtype)
+  ) {
+    return false;
+  }
   return (
-    isRecord(value) &&
-    (value as { [malformedJsonBodyBrand]?: unknown })[
-      malformedJsonBodyBrand
-    ] === true
+    (type === "application" && subtype === "json") ||
+    (subtype.length > "+json".length && subtype.endsWith("+json"))
   );
+}
+
+function parsedBodyValue(body: ParsedResponseBody): unknown {
+  switch (body.kind) {
+    case "json":
+      return body.value;
+    case "text":
+    case "malformed-json":
+      return body.text;
+    case "empty":
+      return undefined;
+  }
+}
+
+function isSuccessfulBodylessResponse(
+  method: HttpMethod,
+  status: number,
+): boolean {
+  return method === "HEAD" || status === 204 || status === 205;
 }
 
 function responseBodyTooLarge(response: Response): CloudApiError {
@@ -241,7 +274,21 @@ async function readBoundedResponseText(
       bytes.set(chunk, offset);
       offset += chunk.byteLength;
     }
-    return new TextDecoder().decode(bytes);
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch (cause) {
+      // error-policy:J2 Invalid UTF-8 is a broken response representation, not
+      // JSON data with silently substituted replacement characters.
+      throw new CloudApiError(
+        response.status,
+        {
+          success: false,
+          error: `HTTP ${response.status}: response body is not valid UTF-8`,
+          code: "invalid_response_encoding",
+        },
+        { cause },
+      );
+    }
   } catch (error) {
     // error-policy:J2 Preserve the selected read or abort failure through teardown.
     failure = error;
@@ -252,39 +299,24 @@ async function readBoundedResponseText(
   }
 }
 
-function hasJsonContentType(response: Response): boolean {
-  const mediaType = response.headers
-    .get("content-type")
-    ?.split(";", 1)[0]
-    ?.trim()
-    .toLowerCase();
-  return (
-    mediaType === "application/json" ||
-    /^application\/[\w.+-]+\+json$/.test(mediaType ?? "")
-  );
-}
-
 async function parseResponseBody(
   response: Response,
   signal: AbortSignal | undefined,
-): Promise<unknown> {
+): Promise<ParsedResponseBody> {
   const text = await readBoundedResponseText(response, signal);
-  if (!text) return undefined;
+  if (!text) return { kind: "empty" };
 
-  if (!hasJsonContentType(response)) {
-    return text;
+  const contentType = response.headers.get("content-type");
+  if (!isJsonMediaType(contentType)) {
+    return { kind: "text", text, contentType };
   }
 
   try {
-    return JSON.parse(text);
+    return { kind: "json", value: JSON.parse(text) };
   } catch {
-    // error-policy:J3 declared-JSON parse failure returns a typed marker; the
+    // error-policy:J3 declared-JSON parse failure returns an explicit state; the
     // caller surfaces it (error path) or throws (2xx), never a fake success.
-    return {
-      [malformedJsonBodyBrand]: true,
-      kind: "malformed-json",
-      text,
-    } satisfies MalformedJsonBody;
+    return { kind: "malformed-json", text };
   }
 }
 
@@ -390,12 +422,6 @@ function normalizeErrorBody(
   statusText: string,
   body: unknown,
 ): CloudApiErrorBody {
-  if (isMalformedJsonBody(body)) {
-    return {
-      success: false,
-      error: `HTTP ${status}: ${body.text}`,
-    };
-  }
   if (isRecord(body)) {
     const rawError = body.error;
     const errorObject = isRecord(rawError) ? rawError : null;
@@ -520,8 +546,12 @@ export class CloudApiError extends Error {
   readonly statusCode: number;
   readonly errorBody: CloudApiErrorBody;
 
-  constructor(statusCode: number, body: CloudApiErrorBody) {
-    super(body.error);
+  constructor(
+    statusCode: number,
+    body: CloudApiErrorBody,
+    options?: ErrorOptions,
+  ) {
+    super(body.error, options);
     this.name = "CloudApiError";
     this.statusCode = statusCode;
     this.errorBody = body;
@@ -667,69 +697,108 @@ export class ElizaCloudHttpClient {
     }
   }
 
-  async request<TResponse>(
+  private requestParsed<TResponse>(
     method: HttpMethod,
     path: string,
-    options: CloudRequestOptions = {},
-  ): Promise<TResponse> {
+    options: CloudRequestOptions,
+    allowBodyless: false,
+  ): Promise<TResponse>;
+  private requestParsed<TResponse>(
+    method: HttpMethod,
+    path: string,
+    options: CloudRequestOptions,
+    allowBodyless: true,
+  ): Promise<CloudResponse<TResponse>>;
+  private async requestParsed<TResponse>(
+    method: HttpMethod,
+    path: string,
+    options: CloudRequestOptions,
+    allowBodyless: boolean,
+  ): Promise<CloudResponse<TResponse>> {
     const { response, deadline } = await this.dispatchRequest(
       method,
       path,
       options,
     );
     try {
+      if (
+        response.ok &&
+        isSuccessfulBodylessResponse(method, response.status)
+      ) {
+        cancelBodyDetached(
+          response.body,
+          "Successful HTTP response is defined as bodyless",
+        );
+        if (allowBodyless) return undefined;
+        throw new CloudApiError(response.status, {
+          success: false,
+          error: `HTTP ${response.status}: expected a JSON response body but the response is defined as bodyless`,
+          code: "empty_response_body",
+        });
+      }
+
       const body = await parseResponseBody(response, deadline.signal);
 
       if (!response.ok) {
         const errorBody = normalizeErrorBody(
           response.status,
           response.statusText,
-          body,
+          parsedBodyValue(body),
         );
         throw response.status === 402
           ? new InsufficientCreditsError(errorBody)
           : new CloudApiError(response.status, errorBody);
       }
 
-      if (
-        method === "HEAD" ||
-        response.status === 204 ||
-        response.status === 205
-      ) {
-        return undefined as TResponse;
+      switch (body.kind) {
+        case "empty":
+          throw new CloudApiError(response.status, {
+            success: false,
+            error: `HTTP ${response.status}: expected a JSON response body but received an empty response`,
+            code: "empty_response_body",
+          });
+        case "text": {
+          const received = body.contentType?.trim() || "no Content-Type";
+          throw new CloudApiError(response.status, {
+            success: false,
+            error: `HTTP ${response.status}: expected a JSON response body but received ${received}`,
+            code: "unexpected_response_content_type",
+          });
+        }
+        case "malformed-json":
+          throw new CloudApiError(response.status, {
+            success: false,
+            error: `HTTP ${response.status}: malformed JSON response body: ${body.text}`,
+            code: "malformed_json_response",
+          });
+        case "json":
+          return body.value as TResponse;
       }
-      if (!hasJsonContentType(response)) {
-        throw new CloudApiError(response.status, {
-          success: false,
-          code: "unexpected_response_content_type",
-          error: `HTTP ${response.status}: expected a JSON response; use requestRaw for text or binary responses`,
-        });
-      }
-      if (body === undefined) {
-        throw new CloudApiError(response.status, {
-          success: false,
-          code: "empty_response_body",
-          error: `HTTP ${response.status}: expected a JSON response body`,
-        });
-      }
-      if (isMalformedJsonBody(body)) {
-        throw new CloudApiError(response.status, {
-          success: false,
-          code: "malformed_json_response",
-          error: `HTTP ${response.status}: malformed JSON response body: ${body.text}`,
-        });
-      }
-
-      return body as TResponse;
     } finally {
       deadline.close();
     }
   }
 
+  async request<TResponse>(
+    method: HttpMethod,
+    path: string,
+    options: CloudRequestOptions = {},
+  ): Promise<CloudResponse<TResponse>> {
+    return this.requestParsed<TResponse>(method, path, options, true);
+  }
+
+  async requestData<TResponse>(
+    method: HttpMethod,
+    path: string,
+    options: CloudRequestOptions = {},
+  ): Promise<TResponse> {
+    return this.requestParsed<TResponse>(method, path, options, false);
+  }
+
   async get<TResponse>(
     path: string,
     options?: CloudRequestOptions,
-  ): Promise<TResponse> {
+  ): Promise<CloudResponse<TResponse>> {
     return this.request<TResponse>("GET", path, options);
   }
 
@@ -737,15 +806,18 @@ export class ElizaCloudHttpClient {
     path: string,
     body?: unknown,
     options: Omit<CloudRequestOptions, "json"> = {},
-  ): Promise<TResponse> {
-    return this.request<TResponse>("POST", path, { ...options, json: body });
+  ): Promise<CloudResponse<TResponse>> {
+    return this.request<TResponse>("POST", path, {
+      ...options,
+      json: body,
+    });
   }
 
   async put<TResponse>(
     path: string,
     body?: unknown,
     options: Omit<CloudRequestOptions, "json"> = {},
-  ): Promise<TResponse> {
+  ): Promise<CloudResponse<TResponse>> {
     return this.request<TResponse>("PUT", path, { ...options, json: body });
   }
 
@@ -753,14 +825,17 @@ export class ElizaCloudHttpClient {
     path: string,
     body?: unknown,
     options: Omit<CloudRequestOptions, "json"> = {},
-  ): Promise<TResponse> {
-    return this.request<TResponse>("PATCH", path, { ...options, json: body });
+  ): Promise<CloudResponse<TResponse>> {
+    return this.request<TResponse>("PATCH", path, {
+      ...options,
+      json: body,
+    });
   }
 
   async delete<TResponse>(
     path: string,
     options?: CloudRequestOptions,
-  ): Promise<TResponse> {
+  ): Promise<CloudResponse<TResponse>> {
     return this.request<TResponse>("DELETE", path, options);
   }
 }
@@ -780,7 +855,7 @@ export class CloudApiClient extends ElizaCloudHttpClient {
   async postUnauthenticated<TResponse>(
     path: string,
     body: unknown,
-  ): Promise<TResponse> {
+  ): Promise<CloudResponse<TResponse>> {
     return this.post<TResponse>(path, body, { skipAuth: true });
   }
 }

--- a/packages/cloud/sdk/src/public-routes.test.ts
+++ b/packages/cloud/sdk/src/public-routes.test.ts
@@ -15,7 +15,7 @@ class TestTransport {
     method: HttpMethod,
     path: string,
     options?: CloudRequestOptions,
-  ): Promise<TResponse> {
+  ): Promise<TResponse | undefined> {
     this.requests.push({ method, path, options });
     return { method, path, options } as TResponse;
   }
@@ -33,6 +33,16 @@ class TestTransport {
 }
 
 describe("ElizaCloudPublicRoutesClient path building", () => {
+  it("keeps custom transports compatible for data-required routes", async () => {
+    const transport = new TestTransport();
+    const client = new ElizaCloudPublicRoutesClient(transport);
+
+    await expect(client.getApiV1Apps()).resolves.toMatchObject({
+      method: "GET",
+      path: "/api/v1/apps",
+    });
+  });
+
   it("keeps storage object identifiers in typed headers", async () => {
     const transport = new TestTransport();
     const client = new ElizaCloudPublicRoutesClient(transport);

--- a/packages/cloud/sdk/src/public-routes.ts
+++ b/packages/cloud/sdk/src/public-routes.ts
@@ -3,7 +3,11 @@
 // The exported PublicRoute* names are retained for backward compatibility.
 // Do not edit by hand.
 
-import type { CloudRequestOptions, HttpMethod } from "./types.js";
+import type {
+  CloudRequestOptions,
+  CloudResponse,
+  HttpMethod,
+} from "./types.js";
 
 export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
   "DELETE /api/elevenlabs/voices/{id}": {
@@ -100,7 +104,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "DELETE",
     path: "/api/v1/apis/storage/objects/_",
     methodName: "deleteApiV1ApisStorageObjects",
-    responseMode: "json",
+    responseMode: "json-or-empty",
     pathParams: [],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/apis/storage/objects/[...key]/route.ts",
@@ -605,7 +609,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "GET",
     path: "/api/v1/advertising/conversions/track",
     methodName: "getApiV1AdvertisingConversionsTrack",
-    responseMode: "json",
+    responseMode: "json-or-empty",
     pathParams: [],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/advertising/conversions/track/route.ts",
@@ -839,7 +843,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "GET",
     path: "/api/v1/apps-ingress/ask",
     methodName: "getApiV1AppsIngressAsk",
-    responseMode: "json",
+    responseMode: "text",
     pathParams: [],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/apps-ingress/ask/route.ts",
@@ -1001,7 +1005,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "GET",
     path: "/api/v1/apps/{id}/frontend/preview/{[...path]}",
     methodName: "getApiV1AppsByIdFrontendPreviewByPath",
-    responseMode: "json",
+    responseMode: "binary",
     pathParams: ["id", "[...path]"],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/apps/[id]/frontend/preview/[[...path]]/route.ts",
@@ -1768,7 +1772,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "GET",
     path: "/api/v1/hosted-frontend/serve/{[...path]}",
     methodName: "getApiV1HostedFrontendServeByPath",
-    responseMode: "json",
+    responseMode: "binary",
     pathParams: ["[...path]"],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/hosted-frontend/serve/[[...path]]/route.ts",
@@ -1921,7 +1925,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "GET",
     path: "/api/v1/marketing/inventory/serve",
     methodName: "getApiV1MarketingInventoryServe",
-    responseMode: "json",
+    responseMode: "json-or-empty",
     pathParams: [],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/marketing/inventory/serve/route.ts",
@@ -2133,6 +2137,15 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/oauth/token/[platform]/route.ts",
   },
+  "GET /api/v1/outreachr": {
+    method: "GET",
+    path: "/api/v1/outreachr",
+    methodName: "getApiV1Outreachr",
+    responseMode: "json",
+    pathParams: [],
+    catchAllPathParams: [],
+    file: "packages/cloud/api/v1/outreachr/route.ts",
+  },
   "GET /api/v1/payment-requests": {
     method: "GET",
     path: "/api/v1/payment-requests",
@@ -2263,7 +2276,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "GET",
     path: "/api/v1/remote/sessions/{id}/commands",
     methodName: "getApiV1RemoteSessionsByIdCommands",
-    responseMode: "json",
+    responseMode: "json-or-empty",
     pathParams: ["id"],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/remote/sessions/[id]/commands/route.ts",
@@ -4424,6 +4437,15 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/oauth/initiate/route.ts",
   },
+  "POST /api/v1/outreachr": {
+    method: "POST",
+    path: "/api/v1/outreachr",
+    methodName: "postApiV1Outreachr",
+    responseMode: "json",
+    pathParams: [],
+    catchAllPathParams: [],
+    file: "packages/cloud/api/v1/outreachr/route.ts",
+  },
   "POST /api/v1/payment-requests": {
     method: "POST",
     path: "/api/v1/payment-requests",
@@ -4806,7 +4828,7 @@ export const ELIZA_CLOUD_PUBLIC_ENDPOINTS = {
     method: "POST",
     path: "/api/v1/twilio/voice/status",
     methodName: "postApiV1TwilioVoiceStatus",
-    responseMode: "json",
+    responseMode: "json-or-empty",
     pathParams: [],
     catchAllPathParams: [],
     file: "packages/cloud/api/v1/twilio/voice/status/route.ts",
@@ -5556,6 +5578,7 @@ export interface PublicRoutePathParams {
   "GET /api/v1/oauth/status": Record<never, never>;
   "GET /api/v1/oauth/success-proof/verify": Record<never, never>;
   "GET /api/v1/oauth/token/{platform}": { platform: string | number };
+  "GET /api/v1/outreachr": Record<never, never>;
   "GET /api/v1/payment-requests": Record<never, never>;
   "GET /api/v1/payment-requests/{id}": { id: string | number };
   "GET /api/v1/pii-scrub/jobs/{id}": { id: string | number };
@@ -5904,6 +5927,7 @@ export interface PublicRoutePathParams {
   "POST /api/v1/oauth/callback/{provider}": { provider: string | number };
   "POST /api/v1/oauth/connect": Record<never, never>;
   "POST /api/v1/oauth/initiate": Record<never, never>;
+  "POST /api/v1/outreachr": Record<never, never>;
   "POST /api/v1/payment-requests": Record<never, never>;
   "POST /api/v1/payment-requests/{id}/cancel": { id: string | number };
   "POST /api/v1/payment-requests/{id}/expire": { id: string | number };
@@ -6261,6 +6285,7 @@ export interface PublicRouteHeaders {
   "GET /api/v1/oauth/status": never;
   "GET /api/v1/oauth/success-proof/verify": never;
   "GET /api/v1/oauth/token/{platform}": never;
+  "GET /api/v1/outreachr": never;
   "GET /api/v1/payment-requests": never;
   "GET /api/v1/payment-requests/{id}": never;
   "GET /api/v1/pii-scrub/jobs/{id}": never;
@@ -6523,6 +6548,7 @@ export interface PublicRouteHeaders {
   "POST /api/v1/oauth/callback/{provider}": never;
   "POST /api/v1/oauth/connect": never;
   "POST /api/v1/oauth/initiate": never;
+  "POST /api/v1/outreachr": never;
   "POST /api/v1/payment-requests": never;
   "POST /api/v1/payment-requests/{id}/cancel": never;
   "POST /api/v1/payment-requests/{id}/expire": never;
@@ -6634,6 +6660,11 @@ interface ElizaCloudPublicRouteTransport {
     method: HttpMethod,
     path: string,
     options?: CloudRequestOptions,
+  ): Promise<CloudResponse<TResponse>>;
+  requestData?<TResponse>(
+    method: HttpMethod,
+    path: string,
+    options?: CloudRequestOptions,
   ): Promise<TResponse>;
   requestRaw(
     method: HttpMethod,
@@ -6726,6 +6757,27 @@ export class ElizaCloudPublicRoutesClient {
     key: TKey,
     options?: PublicRouteCallOptions<TKey>,
   ): Promise<TResponse> {
+    const endpoint = ELIZA_CLOUD_PUBLIC_ENDPOINTS[key];
+    const method = endpoint.method as HttpMethod;
+    const path = buildPublicRoutePath(key, options);
+    const requestOptions = toRequestOptions(options);
+    if (this.client.requestData) {
+      return this.client.requestData<TResponse>(method, path, requestOptions);
+    }
+    return this.client
+      .request<TResponse>(method, path, requestOptions)
+      .then((response) => {
+        if (response === undefined) {
+          throw new Error(`Expected a data response for ${key}`);
+        }
+        return response;
+      });
+  }
+
+  private callBodyless<TKey extends PublicRouteKey, TResponse = unknown>(
+    key: TKey,
+    options?: PublicRouteCallOptions<TKey>,
+  ): Promise<CloudResponse<TResponse>> {
     const endpoint = ELIZA_CLOUD_PUBLIC_ENDPOINTS[key];
     return this.client.request<TResponse>(
       endpoint.method as HttpMethod,
@@ -6849,11 +6901,11 @@ export class ElizaCloudPublicRoutesClient {
 
   deleteApiV1ApisStorageObjects<TResponse = unknown>(
     options: PublicRouteCallOptions<"DELETE /api/v1/apis/storage/objects/_">,
-  ): Promise<TResponse> {
-    return this.call<"DELETE /api/v1/apis/storage/objects/_", TResponse>(
+  ): Promise<CloudResponse<TResponse>> {
+    return this.callBodyless<
       "DELETE /api/v1/apis/storage/objects/_",
-      options,
-    );
+      TResponse
+    >("DELETE /api/v1/apis/storage/objects/_", options);
   }
 
   deleteApiV1AppAuthMobileCredentialsById<TResponse = unknown>(
@@ -7358,11 +7410,11 @@ export class ElizaCloudPublicRoutesClient {
 
   getApiV1AdvertisingConversionsTrack<TResponse = unknown>(
     options: PublicRouteCallOptions<"GET /api/v1/advertising/conversions/track"> = {},
-  ): Promise<TResponse> {
-    return this.call<"GET /api/v1/advertising/conversions/track", TResponse>(
+  ): Promise<CloudResponse<TResponse>> {
+    return this.callBodyless<
       "GET /api/v1/advertising/conversions/track",
-      options,
-    );
+      TResponse
+    >("GET /api/v1/advertising/conversions/track", options);
   }
 
   getApiV1AdvertisingCreativesById<TResponse = unknown>(
@@ -7590,13 +7642,10 @@ export class ElizaCloudPublicRoutesClient {
     );
   }
 
-  getApiV1AppsIngressAsk<TResponse = unknown>(
+  getApiV1AppsIngressAsk(
     options: PublicRouteCallOptions<"GET /api/v1/apps-ingress/ask"> = {},
-  ): Promise<TResponse> {
-    return this.call<"GET /api/v1/apps-ingress/ask", TResponse>(
-      "GET /api/v1/apps-ingress/ask",
-      options,
-    );
+  ): Promise<Response> {
+    return this.callRaw("GET /api/v1/apps-ingress/ask", options);
   }
 
   getApiV1AppsById<TResponse = unknown>(
@@ -7752,13 +7801,13 @@ export class ElizaCloudPublicRoutesClient {
     >("GET /api/v1/apps/{id}/frontend/{deploymentId}", options);
   }
 
-  getApiV1AppsByIdFrontendPreviewByPath<TResponse = unknown>(
+  getApiV1AppsByIdFrontendPreviewByPath(
     options: PublicRouteCallOptions<"GET /api/v1/apps/{id}/frontend/preview/{[...path]}">,
-  ): Promise<TResponse> {
-    return this.call<
+  ): Promise<Response> {
+    return this.callRaw(
       "GET /api/v1/apps/{id}/frontend/preview/{[...path]}",
-      TResponse
-    >("GET /api/v1/apps/{id}/frontend/preview/{[...path]}", options);
+      options,
+    );
   }
 
   getApiV1AppsByIdMonetization<TResponse = unknown>(
@@ -8525,13 +8574,13 @@ export class ElizaCloudPublicRoutesClient {
     );
   }
 
-  getApiV1HostedFrontendServeByPath<TResponse = unknown>(
+  getApiV1HostedFrontendServeByPath(
     options: PublicRouteCallOptions<"GET /api/v1/hosted-frontend/serve/{[...path]}">,
-  ): Promise<TResponse> {
-    return this.call<
+  ): Promise<Response> {
+    return this.callRaw(
       "GET /api/v1/hosted-frontend/serve/{[...path]}",
-      TResponse
-    >("GET /api/v1/hosted-frontend/serve/{[...path]}", options);
+      options,
+    );
   }
 
   getApiV1JobsByJobId<TResponse = unknown>(
@@ -8680,11 +8729,11 @@ export class ElizaCloudPublicRoutesClient {
 
   getApiV1MarketingInventoryServe<TResponse = unknown>(
     options: PublicRouteCallOptions<"GET /api/v1/marketing/inventory/serve"> = {},
-  ): Promise<TResponse> {
-    return this.call<"GET /api/v1/marketing/inventory/serve", TResponse>(
+  ): Promise<CloudResponse<TResponse>> {
+    return this.callBodyless<
       "GET /api/v1/marketing/inventory/serve",
-      options,
-    );
+      TResponse
+    >("GET /api/v1/marketing/inventory/serve", options);
   }
 
   getApiV1MarketingPr<TResponse = unknown>(
@@ -8894,6 +8943,15 @@ export class ElizaCloudPublicRoutesClient {
     );
   }
 
+  getApiV1Outreachr<TResponse = unknown>(
+    options: PublicRouteCallOptions<"GET /api/v1/outreachr"> = {},
+  ): Promise<TResponse> {
+    return this.call<"GET /api/v1/outreachr", TResponse>(
+      "GET /api/v1/outreachr",
+      options,
+    );
+  }
+
   getApiV1PaymentRequests<TResponse = unknown>(
     options: PublicRouteCallOptions<"GET /api/v1/payment-requests"> = {},
   ): Promise<TResponse> {
@@ -9022,11 +9080,11 @@ export class ElizaCloudPublicRoutesClient {
 
   getApiV1RemoteSessionsByIdCommands<TResponse = unknown>(
     options: PublicRouteCallOptions<"GET /api/v1/remote/sessions/{id}/commands">,
-  ): Promise<TResponse> {
-    return this.call<"GET /api/v1/remote/sessions/{id}/commands", TResponse>(
+  ): Promise<CloudResponse<TResponse>> {
+    return this.callBodyless<
       "GET /api/v1/remote/sessions/{id}/commands",
-      options,
-    );
+      TResponse
+    >("GET /api/v1/remote/sessions/{id}/commands", options);
   }
 
   getApiV1RemoteSessionsByIdCommandsByCommandId<TResponse = unknown>(
@@ -11210,6 +11268,15 @@ export class ElizaCloudPublicRoutesClient {
     );
   }
 
+  postApiV1Outreachr<TResponse = unknown>(
+    options: PublicRouteCallOptions<"POST /api/v1/outreachr"> = {},
+  ): Promise<TResponse> {
+    return this.call<"POST /api/v1/outreachr", TResponse>(
+      "POST /api/v1/outreachr",
+      options,
+    );
+  }
+
   postApiV1PaymentRequests<TResponse = unknown>(
     options: PublicRouteCallOptions<"POST /api/v1/payment-requests"> = {},
   ): Promise<TResponse> {
@@ -11593,8 +11660,8 @@ export class ElizaCloudPublicRoutesClient {
 
   postApiV1TwilioVoiceStatus<TResponse = unknown>(
     options: PublicRouteCallOptions<"POST /api/v1/twilio/voice/status"> = {},
-  ): Promise<TResponse> {
-    return this.call<"POST /api/v1/twilio/voice/status", TResponse>(
+  ): Promise<CloudResponse<TResponse>> {
+    return this.callBodyless<"POST /api/v1/twilio/voice/status", TResponse>(
       "POST /api/v1/twilio/voice/status",
       options,
     );
@@ -13523,6 +13590,12 @@ export class ElizaCloudPublicRoutesClient {
     return this.callRaw("GET /api/v1/oauth/token/{platform}", options);
   }
 
+  getApiV1OutreachrRaw(
+    options: PublicRouteCallOptions<"GET /api/v1/outreachr"> = {},
+  ): Promise<Response> {
+    return this.callRaw("GET /api/v1/outreachr", options);
+  }
+
   getApiV1PaymentRequestsRaw(
     options: PublicRouteCallOptions<"GET /api/v1/payment-requests"> = {},
   ): Promise<Response> {
@@ -15204,6 +15277,12 @@ export class ElizaCloudPublicRoutesClient {
     options: PublicRouteCallOptions<"POST /api/v1/oauth/initiate"> = {},
   ): Promise<Response> {
     return this.callRaw("POST /api/v1/oauth/initiate", options);
+  }
+
+  postApiV1OutreachrRaw(
+    options: PublicRouteCallOptions<"POST /api/v1/outreachr"> = {},
+  ): Promise<Response> {
+    return this.callRaw("POST /api/v1/outreachr", options);
   }
 
   postApiV1PaymentRequestsRaw(

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -38,6 +38,9 @@ export type HttpMethod =
   | "OPTIONS"
   | "HEAD";
 
+/** Parsed data, or `undefined` for successful HEAD, 204, and 205 responses. */
+export type CloudResponse<T> = T | undefined;
+
 export type QueryValue = boolean | number | string | null | undefined;
 export type QueryParams =
   | URLSearchParams

--- a/plugins/plugin-elizacloud/__tests__/cloud-api-client-contract.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-api-client-contract.test.ts
@@ -106,7 +106,10 @@ describe("GET requests", () => {
   it("sends correct method and path", async () => {
     setResponse(200, { success: true, data: [1, 2, 3] });
     const client = new CloudApiClient(baseUrl);
-    const result = await client.get<{ success: boolean; data: number[] }>("/items");
+    const result = await client.requestData<{
+      success: boolean;
+      data: number[];
+    }>("GET", "/items");
     expect(lastRequest.method).toBe("GET");
     expect(lastRequest.url).toBe("/items");
     expect(result.data).toEqual([1, 2, 3]);
@@ -115,7 +118,7 @@ describe("GET requests", () => {
   it("includes Authorization header when API key is set", async () => {
     setResponse(200, { success: true });
     const client = new CloudApiClient(baseUrl, "eliza_mykey");
-    await client.get("/auth-check");
+    await client.requestData("GET", "/auth-check");
     expect(lastRequest.headers.authorization).toBe("Bearer eliza_mykey");
   });
 

--- a/plugins/plugin-elizacloud/__tests__/cloud-container-coding-service.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-container-coding-service.test.ts
@@ -1,3 +1,4 @@
+/** Verifies coding-container request forwarding and boundary failures with a deterministic transport stub. */
 import { describe, expect, it } from "vitest";
 import { CloudContainerService } from "../src/services/cloud-container";
 import type {
@@ -6,7 +7,9 @@ import type {
   SyncCloudCodingContainerRequest,
 } from "../src/types/cloud";
 
-function serviceWithClient(client: { post: (path: string, body: unknown) => Promise<unknown> }) {
+function serviceWithClient(client: {
+  requestData: (method: string, path: string, options: { json: unknown }) => Promise<unknown>;
+}) {
   const service = new CloudContainerService({} as never);
   (service as unknown as { authService: unknown }).authService = {
     isAuthenticated: () => true,
@@ -28,7 +31,8 @@ describe("CloudContainerService coding-container methods", () => {
       },
     };
     const service = serviceWithClient({
-      post: async (path, body) => {
+      requestData: async (method, path, { json: body }) => {
+        expect(method).toBe("POST");
         calls.push({ path, body });
         return {
           success: true,
@@ -65,7 +69,8 @@ describe("CloudContainerService coding-container methods", () => {
       },
     };
     const service = serviceWithClient({
-      post: async (path, body) => {
+      requestData: async (method, path, { json: body }) => {
+        expect(method).toBe("POST");
         calls.push({ path, body });
         return {
           success: true,
@@ -95,7 +100,8 @@ describe("CloudContainerService coding-container methods", () => {
       patches: [{ path: "src/app.ts", format: "unified-diff", patch: "@@ -1 +1" }],
     };
     const service = serviceWithClient({
-      post: async (path, body) => {
+      requestData: async (method, path, { json: body }) => {
+        expect(method).toBe("POST");
         calls.push({ path, body });
         return {
           success: true,
@@ -140,7 +146,7 @@ describe("CloudContainerService coding-container methods", () => {
 
   it("fails closed for missing backend coding-container endpoints", async () => {
     const service = serviceWithClient({
-      post: async () => {
+      requestData: async () => {
         throw { statusCode: 501 };
       },
     });

--- a/plugins/plugin-elizacloud/__tests__/cloud-services-contract.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-services-contract.test.ts
@@ -78,7 +78,7 @@ describe("CloudApiClient with route-based server", () => {
     }));
 
     const client = new CloudApiClient(baseUrl, "eliza_test");
-    const result = await client.get<{ data: typeof containers }>("/containers");
+    const result = await client.requestData<{ data: typeof containers }>("GET", "/containers");
     expect(result.data).toHaveLength(2);
     expect(result.data[0].name).toBe("agent-1");
     expect(result.data[1].status).toBe("stopped");
@@ -131,7 +131,10 @@ describe("CloudApiClient with route-based server", () => {
     }));
 
     const client = new CloudApiClient(baseUrl, "eliza_test");
-    const result = await client.get<{ data: { balance: number } }>("/credits/balance");
+    const result = await client.requestData<{ data: { balance: number } }>(
+      "GET",
+      "/credits/balance"
+    );
     expect(result.data.balance).toBeCloseTo(4.37);
   });
 
@@ -282,7 +285,10 @@ describe("credit lifecycle", () => {
     const client = new CloudApiClient(baseUrl, "eliza_test");
 
     // Check balance first
-    const balance = await client.get<{ data: { balance: number } }>("/credits/balance");
+    const balance = await client.requestData<{ data: { balance: number } }>(
+      "GET",
+      "/credits/balance"
+    );
     expect(balance.data.balance).toBe(2.0);
 
     // Attempt container creation — should throw InsufficientCreditsError
@@ -339,7 +345,10 @@ describe("snapshot lifecycle", () => {
     expect(snapshots).toHaveLength(2);
 
     // List
-    const listed = await client.get<{ data: typeof snapshots }>("/agent-state/c1/snapshots");
+    const listed = await client.requestData<{ data: typeof snapshots }>(
+      "GET",
+      "/agent-state/c1/snapshots"
+    );
     expect(listed.data).toHaveLength(2);
 
     // Restore
@@ -350,7 +359,10 @@ describe("snapshot lifecycle", () => {
 
     // Delete
     await client.delete("/agent-state/c1/snapshots/snap-1");
-    const afterDelete = await client.get<{ data: typeof snapshots }>("/agent-state/c1/snapshots");
+    const afterDelete = await client.requestData<{ data: typeof snapshots }>(
+      "GET",
+      "/agent-state/c1/snapshots"
+    );
     expect(afterDelete.data).toHaveLength(1);
     expect(afterDelete.data[0].id).toBe("snap-2");
   });
@@ -368,9 +380,9 @@ describe("concurrent requests", () => {
 
     const client = new CloudApiClient(baseUrl, "eliza_test");
     const results = await Promise.all([
-      client.get<{ n: number }>("/slow"),
-      client.get<{ n: number }>("/slow"),
-      client.get<{ n: number }>("/slow"),
+      client.requestData<{ n: number }>("GET", "/slow"),
+      client.requestData<{ n: number }>("GET", "/slow"),
+      client.requestData<{ n: number }>("GET", "/slow"),
     ]);
 
     expect(results).toHaveLength(3);

--- a/plugins/plugin-elizacloud/__tests__/cloud-setup-failures.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-setup-failures.test.ts
@@ -890,12 +890,17 @@ describe("C7 — saved-key validation against /models", () => {
     const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
 
     // The validation client is constructed via `new CloudApiClient(...)` inside
-    // `probeApiKey`. Monkey-patch the prototype `get` so any new instance fails
-    // with a genuine revoked-key response (401 → CloudApiError).
+    // `probeApiKey`. Monkey-patch `requestData` so any new instance fails with a
+    // genuine revoked-key response (401 → CloudApiError).
     const { CloudApiClient } = await import("../src/utils/cloud-api.js");
-    const getSpy = vi.spyOn(CloudApiClient.prototype, "get").mockImplementation(async () => {
-      throw new CloudApiError(401, { success: false, error: "api key revoked" });
-    });
+    const requestDataSpy = vi
+      .spyOn(CloudApiClient.prototype, "requestData")
+      .mockImplementation(async () => {
+        throw new CloudApiError(401, {
+          success: false,
+          error: "api key revoked",
+        });
+      });
 
     const service = new (
       CloudAuthService as unknown as {
@@ -937,13 +942,16 @@ describe("C7 — saved-key validation against /models", () => {
       // and no loud error is logged.
       expect(service.isApiKeyInvalid()).toBe(false);
       expect(errorSpy).not.toHaveBeenCalled();
+      expect(requestDataSpy).toHaveBeenCalledWith("GET", "/models", {
+        timeoutMs: 2_500,
+      });
 
       // The cached key survives — model calls would continue using it.
       expect(service.getApiKey()).toBe("eliza_saved_key_c7");
     } finally {
       await service.stop();
       errorSpy.mockRestore();
-      getSpy.mockRestore();
+      requestDataSpy.mockRestore();
     }
   });
 });

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-backup.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-backup.test.ts
@@ -6,7 +6,7 @@ import type { AgentSnapshot } from "../../src/types";
 describe("CloudBackupService", () => {
   it("sorts snapshots deterministically even with missing or invalid created_at dates", async () => {
     const mockClient = {
-      get: vi.fn().mockResolvedValue({
+      requestData: vi.fn().mockResolvedValue({
         data: [
           { id: "s1", created_at: "2026-01-01T00:00:00Z", snapshotType: "auto" } as AgentSnapshot,
           {

--- a/plugins/plugin-elizacloud/__tests__/unit/credit-balance-shared-snapshot.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/credit-balance-shared-snapshot.test.ts
@@ -21,7 +21,7 @@ import { type CloudServer, makeRuntime, startCloudServer } from "./cloud-account
  */
 function makeCreditRuntime(options: { balance?: number; fail?: boolean }): IAgentRuntime {
   const client = {
-    get: vi.fn(async () => {
+    requestData: vi.fn(async () => {
       if (options.fail) throw new Error("billing down");
       return { data: { balance: options.balance ?? 7.5 } };
     }),

--- a/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
@@ -45,7 +45,9 @@ export const creditBalanceProvider: Provider = {
 
     let balance: number;
     try {
-      const { data } = await auth.getClient().get<CreditBalanceResponse>("/credits/balance");
+      const { data } = await auth
+        .getClient()
+        .requestData<CreditBalanceResponse>("GET", "/credits/balance");
       balance = data.balance;
     } catch (err) {
       logger.warn(

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -386,9 +386,9 @@ export const elizaOSCloudPlugin: Plugin = {
         {
           name: "ELIZAOS_CLOUD_test_url_and_api_key_validation",
           fn: async (runtime: IAgentRuntime) => {
-            const data = await createCloudApiClient(runtime).get<{
+            const data = await createCloudApiClient(runtime).requestData<{
               data?: Array<Record<string, never>>;
-            }>("/models");
+            }>("GET", "/models");
             logger.log(
               {
                 data: data.data?.length ?? "N/A",

--- a/plugins/plugin-elizacloud/src/init.ts
+++ b/plugins/plugin-elizacloud/src/init.ts
@@ -17,7 +17,7 @@ export function initializeOpenAI(
         return;
       }
       try {
-        await createCloudApiClient(runtime).get("/models");
+        await createCloudApiClient(runtime).requestData("GET", "/models");
         logger.log("ElizaOS Cloud API key validated successfully");
       } catch (fetchError) {
         const message = fetchError instanceof Error ? fetchError.message : String(fetchError);

--- a/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
+++ b/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
@@ -87,6 +87,7 @@ const CLOUD_AUTH_CLEAR_METHODS = [
 
 type CloudClientLike = {
   get?: (path: string) => Promise<unknown>;
+  requestData?: (method: "GET", path: string) => Promise<unknown>;
 };
 
 export type CloudAuthLike = {
@@ -428,15 +429,31 @@ export async function fetchCloudCredits(
   }
 
   const cloudClient = snapshot.cloudAuth?.getClient?.();
-  if (snapshot.authConnected && typeof cloudClient?.get === "function") {
+  if (
+    snapshot.authConnected &&
+    (typeof cloudClient?.requestData === "function" ||
+      typeof cloudClient?.get === "function")
+  ) {
     try {
-      const creditResponse = (await cloudClient.get("/credits/balance")) as {
-        balance?: unknown;
-        data?: { balance?: unknown };
-      };
+      const creditResponse =
+        typeof cloudClient.requestData === "function"
+          ? await cloudClient.requestData("GET", "/credits/balance")
+          : await cloudClient.get?.("/credits/balance");
+      const nestedData =
+        typeof creditResponse === "object" && creditResponse !== null
+          ? Reflect.get(creditResponse, "data")
+          : undefined;
       const rawBalance =
-        coerceCloudBalance(creditResponse?.balance) ??
-        coerceCloudBalance(creditResponse?.data?.balance);
+        coerceCloudBalance(
+          typeof creditResponse === "object" && creditResponse !== null
+            ? Reflect.get(creditResponse, "balance")
+            : undefined,
+        ) ??
+        coerceCloudBalance(
+          typeof nestedData === "object" && nestedData !== null
+            ? Reflect.get(nestedData, "balance")
+            : undefined,
+        );
 
       if (typeof rawBalance === "number") {
         return withCreditFlags(rawBalance, topUpUrl);

--- a/plugins/plugin-elizacloud/src/routes/cloud-status-routes-autonomous.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-status-routes-autonomous.ts
@@ -25,7 +25,9 @@ interface CloudAuthIdentityService {
 
 interface CloudAuthCreditsService {
   isAuthenticated: () => boolean;
-  getClient: () => { get: <T>(path: string) => Promise<T> };
+  getClient: () => {
+    requestData: <T>(method: "GET", path: string) => Promise<T>;
+  };
 }
 
 export interface CloudConfigLike {
@@ -214,8 +216,10 @@ export async function handleCloudStatusRoutes(
     }
 
     const client = cloudAuth.getClient();
-    const creditResponse =
-      await client.get<Record<string, unknown>>("/credits/balance");
+    const creditResponse = await client.requestData<Record<string, unknown>>(
+      "GET",
+      "/credits/balance",
+    );
     const balance =
       coerceCloudBalance(creditResponse?.balance) ??
       coerceCloudBalance(

--- a/plugins/plugin-elizacloud/src/services/cloud-auth.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-auth.ts
@@ -590,7 +590,9 @@ export class CloudAuthService extends Service {
   private async probeApiKey(key: string): Promise<ApiKeyProbe> {
     try {
       const validationClient = new CloudApiClient(this.client.getBaseUrl(), key);
-      await validationClient.get("/models", { timeoutMs: 2_500 });
+      await validationClient.requestData("GET", "/models", {
+        timeoutMs: 2_500,
+      });
       return "valid";
     } catch (err) {
       if (err instanceof CloudApiError && (err.statusCode === 401 || err.statusCode === 403)) {
@@ -664,11 +666,9 @@ export class CloudAuthService extends Service {
 
     logger.info(`[CloudAuth] Authenticating device (platform=${platform})`);
 
-    const response = await this.client.postUnauthenticated<DeviceAuthResponse>("/device-auth", {
-      deviceId,
-      platform,
-      appVersion,
-      deviceName: os.hostname(),
+    const response = await this.client.requestData<DeviceAuthResponse>("POST", "/device-auth", {
+      skipAuth: true,
+      json: { deviceId, platform, appVersion, deviceName: os.hostname() },
     });
 
     this.credentials = {

--- a/plugins/plugin-elizacloud/src/services/cloud-backup.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-backup.ts
@@ -64,9 +64,10 @@ export class CloudBackupService extends Service {
     metadata?: Record<string, unknown>
   ): Promise<AgentSnapshot> {
     const client = this.authService.getClient();
-    const response = await client.post<CreateSnapshotResponse>(
+    const response = await client.requestData<CreateSnapshotResponse>(
+      "POST",
       `/agent-state/${containerId}/snapshot`,
-      { snapshotType, metadata }
+      { json: { snapshotType, metadata } }
     );
 
     logger.info(
@@ -84,8 +85,9 @@ export class CloudBackupService extends Service {
 
   async listSnapshots(containerId: string): Promise<AgentSnapshot[]> {
     const client = this.authService.getClient();
-    const response = await client.get<SnapshotListResponse>(
-      `/agent-state/${containerId}/snapshots`
+    const response = await client.requestData<SnapshotListResponse>(
+      "GET",
+      `/agent-state/${containerId}/snapshots`,
     );
     return response.data;
   }

--- a/plugins/plugin-elizacloud/src/services/cloud-container.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-container.ts
@@ -125,7 +125,7 @@ export class CloudContainerService
       architecture: request.architecture ?? defaults.defaultArchitecture,
     };
 
-    const response = await client.post<CreateContainerResponse>("/containers", payload);
+    const response = await client.requestData<CreateContainerResponse>("POST", "/containers", { json: payload });
 
     // Track the new container
     this.tracked.set(response.data.id, {
@@ -146,13 +146,19 @@ export class CloudContainerService
 
   async listContainers(): Promise<CloudContainer[]> {
     const client = this.getClient();
-    const response = await client.get<ContainerListResponse>("/containers");
+    const response = await client.requestData<ContainerListResponse>(
+      "GET",
+      "/containers",
+    );
     return response.data;
   }
 
   async getContainer(containerId: string): Promise<CloudContainer> {
     const client = this.getClient();
-    const response = await client.get<ContainerGetResponse>(`/containers/${containerId}`);
+    const response = await client.requestData<ContainerGetResponse>(
+      "GET",
+      `/containers/${containerId}`,
+    );
 
     // Update local tracking
     const existing = this.tracked.get(containerId);
@@ -285,7 +291,10 @@ export class CloudContainerService
 
   async getContainerHealth(containerId: string): Promise<ContainerHealthResponse> {
     const client = this.getClient();
-    return client.get<ContainerHealthResponse>(`/containers/${containerId}/health`);
+    return client.requestData<ContainerHealthResponse>(
+      "GET",
+      `/containers/${containerId}/health`,
+    );
   }
 
   // ─── Coding Containers / VFS Promotion ────────────────────────────────
@@ -298,9 +307,10 @@ export class CloudContainerService
     }
 
     try {
-      return await this.getClient().post<PromoteVfsToCloudContainerResponse>(
+      return await this.getClient().requestData<PromoteVfsToCloudContainerResponse>(
+        "POST",
         "/coding-containers/promotions",
-        request,
+        { json: request },
       );
     } catch (error) {
       if (isMissingCloudCodingEndpoint(error)) {
@@ -320,9 +330,10 @@ export class CloudContainerService
     }
 
     try {
-      return await this.getClient().post<RequestCodingAgentContainerResponse>(
+      return await this.getClient().requestData<RequestCodingAgentContainerResponse>(
+        "POST",
         "/coding-containers",
-        request,
+        { json: request },
       );
     } catch (error) {
       if (isMissingCloudCodingEndpoint(error)) {
@@ -343,9 +354,10 @@ export class CloudContainerService
     }
 
     try {
-      return await this.getClient().post<SyncCloudCodingContainerResponse>(
+      return await this.getClient().requestData<SyncCloudCodingContainerResponse>(
+        "POST",
         `/coding-containers/${encodeURIComponent(containerId)}/sync`,
-        request,
+        { json: request },
       );
     } catch (error) {
       if (isMissingCloudCodingEndpoint(error)) {

--- a/plugins/plugin-elizacloud/src/services/cloud-model-registry.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-model-registry.ts
@@ -110,7 +110,7 @@ export class CloudModelRegistryService extends Service {
 
     const client = auth.getClient();
 
-    const response = await client.get<ModelListResponse>("/models");
+    const response = await client.requestData<ModelListResponse>("GET", "/models");
     const entries: ModelListEntry[] = response.data ?? [];
 
     this.models = entries.map((entry) => ({


### PR DESCRIPTION
Related to #30574; follow-up to #30597.

Harden the cloud SDK success-response contract: validate JSON media types and UTF-8, expose bodyless responses as `T | undefined`, and provide `requestData` for callers that require a DTO. Generated routes distinguish JSON, optional JSON and raw responses; plugin consumers use the appropriate contract.

Review found that generic mutation helpers incorrectly rejected successful 204/205 responses. Repaired `post`, `put`, `patch`, `delete` and `postUnauthenticated` to preserve the generic contract, while migrating data-required high-level and plugin callers to `requestData`. Real HTTP regressions fail on the original implementation and pass with the repair. Updated generated routes against the rebased API inventory.

Validation on `298bf89036cb2123baba8393a930fa97ac1e6c59`, based on `9612ff217a00465f63f1854b53ebcd65e2461dcd`, Bun 1.3.14 / Node 24.15.0:
- SDK: 191 passed, 19 expected credential/live skips; generated route audit passed.
- Plugin: 631 passed, 5 skipped; packaged distribution checks: 5 passed.
- Real HTTP mutation regression: 2 failures before repair; complete HTTP server suite: 17 passed after repair.
- Live public API: model listing and CLI login bootstrap/poll both passed. No paid generation or resource provisioning was performed.
- SDK and plugin typecheck, lint and builds passed.
- `bun install` and root `bun run verify` passed: all 376 workspace tasks and repository audits.

Risk: public generic response types now accurately include `undefined`; consumers requiring a body must use the strict helper. Raw-response APIs and the bound legacy custom-transport fallback remain supported.

UI screenshots, video, native captures and model trajectories are N/A: this is a transport/response-contract change with real HTTP and live public API evidence. Credentialed SDK cases remain explicitly skipped.

<!-- evidence-head:298bf89036cb2123baba8393a930fa97ac1e6c59 -->
