### PR TITLE
fix(registry): isolate generation CLI from public imports

### DIFF
--- a/packages/registry/AGENTS.md
+++ b/packages/registry/AGENTS.md
@@ -36,7 +36,8 @@ src/
   types.ts        RegistryEntry (source) + GeneratedRegistry (wire) types
   schema.ts       validateRegistryEntry / assertRegistryEntry (dependency-free)
   loader.ts       loadThirdPartyEntries — read + validate entries/third-party
-  generate.ts     generateRegistry / toGeneratedEntry — entries → wire format
+  generate.ts     import-safe generateRegistry / toGeneratedEntry conversion API
+  generate-cli.ts explicit filesystem writer used only by the package command
   validate-cli.ts `bun run validate`
   index.ts        public barrel (typed loader for programmatic consumers)
   first-party/    @elizaos/registry/first-party — curated bundled registry
@@ -102,8 +103,10 @@ bun run --cwd packages/registry format:check
 
 - The `@elizaos/*` scope is reserved for first-party packages — the validator
   rejects it in source entries.
-- `generate.ts` and `validate-cli.ts` are run with `bun` (TypeScript directly);
-  there is no `dist` build step beyond regenerating the JSON.
+- `generate-cli.ts` and `validate-cli.ts` are run with `bun` (TypeScript
+  directly); there is no `dist` build step beyond regenerating the JSON.
+- Keep executable entrypoints out of `src/index.ts`. Public imports are bundled
+  into native agents and must not perform generation or filesystem writes.
 - `zod` supports the first-party catalog. Do not make community-registry
   validation depend on first-party catalog types or schemas.
 

--- a/packages/registry/CLAUDE.md
+++ b/packages/registry/CLAUDE.md
@@ -36,7 +36,8 @@ src/
   types.ts        RegistryEntry (source) + GeneratedRegistry (wire) types
   schema.ts       validateRegistryEntry / assertRegistryEntry (dependency-free)
   loader.ts       loadThirdPartyEntries — read + validate entries/third-party
-  generate.ts     generateRegistry / toGeneratedEntry — entries → wire format
+  generate.ts     import-safe generateRegistry / toGeneratedEntry conversion API
+  generate-cli.ts explicit filesystem writer used only by the package command
   validate-cli.ts `bun run validate`
   index.ts        public barrel (typed loader for programmatic consumers)
   first-party/    @elizaos/registry/first-party — curated bundled registry
@@ -102,8 +103,10 @@ bun run --cwd packages/registry format:check
 
 - The `@elizaos/*` scope is reserved for first-party packages — the validator
   rejects it in source entries.
