### PR TITLE
fix(app-core): keep source asset manifests stable after normal builds

### DIFF
--- a/packages/app-core/scripts/__tests__/static-asset-contract.test.ts
+++ b/packages/app-core/scripts/__tests__/static-asset-contract.test.ts
@@ -1,17 +1,31 @@
 /**
- * Contract tests for the archive-overlay retirement (#16290): the checked-in
- * static asset manifest must match a pristine checkout (no implicit artifact
- * sync may be needed to make it green), and the overlay-only assets retired
- * with the eliza-archive sync must not resurface — neither as files nor as
- * references from production source. Runs against the real repository tree
- * and the real generator; no mocks.
+ * Contract tests for source-owned static asset inventory. The suite exercises
+ * the real repository and homepage copy producer, temporary Git checkouts, and
+ * standalone filesystem roots so ignored build output cannot alter a source
+ * manifest while real additions and deletions remain visible.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { validateStaticAssetManifest } from "../lib/static-asset-manifest.mjs";
+import {
+  HOMEPAGE_PUBLIC_ASSETS,
+  syncHomepageAssets,
+} from "../../../app/scripts/sync-homepage-assets.mjs";
+import {
+  buildStaticAssetManifest,
+  validateStaticAssetManifest,
+  writeStaticAssetManifest,
+} from "../lib/static-asset-manifest.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -20,6 +34,22 @@ const REPO_ROOT = path.resolve(
   "..",
   "..",
 );
+
+function writeFixtureFile(rootDir: string, relativePath: string): void {
+  const absolutePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, `${relativePath}\n`);
+}
+
+function createGitFixture(): string {
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "eliza-static-assets-"));
+  execFileSync("git", ["init", "--quiet", rootDir]);
+  return rootDir;
+}
+
+function stageFixturePaths(rootDir: string, ...relativePaths: string[]): void {
+  execFileSync("git", ["-C", rootDir, "add", "--", ...relativePaths]);
+}
 
 /**
  * Assets that existed only in the retired eliza-archive overlay. They have no
@@ -166,4 +196,101 @@ describe("static asset manifest contract (#16290)", () => {
       });
     expect(offenders).toEqual([]);
   }, 30_000);
+
+  it("stays valid after the real homepage asset producer copies ignored output", async () => {
+    const rootDir = createGitFixture();
+    try {
+      writeFixtureFile(rootDir, ".gitignore");
+      writeFileSync(
+        path.join(rootDir, ".gitignore"),
+        "packages/app/public/**\n",
+      );
+      for (const relativePath of HOMEPAGE_PUBLIC_ASSETS) {
+        writeFixtureFile(
+          rootDir,
+          path.join("packages/homepage/public", relativePath),
+        );
+      }
+      stageFixturePaths(rootDir, ".gitignore", "packages/homepage/public");
+      writeStaticAssetManifest(rootDir);
+
+      await syncHomepageAssets({
+        sourceRoot: path.join(rootDir, "packages/homepage/public"),
+        destinationRoot: path.join(rootDir, "packages/app/public"),
+      });
+
+      expect(validateStaticAssetManifest(rootDir).ok).toBe(true);
+      expect(
+        HOMEPAGE_PUBLIC_ASSETS.every((relativePath) =>
+          existsSync(path.join(rootDir, "packages/app/public", relativePath)),
+        ),
+      ).toBe(true);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects non-ignored additions and missing tracked assets", () => {
+    const rootDir = createGitFixture();
+    try {
+      const trackedAsset = "packages/app/public/tracked.txt";
+      writeFixtureFile(rootDir, trackedAsset);
+      stageFixturePaths(rootDir, trackedAsset);
+      writeStaticAssetManifest(rootDir);
+
+      const addedAsset = "packages/app/public/added.txt";
+      writeFixtureFile(rootDir, addedAsset);
+      expect(validateStaticAssetManifest(rootDir).ok).toBe(false);
+
+      unlinkSync(path.join(rootDir, addedAsset));
+      unlinkSync(path.join(rootDir, trackedAsset));
+      expect(validateStaticAssetManifest(rootDir).ok).toBe(false);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes present tracked assets even when an ignore rule matches", () => {
+    const rootDir = createGitFixture();
+    try {
+      const trackedAsset = "packages/app/public/tracked.txt";
+      writeFixtureFile(rootDir, trackedAsset);
+      stageFixturePaths(rootDir, trackedAsset);
+      writeFixtureFile(rootDir, ".gitignore");
+      writeFileSync(path.join(rootDir, ".gitignore"), `${trackedAsset}\n`);
+
+      expect(buildStaticAssetManifest(rootDir).app).toContain(trackedAsset);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails explicitly when checkout Git metadata cannot be read", () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), "eliza-static-assets-"));
+    try {
+      mkdirSync(path.join(rootDir, ".git"));
+      expect(() => buildStaticAssetManifest(rootDir)).toThrow(
+        /Failed to inventory checkout assets/,
+      );
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retains filesystem discovery for standalone archive roots", () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), "eliza-static-assets-"));
+    try {
+      const appAsset = "packages/app/public/archive-app.txt";
+      const homepageAsset = "packages/homepage/public/archive-homepage.txt";
+      writeFixtureFile(rootDir, appAsset);
+      writeFixtureFile(rootDir, homepageAsset);
+
+      expect(buildStaticAssetManifest(rootDir)).toEqual({
+        app: [appAsset],
+        homepage: [homepageAsset],
+      });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/app-core/scripts/lib/static-asset-manifest.mjs
+++ b/packages/app-core/scripts/lib/static-asset-manifest.mjs
@@ -1,9 +1,11 @@
 /**
- * Static asset manifest for the public/ trees (app + homepage, plus
- * consumer-wrapper paths): enumerates assets, writes/reads/validates the
- * generated manifest JSON, and lists the bootstrap assets the app dist must
- * keep locally when heavy assets move to the CDN.
+ * Static asset manifest for the app and homepage public trees. Repository
+ * checkouts inventory tracked and non-ignored files so normal build output
+ * cannot change the source contract; standalone archives retain filesystem
+ * discovery. The module also owns manifest persistence and the bootstrap
+ * assets kept locally when heavy assets move to the CDN.
  */
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -80,6 +82,56 @@ function listPublicFiles(rootDir, repoPrefix) {
     .sort();
 }
 
