### PR TITLE
fix(cloud): start managed Google consent from Outreachr

### DIFF
--- a/packages/cloud/api/v1/outreachr/google-connect.test.ts
+++ b/packages/cloud/api/v1/outreachr/google-connect.test.ts
@@ -1,0 +1,175 @@
+/** Exercises the HTTP-to-consent authority boundary using real delegated grants. */
+import { describe, expect, test } from "bun:test";
+import { createHash, randomUUID } from "node:crypto";
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  OutreachrDelegationError,
+  OutreachrDelegationService,
+  type OutreachrGrant,
+} from "@/lib/services/outreachr-delegation";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { createGoogleConnectHandler } from "./google-connect";
+
+async function fixture() {
+  const secret = "google-connect-fixture-client-secret-123456789";
+  const registration = {
+    appId: randomUUID(),
+    origin: "https://outreachr.example.com",
+    clientSecretSha256: createHash("sha256").update(secret).digest("hex"),
+  };
+  const user = {
+    id: randomUUID(),
+    organizationId: randomUUID(),
+    name: "Owner",
+    email: "owner@example.com",
+    emailVerified: true,
+  };
+  const grants = new Map<string, OutreachrGrant>();
+  let now = Date.now();
+  let codeUnused = true;
+  const delegation = new OutreachrDelegationService({
+    async verifyRegistration() {},
+    async consumeCode(code) {
+      if (code !== "eac_fixture" || !codeUnused) return null;
+      codeUnused = false;
+      return { appId: registration.appId, userId: user.id };
+    },
+    async findPrincipal() {
+      return user;
+    },
+    async saveGrant(key, grant) {
+      grants.set(key, grant);
+      return true;
+    },
+    async readGrant(key) {
+      return grants.get(key) ?? null;
+    },
+    async deleteGrant(key) {
+      return grants.delete(key);
+    },
+    now: () => now,
+  });
+  const grant = await delegation.exchange(registration, secret, "eac_fixture");
+  type Connect = Parameters<typeof createGoogleConnectHandler>[0]["connect"];
+  const started: Parameters<Connect>[0][] = [];
+  const authUrl =
+    "https://accounts.google.com/o/oauth2/v2/auth?state=provider-state";
+  const connect: Connect = async (args) => {
+    started.push(args);
+    return {
+      provider: "google",
+      side: args.side,
+      mode: "cloud_managed",
+      requestedCapabilities: args.capabilities ?? [],
+      redirectUri: args.redirectUrl ?? "/auth/success",
+      authUrl,
+    };
+  };
+  const app = new Hono<AppEnv>();
+  app.onError((error, c) =>
+    c.json(
+      { error: error.message },
+      error instanceof OutreachrDelegationError
+        ? error.status
+        : error instanceof z.ZodError
+          ? 400
+          : 500,
+    ),
+  );
+  app.post(
+    "/google/connect",
+    createGoogleConnectHandler({ delegation, connect }),
+  );
+  const env = {
+    OUTREACHR_APP_ID: registration.appId,
+    OUTREACHR_ORIGIN: registration.origin,
+    OUTREACHR_CLIENT_SECRET_SHA256: registration.clientSecretSha256,
+  };
+  const request = (body = "{}", client = secret, token = grant.token) =>
+    app.request(
+      "/google/connect",
+      {
+        method: "POST",
+        body,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Outreachr-Client": client,
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      env,
+    );
+  return {
+    request,
+    started,
+    user,
+    authUrl,
+    expire: () => {
+      now += 8 * 86_400_000;
+    },
+    revoke: () => delegation.revoke(registration, secret, grant.token),
+  };
+}
+
+describe("Outreachr managed Google consent", () => {
+  test("binds a valid request to the verified owner and first-party completion page", async () => {
+    const f = await fixture();
+    const response = await f.request();
+    expect(response.status).toBe(200);
+    const body = z
+      .object({ success: z.boolean(), authUrl: z.string() })
+      .strict()
+      .parse(await response.json());
+    expect(body).toEqual({
+      success: true,
+      authUrl: f.authUrl,
+    });
+    expect(f.started).toEqual([
+      {
+        userId: f.user.id,
+        organizationId: f.user.organizationId,
+        side: "owner",
+        redirectUrl: "/auth/success?platform=google",
+        capabilities: [
+          "google.basic_identity",
+          "google.gmail.triage",
+          "google.gmail.send",
+          "google.calendar.read",
+          "google.calendar.write",
+        ],
+      },
+    ]);
+  });
+  test("rejects forged identity, redirect, side, and capability overrides before OAuth", async () => {
+    const f = await fixture();
+    for (const input of [
+      { userId: randomUUID() },
+      { organizationId: randomUUID() },
+      { side: "agent" },
+      { redirectUrl: "https://attacker.example/" },
+      { capabilities: ["google.gmail.manage"] },
+    ])
+      expect((await f.request(JSON.stringify(input))).status).toBe(400);
+    expect((await f.request("{")).status).toBe(400);
+    expect(f.started).toHaveLength(0);
+  });
+  test("wrong clients and tokens cannot initiate consent", async () => {
+    const f = await fixture();
+    expect((await f.request("{}", "wrong-client")).status).toBe(401);
+    expect((await f.request("{}", undefined, "outreachr_forged")).status).toBe(
+      401,
+    );
+    expect(f.started).toHaveLength(0);
+  });
+  test("expired and revoked grants cannot initiate consent", async () => {
+    const expired = await fixture();
+    expired.expire();
+    expect((await expired.request()).status).toBe(401);
+    expect(expired.started).toHaveLength(0);
+    const revoked = await fixture();
+    await revoked.revoke();
+    expect((await revoked.request()).status).toBe(401);
+    expect(revoked.started).toHaveLength(0);
+  });
+});

--- a/packages/cloud/api/v1/outreachr/google-connect.ts
+++ b/packages/cloud/api/v1/outreachr/google-connect.ts
@@ -1,0 +1,43 @@
+/** Starts managed Google consent using the delegated account, without agent provisioning. */
+import type { Context } from "hono";
+import { z } from "zod";
+import type { initiateManagedGoogleConnection } from "@/lib/services/agent-google-connector";
+import {
+  type OutreachrDelegationService,
+  outreachrRegistration,
+} from "@/lib/services/outreachr-delegation";
+import { decodeRequestJson } from "@/lib/utils/json-parsing";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const input = z.object({}).strict();
+
+export function createGoogleConnectHandler(deps: {
+  delegation: Pick<OutreachrDelegationService, "authorize">;
+  connect: typeof initiateManagedGoogleConnection;
+}) {
+  return async (c: Context<AppEnv>) => {
+    const user = await deps.delegation.authorize(
+      outreachrRegistration(c.env),
+      c.req.header("X-Outreachr-Client") ?? "",
+      c.req.header("Authorization")?.replace(/^Bearer /, "") ?? "",
+    );
+    const decoded = await decodeRequestJson(c.req);
+    if (!decoded.ok)
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    input.parse(decoded.value);
+    const result = await deps.connect({
+      organizationId: user.organizationId,
+      userId: user.id,
+      side: "owner",
+      redirectUrl: "/auth/success?platform=google",
+      capabilities: [
+        "google.basic_identity",
+        "google.gmail.triage",
+        "google.gmail.send",
+        "google.calendar.read",
+        "google.calendar.write",
+      ],
+    });
+    return c.json({ success: true, authUrl: result.authUrl });
+  };
+}

--- a/packages/cloud/api/v1/outreachr/route.ts
+++ b/packages/cloud/api/v1/outreachr/route.ts
@@ -3,7 +3,10 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { listManagedGoogleConnectorAccounts } from "@/lib/services/agent-google-connector";
+import {
+  initiateManagedGoogleConnection,
+  listManagedGoogleConnectorAccounts,
+} from "@/lib/services/agent-google-connector";
 import {
   AgentGoogleConnectorError,
   googleFetch,
@@ -21,6 +24,7 @@ import { validateOutreachrGoogleRequest } from "@/lib/services/outreachr-google-
 import { requireStripe } from "@/lib/stripe";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { createGoogleConnectHandler } from "./google-connect";
 
 const app = new Hono<AppEnv>();
 app.use("*", bodyLimit({ maxSize: 1_600_000 }));
@@ -109,6 +113,14 @@ app.get("/google/connections", async (c) => {
   });
   return c.json({ success: true, connections });
 });