-- `generate.ts` and `validate-cli.ts` are run with `bun` (TypeScript directly);
-  there is no `dist` build step beyond regenerating the JSON.
+- `generate-cli.ts` and `validate-cli.ts` are run with `bun` (TypeScript
+  directly); there is no `dist` build step beyond regenerating the JSON.
+- Keep executable entrypoints out of `src/index.ts`. Public imports are bundled
+  into native agents and must not perform generation or filesystem writes.
 - `zod` supports the first-party catalog. Do not make community-registry
   validation depend on first-party catalog types or schemas.
 

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -19,7 +19,8 @@ packages/registry/
     ├── types.ts                RegistryEntry + GeneratedRegistry types
     ├── schema.ts               dependency-free entry validation
     ├── loader.ts               read + validate entries/third-party/*.json
-    ├── generate.ts             entries → generated-registry.json
+    ├── generate.ts             import-safe entries → wire conversion API
+    ├── generate-cli.ts         explicit generated-registry.json writer
     ├── validate-cli.ts         `bun run validate`
     └── index.ts                typed loader for programmatic consumers
 ```
@@ -30,8 +31,8 @@ Two formats live here:
    `elizaos plugins submit --dry-run` author. One file per package.
 2. **Generated wire registry** (`generated-registry.json`) — the
    `{ registry: { "<package>": { … } } }` shape the runtime consumes from
-   `plugins.eliza.app/generated-registry.json`. Produced by `generate.ts`;
-   never hand-edited.
+   `plugins.eliza.app/generated-registry.json`. Produced by `bun run generate`
+   through `generate-cli.ts`; never hand-edited.
 
 ## Commands
 

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "validate": "bun run src/validate-cli.ts",
-    "generate": "bun run src/generate.ts",
+    "generate": "bun run src/generate-cli.ts",
     "generate:first-party": "bun run src/first-party/generate.ts",
     "generate:first-party:check": "bun run src/first-party/generate.ts --check",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/packages/registry/src/bundled-import.test.ts
+++ b/packages/registry/src/bundled-import.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Proves the public registry API is inert in a real Bun bundle while the explicit
+ * package command still generates the canonical wire artifact in a filesystem fixture.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const bunExecutable = process.env.BUN_EXEC_PATH ?? "bun";
+const temporaryRoots: string[] = [];
+
+function makeTemporaryRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "registry-bundle-import-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("community registry executable boundary", () => {
+  it("does not generate files when the public API runs from a Bun bundle", () => {
+    const root = makeTemporaryRoot();
+    const bundleDir = path.join(root, "bundle");
+    const entryPath = path.join(root, "entry.ts");
+    const bundlePath = path.join(bundleDir, "entry.js");
+    const generatedPath = path.join(root, "generated-registry.json");
+    const publicEntryPath = path.join(packageRoot, "src", "index.ts");
+    mkdirSync(bundleDir);
+    writeFileSync(
+      entryPath,
+      [
+        `import { isValidRegistryPackageName } from ${JSON.stringify(publicEntryPath)};`,
+        'if (!isValidRegistryPackageName("community-plugin")) throw new Error("validator failed");',
+        'console.log("validator-ok");',
+        "",
+      ].join("\n"),
+    );
+
+    execFileSync(
+      bunExecutable,
+      ["build", entryPath, "--target", "bun", "--outfile", bundlePath],
+      { encoding: "utf8", stdio: "pipe" },
+    );
+    const stdout = execFileSync(bunExecutable, [bundlePath], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(stdout).toContain("validator-ok");
+    expect(existsSync(generatedPath)).toBe(false);
+  });
+
+  it("keeps the package generate command explicit and byte-compatible", () => {
+    const root = makeTemporaryRoot();
+    const fixtureRoot = path.join(root, "registry");
+    cpSync(path.join(packageRoot, "src"), path.join(fixtureRoot, "src"), {
+      recursive: true,
+    });
+    cpSync(
+      path.join(packageRoot, "entries"),
+      path.join(fixtureRoot, "entries"),
+      { recursive: true },
+    );
+    cpSync(
+      path.join(packageRoot, "package.json"),
+      path.join(fixtureRoot, "package.json"),
+    );
+
+    const stdout = execFileSync(bunExecutable, ["run", "generate"], {
+      cwd: fixtureRoot,
+      encoding: "utf8",
+    });
+    const generated = readFileSync(
+      path.join(fixtureRoot, "generated-registry.json"),
+      "utf8",
+    );
+    const canonical = readFileSync(
+      path.join(packageRoot, "generated-registry.json"),
+      "utf8",
+    );
+
+    expect(stdout).toContain("third-party entries");
+    expect(generated).toBe(canonical);
+  });
+});

--- a/packages/registry/src/generate-cli.ts
+++ b/packages/registry/src/generate-cli.ts
@@ -1,0 +1,20 @@
+/**
+ * Regenerates the committed community registry wire artifact on explicit invocation.
+ * It is an executable entrypoint and must never be exported by the importable package API.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateRegistry } from "./generate.ts";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const outputPath = path.join(packageRoot, "generated-registry.json");
+const registry = generateRegistry();
+
+fs.writeFileSync(outputPath, `${JSON.stringify(registry, null, 2)}\n`);
+const count = Object.keys(registry.registry).length;
+console.log(`Generated ${outputPath} (${count} third-party entries)`);

--- a/packages/registry/src/generate.ts
+++ b/packages/registry/src/generate.ts
@@ -1,25 +1,14 @@
 /**
- * Generate `generated-registry.json` — the wire format the runtime fetches —
- * from the source `entries/third-party/*.json` files.
- *
- * Run directly (`bun run src/generate.ts`) to regenerate the committed output.
+ * Converts validated community registry entries into the generated wire format.
+ * This module is import-safe; filesystem output belongs to the separate CLI entrypoint.
  */
 
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
 import { loadThirdPartyEntries } from "./loader.ts";
 import type {
   GeneratedRegistry,
   GeneratedRegistryEntry,
   RegistryEntry,
 } from "./types.ts";
