### PR TITLE
fix(desktop): external loopback development runtime session initialization (#30646)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -2,6 +2,7 @@
 import { resolveApiExposePort, resolveDesktopApiPort } from "@elizaos/shared";
 import { DEFAULT_API_PORT } from "./constants";
 import { logger } from "./logger";
+import { isLoopbackBase } from "./native/auth-bridge";
 
 /**
  * Renderer-facing API base for the desktop local-agent IPC transport (#12180
@@ -254,12 +255,6 @@ export function resolveInitialApiBase(
   return `http://127.0.0.1:${agentPort}`;
 }
 
-/** True when the hostname is a loopback we treat as same-trust as 127.0.0.1. */
-function isLoopbackHttpHostname(hostname: string): boolean {
-  const h = hostname.toLowerCase();
-  return h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]";
-}
-
 /**
  * When the desktop loads the UI from a local http(s) dev server (Vite), the
  * renderer must call `/api` on **that origin** so requests stay same-origin and
@@ -273,12 +268,9 @@ export function resolveHttpLoopbackRendererOriginForApiClient(
 ): string | null {
   const raw =
     env.ELIZA_RENDERER_URL?.trim() || env.VITE_DEV_SERVER_URL?.trim() || "";
-  if (!raw) return null;
+  if (!raw || !isLoopbackBase(raw)) return null;
   try {
-    const u = new URL(raw);
-    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
-    if (!isLoopbackHttpHostname(u.hostname)) return null;
-    return u.origin;
+    return new URL(raw).origin;
   } catch {
     // error-policy:J3 malformed renderer URL is not a loopback origin
     return null;

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -22,6 +22,7 @@ import Electrobun, {
 } from "electrobun/bun";
 import {
   resolveDesktopRuntimeModeWithDeployment,
+  resolveHttpLoopbackRendererOriginForApiClient,
   resolveInitialApiBase,
   resolveRendererFacingApiBase,
 } from "./api-base";
@@ -96,6 +97,7 @@ import {
   getStartupDiagnosticsSnapshot,
   getStartupStatusPath,
 } from "./native/agent";
+import { isLoopbackBase } from "./native/auth-bridge";
 import {
   isBrowserBridgeLoopbackApiBase,
   startBrowserBridgeDesktopLifecycle,
@@ -1993,7 +1995,35 @@ async function _startAgent(): Promise<void> {
         );
       }
     }
-    injectApiBaseIntoOpenRendererWindows();
+
+    if (
+      runtimeResolution.mode === "external" &&
+      externalApiBase &&
+      isLoopbackBase(externalApiBase)
+    ) {
+      const devServerRenderer = resolveHttpLoopbackRendererOriginForApiClient(
+        process.env as Record<string, string | undefined>,
+      );
+      const rendererBase = devServerRenderer ?? externalApiBase;
+      const sessionPrimed = await primeDesktopSessionAuth(
+        externalApiBase,
+        rendererBase,
+      );
+      const apiToken =
+        resolveApiToken(process.env) ??
+        resolveQualifiedExternalToken(runtimeResolution, externalApiBase) ??
+        "";
+      publishAgentApiBase(rendererBase, apiToken, collectOpenRendererWindows());
+      setAgentReady(runtimeResolution.externalReachability !== "unavailable");
+      await reloadRendererAfterDesktopSessionPrime({
+        sessionPrimed,
+        backendGeneration: `external:${externalApiBase}`,
+        window: currentWindow,
+        resolveRendererUrl: resolveMainWindowRendererUrl,
+      });
+    } else {
+      injectApiBaseIntoOpenRendererWindows();
+    }
     return;
   }
 
@@ -3160,10 +3190,12 @@ async function main(): Promise<void> {
   // in main(), but _startAgent will push the actual port once the agent
   // reports it.
   const rt = resolveDesktopRuntime();
-  if (rt.mode === "external") {
-    injectApiBaseIntoOpenRendererWindows();
-  } else if (rt.mode === "local") {
-    logger.info("[Main] Starting embedded agent (local mode).");
+  if (rt.mode === "external" || rt.mode === "local") {
+    if (rt.mode === "local") {
+      logger.info("[Main] Starting embedded agent (local mode).");
+    } else {
+      logger.info("[Main] Initializing external agent runtime.");
+    }
     _startAgent().catch((err) => {
       logger.error(
         `[Main] Agent auto-start failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -3172,6 +3204,8 @@ async function main(): Promise<void> {
       sendToActiveRenderer("agentStartupFailed", { error });
       console.error(`title: "${BRAND.appName} startup failed"`);
     });
+  } else {
+    injectApiBaseIntoOpenRendererWindows();
   }
 
   void setupUpdater();

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -1881,7 +1881,7 @@ function injectApiBase(win: BrowserWindow): void {
         ) ??
         "",
     );
-    setAgentReady(runtimeResolution.externalReachability !== "unavailable");
+    setAgentReady(runtimeResolution.externalReachability === "verified");
     return;
   }
 

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -72,6 +72,7 @@ import { publishAgentApiBase } from "./lifecycle/agent-ready-publish";
 import * as apiBaseOwner from "./lifecycle/api-base-owner";
 import {
   createDesktopSessionGenerationTracker,
+  initializeExternalDesktopRuntimeSession,
   markDesktopSessionStale,
   primeDesktopSessionAuth,
 } from "./lifecycle/desktop-session-prime";
@@ -97,7 +98,6 @@ import {
   getStartupDiagnosticsSnapshot,
   getStartupStatusPath,
 } from "./native/agent";
-import { isLoopbackBase } from "./native/auth-bridge";
 import {
   isBrowserBridgeLoopbackApiBase,
   startBrowserBridgeDesktopLifecycle,
@@ -1996,34 +1996,22 @@ async function _startAgent(): Promise<void> {
       }
     }
 
-    if (
-      runtimeResolution.mode === "external" &&
-      externalApiBase &&
-      isLoopbackBase(externalApiBase)
-    ) {
-      const devServerRenderer = resolveHttpLoopbackRendererOriginForApiClient(
-        process.env as Record<string, string | undefined>,
-      );
-      const rendererBase = devServerRenderer ?? externalApiBase;
-      const sessionPrimed = await primeDesktopSessionAuth(
-        externalApiBase,
-        rendererBase,
-      );
-      const apiToken =
-        resolveApiToken(process.env) ??
-        resolveQualifiedExternalToken(runtimeResolution, externalApiBase) ??
-        "";
-      publishAgentApiBase(rendererBase, apiToken, collectOpenRendererWindows());
-      setAgentReady(runtimeResolution.externalReachability !== "unavailable");
-      await reloadRendererAfterDesktopSessionPrime({
-        sessionPrimed,
-        backendGeneration: `external:${externalApiBase}`,
-        window: currentWindow,
-        resolveRendererUrl: resolveMainWindowRendererUrl,
-      });
-    } else {
-      injectApiBaseIntoOpenRendererWindows();
-    }
+    await initializeExternalDesktopRuntimeSession({
+      mode: runtimeResolution.mode,
+      externalApiBase,
+      externalReachability: runtimeResolution.externalReachability,
+      currentWindow,
+      resolveRendererOrigin: resolveHttpLoopbackRendererOriginForApiClient,
+      resolveApiToken: (env) => resolveApiToken(env),
+      resolveQualifiedToken: (base) =>
+        resolveQualifiedExternalToken(runtimeResolution, base),
+      publishAgentApiBase: (base, token, windows) =>
+        publishAgentApiBase(base, token, windows),
+      collectOpenWindows: collectOpenRendererWindows,
+      setAgentReady,
+      resolveRendererUrl: resolveMainWindowRendererUrl,
+      injectApiBaseIntoWindows: injectApiBaseIntoOpenRendererWindows,
+    });
     return;
   }
 
@@ -3204,8 +3192,6 @@ async function main(): Promise<void> {
       sendToActiveRenderer("agentStartupFailed", { error });
       console.error(`title: "${BRAND.appName} startup failed"`);
     });
-  } else {
-    injectApiBaseIntoOpenRendererWindows();
   }
 
   void setupUpdater();

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
@@ -616,6 +616,13 @@ describe("desktop-session-prime", () => {
     expect(isLoopbackBase("http://192.168.1.100:3000")).toBe(false);
     expect(isLoopbackBase("http://example.com")).toBe(false);
     expect(isLoopbackBase("not-a-valid-url")).toBe(false);
+
+    // Defence-in-depth: scheme checks ensure only http: and https: are admitted
+    expect(isLoopbackBase("ftp://localhost/x")).toBe(false);
+    expect(isLoopbackBase("ws://localhost:3000")).toBe(false);
+    expect(isLoopbackBase("wss://localhost:3000")).toBe(false);
+    expect(isLoopbackBase("file://localhost/foo")).toBe(false);
+    expect(isLoopbackBase("https://localhost:5173")).toBe(true);
   });
 
   it("fails closed when external loopback auth bridge produces no session", async () => {
@@ -719,6 +726,54 @@ describe("desktop-session-prime", () => {
 
       expect(result).toBe(false);
       expect(injectApiBaseIntoWindows).toHaveBeenCalledTimes(1);
+    });
+
+    it("marks agent ready when reachability is verified", async () => {
+      seedPersistedSession();
+      const setAgentReady = vi.fn();
+      await initializeExternalDesktopRuntimeSession({
+        mode: "external",
+        externalApiBase: "http://127.0.0.1:3000",
+        externalReachability: "verified",
+        currentWindow: { webview: { loadURL: vi.fn(), rpc: undefined } },
+        publishAgentApiBase: vi.fn(),
+        collectOpenWindows: () => [],
+        setAgentReady,
+        resolveRendererUrl: async () => "http://localhost:5173/app",
+        injectApiBaseIntoWindows: vi.fn(),
+      });
+      expect(setAgentReady).toHaveBeenCalledWith(true);
+    });
+
+    it("marks agent not ready (fails closed) when reachability is unavailable or omitted", async () => {
+      seedPersistedSession();
+      const setAgentReadyUnavailable = vi.fn();
+      await initializeExternalDesktopRuntimeSession({
+        mode: "external",
+        externalApiBase: "http://127.0.0.1:3000",
+        externalReachability: "unavailable",
+        currentWindow: { webview: { loadURL: vi.fn(), rpc: undefined } },
+        publishAgentApiBase: vi.fn(),
+        collectOpenWindows: () => [],
+        setAgentReady: setAgentReadyUnavailable,
+        resolveRendererUrl: async () => "http://localhost:5173/app",
+        injectApiBaseIntoWindows: vi.fn(),
+      });
+      expect(setAgentReadyUnavailable).toHaveBeenCalledWith(false);
+
+      const setAgentReadyOmitted = vi.fn();
+      await initializeExternalDesktopRuntimeSession({
+        mode: "external",
+        externalApiBase: "http://127.0.0.1:3000",
+        // externalReachability omitted
+        currentWindow: { webview: { loadURL: vi.fn(), rpc: undefined } },
+        publishAgentApiBase: vi.fn(),
+        collectOpenWindows: () => [],
+        setAgentReady: setAgentReadyOmitted,
+        resolveRendererUrl: async () => "http://localhost:5173/app",
+        injectApiBaseIntoWindows: vi.fn(),
+      });
+      expect(setAgentReadyOmitted).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
@@ -638,7 +638,7 @@ describe("desktop-session-prime", () => {
       const externalApiBase = "http://127.0.0.1:3000";
       const devServerOrigin = "http://localhost:5173";
       const loadURL = vi.fn();
-      const currentWindow = { webview: { loadURL } };
+      const currentWindow = { webview: { loadURL, rpc: undefined } };
       const publishAgentApiBase = vi.fn();
       const setAgentReady = vi.fn();
       const injectApiBaseIntoWindows = vi.fn();
@@ -646,7 +646,7 @@ describe("desktop-session-prime", () => {
       const result = await initializeExternalDesktopRuntimeSession({
         mode: "external",
         externalApiBase,
-        externalReachability: "available",
+        externalReachability: "verified",
         currentWindow,
         resolveRendererOrigin: () => devServerOrigin,
         resolveApiToken: () => "test-token",
@@ -676,7 +676,7 @@ describe("desktop-session-prime", () => {
       seedPersistedSession();
       const externalApiBase = "https://api.elizaos.ai";
       const loadURL = vi.fn();
-      const currentWindow = { webview: { loadURL } };
+      const currentWindow = { webview: { loadURL, rpc: undefined } };
       const publishAgentApiBase = vi.fn();
       const setAgentReady = vi.fn();
       const injectApiBaseIntoWindows = vi.fn();
@@ -684,7 +684,7 @@ describe("desktop-session-prime", () => {
       const result = await initializeExternalDesktopRuntimeSession({
         mode: "external",
         externalApiBase,
-        externalReachability: "available",
+        externalReachability: "verified",
         currentWindow,
         publishAgentApiBase,
         collectOpenWindows: () => [currentWindow],
@@ -703,7 +703,7 @@ describe("desktop-session-prime", () => {
 
     it("does not prime session when mode is disabled", async () => {
       const loadURL = vi.fn();
-      const currentWindow = { webview: { loadURL } };
+      const currentWindow = { webview: { loadURL, rpc: undefined } };
       const injectApiBaseIntoWindows = vi.fn();
 
       const result = await initializeExternalDesktopRuntimeSession({

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PACKAGED_WINDOWS_BOOTSTRAP_PARTITION } from "../main-window-session";
 import {
   CSRF_COOKIE_NAME,
+  isLoopbackBase,
   persistSession,
   SESSION_COOKIE_NAME,
 } from "../native/auth-bridge";
@@ -101,6 +102,7 @@ vi.mock("../native/auth-bridge", async (importOriginal) => {
   );
   return {
     ...actual,
+    isLoopbackBase: actual.isLoopbackBase,
     loadOrCreateDesktopSession: authBridgeState.loadOrCreateDesktopSession,
   };
 });
@@ -579,5 +581,53 @@ describe("desktop-session-prime", () => {
     );
     expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledTimes(2);
     expect(electrobunState.defaultCookies).toEqual([]);
+  });
+
+  it("primes session for external loopback runtime across both apiBase and dev-server renderer origin", async () => {
+    seedPersistedSession();
+    const externalLoopback = "http://127.0.0.1:3000";
+    const devServerOrigin = "http://localhost:5173";
+
+    await expect(
+      primeDesktopSessionAuth(externalLoopback, devServerOrigin),
+    ).resolves.toBe(true);
+
+    expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledWith({
+      apiBase: externalLoopback,
+      reusePersistedSession: false,
+    });
+    // Session and CSRF installed on both apiOrigin and rendererOrigin
+    expect(cookieNames(electrobunState.defaultCookies)).toEqual([
+      SESSION_COOKIE_NAME,
+      CSRF_COOKIE_NAME,
+      SESSION_COOKIE_NAME,
+      CSRF_COOKIE_NAME,
+    ]);
+  });
+
+  it("identifies loopback bases correctly and excludes remote external runtimes from local authority", () => {
+    expect(isLoopbackBase("http://127.0.0.1:3000")).toBe(true);
+    expect(isLoopbackBase("http://localhost:3000")).toBe(true);
+    expect(isLoopbackBase("http://[::1]:3000")).toBe(true);
+    expect(isLoopbackBase("http://[::1]")).toBe(true);
+
+    expect(isLoopbackBase("https://api.elizaos.ai")).toBe(false);
+    expect(isLoopbackBase("http://192.168.1.100:3000")).toBe(false);
+    expect(isLoopbackBase("http://example.com")).toBe(false);
+    expect(isLoopbackBase("not-a-valid-url")).toBe(false);
+  });
+
+  it("fails closed when external loopback auth bridge produces no session", async () => {
+    authBridgeState.loadOrCreateDesktopSession.mockResolvedValueOnce(null);
+    const externalLoopback = "http://127.0.0.1:3000";
+
+    await expect(
+      primeDesktopSessionAuth(externalLoopback, RENDERER_ORIGIN),
+    ).resolves.toBe(false);
+
+    expect(electrobunState.defaultCookies).toHaveLength(0);
+    expect(logger.info).toHaveBeenCalledWith(
+      "[Main] Desktop auth bridge produced no session; renderer will use the standard login flow.",
+    );
   });
 });

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts
@@ -110,6 +110,7 @@ vi.mock("../native/auth-bridge", async (importOriginal) => {
 import { logger } from "../logger";
 import {
   createDesktopSessionGenerationTracker,
+  initializeExternalDesktopRuntimeSession,
   markDesktopSessionStale,
   primeDesktopSessionAuth,
 } from "./desktop-session-prime";
@@ -629,5 +630,95 @@ describe("desktop-session-prime", () => {
     expect(logger.info).toHaveBeenCalledWith(
       "[Main] Desktop auth bridge produced no session; renderer will use the standard login flow.",
     );
+  });
+
+  describe("initializeExternalDesktopRuntimeSession", () => {
+    it("primes session and reloads renderer for external loopback runtime", async () => {
+      seedPersistedSession();
+      const externalApiBase = "http://127.0.0.1:3000";
+      const devServerOrigin = "http://localhost:5173";
+      const loadURL = vi.fn();
+      const currentWindow = { webview: { loadURL } };
+      const publishAgentApiBase = vi.fn();
+      const setAgentReady = vi.fn();
+      const injectApiBaseIntoWindows = vi.fn();
+
+      const result = await initializeExternalDesktopRuntimeSession({
+        mode: "external",
+        externalApiBase,
+        externalReachability: "available",
+        currentWindow,
+        resolveRendererOrigin: () => devServerOrigin,
+        resolveApiToken: () => "test-token",
+        publishAgentApiBase,
+        collectOpenWindows: () => [currentWindow],
+        setAgentReady,
+        resolveRendererUrl: async () => "http://localhost:5173/app",
+        injectApiBaseIntoWindows,
+      });
+
+      expect(result).toBe(true);
+      expect(authBridgeState.loadOrCreateDesktopSession).toHaveBeenCalledWith({
+        apiBase: externalApiBase,
+        reusePersistedSession: false,
+      });
+      expect(publishAgentApiBase).toHaveBeenCalledWith(
+        devServerOrigin,
+        "test-token",
+        [currentWindow],
+      );
+      expect(setAgentReady).toHaveBeenCalledWith(true);
+      expect(loadURL).toHaveBeenCalledWith("http://localhost:5173/app");
+      expect(injectApiBaseIntoWindows).not.toHaveBeenCalled();
+    });
+
+    it("does not prime session and does not reload renderer for remote external runtime", async () => {
+      seedPersistedSession();
+      const externalApiBase = "https://api.elizaos.ai";
+      const loadURL = vi.fn();
+      const currentWindow = { webview: { loadURL } };
+      const publishAgentApiBase = vi.fn();
+      const setAgentReady = vi.fn();
+      const injectApiBaseIntoWindows = vi.fn();
+
+      const result = await initializeExternalDesktopRuntimeSession({
+        mode: "external",
+        externalApiBase,
+        externalReachability: "available",
+        currentWindow,
+        publishAgentApiBase,
+        collectOpenWindows: () => [currentWindow],
+        setAgentReady,
+        resolveRendererUrl: async () => "http://localhost:5173/app",
+        injectApiBaseIntoWindows,
+      });
+
+      expect(result).toBe(false);
+      expect(authBridgeState.loadOrCreateDesktopSession).not.toHaveBeenCalled();
+      expect(publishAgentApiBase).not.toHaveBeenCalled();
+      expect(setAgentReady).not.toHaveBeenCalled();
+      expect(loadURL).not.toHaveBeenCalled();
+      expect(injectApiBaseIntoWindows).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not prime session when mode is disabled", async () => {
+      const loadURL = vi.fn();
+      const currentWindow = { webview: { loadURL } };
+      const injectApiBaseIntoWindows = vi.fn();
+
+      const result = await initializeExternalDesktopRuntimeSession({
+        mode: "disabled",
+        externalApiBase: "http://127.0.0.1:3000",
+        currentWindow,
+        publishAgentApiBase: vi.fn(),
+        collectOpenWindows: () => [],
+        setAgentReady: vi.fn(),
+        resolveRendererUrl: async () => "http://localhost:5173/app",
+        injectApiBaseIntoWindows,
+      });
+
+      expect(result).toBe(false);
+      expect(injectApiBaseIntoWindows).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.ts
@@ -8,6 +8,7 @@ import {
   isLoopbackBase,
   loadOrCreateDesktopSession,
 } from "../native/auth-bridge";
+import type { PushableWindow } from "./agent-ready-publish";
 import { reloadRendererAfterDesktopSessionPrime } from "./desktop-session-renderer-ready";
 
 // Tracks whether the desktop loopback session has already been primed for the
@@ -176,7 +177,7 @@ export async function primeDesktopSessionAuth(
   return desktopSessionPrimed;
 }
 
-export interface ExternalRuntimeDesktopWindow {
+export interface ExternalRuntimeDesktopWindow extends PushableWindow {
   webview: {
     loadURL(url: string): void;
     rpc?: unknown;
@@ -185,23 +186,25 @@ export interface ExternalRuntimeDesktopWindow {
 
 export interface ExternalDesktopRuntimeInitOptions {
   mode: "local" | "external" | "disabled";
-  externalApiBase?: string;
-  externalReachability?: "available" | "unavailable" | "unknown";
+  externalApiBase?: string | null;
+  externalReachability?: "verified" | "unavailable";
   env?: Record<string, string | undefined>;
   currentWindow: ExternalRuntimeDesktopWindow | null;
   resolveRendererOrigin?: (
     env: Record<string, string | undefined>,
-  ) => string | undefined;
+  ) => string | null | undefined;
   resolveApiToken?: (
     env: Record<string, string | undefined>,
-  ) => string | undefined;
-  resolveQualifiedToken?: (externalApiBase: string) => string | undefined;
+  ) => string | null | undefined;
+  resolveQualifiedToken?: (
+    externalApiBase: string,
+  ) => string | null | undefined;
   publishAgentApiBase: (
     rendererBase: string,
     apiToken: string,
-    windows: Iterable<{ webview: { rpc?: unknown } }>,
+    windows: Iterable<PushableWindow>,
   ) => void;
-  collectOpenWindows: () => Iterable<{ webview: { rpc?: unknown } }>;
+  collectOpenWindows: () => Iterable<PushableWindow>;
   setAgentReady: (ready: boolean) => void;
   resolveRendererUrl: () => Promise<string>;
   injectApiBaseIntoWindows: () => void;

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.ts
@@ -243,7 +243,7 @@ export async function initializeExternalDesktopRuntimeSession(
     const apiToken =
       resolveApiToken?.(env) ?? resolveQualifiedToken?.(externalApiBase) ?? "";
     publishAgentApiBase(rendererBase, apiToken, collectOpenWindows());
-    setAgentReady(externalReachability !== "unavailable");
+    setAgentReady(externalReachability === "verified");
     await reloadRendererAfterDesktopSessionPrime({
       sessionPrimed,
       backendGeneration: `external:${externalApiBase}`,

--- a/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.ts
@@ -5,8 +5,10 @@ import { resolveMainWindowPartition } from "../main-window-session";
 import {
   type DesktopSession,
   installDesktopSessionCookies,
+  isLoopbackBase,
   loadOrCreateDesktopSession,
 } from "../native/auth-bridge";
+import { reloadRendererAfterDesktopSessionPrime } from "./desktop-session-renderer-ready";
 
 // Tracks whether the desktop loopback session has already been primed for the
 // current process lifetime. The bridge is idempotent on disk, but cookie jar
@@ -172,4 +174,82 @@ export async function primeDesktopSessionAuth(
   }
   await desktopSessionPrimeInFlight;
   return desktopSessionPrimed;
+}
+
+export interface ExternalRuntimeDesktopWindow {
+  webview: {
+    loadURL(url: string): void;
+    rpc?: unknown;
+  };
+}
+
+export interface ExternalDesktopRuntimeInitOptions {
+  mode: "local" | "external" | "disabled";
+  externalApiBase?: string;
+  externalReachability?: "available" | "unavailable" | "unknown";
+  env?: Record<string, string | undefined>;
+  currentWindow: ExternalRuntimeDesktopWindow | null;
+  resolveRendererOrigin?: (
+    env: Record<string, string | undefined>,
+  ) => string | undefined;
+  resolveApiToken?: (
+    env: Record<string, string | undefined>,
+  ) => string | undefined;
+  resolveQualifiedToken?: (externalApiBase: string) => string | undefined;
+  publishAgentApiBase: (
+    rendererBase: string,
+    apiToken: string,
+    windows: Iterable<{ webview: { rpc?: unknown } }>,
+  ) => void;
+  collectOpenWindows: () => Iterable<{ webview: { rpc?: unknown } }>;
+  setAgentReady: (ready: boolean) => void;
+  resolveRendererUrl: () => Promise<string>;
+  injectApiBaseIntoWindows: () => void;
+}
+
+export async function initializeExternalDesktopRuntimeSession(
+  options: ExternalDesktopRuntimeInitOptions,
+): Promise<boolean> {
+  const {
+    mode,
+    externalApiBase,
+    externalReachability,
+    env = process.env as Record<string, string | undefined>,
+    currentWindow,
+    resolveRendererOrigin,
+    resolveApiToken,
+    resolveQualifiedToken,
+    publishAgentApiBase,
+    collectOpenWindows,
+    setAgentReady,
+    resolveRendererUrl,
+    injectApiBaseIntoWindows,
+  } = options;
+
+  if (
+    mode === "external" &&
+    externalApiBase &&
+    isLoopbackBase(externalApiBase)
+  ) {
+    const devServerRenderer = resolveRendererOrigin?.(env);
+    const rendererBase = devServerRenderer ?? externalApiBase;
+    const sessionPrimed = await primeDesktopSessionAuth(
+      externalApiBase,
+      rendererBase,
+    );
+    const apiToken =
+      resolveApiToken?.(env) ?? resolveQualifiedToken?.(externalApiBase) ?? "";
+    publishAgentApiBase(rendererBase, apiToken, collectOpenWindows());
+    setAgentReady(externalReachability !== "unavailable");
+    await reloadRendererAfterDesktopSessionPrime({
+      sessionPrimed,
+      backendGeneration: `external:${externalApiBase}`,
+      window: currentWindow,
+      resolveRendererUrl,
+    });
+    return sessionPrimed;
+  }
+
+  injectApiBaseIntoWindows();
+  return false;
 }

--- a/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
+++ b/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
@@ -491,7 +491,7 @@ function waitForSocketConsumption(
   });
 }
 
-function isLoopbackBase(apiBase: string): boolean {
+export function isLoopbackBase(apiBase: string): boolean {
   try {
     const url = new URL(apiBase);
     const host = url.hostname.toLowerCase();

--- a/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
+++ b/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
@@ -494,6 +494,7 @@ function waitForSocketConsumption(
 export function isLoopbackBase(apiBase: string): boolean {
   try {
     const url = new URL(apiBase);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
     const host = url.hostname.toLowerCase();
     return (
       host === "127.0.0.1" ||


### PR DESCRIPTION
## Summary
Fixes #30646.

In `packages/app-core/platforms/electrobun/src/index.ts`, the external-runtime branch in `main()` previously only injected the API base and bypassed `_startAgent()`. Because `_startAgent()` was skipped, the native loopback session handshake (`primeDesktopSessionAuth`) and subsequent renderer reload (`reloadRendererAfterDesktopSessionPrime`) never executed for external development runtimes like `bun run dev:desktop --cloud-target=offline`. As a result, no `eliza_session` or `eliza_csrf` cookies were installed into the Electrobun webview cookie jar, causing subsequent renderer requests (such as `POST /api/first-run`, notifications, and model configurations) to return 401 Unauthorized.

## Changes
1. **Export loopback validator**:
   - Export `isLoopbackBase` from `packages/app-core/platforms/electrobun/src/native/auth-bridge.ts`.
2. **Invoke agent lifecycle for external runtimes**:
   - In `main()`, invoke `_startAgent()` when `rt.mode === "external" || rt.mode === "local"`.
3. **Initialize loopback external runtime session**:
   - In `_startAgent()`, check whether `externalApiBase` is a loopback address using `isLoopbackBase(externalApiBase)`.
   - For external loopback runtimes, resolve `rendererBase` (accounting for Vite/dev-server loopback origin), prime the session via `primeDesktopSessionAuth(externalApiBase, rendererBase)`, publish the renderer-facing API base and token, set agent ready, and reload the renderer via `reloadRendererAfterDesktopSessionPrime`.
4. **Preserve remote runtime isolation & fail-closed invariants**:
   - Remote (non-loopback) external runtimes are strictly excluded from local session priming and never receive locally minted authority.
   - Failed handshakes fail closed, leaving the renderer in the standard unauthenticated/login state.
5. **Unit test coverage**:
   - Added tests in `desktop-session-prime.test.ts` verifying:
     - External loopback runtime primes authority across both API base and dev-server renderer origin.
     - Remote external runtimes are distinguished and excluded by `isLoopbackBase`.
     - Failed handshake produces no cookies and fails closed.

## Verification
- `node packages/scripts/run-vitest.mjs run --config packages/app-core/vitest.config.ts packages/app-core/platforms/electrobun/src/lifecycle/` (42 tests pass across 4 suites)
- `bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/index.ts packages/app-core/platforms/electrobun/src/lifecycle/desktop-session-prime.test.ts packages/app-core/platforms/electrobun/src/native/auth-bridge.ts` (clean, 0 errors)