### PR TITLE
fix(ci): build Apps worker prompt runtime before restart

### DIFF
--- a/.github/workflows/deploy-apps-worker.yml
+++ b/.github/workflows/deploy-apps-worker.yml
@@ -280,6 +280,18 @@ jobs:
 
             # The daemon runs under Node/tsx, which resolves linked workspace
             # packages through their built `node` exports — refresh dist files.
+            # Core's build excludes prompts because its full build generates
+            # action docs back into core. Build only the package artifact and
+            # replace any stale installed copy masking the workspace link.
+            mkdir -p packages/core/node_modules/@elizaos
+            rm -rf packages/core/node_modules/@elizaos/prompts
+            ln -s ../../../prompts packages/core/node_modules/@elizaos/prompts
+            test "$(realpath packages/core/node_modules/@elizaos/prompts)" = \
+              /opt/eliza/packages/prompts
+            bun run --cwd packages/prompts build:package
+            timeout --signal=TERM --kill-after=5s 30s \
+              node --import tsx --input-type=module \
+              -e 'await import("./packages/core/src/prompts.ts")'
             bun run build:core
             mkdir -p plugins/plugin-sql/node_modules/@elizaos
             rm -rf plugins/plugin-sql/node_modules/@elizaos/core


### PR DESCRIPTION
The [staging Apps worker deployment](https://github.com/elizaOS/eliza/actions/runs/33975210775) installed the current source but crashed on startup because Node/tsx could not import `@elizaos/prompts/dist/index.js`. The deploy skips install hooks, and `build:core` does not build the prompts package.

Build the prompts package artifact explicitly, reconcile core's workspace link, and execute the real core prompt import under Node/tsx before restarting the service. This uses the same package preparation already required by the provisioning worker and adds a bounded import check so a missing artifact fails before restart.

Validation:
- Reproduced the exact missing-module error with the compiled prompts artifact removed. Executed the patched workflow preparation against that cold state; the real Node/tsx import then passed.
- Reproduced a retained real package masking the workspace link; the same deployment steps restored the link and the Node/tsx import passed.
- `actionlint .github/workflows/deploy-apps-worker.yml` passed.
- `bun run verify`: 376/376 tasks passed, plus all final repository audits (6m22s Turbo phase).

Live acceptance after merge: redeploy the staging Apps worker and inspect its exact source and stable service health before continuing the staging Cloud release. This follow-up does not close the overall recovery issue.

Refs #30552.
