### PR TITLE
fix(cloud): reconcile outreachr delegations in account-deletion FK policy

### DIFF
--- a/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts
+++ b/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts
@@ -27,7 +27,7 @@ describe("account deletion full-schema foreign-key policy", () => {
       .update(descriptors.map(serializeDescriptor).join("\n"))
       .digest("hex");
 
-    expect(descriptors).toHaveLength(248);
+    expect(descriptors).toHaveLength(250);
     expect(digest).toBe(ACCOUNT_DELETION_FOREIGN_KEY_SNAPSHOT_SHA256);
   });
 
@@ -37,10 +37,10 @@ describe("account deletion full-schema foreign-key policy", () => {
       action: classifyAccountDeletionForeignKey(descriptor),
     }));
 
-    expect(classified).toHaveLength(248);
+    expect(classified).toHaveLength(250);
     expect(classified.every(({ action }) => Boolean(action))).toBe(true);
     expect(classified.filter(({ action }) => action === "reconcile_external_resource").length).toBe(
-      73,
+      75,
     );
     expect(classified.filter(({ action }) => action === "transfer_shared_resource").length).toBe(
       11,
@@ -79,6 +79,32 @@ describe("account deletion full-schema foreign-key policy", () => {
       onDelete: "cascade",
     });
     expect(classifyAccountDeletionForeignKey(admissionWork!)).toBe("reconcile_external_resource");
+  });
+
+  test("requires reconciliation before deleting outreachr delegations", () => {
+    const delegations = listAccountDeletionForeignKeys().filter(
+      ({ sourceTable }) => sourceTable === "outreachr_delegations",
+    );
+
+    expect(delegations).toEqual([
+      {
+        sourceTable: "outreachr_delegations",
+        sourceColumns: "organization_id",
+        targetTable: "organizations",
+        targetColumns: "id",
+        onDelete: "cascade",
+      },
+      {
+        sourceTable: "outreachr_delegations",
+        sourceColumns: "user_id",
+        targetTable: "users",
+        targetColumns: "id",
+        onDelete: "cascade",
+      },
+    ]);
+    for (const descriptor of delegations) {
+      expect(classifyAccountDeletionForeignKey(descriptor)).toBe("reconcile_external_resource");
+    }
   });
 
   test("anonymizes all four billing-cancel subject relationships", () => {

--- a/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.ts
+++ b/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.ts
@@ -23,9 +23,9 @@ export interface AccountDeletionForeignKeyDescriptor {
   targetColumns: string;
   onDelete: string;
 }
-/** SHA-256 of the 248 sorted direct user/organization FK descriptors. */
+/** SHA-256 of the 250 sorted direct user/organization FK descriptors. */
 export const ACCOUNT_DELETION_FOREIGN_KEY_SNAPSHOT_SHA256 =
-  "40df404dcdd7a24d2ff9dae7e9ae308eb4f422db2a94db8ca0d912d5eb1a9608";
+  "188ac83877c2538f847e72cb055a5a684d72fdf9d84c29437d522ce07ab9eb75";
 
 function serializeDescriptor(descriptor: AccountDeletionForeignKeyDescriptor): string {
   return [
@@ -110,6 +110,7 @@ const EXTERNAL_RESOURCE_TABLES = new Set([
   "org_storage_put_operations",
   "org_storage_read_operations",
   "organization_encryption_keys",
+  "outreachr_delegations",
   "platform_credential_sessions",
   "platform_credentials",
   "pooled_credentials",


### PR DESCRIPTION
# Relates to
Develop `develop` workflow health: `Develop Full` run 33953591123 on 1045297ccaffff37519a6a4b2a0203c273443a84 fails in `canonical / Smoke lanes` with 2 failures in `account deletion full-schema foreign-key policy` (Expected length 248, Received 250). No `mission-ready` issue exists; this restores the required gate under the epoch-completion permit.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and relevant verification were run after sync; full `bun run verify` not run due to scope (see Known gaps).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop
- [x] Rebased onto `origin/develop` 1045297ccaffff37519a6a4b2a0203c273443a84; zero conflicts.
- [x] Focused test + typecheck + lint pass post-sync (see Evidence Details).

# Risks
Low. Touches only the account-deletion FK inventory snapshot/classification and its ratchet test. Adds `outreachr_delegations` (added in 182c3ebad without updating the ratchet) to `EXTERNAL_RESOURCE_TABLES` so its user/org FKs require explicit reconciliation instead of silent cascade. No runtime deletion logic changes.

# Background
## What does this PR do?
Updates `packages/cloud/shared/src/db/account-deletion-foreign-key-policy.ts` snapshot from 248 to 250 FKs (SHA 40df40... -> 188ac838...) and classifies the two new `outreachr_delegations` user/org FKs as `reconcile_external_resource` (73 -> 75). Updates the ratchet test counts and adds an explicit test pinning both new FK descriptors and their reconciliation requirement.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
`packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts` — run `bun test packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts`.

## Detailed testing steps
- `git fetch origin && git checkout 76a7d5bbadb57dde84ff6120bb9f419ee2caf828`
- `bun install`
- `bun test packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts` -> 7 pass, 0 fail (was 4 pass, 2 fail on base).
- `bun run --cwd packages/cloud/shared typecheck` -> pass.
- `bun run --cwd packages/cloud/shared lint` -> pass (Biome, no fixes).

# Evidence Gate
<!-- evidence-head:76a7d5bbadb57dde84ff6120bb9f419ee2caf828 -->
<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - No UI surface; DB deletion-policy change only`.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - No UI surface; DB deletion-policy change only`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough of the complete user flow is attached, or marked `N/A - No user flow; backend policy ratchet fix verified by automated test`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end (see Evidence Details).
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response and state change, or marked `N/A - No frontend path; cloud DB policy only`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - No agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts attached (FK inventory count/digest/classification; see Evidence Details).
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached for UI changes, or marked `N/A - No rendered visual surface`.

# Evidence Details
## Backend logs
Base (origin/develop 1045297cc) reproduces the CI failure locally:
```
Expected length: 248
Received length: 250
(fail) account deletion full-schema foreign-key policy > pins the exact direct user and organization FK inventory
(fail) account deletion full-schema foreign-key policy > classifies every FK without an implicit destructive fallback
4 pass, 2 fail
```
After fix:
```
7 pass, 0 fail, 17 expect() calls
Ran 7 tests across 1 file.
```
CI reference: `Develop Full` run 33953591123 jobs `canonical / Smoke lanes` and `canonical / Smoke (6)` fail on the same 2 tests.

## Domain artifacts
- `listAccountDeletionForeignKeys()` count: 250 (was 248)
- Snapshot SHA-256: `188ac83877c2538f847e72cb055a5a684d72fdf9d84c29437d522ce07ab9eb75`
- New descriptors: `outreachr_delegations.organization_id -> organizations.id (cascade)`, `outreachr_delegations.user_id -> users.id (cascade)`
- Classification: `reconcile_external_resource: 75`, `delete_private_data: 100`, `anonymize_retained_record: 64`, `transfer_shared_resource: 11`

## Provider/model disclosure
Provider: meta, Model: muse-spark-1.3-contributor-free, Client: opencode (unsupported adapter; usage unavailable).

# Known gaps / failures
Full `bun run verify` not run (scope is one cloud DB policy + test; focused typecheck/lint/test pass). `Develop Full` CI rerun pending on this PR head.