### PR TITLE
fix(ui): restore current API port for IPv6 and alternate loopback addresses

### DIFF
--- a/packages/ui/src/state/startup-phase-restore.loopback-reconciliation.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.loopback-reconciliation.test.ts
@@ -1,0 +1,93 @@
+/** Verifies reconcilePersistedApiBaseWithLive across IPv6, alternate loopback, and remote boundaries. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const live = vi.hoisted(() => ({ apiBase: undefined as string | undefined }));
+
+vi.mock("../utils/eliza-globals", () => ({
+  getElizaApiBase: () => live.apiBase,
+  getElizaApiToken: () => undefined,
+}));
+
+import { reconcilePersistedApiBaseWithLive } from "./startup-phase-restore";
+
+describe("reconcilePersistedApiBaseWithLive", () => {
+  beforeEach(() => {
+    live.apiBase = undefined;
+  });
+
+  it("reconciles IPv6 loopback when live port changes", () => {
+    live.apiBase = "http://[::1]:31338";
+    expect(reconcilePersistedApiBaseWithLive("http://[::1]:31337")).toBe(
+      "http://[::1]:31338",
+    );
+  });
+
+  it("reconciles alternate 127.0.0.0/8 loopback when live port changes", () => {
+    live.apiBase = "http://127.0.0.2:31338";
+    expect(reconcilePersistedApiBaseWithLive("http://127.0.0.2:31337")).toBe(
+      "http://127.0.0.2:31338",
+    );
+  });
+
+  it("reconciles standard 127.0.0.1 and localhost loopbacks", () => {
+    live.apiBase = "http://127.0.0.1:31338";
+    expect(reconcilePersistedApiBaseWithLive("http://127.0.0.1:31337")).toBe(
+      "http://127.0.0.1:31338",
+    );
+
+    live.apiBase = "http://localhost:31338";
+    expect(reconcilePersistedApiBaseWithLive("http://localhost:31337")).toBe(
+      "http://localhost:31338",
+    );
+  });
+
+  it("reconciles across loopback forms (such as 127.0.0.1 to [::1])", () => {
+    live.apiBase = "http://[::1]:31338";
+    expect(reconcilePersistedApiBaseWithLive("http://127.0.0.1:31337")).toBe(
+      "http://[::1]:31338",
+    );
+  });
+
+  it("preserves persisted remote URL when live is loopback", () => {
+    live.apiBase = "http://127.0.0.1:31338";
+    expect(
+      reconcilePersistedApiBaseWithLive("https://remote-agent.example.com"),
+    ).toBe("https://remote-agent.example.com");
+  });
+
+  it("preserves persisted loopback URL when live is remote", () => {
+    live.apiBase = "https://remote-agent.example.com";
+    expect(reconcilePersistedApiBaseWithLive("http://127.0.0.1:31337")).toBe(
+      "http://127.0.0.1:31337",
+    );
+  });
+
+  it("does not reconcile lookalike or attacker hostnames", () => {
+    live.apiBase = "http://127.0.0.1:31338";
+    expect(
+      reconcilePersistedApiBaseWithLive("http://127.0.0.1.attacker.com:31337"),
+    ).toBe("http://127.0.0.1.attacker.com:31337");
+
+    expect(
+      reconcilePersistedApiBaseWithLive("http://localhost.evil.com:31337"),
+    ).toBe("http://localhost.evil.com:31337");
+  });
+
+  it("returns unchanged on matching or missing URLs", () => {
+    live.apiBase = "http://localhost:31337";
+    expect(reconcilePersistedApiBaseWithLive("http://localhost:31337")).toBe(
+      "http://localhost:31337",
+    );
+
+    live.apiBase = undefined;
+    expect(reconcilePersistedApiBaseWithLive("http://localhost:31337")).toBe(
+      "http://localhost:31337",
+    );
+
+    expect(reconcilePersistedApiBaseWithLive(undefined)).toBeUndefined();
+    expect(reconcilePersistedApiBaseWithLive("not-a-valid-url")).toBe(
+      "not-a-valid-url",
+    );
+  });
+});

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -5,6 +5,7 @@
  */
 
 import { logger } from "@elizaos/logger";
+import { isLoopbackBindHost } from "@elizaos/shared";
 import {
   isCloudPairAgentId,
   isCloudPairLoopbackOrigin,
@@ -284,8 +285,7 @@ function isMobileLocalActiveServer(
 }
 
 function isLoopbackHostname(hostname: string): boolean {
-  const h = hostname.toLowerCase();
-  return h === "127.0.0.1" || h === "localhost" || h === "::1";
+  return isLoopbackBindHost(hostname);
 }
 
 // Re-resolve a persisted loopback apiBase against whatever port the
@@ -293,7 +293,7 @@ function isLoopbackHostname(hostname: string): boolean {
 // previous session may have captured a stale port (e.g. 31337) when
 // the live API has moved (e.g. 31338). Without this, every restore
 // re-applies the dead URL and the renderer 404s on every fetch.
-function reconcilePersistedApiBaseWithLive(
+export function reconcilePersistedApiBaseWithLive(
   apiBase: string | undefined,
 ): string | undefined {
   if (!apiBase) return apiBase;


### PR DESCRIPTION
﻿## What

Uses canonical `isLoopbackBindHost` from `@elizaos/shared` in `reconcilePersistedApiBaseWithLive` within `packages/ui/src/state/startup-phase-restore.ts` instead of narrow string equality against `"127.0.0.1" | "localhost" | "::1"`.

## Why it matters

Fixes #30570.
Persisted desktop API restoration previously reapplied a stale port when the server used IPv6 loopback (`[::1]`) or an alternate address in the `127.0.0.0/8` block (such as `127.0.0.2`), because `URL.hostname` for IPv6 returns `"[::1]"` (with brackets) and alternate `127.x.x.x` addresses failed exact equality with `"127.0.0.1"`.

## Changes

- Updated `isLoopbackHostname` in `packages/ui/src/state/startup-phase-restore.ts` to delegate to `isLoopbackBindHost(hostname)`.
- Exported `reconcilePersistedApiBaseWithLive` for direct verification.
- Added unit tests in `packages/ui/src/state/startup-phase-restore.loopback-reconciliation.test.ts` covering IPv6 `[::1]`, alternate `127.0.0.2`, `localhost`, `127.0.0.1`, cross-loopback reconciliations, and remote/lookalike security boundaries.