+
+app.post(
+  "/google/connect",
+  createGoogleConnectHandler({
+    delegation: outreachrDelegationService,
+    connect: initiateManagedGoogleConnection,
+  }),
+);
 
 app.post("/google/request", async (c) => {
   const user = await outreachrDelegationService.authorize(


### PR DESCRIPTION
# Relates to

Closes #30614. Outreachr needs to initiate Google consent directly from its workspace settings. This route starts the existing managed Google OAuth service using the delegated account, avoiding a detour through the general Cloud settings page.

Definition of Done: full standard in `CONTRIBUTING.md`.

- [x] Targets develop and rebased onto `8508c73dc14ae546717c30d47e5fc948fa436ced` without conflicts.
- [x] Post-sync dependency installation and root verification passed.
- [x] Reproducible tests and live validation limits are recorded below.

# Risks

Medium: credential-bearing OAuth initiation. The existing delegation service verifies client registration, grant validity, and current account authority. The request body cannot override user, organization, scopes, side or redirect. Google state, PKCE, callback and credentials stay in the existing managed service. The completion page is a fixed first-party route. No migration or new environment variables are added.

# Background

## What does this PR do?

Adds POST `/api/v1/outreachr/google/connect`. A valid delegated request starts owner-side Google authorization for identity, Gmail reading/sending and calendar reading/writing. The response contains only the provider authorization URL. Outreachr opens it and reads actual connected accounts after consent; closing the popup is not treated as proof of connection.

## What kind of change is this?

Additive backend feature.

# Documentation changes needed?

No new operator setup: the endpoint uses the existing Outreachr registration and managed Google OAuth configuration. The companion Outreachr UI change is tracked with this issue.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/outreachr/google-connect.test.ts` exercises the Hono handler with real delegation logic and a controlled external OAuth initiation boundary.

## Detailed testing steps

- Run `bun test v1/outreachr/google-connect.test.ts` from packages/cloud/api: four tests and 17 assertions passed after sync.
- Tests reject forged identity/organization/redirect/capabilities, malformed JSON, wrong clients/tokens and expired/revoked grants before provider initiation. Valid consent is bound to the verified owner and fixed completion page.
- Root `bun run verify` passed after dependency installation: 376 successful typecheck/lint tasks, API router contract, Worker bundle dry run and all final repository audits (11,442 test files scanned with zero focused tests or orphaned skips).
- Prior companion evidence, not rerun during this review: Outreachr PostgreSQL integration recorded 13 passing tests. Its browser fixture recorded consent, mailbox persistence and viewer isolation using an explicit external-provider fixture. These are not live OAuth claims.

# Evidence Gate

<!-- evidence-head:61abfd5667f54bccfa8980039fa1527418c86aa9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this repository diff changes only backend routing and tests.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this repository diff has no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only route; companion frontend is tested in Outreachr.
<!-- evidence-row:backend-logs -->
- [ ] Local handler results are below; live route readback awaits deployment.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend files changed in this PR.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action or inference changes.
<!-- evidence-row:domain-artifacts -->
- [x] Authorization tests inspect verified account binding and rejection before OAuth initiation; existing managed service owns provider state.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no inference behavior changes.

## Backend + frontend logs

Local post-sync handler run:

```text
Outreachr managed Google consent
  verified owner and first-party completion: pass
  forged input and malformed JSON: pass
  wrong client and token: pass
  expired and revoked grants: pass
4 pass, 0 fail, 17 assertions
```

External OAuth initiation is a fixture; live provider consent is pending. Frontend logs are N/A for this backend diff.

## Screenshots (before / after) + video walkthrough

### Before
N/A - no rendered UI changes in this repository.
### After
N/A - no rendered UI changes in this repository.
### Walkthrough video
N/A - backend-only change.

## Audio / voice walkthrough

N/A - no audio changes.

## Known gaps / failures

Full post-sync verification passed. Live Google authorization requires deployed configuration and a signed-in account, and is not claimed by the controlled provider tests. The configured companion https://outreachr.eliza.app returned Cloudflare HTTP 530 at 2026-09-05 20:30UTC. No configured local BFF was available. Its README forbids deployment of the old bridge pending generic API cutover; no such deployment was attempted. Keep this PR draft until a compatible configured candidate completes Google consent, the callback, and an owner-bound persisted connection readback.

## Maintainer CI exception record

No exception requested.

## Validated revision and live acceptance path

Validated head: `61abfd5667f54bccfa8980039fa1527418c86aa9`  
Validated develop: `8508c73dc14ae546717c30d47e5fc948fa436ced`

Bun 1.3.14 and Node 24.15.0 were explicitly pinned. Canonical Cloud installation used `ELIZA_SKIP_FUSED_INFERENCE_SETUP=1 bun install` and completed with no dependency changes. The reviewed patch is identical after the base refresh. Final validation above passed with exit 0. [Hosted validation](https://github.com/elizaOS/eliza/actions/runs/33992366307) passed on this revision: source static smoke, subscription authority PostgreSQL, billing payment replay E2E, Windows security, and the aggregate gate.

Live acceptance path: signed-in editable workspace at `/#/settings`, Connect Google, BFF `POST /api/google/connect`, candidate Cloud `POST /api/v1/outreachr/google/connect`, real Google consent and first-party callback, then refresh `/api/google/connections` and inspect the newly persisted owner/org connection. Controlled-provider test results do not establish that live outcome.
