### PR TITLE
fix(sql): reject malformed results in remaining domain stores (#30610)

### DIFF
--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -31,6 +31,7 @@ import {
   parseCanonicalInteger,
   type ReadJsonBodyOptions,
 } from "@elizaos/shared";
+import { extractRows, sqlQuote } from "@elizaos/shared/db/raw-sql";
 import type { infer as ZodInfer } from "zod";
 import * as zod from "zod";
 import {
@@ -645,29 +646,6 @@ interface ConnectorAccountAuditReader {
   getDatabase?: () => {
     execute?: (query: unknown) => Promise<unknown>;
   };
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function extractRows(value: unknown): Record<string, unknown>[] {
-  if (Array.isArray(value)) {
-    return value
-      .map(asRecord)
-      .filter((row): row is Record<string, unknown> => row !== null);
-  }
-  const record = asRecord(value);
-  if (!record || !Array.isArray(record.rows)) return [];
-  return record.rows
-    .map(asRecord)
-    .filter((row): row is Record<string, unknown> => row !== null);
-}
-
-function sqlQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
 }
 
 export function parseAuditLimit(value: string | undefined): number | "invalid" {

--- a/packages/agent/src/services/approval/sql.test.ts
+++ b/packages/agent/src/services/approval/sql.test.ts
@@ -75,14 +75,14 @@ describe("parseJsonRecord", () => {
   });
 
   it("throws when the parsed value is not an object", () => {
-    expect(() => parseJsonRecord("[1]")).toThrow("Expected JSON object");
-    expect(() => parseJsonRecord([])).toThrow("Expected JSON object");
-    expect(() => parseJsonRecord("null")).toThrow("Expected JSON object");
-    expect(() => parseJsonRecord('"x"')).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord("[1]")).toThrow("Expected SQL JSON object");
+    expect(() => parseJsonRecord([])).toThrow("Expected SQL JSON object");
+    expect(() => parseJsonRecord("null")).toThrow("Expected SQL JSON object");
+    expect(() => parseJsonRecord('"x"')).toThrow("Expected SQL JSON object");
   });
 
   it("throws on invalid JSON strings and non-object primitives", () => {
-    expect(() => parseJsonRecord("not json")).toThrow("Invalid JSON value");
+    expect(() => parseJsonRecord("not json")).toThrow("Invalid SQL JSON value");
     expect(() => parseJsonRecord(42)).toThrow(
       "Expected JSON string or object, received number",
     );
@@ -114,12 +114,12 @@ describe("sql literals", () => {
     expect(sqlInteger(0)).toBe("0");
     expect(sqlInteger(null)).toBe("NULL");
     expect(sqlInteger(undefined)).toBe("NULL");
-    expect(() => sqlInteger(Number.NaN)).toThrow("invalid numeric SQL literal");
+    expect(() => sqlInteger(Number.NaN)).toThrow("Invalid numeric SQL literal");
     expect(() => sqlInteger(Number.POSITIVE_INFINITY)).toThrow(
-      "invalid numeric SQL literal",
+      "Invalid numeric SQL literal",
     );
     expect(() => sqlInteger(Number.NEGATIVE_INFINITY)).toThrow(
-      "invalid numeric SQL literal",
+      "Invalid numeric SQL literal",
     );
   });
 
@@ -159,7 +159,7 @@ describe("executeRawSql", () => {
     ]);
   });
 
-  it("drops non-object entries from an array result", async () => {
+  it("rejects non-object entries from an array result", async () => {
     const runtime = runtimeWithExecute(async () => [
       { id: "keep" },
       null,
@@ -167,14 +167,14 @@ describe("executeRawSql", () => {
       "nope",
       1,
     ]);
-    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
-      { id: "keep" },
-    ]);
+    await expect(executeRawSql(runtime, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
   });
 
-  it("extracts object rows from a { rows } envelope", async () => {
+  it("extracts object rows from a valid { rows } envelope", async () => {
     const runtime = runtimeWithExecute(async () => ({
-      rows: [{ id: "a" }, null, { id: "b" }, "skip"],
+      rows: [{ id: "a" }, { id: "b" }],
     }));
     await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
       { id: "a" },
@@ -182,18 +182,26 @@ describe("executeRawSql", () => {
     ]);
   });
 
-  it("returns an empty list when { rows } is missing or not an array", async () => {
+  it("rejects when { rows } is missing or not an array", async () => {
     const missing = runtimeWithExecute(async () => ({ count: 0 }));
     const notArray = runtimeWithExecute(async () => ({ rows: "nope" }));
-    await expect(executeRawSql(missing, "SELECT 1")).resolves.toEqual([]);
-    await expect(executeRawSql(notArray, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(missing, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
+    await expect(executeRawSql(notArray, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
   });
 
-  it("returns an empty list for a non-object, non-array execute result", async () => {
+  it("rejects a non-object, non-array execute result", async () => {
     const none = runtimeWithExecute(async () => null);
     const scalar = runtimeWithExecute(async () => 42);
-    await expect(executeRawSql(none, "SELECT 1")).resolves.toEqual([]);
-    await expect(executeRawSql(scalar, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(none, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
+    await expect(executeRawSql(scalar, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
   });
 
   it("throws when the runtime database adapter is unavailable", async () => {

--- a/packages/agent/src/services/approval/sql.ts
+++ b/packages/agent/src/services/approval/sql.ts
@@ -1,89 +1,38 @@
 /**
- * Self-contained raw-SQL helpers for the runtime approval queue.
- *
- * The approval store issues raw SQL against the agent's database adapter over
- * the `approval_requests` table owned by `@elizaos/plugin-sql` (public schema).
- * This is the minimal subset of encoders/parsers/runners the store needs; it is
- * intentionally local to `@elizaos/agent` so the runtime approval queue carries
- * no dependency on plugin-side SQL glue. Mirrors `knowledge-graph/sql.ts`.
+ * Resolves the runtime approval database and delegates raw-SQL primitives
+ * to shared. Existing domain exports and transaction boundaries remain stable.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import {
+  executeSql,
+  type RuntimeDb,
+  type TransactionalDb,
+} from "@elizaos/shared/db/raw-sql";
 
-type RawSqlQuery = {
-  queryChunks: Array<{ value?: unknown }>;
-};
+export {
+  asObject,
+  extractRows,
+  OptimisticLockError,
+  parseJsonArray,
+  parseJsonRecord,
+  parseJsonValue,
+  type RawSqlQuery,
+  type RuntimeDb,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  type TransactionalDb,
+  toBoolean,
+  toNumber,
+  toText,
+  withOptimisticRetry,
+} from "@elizaos/shared/db/raw-sql";
 
-type RuntimeDb = {
-  execute: (query: RawSqlQuery) => Promise<unknown>;
-};
-
-let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
-
-function asObject(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-export function toText(value: unknown, fallback = ""): string {
-  if (typeof value === "string") return value;
-  if (value === null || value === undefined) return fallback;
-  return String(value);
-}
-
-function isMissingJsonValue(value: unknown): boolean {
-  return value === null || value === undefined || value === "";
-}
-
-function parseJsonValue<T>(value: unknown, fallback: T): T {
-  if (isMissingJsonValue(value)) return fallback;
-  if (typeof value !== "string") {
-    if (typeof value === "object") return value as T;
-    throw new Error(
-      `[ApprovalSql] Expected JSON string or object, received ${typeof value}`,
-    );
-  }
-  try {
-    return JSON.parse(value) as T;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`[ApprovalSql] Invalid JSON value: ${message}`);
-  }
-}
-
-export function parseJsonRecord(value: unknown): Record<string, unknown> {
-  if (isMissingJsonValue(value)) return {};
-  const parsed = parseJsonValue<Record<string, unknown> | null>(value, null);
-  const object = asObject(parsed);
-  if (object) return object;
-  throw new Error("[ApprovalSql] Expected JSON object");
-}
-
-function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result
-      .map((row) => asObject(row))
-      .filter((row): row is Record<string, unknown> => row !== null);
-  }
-  const object = asObject(result);
-  if (!object) return [];
-  const rows = object.rows;
-  if (!Array.isArray(rows)) return [];
-  return rows
-    .map((row) => asObject(row))
-    .filter((row): row is Record<string, unknown> => row !== null);
-}
-
-async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
-  if (cachedSqlRaw) return cachedSqlRaw;
-  const drizzle = (await import("drizzle-orm")) as {
-    sql: { raw: (query: string) => RawSqlQuery };
-  };
-  cachedSqlRaw = drizzle.sql.raw;
-  return cachedSqlRaw;
-}
-
-function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
+export function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.adapter.db as RuntimeDb | undefined;
   if (!db || typeof db.execute !== "function") {
     throw new Error("runtime database adapter unavailable");
@@ -95,10 +44,8 @@ export async function executeRawSql(
   runtime: IAgentRuntime,
   sqlText: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const raw = await getSqlRaw();
   const db = getRuntimeDb(runtime);
-  const result = await db.execute(raw(sqlText));
-  return extractRows(result);
+  return executeSql(db, sqlText);
 }
 
 /**
@@ -107,38 +54,9 @@ export async function executeRawSql(
  * accepted directly: plugins that must commit a domain mutation and its owner
  * approval together pass their `tx` into the approval store.
  */
-export type TransactionalDb = {
-  execute: (query: RawSqlQuery) => Promise<unknown>;
-};
-
-/**
- * Transactional analogue of {@link executeRawSql}. Every statement issued
- * through the same handle commits or rolls back as one unit.
- */
 export async function executeRawSqlTx(
   tx: TransactionalDb,
   sqlText: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const raw = await getSqlRaw();
-  const result = await tx.execute(raw(sqlText));
-  return extractRows(result);
-}
-
-export function sqlQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-export function sqlText(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  return sqlQuote(value);
-}
-
-export function sqlInteger(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(Math.trunc(value));
-}
-
-export function sqlJson(value: unknown): string {
-  return sqlQuote(JSON.stringify(value ?? null));
+  return executeSql(tx, sqlText);
 }

--- a/packages/agent/src/services/knowledge-graph/sql.test.ts
+++ b/packages/agent/src/services/knowledge-graph/sql.test.ts
@@ -142,7 +142,7 @@ describe("parseJsonValue", () => {
 
   it("throws on invalid JSON strings and non-object primitives", () => {
     expect(() => parseJsonValue("not json", null)).toThrow(
-      "Invalid JSON value",
+      "Invalid SQL JSON value",
     );
     expect(() => parseJsonValue(42, null)).toThrow(
       "Expected JSON string or object, received number",
@@ -170,14 +170,14 @@ describe("parseJsonRecord", () => {
   });
 
   it("throws when the parsed value is not an object", () => {
-    expect(() => parseJsonRecord("[1]")).toThrow("Expected JSON object");
-    expect(() => parseJsonRecord([])).toThrow("Expected JSON object");
-    expect(() => parseJsonRecord("null")).toThrow("Expected JSON object");
-    expect(() => parseJsonRecord('"x"')).toThrow("Expected JSON object");
+    expect(() => parseJsonRecord("[1]")).toThrow("Expected SQL JSON object");
+    expect(() => parseJsonRecord([])).toThrow("Expected SQL JSON object");
+    expect(() => parseJsonRecord("null")).toThrow("Expected SQL JSON object");
+    expect(() => parseJsonRecord('"x"')).toThrow("Expected SQL JSON object");
   });
 
   it("throws on invalid JSON strings and non-object primitives", () => {
-    expect(() => parseJsonRecord("not json")).toThrow("Invalid JSON value");
+    expect(() => parseJsonRecord("not json")).toThrow("Invalid SQL JSON value");
     expect(() => parseJsonRecord(42)).toThrow(
       "Expected JSON string or object, received number",
     );
@@ -204,10 +204,10 @@ describe("parseJsonArray", () => {
   });
 
   it("throws when the parsed value is not an array", () => {
-    expect(() => parseJsonArray('{"a":1}')).toThrow("Expected JSON array");
-    expect(() => parseJsonArray({ a: 1 })).toThrow("Expected JSON array");
-    expect(() => parseJsonArray("null")).toThrow("Expected JSON array");
-    expect(() => parseJsonArray('"x"')).toThrow("Expected JSON array");
+    expect(() => parseJsonArray('{"a":1}')).toThrow("Expected SQL JSON array");
+    expect(() => parseJsonArray({ a: 1 })).toThrow("Expected SQL JSON array");
+    expect(() => parseJsonArray("null")).toThrow("Expected SQL JSON array");
+    expect(() => parseJsonArray('"x"')).toThrow("Expected SQL JSON array");
   });
 });
 
@@ -233,12 +233,12 @@ describe("sql literals", () => {
     expect(sqlInteger(0)).toBe("0");
     expect(sqlInteger(null)).toBe("NULL");
     expect(sqlInteger(undefined)).toBe("NULL");
-    expect(() => sqlInteger(Number.NaN)).toThrow("invalid numeric SQL literal");
+    expect(() => sqlInteger(Number.NaN)).toThrow("Invalid numeric SQL literal");
     expect(() => sqlInteger(Number.POSITIVE_INFINITY)).toThrow(
-      "invalid numeric SQL literal",
+      "Invalid numeric SQL literal",
     );
     expect(() => sqlInteger(Number.NEGATIVE_INFINITY)).toThrow(
-      "invalid numeric SQL literal",
+      "Invalid numeric SQL literal",
     );
   });
 
@@ -248,9 +248,9 @@ describe("sql literals", () => {
     expect(sqlNumber(0)).toBe("0");
     expect(sqlNumber(null)).toBe("NULL");
     expect(sqlNumber(undefined)).toBe("NULL");
-    expect(() => sqlNumber(Number.NaN)).toThrow("invalid numeric SQL literal");
+    expect(() => sqlNumber(Number.NaN)).toThrow("Invalid numeric SQL literal");
     expect(() => sqlNumber(Number.POSITIVE_INFINITY)).toThrow(
-      "invalid numeric SQL literal",
+      "Invalid numeric SQL literal",
     );
   });
 
@@ -290,7 +290,7 @@ describe("executeRawSql", () => {
     ]);
   });
 
-  it("drops non-object entries from an array result", async () => {
+  it("rejects non-object entries from an array result", async () => {
     const runtime = runtimeWithExecute(async () => [
       { id: "keep" },
       null,
@@ -298,14 +298,14 @@ describe("executeRawSql", () => {
       "nope",
       1,
     ]);
-    await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
-      { id: "keep" },
-    ]);
+    await expect(executeRawSql(runtime, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
   });
 
-  it("extracts object rows from a { rows } envelope", async () => {
+  it("extracts object rows from a valid { rows } envelope", async () => {
     const runtime = runtimeWithExecute(async () => ({
-      rows: [{ id: "a" }, null, { id: "b" }, "skip"],
+      rows: [{ id: "a" }, { id: "b" }],
     }));
     await expect(executeRawSql(runtime, "SELECT 1")).resolves.toEqual([
       { id: "a" },
@@ -313,18 +313,26 @@ describe("executeRawSql", () => {
     ]);
   });
 
-  it("returns an empty list when { rows } is missing or not an array", async () => {
+  it("rejects when { rows } is missing or not an array", async () => {
     const missing = runtimeWithExecute(async () => ({ count: 0 }));
     const notArray = runtimeWithExecute(async () => ({ rows: "nope" }));
-    await expect(executeRawSql(missing, "SELECT 1")).resolves.toEqual([]);
-    await expect(executeRawSql(notArray, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(missing, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
+    await expect(executeRawSql(notArray, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
   });
 
-  it("returns an empty list for a non-object, non-array execute result", async () => {
+  it("rejects a non-object, non-array execute result", async () => {
     const none = runtimeWithExecute(async () => null);
     const scalar = runtimeWithExecute(async () => 42);
-    await expect(executeRawSql(none, "SELECT 1")).resolves.toEqual([]);
-    await expect(executeRawSql(scalar, "SELECT 1")).resolves.toEqual([]);
+    await expect(executeRawSql(none, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
+    await expect(executeRawSql(scalar, "SELECT 1")).rejects.toMatchObject({
+      code: "SQL_RESULT_INVALID",
+    });
   });
 
   it("throws when the runtime database adapter is unavailable", async () => {

--- a/packages/agent/src/services/knowledge-graph/sql.ts
+++ b/packages/agent/src/services/knowledge-graph/sql.ts
@@ -1,115 +1,34 @@
 /**
- * Self-contained raw-SQL helpers for the runtime knowledge-graph stores.
- *
- * The entity/relationship stores issue raw SQL against the agent's database
- * adapter. This is the minimal subset of encoders/parsers/runners those
- * stores need; it is intentionally local to `@elizaos/agent` so the runtime
- * knowledge graph carries no dependency on plugin-side SQL glue.
+ * Resolves the knowledge-graph runtime database and delegates raw-SQL primitives
+ * to shared. Existing domain exports and transaction boundaries remain stable.
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { executeSql, type RuntimeDb } from "@elizaos/shared/db/raw-sql";
 
-type RawSqlQuery = {
-  queryChunks: Array<{ value?: unknown }>;
-};
+export {
+  asObject,
+  extractRows,
+  OptimisticLockError,
+  parseJsonArray,
+  parseJsonRecord,
+  parseJsonValue,
+  type RawSqlQuery,
+  type RuntimeDb,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  type TransactionalDb,
+  toBoolean,
+  toNumber,
+  toText,
+  withOptimisticRetry,
+} from "@elizaos/shared/db/raw-sql";
 
-type RuntimeDb = {
-  execute: (query: RawSqlQuery) => Promise<unknown>;
-};
-
-let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
-
-function asObject(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-export function toText(value: unknown, fallback = ""): string {
-  if (typeof value === "string") return value;
-  if (value === null || value === undefined) return fallback;
-  return String(value);
-}
-
-export function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return fallback;
-}
-
-export function toBoolean(value: unknown, fallback = false): boolean {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value !== 0;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (["1", "true", "yes", "on"].includes(normalized)) return true;
-    if (["0", "false", "no", "off"].includes(normalized)) return false;
-  }
-  return fallback;
-}
-
-function isMissingJsonValue(value: unknown): boolean {
-  return value === null || value === undefined || value === "";
-}
-
-export function parseJsonValue<T>(value: unknown, fallback: T): T {
-  if (isMissingJsonValue(value)) return fallback;
-  if (typeof value !== "string") {
-    if (typeof value === "object") return value as T;
-    throw new Error(
-      `[KnowledgeGraphSql] Expected JSON string or object, received ${typeof value}`,
-    );
-  }
-  try {
-    return JSON.parse(value) as T;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`[KnowledgeGraphSql] Invalid JSON value: ${message}`);
-  }
-}
-
-export function parseJsonRecord(value: unknown): Record<string, unknown> {
-  if (isMissingJsonValue(value)) return {};
-  const parsed = parseJsonValue<Record<string, unknown> | null>(value, null);
-  const object = asObject(parsed);
-  if (object) return object;
-  throw new Error("[KnowledgeGraphSql] Expected JSON object");
-}
-
-export function parseJsonArray<T>(value: unknown): T[] {
-  if (isMissingJsonValue(value)) return [];
-  const parsed = parseJsonValue<T[] | null>(value, null);
-  if (Array.isArray(parsed)) return parsed;
-  throw new Error("[KnowledgeGraphSql] Expected JSON array");
-}
-
-function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result
-      .map((row) => asObject(row))
-      .filter((row): row is Record<string, unknown> => row !== null);
-  }
-  const object = asObject(result);
-  if (!object) return [];
-  const rows = object.rows;
-  if (!Array.isArray(rows)) return [];
-  return rows
-    .map((row) => asObject(row))
-    .filter((row): row is Record<string, unknown> => row !== null);
-}
-
-async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
-  if (cachedSqlRaw) return cachedSqlRaw;
-  const drizzle = (await import("drizzle-orm")) as {
-    sql: { raw: (query: string) => RawSqlQuery };
-  };
-  cachedSqlRaw = drizzle.sql.raw;
-  return cachedSqlRaw;
-}
-
-function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
+export function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.adapter.db as RuntimeDb | undefined;
   if (!db || typeof db.execute !== "function") {
     throw new Error("runtime database adapter unavailable");
@@ -121,33 +40,6 @@ export async function executeRawSql(
   runtime: IAgentRuntime,
   sqlText: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const raw = await getSqlRaw();
   const db = getRuntimeDb(runtime);
-  const result = await db.execute(raw(sqlText));
-  return extractRows(result);
-}
-
-export function sqlQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-export function sqlText(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  return sqlQuote(value);
-}
-
-export function sqlInteger(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(Math.trunc(value));
-}
-
-export function sqlNumber(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(value);
-}
-
-export function sqlJson(value: unknown): string {
-  return sqlQuote(JSON.stringify(value ?? null));
+  return executeSql(db, sqlText);
 }

--- a/packages/agent/src/services/pendant-session/repository.ts
+++ b/packages/agent/src/services/pendant-session/repository.ts
@@ -16,50 +16,24 @@ import {
   type PendantSession,
   PendantSessionStateSchema,
 } from "@elizaos/shared/contracts/pendant-session-sync";
-
-type RuntimeDb = {
-  execute: (query: RawSqlQuery) => Promise<unknown>;
-  transaction?: <T>(work: (tx: RuntimeDb) => Promise<T>) => Promise<T>;
-};
-
-type RawSqlQuery = {
-  queryChunks: Array<{ value?: unknown }>;
-};
+import {
+  executeSql,
+  parseJsonArray,
+  type RuntimeDb,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  toNumber,
+  toText,
+} from "@elizaos/shared/db/raw-sql";
 
 type RuntimeWithDatabase = {
   adapter: {
     db?: unknown;
   };
 };
-
-let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
-
-function asObject(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result
-      .map((row) => asObject(row))
-      .filter((row): row is Record<string, unknown> => row !== null);
-  }
-  const object = asObject(result);
-  if (!object || !Array.isArray(object.rows)) return [];
-  return object.rows
-    .map((row) => asObject(row))
-    .filter((row): row is Record<string, unknown> => row !== null);
-}
-
-async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
-  if (cachedSqlRaw) return cachedSqlRaw;
-  const drizzle = (await import("drizzle-orm")) as {
-    sql: { raw: (query: string) => RawSqlQuery };
-  };
-  cachedSqlRaw = drizzle.sql.raw;
-  return cachedSqlRaw;
-}
 
 async function executeRawSql(
   runtime: RuntimeWithDatabase,
@@ -70,67 +44,22 @@ async function executeRawSql(
   if (!db || typeof db.execute !== "function") {
     throw new Error("runtime database adapter unavailable");
   }
-  const raw = await getSqlRaw();
-  const result = await db.execute(raw(sqlText));
-  return extractRows(result);
+  return executeSql(db, sqlText);
 }
 
 async function runTransaction<T>(
   runtime: RuntimeWithDatabase,
   work: (db: RuntimeDb) => Promise<T>,
 ): Promise<T> {
-  const db = runtime.adapter.db as RuntimeDb | undefined;
+  const db = runtime.adapter.db as
+    | (RuntimeDb & {
+        transaction?: <U>(work: (tx: RuntimeDb) => Promise<U>) => Promise<U>;
+      })
+    | undefined;
   if (!db || typeof db.transaction !== "function") {
     throw new Error("runtime database transaction adapter unavailable");
   }
   return db.transaction((tx) => work(tx));
-}
-
-function toText(value: unknown, fallback = ""): string {
-  if (typeof value === "string") return value;
-  if (value === null || value === undefined) return fallback;
-  return String(value);
-}
-
-function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return fallback;
-}
-
-function parseJsonArray<T>(value: unknown): T[] {
-  if (value === null || value === undefined || value === "") return [];
-  const parsed = typeof value === "string" ? JSON.parse(value) : value;
-  if (Array.isArray(parsed)) return parsed as T[];
-  throw new Error("[PendantSessionRepository] Expected JSON array");
-}
-
-function sqlQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-function sqlText(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  return sqlQuote(value);
-}
-
-function sqlInteger(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(Math.trunc(value));
-}
-
-function sqlNumber(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(value);
-}
-
-function sqlJson(value: unknown): string {
-  return sqlQuote(JSON.stringify(value ?? null));
 }
 
 export interface StoredCaptureLease {

--- a/packages/shared/src/db/raw-sql.test.ts
+++ b/packages/shared/src/db/raw-sql.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit coverage for shared raw-SQL execution, row validation, and encoders.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  asObject,
+  executeSql,
+  extractRows,
+  OptimisticLockError,
+  parseJsonArray,
+  parseJsonRecord,
+  parseJsonValue,
+  RawSqlError,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  toBoolean,
+  toNumber,
+  toText,
+  withOptimisticRetry,
+} from "./raw-sql.ts";
+
+describe("RawSqlError", () => {
+  it("sets code, message, and optional rowIndex context", () => {
+    const errWithoutIndex = new RawSqlError("SQL_RESULT_INVALID", "bad result");
+    expect(errWithoutIndex.code).toBe("SQL_RESULT_INVALID");
+    expect(errWithoutIndex.message).toBe("bad result");
+    expect(errWithoutIndex.name).toBe("RawSqlError");
+    expect(errWithoutIndex.context).toBeUndefined();
+
+    const errWithIndex = new RawSqlError("SQL_RESULT_INVALID", "bad row", {
+      rowIndex: 3,
+    });
+    expect(errWithIndex.context).toEqual({ rowIndex: 3 });
+  });
+});
+
+describe("asObject", () => {
+  it("returns plain objects and filters non-objects/arrays", () => {
+    expect(asObject({ a: 1 })).toEqual({ a: 1 });
+    expect(asObject(null)).toBeNull();
+    expect(asObject(undefined)).toBeNull();
+    expect(asObject([1, 2])).toBeNull();
+    expect(asObject("string")).toBeNull();
+    expect(asObject(42)).toBeNull();
+    expect(asObject(true)).toBeNull();
+  });
+});
+
+describe("toText", () => {
+  it("converts primitives to text with fallback", () => {
+    expect(toText("hello")).toBe("hello");
+    expect(toText(null)).toBe("");
+    expect(toText(undefined, "default")).toBe("default");
+    expect(toText(123)).toBe("123");
+    expect(toText(true)).toBe("true");
+  });
+});
+
+describe("toNumber", () => {
+  it("converts numbers and strings to number with fallback", () => {
+    expect(toNumber(42)).toBe(42);
+    expect(toNumber("42.5")).toBe(42.5);
+    expect(toNumber(null)).toBe(0);
+    expect(toNumber(undefined, 99)).toBe(99);
+    expect(toNumber("invalid", 10)).toBe(10);
+    expect(toNumber(Number.NaN, 5)).toBe(5);
+    expect(toNumber(Number.POSITIVE_INFINITY, 5)).toBe(5);
+  });
+});
+
+describe("toBoolean", () => {
+  it("converts values to boolean with fallback", () => {
+    expect(toBoolean(true)).toBe(true);
+    expect(toBoolean(false)).toBe(false);
+    expect(toBoolean(1)).toBe(true);
+    expect(toBoolean(0)).toBe(false);
+    expect(toBoolean("true")).toBe(true);
+    expect(toBoolean("1")).toBe(true);
+    expect(toBoolean("yes")).toBe(true);
+    expect(toBoolean("on")).toBe(true);
+    expect(toBoolean("false")).toBe(false);
+    expect(toBoolean("0")).toBe(false);
+    expect(toBoolean("no")).toBe(false);
+    expect(toBoolean("off")).toBe(false);
+    expect(toBoolean("other", true)).toBe(true);
+    expect(toBoolean(null, false)).toBe(false);
+  });
+});
+
+describe("parseJsonValue / parseJsonRecord / parseJsonArray", () => {
+  it("handles parseJsonValue with valid and invalid values", () => {
+    expect(parseJsonValue(null, "fb")).toBe("fb");
+    expect(parseJsonValue(undefined, "fb")).toBe("fb");
+    expect(parseJsonValue("", "fb")).toBe("fb");
+    expect(parseJsonValue({ a: 1 }, null)).toEqual({ a: 1 });
+    expect(parseJsonValue('{"a":1}', null)).toEqual({ a: 1 });
+    expect(() => parseJsonValue(123, null)).toThrowError(RawSqlError);
+    expect(() => parseJsonValue("invalid json", null)).toThrowError(
+      RawSqlError,
+    );
+  });
+
+  it("handles parseJsonRecord", () => {
+    expect(parseJsonRecord(null)).toEqual({});
+    expect(parseJsonRecord('{"x":1}')).toEqual({ x: 1 });
+    expect(parseJsonRecord({ x: 1 })).toEqual({ x: 1 });
+    expect(() => parseJsonRecord("[1,2]")).toThrowError(RawSqlError);
+    expect(() => parseJsonRecord(123)).toThrowError(RawSqlError);
+  });
+
+  it("handles parseJsonArray", () => {
+    expect(parseJsonArray(null)).toEqual([]);
+    expect(parseJsonArray("[1,2,3]")).toEqual([1, 2, 3]);
+    expect(parseJsonArray([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(() => parseJsonArray('{"x":1}')).toThrowError(RawSqlError);
+  });
+});
+
+describe("extractRows", () => {
+  it("extracts from arrays and result envelopes", () => {
+    expect(extractRows([{ id: 1 }, { id: 2 }])).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(extractRows({ rows: [{ id: 1 }] })).toEqual([{ id: 1 }]);
+    expect(() => extractRows(null)).toThrowError(RawSqlError);
+    expect(() => extractRows({})).toThrowError(RawSqlError);
+    expect(() => extractRows({ rows: "not-an-array" })).toThrowError(
+      RawSqlError,
+    );
+    expect(() => extractRows([{ id: 1 }, null])).toThrowError(RawSqlError);
+  });
+});
+
+describe("executeSql", () => {
+  it("delegates query to db.execute and extracts rows", async () => {
+    const mockDb = {
+      execute: async () => [{ id: "row1" }],
+    };
+    const rows = await executeSql(mockDb, "SELECT 1");
+    expect(rows).toEqual([{ id: "row1" }]);
+  });
+});
+
+describe("OptimisticLockError and withOptimisticRetry", () => {
+  it("creates OptimisticLockError with attributes", () => {
+    const err = new OptimisticLockError({
+      table: "users",
+      id: "u1",
+      expectedVersion: 2,
+    });
+    expect(err.code).toBe("OPTIMISTIC_LOCK_ERROR");
+    expect(err.table).toBe("users");
+    expect(err.id).toBe("u1");
+    expect(err.expectedVersion).toBe(2);
+    expect(err.message).toContain("Optimistic lock conflict");
+  });
+
+  it("retries on OptimisticLockError and resolves on eventual success", async () => {
+    let attempts = 0;
+    const result = await withOptimisticRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new OptimisticLockError({
+            table: "items",
+            id: "1",
+            expectedVersion: 1,
+          });
+        }
+        return "success";
+      },
+      { maxAttempts: 3, baseDelayMs: 1 },
+    );
+    expect(result).toBe("success");
+    expect(attempts).toBe(3);
+  });
+
+  it("propagates non-optimistic errors immediately without retry", async () => {
+    let attempts = 0;
+    await expect(
+      withOptimisticRetry(
+        async () => {
+          attempts += 1;
+          throw new Error("non-retryable");
+        },
+        { maxAttempts: 3, baseDelayMs: 1 },
+      ),
+    ).rejects.toThrow("non-retryable");
+    expect(attempts).toBe(1);
+  });
+
+  it("throws when maxAttempts are exhausted", async () => {
+    let attempts = 0;
+    await expect(
+      withOptimisticRetry(
+        async () => {
+          attempts += 1;
+          throw new OptimisticLockError({
+            table: "items",
+            id: "1",
+            expectedVersion: 1,
+          });
+        },
+        { maxAttempts: 2, baseDelayMs: 1 },
+      ),
+    ).rejects.toThrowError(OptimisticLockError);
+    expect(attempts).toBe(2);
+  });
+});
+
+describe("SQL encoders", () => {
+  it("encodes literals safely", () => {
+    expect(sqlQuote("test's string")).toBe("'test''s string'");
+    expect(sqlText("hello")).toBe("'hello'");
+    expect(sqlText(null)).toBe("NULL");
+    expect(sqlText(undefined)).toBe("NULL");
+
+    expect(sqlInteger(42)).toBe("42");
+    expect(sqlInteger(42.9)).toBe("42");
+    expect(sqlInteger(null)).toBe("NULL");
+    expect(() => sqlInteger(Number.NaN)).toThrowError(RawSqlError);
+
+    expect(sqlNumber(42.5)).toBe("42.5");
+    expect(sqlNumber(null)).toBe("NULL");
+    expect(() => sqlNumber(Number.POSITIVE_INFINITY)).toThrowError(RawSqlError);
+
+    expect(sqlBoolean(true)).toBe("TRUE");
+    expect(sqlBoolean(false)).toBe("FALSE");
+
+    expect(sqlJson({ key: "val" })).toBe('\'{"key":"val"}\'');
+    expect(sqlJson(null)).toBe("'null'");
+  });
+});

--- a/plugins/plugin-calendar/AGENTS.md
+++ b/plugins/plugin-calendar/AGENTS.md
@@ -32,6 +32,9 @@ behind its OWNER/ADMIN role gate.
 - **Contract types live in `@elizaos/shared/contracts/calendar`** so `@elizaos/ui`
   (which types its `client` against them) and the plugins can both depend on them
   without a cycle.
+- **`src/internal/sql.ts` delegates common SQL primitives to `@elizaos/shared/db/raw-sql`.**
+  Runtime database lookup and calendar transaction requirements stay local.
+  Invalid adapter results fail explicitly; no PA dependency is introduced.
 - **Logger only, never `console`.** Prefix with `[ClassName]`.
 
 ## Layout

--- a/plugins/plugin-calendar/CLAUDE.md
+++ b/plugins/plugin-calendar/CLAUDE.md
@@ -32,6 +32,9 @@ behind its OWNER/ADMIN role gate.
 - **Contract types live in `@elizaos/shared/contracts/calendar`** so `@elizaos/ui`
   (which types its `client` against them) and the plugins can both depend on them
   without a cycle.
+- **`src/internal/sql.ts` delegates common SQL primitives to `@elizaos/shared/db/raw-sql`.**
+  Runtime database lookup and calendar transaction requirements stay local.
+  Invalid adapter results fail explicitly; no PA dependency is introduced.
 - **Logger only, never `console`.** Prefix with `[ClassName]`.
 
 ## Layout

--- a/plugins/plugin-calendar/src/internal/sql-contract.test.ts
+++ b/plugins/plugin-calendar/src/internal/sql-contract.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Exercises calendar SQL helpers through real PGlite/Drizzle execution. Faults
+ * replace only the adapter result envelope; queries, statements, transactions
+ * and rollback still execute against the real database.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import type { IAgentRuntime } from "@elizaos/core";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CalendarRepository } from "../service/CalendarRepository.ts";
+import {
+  executeRawSql,
+  executeRawSqlTx,
+  parseJsonRecord,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlText,
+  withCalendarTransaction,
+} from "./sql.ts";
+
+let pg: PGlite;
+let db: ReturnType<typeof drizzle>;
+let runtime: IAgentRuntime;
+beforeEach(async () => {
+  pg = new PGlite();
+  db = drizzle(pg);
+  runtime = {
+    agentId: "fixture-agent",
+    adapter: { db },
+  } as unknown as IAgentRuntime;
+  await executeRawSql(
+    runtime,
+    "CREATE TABLE source_rows (id integer PRIMARY KEY, label text, enabled boolean, amount real, metadata jsonb)",
+  );
+});
+afterEach(async () => {
+  await pg.close();
+});
+
+it("preserves SQL value encodings, complete result rows, and empty statement/query results", async () => {
+  const label = "O'Reilly event";
+  const metadata = { owner: "fixture", values: [0, false, "complete"] };
+  await expect(
+    executeRawSql(
+      runtime,
+      `INSERT INTO source_rows VALUES (${sqlInteger(1)}, ${sqlText(label)}, ${sqlBoolean(true)}, ${sqlNumber(12.5)}, ${sqlJson(metadata)})`,
+    ),
+  ).resolves.toEqual([]);
+  const rows = await executeRawSql(runtime, "SELECT * FROM source_rows");
+  expect(rows).toEqual([
+    { id: 1, label, enabled: true, amount: 12.5, metadata },
+  ]);
+  expect(parseJsonRecord(rows[0]?.metadata)).toEqual(metadata);
+  await expect(
+    executeRawSql(runtime, "SELECT * FROM source_rows WHERE id = 2"),
+  ).resolves.toEqual([]);
+  await expect(
+    executeRawSql(
+      runtime,
+      "UPDATE source_rows SET label = 'changed' WHERE id = 1 RETURNING label",
+    ),
+  ).resolves.toEqual([{ label: "changed" }]);
+  await expect(
+    executeRawSql(runtime, "DELETE FROM source_rows WHERE id = 1"),
+  ).resolves.toEqual([]);
+});
+
+it("rolls back a real multi-statement mutation when the callback fails", async () => {
+  await expect(
+    withCalendarTransaction(runtime, async (tx) => {
+      await executeRawSqlTx(tx, "INSERT INTO source_rows(id) VALUES (1)");
+      await executeRawSqlTx(tx, "INSERT INTO source_rows(id) VALUES (1)");
+    }),
+  ).rejects.toThrow();
+  expect(await executeRawSql(runtime, "SELECT * FROM source_rows")).toEqual([]);
+});
+
+it("rejects an adapter without transaction support before its mutation executes", async () => {
+  const noTransaction = {
+    agentId: runtime.agentId,
+    adapter: { db: { execute: db.execute.bind(db) } },
+  } as unknown as IAgentRuntime;
+  await expect(
+    withCalendarTransaction(noTransaction, async (tx) => {
+      await executeRawSqlTx(tx, "INSERT INTO source_rows(id) VALUES (1)");
+      throw new Error("failure after a partial write");
+    }),
+  ).rejects.toMatchObject({ code: "CALENDAR_SOURCE_TRANSACTION_REQUIRED" });
+  expect(await executeRawSql(runtime, "SELECT * FROM source_rows")).toEqual([]);
+});
+
+describe("invalid adapter results reach repository callers", () => {
+  it.each([
+    null,
+    undefined,
+    {},
+    { rows: null },
+    { rows: [null] },
+    [{ id: 1 }, false],
+  ])(
+    "rejects malformed result %# instead of an empty or partial calendar list",
+    async (result) => {
+      const invalid = {
+        agentId: runtime.agentId,
+        adapter: { db: { execute: async () => result } },
+      } as unknown as IAgentRuntime;
+      await expect(
+        new CalendarRepository(invalid).listCalendarEvents(
+          runtime.agentId,
+          "google",
+        ),
+      ).rejects.toMatchObject({ code: "SQL_RESULT_INVALID" });
+    },
+  );
+
+  it("accepts a row-array adapter without changing or dropping its SQL values", async () => {
+    await executeRawSql(
+      runtime,
+      "INSERT INTO source_rows(id, label) VALUES (1, 'first'), (2, 'second')",
+    );
+    const arrays = {
+      agentId: runtime.agentId,
+      adapter: {
+        db: {
+          execute: async (query: Parameters<typeof db.execute>[0]) =>
+            (await db.execute(query)).rows,
+        },
+      },
+    } as unknown as IAgentRuntime;
+    expect(
+      await executeRawSql(
+        arrays,
+        "SELECT id, label FROM source_rows ORDER BY id",
+      ),
+    ).toEqual([
+      { id: 1, label: "first" },
+      { id: 2, label: "second" },
+    ]);
+  });
+});

--- a/plugins/plugin-calendar/src/internal/sql.ts
+++ b/plugins/plugin-calendar/src/internal/sql.ts
@@ -1,117 +1,41 @@
 /**
- * Raw-SQL helpers for the calendar repository: lazily resolves the runtime's
- * `sql` tag, exposes the `RuntimeDb.execute` shape, and coerces DB result cells
- * to text/number/boolean.
+ * Resolves the calendar runtime database and delegates raw-SQL primitives
+ * to shared. Existing domain exports and transaction boundaries remain stable.
  */
 import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import {
+  executeSql,
+  type RuntimeDb,
+  type TransactionalDb,
+} from "@elizaos/shared/db/raw-sql";
 
-export type RawSqlQuery = {
-  queryChunks: Array<{ value?: unknown }>;
-};
-
-export type RuntimeDb = {
-  execute: (query: RawSqlQuery) => Promise<unknown>;
-};
-
-export type TransactionalDb = RuntimeDb;
+export {
+  asObject,
+  extractRows,
+  OptimisticLockError,
+  parseJsonArray,
+  parseJsonRecord,
+  parseJsonValue,
+  type RawSqlQuery,
+  type RuntimeDb,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  type TransactionalDb,
+  toBoolean,
+  toNumber,
+  toText,
+  withOptimisticRetry,
+} from "@elizaos/shared/db/raw-sql";
 
 type TransactionalRuntimeDb = RuntimeDb & {
   transaction?: <T>(
     callback: (tx: TransactionalDb) => Promise<T>,
   ) => Promise<T>;
 };
-
-let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
-
-function asObject(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-export function toText(value: unknown, fallback = ""): string {
-  if (typeof value === "string") return value;
-  if (value === null || value === undefined) return fallback;
-  return String(value);
-}
-
-export function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return fallback;
-}
-
-export function toBoolean(value: unknown, fallback = false): boolean {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value !== 0;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (["1", "true", "yes", "on"].includes(normalized)) return true;
-    if (["0", "false", "no", "off"].includes(normalized)) return false;
-  }
-  return fallback;
-}
-
-function isMissingJsonValue(value: unknown): boolean {
-  return value === null || value === undefined || value === "";
-}
-
-function parseJsonValue<T>(value: unknown, fallback: T): T {
-  if (isMissingJsonValue(value)) return fallback;
-  if (typeof value !== "string") {
-    if (typeof value === "object") return value as T;
-    throw new Error(
-      `[CalendarSql] Expected JSON string or object, received ${typeof value}`,
-    );
-  }
-  try {
-    return JSON.parse(value) as T;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`[CalendarSql] Invalid JSON value: ${message}`);
-  }
-}
-
-export function parseJsonRecord(value: unknown): Record<string, unknown> {
-  if (isMissingJsonValue(value)) return {};
-  const parsed = parseJsonValue<Record<string, unknown> | null>(value, null);
-  const object = asObject(parsed);
-  if (object) return object;
-  throw new Error("[CalendarSql] Expected JSON object");
-}
-
-export function parseJsonArray<T>(value: unknown): T[] {
-  if (isMissingJsonValue(value)) return [];
-  const parsed = parseJsonValue<T[] | null>(value, null);
-  if (Array.isArray(parsed)) return parsed;
-  throw new Error("[CalendarSql] Expected JSON array");
-}
-
-export function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result
-      .map((row) => asObject(row))
-      .filter((row): row is Record<string, unknown> => row !== null);
-  }
-  const object = asObject(result);
-  if (!object) return [];
-  const rows = object.rows;
-  if (!Array.isArray(rows)) return [];
-  return rows
-    .map((row) => asObject(row))
-    .filter((row): row is Record<string, unknown> => row !== null);
-}
-
-async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
-  if (cachedSqlRaw) return cachedSqlRaw;
-  const drizzle = (await import("drizzle-orm")) as {
-    sql: { raw: (query: string) => RawSqlQuery };
-  };
-  cachedSqlRaw = drizzle.sql.raw;
-  return cachedSqlRaw;
-}
 
 export function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.adapter.db as RuntimeDb | undefined;
@@ -125,19 +49,15 @@ export async function executeRawSql(
   runtime: IAgentRuntime,
   sqlText: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const raw = await getSqlRaw();
   const db = getRuntimeDb(runtime);
-  const result = await db.execute(raw(sqlText));
-  return extractRows(result);
+  return executeSql(db, sqlText);
 }
 
 export async function executeRawSqlTx(
   tx: TransactionalDb,
   sqlText: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const raw = await getSqlRaw();
-  const result = await tx.execute(raw(sqlText));
-  return extractRows(result);
+  return executeSql(tx, sqlText);
 }
 
 /**
@@ -161,32 +81,4 @@ export async function withCalendarTransaction<T>(
     );
   }
   return db.transaction(operation);
-}
-
-// ---------------------------------------------------------------------------
-// SQL value encoders
-// ---------------------------------------------------------------------------
-
-export function sqlQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-export function sqlText(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  return sqlQuote(value);
-}
-
-export function sqlBoolean(value: boolean): string {
-  return value ? "TRUE" : "FALSE";
-}
-
-export function sqlInteger(value: number): string {
-  if (!Number.isSafeInteger(value)) {
-    throw new Error("invalid integer SQL literal");
-  }
-  return String(value);
-}
-
-export function sqlJson(value: unknown): string {
-  return sqlQuote(JSON.stringify(value ?? null));
 }

--- a/plugins/plugin-calendar/src/service/migration.ts
+++ b/plugins/plugin-calendar/src/service/migration.ts
@@ -23,6 +23,7 @@
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import { executeSql, type RuntimeDb } from "@elizaos/shared/db/raw-sql";
 
 export const CALENDAR_MIGRATION_LOG_PREFIX = "[Calendar]";
 export const CALENDAR_MIGRATION_SERVICE_TYPE = "calendar_migration";
@@ -495,10 +496,6 @@ export async function migrateCalendarTables(
   return results;
 }
 
-type RuntimeDb = {
-  execute: (query: unknown) => Promise<unknown>;
-};
-
 function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.db as RuntimeDb | undefined;
   if (!db || typeof db.execute !== "function") {
@@ -507,25 +504,6 @@ function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
     );
   }
   return db;
-}
-
-function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result.filter(
-      (row): row is Record<string, unknown> =>
-        typeof row === "object" && row !== null && !Array.isArray(row),
-    );
-  }
-  if (result && typeof result === "object" && "rows" in result) {
-    const rows = (result as { rows: unknown }).rows;
-    if (Array.isArray(rows)) {
-      return rows.filter(
-        (row): row is Record<string, unknown> =>
-          typeof row === "object" && row !== null && !Array.isArray(row),
-      );
-    }
-  }
-  return [];
 }
 
 /**
@@ -548,9 +526,7 @@ export class CalendarMigrationService extends Service {
 
   private async run(): Promise<void> {
     const db = getRuntimeDb(this.runtime);
-    const { sql } = await import("drizzle-orm");
-    const exec: SqlExecutor = async (statement) =>
-      extractRows(await db.execute(sql.raw(statement)));
+    const exec: SqlExecutor = (statement) => executeSql(db, statement);
 
     const results = await migrateCalendarTables(exec);
     const copied = results.filter((r) => r.outcome === "copied");

--- a/plugins/plugin-goals/AGENTS.md
+++ b/plugins/plugin-goals/AGENTS.md
@@ -47,8 +47,7 @@ across `@elizaos/plugin-reminders` and the shared scheduled-task runner.
   repointed to `app_goals` in the same carve — so a single owner backs every
   reader. The cross-schema writes to `app_lifeops.life_task_definitions` (the
   spine FK-nullout in `deleteGoal`) and `app_lifeops.life_audit_events` (audit)
-  stay on `app_lifeops`. Reaches the DB through the self-contained
-  `src/db/sql.ts` helpers.
+  stay on `app_lifeops`. Uses `src/db/sql.ts` for the runtime DB handle and shared SQL primitives.
 - **`goal-grounding.ts`** / **`goal-semantic-evaluator.ts`** — goal grounding
   metadata + the LLM-backed `evaluateGoalProgressWithLlm`. PA re-exports these
   from here for back-compat (`plugin-personal-assistant/src/lifeops/goal-grounding.ts`
@@ -96,7 +95,7 @@ src/
   db/
     index.ts                     Re-exports schema
     schema.ts                    Drizzle pgSchema('app_goals')
-    sql.ts                       Self-contained raw-SQL helpers (runtime DB)
+    sql.ts                       Runtime DB lookup and shared raw-SQL helpers
     goals-repository.ts          GoalsRepository (raw SQL over app_goals.life_goal_*)
   components/
     goals/
@@ -156,9 +155,9 @@ with import-cycle checks and parity tests across both plugins.
   `@elizaos/plugin-sql` loaded first. PA auto-registers this plugin
   (`ensureLifeOpsGoalsPluginRegistered`) so `app_goals` exists and the migration
   runs whenever PA is loaded.
-- **`src/db/sql.ts` is a self-contained copy** of PA's raw-SQL helpers (so the
-  back-end carries no PA dependency). Keep it in sync only if a correctness fix
-  applies to both; do not add goals-specific logic.
+- **`src/db/sql.ts` delegates common SQL primitives to `@elizaos/shared/db/raw-sql`.**
+  Runtime database lookup stays local. Invalid adapter results fail explicitly;
+  no PA dependency is introduced.
 - **Only OWNER_GOALS is registered here.** Routines, reminders, and alarms are
   PA-owned owner actions; this package owns the goal CRUD/domain service.
 - **View bundles separately.** `build:views` (Vite) produces

--- a/plugins/plugin-goals/CLAUDE.md
+++ b/plugins/plugin-goals/CLAUDE.md
@@ -47,8 +47,7 @@ across `@elizaos/plugin-reminders` and the shared scheduled-task runner.
   repointed to `app_goals` in the same carve — so a single owner backs every
   reader. The cross-schema writes to `app_lifeops.life_task_definitions` (the
   spine FK-nullout in `deleteGoal`) and `app_lifeops.life_audit_events` (audit)
-  stay on `app_lifeops`. Reaches the DB through the self-contained
-  `src/db/sql.ts` helpers.
+  stay on `app_lifeops`. Uses `src/db/sql.ts` for the runtime DB handle and shared SQL primitives.
 - **`goal-grounding.ts`** / **`goal-semantic-evaluator.ts`** — goal grounding
   metadata + the LLM-backed `evaluateGoalProgressWithLlm`. PA re-exports these
   from here for back-compat (`plugin-personal-assistant/src/lifeops/goal-grounding.ts`
@@ -96,7 +95,7 @@ src/
   db/
     index.ts                     Re-exports schema
     schema.ts                    Drizzle pgSchema('app_goals')
-    sql.ts                       Self-contained raw-SQL helpers (runtime DB)
+    sql.ts                       Runtime DB lookup and shared raw-SQL helpers
     goals-repository.ts          GoalsRepository (raw SQL over app_goals.life_goal_*)
   components/
     goals/
@@ -156,9 +155,9 @@ with import-cycle checks and parity tests across both plugins.
   `@elizaos/plugin-sql` loaded first. PA auto-registers this plugin
   (`ensureLifeOpsGoalsPluginRegistered`) so `app_goals` exists and the migration
   runs whenever PA is loaded.
-- **`src/db/sql.ts` is a self-contained copy** of PA's raw-SQL helpers (so the
-  back-end carries no PA dependency). Keep it in sync only if a correctness fix
-  applies to both; do not add goals-specific logic.
+- **`src/db/sql.ts` delegates common SQL primitives to `@elizaos/shared/db/raw-sql`.**
+  Runtime database lookup stays local. Invalid adapter results fail explicitly;
+  no PA dependency is introduced.
 - **Only OWNER_GOALS is registered here.** Routines, reminders, and alarms are
   PA-owned owner actions; this package owns the goal CRUD/domain service.
 - **View bundles separately.** `build:views` (Vite) produces

--- a/plugins/plugin-goals/src/db/sql-contract.test.ts
+++ b/plugins/plugin-goals/src/db/sql-contract.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Exercises goals SQL helpers through real PGlite/Drizzle execution. Faults
+ * replace only the adapter result envelope; queries, statements, and raw SQL
+ * still execute against the real database.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import type { IAgentRuntime } from "@elizaos/core";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GoalsRepository } from "./goals-repository.ts";
+import {
+  executeRawSql,
+  parseJsonRecord,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlText,
+} from "./sql.ts";
+
+let pg: PGlite;
+let db: ReturnType<typeof drizzle>;
+let runtime: IAgentRuntime;
+beforeEach(async () => {
+  pg = new PGlite();
+  db = drizzle(pg);
+  runtime = {
+    agentId: "fixture-agent",
+    adapter: { db },
+  } as unknown as IAgentRuntime;
+  await executeRawSql(
+    runtime,
+    "CREATE TABLE source_rows (id integer PRIMARY KEY, label text, enabled boolean, amount real, metadata jsonb)",
+  );
+});
+afterEach(async () => {
+  await pg.close();
+});
+
+it("preserves SQL value encodings, complete result rows, and empty statement/query results", async () => {
+  const label = "O'Reilly goal";
+  const metadata = { owner: "fixture", values: [0, false, "complete"] };
+  await expect(
+    executeRawSql(
+      runtime,
+      `INSERT INTO source_rows VALUES (${sqlInteger(1)}, ${sqlText(label)}, ${sqlBoolean(true)}, ${sqlNumber(12.5)}, ${sqlJson(metadata)})`,
+    ),
+  ).resolves.toEqual([]);
+  const rows = await executeRawSql(runtime, "SELECT * FROM source_rows");
+  expect(rows).toEqual([
+    { id: 1, label, enabled: true, amount: 12.5, metadata },
+  ]);
+  expect(parseJsonRecord(rows[0]?.metadata)).toEqual(metadata);
+  await expect(
+    executeRawSql(runtime, "SELECT * FROM source_rows WHERE id = 2"),
+  ).resolves.toEqual([]);
+  await expect(
+    executeRawSql(
+      runtime,
+      "UPDATE source_rows SET label = 'changed' WHERE id = 1 RETURNING label",
+    ),
+  ).resolves.toEqual([{ label: "changed" }]);
+  await expect(
+    executeRawSql(runtime, "DELETE FROM source_rows WHERE id = 1"),
+  ).resolves.toEqual([]);
+});
+
+describe("invalid adapter results reach repository callers", () => {
+  it.each([
+    null,
+    undefined,
+    {},
+    { rows: null },
+    { rows: [null] },
+    [{ id: 1 }, false],
+  ])(
+    "rejects malformed result %# instead of an empty or partial goals list",
+    async (result) => {
+      const invalid = {
+        agentId: runtime.agentId,
+        adapter: { db: { execute: async () => result } },
+      } as unknown as IAgentRuntime;
+      await expect(
+        new GoalsRepository(invalid).listGoals(runtime.agentId),
+      ).rejects.toMatchObject({ code: "SQL_RESULT_INVALID" });
+    },
+  );
+
+  it("accepts a row-array adapter without changing or dropping its SQL values", async () => {
+    await executeRawSql(
+      runtime,
+      "INSERT INTO source_rows(id, label) VALUES (1, 'first'), (2, 'second')",
+    );
+    const arrays = {
+      agentId: runtime.agentId,
+      adapter: {
+        db: {
+          execute: async (query: Parameters<typeof db.execute>[0]) =>
+            (await db.execute(query)).rows,
+        },
+      },
+    } as unknown as IAgentRuntime;
+    expect(
+      await executeRawSql(
+        arrays,
+        "SELECT id, label FROM source_rows ORDER BY id",
+      ),
+    ).toEqual([
+      { id: 1, label: "first" },
+      { id: 2, label: "second" },
+    ]);
+  });
+});

--- a/plugins/plugin-goals/src/db/sql.ts
+++ b/plugins/plugin-goals/src/db/sql.ts
@@ -1,113 +1,31 @@
 /**
- * Self-contained raw-SQL helpers for the goals back-end — value coercers and a
- * cached `sql.raw` accessor over the runtime DB handle.
- *
- * A verbatim copy of the PA LifeOps SQL helpers (only the error prefixes differ)
- * so this plugin carries no dependency on `@elizaos/plugin-personal-assistant`.
- * Keep in sync only when a correctness fix applies to both; do not add
- * goals-specific logic here.
+ * Resolves the goals runtime database and delegates raw-SQL primitives
+ * to shared. Existing domain exports and transaction boundaries remain stable.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { executeSql, type RuntimeDb } from "@elizaos/shared/db/raw-sql";
 
-export type RawSqlQuery = {
-  queryChunks: Array<{ value?: unknown }>;
-};
-
-export type RuntimeDb = {
-  execute: (query: RawSqlQuery) => Promise<unknown>;
-};
-
-let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
-
-export function asObject(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-export function toText(value: unknown, fallback = ""): string {
-  if (typeof value === "string") return value;
-  if (value === null || value === undefined) return fallback;
-  return String(value);
-}
-
-export function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return fallback;
-}
-
-export function toBoolean(value: unknown, fallback = false): boolean {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value !== 0;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (["1", "true", "yes", "on"].includes(normalized)) return true;
-    if (["0", "false", "no", "off"].includes(normalized)) return false;
-  }
-  return fallback;
-}
-
-function isMissingJsonValue(value: unknown): boolean {
-  return value === null || value === undefined || value === "";
-}
-
-export function parseJsonValue<T>(value: unknown, fallback: T): T {
-  if (isMissingJsonValue(value)) return fallback;
-  if (typeof value !== "string") {
-    if (typeof value === "object") return value as T;
-    throw new Error(
-      `[GoalsSql] Expected JSON string or object, received ${typeof value}`,
-    );
-  }
-  try {
-    return JSON.parse(value) as T;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`[GoalsSql] Invalid JSON value: ${message}`);
-  }
-}
-
-export function parseJsonRecord(value: unknown): Record<string, unknown> {
-  if (isMissingJsonValue(value)) return {};
-  const parsed = parseJsonValue<Record<string, unknown> | null>(value, null);
-  const object = asObject(parsed);
-  if (object) return object;
-  throw new Error("[GoalsSql] Expected JSON object");
-}
-
-export function parseJsonArray<T>(value: unknown): T[] {
-  if (isMissingJsonValue(value)) return [];
-  const parsed = parseJsonValue<T[] | null>(value, null);
-  if (Array.isArray(parsed)) return parsed;
-  throw new Error("[GoalsSql] Expected JSON array");
-}
-
-export function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result
-      .map((row) => asObject(row))
-      .filter((row): row is Record<string, unknown> => row !== null);
-  }
-  const object = asObject(result);
-  if (!object) return [];
-  const rows = object.rows;
-  if (!Array.isArray(rows)) return [];
-  return rows
-    .map((row) => asObject(row))
-    .filter((row): row is Record<string, unknown> => row !== null);
-}
-
-async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
-  if (cachedSqlRaw) return cachedSqlRaw;
-  const drizzle = (await import("drizzle-orm")) as {
-    sql: { raw: (query: string) => RawSqlQuery };
-  };
-  cachedSqlRaw = drizzle.sql.raw;
-  return cachedSqlRaw;
-}
+export {
+  asObject,
+  extractRows,
+  OptimisticLockError,
+  parseJsonArray,
+  parseJsonRecord,
+  parseJsonValue,
+  type RawSqlQuery,
+  type RuntimeDb,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  type TransactionalDb,
+  toBoolean,
+  toNumber,
+  toText,
+  withOptimisticRetry,
+} from "@elizaos/shared/db/raw-sql";
 
 export function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.adapter.db as RuntimeDb | undefined;
@@ -121,41 +39,6 @@ export async function executeRawSql(
   runtime: IAgentRuntime,
   sqlText: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const raw = await getSqlRaw();
   const db = getRuntimeDb(runtime);
-  const result = await db.execute(raw(sqlText));
-  return extractRows(result);
-}
-
-// ---------------------------------------------------------------------------
-// SQL value encoders
-// ---------------------------------------------------------------------------
-
-export function sqlQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-export function sqlText(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  return sqlQuote(value);
-}
-
-export function sqlInteger(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(Math.trunc(value));
-}
-
-export function sqlNumber(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(value);
-}
-
-export function sqlBoolean(value: boolean): string {
-  return value ? "TRUE" : "FALSE";
-}
-
-export function sqlJson(value: unknown): string {
-  return sqlQuote(JSON.stringify(value ?? null));
+  return executeSql(db, sqlText);
 }

--- a/plugins/plugin-goals/src/services/migration.ts
+++ b/plugins/plugin-goals/src/services/migration.ts
@@ -25,6 +25,7 @@
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import { executeSql, type RuntimeDb } from "@elizaos/shared/db/raw-sql";
 
 export const GOALS_MIGRATION_LOG_PREFIX = "[Goals]";
 export const GOALS_MIGRATION_SERVICE_TYPE = "goals_migration";
@@ -106,10 +107,6 @@ export async function migrateGoalTables(
   return results;
 }
 
-type RuntimeDb = {
-  execute: (query: unknown) => Promise<unknown>;
-};
-
 function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.db as RuntimeDb | undefined;
   if (!db || typeof db.execute !== "function") {
@@ -118,25 +115,6 @@ function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
     );
   }
   return db;
-}
-
-function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result.filter(
-      (row): row is Record<string, unknown> =>
-        typeof row === "object" && row !== null && !Array.isArray(row),
-    );
-  }
-  if (result && typeof result === "object" && "rows" in result) {
-    const rows = (result as { rows: unknown }).rows;
-    if (Array.isArray(rows)) {
-      return rows.filter(
-        (row): row is Record<string, unknown> =>
-          typeof row === "object" && row !== null && !Array.isArray(row),
-      );
-    }
-  }
-  return [];
 }
 
 /**
@@ -157,9 +135,7 @@ export class GoalsMigrationService extends Service {
 
   private async run(): Promise<void> {
     const db = getRuntimeDb(this.runtime);
-    const { sql } = await import("drizzle-orm");
-    const exec: SqlExecutor = async (statement) =>
-      extractRows(await db.execute(sql.raw(statement)));
+    const exec: SqlExecutor = (statement) => executeSql(db, statement);
 
     const results = await migrateGoalTables(exec);
     const copied = results.filter((r) => r.outcome === "copied");

--- a/plugins/plugin-inbox/AGENTS.md
+++ b/plugins/plugin-inbox/AGENTS.md
@@ -79,6 +79,7 @@ src/
   db/
     index.ts                          re-exports schema.ts
     schema.ts                         drizzle pgSchema('app_inbox') + 3 tables
+    sql.ts                            Runtime DB lookup and shared raw-SQL helpers
   components/
     inbox/
       InboxView.tsx                   React inbox triage view
@@ -120,6 +121,9 @@ the operation truly needs lifecycle ownership; export public contracts from
 - **Complete planner choices.** Triage responses emit an actionable choice block for every returned entry. Do not cap the entry count in `appendInboxTriageChoiceMarkers`; connector-specific hard limits belong in the connector adapter, which must preserve every option through native controls or a truthful free-text fallback.
 - **Schema name is `app_inbox`** (not `inbox`) to avoid collisions with any host-app `inbox` table the runtime might also surface.
 - **Snooze is additive.** `snoozed_until` is append-only schema growth on `life_inbox_triage_entries`; migration repairs old targets and maps old `app_lifeops` rows with `NULL AS snoozed_until`.
+- **`src/db/sql.ts` delegates common SQL primitives to `@elizaos/shared/db/raw-sql`.**
+  Runtime database lookup stays local. Invalid adapter results fail explicitly;
+  no PA dependency is introduced.
 - **Two build steps.** The JS/types build (tsup + tsc) and the Vite views build are separate. The views bundle (`dist/views/bundle.js`) is what the view registration's `bundlePath` points to. Both must be run for a complete build.
 - **Peer deps.** React 19 and react-dom 19 are peer dependencies. The host app must provide them.
 - See the root `CLAUDE.md` for repo-wide architecture rules, logger requirements,

--- a/plugins/plugin-inbox/CLAUDE.md
+++ b/plugins/plugin-inbox/CLAUDE.md
@@ -79,6 +79,7 @@ src/
   db/
     index.ts                          re-exports schema.ts
     schema.ts                         drizzle pgSchema('app_inbox') + 3 tables
+    sql.ts                            Runtime DB lookup and shared raw-SQL helpers
   components/
     inbox/
       InboxView.tsx                   React inbox triage view
@@ -120,6 +121,9 @@ the operation truly needs lifecycle ownership; export public contracts from
 - **Complete planner choices.** Triage responses emit an actionable choice block for every returned entry. Do not cap the entry count in `appendInboxTriageChoiceMarkers`; connector-specific hard limits belong in the connector adapter, which must preserve every option through native controls or a truthful free-text fallback.
 - **Schema name is `app_inbox`** (not `inbox`) to avoid collisions with any host-app `inbox` table the runtime might also surface.
 - **Snooze is additive.** `snoozed_until` is append-only schema growth on `life_inbox_triage_entries`; migration repairs old targets and maps old `app_lifeops` rows with `NULL AS snoozed_until`.
+- **`src/db/sql.ts` delegates common SQL primitives to `@elizaos/shared/db/raw-sql`.**
+  Runtime database lookup stays local. Invalid adapter results fail explicitly;
+  no PA dependency is introduced.
 - **Two build steps.** The JS/types build (tsup + tsc) and the Vite views build are separate. The views bundle (`dist/views/bundle.js`) is what the view registration's `bundlePath` points to. Both must be run for a complete build.
 - **Peer deps.** React 19 and react-dom 19 are peer dependencies. The host app must provide them.
 - See the root `CLAUDE.md` for repo-wide architecture rules, logger requirements,

--- a/plugins/plugin-inbox/src/db/sql-contract.test.ts
+++ b/plugins/plugin-inbox/src/db/sql-contract.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Exercises inbox SQL helpers through real PGlite/Drizzle execution. Faults
+ * replace only the adapter result envelope; queries, statements, and raw SQL
+ * still execute against the real database.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import type { IAgentRuntime } from "@elizaos/core";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InboxRepository } from "../inbox/repository.ts";
+import {
+  executeRawSql,
+  parseJsonRecord,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlText,
+} from "./sql.ts";
+
+let pg: PGlite;
+let db: ReturnType<typeof drizzle>;
+let runtime: IAgentRuntime;
+beforeEach(async () => {
+  pg = new PGlite();
+  db = drizzle(pg);
+  runtime = {
+    agentId: "fixture-agent",
+    adapter: { db },
+  } as unknown as IAgentRuntime;
+  await executeRawSql(
+    runtime,
+    "CREATE TABLE source_rows (id integer PRIMARY KEY, label text, enabled boolean, amount real, metadata jsonb)",
+  );
+});
+afterEach(async () => {
+  await pg.close();
+});
+
+it("preserves SQL value encodings, complete result rows, and empty statement/query results", async () => {
+  const label = "O'Reilly inbox";
+  const metadata = { owner: "fixture", values: [0, false, "complete"] };
+  await expect(
+    executeRawSql(
+      runtime,
+      `INSERT INTO source_rows VALUES (${sqlInteger(1)}, ${sqlText(label)}, ${sqlBoolean(true)}, ${sqlNumber(12.5)}, ${sqlJson(metadata)})`,
+    ),
+  ).resolves.toEqual([]);
+  const rows = await executeRawSql(runtime, "SELECT * FROM source_rows");
+  expect(rows).toEqual([
+    { id: 1, label, enabled: true, amount: 12.5, metadata },
+  ]);
+  expect(parseJsonRecord(rows[0]?.metadata)).toEqual(metadata);
+  await expect(
+    executeRawSql(runtime, "SELECT * FROM source_rows WHERE id = 2"),
+  ).resolves.toEqual([]);
+  await expect(
+    executeRawSql(
+      runtime,
+      "UPDATE source_rows SET label = 'changed' WHERE id = 1 RETURNING label",
+    ),
+  ).resolves.toEqual([{ label: "changed" }]);
+  await expect(
+    executeRawSql(runtime, "DELETE FROM source_rows WHERE id = 1"),
+  ).resolves.toEqual([]);
+});
+
+describe("invalid adapter results reach repository callers", () => {
+  it.each([
+    null,
+    undefined,
+    {},
+    { rows: null },
+    { rows: [null] },
+    [{ id: 1 }, false],
+  ])(
+    "rejects malformed result %# instead of an empty or partial inbox list",
+    async (result) => {
+      const invalid = {
+        agentId: runtime.agentId,
+        adapter: { db: { execute: async () => result } },
+      } as unknown as IAgentRuntime;
+      await expect(
+        new InboxRepository(invalid).getUnresolved(),
+      ).rejects.toMatchObject({ code: "SQL_RESULT_INVALID" });
+    },
+  );
+
+  it("accepts a row-array adapter without changing or dropping its SQL values", async () => {
+    await executeRawSql(
+      runtime,
+      "INSERT INTO source_rows(id, label) VALUES (1, 'first'), (2, 'second')",
+    );
+    const arrays = {
+      agentId: runtime.agentId,
+      adapter: {
+        db: {
+          execute: async (query: Parameters<typeof db.execute>[0]) =>
+            (await db.execute(query)).rows,
+        },
+      },
+    } as unknown as IAgentRuntime;
+    expect(
+      await executeRawSql(
+        arrays,
+        "SELECT id, label FROM source_rows ORDER BY id",
+      ),
+    ).toEqual([
+      { id: 1, label: "first" },
+      { id: 2, label: "second" },
+    ]);
+  });
+});

--- a/plugins/plugin-inbox/src/db/sql.ts
+++ b/plugins/plugin-inbox/src/db/sql.ts
@@ -1,110 +1,31 @@
 /**
- * Provides the raw-SQL value encoders and row coercion helpers used by the
- * inbox repositories. This is a self-contained copy of the LifeOps SQL helper
- * surface so plugin-inbox can own `app_inbox` persistence without importing
- * `@elizaos/plugin-personal-assistant`.
+ * Resolves the inbox runtime database and delegates raw-SQL primitives
+ * to shared. Existing domain exports and transaction boundaries remain stable.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { executeSql, type RuntimeDb } from "@elizaos/shared/db/raw-sql";
 
-export type RawSqlQuery = {
-  queryChunks: Array<{ value?: unknown }>;
-};
-
-export type RuntimeDb = {
-  execute: (query: RawSqlQuery) => Promise<unknown>;
-};
-
-let cachedSqlRaw: ((query: string) => RawSqlQuery) | null = null;
-
-export function asObject(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return value as Record<string, unknown>;
-}
-
-export function toText(value: unknown, fallback = ""): string {
-  if (typeof value === "string") return value;
-  if (value === null || value === undefined) return fallback;
-  return String(value);
-}
-
-export function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return fallback;
-}
-
-export function toBoolean(value: unknown, fallback = false): boolean {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value !== 0;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (["1", "true", "yes", "on"].includes(normalized)) return true;
-    if (["0", "false", "no", "off"].includes(normalized)) return false;
-  }
-  return fallback;
-}
-
-function isMissingJsonValue(value: unknown): boolean {
-  return value === null || value === undefined || value === "";
-}
-
-export function parseJsonValue<T>(value: unknown, fallback: T): T {
-  if (isMissingJsonValue(value)) return fallback;
-  if (typeof value !== "string") {
-    if (typeof value === "object") return value as T;
-    throw new Error(
-      `[InboxSql] Expected JSON string or object, received ${typeof value}`,
-    );
-  }
-  try {
-    return JSON.parse(value) as T;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`[InboxSql] Invalid JSON value: ${message}`);
-  }
-}
-
-export function parseJsonRecord(value: unknown): Record<string, unknown> {
-  if (isMissingJsonValue(value)) return {};
-  const parsed = parseJsonValue<Record<string, unknown> | null>(value, null);
-  const object = asObject(parsed);
-  if (object) return object;
-  throw new Error("[InboxSql] Expected JSON object");
-}
-
-export function parseJsonArray<T>(value: unknown): T[] {
-  if (isMissingJsonValue(value)) return [];
-  const parsed = parseJsonValue<T[] | null>(value, null);
-  if (Array.isArray(parsed)) return parsed;
-  throw new Error("[InboxSql] Expected JSON array");
-}
-
-export function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result
-      .map((row) => asObject(row))
-      .filter((row): row is Record<string, unknown> => row !== null);
-  }
-  const object = asObject(result);
-  if (!object) return [];
-  const rows = object.rows;
-  if (!Array.isArray(rows)) return [];
-  return rows
-    .map((row) => asObject(row))
-    .filter((row): row is Record<string, unknown> => row !== null);
-}
-
-async function getSqlRaw(): Promise<(query: string) => RawSqlQuery> {
-  if (cachedSqlRaw) return cachedSqlRaw;
-  const drizzle = (await import("drizzle-orm")) as {
-    sql: { raw: (query: string) => RawSqlQuery };
-  };
-  cachedSqlRaw = drizzle.sql.raw;
-  return cachedSqlRaw;
-}
+export {
+  asObject,
+  extractRows,
+  OptimisticLockError,
+  parseJsonArray,
+  parseJsonRecord,
+  parseJsonValue,
+  type RawSqlQuery,
+  type RuntimeDb,
+  sqlBoolean,
+  sqlInteger,
+  sqlJson,
+  sqlNumber,
+  sqlQuote,
+  sqlText,
+  type TransactionalDb,
+  toBoolean,
+  toNumber,
+  toText,
+  withOptimisticRetry,
+} from "@elizaos/shared/db/raw-sql";
 
 export function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.adapter.db as RuntimeDb | undefined;
@@ -118,41 +39,6 @@ export async function executeRawSql(
   runtime: IAgentRuntime,
   sqlText: string,
 ): Promise<Array<Record<string, unknown>>> {
-  const raw = await getSqlRaw();
   const db = getRuntimeDb(runtime);
-  const result = await db.execute(raw(sqlText));
-  return extractRows(result);
-}
-
-// ---------------------------------------------------------------------------
-// SQL value encoders
-// ---------------------------------------------------------------------------
-
-export function sqlQuote(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-export function sqlText(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  return sqlQuote(value);
-}
-
-export function sqlInteger(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(Math.trunc(value));
-}
-
-export function sqlNumber(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "NULL";
-  if (!Number.isFinite(value)) throw new Error("invalid numeric SQL literal");
-  return String(value);
-}
-
-export function sqlBoolean(value: boolean): string {
-  return value ? "TRUE" : "FALSE";
-}
-
-export function sqlJson(value: unknown): string {
-  return sqlQuote(JSON.stringify(value ?? null));
+  return executeSql(db, sqlText);
 }

--- a/plugins/plugin-inbox/src/inbox/migration.ts
+++ b/plugins/plugin-inbox/src/inbox/migration.ts
@@ -23,6 +23,7 @@
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import { executeSql, type RuntimeDb } from "@elizaos/shared/db/raw-sql";
 
 export const INBOX_MIGRATION_LOG_PREFIX = "[Inbox]";
 export const INBOX_MIGRATION_SERVICE_TYPE = "inbox_migration";
@@ -184,10 +185,6 @@ export async function migrateInboxTables(
   return results;
 }
 
-type RuntimeDb = {
-  execute: (query: unknown) => Promise<unknown>;
-};
-
 function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.db as RuntimeDb | undefined;
   if (!db || typeof db.execute !== "function") {
@@ -196,25 +193,6 @@ function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
     );
   }
   return db;
-}
-
-function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result.filter(
-      (row): row is Record<string, unknown> =>
-        typeof row === "object" && row !== null && !Array.isArray(row),
-    );
-  }
-  if (result && typeof result === "object" && "rows" in result) {
-    const rows = (result as { rows: unknown }).rows;
-    if (Array.isArray(rows)) {
-      return rows.filter(
-        (row): row is Record<string, unknown> =>
-          typeof row === "object" && row !== null && !Array.isArray(row),
-      );
-    }
-  }
-  return [];
 }
 
 /**
@@ -235,9 +213,7 @@ export class InboxMigrationService extends Service {
 
   private async run(): Promise<void> {
     const db = getRuntimeDb(this.runtime);
-    const { sql } = await import("drizzle-orm");
-    const exec: SqlExecutor = async (statement) =>
-      extractRows(await db.execute(sql.raw(statement)));
+    const exec: SqlExecutor = (statement) => executeSql(db, statement);
 
     const results = await migrateInboxTables(exec);
     const copied = results.filter((r) => r.outcome === "copied");

--- a/plugins/plugin-reminders/src/services/migration.ts
+++ b/plugins/plugin-reminders/src/services/migration.ts
@@ -25,6 +25,7 @@
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import { executeSql, type RuntimeDb } from "@elizaos/shared/db/raw-sql";
 
 export const REMINDERS_LOG_PREFIX = "[Reminders]";
 export const REMINDERS_MIGRATION_SERVICE_TYPE = "reminders_migration";
@@ -154,10 +155,6 @@ export async function migrateReminderTables(
   return results;
 }
 
-type RuntimeDb = {
-  execute: (query: unknown) => Promise<unknown>;
-};
-
 function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
   const db = runtime.db as RuntimeDb | undefined;
   if (!db || typeof db.execute !== "function") {
@@ -166,25 +163,6 @@ function getRuntimeDb(runtime: IAgentRuntime): RuntimeDb {
     );
   }
   return db;
-}
-
-function extractRows(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) {
-    return result.filter(
-      (row): row is Record<string, unknown> =>
-        typeof row === "object" && row !== null && !Array.isArray(row),
-    );
-  }
-  if (result && typeof result === "object" && "rows" in result) {
-    const rows = (result as { rows: unknown }).rows;
-    if (Array.isArray(rows)) {
-      return rows.filter(
-        (row): row is Record<string, unknown> =>
-          typeof row === "object" && row !== null && !Array.isArray(row),
-      );
-    }
-  }
-  return [];
 }
 
 /**
@@ -207,9 +185,7 @@ export class RemindersMigrationService extends Service {
 
   private async run(): Promise<void> {
     const db = getRuntimeDb(this.runtime);
-    const { sql } = await import("drizzle-orm");
-    const exec: SqlExecutor = async (statement) =>
-      extractRows(await db.execute(sql.raw(statement)));
+    const exec: SqlExecutor = (statement) => executeSql(db, statement);
 
     const results = await migrateReminderTables(exec);
     const copied = results.filter((r) => r.outcome === "copied");


### PR DESCRIPTION
## Summary
Closes #30610
Follow-up to #30605 (which established `@elizaos/shared/db/raw-sql` for `plugin-finances`, `plugin-health`, `plugin-personal-assistant`, and `plugin-scheduling`).

Consolidates the remaining 11 custom raw-SQL row parsers, value encoders, and transaction delegators across domain stores to use the canonical `@elizaos/shared/db/raw-sql` primitives:
1. **`plugins/plugin-goals`** (`src/db/sql.ts`, `src/services/migration.ts`)
2. **`plugins/plugin-inbox`** (`src/db/sql.ts`, `src/inbox/migration.ts`)
3. **`plugins/plugin-calendar`** (`src/internal/sql.ts`, `src/service/migration.ts`)
4. **`plugins/plugin-reminders`** (`src/services/migration.ts`)
5. **`packages/agent`** (`src/services/approval/sql.ts`, `src/services/knowledge-graph/sql.ts`, `src/services/pendant-session/repository.ts`, `src/api/connector-account-routes.ts`)

### Key Improvements:
- **Strict result validation:** All stores reject malformed database execution results (`null`, `undefined`, non-array `{ rows }`, sparse/invalid rows) throwing `RawSqlError` with code `SQL_RESULT_INVALID`, rather than returning fake empty arrays `[]` or silently dropping bad rows.
- **Deduplication:** Removed ~950 lines of duplicate row-parsing and encoder logic across plugins and agent packages.
- **Contract & unit tests added:**
  - Added real DB / PGlite contract test suites: `plugins/plugin-goals/src/db/sql-contract.test.ts`, `plugins/plugin-inbox/src/db/sql-contract.test.ts`, and `plugins/plugin-calendar/src/internal/sql-contract.test.ts` verifying malformed adapter result rejection, transaction rollback, and row extraction parity.
  - Added `packages/shared/src/db/raw-sql.test.ts` exercising 100% of `@elizaos/shared/db/raw-sql` primitives.
- **Documentation:** Synchronized `CLAUDE.md` and `AGENTS.md` guidelines in touched plugins.

## Verification
- `bun test packages/shared/src/db/raw-sql.test.ts` (15/15 PASS - 100% coverage)
- `bun test plugins/plugin-goals/src/db/sql-contract.test.ts` (8/8 PASS)
- `bun test plugins/plugin-inbox/src/db/sql-contract.test.ts` (8/8 PASS)
- `bun test plugins/plugin-calendar/src/internal/sql-contract.test.ts` (10/10 PASS)
- `bun test packages/agent/src/services/approval/sql.test.ts` (24/24 PASS)
- `bun test packages/agent/src/services/approval/service.test.ts` (21/21 PASS)
- `bun test packages/agent/src/services/knowledge-graph/sql.test.ts` (39/39 PASS)
- `bun test packages/agent/src/services/pendant-session/repository.test.ts` (8/8 PASS)
- `bun test plugins/plugin-goals/src/services/migration.test.ts` (4/4 PASS)
- `bun test plugins/plugin-inbox/src/inbox/migration.test.ts` (5/5 PASS)
- `bun test plugins/plugin-calendar/src/service/migration.test.ts` (6/6 PASS)
- `bun test plugins/plugin-reminders/src/services/migration.test.ts` (8/8 PASS)
- `bun run check:agents-claude` (160/160 pairs byte-identical)
- `bun run biome check` (0 errors across touched files)

CC @lalalune