+function isIncludedStaticAsset(repoRelativePath) {
+  return repoRelativePath
+    .split("/")
+    .every(
+      (segment) =>
+        !segment.startsWith(".") &&
+        !IGNORED_STATIC_ASSET_BASENAMES.has(segment),
+    );
+}
+
+function listCheckoutPublicFiles(rootDir, repoPrefixes) {
+  let output;
+  try {
+    output = execFileSync(
+      "git",
+      [
+        "-C",
+        rootDir,
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        "--",
+        ...repoPrefixes,
+      ],
+      {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  } catch (cause) {
+    // error-policy:J2 A checkout must not validate from an incomplete Git inventory.
+    throw new Error(
+      `[static-asset-manifest] Failed to inventory checkout assets under ${rootDir}`,
+      { cause },
+    );
+  }
+
+  return output
+    .split("\0")
+    .filter(Boolean)
+    .filter(isIncludedStaticAsset)
+    .filter((repoRelativePath) =>
+      fs.existsSync(path.join(rootDir, repoRelativePath)),
+    )
+    .sort();
+}
+
 function resolvePublicRepoPrefix(rootDir, innerPrefix, wrapperPrefix) {
   if (fs.existsSync(path.join(rootDir, wrapperPrefix))) {
     return wrapperPrefix;
@@ -88,23 +140,33 @@ function resolvePublicRepoPrefix(rootDir, innerPrefix, wrapperPrefix) {
 }
 
 export function buildStaticAssetManifest(rootDir) {
+  const appPrefix = resolvePublicRepoPrefix(
+    rootDir,
+    APP_PUBLIC_REPO_PREFIX,
+    WRAPPER_APP_PUBLIC_REPO_PREFIX,
+  );
+  const homepagePrefix = resolvePublicRepoPrefix(
+    rootDir,
+    HOMEPAGE_PUBLIC_REPO_PREFIX,
+    WRAPPER_HOMEPAGE_PUBLIC_REPO_PREFIX,
+  );
+
+  if (fs.existsSync(path.join(rootDir, ".git"))) {
+    const checkoutFiles = listCheckoutPublicFiles(rootDir, [
+      appPrefix,
+      homepagePrefix,
+    ]);
+    return {
+      app: checkoutFiles.filter((entry) => entry.startsWith(`${appPrefix}/`)),
+      homepage: checkoutFiles.filter((entry) =>
+        entry.startsWith(`${homepagePrefix}/`),
+      ),
+    };
+  }
+
   return {
-    app: listPublicFiles(
-      rootDir,
-      resolvePublicRepoPrefix(
-        rootDir,
-        APP_PUBLIC_REPO_PREFIX,
-        WRAPPER_APP_PUBLIC_REPO_PREFIX,
-      ),
-    ),
-    homepage: listPublicFiles(
-      rootDir,
-      resolvePublicRepoPrefix(
-        rootDir,
-        HOMEPAGE_PUBLIC_REPO_PREFIX,
-        WRAPPER_HOMEPAGE_PUBLIC_REPO_PREFIX,
-      ),
-    ),
+    app: listPublicFiles(rootDir, appPrefix),
+    homepage: listPublicFiles(rootDir, homepagePrefix),
   };
 }
 


### PR DESCRIPTION
Closes #30601.

Normal homepage synchronization copies ignored files into `packages/app/public`. The source-manifest generator previously included those build outputs, so normal builds made an otherwise valid source manifest appear stale.

Use Git's tracked and unignored inventory in repository checkouts, while retaining the filesystem walk for source archives. Deleted source files are excluded; invalid repository metadata produces an explicit error. The canonical manifest is `scripts/generated/static-asset-manifest.json`.

Reviewed the Git inventory boundary, filesystem archive fallback, symlink/error behavior, callers, and the actual asset-sync producer. This is a useful fix: normal ignored build output must not alter the source manifest.

Validated head `98023bb6a4638dff119d54ba49f08e34b9bee6b8` after rebase onto `f567055f1c3656590369e6f9c416c253a773f283` with Bun 1.3.14 / Node 24.15.0:
- `bun install` passed.
- Actual homepage asset sync: the old builder counted 105 app assets; this builder correctly counted 97, excluding eight ignored copies. The 71 homepage assets and canonical `scripts/generated/static-asset-manifest.json` stayed unchanged; manifest validation passed.
- Focused static-asset contract: 8/8 passed.
- Full app-core Vitest run: 4,467 passed, 25 skipped, one 120-second timeout in an unchanged coding-account refresh test under machine load. An unchanged rerun of that entire file passed all 27 tests. No timeout was raised or test disabled.
- Package script suites: 74 Node tests and 21 Bun tests passed.
- Changed-file Biome and package format check passed. Root `bun run verify` passed all 376 workspace tasks and every repository audit, including package lint/typecheck.

No implementation changes were needed beyond rebasing. This script-only change has no rendered UI or model behavior; screenshots, native captures, and model trajectories are N/A. Hosted checks must pass on this head before merge.

<!-- evidence-head:98023bb6a4638dff119d54ba49f08e34b9bee6b8 -->
