### PR TITLE
fix(ci): restore standalone boot and APNs Workerd validation

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -181,7 +181,11 @@ import {
 import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import { resolveDefaultVaultDataDir } from "@elizaos/vault";
 import { registerDesktopScreenCaptureBridgeService } from "./desktop-screen-capture-bridge-service.ts";
-import { type AgentHostBridge, getAgentHostBridge } from "./host-bridge.ts";
+import {
+  type AgentHostBridge,
+  getAgentHostBridge,
+  hasDurableHostVault,
+} from "./host-bridge.ts";
 
 // Host capabilities (wallet-key hydration, vault bootstrap/access, account
 // pool, build variant) are INJECTED downward by the app-core host via
@@ -4262,7 +4266,9 @@ export async function startEliza(
     const { sharedVault } = await importAppCoreRuntime();
     const vault = sharedVault();
 
-    if (!process.env.ELIZA_OPTIMIZED_PROMPT_HMAC_KEY) {
+    // Standalone hosts without a durable vault use the baseline prompts;
+    // the no-op bridge cannot persist an integrity key for optimized prompts.
+    if (!process.env.ELIZA_OPTIMIZED_PROMPT_HMAC_KEY && hasDurableHostVault()) {
       process.env.ELIZA_OPTIMIZED_PROMPT_HMAC_KEY =
         await resolveOptimizedPromptIntegrityKey(vault);
     }

--- a/packages/cloud/api/__tests__/apns-provider.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/apns-provider.miniflare.test.ts
@@ -13,6 +13,26 @@ describe("Cloud APNs provider Workerd boundary", () => {
 
   beforeAll(async () => {
     buildDirectory = await mkdtemp(join(tmpdir(), "eliza-apns-workerd-"));
+    const coreDirectory = fileURLToPath(
+      new URL("../../../core/", import.meta.url),
+    );
+    const coreBuild = Bun.spawn({
+      cmd: [process.execPath, "build.ts", "--edge-only"],
+      cwd: coreDirectory,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [coreBuildExitCode, coreBuildStdout, coreBuildStderr] =
+      await Promise.all([
+        coreBuild.exited,
+        new Response(coreBuild.stdout).text(),
+        new Response(coreBuild.stderr).text(),
+      ]);
+    if (coreBuildExitCode !== 0) {
+      throw new Error(
+        `Failed to build @elizaos/core/edge:\n${coreBuildStdout}\n${coreBuildStderr}`,
+      );
+    }
     const entrypoint = fileURLToPath(
       new URL("../test/fixtures/apns-provider-worker.ts", import.meta.url),
     );
@@ -22,7 +42,20 @@ describe("Cloud APNs provider Workerd boundary", () => {
       format: "esm",
       target: "browser",
       conditions: ["worker"],
+      external: ["node:*"],
       minify: true,
+      plugins: [
+        {
+          name: "eliza-core-edge-boundary",
+          setup(build) {
+            // Match the deployed Worker artifact instead of following the
+            // workspace TypeScript alias into core's unbundled source graph.
+            build.onResolve({ filter: /^@elizaos\/core\/edge$/ }, () => ({
+              path: join(coreDirectory, "dist/edge/index.edge.js"),
+            }));
+          },
+        },
+      ],
     });
     if (!result.success) {
       throw new Error(
@@ -34,6 +67,7 @@ describe("Cloud APNs provider Workerd boundary", () => {
     await Bun.write(outputPath, output);
     miniflare = new Miniflare({
       compatibilityDate: "2026-04-01",
+      compatibilityFlags: ["nodejs_compat"],
       modules: [
         {
           type: "ESModule",
@@ -42,7 +76,7 @@ describe("Cloud APNs provider Workerd boundary", () => {
         },
       ],
     });
-  });
+  }, 120_000);
 
   afterAll(async () => {
     await miniflare?.dispose();


### PR DESCRIPTION
Develop Full cannot certify the release because the APNs Workerd fixture bundles the uncompiled core source graph without Node compatibility, and standalone agent startup tries to create an optimized-prompt integrity key through the default no-op host vault. The latter aborts both the production Docker smoke and the real standalone credential-restart integration before readiness.

Use the deployed core edge artifact and `nodejs_compat` in the APNs fixture, with the same bounded build setup timeout as the other Workerd integration fixtures. Gate host-vault integrity-key persistence on the existing durable-vault capability; hostless standalone boot keeps the baseline prompts, while strict validation and recovery for durable vaults remain in place.

Refs #30552.

Validation:

- Reproduced the exact standalone `OPTIMIZED_PROMPT_INTEGRITY_KEY_INVALID` failure with the existing real restart integration, then passed both standalone restart and Cloud replacement cases after the repair (including the wrong-passphrase negative control).
- All 23 host-bridge and optimized-prompt vault tests passed, including persisted recovery, invalid readback, and concurrency.
- The real APNs Workerd test passed from both the root and the isolated package runner: signing, signature verification, and cached-token reuse. The isolated run completed in 14.81s after repository verification finished.
- Root `bun run verify` passed: 376/376 tasks and all final audits; no focused tests or orphaned skips in 11,409 test files.
- Hosted [Cloud Tests](https://github.com/elizaOS/eliza/actions/runs/33978472825) passed all eight jobs on `d1e529ff550d7fde7ad29c4404672a1132b4d6bb`: 1,944 unit files ran exactly once across four shards, 517 integration tests, 117 Vitest tests, ten real browser stack scenarios, and the PostgreSQL/end-to-end lane.
- The [production Docker image smoke](https://github.com/elizaOS/eliza/actions/runs/33978470846) passed on the same head. The real Node/tsx `packages/agent/dist/bin.js start` entrypoint returned `{"ready":true}` from `/api/health` and stayed up after readiness.

UI captures and live-model trajectories: N/A; the change repairs test packaging and pre-runtime vault capability selection. The existing full process restart test and production image smoke exercise the affected consumer boundary.
