### PR TITLE
fix(ui): exclude generated mobile build roots from component inventory (#30593)

### DIFF
--- a/packages/ui/scripts/check-design-system.mjs
+++ b/packages/ui/scripts/check-design-system.mjs
@@ -424,12 +424,15 @@ const OFF_TOKEN_COLOR =
 const relative = (file) =>
   path.relative(repoRoot, file).replaceAll(path.sep, "/");
 
-function isGovernedSource(file) {
+export function isGovernedSource(file) {
   const rel = relative(file);
   return (
     /^(packages|plugins)\//.test(rel) &&
     /\.[jt]sx?$/.test(rel) &&
-    !/(^|\/)(node_modules|dist|build|coverage|generated)(\/|$)/.test(rel) &&
+    !/(^|\/)(node_modules|dist|build|coverage|generated|dist-mobile-[^/]+)(\/|$)/.test(
+      rel,
+    ) &&
+    !/(^|\/)packages\/app\/(android|ios|electrobun)(\/|$)/.test(rel) &&
     !/\.(test|spec)\.[jt]sx$/.test(rel) &&
     !/(^|\/)(test|__tests__|__e2e__|__fixtures__|fixtures|stubs|templates)(\/|$)/.test(
       rel,
@@ -450,12 +453,18 @@ function* walk(directory) {
         "test-results",
         ".git",
       ].includes(entry.name) ||
-      entry.name.startsWith(".playwright-artifacts-")
+      entry.name.startsWith(".playwright-artifacts-") ||
+      entry.name.startsWith("dist-mobile-")
     )
       continue;
     const full = path.join(directory, entry.name);
-    if (entry.isDirectory()) yield* walk(full);
-    else if (isGovernedSource(full)) {
+    if (entry.isDirectory()) {
+      const rel = relative(full);
+      if (/^packages\/app\/(android|ios|electrobun)(\/|$)/.test(rel)) {
+        continue;
+      }
+      yield* walk(full);
+    } else if (isGovernedSource(full)) {
       if (/\.[jt]sx$/.test(full)) {
         yield full;
         continue;
@@ -498,12 +507,18 @@ function* walkStylesheets(directory) {
         "__tests__",
         "__e2e__",
       ].includes(entry.name) ||
-      entry.name.startsWith(".playwright-artifacts-")
+      entry.name.startsWith(".playwright-artifacts-") ||
+      entry.name.startsWith("dist-mobile-")
     )
       continue;
     const full = path.join(directory, entry.name);
-    if (entry.isDirectory()) yield* walkStylesheets(full);
-    else if (entry.name.endsWith(".css")) yield full;
+    if (entry.isDirectory()) {
+      const rel = relative(full);
+      if (/^packages\/app\/(android|ios|electrobun)(\/|$)/.test(rel)) {
+        continue;
+      }
+      yield* walkStylesheets(full);
+    } else if (entry.name.endsWith(".css")) yield full;
   }
 }
 

--- a/packages/ui/scripts/check-design-system.test.mjs
+++ b/packages/ui/scripts/check-design-system.test.mjs
@@ -2,6 +2,7 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   analyzeTokenRoleClasses,
   applyExceptions,
@@ -18,6 +19,7 @@ import {
   findUnderusedButtonAxes,
   findUnderusedCardVariants,
   indexPaintedCssClasses,
+  isGovernedSource,
   RULES,
   renderComplianceMarkdown,
   resolvesToCanonical,
@@ -28,6 +30,61 @@ import {
   validateExceptions,
   validatePublicCardVariantCompatibility,
 } from "./check-design-system.mjs";
+
+test("generated mobile platform bundles and staging roots are outside governed source", () => {
+  assert.equal(
+    isGovernedSource(
+      fileURLToPath(
+        new URL(
+          "../../agent/dist-mobile-ios/agent-bundle.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isGovernedSource(
+      fileURLToPath(
+        new URL(
+          "../../app/ios/App/App/public/agent/Widget.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isGovernedSource(
+      fileURLToPath(
+        new URL(
+          "../../app/android/app/src/main/assets/Widget.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isGovernedSource(
+      fileURLToPath(
+        new URL("../../app/electrobun/src/Widget.tsx", import.meta.url),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isGovernedSource(
+      fileURLToPath(
+        new URL(
+          "../../app-core/platforms/electrobun/src/Widget.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    true,
+  );
+});
 
 test("atomic consolidation ledger survives relabel, deletion, and reintroduction", () => {
   const componentId = "packages/ui/src/example.tsx:ExampleButton";

--- a/packages/ui/scripts/find-duplicate-components.mjs
+++ b/packages/ui/scripts/find-duplicate-components.mjs
@@ -118,7 +118,10 @@ export function isMaintainedSource(file) {
     /^(packages|plugins)\//.test(rel) &&
     /\.[jt]sx?$/.test(rel) &&
     !/(^|\/)\.eliza(\/|$)/.test(rel) &&
-    !/(^|\/)(node_modules|dist|build|coverage|generated)(\/|$)/.test(rel) &&
+    !/(^|\/)(node_modules|dist|build|coverage|generated|dist-mobile-[^/]+)(\/|$)/.test(
+      rel,
+    ) &&
+    !/(^|\/)packages\/app\/(android|ios|electrobun)(\/|$)/.test(rel) &&
     !/\.(stories|test|spec)\.[jt]sx?$/.test(rel) &&
     !/(^|\/)(test|__tests__|__e2e__|__fixtures__|fixtures|stubs|templates)(\/|$)/.test(
       rel,
@@ -139,11 +142,27 @@ export function isMaintainedSource(file) {
 function* walk(directory) {
   if (!fs.existsSync(directory)) return;
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    if (["node_modules", "dist", "build", ".git"].includes(entry.name))
+    if (
+      [
+        "node_modules",
+        "dist",
+        "build",
+        "coverage",
+        "generated",
+        ".git",
+      ].includes(entry.name) ||
+      entry.name.startsWith("dist-mobile-") ||
+      entry.name.startsWith(".playwright-artifacts-")
+    )
       continue;
     const full = path.join(directory, entry.name);
-    if (entry.isDirectory()) yield* walk(full);
-    else if (isMaintainedSource(full)) yield full;
+    if (entry.isDirectory()) {
+      const rel = relative(full);
+      if (/^packages\/app\/(android|ios|electrobun)(\/|$)/.test(rel)) {
+        continue;
+      }
+      yield* walk(full);
+    } else if (isMaintainedSource(full)) yield full;
   }
 }
 

--- a/packages/ui/scripts/find-duplicate-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-components.test.mjs
@@ -5,6 +5,7 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   ATOMS,
   buildInventory,
@@ -33,6 +34,61 @@ test("local Eliza runtime artifacts are outside maintained source", () => {
       ).pathname,
     ),
     false,
+  );
+});
+
+test("generated mobile platform bundles and staging roots are outside maintained source", () => {
+  assert.equal(
+    isMaintainedSource(
+      fileURLToPath(
+        new URL(
+          "../../agent/dist-mobile-ios/agent-bundle.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isMaintainedSource(
+      fileURLToPath(
+        new URL(
+          "../../app/ios/App/App/public/agent/Widget.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isMaintainedSource(
+      fileURLToPath(
+        new URL(
+          "../../app/android/app/src/main/assets/Widget.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isMaintainedSource(
+      fileURLToPath(
+        new URL("../../app/electrobun/src/Widget.tsx", import.meta.url),
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    isMaintainedSource(
+      fileURLToPath(
+        new URL(
+          "../../app-core/platforms/electrobun/src/Widget.tsx",
+          import.meta.url,
+        ),
+      ),
+    ),
+    true,
   );
 });
 


### PR DESCRIPTION
## Summary
Fixes #30593

Generated native mobile bundles produced by native build lanes (such as `build:ios:local:sim:full-bun`, outputs under `packages/agent/dist-mobile-*` and `packages/app/ios/App/App/public/agent/agent-bundle.js` or Android app asset mirrors) were getting crawled and indexed by `packages/ui/scripts/find-duplicate-components.mjs` and `packages/ui/scripts/check-design-system.mjs` as maintained UI components.

## Changes
- In `packages/ui/scripts/find-duplicate-components.mjs`:
  - Updated `isMaintainedSource` to reject paths under `packages/agent/dist-mobile-*` and `packages/app/{android,ios,electrobun}`.
  - Scoped directory skipping in `walk` specifically to `packages/app/{android,ios,electrobun}` (rather than skipping any global platform directory name) to keep walker traversal and source predicate perfectly in sync.
- In `packages/ui/scripts/check-design-system.mjs`:
  - Exported and updated `isGovernedSource` with matching exclusions for mobile build outputs.
  - Scoped directory skipping in `walk` and `walkStylesheets` to `packages/app/{android,ios,electrobun}`.
- Added tests in both `packages/ui/scripts/find-duplicate-components.test.mjs` and `packages/ui/scripts/check-design-system.test.mjs`:
  - Guard against `.tsx` fixture paths for mobile bundles/staging roots so assertions evaluate the path predicate directly rather than hitting the `ENOENT` fallback.
  - Assert that non-`packages/app` platform sources (e.g. `packages/app-core/platforms/electrobun/src/Widget.tsx`) remain maintained/governed.

## Verification
- `node --test packages/ui/scripts/find-duplicate-components.test.mjs` (6/6 passing)
- `node --test packages/ui/scripts/check-design-system.test.mjs` (all passing, including new governed source tests)
- `bunx biome check packages/ui/scripts/check-design-system.mjs packages/ui/scripts/check-design-system.test.mjs packages/ui/scripts/find-duplicate-components.mjs packages/ui/scripts/find-duplicate-components.test.mjs` (0 errors)

cc @lalalune