### PR TITLE
fix(cloud): repair cloud test contracts dropped with Outreachr FKs and admission reads

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-explicit-max-tokens-route.test.ts
@@ -304,6 +304,10 @@ mock.module("@/lib/services/ai-billing", () => ({
   })),
   recordUsageAnalytics: mock(async () => ({ id: "usage-record-1" })),
   InsufficientCreditsError: TestInsufficientCreditsError,
+  // Admission pays its authoritative subscription-entitlement read before credit
+  // reservation (organization-inference-admission); this harness has no
+  // subscription schema, so treat every org as credits-funded.
+  isSubscriptionFundedOrganization: mock(async () => false),
 }));
 
 mock.module("@/lib/services/ai-billing-records", () => ({

--- a/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts
+++ b/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts
@@ -27,7 +27,7 @@ describe("account deletion full-schema foreign-key policy", () => {
       .update(descriptors.map(serializeDescriptor).join("\n"))
       .digest("hex");
 
-    expect(descriptors).toHaveLength(248);
+    expect(descriptors).toHaveLength(250);
     expect(digest).toBe(ACCOUNT_DELETION_FOREIGN_KEY_SNAPSHOT_SHA256);
   });
 
@@ -37,10 +37,10 @@ describe("account deletion full-schema foreign-key policy", () => {
       action: classifyAccountDeletionForeignKey(descriptor),
     }));
 
-    expect(classified).toHaveLength(248);
+    expect(classified).toHaveLength(250);
     expect(classified.every(({ action }) => Boolean(action))).toBe(true);
     expect(classified.filter(({ action }) => action === "reconcile_external_resource").length).toBe(
-      73,
+      75,
     );
     expect(classified.filter(({ action }) => action === "transfer_shared_resource").length).toBe(
       11,

--- a/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.ts
+++ b/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.ts
@@ -23,9 +23,9 @@ export interface AccountDeletionForeignKeyDescriptor {
   targetColumns: string;
   onDelete: string;
 }
-/** SHA-256 of the 248 sorted direct user/organization FK descriptors. */
+/** SHA-256 of the 250 sorted direct user/organization FK descriptors. */
 export const ACCOUNT_DELETION_FOREIGN_KEY_SNAPSHOT_SHA256 =
-  "40df404dcdd7a24d2ff9dae7e9ae308eb4f422db2a94db8ca0d912d5eb1a9608";
+  "188ac83877c2538f847e72cb055a5a684d72fdf9d84c29437d522ce07ab9eb75";
 
 function serializeDescriptor(descriptor: AccountDeletionForeignKeyDescriptor): string {
   return [
@@ -110,6 +110,7 @@ const EXTERNAL_RESOURCE_TABLES = new Set([
   "org_storage_put_operations",
   "org_storage_read_operations",
   "organization_encryption_keys",
+  "outreachr_delegations",
   "platform_credential_sessions",
   "platform_credentials",
   "pooled_credentials",


### PR DESCRIPTION
## Summary

Two deterministic `Cloud tests` failures at the develop head (`1045297ccaffff37519a6a4b2a0203c273443a84`, Develop Full run 33953591123, job 101273052031):

1. **`account-deletion-foreign-key-policy.test.ts`** — pinned a 248-descriptor FK inventory, got 250. `182c3ebad2` (#30607) added `outreachr_delegations` with `user_id`→users and `organization_id`→organizations cascade FKs without classifying them. The delegation client exposes an external revoke (`outreachr-delegation.ts` `deleteGrant`), and every other connection-style table (`discord_connections`, `telegram_chats`, `vendor_connections`, …) is `reconcile_external_resource` — a bare cascade would leave a live external identity grant behind after account deletion. This classifies the table as an external resource and re-pins the inventory (250, external 75) with the recomputed snapshot digest.
2. **`chat-completions-explicit-max-tokens-route.test.ts`** — 6 failures turning the 402-translation and forwarding cases into 500s. `a445c705a` (#30166) moved the authoritative subscription-entitlement read (`isSubscriptionFundedOrganization`) ahead of credit reservation in `admitOrganizationInference`; this suite's spread-actuals `ai-billing` mock let the real read hit the schemaless test PGlite (`relation "organization_entitlements" does not exist`). The same commit updated its sibling suites (`messages-billing-offpath.test.ts`, `generative-route-auth.test.ts`) but missed this one. The fix pins the boundary to credits-funded with the sibling-suite idiom.

## Evidence

| Row | Result |
| --- | --- |
| Evidence head | `da8092db990d5433c3308a5ffd382938230c9989` |
| Reproduction (red) at develop head | disposable container (oven/bun:1.3.14, `bun install --frozen-lockfile --ignore-scripts`, archive of `1045297cca`, md5-verified): FK policy 2 fail/6, max-tokens 6 fail/10 — matches hosted job 101273052031 |
| Fix (green) at fix head, same container | FK policy 6/6 pass, max-tokens 10/10 pass |
| Regression sweep | `account-deletion-provider-adapters.test.ts` 13/13, `account-deletion-export.test.ts` 8/8 (isolated per the run-unit-isolated contract) |
| Hygiene | `biome check` clean on all three changed files; `tsc --noEmit` clean in `packages/cloud/shared` and `packages/cloud/api` |
| Hosted checks | fork PR — awaiting maintainer workflow approval (native `action_required` banner); no hosted lane runs on fork heads until then |
| Desktop/mobile screenshots | N/A - no UI surface changed (cloud test/policy files only) |
| Walkthrough video | N/A - no user-visible behavior change |
| Live-model trajectory | N/A - no agent/model-path change |

## Reviewer notes

- The digest constant change (`40df404d…` → `188ac838…`) is the recomputed SHA-256 over the widened 250-descriptor serialization; the recompute script and per-class counts (`reconcile_external_resource` 73→75 — the table contributes **two** FKs) are in the container log.
- The remaining `Smoke lanes` failures at this head are NOT addressed here and are separately owned or unclassified: cartesia-synthesis (open #30529), route-provider-selection Server-Timing (open #30395), the `object-store-immutable-upload` 15ms HEAD deadline race and the `agent-bridge-runtime-routing` sentinel-traceId assertion (both flaky-suspect, no repo cause pinned), and the Smoke (6) browser-workspace assertion.

— [eliza-review]
<!-- slop-contribution-attribution:v1 {"provider":"zai","model":"glm-5.3-1m","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1RBF3JAVFDQFV3QPW0DK7TX","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-05T08:37:52.843Z","completed_at":"2026-09-05T10:53:33.802Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-05T08:38:02.084Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":551729,"output_tokens":213036,"cache_creation_tokens":0,"cache_read_tokens":61051584,"total_tokens":61816349,"cost_micro_usd":"17583192","session_count":4},"trajectory_sha256":"4264aae6bbb10f75b4d6d88f0053ec77ba5417f58785161b27aa1da3791ba838","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d3a00b72-a444-41ce-b2a9-288e82576587","object_id":"sha256:4264aae6bbb10f75b4d6d88f0053ec77ba5417f58785161b27aa1da3791ba838","sha256":"4264aae6bbb10f75b4d6d88f0053ec77ba5417f58785161b27aa1da3791ba838"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAR850XHeZVEfYMatnrCiWT7P3QZHECM3R-C2VnfZ8iZQ","device_key_id":"5935e4ed75d7ef04a6827ac468d61a17e4bba8f871647762e8ff62c5e50dda49","device_signature":"8LGwdZ5hUK-PEgtbDy7zR_e1U4esX7btIaYN1ai7VOikqMK0gQKTqjjmPThw2fbUfY_oCNkvQWEt_6ZJz9qCCQ"}} -->