-
-const packageRoot = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-);
-const OUTPUT_PATH = path.join(packageRoot, "generated-registry.json");
 
 function repoSlug(repository: string): string {
   return repository.replace(/^github:/, "");
@@ -95,31 +84,4 @@ export function generateRegistry(
     registry[entry.package] = toGeneratedEntry(entry);
   }
   return { registry };
-}
-
-function main(): void {
-  const registry = generateRegistry();
-  fs.writeFileSync(OUTPUT_PATH, `${JSON.stringify(registry, null, 2)}\n`);
-  const count = Object.keys(registry.registry).length;
-  console.log(`Generated ${OUTPUT_PATH} (${count} third-party entries)`);
-}
-
-function isDirectExecution(): boolean {
-  // Mobile builds bundle this module into the agent entry point. In that
-  // artifact import.meta.url and process.argv[1] both identify the bundle, so
-  // the ordinary direct-run check would regenerate a packaged read-only asset
-  // during every agent boot. The mobile bundler defines both markers.
-  if (
-    process.env.ELIZA_DISABLE_DIRECT_RUN === "1" ||
-    (globalThis as { __ELIZA_MOBILE_BUNDLE__?: unknown })
-      .__ELIZA_MOBILE_BUNDLE__ === true
-  ) {
-    return false;
-  }
-  const entry = process.argv[1];
-  return Boolean(entry) && import.meta.url === pathToFileURL(entry).href;
-}
-
-if (isDirectExecution()) {
-  main();
 }


### PR DESCRIPTION
Closes #30587.

Separate the registry filesystem writer into an unexported CLI entrypoint. Importing the public conversion API from an executed Bun bundle now has no generation side effect; the explicit package generate command keeps byte-identical output.

## Validation

Reviewed the complete diff and public registry consumers. This fixes a real import side effect: with current develop's generator, a minimal executed Bun bundle importing `isValidRegistryPackageName` writes an unintended empty generated-registry.json. I reproduced that behavior independently. The separated CLI prevents the write, while explicit generation remains byte-compatible.

Rebased head `6f17ed026f379727ff8c17b5757db02ddf08bc93` onto `f567055f1c3656590369e6f9c416c253a773f283` without conflicts. No implementation changes were necessary.

Independent validation with Bun 1.3.14 / Node 24.15.0:

- Registry tests: 7 files, 57 tests passed, including actual Bun build/subprocess import and CLI generation.
- Registry typecheck, lint:check, format:check, validate, generate:first-party:check: passed.
- Explicit `generate` left the canonical JSON byte-unchanged.
- Guide parity: passed.
- `bun install`: passed.
- Root `bun run verify`: 376/376 workspace tasks and all repository audits passed.

No rendered UI or model-facing behavior changed. The real executed bundle and generated-file inspection cover the changed package boundary; the author's separately documented native simulator startup is additional evidence, not a run I performed.


## Evidence

<!-- evidence-head:6f17ed026f379727ff8c17b5757db02ddf08bc93 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - No rendered UI change.

<!-- evidence-row:after-screenshots -->
- [x] N/A - No rendered UI change.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - No interactive UI or native transport behavior changes.

<!-- evidence-row:backend-logs -->
- [x] Executed Bun bundle and generator command results are documented above.

<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend path changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - No model, prompt, provider inference, or action behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] The explicit generator output was byte-compared against the canonical JSON; import-only execution creates no file.

<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered UI change.
