### PR TITLE
fix(cloud): atomically commit inference lease at dispatch

### DIFF
--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -92,6 +92,9 @@ const inferenceCredential = {
   credentialId: "key-1",
   userId: USER_ID,
 };
+let routeExecutionCtx:
+  | { waitUntil(promise: Promise<unknown>): void }
+  | undefined;
 const requireGenerativeRouteCaller = mock(
   async (
     _c?: unknown,
@@ -126,7 +129,7 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   asGenerativeCacheApiError: (error: unknown) =>
     error instanceof ApiError ? error : null,
-  getGenerativeExecutionContext: () => undefined,
+  getGenerativeExecutionContext: () => routeExecutionCtx,
   resolveInferenceCredentialAdmissionDenial: () => null,
   requireGenerativeRouteCaller,
 }));
@@ -136,7 +139,13 @@ mock.module("@/lib/services/inference-credential-revocation", () => ({
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
-  charactersService: { getById: charactersGetById },
+  charactersService: {
+    getById: charactersGetById,
+    getByIdCacheOnly: async (id: string) => ({
+      kind: "ready" as const,
+      character: await charactersGetById(id),
+    }),
+  },
 }));
 
 const requireUserOrApiKeyWithOrg = mock();
@@ -229,6 +238,7 @@ function callChat(
 }
 
 beforeEach(() => {
+  routeExecutionCtx = undefined;
   getLanguageModel.mockClear();
   streamText.mockReset();
   resolveAnthropicThinkingBudgetTokens.mockReset();
@@ -426,6 +436,27 @@ describe("Agent A2A billing", () => {
     expect(body.result?.content).toBe("hello from model");
   });
 
+  test("Worker chat opts into atomic admission at the provider boundary", async () => {
+    const retained: Promise<unknown>[] = [];
+    routeExecutionCtx = {
+      waitUntil(promise) {
+        retained.push(Promise.resolve(promise));
+      },
+    };
+    makeReservation({ adjustmentType: "none" });
+
+    const response = await callChat();
+
+    expect(response.status).toBe(200);
+    expect(admitOrganizationInference).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionCtx: routeExecutionCtx,
+        atomicProviderBoundary: true,
+      }),
+    );
+    await Promise.all(retained);
+  });
+
   // Billing uses a conservative estimate without turning that estimate into a
   // provider cap. Final usage is reconciled separately.
   test.each([
@@ -563,6 +594,25 @@ describe("Agent A2A billing", () => {
     expect(reconcile).toHaveBeenCalledWith(0);
     expect(streamText).not.toHaveBeenCalled();
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test("a typed late dispatch denial remains a retryable JSON-RPC admission failure", async () => {
+    const reconcile = makeReservation({ adjustmentType: "refund" });
+    markProviderDispatched.mockRejectedValue(
+      new ApiError(
+        503,
+        "service_unavailable",
+        "dispatch admission unavailable",
+      ),
+    );
+
+    const response = await callChat();
+    const body = (await response.json()) as { error?: { code: number } };
+
+    expect(response.status).toBe(503);
+    expect(body.error?.code).toBe(-32004);
+    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(streamText).not.toHaveBeenCalled();
   });
 
   // Regression for #10266 (A2A side).

--- a/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-mcp-billing.test.ts
@@ -85,6 +85,9 @@ const inferenceCredential = {
   credentialId: "key-1",
   userId: USER_ID,
 };
+let routeExecutionCtx:
+  | { waitUntil(promise: Promise<unknown>): void }
+  | undefined;
 const requireGenerativeRouteCaller = mock(
   async (
     _c?: unknown,
@@ -119,7 +122,7 @@ mock.module("@/lib/services/organization-inference-admission", () => ({
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   asGenerativeCacheApiError: (error: unknown) =>
     error instanceof ApiError ? error : null,
-  getGenerativeExecutionContext: () => undefined,
+  getGenerativeExecutionContext: () => routeExecutionCtx,
   resolveInferenceCredentialAdmissionDenial: () => null,
   requireGenerativeRouteCaller,
 }));
@@ -129,7 +132,13 @@ mock.module("@/lib/services/inference-credential-revocation", () => ({
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
-  charactersService: { getById: charactersGetById },
+  charactersService: {
+    getById: charactersGetById,
+    getByIdCacheOnly: async (id: string) => ({
+      kind: "ready" as const,
+      character: await charactersGetById(id),
+    }),
+  },
 }));
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
@@ -244,6 +253,7 @@ function callRouteChat() {
 }
 
 beforeEach(() => {
+  routeExecutionCtx = undefined;
   requireGenerativeRouteCaller.mockReset();
   requireGenerativeRouteCaller.mockResolvedValue({
     user: { id: USER_ID, organization_id: ORG_ID },
@@ -378,6 +388,27 @@ describe("Agent MCP billing", () => {
     expect(reconcile.mock.invocationCallOrder[0]).toBeLessThan(
       recordCreatorEarnings.mock.invocationCallOrder[0],
     );
+  });
+
+  test("Worker chat opts into atomic admission at the provider boundary", async () => {
+    const retained: Promise<unknown>[] = [];
+    routeExecutionCtx = {
+      waitUntil(promise) {
+        retained.push(Promise.resolve(promise));
+      },
+    };
+    makeReservation({ adjustmentType: "none" });
+
+    const response = await callRouteChat();
+
+    expect(response.status).toBe(200);
+    expect(admitOrganizationInference).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionCtx: routeExecutionCtx,
+        atomicProviderBoundary: true,
+      }),
+    );
+    await Promise.all(retained);
   });
 
   // Billing uses a conservative estimate without turning that estimate into a
@@ -615,5 +646,24 @@ describe("Agent MCP billing", () => {
     expect(reconcile).toHaveBeenCalledWith(0);
     expect(streamText).not.toHaveBeenCalled();
     expect(recordCreatorEarnings).not.toHaveBeenCalled();
+  });
+
+  test("a typed late dispatch denial remains a retryable JSON-RPC admission failure", async () => {
+    const reconcile = makeReservation({ adjustmentType: "refund" });
+    markProviderDispatched.mockRejectedValue(
+      new ApiError(
+        503,
+        "service_unavailable",
+        "dispatch admission unavailable",
+      ),
+    );
+
+    const response = await callChat();
+    const body = (await response.json()) as { error?: { code: number } };
+
+    expect(response.status).toBe(503);
+    expect(body.error?.code).toBe(-32004);
+    expect(reconcile).toHaveBeenCalledWith(0);
+    expect(streamText).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-cache-hotpath.test.ts
@@ -146,6 +146,9 @@ mock.module("@/lib/services/inference-auth-context", () => ({
 
 const settle = mock(async () => null);
 const settleUnknown = mock(async () => null);
+const markProviderDispatched = mock(async () => {
+  callOrder.push("mark");
+});
 const admitOrganizationInference = mock(
   async (_params: Record<string, unknown>) => {
     callOrder.push("admission");
@@ -153,6 +156,7 @@ const admitOrganizationInference = mock(
       mode: "deferred_reservation",
       settle,
       settleUnknown,
+      markProviderDispatched,
       reservation: RESERVATION,
     };
   },
@@ -235,6 +239,7 @@ beforeEach(() => {
   billUsage.mockClear();
   settle.mockClear();
   settleUnknown.mockClear();
+  markProviderDispatched.mockClear();
   admitOrganizationInference.mockClear();
   getCurrentUser.mockClear();
   getAnonymousUser.mockClear();
@@ -415,7 +420,7 @@ describe("/v1/chat Worker cache hot path", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(callOrder).toEqual(["rate-limit", "admission", "provider"]);
+    expect(callOrder).toEqual(["rate-limit", "admission", "mark", "provider"]);
     expect(getCurrentUser).not.toHaveBeenCalled();
     expect(getAnonymousUser).not.toHaveBeenCalled();
     expect(reserveAnonymousMessageSlot).not.toHaveBeenCalled();
@@ -433,6 +438,7 @@ describe("/v1/chat Worker cache hot path", () => {
         affiliateCode: "affiliate-a",
         executionCtx,
         estimatedOutputTokens: 500,
+        atomicProviderBoundary: true,
       }),
     );
 

--- a/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-optimistic-billing.test.ts
@@ -44,6 +44,7 @@ let deferredEnabled = false;
 let ledgerAdmits = true;
 let reserveCreditsThrows: Error | null = null;
 let organizationAdmissionError: Error | null = null;
+let dispatchAdmissionError: Error | null = null;
 let strongRevocationEnabled = true;
 const callOrder: string[] = [];
 
@@ -71,6 +72,7 @@ const organizationSettler = mock(async (_actualCostUsd: number) => null);
 const organizationUnknownSettler = mock(async () => null);
 const markProviderDispatched = mock(async () => {
   callOrder.push("dispatch");
+  if (dispatchAdmissionError) throw dispatchAdmissionError;
 });
 type OrganizationAdmissionParams = Parameters<
   typeof organizationAdmissionActual.admitOrganizationInference
@@ -392,6 +394,7 @@ describe("chat/completions cache-only organization admission", () => {
     ledgerAdmits = true;
     reserveCreditsThrows = null;
     organizationAdmissionError = null;
+    dispatchAdmissionError = null;
     strongRevocationEnabled = true;
     callOrder.length = 0;
     writePendingInferenceCharge.mockClear();
@@ -543,6 +546,7 @@ describe("chat/completions cache-only organization admission", () => {
       >
     )[0]?.[0];
     expect(admission?.executionCtx).toBeDefined();
+    expect(admission?.atomicProviderBoundary).toBe(true);
     expect(admission?.credential).toEqual({
       kind: "api_key",
       credentialId: API_KEY_ID,
@@ -710,6 +714,55 @@ describe("chat/completions cache-only organization admission", () => {
     expect(reserveCredits).not.toHaveBeenCalled();
     expect(writePendingInferenceCharge).not.toHaveBeenCalled();
     expect(admitInferenceChargeViaLedger).not.toHaveBeenCalled();
+  });
+
+  test("a provider-boundary admission timeout returns 503 without invoking the provider", async () => {
+    dispatchAdmissionError =
+      new organizationAdmissionActual.InferenceAdmissionUnavailableError({
+        cause: new Error("combined lease acknowledgement lost"),
+      });
+    const captured: Promise<unknown>[] = [];
+
+    const response = await driveWithCtx(captured);
+    await Promise.all(captured);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "inference_admission_unavailable" },
+    });
+    expect(generateText).not.toHaveBeenCalled();
+    expect(organizationSettler).toHaveBeenCalledWith(0);
+  });
+
+  test("provider-boundary balance and credential denials remain typed before provider work", async () => {
+    for (const candidate of [
+      {
+        error: new aiBillingActual.InsufficientCreditsError(0.05, 0.01),
+        status: 402,
+      },
+      {
+        error:
+          new inferenceCredentialRevocationActual.InferenceCredentialRevokedError(
+            "organization_disabled",
+          ),
+        status: 403,
+      },
+    ]) {
+      dispatchAdmissionError = candidate.error;
+      const captured: Promise<unknown>[] = [];
+      const response = await driveWithCtx(captured);
+      await Promise.all(captured);
+
+      expect(response.status).toBe(candidate.status);
+      expect(generateText).not.toHaveBeenCalled();
+      expect(organizationSettler).toHaveBeenCalledWith(0);
+
+      dispatchAdmissionError = null;
+      organizationSettler.mockClear();
+      markProviderDispatched.mockClear();
+      callOrder.length = 0;
+    }
   });
 
   test("a cached insufficient-balance decision returns 402 without provider dispatch or DB fallback", async () => {

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -26,9 +26,9 @@ import * as aiBillingActual from "@/lib/services/ai-billing";
 import * as aiBillingRecordsActual from "@/lib/services/ai-billing-records";
 import { InferenceAdmissionDispatchMarkError } from "@/lib/services/inference-admission-gate";
 import * as teamCredentialPoolActual from "@/lib/services/team-credential-pool";
-
 // The REAL settler — explicitly NOT mocked; reservation math is under test.
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
+import * as loggerActual from "@/lib/utils/logger";
 
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const USER = "00000000-0000-4000-8000-0000000000bb";
@@ -119,6 +119,17 @@ mock.module("@/lib/services/team-credential-pool", () => ({
   }),
 }));
 
+const errorCalls: Array<{ message: string; context: unknown }> = [];
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: {
+    ...loggerActual.logger,
+    error(message: string, context?: unknown) {
+      errorCalls.push({ message, context });
+    },
+  },
+}));
+
 // Import the route AFTER the mocks so it binds to the stubs.
 const {
   default: chatCompletionsRouter,
@@ -162,6 +173,7 @@ afterAll(() => {
     "@/lib/services/team-credential-pool",
     () => teamCredentialPoolActual,
   );
+  mock.module("@/lib/utils/logger", () => loggerActual);
   globalThis.fetch = realFetch;
   for (const key of ENV_KEYS) {
     if (savedEnv[key] === undefined) delete process.env[key];
@@ -177,6 +189,7 @@ beforeEach(() => {
   aiBillingRecord.mockClear();
   poolRecordUse.mockClear();
   poolRecordProviderFailure.mockClear();
+  errorCalls.length = 0;
   fetchMock.mockClear();
   generateTextImpl = null;
   streamTextImpl = null;
@@ -311,6 +324,7 @@ function callNonStreaming(
   settlement?: {
     settle(actualCost: number): Promise<unknown>;
     settleUnknown(): Promise<unknown>;
+    markProviderDispatched?(): Promise<void>;
   },
 ) {
   return handleNonStreamingRequest(
@@ -342,6 +356,8 @@ function callNonStreaming(
     null,
     false,
     undefined,
+    undefined,
+    settlement?.markProviderDispatched,
   );
 }
 
@@ -760,6 +776,41 @@ describe("passthrough streaming — fallthrough to the SDK path", () => {
     });
   });
 
+  test("SDK streaming and non-streaming both stop before provider work when atomic admission fails", async () => {
+    const denial = new InferenceAdmissionDispatchMarkError(
+      "combined admission denied before provider work",
+    );
+    const markProviderDispatched = async () => {
+      throw denial;
+    };
+
+    await expect(
+      callStreaming(async () => null, {
+        request: {
+          ...QUALIFYING_REQUEST,
+          tools: [
+            {
+              type: "function",
+              function: { name: "get_weather", parameters: {} },
+            },
+          ],
+        },
+        markProviderDispatched,
+      }),
+    ).rejects.toBe(denial);
+    await expect(
+      callNonStreaming("zai-glm-4.7", "none", undefined, {
+        settle: async () => null,
+        settleUnknown: async () => null,
+        markProviderDispatched,
+      }),
+    ).rejects.toBe(denial);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(streamText).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
   test("SDK non-streaming keeps the admitted estimate when billing fails after provider output", async () => {
     generateTextImpl = () => ({
       text: "Hello",
@@ -995,7 +1046,7 @@ describe("passthrough streaming — upstream errors settle by provable outcome",
         JSON.stringify({
           error: { message: "queue is saturated", type: "rate_limit_error" },
         }),
-        { status: 429 },
+        { status: 429, headers: { "x-request-id": "provider-req-429" } },
       );
 
     const res = await callStreaming(settle, {});
@@ -1012,6 +1063,17 @@ describe("passthrough streaming — upstream errors settle by provable outcome",
     expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
     expect(billUsage).not.toHaveBeenCalled();
     expect(streamText).not.toHaveBeenCalled();
+    expect(errorCalls).toContainEqual({
+      message: "[Chat Completions] Passthrough upstream error status",
+      context: {
+        model: MODEL,
+        provider: "cerebras-api",
+        traceId: "req-1",
+        providerRequestId: "provider-req-429",
+        upstreamStatus: 429,
+        mappedStatus: 429,
+      },
+    });
   });
 
   test("redacts an echoed prompt cache key from an upstream error", async () => {
@@ -1085,9 +1147,40 @@ describe("passthrough streaming — upstream errors settle by provable outcome",
     expect(ledger.reconcileCalls).toBe(1);
     expect(ledger.actualCosts).toEqual([ledger.hold]);
     expect(billUsage).not.toHaveBeenCalled();
+    expect(errorCalls).toContainEqual({
+      message: "[Chat Completions] Passthrough upstream fetch failed",
+      context: {
+        model: MODEL,
+        provider: "cerebras-api",
+        traceId: "req-1",
+        error: "network down",
+      },
+    });
   });
 
-  test("dispatch acknowledgement failure cancels before the provider is invoked", async () => {
+  test("accepted response without a body logs the trace and sanitized provider request id", async () => {
+    fetchImpl = async () =>
+      new Response(null, {
+        status: 200,
+        headers: { "x-request-id": "provider req<missing-body>" },
+      });
+
+    const res = await callStreaming(async () => null, {});
+
+    expect(res.status).toBe(503);
+    expect(errorCalls).toContainEqual({
+      message:
+        "[Chat Completions] Passthrough upstream returned an accepted response without a stream body",
+      context: {
+        model: MODEL,
+        provider: "cerebras-api",
+        traceId: "req-1",
+        providerRequestId: "provider_req_missing-body_",
+      },
+    });
+  });
+
+  test("dispatch acknowledgement failure escapes to the route cancellation boundary", async () => {
     const ledger = makeLedgerReservation(100, 0.9);
     const settle = createCreditReservationSettler(ledger.reservation);
     let unknownSettles = 0;
@@ -1095,23 +1188,24 @@ describe("passthrough streaming — upstream errors settle by provable outcome",
       throw new Error("provider fetch must not run");
     };
 
-    const res = await callStreaming(settle, {
-      markProviderDispatched: async () => {
-        throw new InferenceAdmissionDispatchMarkError(
-          "dispatch acknowledgement remained ambiguous",
-        );
-      },
-      settleUnknown: async () => {
-        unknownSettles++;
-        return null;
-      },
-    });
+    await expect(
+      callStreaming(settle, {
+        markProviderDispatched: async () => {
+          throw new InferenceAdmissionDispatchMarkError(
+            "dispatch acknowledgement remained ambiguous",
+          );
+        },
+        settleUnknown: async () => {
+          unknownSettles++;
+          return null;
+        },
+      }),
+    ).rejects.toBeInstanceOf(InferenceAdmissionDispatchMarkError);
 
-    expect(res.status).toBe(503);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(unknownSettles).toBe(0);
-    expect(ledger.actualCosts).toEqual([0]);
-    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+    expect(ledger.actualCosts).toEqual([]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - ledger.hold, 10);
   });
 
   test("partial output followed by an in-stream error retains the admitted estimate", async () => {

--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -32,6 +32,7 @@ let authResult:
   | "forbidden"
   | "unexpected" = "throw";
 let sandboxResult: Record<string, unknown> | null = null;
+let sandboxLookupError: Error | null = null;
 let creditGateResult: { allowed: boolean; balance: number; error?: string } = {
   allowed: true,
   balance: 100,
@@ -56,6 +57,7 @@ const authRequests: Request[] = [];
 const authDbCacheContexts: boolean[] = [];
 const sandboxDbCacheContexts: boolean[] = [];
 const warnCalls: Array<{ message: string; context: unknown }> = [];
+const errorCalls: Array<{ message: string; context: unknown }> = [];
 
 mock.module("@/lib/runtime/cloud-bindings", () => ({
   ...cloudBindingsActual,
@@ -78,6 +80,7 @@ mock.module("@/db/repositories/agent-sandboxes", () => ({
     ...agentSandboxesActual.agentSandboxesRepository,
     findByIdAndOrg: async () => {
       sandboxDbCacheContexts.push(hasDbCacheContext());
+      if (sandboxLookupError) throw sandboxLookupError;
       return sandboxResult;
     },
   },
@@ -123,7 +126,9 @@ mock.module("@/lib/utils/logger", () => ({
     warn(message: string, context?: unknown) {
       warnCalls.push({ message, context });
     },
-    error() {},
+    error(message: string, context?: unknown) {
+      errorCalls.push({ message, context });
+    },
     info() {},
     debug() {},
   },
@@ -249,6 +254,7 @@ beforeEach(() => {
   fetchImpl = null;
   authResult = "throw";
   sandboxResult = null;
+  sandboxLookupError = null;
   creditGateResult = { allowed: true, balance: 100 };
   enqueueCalls = 0;
   browserClaimResult = { status: "invalid" };
@@ -258,6 +264,7 @@ beforeEach(() => {
   authDbCacheContexts.length = 0;
   sandboxDbCacheContexts.length = 0;
   warnCalls.length = 0;
+  errorCalls.length = 0;
   rateLimitResult = { success: true };
   rateLimitError = null;
   rateLimitKeys.length = 0;
@@ -1280,6 +1287,29 @@ describe("dedicated-agent-proxy — unified auth", () => {
     expect(captured).toBeNull();
   });
 
+  test("owner credential lookup failure logs the validated trace", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxLookupError = new Error("sandbox lookup failed");
+    const traceId = "0123456789abcdef0123456789abcdef";
+    const r = makeRequest("cloud-token", undefined, {
+      "X-Eliza-Trace-Id": traceId,
+    });
+
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    expect(res.status).toBe(503);
+    expect(errorCalls).toContainEqual({
+      message: "[dedicated-proxy] owner credential resolution failed",
+      context: {
+        agentId: AGENT,
+        orgId: "org1",
+        traceId,
+        error: "sandbox lookup failed",
+      },
+    });
+    expect(captured).toBeNull();
+  });
+
   test("owner of a NON-RUNNING agent → 202 resume, does NOT proxy to the container", async () => {
     authResult = { user: { id: "u1", organization_id: "org1" } };
     sandboxResult = { ...runningDedicated, status: "stopped" };
@@ -1759,7 +1789,10 @@ describe("dedicated-agent-proxy — stream-aware origin timeout", () => {
         );
       });
 
-    const r = makeRequest("cloud-token", ORIGIN);
+    const traceId = "0123456789abcdef0123456789abcdef";
+    const r = makeRequest("cloud-token", ORIGIN, {
+      "X-Eliza-Trace-Id": traceId,
+    });
     // Old behavior: this await THROWS (client saw CF 1101 / empty body).
     const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
 
@@ -1770,6 +1803,15 @@ describe("dedicated-agent-proxy — stream-aware origin timeout", () => {
     const body = (await res.json()) as { code?: string; success?: boolean };
     expect(body.success).toBe(false);
     expect(body.code).toBe("agent_timeout");
+    expect(warnCalls).toContainEqual({
+      message: "[dedicated-proxy] origin did not respond within timeout",
+      context: {
+        host: "cp.example.test",
+        path: "/api/status",
+        timeoutMs: 20,
+        traceId,
+      },
+    });
   });
 
   test("non-timeout fetch failures still propagate (fail-closed pass-through untouched)", async () => {

--- a/packages/cloud/api/__tests__/embeddings-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-cache-hotpath.test.ts
@@ -49,6 +49,7 @@ mock.module("@/lib/providers/language-model", () => ({
 }));
 
 const settleAdmission = mock(async () => null);
+const markProviderDispatched = mock(async () => undefined);
 const admitOrganizationInference = mock();
 mock.module("@/lib/services/organization-inference-admission", () => ({
   ...admissionActual,
@@ -136,6 +137,8 @@ beforeEach(() => {
   resolveInferenceAuthContext.mockReset();
   admitOrganizationInference.mockReset();
   settleAdmission.mockClear();
+  markProviderDispatched.mockReset();
+  markProviderDispatched.mockResolvedValue(undefined);
   billUsage.mockReset();
   usageCreate.mockReset();
   embed.mockReset();
@@ -158,6 +161,7 @@ beforeEach(() => {
     mode: "deferred_kv_ledger",
     settle: settleAdmission,
     settleUnknown: settleAdmission,
+    markProviderDispatched,
   });
   billUsage.mockResolvedValue({
     inputCost: 0.001,
@@ -229,6 +233,7 @@ describe("POST /api/v1/embeddings Worker cache hot path", () => {
           mode: "deferred_kv_ledger",
           settle: settleAdmission,
           settleUnknown: settleAdmission,
+          markProviderDispatched,
         };
       },
     );
@@ -259,6 +264,7 @@ describe("POST /api/v1/embeddings Worker cache hot path", () => {
       expect.objectContaining({
         apiKeyId: API_KEY_ID,
         executionCtx: ctx,
+        atomicProviderBoundary: true,
         context: expect.objectContaining({
           organizationId: ORG,
           userId: USER,
@@ -273,6 +279,28 @@ describe("POST /api/v1/embeddings Worker cache hot path", () => {
 
     authoritativeAdmission.resolve();
     await Promise.all(scheduled);
+  });
+
+  test("late dispatch admission failure returns 503 without invoking the embedder", async () => {
+    markProviderDispatched.mockRejectedValueOnce(
+      new admissionActual.InferenceAdmissionUnavailableError({
+        cause: new Error("dispatch marker unavailable"),
+      }),
+    );
+    const { ctx, scheduled } = makeExecutionCtx();
+
+    const response = await post(ctx);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "inference_admission_unavailable" },
+    });
+    expect(markProviderDispatched).toHaveBeenCalledTimes(1);
+    expect(embed).not.toHaveBeenCalled();
+    expect(embedMany).not.toHaveBeenCalled();
+    await Promise.all(scheduled);
+    expect(settleAdmission).toHaveBeenCalledWith(0);
   });
 
   test("warm Steward session stays cache-only and attributes no API key", async () => {

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -248,6 +248,8 @@ function post(
     | "/hydrate"
     | "/lease"
     | "/lease-authorized"
+    | "/lease-dispatched"
+    | "/lease-dispatched-authorized"
     | "/dispatch"
     | "/release"
     | "/settle"
@@ -264,7 +266,10 @@ function post(
   body: Record<string, unknown>,
 ): Promise<Response> {
   const payload =
-    (path === "/lease" || path === "/lease-authorized") &&
+    (path === "/lease" ||
+      path === "/lease-authorized" ||
+      path === "/lease-dispatched" ||
+      path === "/lease-dispatched-authorized") &&
     body.recovery === undefined
       ? {
           ...body,
@@ -282,7 +287,10 @@ function post(
             accounting: { kind: "direct_debit" },
           },
         }
-      : path === "/lease" || path === "/lease-authorized"
+      : path === "/lease" ||
+          path === "/lease-authorized" ||
+          path === "/lease-dispatched" ||
+          path === "/lease-dispatched-authorized"
         ? { ...body, organizationId: body.organizationId ?? "org-a" }
         : body;
   return gate.fetch(
@@ -1194,6 +1202,151 @@ describe("InferenceAdmissionGate", () => {
     expect(statuses.sort()).toEqual([200, 402]);
   });
 
+  test("combined lease and dispatch is idempotent, conflict-safe, and balance-serialized", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 2);
+    const body = {
+      requestId: "combined-a",
+      balanceUsd: 2,
+      balanceRevision: "1",
+      estimatedCostUsd: 1,
+      preProviderCancellationToken: "cancel-combined-a",
+    };
+
+    const first = await post(gate, "/lease-dispatched", body);
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({
+      admitted: true,
+      dispatched: true,
+    });
+    expect(
+      storage.read<{ phase: string; preProviderCancellationToken?: string }>(
+        storedLeaseKey("combined-a"),
+      ),
+    ).toMatchObject({
+      phase: "dispatched",
+      preProviderCancellationToken: "cancel-combined-a",
+    });
+
+    const replay = await post(gate, "/lease-dispatched", body);
+    expect(replay.status).toBe(200);
+    expect(await replay.json()).toMatchObject({ duplicate: true });
+    expect(
+      (
+        await post(gate, "/lease-dispatched", {
+          ...body,
+          preProviderCancellationToken: "different-capability",
+        })
+      ).status,
+    ).toBe(409);
+
+    const concurrent = await Promise.all(
+      ["combined-b", "combined-c"].map((requestId) =>
+        post(gate, "/lease-dispatched", {
+          requestId,
+          balanceUsd: 2,
+          balanceRevision: "1",
+          estimatedCostUsd: 1,
+          preProviderCancellationToken: `cancel-${requestId}`,
+        }),
+      ),
+    );
+    expect(concurrent.map((response) => response.status).sort()).toEqual([
+      200, 402,
+    ]);
+  });
+
+  test("combined authorized dispatch applies revocation before creating a lease", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 2);
+    expect(
+      (
+        await post(gate, "/credential/revoke", {
+          organizationId: "org-a",
+          kind: "api_key",
+          credentialId: "key-a",
+        })
+      ).status,
+    ).toBe(200);
+
+    const denied = await post(gate, "/lease-dispatched-authorized", {
+      requestId: "combined-revoked",
+      balanceUsd: 2,
+      balanceRevision: "1",
+      estimatedCostUsd: 1,
+      preProviderCancellationToken: "cancel-combined-revoked",
+      credential: {
+        organizationId: "org-a",
+        kind: "api_key",
+        credentialId: "key-a",
+        userId: "user-a",
+      },
+    });
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toMatchObject({ reason: "credential_revoked" });
+    expect(storage.read(storedLeaseKey("combined-revoked"))).toBeUndefined();
+    expect(storage.read<{ activeLeaseCount: number }>("ledger")).toMatchObject({
+      activeLeaseCount: 0,
+    });
+  });
+
+  test("combined dispatch upgrades an identical rolling-deploy legacy lease", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 2);
+    const legacyBody = {
+      requestId: "rolling-legacy",
+      balanceUsd: 2,
+      balanceRevision: "1",
+      estimatedCostUsd: 1,
+    };
+    expect((await post(gate, "/lease", legacyBody)).status).toBe(200);
+    expect(
+      (
+        await post(gate, "/lease-dispatched", {
+          ...legacyBody,
+          preProviderCancellationToken: "cancel-rolling-legacy",
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      storage.read<{ phase: string }>(storedLeaseKey("rolling-legacy")),
+    ).toMatchObject({ phase: "dispatched" });
+  });
+
+  test("combined dispatch publishes neither lease nor alarm on transaction failure", async () => {
+    for (const fault of ["setAlarm", "commit"] as const) {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 2);
+      if (fault === "setAlarm") storage.failNextSetAlarm = true;
+      else storage.failNextTransactionCommit = true;
+
+      await expect(
+        post(gate, "/lease-dispatched", {
+          requestId: `combined-${fault}`,
+          balanceUsd: 2,
+          balanceRevision: "1",
+          estimatedCostUsd: 1,
+          preProviderCancellationToken: `cancel-combined-${fault}`,
+        }),
+      ).rejects.toThrow(
+        fault === "setAlarm"
+          ? "injected setAlarm failure"
+          : "injected transaction commit failure",
+      );
+      expect(storage.read(storedLeaseKey(`combined-${fault}`))).toBeUndefined();
+      expect(
+        storage.read<{ activeLeaseCount: number }>("ledger"),
+      ).toMatchObject({
+        activeLeaseCount: 0,
+      });
+      expect(storage.alarm).toBeUndefined();
+    }
+  });
+
   test("authorized lease persistence failures publish neither admission nor balance hold", async () => {
     const storage = new TestStorage();
     const gate = createGate(storage);
@@ -1859,6 +2012,205 @@ describe("InferenceAdmissionGate", () => {
     expect(recoverExpiredLease).not.toHaveBeenCalled();
   });
 
+  test("prepared admission performs exactly one combined gate call before provider invocation", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10);
+    const paths: string[] = [];
+    let providerInvocations = 0;
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            paths.push(new URL(incoming.url).pathname);
+            return await gate.fetch(incoming);
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "prepared-one-call",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 1,
+        recovery: organizationRecovery("prepared-one-call"),
+        deferCommitUntilDispatch: true,
+      });
+      expect(paths).toEqual([]);
+      expect(storage.read(storedLeaseKey("prepared-one-call"))).toBeUndefined();
+
+      await markInferenceAdmissionLeaseDispatched(lease);
+      providerInvocations++;
+      expect(paths).toEqual(["/lease-dispatched"]);
+      expect(providerInvocations).toBe(1);
+      expect(
+        storage.read<{ phase: string }>(storedLeaseKey("prepared-one-call")),
+      ).toMatchObject({ phase: "dispatched" });
+    });
+  });
+
+  test("prepared combined denials are typed and never invoke the provider", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 0);
+    await runWithCloudBindingsAsync(gateBindings(gate), async () => {
+      const insufficient = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "prepared-insufficient",
+        balanceUsd: 0,
+        balanceRevision: "1",
+        estimatedCostUsd: 1,
+        recovery: organizationRecovery("prepared-insufficient"),
+        deferCommitUntilDispatch: true,
+      });
+      await expect(
+        markInferenceAdmissionLeaseDispatched(insufficient),
+      ).rejects.toBeInstanceOf(InferenceAdmissionLeaseRejectedError);
+      await settleInferenceAdmissionLease(insufficient, 0, 0);
+
+      expect(
+        (
+          await post(gate, "/credential/revoke", {
+            organizationId: "org-a",
+            kind: "api_key",
+            credentialId: "key-a",
+          })
+        ).status,
+      ).toBe(200);
+      const revoked = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "prepared-revoked",
+        balanceUsd: 0,
+        balanceRevision: "1",
+        estimatedCostUsd: 1,
+        recovery: organizationRecovery("prepared-revoked"),
+        credential: {
+          kind: "api_key",
+          credentialId: "key-a",
+          userId: "user-a",
+        },
+        deferCommitUntilDispatch: true,
+      });
+      await expect(
+        markInferenceAdmissionLeaseDispatched(revoked),
+      ).rejects.toBeInstanceOf(InferenceCredentialRevokedError);
+      await settleInferenceAdmissionLease(revoked, 0, 0);
+    });
+
+    expect(
+      storage.read(storedLeaseKey("prepared-insufficient")),
+    ).toBeUndefined();
+    expect(storage.read(storedLeaseKey("prepared-revoked"))).toBeUndefined();
+  });
+
+  test("lost combined acknowledgements release a committed lease before provider work", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10);
+    const combinedBodies: string[] = [];
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            const path = new URL(incoming.url).pathname;
+            const combinedBody =
+              path === "/lease-dispatched"
+                ? await incoming.clone().text()
+                : undefined;
+            const response = await gate.fetch(incoming);
+            if (combinedBody !== undefined) {
+              combinedBodies.push(combinedBody);
+              throw new Error("injected lost combined response");
+            }
+            return response;
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "prepared-lost-ack",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 4,
+        recovery: organizationRecovery("prepared-lost-ack"),
+        deferCommitUntilDispatch: true,
+      });
+      await expect(
+        markInferenceAdmissionLeaseDispatched(lease),
+      ).rejects.toBeInstanceOf(InferenceAdmissionGateUnavailableError);
+      await settleInferenceAdmissionLease(lease, 0, 0);
+    });
+
+    expect(combinedBodies).toHaveLength(3);
+    expect(new Set(combinedBodies).size).toBe(1);
+    expect(storage.read(storedLeaseKey("prepared-lost-ack"))).toBeUndefined();
+    expect(storage.read<{ activeLeaseCount: number }>("ledger")).toMatchObject({
+      activeLeaseCount: 0,
+    });
+    expect(storage.alarm).toBeUndefined();
+  });
+
+  test("combined requests that never reach the gate settle zero provider work idempotently", async () => {
+    const storage = new TestStorage();
+    const gate = createGate(storage);
+    await hydrateGate(gate, 10);
+    const paths: string[] = [];
+    const bindings = {
+      INFERENCE_ADMISSION_GATES: {
+        getByName: (_name: string) => ({
+          fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+            const incoming = new Request(request, init);
+            const path = new URL(incoming.url).pathname;
+            paths.push(path);
+            if (path === "/lease-dispatched") {
+              throw new Error("injected request never reached gate");
+            }
+            return await gate.fetch(incoming);
+          },
+        }),
+      },
+    };
+
+    await runWithCloudBindingsAsync(bindings, async () => {
+      const lease = await acquireInferenceAdmissionLease({
+        organizationId: "org-a",
+        requestId: "prepared-never-landed",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 4,
+        recovery: organizationRecovery("prepared-never-landed"),
+        deferCommitUntilDispatch: true,
+      });
+      await expect(
+        markInferenceAdmissionLeaseDispatched(lease),
+      ).rejects.toBeInstanceOf(InferenceAdmissionGateUnavailableError);
+      await expect(
+        settleInferenceAdmissionLease(lease, 0, 0),
+      ).resolves.toBeUndefined();
+    });
+
+    expect(paths).toEqual([
+      "/lease-dispatched",
+      "/lease-dispatched",
+      "/lease-dispatched",
+      "/release",
+    ]);
+    expect(
+      storage.read(storedLeaseKey("prepared-never-landed")),
+    ).toBeUndefined();
+    expect(storage.read<{ activeLeaseCount: number }>("ledger")).toMatchObject({
+      activeLeaseCount: 0,
+    });
+  });
+
   test("a dispatched lease cannot use the pre-provider release path without its capability", async () => {
     const gate = createGate();
     await hydrateGate(gate, 5);
@@ -2086,18 +2438,12 @@ describe("InferenceAdmissionGate", () => {
       await hydrateGate(gate, 10, "1");
       expect(
         (
-          await post(gate, "/lease", {
+          await post(gate, "/lease-dispatched", {
             requestId: "request-a",
             balanceUsd: 10,
             balanceRevision: "1",
             estimatedCostUsd: 8,
-          })
-        ).status,
-      ).toBe(200);
-      expect(
-        (
-          await post(gate, "/dispatch", {
-            requestId: "request-a",
+            preProviderCancellationToken: "cancel-request-a",
           })
         ).status,
       ).toBe(200);

--- a/packages/cloud/api/__tests__/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud/api/__tests__/inference-hot-path-benchmark.test.ts
@@ -68,7 +68,7 @@ function createGate(): InferenceAdmissionGate {
 
 function post(
   gate: InferenceAdmissionGate,
-  path: "/hydrate" | "/rate-limit" | "/lease" | "/dispatch" | "/settle",
+  path: "/hydrate" | "/rate-limit" | "/lease-dispatched" | "/settle",
   body: Record<string, unknown>,
 ): Promise<Response> {
   return gate.fetch(
@@ -110,12 +110,13 @@ test("warm exact rate plus monetary lease remains a bounded cache-local operatio
       windowMs: 60_000,
       maxRequests: iterations + 1,
     });
-    const lease = await post(gate, "/lease", {
+    const dispatch = await post(gate, "/lease-dispatched", {
       organizationId: "org-benchmark",
       requestId,
       balanceUsd: 100,
       balanceRevision: "1",
       estimatedCostUsd,
+      preProviderCancellationToken: `cancel-${requestId}`,
       recovery: {
         version: 1,
         kind: "organization",
@@ -129,11 +130,9 @@ test("warm exact rate plus monetary lease remains a bounded cache-local operatio
         accounting: { kind: "direct_debit" },
       },
     });
-    const dispatch = await post(gate, "/dispatch", { requestId });
     durationsMs.push(performance.now() - startedAt);
 
     expect(rate.status).toBe(200);
-    expect(lease.status).toBe(200);
     expect(dispatch.status).toBe(200);
 
     // Settlement represents post-provider work and is deliberately excluded
@@ -156,7 +155,7 @@ test("warm exact rate plus monetary lease remains a bounded cache-local operatio
   if (process.env.REPORT_INFERENCE_BENCHMARK === "true") {
     process.stdout.write(
       `${JSON.stringify({
-        benchmark: "inference_durable_object_rate_lease_and_dispatch",
+        benchmark: "inference_durable_object_rate_and_atomic_lease_dispatch",
         iterations,
         p50Ms: Number(p50Ms.toFixed(3)),
         p95Ms: Number(p95Ms.toFixed(3)),

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -13,9 +13,10 @@ import { __mcpProxyHopTestHooks } from "../mcp/proxy/[mcpId]/proxy-body-budget";
 const requireGenerativeRouteCaller = mock();
 const admitFlatGenerativeOperation = mock();
 let executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined;
+let generativeCacheError: ApiError | null;
 mock.module("@/api-app/lib/generative-route-auth", () => ({
   admitFlatGenerativeOperation,
-  asGenerativeCacheApiError: () => null,
+  asGenerativeCacheApiError: () => generativeCacheError,
   getGenerativeExecutionContext: () => executionCtx,
   requireGenerativeRouteCaller,
 }));
@@ -93,6 +94,7 @@ const EXTERNAL_MCP = {
 
 beforeEach(() => {
   executionCtx = undefined;
+  generativeCacheError = null;
   requireGenerativeRouteCaller.mockReset();
   requireGenerativeRouteCaller.mockResolvedValue({
     user: { id: "u1", organization_id: "org1" },
@@ -174,8 +176,51 @@ test("admits before marking dispatch and marks immediately before fetch", async 
   expect(admitFlatGenerativeOperation.mock.invocationCallOrder[0]).toBeLessThan(
     markProviderDispatched.mock.invocationCallOrder[0],
   );
+  expect(
+    admitFlatGenerativeOperation.mock.calls[0]?.[0].atomicProviderBoundary,
+  ).toBe(true);
   expect(markProviderDispatched.mock.invocationCallOrder[0]).toBeLessThan(
     safeFetch.mock.invocationCallOrder[0],
+  );
+});
+
+test("a late balance denial refunds without reaching or blaming the MCP", async () => {
+  markProviderDispatched.mockRejectedValueOnce(
+    new InsufficientCreditsError(0.05, 0.01),
+  );
+
+  const res = await post();
+
+  expect(res.status).toBe(402);
+  expect(settle).toHaveBeenCalledWith(0);
+  expect(settleUnknown).not.toHaveBeenCalled();
+  expect(safeFetch).not.toHaveBeenCalled();
+  expect(loggerError).toHaveBeenCalledWith(
+    "[MCP Proxy] Provider dispatch admission denied",
+    expect.objectContaining({ phase: "provider_dispatch" }),
+  );
+});
+
+test("a late cache denial remains a retryable admission failure", async () => {
+  generativeCacheError = new ApiError(
+    503,
+    "service_unavailable",
+    "Generative admission cache is warming; retry shortly",
+    { retryable: true, retryAfterSeconds: 1 },
+  );
+  markProviderDispatched.mockRejectedValueOnce(
+    new Error("dispatch admission unavailable"),
+  );
+
+  const res = await post();
+
+  expect(res.status).toBe(503);
+  expect(settle).toHaveBeenCalledWith(0);
+  expect(settleUnknown).not.toHaveBeenCalled();
+  expect(safeFetch).not.toHaveBeenCalled();
+  expect(loggerError).toHaveBeenCalledWith(
+    "[MCP Proxy] Provider dispatch admission failed",
+    expect.objectContaining({ phase: "provider_dispatch" }),
   );
 });
 

--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -175,6 +175,8 @@ mock.module("@/lib/services/apps", () => ({
 }));
 
 const admitAppInferenceCacheOnly = mock();
+const settleAppAdmission = mock(async () => null);
+const markAppProviderDispatched = mock(async () => undefined);
 class TestInferenceAppAffiliateUnsupportedError extends Error {}
 const assertInferenceAppAffiliateSupported = mock(
   (_appId: string, affiliateCode: string | null | undefined) => {
@@ -239,6 +241,10 @@ beforeEach(() => {
   getAuthorizedMonetizedAppForUser.mockReset();
   getAuthorizedMonetizedAppForUserCacheOnly.mockReset();
   admitAppInferenceCacheOnly.mockReset();
+  settleAppAdmission.mockReset();
+  settleAppAdmission.mockResolvedValue(null);
+  markAppProviderDispatched.mockReset();
+  markAppProviderDispatched.mockResolvedValue(undefined);
   assertInferenceAppAffiliateSupported.mockClear();
   createCreditReservationSettler.mockReset();
   generateText.mockReset();
@@ -268,8 +274,9 @@ beforeEach(() => {
   admitAppInferenceCacheOnly.mockResolvedValue({
     mode: "deferred_app_reservation",
     estimatedTotalCostUsd: 0.002,
-    settle: async () => null,
-    settleUnknown: async () => null,
+    settle: settleAppAdmission,
+    settleUnknown: settleAppAdmission,
+    markProviderDispatched: markAppProviderDispatched,
   });
   reserveCredits.mockResolvedValue({
     reservedAmount: 0.01,
@@ -393,6 +400,33 @@ describe("/v1/messages IAC fast path", () => {
       { subscriptionFunded: false },
     );
     expect(generateText).toHaveBeenCalledTimes(1);
+  });
+
+  test("late app dispatch admission denial returns Anthropic 402 before the model call", async () => {
+    const app = {
+      id: "00000000-0000-4000-8000-0000000000dd",
+      organization_id: ORG,
+      created_by_user_id: USER,
+      monetization_enabled: true,
+      inference_markup_percentage: "100",
+    };
+    getAuthorizedMonetizedAppForUserCacheOnly.mockResolvedValueOnce({
+      kind: "ready",
+      app,
+    });
+    markAppProviderDispatched.mockRejectedValueOnce(
+      new TestInsufficientCreditsError(0.002),
+    );
+
+    const response = await postMessagesInWorker({ "X-App-Id": app.id });
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      type: "error",
+      error: { type: "billing_error" },
+    });
+    expect(settleAppAdmission).toHaveBeenCalledWith(0);
+    expect(generateText).not.toHaveBeenCalled();
   });
 
   test("Worker requests fail closed while the API-key cache warms", async () => {
@@ -698,6 +732,7 @@ describe("/v1/messages IAC fast path", () => {
         appId: app.id,
         organizationId: ORG,
         userId: USER,
+        atomicProviderBoundary: true,
       }),
     );
     expect(reserveInferenceCredits).not.toHaveBeenCalled();

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -461,6 +461,7 @@ async function handleChat(
       executionCtx: authUser.executionCtx,
       admissionSnapshot: authUser.admissionSnapshot,
       credential: authUser.credentialForAdmission?.(),
+      atomicProviderBoundary: Boolean(authUser.executionCtx),
     });
   } catch (error) {
     // error-policy:J1 the route boundary translates the expected credit
@@ -606,9 +607,30 @@ async function handleChat(
       : admission.settle(0);
     if (authUser.executionCtx) authUser.executionCtx.waitUntil(terminal);
     else await terminal;
+    if (error instanceof InsufficientCreditsError) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: {
+            code: -32003,
+            message: `Insufficient credits. Required: $${error.required.toFixed(4)}`,
+          },
+          id: rpcId,
+        },
+        402,
+      );
+    }
+    if (asGenerativeCacheApiError(error)) {
+      return a2aAuthError(c, error, rpcId);
+    }
     logger.error("[Agent A2A] Error generating response", {
       error: error instanceof Error ? error.message : "Unknown error",
       agentId: character.id,
+      phase: providerDispatchStarted ? "provider" : "provider_dispatch",
+      cause:
+        error instanceof Error && error.cause instanceof Error
+          ? `${error.cause.name}: ${error.cause.message}`
+          : undefined,
     });
     return c.json({
       jsonrpc: "2.0",

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -504,6 +504,7 @@ export async function handleToolCall(
         executionCtx: authUser.executionCtx,
         admissionSnapshot: authUser.admissionSnapshot,
         credential: authUser.credentialForAdmission?.(),
+        atomicProviderBoundary: Boolean(authUser.executionCtx),
       });
     } catch (error) {
       // error-policy:J1 the route boundary translates the expected credit
@@ -661,9 +662,30 @@ export async function handleToolCall(
         : admission.settle(0);
       if (authUser.executionCtx) authUser.executionCtx.waitUntil(terminal);
       else await terminal;
+      if (error instanceof InsufficientCreditsError) {
+        return c.json(
+          {
+            jsonrpc: "2.0",
+            error: {
+              code: -32003,
+              message: `Insufficient credits. Required: $${error.required.toFixed(4)}`,
+            },
+            id: rpcId,
+          },
+          402,
+        );
+      }
+      if (asGenerativeCacheApiError(error)) {
+        return mcpAuthError(c, error, rpcId);
+      }
       logger.error("[Agent MCP] Error generating response", {
         error: error instanceof Error ? error.message : "Unknown error",
         agentId: character.id,
+        phase: providerDispatchStarted ? "provider" : "provider_dispatch",
+        cause:
+          error instanceof Error && error.cause instanceof Error
+            ? `${error.cause.name}: ${error.cause.message}`
+            : undefined,
       });
       return c.json({
         jsonrpc: "2.0",

--- a/packages/cloud/api/fal/proxy/route.ts
+++ b/packages/cloud/api/fal/proxy/route.ts
@@ -256,6 +256,7 @@ const handle: Handler<AppEnv> = async (c) => {
           cost: pricedMutation.cost,
           admissionSnapshot: caller.admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: true,
         });
       } catch (error) {
         const admissionError = asGenerativeCacheApiError(error);

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -580,6 +580,7 @@ app.post("/", async (c) => {
           apiKeyId: caller.apiKeyId,
           admissionSnapshot: caller.admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: true,
           cost: {
             baseTotalCost: chargeReceipt.baseAmountUsd,
             platformMarkup:
@@ -649,10 +650,49 @@ app.post("/", async (c) => {
         if (hopAborted(error)) {
           return await refundDeadline();
         }
+        if (error instanceof InsufficientCreditsError) {
+          logger.error("[MCP Proxy] Provider dispatch admission denied", {
+            mcpId,
+            organizationId: user.organization_id,
+            requestId,
+            phase: "provider_dispatch",
+            error: error.message,
+            errorName: error.name,
+          });
+          await settleFailure("provider_dispatch_admission_failed");
+          return c.json(
+            {
+              error: "Insufficient credits",
+              creditUnit: ORGANIZATION_CREDIT_UNIT,
+              requiredUsd: chargeReceipt.totalAmountUsd,
+              /** @deprecated Legacy MCP pricing points (100 points = $1). */
+              required: totalCreditsRequired,
+              balance: error.available,
+            },
+            402,
+          );
+        }
+        const admissionError = asGenerativeCacheApiError(error);
+        if (admissionError) {
+          logger.error("[MCP Proxy] Provider dispatch admission failed", {
+            mcpId,
+            organizationId: user.organization_id,
+            requestId,
+            phase: "provider_dispatch",
+            error: error instanceof Error ? error.message : String(error),
+            errorName: error instanceof Error ? error.name : "unknown",
+          });
+          await settleFailure("provider_dispatch_admission_failed");
+          return failureResponse(c, admissionError);
+        }
         logger.error("[MCP Proxy] Failed to reach MCP endpoint", {
           mcpId,
           targetUrl,
+          organizationId: user.organization_id,
+          requestId,
+          phase: "provider_request",
           error: error instanceof Error ? error.message : String(error),
+          errorName: error instanceof Error ? error.name : "unknown",
         });
         await settleFailure("upstream_unreachable");
         return c.json({ error: "Failed to reach MCP endpoint" }, 502);

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -440,6 +440,7 @@ async function proxyToOrigin(
   headers.delete("host");
   stripCloudOnlyCredentials(headers);
   sanitizeDedicatedTraceHeaders(headers);
+  const traceId = headers.get("x-eliza-trace-id");
   headers.set("x-forwarded-host", url.host);
   headers.set("x-forwarded-proto", url.protocol.replace(":", ""));
   if (injectBearer) {
@@ -498,6 +499,7 @@ async function proxyToOrigin(
       host: targetUrl.hostname,
       path: targetUrl.pathname,
       timeoutMs,
+      ...(traceId ? { traceId } : {}),
     });
     const response = Response.json(
       {
@@ -1113,6 +1115,8 @@ async function proxyDedicatedAgent(
   agentId: string,
   timing: DedicatedProxyTiming,
 ): Promise<Response> {
+  const rawTraceId = request.headers.get("x-eliza-trace-id");
+  const traceId = isInferenceTraceId(rawTraceId) ? rawTraceId : undefined;
   const queryCredentials = readRealtimeQueryCredentials(url);
   const headerCarriesCredential = Boolean(
     request.headers.get("authorization") || request.headers.get("x-api-key"),
@@ -1302,6 +1306,7 @@ async function proxyDedicatedAgent(
     logger.error("[dedicated-proxy] owner credential resolution failed", {
       agentId,
       orgId,
+      ...(traceId ? { traceId } : {}),
       error: error instanceof Error ? error.message : String(error),
     });
     return Response.json(

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -66,6 +66,14 @@ interface AuthorizedLeaseRequest extends LeaseRequest {
   credential: CredentialCheckRequest;
 }
 
+interface LeaseDispatchRequest extends LeaseRequest {
+  preProviderCancellationToken: string;
+}
+
+interface AuthorizedLeaseDispatchRequest extends AuthorizedLeaseRequest {
+  preProviderCancellationToken: string;
+}
+
 interface HydrateRequest {
   balanceUsd: number;
   balanceRevision: string;
@@ -764,7 +772,10 @@ export class InferenceAdmissionGate {
     }
   }
 
-  private async lease(request: LeaseRequest): Promise<Response> {
+  private async lease(
+    request: LeaseRequest,
+    preProviderCancellationToken?: string,
+  ): Promise<Response> {
     if (
       !validRequestId(request.requestId) ||
       !validId(request.organizationId) ||
@@ -772,6 +783,8 @@ export class InferenceAdmissionGate {
       balanceRevision(request.balanceRevision) === null ||
       !nonNegativeFinite(request.estimatedCostUsd) ||
       request.estimatedCostUsd === 0 ||
+      (preProviderCancellationToken !== undefined &&
+        !validTrimmedId(preProviderCancellationToken)) ||
       !validRecoveryContext(
         request.recovery,
         request.requestId,
@@ -815,6 +828,40 @@ export class InferenceAdmissionGate {
           409,
         );
       }
+      if (preProviderCancellationToken !== undefined) {
+        if (prior.phase === "recovering") {
+          return jsonError(
+            "Inference admission lease recovery is in progress",
+            409,
+          );
+        }
+        if (
+          prior.phase === "dispatched" &&
+          prior.preProviderCancellationToken !== preProviderCancellationToken
+        ) {
+          return jsonError(
+            "Inference admission dispatch capability does not match",
+            409,
+          );
+        }
+        const dispatched: ActiveLease = {
+          ...prior,
+          phase: "dispatched",
+          preProviderCancellationToken,
+          expiresAt: Date.now() + MAX_LEASE_AGE_MS,
+        };
+        await this.save(ledger, {
+          delete: [{ requestId: request.requestId, lease: prior }],
+          put: [{ requestId: request.requestId, lease: dispatched }],
+        });
+        return Response.json({
+          admitted: true,
+          dispatched: true,
+          duplicate: prior.phase === "dispatched",
+          availableUsd: ledger.availableUsd,
+          requiredUsd: request.estimatedCostUsd,
+        });
+      }
       await this.save(ledger);
       return Response.json({
         admitted: true,
@@ -849,7 +896,11 @@ export class InferenceAdmissionGate {
       estimatedCostUsd: request.estimatedCostUsd,
       createdAt: now,
       expiresAt: now + MAX_LEASE_AGE_MS,
-      phase: "leased",
+      phase:
+        preProviderCancellationToken === undefined ? "leased" : "dispatched",
+      ...(preProviderCancellationToken !== undefined && {
+        preProviderCancellationToken,
+      }),
       recovery: structuredClone(request.recovery),
     };
     ledger.activeLeaseCount++;
@@ -863,6 +914,7 @@ export class InferenceAdmissionGate {
     });
     return Response.json({
       admitted: true,
+      ...(preProviderCancellationToken !== undefined && { dispatched: true }),
       availableUsd: ledger.availableUsd,
       requiredUsd: request.estimatedCostUsd,
     });
@@ -870,6 +922,7 @@ export class InferenceAdmissionGate {
 
   private async authorizedLease(
     request: AuthorizedLeaseRequest,
+    preProviderCancellationToken?: string,
   ): Promise<Response> {
     if (
       !request.credential ||
@@ -879,7 +932,7 @@ export class InferenceAdmissionGate {
     }
     const denial = await this.credentialDenial(request.credential);
     if (denial) return denial;
-    return await this.lease(request);
+    return await this.lease(request, preProviderCancellationToken);
   }
 
   private async hydrate(request: HydrateRequest): Promise<Response> {
@@ -1032,7 +1085,14 @@ export class InferenceAdmissionGate {
     const ledger = cloneLedger(existing);
     const lease = await this.loadLease(request.requestId);
     if (!lease) {
-      return jsonError("Inference admission lease was not found", 409);
+      return Response.json(
+        {
+          success: false,
+          code: "inference_admission_lease_not_found",
+          error: "Inference admission lease was not found",
+        },
+        { status: 409 },
+      );
     }
     if (lease.phase === "recovering") {
       return jsonError(
@@ -1369,6 +1429,8 @@ export class InferenceAdmissionGate {
     let body:
       | LeaseRequest
       | AuthorizedLeaseRequest
+      | LeaseDispatchRequest
+      | AuthorizedLeaseDispatchRequest
       | HydrateRequest
       | SettleRequest
       | LeaseIdentityRequest
@@ -1384,6 +1446,8 @@ export class InferenceAdmissionGate {
       body = (await request.json()) as
         | LeaseRequest
         | AuthorizedLeaseRequest
+        | LeaseDispatchRequest
+        | AuthorizedLeaseDispatchRequest
         | HydrateRequest
         | SettleRequest
         | LeaseIdentityRequest
@@ -1408,6 +1472,20 @@ export class InferenceAdmissionGate {
       return await this.serializeRevocation(() =>
         this.serialize(() =>
           this.authorizedLease(body as AuthorizedLeaseRequest),
+        ),
+      );
+    }
+    if (path === "/lease-dispatched") {
+      const dispatch = body as LeaseDispatchRequest;
+      return await this.serialize(() =>
+        this.lease(dispatch, dispatch.preProviderCancellationToken),
+      );
+    }
+    if (path === "/lease-dispatched-authorized") {
+      const dispatch = body as AuthorizedLeaseDispatchRequest;
+      return await this.serializeRevocation(() =>
+        this.serialize(() =>
+          this.authorizedLease(dispatch, dispatch.preProviderCancellationToken),
         ),
       );
     }

--- a/packages/cloud/api/src/lib/generative-route-auth.test.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.test.ts
@@ -729,6 +729,7 @@ describe("admitFlatGenerativeOperation", () => {
       apiKeyId: "key-1",
       cost: FLAT_COST,
       admissionSnapshot: snapshot,
+      atomicProviderBoundary: true,
     });
 
     expect(result).toBe(workerAdmission);
@@ -742,7 +743,29 @@ describe("admitFlatGenerativeOperation", () => {
       executionCtx,
       flatCost: FLAT_COST,
       admissionSnapshot: snapshot,
+      atomicProviderBoundary: true,
     });
+  });
+
+  test("keeps legacy Worker admission when the caller has no explicit provider boundary", async () => {
+    const { c } = workerContext();
+    admitOrganizationInference.mockResolvedValueOnce({
+      mode: "durable_object_debit",
+      settle: async () => null,
+      settleUnknown: async () => null,
+    });
+
+    await admitFlatGenerativeOperation({
+      c: c as never,
+      context: billingContext(),
+      apiKeyId: null,
+      cost: FLAT_COST,
+      admissionSnapshot: admissionSnapshot(),
+    });
+
+    expect(admitOrganizationInference).toHaveBeenCalledWith(
+      expect.objectContaining({ atomicProviderBoundary: false }),
+    );
   });
 
   test("threads the exact deferred credential into Worker flat admission", async () => {

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -335,6 +335,8 @@ export async function admitFlatGenerativeOperation(params: {
   idempotencyKey?: string;
   admissionSnapshot?: InferenceAdmissionSnapshot;
   credential?: InferenceCredentialCheck;
+  /** Use only when the caller must invoke the returned dispatch marker. */
+  atomicProviderBoundary?: boolean;
 }): Promise<OrganizationInferenceAdmission> {
   const executionCtx = getGenerativeExecutionContext(params.c);
   const { provider, billingSource, requestId } = params.context;
@@ -388,6 +390,7 @@ export async function admitFlatGenerativeOperation(params: {
       flatCost: params.cost,
       admissionSnapshot: params.admissionSnapshot,
       ...(params.credential ? { credential: params.credential } : {}),
+      atomicProviderBoundary: params.atomicProviderBoundary === true,
     });
   } catch (error) {
     if (

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -100,7 +100,6 @@ import type {
   CreditReconciliationResult,
   CreditReservation,
 } from "@/lib/services/credits";
-import { isInferenceAdmissionDispatchMarkError } from "@/lib/services/inference-admission-gate";
 import { inferenceRateLimitConfig } from "@/lib/services/inference-admission-snapshot";
 import type { InferenceAdmissionSnapshot } from "@/lib/services/inference-auth-cache";
 import {
@@ -1850,6 +1849,7 @@ export async function handleChatCompletionsPOST(
             executionCtx: options.executionCtx,
             admissionSnapshot,
             credential: credentialGuard.credentialForAdmission(),
+            atomicProviderBoundary: true,
           });
           settleReservation = admission.settle;
           settleUnknown = admission.settleUnknown;
@@ -1887,6 +1887,7 @@ export async function handleChatCompletionsPOST(
           executionCtx: options.executionCtx,
           admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: Boolean(options.executionCtx),
         });
         settleReservation = admission.settle;
         settleUnknown = admission.settleUnknown;
@@ -2196,6 +2197,43 @@ export async function handleChatCompletionsPOST(
               },
             },
             { status: credentialDenial.status },
+          ),
+        ),
+      );
+    }
+    if (
+      error instanceof InferenceAdmissionUnavailableError ||
+      error instanceof InferenceBalanceCacheWarmingError
+    ) {
+      logger.error(
+        "[Chat Completions] provider-boundary admission failed closed",
+        {
+          traceId,
+          requestId,
+          model,
+          phase: "provider_dispatch",
+          errorName: error.name,
+          error: error.message,
+          cause:
+            error.cause instanceof Error
+              ? `${error.cause.name}: ${error.cause.message}`
+              : error.cause === undefined
+                ? undefined
+                : String(error.cause),
+        },
+      );
+      return attachPreforwardTelemetry(
+        addCorsHeaders(
+          Response.json(
+            {
+              error: {
+                message:
+                  "Inference admission is temporarily unavailable. Retry shortly.",
+                type: "service_unavailable",
+                code: "inference_admission_unavailable",
+              },
+            },
+            { status: 503, headers: { "Retry-After": "1" } },
           ),
         ),
       );
@@ -2686,24 +2724,30 @@ async function tryPassthroughStreamingRequest(params: {
       () => fetch(upstream.url, upstreamInit),
     );
   } catch (error) {
-    // A failed dispatch marker proves this Worker never called the provider,
-    // even when the Durable Object committed but every acknowledgement was
-    // lost. Once fetch starts, transport failure remains ambiguous.
+    if (upstreamFetchStartedAt === 0) {
+      // The combined admission failed before fetch. Preserve its typed
+      // standing, balance, or transport decision for the route boundary; the
+      // outer zero settlement cancels any acknowledgement-ambiguous commit.
+      throw error;
+    }
+    // Once fetch starts, transport failure is ambiguous and retains the
+    // estimate. Admission failures returned above are handled by the route's
+    // zero-settlement path because the provider boundary was never crossed.
     await settleOffResponsePath(params.executionCtx, async () => {
-      if (isInferenceAdmissionDispatchMarkError(error)) {
-        await params.settleReservation(0);
-      } else {
-        await params.settleUnknown();
-      }
+      await params.settleUnknown();
     });
     logger.error("[Chat Completions] Passthrough upstream fetch failed", {
       model,
       provider: upstream.providerId,
+      traceId: params.traceId,
       error: error instanceof Error ? error.message : String(error),
     });
     return passthroughErrorResponse(503, "upstream provider request failed");
   }
 
+  const providerRequestId = sanitizeProviderRequestId(
+    upstreamResponse.headers.get("x-request-id"),
+  );
   if (!upstreamResponse.ok) {
     await settleOffResponsePath(params.executionCtx, async () => {
       if (isKnownUnacceptedProviderStatus(upstreamResponse.status)) {
@@ -2738,6 +2782,8 @@ async function tryPassthroughStreamingRequest(params: {
     logger.error("[Chat Completions] Passthrough upstream error status", {
       model,
       provider: upstream.providerId,
+      traceId: params.traceId,
+      ...(providerRequestId ? { providerRequestId } : {}),
       upstreamStatus: upstreamResponse.status,
       mappedStatus: status,
     });
@@ -2749,7 +2795,12 @@ async function tryPassthroughStreamingRequest(params: {
     });
     logger.error(
       "[Chat Completions] Passthrough upstream returned an accepted response without a stream body",
-      { model, provider: upstream.providerId },
+      {
+        model,
+        provider: upstream.providerId,
+        traceId: params.traceId,
+        ...(providerRequestId ? { providerRequestId } : {}),
+      },
     );
     return passthroughErrorResponse(
       503,
@@ -2762,9 +2813,6 @@ async function tryPassthroughStreamingRequest(params: {
   // arbitrary upstream header content (same character policy as Server-Timing
   // descriptions).
   const upstreamHeadersMs = round2(performance.now() - upstreamFetchStartedAt);
-  const providerRequestId = sanitizeProviderRequestId(
-    upstreamResponse.headers.get("x-request-id"),
-  );
   // Single-reader fan-out (#20032 defect 4): the client stream is the ONLY
   // consumer of the upstream body, and the meter observes each chunk
   // synchronously as it is forwarded. Upstream pulling is therefore bounded

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -238,6 +238,9 @@ app.post("/", async (c) => {
   let commitAnonymousMessageSlot: (() => Promise<void>) | null = null;
   let markAnonymousMessageSlotDispatched: (() => Promise<void>) | null = null;
   let providerDispatchStarted = false;
+  let providerLogContext:
+    | { requestId: string; userId: string; model: string }
+    | undefined;
 
   try {
     const decodedBody = await decodeRequestJson(c.req);
@@ -528,6 +531,11 @@ app.post("/", async (c) => {
     }
 
     const requestId = crypto.randomUUID();
+    providerLogContext = {
+      requestId,
+      userId: user.id,
+      model: selectedModel,
+    };
     if (isAnonymous && anonymousSession) {
       if (executionCtx && anonymousCredential) {
         const leaseResolution = await reserveAnonymousChatSlot(
@@ -628,6 +636,7 @@ app.post("/", async (c) => {
           executionCtx,
           admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: Boolean(executionCtx),
         });
         settleReservation = admission.settle;
         settleUnknownReservation = admission.settleUnknown;
@@ -949,6 +958,32 @@ app.post("/", async (c) => {
         },
         credentialDenial.status,
       );
+    }
+    if (error instanceof InsufficientCreditsError) {
+      logger.error("chat-api", "Provider dispatch admission denied", {
+        ...providerLogContext,
+        phase: "provider_dispatch",
+        error: error.message,
+      });
+      return c.json(
+        { error: "Insufficient balance", details: error.message },
+        402,
+      );
+    }
+    if (
+      error instanceof InferenceAdmissionUnavailableError ||
+      error instanceof InferenceBalanceCacheWarmingError
+    ) {
+      logger.error("chat-api", "Provider dispatch admission failed closed", {
+        ...providerLogContext,
+        phase: "provider_dispatch",
+        error: error.message,
+        cause:
+          error.cause instanceof Error
+            ? `${error.cause.name}: ${error.cause.message}`
+            : undefined,
+      });
+      return retryableWarmingResponse(c, "Billing");
     }
     logger.error("chat-api", "Error processing chat", {
       error: error instanceof Error ? error.message : String(error),

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -75,6 +75,8 @@ app.post("/", async (c) => {
   let executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined;
   let admissionSnapshot: InferenceAdmissionSnapshot | undefined;
   let admissionCredential: InferenceCredentialCheck | undefined;
+  let providerRequestId: string | undefined;
+  let providerModel: string | undefined;
   try {
     const candidate = c.executionCtx;
     executionCtx =
@@ -293,6 +295,7 @@ app.post("/", async (c) => {
     }
 
     const model = request.model;
+    providerModel = model;
     const provider = getProviderFromModel(model);
     const normalizedModel = normalizeModelName(model);
     const billingSource = resolveEmbeddingProviderSource();
@@ -316,6 +319,7 @@ app.post("/", async (c) => {
     const estimatedInputTokens = estimateTokens(inputText);
 
     const requestId = crypto.randomUUID();
+    providerRequestId = requestId;
     const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
     try {
       const admission = await admitOrganizationInference({
@@ -335,6 +339,7 @@ app.post("/", async (c) => {
         executionCtx,
         admissionSnapshot,
         credential: credentialGuard.credentialForAdmission(),
+        atomicProviderBoundary: Boolean(executionCtx),
       });
       settleReservation = admission.settle;
       settleUnknown = admission.settleUnknown;
@@ -669,6 +674,44 @@ app.post("/", async (c) => {
           },
         },
         credentialDenial.status,
+      );
+    }
+
+    if (error instanceof InsufficientCreditsError) {
+      return c.json(
+        {
+          error: {
+            message: `Insufficient credits. Required: $${error.required.toFixed(4)}`,
+            type: "insufficient_quota",
+            code: "insufficient_balance",
+          },
+        },
+        402,
+      );
+    }
+    if (error instanceof InferenceAdmissionUnavailableError) {
+      logger.error("[Embeddings] provider-boundary admission failed closed", {
+        traceId: c.get("traceId") ?? c.get("requestId"),
+        requestId: providerRequestId,
+        model: providerModel,
+        phase: "provider_dispatch",
+        error: error.message,
+        cause:
+          error.cause instanceof Error
+            ? `${error.cause.name}: ${error.cause.message}`
+            : undefined,
+      });
+      return c.json(
+        {
+          error: {
+            message:
+              "Inference admission is temporarily unavailable. Retry shortly.",
+            type: "service_unavailable",
+            code: "inference_admission_unavailable",
+          },
+        },
+        503,
+        { "Retry-After": "1" },
       );
     }
 

--- a/packages/cloud/api/v1/generate-image/route.ts
+++ b/packages/cloud/api/v1/generate-image/route.ts
@@ -129,6 +129,7 @@ export async function handleGenerateImagePOST(
             executionCtx,
             admissionSnapshot,
             credential: credentialGuard.credentialForAdmission(),
+            atomicProviderBoundary: true,
             metadata: {
               endpoint: "apps.generate-image",
               numImages: request.numImages,
@@ -143,6 +144,7 @@ export async function handleGenerateImagePOST(
           cost,
           admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: true,
         });
         return { kind: "organization" as const, admission };
       },

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -341,6 +341,7 @@ app.post("/", async (c) => {
         cost,
         admissionSnapshot,
         credential: credentialGuard.credentialForAdmission(),
+        atomicProviderBoundary: true,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/generate-prompts/route.ts
+++ b/packages/cloud/api/v1/generate-prompts/route.ts
@@ -100,6 +100,7 @@ Random seed: ${promptSeed}`;
       executionCtx,
       admissionSnapshot: caller.admissionSnapshot,
       credential: credentialGuard.credentialForAdmission(),
+      atomicProviderBoundary: Boolean(executionCtx),
     });
     await admission.markProviderDispatched?.();
     providerDispatchStarted = true;

--- a/packages/cloud/api/v1/generate-sfx/route.ts
+++ b/packages/cloud/api/v1/generate-sfx/route.ts
@@ -248,6 +248,7 @@ app.post("/", async (c) => {
         cost,
         admissionSnapshot,
         credential: credentialGuard.credentialForAdmission(),
+        atomicProviderBoundary: true,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -301,6 +301,7 @@ app.post("/", async (c) => {
           idempotencyKey: candidate.billingContext.requestId ?? undefined,
           admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: true,
         });
       } catch (error) {
         // error-policy:J1 the HTTP boundary translates insufficient-credit

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -912,6 +912,7 @@ app.post("/", async (c) => {
             executionCtx,
             admissionSnapshot,
             credential: credentialGuard.credentialForAdmission(),
+            atomicProviderBoundary: true,
           });
           settleReservation = admission.settle;
           settleUnknownReservation = admission.settleUnknown;
@@ -989,6 +990,7 @@ app.post("/", async (c) => {
           executionCtx,
           admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: Boolean(executionCtx),
         });
         settleReservation = admission.settle;
         settleUnknownReservation = admission.settleUnknown;
@@ -1143,6 +1145,51 @@ app.post("/", async (c) => {
           await settleUnknownReservation?.();
         }
       });
+      const denial = resolveInferenceCredentialAdmissionDenial(error, {
+        route: "messages",
+        traceId,
+      });
+      if (denial) {
+        return attachPreforwardTelemetry(
+          anthropicError(denial.type, denial.message, denial.status),
+        );
+      }
+      if (error instanceof InsufficientCreditsError) {
+        return attachPreforwardTelemetry(
+          anthropicError(
+            "billing_error",
+            `Insufficient credits. Required: $${error.required.toFixed(4)}`,
+            402,
+          ),
+        );
+      }
+      if (
+        error instanceof InferenceAdmissionUnavailableError ||
+        error instanceof InferenceBalanceCacheWarmingError
+      ) {
+        logger.error(
+          "[Messages API] provider-boundary admission failed closed",
+          {
+            traceId,
+            requestId,
+            model,
+            phase: "provider_dispatch",
+            errorName: error.name,
+            error: error.message,
+            cause:
+              error.cause instanceof Error
+                ? `${error.cause.name}: ${error.cause.message}`
+                : undefined,
+          },
+        );
+        return attachPreforwardTelemetry(
+          anthropicError(
+            "api_error",
+            "Inference admission is temporarily unavailable. Retry shortly.",
+            503,
+          ),
+        );
+      }
       const message = error instanceof Error ? error.message : String(error);
       // A provider-configuration failure (unknown model / unconfigured gateway)
       // carries internal setup guidance in its message — return a clean,

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -448,6 +448,7 @@ app.post("/", async (c) => {
         cost: cloneCost,
         admissionSnapshot: caller.admissionSnapshot,
         credential: credentialGuard.credentialForAdmission(),
+        atomicProviderBoundary: true,
       });
     } catch (error) {
       if (error instanceof InsufficientCreditsError) {

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -604,6 +604,7 @@ async function __hono_POST(c: AppContext) {
           cost: sttCost,
           admissionSnapshot,
           credential: credentialGuard.credentialForAdmission(),
+          atomicProviderBoundary: true,
         });
       } catch (error) {
         if (error instanceof InsufficientCreditsError) {
@@ -1235,6 +1236,7 @@ async function __hono_POST(c: AppContext) {
         cost: sttCost,
         admissionSnapshot,
         credential: credentialGuard.credentialForAdmission(),
+        atomicProviderBoundary: true,
       });
       reservation = admission.reservation;
       settleUnknown = admission.settleUnknown;

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -668,6 +668,7 @@ async function __hono_POST(c: AppContext) {
         admissionSnapshot,
         credential: credentialGuard.credentialForAdmission(),
         idempotencyKey: ttsIdempotencyKey ?? undefined,
+        atomicProviderBoundary: true,
       });
       reservation = admission.reservation;
       settleUnknown = admission.settleUnknown;

--- a/packages/cloud/shared/src/lib/services/app-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-inference-admission.test.ts
@@ -17,6 +17,13 @@ class TestInsufficientCreditsError extends Error {
   }
 }
 
+class TestInferenceAdmissionLeaseRejectedError extends Error {
+  readonly requiredUsd = 1;
+  readonly availableUsd = 0;
+}
+
+class TestInferenceAdmissionGateUnavailableError extends Error {}
+
 let cachedBalanceUsd = 100;
 let gateError: Error | null = null;
 let gateReads = 0;
@@ -47,6 +54,7 @@ const acquireInferenceAdmissionLease = mock(
   }),
 );
 const settleInferenceAdmissionLease = mock(async () => undefined);
+const markInferenceAdmissionLeaseDispatched = mock(async () => undefined);
 
 mock.module("./app-credits", () => ({
   appCreditsService: {
@@ -109,12 +117,9 @@ mock.module("./inference-admission-gate", () => ({
     balanceBackedUsd: actualCostUsd,
     gateConsumedUsd: actualCostUsd,
   }),
-  InferenceAdmissionGateUnavailableError: class InferenceAdmissionGateUnavailableError extends Error {},
-  InferenceAdmissionLeaseRejectedError: class InferenceAdmissionLeaseRejectedError extends Error {
-    readonly requiredUsd = 1;
-    readonly availableUsd = 0;
-  },
-  markInferenceAdmissionLeaseDispatched: async () => undefined,
+  InferenceAdmissionGateUnavailableError: TestInferenceAdmissionGateUnavailableError,
+  InferenceAdmissionLeaseRejectedError: TestInferenceAdmissionLeaseRejectedError,
+  markInferenceAdmissionLeaseDispatched,
   settleInferenceAdmissionLease,
 }));
 
@@ -186,6 +191,7 @@ beforeEach(() => {
   usageProjections = [];
   acquireInferenceAdmissionLease.mockClear();
   settleInferenceAdmissionLease.mockClear();
+  markInferenceAdmissionLeaseDispatched.mockClear();
   authoritativeBalanceUsd = 80;
   reserveImpl = async () => ({
     reservedAmount: 1.2,
@@ -195,6 +201,45 @@ beforeEach(() => {
 });
 
 describe("admitAppInferenceCacheOnly", () => {
+  test("opts into the atomic provider-boundary lease only when requested", async () => {
+    const admission = await admitAppInferenceCacheOnly({
+      ...params({ waitUntil: () => undefined }),
+      atomicProviderBoundary: true,
+    });
+    expect(acquireInferenceAdmissionLease.mock.calls[0]?.[0]).toMatchObject({
+      deferCommitUntilDispatch: true,
+    });
+    expect(markInferenceAdmissionLeaseDispatched).not.toHaveBeenCalled();
+
+    await admission.markProviderDispatched();
+    expect(markInferenceAdmissionLeaseDispatched).toHaveBeenCalledTimes(1);
+  });
+
+  test("a late atomic balance denial releases locally without authoritative accounting", async () => {
+    markInferenceAdmissionLeaseDispatched.mockRejectedValueOnce(
+      new TestInferenceAdmissionLeaseRejectedError(),
+    );
+    const admission = await admitAppInferenceCacheOnly({
+      ...params({ waitUntil: () => undefined }),
+      atomicProviderBoundary: true,
+    });
+
+    await expect(admission.markProviderDispatched()).rejects.toMatchObject({
+      name: "InsufficientCreditsError",
+      required: 1,
+      available: 0,
+      reason: "cached_balance_gate",
+    });
+    await expect(admission.settle(0)).resolves.toBeNull();
+
+    expect(reserveCalls).toBe(0);
+    expect(settleInferenceAdmissionLease).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: "request-1" }),
+      0,
+      0,
+    );
+  });
+
   test("uses the Durable Object lease as the sole pre-dispatch WAL", async () => {
     const credential = {
       kind: "api_key" as const,
@@ -250,6 +295,7 @@ describe("admitAppInferenceCacheOnly", () => {
     expect(reserveCalls).toBe(0);
 
     const settlement = admission.settle(0.4);
+    await Promise.resolve();
     await Promise.resolve();
     expect(reserveCalls).toBe(1);
     expect(

--- a/packages/cloud/shared/src/lib/services/app-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/app-inference-admission.ts
@@ -37,7 +37,10 @@ import {
   getGateBalanceHint,
   InferenceBalanceCacheWarmingError,
 } from "./inference-billing-fast-path";
-import type { InferenceCredentialCheck } from "./inference-credential-revocation";
+import {
+  type InferenceCredentialCheck,
+  InferenceCredentialRevokedError,
+} from "./inference-credential-revocation";
 
 export interface AppInferenceAdmissionExecutionContext {
   waitUntil(promise: Promise<unknown>): void;
@@ -62,6 +65,8 @@ export interface AppInferenceAdmissionParams {
   admissionSnapshot?: InferenceAdmissionSnapshot;
   /** Strong standing proof consumed atomically by the app balance lease. */
   credential?: InferenceCredentialCheck;
+  /** Commit the balance lease with dispatch at an audited provider boundary. */
+  atomicProviderBoundary?: boolean;
 }
 
 export interface AppInferenceAdmission {
@@ -212,6 +217,7 @@ export async function admitAppInferenceCacheOnly(
       },
       ...(params.credential ? { credential: params.credential } : {}),
       executionCtx: params.executionCtx,
+      deferCommitUntilDispatch: params.atomicProviderBoundary === true,
     });
   } catch (error) {
     if (error instanceof InferenceAdmissionLeaseRejectedError) {
@@ -230,6 +236,26 @@ export async function admitAppInferenceCacheOnly(
   let settlement: Promise<CreditReconciliationResult | null> | null = null;
   let firstActualBaseCostUsd: number | null = null;
   let usageProjectionTransactionId: string | null = null;
+  const markProviderDispatched = async (): Promise<void> => {
+    try {
+      await markInferenceAdmissionLeaseDispatched(inferenceLease);
+    } catch (error) {
+      // error-policy:J2 preserve provider-boundary admission failures as the
+      // public app billing errors already handled by transport callers.
+      if (error instanceof InferenceCredentialRevokedError) throw error;
+      if (error instanceof InferenceAdmissionLeaseRejectedError) {
+        throw new InsufficientCreditsError(
+          error.requiredUsd,
+          error.availableUsd,
+          "cached_balance_gate",
+        );
+      }
+      if (error instanceof InferenceAdmissionGateUnavailableError) {
+        throw new InferenceBalanceCacheWarmingError(error);
+      }
+      throw error;
+    }
+  };
 
   const settle = async (actualBaseCostUsd: number): Promise<CreditReconciliationResult | null> => {
     let reservation: Awaited<ReturnType<typeof appCreditsService.reserveInferenceCredits>>;
@@ -276,8 +302,12 @@ export async function admitAppInferenceCacheOnly(
     if (firstActualBaseCostUsd === null) firstActualBaseCostUsd = actualBaseCostUsd;
     if (settlement) return settlement;
     const current = (async () => {
+      if ((firstActualBaseCostUsd ?? 0) === 0 && !inferenceLease.providerDispatched) {
+        await settleInferenceAdmissionLease(inferenceLease, 0, 0);
+        return null;
+      }
       if ((firstActualBaseCostUsd ?? 0) > 0) {
-        await markInferenceAdmissionLeaseDispatched(inferenceLease);
+        await markProviderDispatched();
       }
       const reconciliation = await settle(firstActualBaseCostUsd ?? 0);
       const actualTotalCostUsd =
@@ -324,6 +354,6 @@ export async function admitAppInferenceCacheOnly(
     estimatedTotalCostUsd,
     settle: settleTerminal,
     settleUnknown: () => settleTerminal(reservedBaseCostUsd),
-    markProviderDispatched: () => markInferenceAdmissionLeaseDispatched(inferenceLease),
+    markProviderDispatched,
   };
 }

--- a/packages/cloud/shared/src/lib/services/generative-operation.test.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.test.ts
@@ -75,6 +75,7 @@ describe("runFlatProviderOperation", () => {
 
     expect(events).toEqual(["admit", "mark", "provider", "settle"]);
     expect(admitOrganizationInference.mock.calls.at(-1)?.[0].credential).toBe(credential);
+    expect(admitOrganizationInference.mock.calls.at(-1)?.[0].atomicProviderBoundary).toBe(true);
   });
 
   test("reuses one exact deferred credential across multiple atomic admissions", async () => {

--- a/packages/cloud/shared/src/lib/services/generative-operation.ts
+++ b/packages/cloud/shared/src/lib/services/generative-operation.ts
@@ -116,6 +116,7 @@ async function admitFlatCost(
         return credential ? { credential } : {};
       })(),
       executionCtx: context.executionCtx,
+      atomicProviderBoundary: true,
     });
   } catch (error) {
     if (typeof error === "object" && error !== null) admissionErrors.add(error);

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -51,6 +51,8 @@ interface DispatchResponse {
   dispatched: boolean;
 }
 
+interface LeaseDispatchResponse extends LeaseResponse, DispatchResponse {}
+
 interface ReleaseResponse {
   released: boolean;
 }
@@ -81,6 +83,17 @@ export interface InferenceAdmissionLease {
    * It is destroyed as soon as dispatch acknowledgement is received.
    */
   preProviderCancellationToken?: string;
+  /**
+   * Immutable lease body retained locally until the provider-boundary commit.
+   * Only explicitly audited callers use this mode; legacy callers still
+   * acquire a durable `leased` record before this object is returned.
+   */
+  preparedDispatch?: {
+    path: "/lease-dispatched" | "/lease-dispatched-authorized";
+    body: Record<string, unknown>;
+    executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+    state: "prepared" | "ambiguous" | "rejected";
+  };
 }
 
 export class InferenceAdmissionGateUnavailableError extends Error {
@@ -205,6 +218,16 @@ async function parseLeaseResponse(response: Response): Promise<LeaseResponse> {
       }`,
     );
   }
+}
+
+async function parseLeaseDispatchResponse(response: Response): Promise<LeaseDispatchResponse> {
+  const lease = await parseLeaseResponse(response);
+  if ((lease as Partial<LeaseDispatchResponse>).dispatched !== true) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission gate returned an invalid combined dispatch response",
+    );
+  }
+  return lease as LeaseDispatchResponse;
 }
 
 async function parseSettleResponse(response: Response): Promise<SettleResponse> {
@@ -561,6 +584,8 @@ export async function acquireInferenceAdmissionLease(params: {
   /** Strong standing proof fused into the lease transaction when supplied. */
   credential?: InferenceCredentialCheck;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+  /** Commit the balance lease atomically with dispatch at an audited provider boundary. */
+  deferCommitUntilDispatch?: boolean;
 }): Promise<InferenceAdmissionLease> {
   const balanceUsd = finiteNonNegative(params.balanceUsd, "balanceUsd");
   const estimatedCostUsd = finiteNonNegative(params.estimatedCostUsd, "estimatedCostUsd");
@@ -593,6 +618,23 @@ export async function acquireInferenceAdmissionLease(params: {
         }
       : {}),
   };
+  const preProviderCancellationToken = crypto.randomUUID();
+  if (params.deferCommitUntilDispatch) {
+    return {
+      organizationId: params.organizationId,
+      requestId: params.requestId,
+      estimatedCostUsd,
+      gate: stub,
+      providerDispatched: false,
+      preProviderCancellationToken,
+      preparedDispatch: {
+        path: params.credential ? "/lease-dispatched-authorized" : "/lease-dispatched",
+        body,
+        executionCtx: params.executionCtx,
+        state: "prepared",
+      },
+    };
+  }
   let response: Response | undefined;
   for (let attempt = 1; attempt <= LEASE_GATE_MAX_ATTEMPTS; attempt += 1) {
     try {
@@ -649,7 +691,7 @@ export async function acquireInferenceAdmissionLease(params: {
     estimatedCostUsd,
     gate: stub,
     providerDispatched: false,
-    preProviderCancellationToken: crypto.randomUUID(),
+    preProviderCancellationToken,
   };
 }
 
@@ -692,7 +734,7 @@ export function inferenceSettlementAmounts(
   return { balanceBackedUsd, gateConsumedUsd };
 }
 
-/** Persist dispatch intent immediately before invoking the upstream provider. */
+/** Commit a prepared lease or persist legacy dispatch intent immediately before provider work. */
 export async function markInferenceAdmissionLeaseDispatched(
   lease: InferenceAdmissionLease,
 ): Promise<void> {
@@ -705,16 +747,22 @@ export async function markInferenceAdmissionLeaseDispatched(
   }
 
   let lastAmbiguousError: unknown;
+  const prepared = lease.preparedDispatch;
+  const path = prepared?.path ?? "/dispatch";
+  const body = prepared
+    ? { ...prepared.body, preProviderCancellationToken: cancellationToken }
+    : {
+        requestId: lease.requestId,
+        preProviderCancellationToken: cancellationToken,
+      };
+  if (prepared) prepared.state = "ambiguous";
   for (let attempt = 1; attempt <= DISPATCH_GATE_MAX_ATTEMPTS; attempt += 1) {
     let response: Response;
     try {
       response = await gateFetch(
         lease.organizationId,
-        "/dispatch",
-        {
-          requestId: lease.requestId,
-          preProviderCancellationToken: cancellationToken,
-        },
+        path,
+        body,
         lease.gate,
         AbortSignal.timeout(DISPATCH_GATE_TIMEOUT_MS),
       );
@@ -723,7 +771,40 @@ export async function markInferenceAdmissionLeaseDispatched(
       if (attempt < DISPATCH_GATE_MAX_ATTEMPTS) continue;
       break;
     }
+    if (prepared && response.status === 403) {
+      prepared.state = "rejected";
+      let reason = "revoked";
+      try {
+        const payload = (await response.json()) as { reason?: unknown };
+        if (typeof payload.reason === "string") reason = payload.reason;
+      } catch {
+        // error-policy:J3 malformed denial output remains a fail-closed generic revocation.
+      }
+      throw new InferenceCredentialRevokedError(reason);
+    }
+    if (prepared && response.status === 402) {
+      prepared.state = "rejected";
+      const payload = await parseLeaseResponse(response);
+      throw new InferenceAdmissionLeaseRejectedError(payload.requiredUsd, payload.availableUsd);
+    }
+    if (prepared && response.status === 503) {
+      const code = await readGateErrorCode(response);
+      if (
+        attempt === DISPATCH_GATE_MAX_ATTEMPTS &&
+        code === "inference_admission_gate_uninitialized" &&
+        prepared.executionCtx
+      ) {
+        scheduleGateHydration(lease.organizationId, lease.gate, prepared.executionCtx);
+      }
+      const error = new InferenceAdmissionDispatchMarkError(
+        `Inference admission gate combined dispatch failed with status ${response.status}`,
+      );
+      lastAmbiguousError = error;
+      if (attempt < DISPATCH_GATE_MAX_ATTEMPTS) continue;
+      break;
+    }
     if (!response.ok) {
+      if (prepared && response.status < 500) prepared.state = "rejected";
       const error = new InferenceAdmissionDispatchMarkError(
         `Inference admission gate dispatch failed with status ${response.status}`,
       );
@@ -733,7 +814,8 @@ export async function markInferenceAdmissionLeaseDispatched(
       break;
     }
     try {
-      await parseLeaseTransitionResponse(response, "dispatched");
+      if (prepared) await parseLeaseDispatchResponse(response);
+      else await parseLeaseTransitionResponse(response, "dispatched");
     } catch (error) {
       // A valid 2xx transport with an unreadable body can still follow a
       // committed dispatch. Replaying the same capability resolves ambiguity.
@@ -743,6 +825,7 @@ export async function markInferenceAdmissionLeaseDispatched(
     }
     lease.providerDispatched = true;
     lease.preProviderCancellationToken = undefined;
+    lease.preparedDispatch = undefined;
     return;
   }
   // error-policy:J2 all attempts remain ambiguous. The capability stays on
@@ -762,6 +845,14 @@ export async function releaseInferenceAdmissionLease(
       "Dispatched inference work cannot be released without accounting",
     );
   }
+  if (
+    lease.preparedDispatch?.state === "prepared" ||
+    lease.preparedDispatch?.state === "rejected"
+  ) {
+    lease.preProviderCancellationToken = undefined;
+    lease.preparedDispatch = undefined;
+    return;
+  }
   const response = await gateFetch(
     lease.organizationId,
     "/release",
@@ -775,6 +866,18 @@ export async function releaseInferenceAdmissionLease(
     AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
   );
   if (!response.ok) {
+    if (
+      lease.preparedDispatch?.state === "ambiguous" &&
+      response.status === 409 &&
+      (await readGateErrorCode(response)) === "inference_admission_lease_not_found"
+    ) {
+      // The combined request may have failed before reaching the Durable
+      // Object. No lease and no provider invocation is already the requested
+      // zero-cost terminal state, so cleanup is idempotently complete.
+      lease.preProviderCancellationToken = undefined;
+      lease.preparedDispatch = undefined;
+      return;
+    }
     throw new InferenceAdmissionGateUnavailableError(
       `Inference admission gate release failed with status ${response.status}`,
     );

--- a/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-fast-path.ts
@@ -125,8 +125,8 @@ export interface GateBalanceReadOptions {
 }
 
 export class InferenceBalanceCacheWarmingError extends Error {
-  constructor() {
-    super("Inference billing cache is warming; retry the request");
+  constructor(cause?: unknown) {
+    super("Inference billing cache is warming; retry the request", { cause });
     this.name = "InferenceBalanceCacheWarmingError";
   }
 }

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -163,6 +163,7 @@ const acquireInferenceAdmissionLease = mock(
   },
 );
 const settleInferenceAdmissionLease = mock(async () => undefined);
+const markInferenceAdmissionLeaseDispatched = mock(async () => undefined);
 
 class TestInferenceBalanceCacheWarmingError extends Error {}
 class TestInferenceAdmissionGateUnavailableError extends Error {}
@@ -224,7 +225,7 @@ mock.module("./inference-admission-gate", () => ({
     readonly requiredUsd = 1;
     readonly availableUsd = 0;
   },
-  markInferenceAdmissionLeaseDispatched: async () => undefined,
+  markInferenceAdmissionLeaseDispatched,
   settleInferenceAdmissionLease,
 }));
 mock.module("./inference-billing-ledger", () => ({
@@ -251,7 +252,7 @@ function nextModel(): string {
 function admissionParams(
   model: string,
   background: Promise<unknown>[],
-  overrides: { affiliateCode?: string } = {},
+  overrides: { affiliateCode?: string; atomicProviderBoundary?: boolean } = {},
 ) {
   return {
     context: {
@@ -305,6 +306,7 @@ beforeEach(() => {
   optimisticSettle.mockClear();
   acquireInferenceAdmissionLease.mockClear();
   settleInferenceAdmissionLease.mockClear();
+  markInferenceAdmissionLeaseDispatched.mockClear();
   isOptimisticEligible.mockClear();
   listActiveEntriesForProviderModelPairs.mockClear();
   listActiveEntries.mockClear();
@@ -488,6 +490,21 @@ test("strong proof on and off each acquire exactly one Durable Object lease", as
     expect(acquireInferenceAdmissionLease.mock.calls[0]?.[0].credential).toEqual(strongProof);
   }
   expect(reserveCredits).not.toHaveBeenCalled();
+});
+
+test("audited provider boundaries defer the lease commit until the required marker", async () => {
+  const model = nextModel();
+  await hydratePricing(model);
+  const admission = await admitOrganizationInference(
+    admissionParams(model, [], { atomicProviderBoundary: true }),
+  );
+
+  expect(acquireInferenceAdmissionLease.mock.calls[0]?.[0]).toMatchObject({
+    deferCommitUntilDispatch: true,
+  });
+  expect(markInferenceAdmissionLeaseDispatched).not.toHaveBeenCalled();
+  await admission.markProviderDispatched?.();
+  expect(markInferenceAdmissionLeaseDispatched).toHaveBeenCalledTimes(1);
 });
 
 test("flat Worker admission leases the fixed catalog cost without token pricing reads", async () => {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -110,6 +110,11 @@ export interface OrganizationInferenceAdmissionParams {
   admissionSnapshot?: InferenceAdmissionSnapshot;
   /** Strong standing proof consumed atomically by the primary admission gate. */
   credential?: InferenceCredentialCheck;
+  /**
+   * Prepare the lease locally and commit it with dispatch at an audited
+   * provider boundary. Limited to callers whose dispatch callback is required.
+   */
+  atomicProviderBoundary?: boolean;
 }
 
 /** Retryable signal preserving route compatibility while identifying pricing hydration. */
@@ -211,18 +216,54 @@ async function reserveSynchronously(
 function attachInferenceAdmissionLease(
   admission: OrganizationInferenceAdmission,
   lease: InferenceAdmissionLease,
+  params: OrganizationInferenceAdmissionParams,
 ): OrganizationInferenceAdmission {
   const settleAuthoritatively = admission.settle;
   const settleUnknownAuthoritatively = admission.settleUnknown;
   type SettlementChoice = { kind: "actual"; actualCostUsd: number } | { kind: "unknown" };
   let choice: SettlementChoice | undefined;
   let settlement: Promise<CreditReconciliationResult | null> | null = null;
-  const markProviderDispatched = () => markInferenceAdmissionLeaseDispatched(lease);
+  const markProviderDispatched = async (): Promise<void> => {
+    try {
+      await markInferenceAdmissionLeaseDispatched(lease);
+    } catch (error) {
+      // error-policy:J2 add request identity and preserve the established
+      // transport-facing standing, balance, and availability error types.
+      if (error instanceof InferenceCredentialRevokedError) {
+        logger.warn(
+          "[OrganizationInferenceAdmission] blocked provider dispatch at combined credential and balance gate",
+          {
+            organizationId: params.context.organizationId,
+            userId: params.context.userId,
+            requestId: params.context.requestId,
+            credentialKind: params.credential?.kind ?? "unavailable",
+            reason: error.reason,
+          },
+        );
+        throw error;
+      }
+      if (error instanceof InferenceAdmissionLeaseRejectedError) {
+        throw new InsufficientCreditsError(
+          error.requiredUsd,
+          error.availableUsd,
+          "cached_balance_gate",
+        );
+      }
+      if (error instanceof InferenceAdmissionGateUnavailableError) {
+        throw admissionUnavailable(params, error);
+      }
+      throw error;
+    }
+  };
   const run = (requestedChoice: SettlementChoice): Promise<CreditReconciliationResult | null> => {
     choice ??= requestedChoice;
     if (settlement) return settlement;
     const selected = choice;
     const current = (async () => {
+      if (selected.kind === "actual" && selected.actualCostUsd === 0 && !lease.providerDispatched) {
+        await settleInferenceAdmissionLease(lease, 0, 0);
+        return null;
+      }
       if (selected.kind === "unknown" || selected.actualCostUsd > 0) {
         await markProviderDispatched();
       }
@@ -425,6 +466,7 @@ export async function admitOrganizationInference(
         },
         credential: params.credential,
         executionCtx: params.executionCtx,
+        deferCommitUntilDispatch: params.atomicProviderBoundary === true,
       });
     } catch (error) {
       if (error instanceof InferenceCredentialRevokedError) {
@@ -514,7 +556,7 @@ export async function admitOrganizationInference(
         },
         affiliateAttribution,
       };
-      return attachInferenceAdmissionLease(result, inferenceLease);
+      return attachInferenceAdmissionLease(result, inferenceLease, params);
     }
 
     const settle = async (actualCostUsd: number): Promise<CreditReconciliationResult> => {
@@ -553,6 +595,7 @@ export async function admitOrganizationInference(
         affiliateAttribution: null,
       },
       inferenceLease,
+      params,
     );
   }
 

--- a/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.combined-admission.test.ts
@@ -141,11 +141,47 @@ test("combined admission orders mark before dispatch and returns before settleme
   expect(admit.mock.calls[0]?.[0].apiKeyId).toBe("key-1");
   expect(admit.mock.calls[0]?.[0].admissionSnapshot).toBe(snapshot);
   expect(admit.mock.calls[0]?.[0].credential).toBe(credential);
+  expect(admit.mock.calls[0]?.[0].atomicProviderBoundary).toBe(true);
   expect(settle).toHaveBeenCalledTimes(1);
   expect(proxyCacheGet).not.toHaveBeenCalled();
   expect(proxyCacheSet).not.toHaveBeenCalled();
   expect(retained).toHaveLength(1);
   finishSettlement?.();
+  await Promise.all(retained);
+});
+
+test("late combined dispatch denial settles zero and never invokes the provider", async () => {
+  const settle = mock(async () => null);
+  const settleUnknown = mock(async () => null);
+  admit.mockResolvedValue({
+    mode: "durable_object_debit",
+    markProviderDispatched: async () => {
+      throw new TestInsufficientCreditsError(0.25, 0);
+    },
+    settle,
+    settleUnknown,
+  });
+  const retained: Promise<unknown>[] = [];
+  const work = mock(async () => ({ response: Response.json({ ok: true }) }));
+  const handler = createHandler(config, work, {
+    mode: "combined",
+    auth: { user: { id: "user-1", organization_id: "org-1" } },
+    admissionSnapshot: snapshot,
+    executionCtx: { waitUntil: (promise) => retained.push(promise) },
+    requestId: "rpc-late-denial",
+  });
+
+  const response = await handler(
+    new Request("https://api.test/api/v1/rpc/ethereum", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", id: 1 }),
+    }),
+  );
+
+  expect(response.status).toBe(402);
+  expect(work).not.toHaveBeenCalled();
+  expect(settle).toHaveBeenCalledWith(0);
+  expect(settleUnknown).not.toHaveBeenCalled();
   await Promise.all(retained);
 });
 

--- a/packages/cloud/shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/engine.ts
@@ -283,6 +283,7 @@ export function createHandler(
               : combinedAdmission.credential;
             return credential ? { credential } : {};
           })(),
+          atomicProviderBoundary: true,
         });
       } else {
         const reservation = await creditsService.reserve({
@@ -386,23 +387,28 @@ export function createHandler(
       }
 
       let result: HandlerResult;
+      let providerDispatchStarted = false;
       try {
         // The durable dispatch marker is the last awaited operation before the
         // provider boundary. Auth, standing, pricing, balance, and the lease
         // all come from the caller's one combined admission projection.
         await settlement.markProviderDispatched?.();
+        providerDispatchStarted = true;
         result = await work({ body, auth, searchParams });
       } catch (error) {
-        // error-policy:J2 provider dispatch may have been accepted before the
-        // transport threw, so conservatively settle the marked admission.
+        // error-policy:J2 only accepted provider work settles unknown. A late
+        // atomic admission denial still owns its cancellation capability and
+        // releases the pre-provider lease with zero usage.
         const pending =
-          combinedAdmission?.mode === "combined"
+          combinedAdmission?.mode === "combined" && providerDispatchStarted
             ? settlement.settleUnknown()
             : settlement.settle(0);
         if (combinedAdmission?.mode === "combined") {
           void retainProxySettlement(pending, combinedAdmission.executionCtx, {
             serviceId: config.id,
-            operation: "provider_error",
+            operation: providerDispatchStarted
+              ? "provider_error"
+              : "provider_dispatch_admission_failed",
           });
         } else {
           await pending;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -164,6 +164,7 @@ const admitOrganizationInference = mock(
     context?: { metadata?: Record<string, unknown> };
     estimatedInputTokens?: number;
     executionCtx?: { waitUntil(promise: Promise<unknown>): void };
+    atomicProviderBoundary?: boolean;
   }) => {
     if (admissionError) throw admissionError;
     params.executionCtx?.waitUntil(Promise.resolve());
@@ -402,6 +403,7 @@ mock.module("../../cache/client", () => ({
 
 const { InsufficientCreditsError } = await import("../ai-billing");
 const { InferenceAdmissionDispatchMarkError } = await import("../inference-admission-gate");
+const { InferenceAdmissionUnavailableError } = await import("../organization-inference-admission");
 const { personalSharedAgentId } = await import("./personal-shared-agent");
 const { SharedRuntimeChatService, sharedRuntimeChannelId } = await import("./shared-runtime-chat");
 
@@ -626,6 +628,7 @@ describe("SharedRuntimeChatService", () => {
       config: { windowMs: 60_000, maxRequests: 120 },
     });
     const admissionContext = admitOrganizationInference.mock.calls[0]?.[0].context;
+    expect(admitOrganizationInference.mock.calls[0]?.[0].atomicProviderBoundary).toBe(true);
     expect(admissionContext?.metadata).toMatchObject({
       agentId: agent.id,
       channelId: expect.any(String),
@@ -1233,6 +1236,25 @@ describe("SharedRuntimeChatService", () => {
       cause: new InferenceAdmissionDispatchMarkError("dispatch acknowledgement remained ambiguous"),
     });
     await expect(service.bridge(agent, rpc, harness())).rejects.toThrow("shared turn failed");
+    expect(settleCalls).toEqual([0]);
+    expect(settleUnknownCalls).toBe(0);
+
+    settleCalls.length = 0;
+    turnError = new Error("late balance denial", {
+      cause: new InsufficientCreditsError(0.25, 0),
+    });
+    const denied = await service.bridge(agent, rpc, harness());
+    expect(denied.error?.code).toBe(-32002);
+    expect(settleCalls).toEqual([0]);
+    expect(settleUnknownCalls).toBe(0);
+
+    settleCalls.length = 0;
+    turnError = new Error("late admission outage", {
+      cause: new InferenceAdmissionUnavailableError(),
+    });
+    await expect(service.bridge(agent, rpc, harness())).rejects.toMatchObject({
+      name: "SharedRuntimeCacheWarmingError",
+    });
     expect(settleCalls).toEqual([0]);
     expect(settleUnknownCalls).toBe(0);
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -1102,6 +1102,7 @@ async function admitTurn(
       estimatedOutputTokens: 500,
       executionCtx,
       admissionSnapshot,
+      atomicProviderBoundary: Boolean(executionCtx),
     });
   } catch (error) {
     // error-policy:J1 translate the billing-cache boundary into the shared
@@ -1249,8 +1250,28 @@ function observeProviderCancellationOffPath(
   });
 }
 
+function providerBoundaryAdmissionFailure(
+  error: unknown,
+): InsufficientCreditsError | InferenceAdmissionUnavailableError | null {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  for (let depth = 0; depth < 12 && current !== undefined; depth += 1) {
+    if (seen.has(current)) return null;
+    seen.add(current);
+    if (
+      current instanceof InsufficientCreditsError ||
+      current instanceof InferenceAdmissionUnavailableError
+    ) {
+      return current;
+    }
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return null;
+}
+
 function isProvablyZeroProviderFailure(error: unknown): boolean {
   return (
+    providerBoundaryAdmissionFailure(error) !== null ||
     isInferenceAdmissionDispatchMarkError(error) ||
     isKnownPreDispatchProviderConfigurationError(error) ||
     isKnownUnacceptedProviderError(error)
@@ -1448,6 +1469,22 @@ export class SharedRuntimeChatService {
         error,
         "bridge provider invocation failed",
       );
+      const admissionFailure = providerBoundaryAdmissionFailure(error);
+      if (admissionFailure instanceof InsufficientCreditsError) {
+        return {
+          jsonrpc: "2.0",
+          id: rpc.id,
+          error: {
+            code: BRIDGE_INSUFFICIENT_CREDITS_CODE,
+            message: `Insufficient credits. Required: $${admissionFailure.required.toFixed(4)}, Available: $${admissionFailure.available.toFixed(4)}`,
+          },
+        };
+      }
+      if (admissionFailure instanceof InferenceAdmissionUnavailableError) {
+        throw new SharedRuntimeCacheWarmingError(
+          "Billing authorization is warming. Retry shortly.",
+        );
+      }
       throw error;
     }
 
@@ -1732,6 +1769,17 @@ export class SharedRuntimeChatService {
       );
       if (turnTimedOut) {
         return withTurnTimingHeaders(sseError("Shared runtime stream timed out"), timings);
+      }
+      const admissionFailure = providerBoundaryAdmissionFailure(error);
+      if (admissionFailure instanceof InsufficientCreditsError) {
+        throw new InsufficientCreditsApiError(
+          `Insufficient credits. Required: $${admissionFailure.required.toFixed(4)}, Available: $${admissionFailure.available.toFixed(4)}`,
+        );
+      }
+      if (admissionFailure instanceof InferenceAdmissionUnavailableError) {
+        throw new SharedRuntimeCacheWarmingError(
+          "Billing authorization is warming. Retry shortly.",
+        );
       }
       throw error;
     }


### PR DESCRIPTION
Closes #30635

Paid provider calls previously required separate Durable Object requests to acquire a billing lease and mark provider dispatch. This change commits both atomically immediately before provider invocation, removing one network round trip while preserving standing checks, revocation ordering, and durable settlement.

The optimization covers chat completions, messages, embeddings, media generation, voice, MCP/A2A, shared runtime chat, and the generic proxy engine. Standing retains one cache read with asynchronous projection updates and no reread. Provider and dedicated proxy failures include validated trace IDs and sanitized upstream request IDs where available.

Retries reuse a cancellation capability. Both lost acknowledgements and requests that never reach the Durable Object are covered: failures before provider execution settle zero, definitive denials create no lease, and ambiguous release treats only the specific missing-lease response as idempotent. Legacy endpoints remain compatible during rolling deployments.

Validation: focused provider and admission suites passed; API/shared typechecks, 709 mounted route contracts, production Worker dry-run, formatting, and root `bun run verify` passed (376/376 tasks plus repository audits). GitHub run 33979069995 passed every required check for commit 13b9d84028bf0c4a1d402f8919279cf2458091b8, including PostgreSQL authority constraints and billing replay E2E.

The deterministic benchmark proves one billing Durable Object fetch before provider work. Prior staging measurements attributed roughly 20–25 ms to the removed hop; deployed latency certification remains required to establish the actual improvement.
