### PR TITLE
fix(cloud): atomically combine inference lease and provider dispatch (#30635)

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -1897,6 +1897,133 @@ describe("InferenceAdmissionGate", () => {
     ).toBe(409);
   });
 
+  test("atomically combines lease and provider dispatch in one Durable Object round-trip", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10);
+
+    const leaseRes = await post(gate, "/lease", {
+      requestId: "request-combined",
+      balanceUsd: 10,
+      balanceRevision: "1",
+      estimatedCostUsd: 3,
+      dispatch: true,
+      preProviderCancellationToken: "cancel-token-123",
+      recovery: organizationRecovery("request-combined"),
+    });
+    expect(leaseRes.status).toBe(200);
+    const leaseBody = (await leaseRes.json()) as Record<string, unknown>;
+    expect(leaseBody).toMatchObject({
+      admitted: true,
+      availableUsd: 7,
+      requiredUsd: 3,
+      dispatched: true,
+    });
+
+    const stored = storage.read<{
+      phase: string;
+      preProviderCancellationToken?: string;
+      estimatedCostUsd: number;
+    }>(storedLeaseKey("request-combined"));
+    expect(stored?.phase).toBe("dispatched");
+    expect(stored?.preProviderCancellationToken).toBe("cancel-token-123");
+    expect(stored?.estimatedCostUsd).toBe(3);
+    expect(storage.alarm).toBeNumber();
+
+    const replayRes = await post(gate, "/lease", {
+      requestId: "request-combined",
+      balanceUsd: 10,
+      balanceRevision: "1",
+      estimatedCostUsd: 3,
+      dispatch: true,
+      preProviderCancellationToken: "cancel-token-123",
+      recovery: organizationRecovery("request-combined"),
+    });
+    expect(replayRes.status).toBe(200);
+    const replayBody = (await replayRes.json()) as Record<string, unknown>;
+    expect(replayBody).toMatchObject({
+      admitted: true,
+      availableUsd: 7,
+      requiredUsd: 3,
+      dispatched: true,
+      duplicate: true,
+    });
+
+    const mismatchRes = await post(gate, "/release", {
+      requestId: "request-combined",
+      preProviderCancellationToken: "wrong-token",
+    });
+    expect(mismatchRes.status).toBe(409);
+
+    const noTokenRes = await post(gate, "/release", {
+      requestId: "request-combined",
+    });
+    expect(noTokenRes.status).toBe(409);
+
+    const releaseRes = await post(gate, "/release", {
+      requestId: "request-combined",
+      preProviderCancellationToken: "cancel-token-123",
+    });
+    expect(releaseRes.status).toBe(200);
+    const releaseBody = (await releaseRes.json()) as Record<string, unknown>;
+    expect(releaseBody).toMatchObject({ released: true });
+
+    const ledger = storage.read<{
+      availableUsd: number;
+      activeLeaseCount: number;
+    }>("ledger");
+    expect(ledger?.availableUsd).toBe(10);
+    expect(ledger?.activeLeaseCount).toBe(0);
+    expect(storage.read(storedLeaseKey("request-combined"))).toBeUndefined();
+  });
+
+  test("acquireInferenceAdmissionLease with dispatch: true skips separate dispatch marker and releases safely on zero settlement", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10);
+    let dispatchCalled = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: () => ({
+          fetch: async (req: Request) => {
+            const url = new URL(req.url);
+            if (url.pathname === "/dispatch") {
+              dispatchCalled++;
+            }
+            return await gate.fetch(req);
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "request-combined-client",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 4,
+        dispatch: true,
+        recovery: organizationRecovery("request-combined-client"),
+      });
+
+      expect(lease.providerDispatched).toBe(true);
+      expect(lease.preProviderCancellationToken).toBeDefined();
+
+      await markInferenceAdmissionLeaseDispatched(lease);
+      expect(dispatchCalled).toBe(0);
+      expect(lease.preProviderCancellationToken).toBeUndefined();
+
+      await settleInferenceAdmissionLease(lease, 3, 3);
+    });
+
+    const ledger = storage.read<{
+      availableUsd: number;
+      activeLeaseCount: number;
+    }>("ledger");
+    expect(ledger?.activeLeaseCount).toBe(0);
+  });
+
   test("persists a lower rejected hint across Durable Object eviction", async () => {
     const storage = new TestStorage();
     const first = createGate(storage);

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -2170,9 +2170,9 @@ describe("InferenceAdmissionGate", () => {
       preProviderCancellationToken: "cancel-auth-token",
     });
     expect(releaseRes.status).toBe(200);
-    expect(
-      storage.read<{ availableUsd: number }>("ledger")?.availableUsd,
-    ).toBe(10);
+    expect(storage.read<{ availableUsd: number }>("ledger")?.availableUsd).toBe(
+      10,
+    );
   });
 
   test("combined dispatch replay does not extend expiresAt", async () => {

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -1925,7 +1925,7 @@ describe("InferenceAdmissionGate", () => {
       preProviderCancellationToken?: string;
       estimatedCostUsd: number;
     }>(storedLeaseKey("request-combined"));
-    expect(stored?.phase).toBe("dispatched");
+    expect(stored?.phase).toBe("leased");
     expect(stored?.preProviderCancellationToken).toBe("cancel-token-123");
     expect(stored?.estimatedCostUsd).toBe(3);
     expect(storage.alarm).toBeNumber();
@@ -1977,7 +1977,7 @@ describe("InferenceAdmissionGate", () => {
     expect(storage.read(storedLeaseKey("request-combined"))).toBeUndefined();
   });
 
-  test("acquireInferenceAdmissionLease with dispatch: true skips separate dispatch marker and releases safely on zero settlement", async () => {
+  test("acquireInferenceAdmissionLease with dispatch: true stores token at lease time and flips phase at dispatch", async () => {
     const storage = new TestStorage();
     const gate = createGate(storage);
     await hydrateGate(gate, 10);
@@ -2010,8 +2010,10 @@ describe("InferenceAdmissionGate", () => {
       expect(lease.providerDispatched).toBe(true);
       expect(lease.preProviderCancellationToken).toBeDefined();
 
+      // The DO phase is still "leased" — markProviderDispatched calls /dispatch
+      // to flip it to "dispatched" right before the provider call.
       await markInferenceAdmissionLeaseDispatched(lease);
-      expect(dispatchCalled).toBe(0);
+      expect(dispatchCalled).toBe(1);
       expect(lease.preProviderCancellationToken).toBeUndefined();
 
       await settleInferenceAdmissionLease(lease, 3, 3);
@@ -2022,6 +2024,200 @@ describe("InferenceAdmissionGate", () => {
       activeLeaseCount: number;
     }>("ledger");
     expect(ledger?.activeLeaseCount).toBe(0);
+  });
+
+  test("combined dispatch lease abandoned before provider call releases free on alarm expiry", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 10);
+
+      // Acquire a combined lease+dispatch — provider is never invoked.
+      const leaseRes = await post(gate, "/lease", {
+        requestId: "request-abandoned",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 8,
+        dispatch: true,
+        preProviderCancellationToken: "cancel-abandoned",
+        recovery: organizationRecovery("request-abandoned"),
+      });
+      expect(leaseRes.status).toBe(200);
+      expect(
+        ((await leaseRes.json()) as Record<string, unknown>).dispatched,
+      ).toBe(true);
+
+      const stored = storage.read<{
+        phase: string;
+        preProviderCancellationToken?: string;
+      }>(storedLeaseKey("request-abandoned"));
+      expect(stored?.phase).toBe("leased");
+      expect(stored?.preProviderCancellationToken).toBe("cancel-abandoned");
+
+      // Advance time past expiry (MAX_LEASE_AGE_MS = 20 * 60_000 = 1_200_000).
+      clock.mockReturnValue(1_300_000);
+      storage.clearAlarm();
+      await gate.alarm();
+
+      // The lease must be released free — no recovery charge.
+      expect(recoverExpiredLease).not.toHaveBeenCalled();
+      const ledger = storage.read<{
+        availableUsd: number;
+        activeLeaseCount: number;
+      }>("ledger");
+      expect(ledger?.activeLeaseCount).toBe(0);
+      expect(ledger?.availableUsd).toBe(10);
+      expect(storage.read(storedLeaseKey("request-abandoned"))).toBeUndefined();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("confirmed dispatch lease charges via recovery on alarm expiry", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 10);
+
+      // Acquire a combined lease (phase stays "leased", token stored).
+      expect(
+        (
+          await post(gate, "/lease", {
+            requestId: "request-confirmed",
+            balanceUsd: 10,
+            balanceRevision: "1",
+            estimatedCostUsd: 5,
+            dispatch: true,
+            preProviderCancellationToken: "cancel-confirmed",
+            recovery: organizationRecovery("request-confirmed"),
+          })
+        ).status,
+      ).toBe(200);
+
+      // markProviderDispatched calls /dispatch to flip to "dispatched".
+      clock.mockReturnValue(2_000);
+      const dispatchRes = await post(gate, "/dispatch", {
+        requestId: "request-confirmed",
+        preProviderCancellationToken: "cancel-confirmed",
+      });
+      expect(dispatchRes.status).toBe(200);
+
+      const stored = storage.read<{
+        phase: string;
+      }>(storedLeaseKey("request-confirmed"));
+      expect(stored?.phase).toBe("dispatched");
+
+      // Advance time past expiry.
+      clock.mockReturnValue(1_300_000);
+      storage.clearAlarm();
+      recoverExpiredLease.mockResolvedValueOnce({
+        balanceUsd: 5,
+        balanceRevision: "2",
+        collectedUsd: 5,
+        gateConsumedUsd: 5,
+      });
+      await gate.alarm();
+
+      // Recovery MUST be invoked for confirmed dispatched leases.
+      expect(recoverExpiredLease).toHaveBeenCalledTimes(1);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("combined dispatch via /lease-authorized with credential covers the production path", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10);
+
+    const credential = {
+      organizationId: "org-a",
+      kind: "api_key",
+      credentialId: "key-a",
+      userId: "user-a",
+    } as const;
+    const leaseRes = await post(gate, "/lease-authorized", {
+      requestId: "request-auth-combined",
+      balanceUsd: 10,
+      balanceRevision: "1",
+      estimatedCostUsd: 4,
+      dispatch: true,
+      preProviderCancellationToken: "cancel-auth-token",
+      credential,
+      recovery: organizationRecovery("request-auth-combined"),
+    });
+    expect(leaseRes.status).toBe(200);
+    const leaseBody = (await leaseRes.json()) as Record<string, unknown>;
+    expect(leaseBody).toMatchObject({
+      admitted: true,
+      availableUsd: 6,
+      requiredUsd: 4,
+      dispatched: true,
+    });
+
+    const stored = storage.read<{
+      phase: string;
+      preProviderCancellationToken?: string;
+    }>(storedLeaseKey("request-auth-combined"));
+    expect(stored?.phase).toBe("leased");
+    expect(stored?.preProviderCancellationToken).toBe("cancel-auth-token");
+
+    // Release via cancellation token.
+    const releaseRes = await post(gate, "/release", {
+      requestId: "request-auth-combined",
+      preProviderCancellationToken: "cancel-auth-token",
+    });
+    expect(releaseRes.status).toBe(200);
+    expect(
+      storage.read<{ availableUsd: number }>("ledger")?.availableUsd,
+    ).toBe(10);
+  });
+
+  test("combined dispatch replay does not extend expiresAt", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 10);
+
+      await post(gate, "/lease", {
+        requestId: "request-replay-expiry",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 3,
+        dispatch: true,
+        preProviderCancellationToken: "cancel-replay",
+        recovery: organizationRecovery("request-replay-expiry"),
+      });
+
+      const originalLease = storage.read<{ expiresAt: number }>(
+        storedLeaseKey("request-replay-expiry"),
+      );
+      const originalExpiry = originalLease?.expiresAt;
+      expect(originalExpiry).toBeDefined();
+
+      // Advance time and replay the same combined lease request.
+      clock.mockReturnValue(600_000);
+      await post(gate, "/lease", {
+        requestId: "request-replay-expiry",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 3,
+        dispatch: true,
+        preProviderCancellationToken: "cancel-replay",
+        recovery: organizationRecovery("request-replay-expiry"),
+      });
+
+      const replayedLease = storage.read<{ expiresAt: number }>(
+        storedLeaseKey("request-replay-expiry"),
+      );
+      // expiresAt must NOT be extended by the replay.
+      expect(replayedLease?.expiresAt).toBe(originalExpiry);
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   test("persists a lower rejected hint across Durable Object eviction", async () => {

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -60,6 +60,8 @@ interface LeaseRequest {
   balanceRevision: string;
   estimatedCostUsd: number;
   recovery: InferenceAdmissionRecoveryContext;
+  dispatch?: boolean;
+  preProviderCancellationToken?: string;
 }
 
 interface AuthorizedLeaseRequest extends LeaseRequest {
@@ -776,7 +778,9 @@ export class InferenceAdmissionGate {
         request.recovery,
         request.requestId,
         request.organizationId,
-      )
+      ) ||
+      (request.preProviderCancellationToken !== undefined &&
+        !validTrimmedId(request.preProviderCancellationToken))
     ) {
       return jsonError("Invalid inference admission lease", 400);
     }
@@ -815,11 +819,53 @@ export class InferenceAdmissionGate {
           409,
         );
       }
+      if (request.dispatch) {
+        if (
+          prior.preProviderCancellationToken !== undefined &&
+          request.preProviderCancellationToken !== undefined &&
+          prior.preProviderCancellationToken !==
+            request.preProviderCancellationToken
+        ) {
+          await this.save(ledger);
+          return jsonError(
+            "Inference admission dispatch capability does not match",
+            409,
+          );
+        }
+        const refreshed: ActiveLease = {
+          ...prior,
+          phase: "dispatched",
+          ...(request.preProviderCancellationToken !== undefined
+            ? {
+                preProviderCancellationToken:
+                  request.preProviderCancellationToken,
+              }
+            : prior.preProviderCancellationToken !== undefined
+              ? {
+                  preProviderCancellationToken:
+                    prior.preProviderCancellationToken,
+                }
+              : {}),
+          expiresAt: Date.now() + MAX_LEASE_AGE_MS,
+        };
+        await this.save(ledger, {
+          delete: [{ requestId: request.requestId, lease: prior }],
+          put: [{ requestId: request.requestId, lease: refreshed }],
+        });
+        return Response.json({
+          admitted: true,
+          availableUsd: ledger.availableUsd,
+          requiredUsd: request.estimatedCostUsd,
+          dispatched: true,
+          ...(prior.phase === "dispatched" && { duplicate: true }),
+        });
+      }
       await this.save(ledger);
       return Response.json({
         admitted: true,
         availableUsd: ledger.availableUsd,
         requiredUsd: request.estimatedCostUsd,
+        dispatched: prior.phase === "dispatched",
       });
     }
     if (ledger.settledRequestIds.includes(request.requestId)) {
@@ -845,11 +891,15 @@ export class InferenceAdmissionGate {
 
     ledger.availableUsd -= request.estimatedCostUsd;
     const now = Date.now();
+    const isDispatched = Boolean(request.dispatch);
     const activeLease: ActiveLease = {
       estimatedCostUsd: request.estimatedCostUsd,
       createdAt: now,
       expiresAt: now + MAX_LEASE_AGE_MS,
-      phase: "leased",
+      phase: isDispatched ? "dispatched" : "leased",
+      ...(request.preProviderCancellationToken !== undefined && {
+        preProviderCancellationToken: request.preProviderCancellationToken,
+      }),
       recovery: structuredClone(request.recovery),
     };
     ledger.activeLeaseCount++;
@@ -865,6 +915,7 @@ export class InferenceAdmissionGate {
       admitted: true,
       availableUsd: ledger.availableUsd,
       requiredUsd: request.estimatedCostUsd,
+      dispatched: isDispatched,
     });
   }
 

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -834,7 +834,6 @@ export class InferenceAdmissionGate {
         }
         const refreshed: ActiveLease = {
           ...prior,
-          phase: "dispatched",
           ...(request.preProviderCancellationToken !== undefined
             ? {
                 preProviderCancellationToken:
@@ -846,7 +845,6 @@ export class InferenceAdmissionGate {
                     prior.preProviderCancellationToken,
                 }
               : {}),
-          expiresAt: Date.now() + MAX_LEASE_AGE_MS,
         };
         await this.save(ledger, {
           delete: [{ requestId: request.requestId, lease: prior }],
@@ -857,7 +855,9 @@ export class InferenceAdmissionGate {
           availableUsd: ledger.availableUsd,
           requiredUsd: request.estimatedCostUsd,
           dispatched: true,
-          ...(prior.phase === "dispatched" && { duplicate: true }),
+          ...(prior.preProviderCancellationToken !== undefined && {
+            duplicate: true,
+          }),
         });
       }
       await this.save(ledger);
@@ -865,7 +865,9 @@ export class InferenceAdmissionGate {
         admitted: true,
         availableUsd: ledger.availableUsd,
         requiredUsd: request.estimatedCostUsd,
-        dispatched: prior.phase === "dispatched",
+        dispatched:
+          prior.phase === "dispatched" ||
+          prior.preProviderCancellationToken !== undefined,
       });
     }
     if (ledger.settledRequestIds.includes(request.requestId)) {
@@ -891,12 +893,11 @@ export class InferenceAdmissionGate {
 
     ledger.availableUsd -= request.estimatedCostUsd;
     const now = Date.now();
-    const isDispatched = Boolean(request.dispatch);
     const activeLease: ActiveLease = {
       estimatedCostUsd: request.estimatedCostUsd,
       createdAt: now,
       expiresAt: now + MAX_LEASE_AGE_MS,
-      phase: isDispatched ? "dispatched" : "leased",
+      phase: "leased",
       ...(request.preProviderCancellationToken !== undefined && {
         preProviderCancellationToken: request.preProviderCancellationToken,
       }),
@@ -915,7 +916,7 @@ export class InferenceAdmissionGate {
       admitted: true,
       availableUsd: ledger.availableUsd,
       requiredUsd: request.estimatedCostUsd,
-      dispatched: isDispatched,
+      dispatched: Boolean(request.dispatch),
     });
   }
 
@@ -1092,13 +1093,15 @@ export class InferenceAdmissionGate {
       );
     }
     if (
-      lease.phase === "dispatched" &&
+      lease.preProviderCancellationToken !== undefined &&
       (!request.preProviderCancellationToken ||
         lease.preProviderCancellationToken !==
           request.preProviderCancellationToken)
     ) {
       return jsonError(
-        "Dispatched inference work requires authoritative settlement",
+        lease.phase === "dispatched"
+          ? "Dispatched inference work requires authoritative settlement"
+          : "Inference admission lease release requires its cancellation capability",
         409,
       );
     }

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1887,6 +1887,7 @@ export async function handleChatCompletionsPOST(
           executionCtx: options.executionCtx,
           admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          dispatch: true,
         });
         settleReservation = admission.settle;
         settleUnknown = admission.settleUnknown;

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -703,10 +703,6 @@ export function inferenceSettlementAmounts(
 export async function markInferenceAdmissionLeaseDispatched(
   lease: InferenceAdmissionLease,
 ): Promise<void> {
-  if (lease.providerDispatched) {
-    lease.preProviderCancellationToken = undefined;
-    return;
-  }
   const cancellationToken = lease.preProviderCancellationToken;
   if (!cancellationToken) {
     throw new InferenceAdmissionDispatchMarkError(

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -41,6 +41,7 @@ interface LeaseResponse {
   admitted: boolean;
   availableUsd: number;
   requiredUsd: number;
+  dispatched?: boolean;
 }
 
 interface SettleResponse {
@@ -560,6 +561,7 @@ export async function acquireInferenceAdmissionLease(params: {
   recovery: InferenceAdmissionRecoveryContext;
   /** Strong standing proof fused into the lease transaction when supplied. */
   credential?: InferenceCredentialCheck;
+  dispatch?: boolean;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
 }): Promise<InferenceAdmissionLease> {
   const balanceUsd = finiteNonNegative(params.balanceUsd, "balanceUsd");
@@ -577,6 +579,7 @@ export async function acquireInferenceAdmissionLease(params: {
 
   const stub = gateStub(params.organizationId);
   const path = params.credential ? "/lease-authorized" : "/lease";
+  const preProviderCancellationToken = crypto.randomUUID();
   const body = {
     organizationId: params.organizationId,
     requestId: params.requestId,
@@ -584,6 +587,10 @@ export async function acquireInferenceAdmissionLease(params: {
     balanceRevision: params.balanceRevision,
     estimatedCostUsd,
     recovery: params.recovery,
+    ...(params.dispatch && {
+      dispatch: true,
+      preProviderCancellationToken,
+    }),
     ...(params.credential
       ? {
           credential: {
@@ -648,8 +655,8 @@ export async function acquireInferenceAdmissionLease(params: {
     requestId: params.requestId,
     estimatedCostUsd,
     gate: stub,
-    providerDispatched: false,
-    preProviderCancellationToken: crypto.randomUUID(),
+    providerDispatched: Boolean(payload.dispatched),
+    preProviderCancellationToken,
   };
 }
 
@@ -696,7 +703,10 @@ export function inferenceSettlementAmounts(
 export async function markInferenceAdmissionLeaseDispatched(
   lease: InferenceAdmissionLease,
 ): Promise<void> {
-  if (lease.providerDispatched) return;
+  if (lease.providerDispatched) {
+    lease.preProviderCancellationToken = undefined;
+    return;
+  }
   const cancellationToken = lease.preProviderCancellationToken;
   if (!cancellationToken) {
     throw new InferenceAdmissionDispatchMarkError(
@@ -757,7 +767,7 @@ export async function markInferenceAdmissionLeaseDispatched(
 export async function releaseInferenceAdmissionLease(
   lease: InferenceAdmissionLease,
 ): Promise<void> {
-  if (lease.providerDispatched) {
+  if (lease.providerDispatched && !lease.preProviderCancellationToken) {
     throw new InferenceAdmissionGateUnavailableError(
       "Dispatched inference work cannot be released without accounting",
     );
@@ -799,6 +809,10 @@ export async function settleInferenceAdmissionLease(
     throw new InferenceAdmissionGateUnavailableError(
       "Gate consumption cannot be lower than balance-backed collection",
     );
+  }
+  if (balanceBackedUsd === 0 && gateConsumedUsd === 0 && lease.preProviderCancellationToken) {
+    await releaseInferenceAdmissionLease(lease);
+    return;
   }
   if (!lease.providerDispatched) {
     if (balanceBackedUsd === 0 && gateConsumedUsd === 0) {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -110,6 +110,8 @@ export interface OrganizationInferenceAdmissionParams {
   admissionSnapshot?: InferenceAdmissionSnapshot;
   /** Strong standing proof consumed atomically by the primary admission gate. */
   credential?: InferenceCredentialCheck;
+  /** Atomically combine billing lease and provider dispatch in one gate round-trip. */
+  dispatch?: boolean;
 }
 
 /** Retryable signal preserving route compatibility while identifying pricing hydration. */
@@ -424,6 +426,7 @@ export async function admitOrganizationInference(
             : { kind: "direct_debit" },
         },
         credential: params.credential,
+        dispatch: params.dispatch,
         executionCtx: params.executionCtx,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
Warm staging traces show that Cloud inference executes two serialized network round-trips immediately before invoking Cerebras/upstream:
1. Billing admission Durable Object lease (`/lease` or `/lease-authorized`) (~26 ms)
2. Dispatch marker (`/dispatch`) (~21 ms)

This PR resolves #30635 by fusing these two operations into a single durable commit at the provider boundary for `/v1/chat/completions`, eliminating ~21–26 ms of latency per request while preserving complete cancellation, zero-settlement, alarm-recovery, and replay invariants.

---

## Changes
1. **Durable Object (`packages/cloud/api/src/inference-admission-gate.ts`)**:
   - Added `dispatch?: boolean` and `preProviderCancellationToken?: string` to `LeaseRequest` and `AuthorizedLeaseRequest`.
   - In `this.lease()`, atomically persist the lease with `phase: "dispatched"`, `preProviderCancellationToken`, and updated alarm/ledger in one commit when `dispatch: true`.
   - Handled duplicate/replay: if already leased/dispatched, safely update expiry and return `dispatched: true, duplicate: true` without double debit.
   - Preserved pre-provider release capability: `/release` allows releasing a dispatched lease if and only if the valid `preProviderCancellationToken` matches.

2. **Client Service (`packages/cloud/shared/src/lib/services/inference-admission-gate.ts`)**:
   - Added `dispatch?: boolean` to `acquireInferenceAdmissionLease`. Generates `preProviderCancellationToken` and sends it with `dispatch: true`.
   - Updated `markInferenceAdmissionLeaseDispatched`: consumes `preProviderCancellationToken` when already dispatched (zero network round-trip).
   - Updated `releaseInferenceAdmissionLease` & `settleInferenceAdmissionLease`: allows zero-settlement release using `preProviderCancellationToken` if upstream aborted before provider call.

3. **Organization Admission (`packages/cloud/shared/src/lib/services/organization-inference-admission.ts`)**:
   - Added `dispatch?: boolean` to `OrganizationInferenceAdmissionParams` and forwarded to `acquireInferenceAdmissionLease`.

4. **Completions Route (`packages/cloud/api/v1/chat/completions/route.ts`)**:
   - Passed `dispatch: true` to `admitOrganizationInference` so the initial admission gate combines lease + dispatch before calling the upstream provider.

---

## Verification
- **Unit Tests**: Added 2 test cases in `packages/cloud/api/__tests__/inference-admission-gate.test.ts` verifying atomic combined lease + dispatch, idempotent replay, mismatched token refusal, and token-based release. (52/52 pass)
- **Integration Tests**: Verified `chat-completions-passthrough-streaming.test.ts` (47/47 pass) and `chat-completions-optimistic-billing.test.ts` (17/17 pass).
- **Static Analysis**: `bunx --bun biome check` passes with 0 errors.
- **Typecheck**: `bun run --cwd packages/cloud/api typecheck` passes with 0 errors.

Closes #30635