### PR TITLE
feat(model-catalog): add Atlas Cloud as an OpenAI-compatible model provider

### DIFF
--- a/packages/agent/src/api/model-provider-helpers.ts
+++ b/packages/agent/src/api/model-provider-helpers.ts
@@ -281,6 +281,10 @@ const PROVIDER_ENV_KEYS: Record<
     altEnvKeys: ["KIMI_API_KEY"],
     baseUrl: "https://api.moonshot.ai/v1",
   },
+  atlascloud: {
+    envKey: "ATLASCLOUD_API_KEY",
+    baseUrl: "https://api.atlascloud.ai/v1",
+  },
   "google-genai": {
     envKey: "GOOGLE_GENERATIVE_AI_API_KEY",
     altEnvKeys: ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
@@ -704,6 +708,12 @@ export async function fetchProviderModels(
         providerId,
         apiKey,
         baseUrl ?? "https://api.moonshot.ai/v1",
+      );
+    case "atlascloud":
+      return fetchModelsREST(
+        providerId,
+        apiKey,
+        baseUrl ?? "https://api.atlascloud.ai/v1",
       );
     default:
       return [];


### PR DESCRIPTION
## Summary

Registers Atlas Cloud as one more OpenAI-compatible provider in `PROVIDER_ENV_KEYS`, routed through the existing `fetchModelsREST` path. Ten lines, one file, no new code path.

It only becomes visible when `ATLASCLOUD_API_KEY` is set — unset, `getOrFetchProvider` skips it exactly like any other unconfigured provider.

## Why This PR

`PROVIDER_ENV_KEYS` + the `fetchProviderModels` switch is already the extension point for OpenAI-compatible catalogs — `groq`, `xai`, `deepseek`, `zai` and `moonshot` are all the same two-part shape (a registry entry, and a `case` delegating to `fetchModelsREST`). Atlas Cloud serves a standard `/v1/models` document, so it fits that shape without touching `fetchModelsREST` itself.

Disclosure: I work at Atlas Cloud. This is a registry-level addition, so closing it costs nothing if another provider isn't wanted here.

## Validation

Run locally against a real key:

- `GET https://api.atlascloud.ai/v1/models` → **HTTP 200**, 117 models. I re-ran `fetchModelsREST`'s exact logic (same trailing-slash strip, `Authorization: Bearer` header, `{data:[{id,name?,type?}]}` parse, `localeCompare` sort) against the live response — it parses cleanly, every entry has an `id`, first ids are `anthropic/claude-haiku-4.5-20251001`, `anthropic/claude-opus-4-20250514`, …
- Evaluated the edited `PROVIDER_ENV_KEYS` literal straight out of the file: 12 providers, `atlascloud` resolves to `{envKey:"ATLASCLOUD_API_KEY", baseUrl:"https://api.atlascloud.ai/v1"}`, and `groq`/`xai`/`deepseek`/`moonshot` base URLs are byte-identical to before.
- `atlascloud` satisfies `MODEL_PROVIDER_ID_PATTERN` (`/^[a-z0-9][a-z0-9-]*$/`), so `providerCachePath()` accepts it and the cache file lands inside the models cache dir.

Repo tests, after a full `bun install`, run with vitest:

```
vitest run packages/agent/src/api/model-provider-helpers.test.ts \
           packages/agent/src/api/model-provider-helpers.timeout.test.ts \
           packages/agent/src/api/model-catalog.test.ts \
           packages/agent/src/api/models-routes.test.ts
→ Test Files 4 passed (4), Tests 26 passed (26)
```

One note for anyone else touching these files: running them with `bun test` instead reports 2 failures in `fetchNearAIModels`, but that's the runner, not the code — the file uses `vi.stubGlobal` / `vi.unstubAllGlobals`, which bun's `vi` shim doesn't implement. `packages/agent`'s own `test` script goes through vitest, and under vitest all 4 pass. I hit this and briefly mistook it for a pre-existing failure.
