### PR TITLE
test(cloud): use a schema-valid trace id sentinel in agent bridge routing suite

### DIFF
--- a/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
+++ b/packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts
@@ -93,7 +93,10 @@ const sharedAgent = {
 const executionCtx = {
   waitUntil() {},
 };
-const TRACE_ID = "11111111-1111-4111-8111-111111111111";
+// Must satisfy the closed-schema trace-id validator (32 lowercase hex):
+// resolveElizaTraceId replaces UUID-shaped caller ids with a minted id at
+// ingress, so a UUID sentinel here would assert the replaced id, not ours.
+const TRACE_ID = "11111111111111111111111111111111";
 
 describe("agent bridge runtime routing", () => {
   test("records an allow-listed bridge method and first logical attempt on early warming", async () => {


### PR DESCRIPTION
# Relates to

- Develop Full cloud-lane failures: `agent-bridge-runtime-routing.test.ts:125` and `:172` — "records an allow-listed bridge method and first logical attempt on early warming" and "records a joinable stream trace and bounded retry attempt on early warming" fail on every run at the current develop head (most recently run 33953591123 at `1045297cca`, job group `smoke-lanes-cloudtests`, 2 tests failed).
- One line of the develop-red decomposition coordinated across contribution runs this cycle; the other two remaining lines (object-store `:539`, browser-workspace `:82`) are tracked separately.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3-1m`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from `origin/develop` at `1045297ccaffff37519a6a4b2a0203c273443a84`; zero conflicts. Exact head `1d7a27dff1eee12f5566ff174c3c73c12327b2cf`.

# Risks

Minimal: one test-file constant plus a four-line why-comment. No source, manifest, lockfile, workflow, or script changes. The suite's other nine tests are untouched and the negative half of the trace-id contract (invalid caller text is minted over, never normalized) stays pinned where it belongs, in `http-telemetry.test.ts`.

# Background

## What does this PR do?

Both failing tests send `X-Eliza-Trace-Id: 11111111-1111-4111-8111-111111111111` and assert the shared-turn baseline warn carries that same `traceId`. The gateway's ingress rule `resolveElizaTraceId` (`packages/cloud/shared/src/lib/observability/http-telemetry.ts:45`) adopts only closed-schema ids — `INFERENCE_TRACE_ID_PATTERN = /^[0-9a-f]{32}$/` (`packages/core/src/inference-timing.ts:344`) — and mints `crypto.randomUUID().replace(/-/g, "")` otherwise. A dashed UUID fails the pattern, so the warn carries a freshly minted id (CI received `7511cc7cc61042d7b5ca87e76f36e079`), and both assertions fail deterministically.

This is deliberate product behavior — the doc comment on `resolveElizaTraceId` names legacy UUIDs as replaced-at-ingress by design, `dedicated-agent-proxy.test.ts:460` already uses a 32-hex id, and `http-telemetry.test.ts` pins the mint-over-invalid half. The suite's sentinel simply predates the rule: it was written 2026-08-20 (#22831) and the closed schema landed 2026-08-21 (#23035). The suite runs only in the post-merge Develop Full cloud lane, so PR CI never caught it and the lane has carried these two failures since.

The fix swaps the sentinel for `"11111111111111111111111111111111"` — same visual style, schema-valid — so the tests once again pin the real contract: a valid caller-supplied gateway trace id propagates to the shared-turn baseline log.

## What kind of change is this?

CI/test repair of a deterministically failing post-merge-lane suite (develop workflow health).

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/__tests__/agent-bridge-runtime-routing.test.ts` — the `TRACE_ID` constant and its comment; then run the suite.

## Detailed testing steps

1. Check out exact head `1d7a27dff1eee12f5566ff174c3c73c12327b2cf`.
2. RED control — pristine `1045297cc` tree, disposable `oven/bun:1.3.14` container, `bun install --frozen-lockfile --ignore-scripts` (6923 packages), `packages/core` build emitted (its trailing `npm pack` edge-contract verify is not runnable in the image; dist is written before it) plus `packages/shared` build, then from `packages/cloud/api`: `bun test __tests__/agent-bridge-runtime-routing.test.ts` → **9 pass / 2 fail**, exactly the two CI failures (`traceId` expected `11111111-…` received minted `…hex`), matching run 33953591123.
3. GREEN — same container, only this file replaced by the head version: **11 pass / 0 fail** (44 expect calls).
4. Contract regression — `packages/cloud/shared`: `bun test src/lib/observability/http-telemetry.test.ts src/lib/observability/http-telemetry-hono.test.ts` → **25 pass / 0 fail** (the mint-over-invalid and adopt-valid halves stay pinned).
5. Pinned Biome on the changed file: exit 0.

<!-- evidence-head:1d7a27dff1eee12f5566ff174c3c73c12327b2cf -->

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A — CI test repair with no rendered surface.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A — CI test repair with no rendered surface.
<!-- evidence-row:desktop-walkthrough -->
- Desktop walkthrough: N/A — no UI change.
<!-- evidence-row:mobile-walkthrough -->
- Mobile walkthrough: N/A — no UI change.
<!-- evidence-row:backend-logs -->
- Backend logs: RED `9 pass / 2 fail` and GREEN `11 pass / 0 fail` transcripts in Detailed testing steps, from the disposable container at the exact heads; CI baseline is Develop Full run 33953591123 job `smoke-lanes-cloudtests` (2 tests failed, both named above).
<!-- evidence-row:frontend-console -->
- Frontend console/network logs: N/A — no UI change.
<!-- evidence-row:live-model -->
- Live model trajectory: N/A — no model-path change.

## Remaining human checks

- Post-merge Develop Full rerun at the new develop head is the authoritative close-out for these two failures; PR lanes do not run this suite.

Compute receipt: 59519447 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: zai / glm-5.3-1m
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-review]
<!-- slop-contribution-attribution:v1 {"provider":"zai","model":"glm-5.3-1m","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1RH2PS0QSW1KNHEHYQTQS71","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-05T10:15:57.984Z","completed_at":"2026-09-05T12:05:11.268Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-05T10:16:07.045Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":306473,"output_tokens":131310,"cache_creation_tokens":0,"cache_read_tokens":59081664,"total_tokens":59519447,"cost_micro_usd":"16368057","session_count":5},"trajectory_sha256":"bcfc81554605294f4b980128b9cf1ce7d976878333914fae66761f4d0999265a","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7bc73d74-3aca-45cc-a686-5185a7086814","object_id":"sha256:bcfc81554605294f4b980128b9cf1ce7d976878333914fae66761f4d0999265a","sha256":"bcfc81554605294f4b980128b9cf1ce7d976878333914fae66761f4d0999265a"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAR850XHeZVEfYMatnrCiWT7P3QZHECM3R-C2VnfZ8iZQ","device_key_id":"5935e4ed75d7ef04a6827ac468d61a17e4bba8f871647762e8ff62c5e50dda49","device_signature":"nVCVkqj5wF-dtG4SmG-HnXfvhL2W_Zvg3RFtPz00rgvtuF25rhUDlqcwIuA15o1h5jupUXyZUYB7o5QNaSf2BQ"}} -->
