### PR TITLE
fix(app): exclude unpublished local models from setup recommendations (#30650)

### DIFF
--- a/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
@@ -934,7 +934,7 @@ describe("Eliza-1 manifest download timeout (real route, portable fallback, fake
     expect(body.error).toContain("Unknown model id: eliza-1-9b");
   });
 
-  it("only returns published models from GET /api/local-inference/catalog", async () => {
+  it("only returns published models from GET /api/local-inference/catalog when none are installed or downloading", async () => {
     const kernel = await loadKernel();
     const body = (await jsonRequest(
       kernel,
@@ -942,6 +942,32 @@ describe("Eliza-1 manifest download timeout (real route, portable fallback, fake
       "/api/local-inference/catalog",
     )) as { models: Array<{ id: string }> };
     expect(body.models.some((m) => m.id === "eliza-1-9b")).toBe(false);
+    expect(body.models.some((m) => m.id === "eliza-1-2b")).toBe(true);
+    expect(body.models.some((m) => m.id === "eliza-1-4b")).toBe(true);
+  });
+
+  it("includes unpublished model in GET /api/local-inference/catalog when already installed", async () => {
+    const kernel = await loadKernel({
+      availableModels: [
+        {
+          name: "eliza-1-9b-128k.gguf",
+          path: "/models/eliza-1-9b-128k.gguf",
+          size: 5_000_000_000,
+        },
+      ],
+      bundleRecords: [
+        verifiedEliza1BundleRecord(
+          "eliza-1-9b",
+          "/models/eliza-1-9b-128k.gguf",
+        ),
+      ],
+    });
+    const body = (await jsonRequest(
+      kernel,
+      "GET",
+      "/api/local-inference/catalog",
+    )) as { models: Array<{ id: string }> };
+    expect(body.models.some((m) => m.id === "eliza-1-9b")).toBe(true);
     expect(body.models.some((m) => m.id === "eliza-1-2b")).toBe(true);
     expect(body.models.some((m) => m.id === "eliza-1-4b")).toBe(true);
   });

--- a/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
@@ -920,4 +920,32 @@ describe("Eliza-1 manifest download timeout (real route, portable fallback, fake
     expect(job.state).toBe("completed");
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it("rejects downloading an unpublished/pending model tier with 404", async () => {
+    const kernel = await loadKernel();
+    const res = await jsonRequest(
+      kernel,
+      "POST",
+      "/api/local-inference/downloads",
+      { modelId: "eliza-1-9b" },
+    );
+    expect(res.status).toBe(404);
+    expect((res.body as { error?: string }).error).toContain(
+      "Unknown model id: eliza-1-9b",
+    );
+  });
+
+  it("only returns published models from GET /api/local-inference/catalog", async () => {
+    const kernel = await loadKernel();
+    const res = await jsonRequest(
+      kernel,
+      "GET",
+      "/api/local-inference/catalog",
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { models: Array<{ id: string }> };
+    expect(body.models.some((m) => m.id === "eliza-1-9b")).toBe(false);
+    expect(body.models.some((m) => m.id === "eliza-1-2b")).toBe(true);
+    expect(body.models.some((m) => m.id === "eliza-1-4b")).toBe(true);
+  });
 });

--- a/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
@@ -923,27 +923,24 @@ describe("Eliza-1 manifest download timeout (real route, portable fallback, fake
 
   it("rejects downloading an unpublished/pending model tier with 404", async () => {
     const kernel = await loadKernel();
-    const res = await jsonRequest(
-      kernel,
-      "POST",
-      "/api/local-inference/downloads",
-      { modelId: "eliza-1-9b" },
+    const response = await kernel.handleIosLocalAgentRequest(
+      new Request("http://127.0.0.1:31337/api/local-inference/downloads", {
+        method: "POST",
+        body: JSON.stringify({ modelId: "eliza-1-9b" }),
+      }),
     );
-    expect(res.status).toBe(404);
-    expect((res.body as { error?: string }).error).toContain(
-      "Unknown model id: eliza-1-9b",
-    );
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error?: string };
+    expect(body.error).toContain("Unknown model id: eliza-1-9b");
   });
 
   it("only returns published models from GET /api/local-inference/catalog", async () => {
     const kernel = await loadKernel();
-    const res = await jsonRequest(
+    const body = (await jsonRequest(
       kernel,
       "GET",
       "/api/local-inference/catalog",
-    );
-    expect(res.status).toBe(200);
-    const body = res.body as { models: Array<{ id: string }> };
+    )) as { models: Array<{ id: string }> };
     expect(body.models.some((m) => m.id === "eliza-1-9b")).toBe(false);
     expect(body.models.some((m) => m.id === "eliza-1-2b")).toBe(true);
     expect(body.models.some((m) => m.id === "eliza-1-4b")).toBe(true);

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -3811,9 +3811,18 @@ export async function handleIosLocalAgentRequest(
   }
 
   if (method === "GET" && pathname === "/api/local-inference/catalog") {
+    const installedIds = new Set(
+      (await listInstalledModels()).map((m) => m.id),
+    );
+    const downloadingIds = new Set(
+      [...downloads.values()].map((j) => j.modelId),
+    );
     return json({
       models: filterSettingsDefaultLocalModels(MODEL_CATALOG).filter(
-        isPublishedLocalModel,
+        (model) =>
+          isPublishedLocalModel(model) ||
+          installedIds.has(model.id) ||
+          downloadingIds.has(model.id),
       ),
     });
   }

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -34,6 +34,7 @@ import {
 } from "../services/local-inference/catalog";
 import {
   filterSettingsDefaultLocalModels,
+  isPublishedLocalModel,
   isSettingsDefaultLocalModel,
 } from "../services/local-inference/catalog-policy";
 import {
@@ -3810,7 +3811,11 @@ export async function handleIosLocalAgentRequest(
   }
 
   if (method === "GET" && pathname === "/api/local-inference/catalog") {
-    return json({ models: filterSettingsDefaultLocalModels(MODEL_CATALOG) });
+    return json({
+      models: filterSettingsDefaultLocalModels(MODEL_CATALOG).filter(
+        isPublishedLocalModel,
+      ),
+    });
   }
 
   if (method === "GET" && pathname === "/api/local-inference/installed") {
@@ -3838,7 +3843,11 @@ export async function handleIosLocalAgentRequest(
     const body = await requestJson(request);
     const modelId = typeof body.modelId === "string" ? body.modelId : "";
     const catalog = findCatalogModel(modelId);
-    if (!catalog || !isSettingsDefaultLocalModel(catalog)) {
+    if (
+      !catalog ||
+      !isSettingsDefaultLocalModel(catalog) ||
+      !isPublishedLocalModel(catalog)
+    ) {
       return json({ error: `Unknown model id: ${modelId}` }, 404);
     }
     const validationError = await validateMobileModelFit(catalog);

--- a/packages/ui/src/components/local-inference/FirstRunOffer.test.tsx
+++ b/packages/ui/src/components/local-inference/FirstRunOffer.test.tsx
@@ -6,8 +6,8 @@
  * render a distinct unavailable state without download buttons when none exist (#30650).
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   CatalogModel,
   HardwareProbe,
@@ -48,6 +48,8 @@ const appleSilicon24Gb: HardwareProbe = {
 };
 
 describe("FirstRunOffer", () => {
+  afterEach(cleanup);
+
   it("recommends the published 4B model and enables download on 24 GB Apple Silicon", () => {
     const catalog: CatalogModel[] = [
       makeCatalogModel("eliza-1-2b", { minRamGb: 4, sizeGb: 1.5 }),
@@ -68,7 +70,7 @@ describe("FirstRunOffer", () => {
     expect(screen.getByText("Local model required")).toBeTruthy();
     expect(
       screen.getByText(
-        /Download the default local model \(Eliza-1 4B\) to run chat on this device\./,
+        /Download the default local model \(eliza-1-4b\) to run chat on this device\./,
       ),
     ).toBeTruthy();
     expect(
@@ -80,6 +82,33 @@ describe("FirstRunOffer", () => {
     render(
       <FirstRunOffer
         catalog={[]}
+        installed={[]}
+        downloads={[]}
+        hardware={appleSilicon24Gb}
+        onDownload={vi.fn()}
+        busy={false}
+      />,
+    );
+
+    expect(screen.getByText("Local model required")).toBeTruthy();
+    expect(
+      screen.getByText("No local chat model is available on this device."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("shows unavailable state when only pending models exist in catalog", () => {
+    const catalog: CatalogModel[] = [
+      makeCatalogModel("eliza-1-9b", {
+        minRamGb: 14,
+        sizeGb: 5.5,
+        publishStatus: "pending",
+      }),
+    ];
+
+    render(
+      <FirstRunOffer
+        catalog={catalog}
         installed={[]}
         downloads={[]}
         hardware={appleSilicon24Gb}

--- a/packages/ui/src/components/local-inference/FirstRunOffer.test.tsx
+++ b/packages/ui/src/components/local-inference/FirstRunOffer.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for FirstRunOffer publication filtering and unavailable state.
+ * Validates that setup recommendations only pick published eligible tiers and
+ * render a distinct unavailable state without download buttons when none exist (#30650).
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  CatalogModel,
+  HardwareProbe,
+} from "../../api/client-local-inference";
+import { FirstRunOffer } from "./FirstRunOffer";
+
+function makeCatalogModel(
+  id: string,
+  overrides?: Partial<CatalogModel>,
+): CatalogModel {
+  return {
+    id,
+    displayName: `Eliza-1 ${id.replace("eliza-1-", "").toUpperCase()}`,
+    hfRepo: "elizaos/eliza-1",
+    ggufFile: `${id}.gguf`,
+    params: "4B",
+    quant: "Q4_K_M",
+    sizeGb: 2.5,
+    minRamGb: 6,
+    category: "chat",
+    bucket: "small",
+    blurb: `Model ${id}`,
+    hiddenFromCatalog: false,
+    ...overrides,
+  };
+}
+
+const appleSilicon24Gb: HardwareProbe = {
+  totalRamGb: 24,
+  freeRamGb: 16,
+  gpu: null,
+  cpuCores: 8,
+  platform: "darwin",
+  arch: "arm64",
+  appleSilicon: true,
+  recommendedBucket: "mid",
+  source: "os-fallback",
+};
+
+describe("FirstRunOffer", () => {
+  it("recommends the published 4B model and enables download on 24 GB Apple Silicon", () => {
+    const catalog: CatalogModel[] = [
+      makeCatalogModel("eliza-1-2b", { minRamGb: 4, sizeGb: 1.5 }),
+      makeCatalogModel("eliza-1-4b", { minRamGb: 6, sizeGb: 2.5 }),
+    ];
+
+    render(
+      <FirstRunOffer
+        catalog={catalog}
+        installed={[]}
+        downloads={[]}
+        hardware={appleSilicon24Gb}
+        onDownload={vi.fn()}
+        busy={false}
+      />,
+    );
+
+    expect(screen.getByText("Local model required")).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Download the default local model \(Eliza-1 4B\) to run chat on this device\./,
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Download default model" }),
+    ).toBeTruthy();
+  });
+
+  it("shows distinct unavailable state without download button when no models are published", () => {
+    render(
+      <FirstRunOffer
+        catalog={[]}
+        installed={[]}
+        downloads={[]}
+        hardware={appleSilicon24Gb}
+        onDownload={vi.fn()}
+        busy={false}
+      />,
+    );
+
+    expect(screen.getByText("Local model required")).toBeTruthy();
+    expect(
+      screen.getByText("No local chat model is available on this device."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/local-inference/FirstRunOffer.tsx
+++ b/packages/ui/src/components/local-inference/FirstRunOffer.tsx
@@ -11,6 +11,10 @@ import type {
   HardwareProbe,
   InstalledModel,
 } from "../../api/client-local-inference";
+import {
+  type Eliza1TierId,
+  eliza1TierPublishStatus,
+} from "../../services/local-inference/catalog";
 import { selectRecommendedModels } from "../../services/local-inference/recommendation";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
@@ -119,7 +123,10 @@ function pickRecommended(
   return (
     catalog.find(
       (model) =>
-        model.id.startsWith("eliza-1-") && !findInstalled(model, installed),
+        model.id.startsWith("eliza-1-") &&
+        !findInstalled(model, installed) &&
+        (model.publishStatus ??
+          eliza1TierPublishStatus(model.id as Eliza1TierId)) === "published",
     ) ?? null
   );
 }

--- a/packages/ui/src/components/local-inference/FirstRunOffer.tsx
+++ b/packages/ui/src/components/local-inference/FirstRunOffer.tsx
@@ -12,9 +12,9 @@ import type {
   InstalledModel,
 } from "../../api/client-local-inference";
 import {
-  type Eliza1TierId,
-  eliza1TierPublishStatus,
-} from "../../services/local-inference/catalog";
+  isPublishedLocalModel,
+  type LocalModelCatalogEntry,
+} from "../../services/local-inference/catalog-policy";
 import { selectRecommendedModels } from "../../services/local-inference/recommendation";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
@@ -125,8 +125,7 @@ function pickRecommended(
       (model) =>
         model.id.startsWith("eliza-1-") &&
         !findInstalled(model, installed) &&
-        (model.publishStatus ??
-          eliza1TierPublishStatus(model.id as Eliza1TierId)) === "published",
+        isPublishedLocalModel(model as unknown as LocalModelCatalogEntry),
     ) ?? null
   );
 }

--- a/packages/ui/src/components/local-inference/FirstRunOffer.tsx
+++ b/packages/ui/src/components/local-inference/FirstRunOffer.tsx
@@ -11,10 +11,7 @@ import type {
   HardwareProbe,
   InstalledModel,
 } from "../../api/client-local-inference";
-import {
-  isPublishedLocalModel,
-  type LocalModelCatalogEntry,
-} from "../../services/local-inference/catalog-policy";
+import { isPublishedLocalModel } from "../../services/local-inference/catalog-policy";
 import { selectRecommendedModels } from "../../services/local-inference/recommendation";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
@@ -125,7 +122,7 @@ function pickRecommended(
       (model) =>
         model.id.startsWith("eliza-1-") &&
         !findInstalled(model, installed) &&
-        isPublishedLocalModel(model as unknown as LocalModelCatalogEntry),
+        isPublishedLocalModel(model),
     ) ?? null
   );
 }

--- a/packages/ui/src/components/local-inference/LocalInferencePanel.test.tsx
+++ b/packages/ui/src/components/local-inference/LocalInferencePanel.test.tsx
@@ -37,6 +37,8 @@ vi.mock("../../hooks/useRole", () => ({
 }));
 vi.mock("../../services/local-inference/catalog-policy", () => ({
   filterSettingsDefaultLocalModels: (models: unknown[]) => models,
+  isPublishedLocalModel: (model: unknown) =>
+    (model as { publishStatus?: string })?.publishStatus !== "pending",
 }));
 vi.mock("../../state", () => ({
   useAppSelectorShallow: (selector: (state: unknown) => unknown) =>

--- a/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
+++ b/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
@@ -17,10 +17,12 @@ import type {
   ModelHubSnapshot,
 } from "../../api/client-local-inference";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
+import { useRole } from "../../hooks/useRole";
 import {
   filterSettingsDefaultLocalModels,
   isPublishedLocalModel,
 } from "../../services/local-inference/catalog-policy";
+import { useAppSelectorShallow } from "../../state";
 import { resolveApiUrl } from "../../utils/asset-url";
 import { getElizaApiToken } from "../../utils/eliza-globals";
 import { openEventSource } from "../../utils/event-source";

--- a/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
+++ b/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
@@ -17,9 +17,10 @@ import type {
   ModelHubSnapshot,
 } from "../../api/client-local-inference";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
-import { useRole } from "../../hooks/useRole";
-import { filterSettingsDefaultLocalModels } from "../../services/local-inference/catalog-policy";
-import { useAppSelectorShallow } from "../../state";
+import {
+  filterSettingsDefaultLocalModels,
+  isPublishedLocalModel,
+} from "../../services/local-inference/catalog-policy";
 import { resolveApiUrl } from "../../utils/asset-url";
 import { getElizaApiToken } from "../../utils/eliza-globals";
 import { openEventSource } from "../../utils/event-source";
@@ -327,7 +328,9 @@ export function LocalInferencePanel() {
     );
   }
 
-  const catalog = filterSettingsDefaultLocalModels(hub.catalog);
+  const catalog = filterSettingsDefaultLocalModels(hub.catalog).filter(
+    isPublishedLocalModel,
+  );
 
   return (
     <div className="flex flex-col gap-3">

--- a/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
+++ b/packages/ui/src/components/local-inference/LocalInferencePanel.tsx
@@ -35,6 +35,7 @@ import { DevicesPanel } from "./DevicesPanel";
 import { DownloadQueue } from "./DownloadQueue";
 import { FirstRunOffer } from "./FirstRunOffer";
 import { HardwareBadge } from "./HardwareBadge";
+import { findDownload, findInstalled } from "./hub-utils";
 import { ModelHubView } from "./ModelHubView";
 import type {
   VoiceModelInstallationView,
@@ -331,7 +332,10 @@ export function LocalInferencePanel() {
   }
 
   const catalog = filterSettingsDefaultLocalModels(hub.catalog).filter(
-    isPublishedLocalModel,
+    (model) =>
+      isPublishedLocalModel(model) ||
+      Boolean(findInstalled(model, hub.installed)) ||
+      Boolean(findDownload(model.id, hub.downloads)),
   );
 
   return (

--- a/packages/ui/src/components/local-inference/ModelHubView.test.tsx
+++ b/packages/ui/src/components/local-inference/ModelHubView.test.tsx
@@ -23,19 +23,43 @@ vi.mock("../../state/TranslationContext.hooks", () => ({
   }),
 }));
 
+function makeCatalogModel(
+  id: string,
+  overrides?: Partial<CatalogModel>,
+): CatalogModel {
+  return {
+    id,
+    displayName: `Eliza-1 ${id.replace("eliza-1-", "").toUpperCase()}`,
+    hfRepo: "elizaos/eliza-1",
+    ggufFile: `${id}.gguf`,
+    params: "4B",
+    quant: "Q4_K_M",
+    sizeGb: 2.5,
+    minRamGb: 6,
+    category: "chat",
+    bucket: "small",
+    blurb: `Model ${id}`,
+    hiddenFromCatalog: false,
+    ...overrides,
+  };
+}
+
 const mockHardware: HardwareProbe = {
   platform: "darwin",
   arch: "arm64",
-  totalMemoryBytes: 24 * 1024 * 1024 * 1024,
-  freeMemoryBytes: 16 * 1024 * 1024 * 1024,
+  totalRamGb: 24,
+  freeRamGb: 16,
+  gpu: null,
   cpuCores: 8,
+  appleSilicon: true,
+  recommendedBucket: "mid",
+  source: "os-fallback",
 };
 
 const mockActive: ActiveModelState = {
-  slot: "TEXT_LARGE",
   modelId: null,
-  activeState: "idle",
-  loadedModel: null,
+  loadedAt: null,
+  status: "idle",
 };
 
 describe("ModelHubView publication filtering", () => {
@@ -45,15 +69,10 @@ describe("ModelHubView publication filtering", () => {
 
   it("renders unavailable banner and no download buttons when all catalog models are pending", () => {
     const pendingCatalog: CatalogModel[] = [
-      {
-        id: "eliza-1-9b",
-        name: "Eliza 1 9B",
+      makeCatalogModel("eliza-1-9b", {
         bucket: "large",
-        sizeBytes: 6 * 1024 * 1024 * 1024,
         publishStatus: "pending",
-        hiddenFromCatalog: false,
-        ggufFile: "eliza-1-9b.gguf",
-      } as CatalogModel,
+      }),
     ];
 
     render(
@@ -81,30 +100,14 @@ describe("ModelHubView publication filtering", () => {
 
   it("renders model rows with download button when published models exist", () => {
     const mixedCatalog: CatalogModel[] = [
-      {
-        id: "eliza-1-4b",
-        name: "Eliza 1 4B",
+      makeCatalogModel("eliza-1-4b", {
         bucket: "mid",
-        sizeBytes: 3 * 1024 * 1024 * 1024,
-        sizeGb: 3.0,
-        params: "4B",
-        quant: "Q4_K_M",
         publishStatus: "published",
-        hiddenFromCatalog: false,
-        ggufFile: "eliza-1-4b.gguf",
-      } as CatalogModel,
-      {
-        id: "eliza-1-9b",
-        name: "Eliza 1 9B",
+      }),
+      makeCatalogModel("eliza-1-9b", {
         bucket: "large",
-        sizeBytes: 6 * 1024 * 1024 * 1024,
-        sizeGb: 6.0,
-        params: "9B",
-        quant: "Q4_K_M",
         publishStatus: "pending",
-        hiddenFromCatalog: false,
-        ggufFile: "eliza-1-9b.gguf",
-      } as CatalogModel,
+      }),
     ];
 
     render(

--- a/packages/ui/src/components/local-inference/ModelHubView.test.tsx
+++ b/packages/ui/src/components/local-inference/ModelHubView.test.tsx
@@ -2,8 +2,9 @@
 
 /**
  * Tests for ModelHubView publication filtering:
- * Verifies that pending/unpublished models are excluded from the hub grid,
- * and when no published models exist, the unavailable banner is rendered with no download buttons.
+ * Verifies that pending/unpublished models are excluded from the hub grid when uninstalled,
+ * that an unavailable banner is rendered when no published/installed models exist,
+ * and that already-installed or actively downloading pending models retain their management rows and actions (#30650).
  */
 
 import { cleanup, render, screen } from "@testing-library/react";
@@ -11,7 +12,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ActiveModelState,
   CatalogModel,
+  DownloadJob,
   HardwareProbe,
+  InstalledModel,
 } from "../../api/client-local-inference";
 import { ModelHubView } from "./ModelHubView";
 
@@ -67,7 +70,7 @@ describe("ModelHubView publication filtering", () => {
     cleanup();
   });
 
-  it("renders unavailable banner and no download buttons when all catalog models are pending", () => {
+  it("renders unavailable banner and no download buttons when all catalog models are pending and uninstalled", () => {
     const pendingCatalog: CatalogModel[] = [
       makeCatalogModel("eliza-1-9b", {
         bucket: "large",
@@ -130,5 +133,93 @@ describe("ModelHubView publication filtering", () => {
       name: /download/i,
     });
     expect(downloadButtons.length).toBe(1);
+  });
+
+  it("preserves model row and uninstall control for already-installed pending model", () => {
+    const onUninstall = vi.fn();
+    const pendingCatalog: CatalogModel[] = [
+      makeCatalogModel("eliza-1-9b", {
+        bucket: "large",
+        publishStatus: "pending",
+      }),
+    ];
+    const installed: InstalledModel[] = [
+      {
+        id: "eliza-1-9b",
+        displayName: "Eliza-1 9B",
+        path: "/models/eliza-1-9b.gguf",
+        sizeBytes: 6 * 1024 * 1024 * 1024,
+        installedAt: "2026-08-28T00:00:00.000Z",
+        lastUsedAt: null,
+        source: "eliza-download",
+      },
+    ];
+
+    render(
+      <ModelHubView
+        catalog={pendingCatalog}
+        installed={installed}
+        downloads={[]}
+        active={mockActive}
+        hardware={mockHardware}
+        onDownload={vi.fn()}
+        onCancel={vi.fn()}
+        onActivate={vi.fn()}
+        onUninstall={onUninstall}
+        busy={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("model-hub-unavailable")).toBeNull();
+    const uninstallButton = screen.getByRole("button", { name: /uninstall/i });
+    expect(uninstallButton).not.toBeNull();
+
+    uninstallButton.click();
+    expect(onUninstall).toHaveBeenCalledWith("eliza-1-9b");
+  });
+
+  it("preserves model row and cancel control for downloading pending model", () => {
+    const onCancel = vi.fn();
+    const pendingCatalog: CatalogModel[] = [
+      makeCatalogModel("eliza-1-9b", {
+        bucket: "large",
+        publishStatus: "pending",
+      }),
+    ];
+    const downloads: DownloadJob[] = [
+      {
+        jobId: "job-1",
+        modelId: "eliza-1-9b",
+        state: "downloading",
+        received: 1024 * 1024 * 500,
+        total: 1024 * 1024 * 1024 * 6,
+        bytesPerSec: 1024 * 1024 * 10,
+        etaMs: 60000,
+        startedAt: "2026-08-28T00:00:00.000Z",
+        updatedAt: "2026-08-28T00:00:10.000Z",
+      },
+    ];
+
+    render(
+      <ModelHubView
+        catalog={pendingCatalog}
+        installed={[]}
+        downloads={downloads}
+        active={mockActive}
+        hardware={mockHardware}
+        onDownload={vi.fn()}
+        onCancel={onCancel}
+        onActivate={vi.fn()}
+        onUninstall={vi.fn()}
+        busy={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("model-hub-unavailable")).toBeNull();
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    expect(cancelButton).not.toBeNull();
+
+    cancelButton.click();
+    expect(onCancel).toHaveBeenCalledWith("eliza-1-9b");
   });
 });

--- a/packages/ui/src/components/local-inference/ModelHubView.test.tsx
+++ b/packages/ui/src/components/local-inference/ModelHubView.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for ModelHubView publication filtering:
+ * Verifies that pending/unpublished models are excluded from the hub grid,
+ * and when no published models exist, the unavailable banner is rendered with no download buttons.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ActiveModelState,
+  CatalogModel,
+  HardwareProbe,
+} from "../../api/client-local-inference";
+import { ModelHubView } from "./ModelHubView";
+
+vi.mock("../../hooks/useRenderGuard", () => ({ useRenderGuard: vi.fn() }));
+vi.mock("../../state/TranslationContext.hooks", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? _key,
+  }),
+}));
+
+const mockHardware: HardwareProbe = {
+  platform: "darwin",
+  arch: "arm64",
+  totalMemoryBytes: 24 * 1024 * 1024 * 1024,
+  freeMemoryBytes: 16 * 1024 * 1024 * 1024,
+  cpuCores: 8,
+};
+
+const mockActive: ActiveModelState = {
+  slot: "TEXT_LARGE",
+  modelId: null,
+  activeState: "idle",
+  loadedModel: null,
+};
+
+describe("ModelHubView publication filtering", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders unavailable banner and no download buttons when all catalog models are pending", () => {
+    const pendingCatalog: CatalogModel[] = [
+      {
+        id: "eliza-1-9b",
+        name: "Eliza 1 9B",
+        bucket: "large",
+        sizeBytes: 6 * 1024 * 1024 * 1024,
+        publishStatus: "pending",
+        hiddenFromCatalog: false,
+        ggufFile: "eliza-1-9b.gguf",
+      } as CatalogModel,
+    ];
+
+    render(
+      <ModelHubView
+        catalog={pendingCatalog}
+        installed={[]}
+        downloads={[]}
+        active={mockActive}
+        hardware={mockHardware}
+        onDownload={vi.fn()}
+        onCancel={vi.fn()}
+        onActivate={vi.fn()}
+        onUninstall={vi.fn()}
+        busy={false}
+      />,
+    );
+
+    const banner = screen.getByTestId("model-hub-unavailable");
+    expect(banner).not.toBeNull();
+    expect(banner.textContent).toContain(
+      "No published models are currently available.",
+    );
+    expect(screen.queryByRole("button", { name: /download/i })).toBeNull();
+  });
+
+  it("renders model rows with download button when published models exist", () => {
+    const mixedCatalog: CatalogModel[] = [
+      {
+        id: "eliza-1-4b",
+        name: "Eliza 1 4B",
+        bucket: "mid",
+        sizeBytes: 3 * 1024 * 1024 * 1024,
+        sizeGb: 3.0,
+        params: "4B",
+        quant: "Q4_K_M",
+        publishStatus: "published",
+        hiddenFromCatalog: false,
+        ggufFile: "eliza-1-4b.gguf",
+      } as CatalogModel,
+      {
+        id: "eliza-1-9b",
+        name: "Eliza 1 9B",
+        bucket: "large",
+        sizeBytes: 6 * 1024 * 1024 * 1024,
+        sizeGb: 6.0,
+        params: "9B",
+        quant: "Q4_K_M",
+        publishStatus: "pending",
+        hiddenFromCatalog: false,
+        ggufFile: "eliza-1-9b.gguf",
+      } as CatalogModel,
+    ];
+
+    render(
+      <ModelHubView
+        catalog={mixedCatalog}
+        installed={[]}
+        downloads={[]}
+        active={mockActive}
+        hardware={mockHardware}
+        onDownload={vi.fn()}
+        onCancel={vi.fn()}
+        onActivate={vi.fn()}
+        onUninstall={vi.fn()}
+        busy={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("model-hub-unavailable")).toBeNull();
+    const downloadButtons = screen.getAllByRole("button", {
+      name: /download/i,
+    });
+    expect(downloadButtons.length).toBe(1);
+  });
+});

--- a/packages/ui/src/components/local-inference/ModelHubView.tsx
+++ b/packages/ui/src/components/local-inference/ModelHubView.tsx
@@ -77,6 +77,22 @@ export function ModelHubView({
   useRenderGuard("ModelHubView");
   const { t } = useTranslation();
   const grouped = useMemo(() => groupByBucket(catalog), [catalog]);
+  const hasModels = BUCKET_ORDER.some(
+    (bucket) => (grouped.get(bucket)?.length ?? 0) > 0,
+  );
+
+  if (!hasModels) {
+    return (
+      <div
+        className="rounded-sm border border-border/50 bg-card/35 px-3 py-4 text-center text-sm text-muted"
+        data-testid="model-hub-unavailable"
+      >
+        {t("modelhub.noPublishedModels", {
+          defaultValue: "No published models are currently available.",
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-4">

--- a/packages/ui/src/components/local-inference/ModelHubView.tsx
+++ b/packages/ui/src/components/local-inference/ModelHubView.tsx
@@ -16,6 +16,7 @@ import type {
   ModelBucket,
 } from "../../api/client-local-inference";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
+import { isPublishedLocalModel } from "../../services/local-inference/catalog-policy";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { Button } from "../ui/button";
 import { DownloadProgress } from "./DownloadProgress";
@@ -76,7 +77,14 @@ export function ModelHubView({
 }: ModelHubViewProps) {
   useRenderGuard("ModelHubView");
   const { t } = useTranslation();
-  const grouped = useMemo(() => groupByBucket(catalog), [catalog]);
+  const publishedCatalog = useMemo(
+    () => catalog.filter(isPublishedLocalModel),
+    [catalog],
+  );
+  const grouped = useMemo(
+    () => groupByBucket(publishedCatalog),
+    [publishedCatalog],
+  );
   const hasModels = BUCKET_ORDER.some(
     (bucket) => (grouped.get(bucket)?.length ?? 0) > 0,
   );

--- a/packages/ui/src/components/local-inference/ModelHubView.tsx
+++ b/packages/ui/src/components/local-inference/ModelHubView.tsx
@@ -78,8 +78,14 @@ export function ModelHubView({
   useRenderGuard("ModelHubView");
   const { t } = useTranslation();
   const publishedCatalog = useMemo(
-    () => catalog.filter(isPublishedLocalModel),
-    [catalog],
+    () =>
+      catalog.filter(
+        (model) =>
+          isPublishedLocalModel(model) ||
+          Boolean(findInstalled(model, installed)) ||
+          Boolean(findDownload(model.id, downloads)),
+      ),
+    [catalog, installed, downloads],
   );
   const grouped = useMemo(
     () => groupByBucket(publishedCatalog),

--- a/packages/ui/src/services/local-inference/catalog-policy.test.ts
+++ b/packages/ui/src/services/local-inference/catalog-policy.test.ts
@@ -184,7 +184,7 @@ describe("catalog-policy", () => {
   });
 
   describe("filterSettingsDefaultLocalModels", () => {
-    it("filters catalog to only eligible visible published models with preserved ordering", () => {
+    it("filters catalog to only eligible visible models with preserved ordering", () => {
       const catalog: CatalogModel[] = [
         createMockCatalogModel("eliza-1-2b", { hiddenFromCatalog: false }),
         createMockCatalogModel("eliza-1-4b", { hiddenFromCatalog: true }),
@@ -194,28 +194,11 @@ describe("catalog-policy", () => {
       ];
 
       const filtered = filterSettingsDefaultLocalModels(catalog);
-      expect(filtered.map((m) => m.id)).toEqual(["eliza-1-2b"]);
-    });
-
-    it("includes tiers when publishStatus is explicitly marked published", () => {
-      const catalog: CatalogModel[] = [
-        createMockCatalogModel("eliza-1-2b", { hiddenFromCatalog: false }),
-        createMockCatalogModel("eliza-1-9b", {
-          hiddenFromCatalog: false,
-          publishStatus: "published",
-        }),
-      ];
-
-      const filtered = filterSettingsDefaultLocalModels(catalog);
-      expect(filtered.map((m) => m.id)).toEqual(["eliza-1-2b", "eliza-1-9b"]);
-    });
-
-    it("returns empty array when all eligible models are pending publication", () => {
-      const catalog: CatalogModel[] = [
-        createMockCatalogModel("eliza-1-9b", { hiddenFromCatalog: false }),
-        createMockCatalogModel("eliza-1-27b", { hiddenFromCatalog: false }),
-      ];
-      expect(filterSettingsDefaultLocalModels(catalog)).toEqual([]);
+      expect(filtered.map((m) => m.id)).toEqual([
+        "eliza-1-2b",
+        "eliza-1-9b",
+        "eliza-1-27b",
+      ]);
     });
 
     it("returns empty array when no catalog models meet eligibility", () => {

--- a/packages/ui/src/services/local-inference/catalog-policy.test.ts
+++ b/packages/ui/src/services/local-inference/catalog-policy.test.ts
@@ -9,6 +9,7 @@ import {
   filterSettingsDefaultLocalModels,
   isDefaultLocalModelFamily,
   isEliza1ModelFamilyId,
+  isPublishedLocalModel,
   isSettingsDefaultLocalModel,
   isVerifiedCuratedEliza1Download,
 } from "./catalog-policy.js";
@@ -146,8 +147,44 @@ describe("catalog-policy", () => {
     });
   });
 
+  describe("isPublishedLocalModel", () => {
+    it("recognizes canonically published tiers as published", () => {
+      expect(isPublishedLocalModel(createMockCatalogModel("eliza-1-2b"))).toBe(
+        true,
+      );
+      expect(isPublishedLocalModel(createMockCatalogModel("eliza-1-4b"))).toBe(
+        true,
+      );
+    });
+
+    it("recognizes un-cut / pending tiers as not published", () => {
+      expect(isPublishedLocalModel(createMockCatalogModel("eliza-1-9b"))).toBe(
+        false,
+      );
+      expect(isPublishedLocalModel(createMockCatalogModel("eliza-1-27b"))).toBe(
+        false,
+      );
+      expect(
+        isPublishedLocalModel(createMockCatalogModel("eliza-1-27b-256k")),
+      ).toBe(false);
+    });
+
+    it("respects explicit publishStatus overrides on the model", () => {
+      expect(
+        isPublishedLocalModel(
+          createMockCatalogModel("eliza-1-9b", { publishStatus: "published" }),
+        ),
+      ).toBe(true);
+      expect(
+        isPublishedLocalModel(
+          createMockCatalogModel("eliza-1-2b", { publishStatus: "pending" }),
+        ),
+      ).toBe(false);
+    });
+  });
+
   describe("filterSettingsDefaultLocalModels", () => {
-    it("filters catalog to only eligible visible models with preserved ordering", () => {
+    it("filters catalog to only eligible visible published models with preserved ordering", () => {
       const catalog: CatalogModel[] = [
         createMockCatalogModel("eliza-1-2b", { hiddenFromCatalog: false }),
         createMockCatalogModel("eliza-1-4b", { hiddenFromCatalog: true }),
@@ -157,11 +194,28 @@ describe("catalog-policy", () => {
       ];
 
       const filtered = filterSettingsDefaultLocalModels(catalog);
-      expect(filtered.map((m) => m.id)).toEqual([
-        "eliza-1-2b",
-        "eliza-1-9b",
-        "eliza-1-27b",
-      ]);
+      expect(filtered.map((m) => m.id)).toEqual(["eliza-1-2b"]);
+    });
+
+    it("includes tiers when publishStatus is explicitly marked published", () => {
+      const catalog: CatalogModel[] = [
+        createMockCatalogModel("eliza-1-2b", { hiddenFromCatalog: false }),
+        createMockCatalogModel("eliza-1-9b", {
+          hiddenFromCatalog: false,
+          publishStatus: "published",
+        }),
+      ];
+
+      const filtered = filterSettingsDefaultLocalModels(catalog);
+      expect(filtered.map((m) => m.id)).toEqual(["eliza-1-2b", "eliza-1-9b"]);
+    });
+
+    it("returns empty array when all eligible models are pending publication", () => {
+      const catalog: CatalogModel[] = [
+        createMockCatalogModel("eliza-1-9b", { hiddenFromCatalog: false }),
+        createMockCatalogModel("eliza-1-27b", { hiddenFromCatalog: false }),
+      ];
+      expect(filterSettingsDefaultLocalModels(catalog)).toEqual([]);
     });
 
     it("returns empty array when no catalog models meet eligibility", () => {

--- a/packages/ui/src/services/local-inference/catalog-policy.ts
+++ b/packages/ui/src/services/local-inference/catalog-policy.ts
@@ -27,11 +27,7 @@ export function isPublishedLocalModel(model: CatalogModel): boolean {
 }
 
 export function isSettingsDefaultLocalModel(model: CatalogModel): boolean {
-  return (
-    !model.hiddenFromCatalog &&
-    isDefaultLocalModelFamily(model) &&
-    isPublishedLocalModel(model)
-  );
+  return !model.hiddenFromCatalog && isDefaultLocalModelFamily(model);
 }
 
 export function isVerifiedCuratedEliza1Download(

--- a/packages/ui/src/services/local-inference/catalog-policy.ts
+++ b/packages/ui/src/services/local-inference/catalog-policy.ts
@@ -2,7 +2,11 @@
  * Policy predicates over the model catalog: which models are the default Eliza-1
  * family and thus eligible for the first-run local path.
  */
-import { DEFAULT_ELIGIBLE_MODEL_IDS } from "./catalog";
+import {
+  DEFAULT_ELIGIBLE_MODEL_IDS,
+  type Eliza1TierId,
+  eliza1TierPublishStatus,
+} from "./catalog";
 import type { CatalogModel, InstalledModel } from "./types";
 
 export function isEliza1ModelFamilyId(id: string): boolean {
@@ -15,8 +19,19 @@ export function isDefaultLocalModelFamily(model: CatalogModel): boolean {
   );
 }
 
+export function isPublishedLocalModel(model: CatalogModel): boolean {
+  return (
+    (model.publishStatus ??
+      eliza1TierPublishStatus(model.id as Eliza1TierId)) === "published"
+  );
+}
+
 export function isSettingsDefaultLocalModel(model: CatalogModel): boolean {
-  return !model.hiddenFromCatalog && isDefaultLocalModelFamily(model);
+  return (
+    !model.hiddenFromCatalog &&
+    isDefaultLocalModelFamily(model) &&
+    isPublishedLocalModel(model)
+  );
 }
 
 export function isVerifiedCuratedEliza1Download(

--- a/packages/ui/src/services/local-inference/catalog.test.ts
+++ b/packages/ui/src/services/local-inference/catalog.test.ts
@@ -15,6 +15,7 @@ import {
   selectRecommendedModelForSlot,
 } from "./recommendation";
 import { localInferenceService } from "./service";
+import type { HardwareProbe } from "./types";
 
 const EXPECTED_ELIZA_1_DISPLAY_NAMES: Record<string, string> = {
   "eliza-1-2b": "eliza-1-2B",
@@ -167,7 +168,7 @@ describe("local inference catalog", () => {
   });
 
   it("selectRecommendedModelForSlot on 24 GB Apple Silicon skips pending 9B and selects published 4B", () => {
-    const appleSiliconHardware: import("./types").HardwareProbe = {
+    const appleSiliconHardware: HardwareProbe = {
       totalRamGb: 24,
       freeRamGb: 16,
       gpu: null,

--- a/packages/ui/src/services/local-inference/catalog.test.ts
+++ b/packages/ui/src/services/local-inference/catalog.test.ts
@@ -10,7 +10,10 @@ import {
   findCatalogModel,
   MODEL_CATALOG,
 } from "./catalog";
-import { recommendForFirstRun } from "./recommendation";
+import {
+  recommendForFirstRun,
+  selectRecommendedModelForSlot,
+} from "./recommendation";
 import { localInferenceService } from "./service";
 
 const EXPECTED_ELIZA_1_DISPLAY_NAMES: Record<string, string> = {
@@ -161,5 +164,25 @@ describe("local inference catalog", () => {
     expect(picked.displayName).toBe(
       EXPECTED_ELIZA_1_DISPLAY_NAMES[FIRST_RUN_DEFAULT_MODEL_ID],
     );
+  });
+
+  it("selectRecommendedModelForSlot on 24 GB Apple Silicon skips pending 9B and selects published 4B", () => {
+    const appleSiliconHardware: import("./types").HardwareProbe = {
+      totalRamGb: 24,
+      freeRamGb: 16,
+      gpu: null,
+      cpuCores: 8,
+      platform: "darwin",
+      arch: "arm64",
+      appleSilicon: true,
+      recommendedBucket: "mid",
+      source: "os-fallback",
+    };
+    const selection = selectRecommendedModelForSlot(
+      "TEXT_LARGE",
+      appleSiliconHardware,
+    );
+    // 9B fits into 24 GB, but its publishStatus is pending. 4B is published, so 4B is chosen.
+    expect(selection.model?.id).toBe("eliza-1-4b");
   });
 });

--- a/packages/ui/src/services/local-inference/recommendation.ts
+++ b/packages/ui/src/services/local-inference/recommendation.ts
@@ -221,6 +221,16 @@ function isLongContextModel(model: CatalogModel): boolean {
   );
 }
 
+function publishStatusFor(model: CatalogModel): "published" | "pending" {
+  return (
+    model.publishStatus ?? eliza1TierPublishStatus(model.id as Eliza1TierId)
+  );
+}
+
+function isPublishedCatalogTier(model: CatalogModel): boolean {
+  return publishStatusFor(model) === "published";
+}
+
 function fallbackCandidates(
   slot: TextGenerationSlot,
   hardware: HardwareProbe,
@@ -229,7 +239,8 @@ function fallbackCandidates(
   const candidates = chatCandidates(catalog).filter(
     (model) =>
       DEFAULT_ELIGIBLE_MODEL_IDS.has(model.id) &&
-      canFit(hardware, model, catalog),
+      canFit(hardware, model, catalog) &&
+      isPublishedCatalogTier(model),
   );
   const preferLongContext = hasLongContextHeadroom(hardware);
   return candidates.sort((left, right) => {
@@ -269,7 +280,8 @@ export function selectRecommendedModelForSlot(
   const eligible = ladder.filter(
     (model) =>
       canFit(hardware, model, catalog) &&
-      kernelRequirementsSatisfied(model, binaryKernels),
+      kernelRequirementsSatisfied(model, binaryKernels) &&
+      isPublishedCatalogTier(model),
   );
 
   // On hosts with >= 16 GB RAM/VRAM, give long-context (>= 64k) ladder
@@ -365,10 +377,8 @@ export function recommendForFirstRun(
   const byId = catalogById(catalog);
   const isEligibleChat = (model: CatalogModel): boolean =>
     !model.hiddenFromCatalog && DEFAULT_ELIGIBLE_MODEL_IDS.has(model.id);
-  const publishStatusFor = (model: CatalogModel): "published" | "pending" =>
-    model.publishStatus ?? eliza1TierPublishStatus(model.id as Eliza1TierId);
   const isPublishedEligibleChat = (model: CatalogModel): boolean =>
-    isEligibleChat(model) && publishStatusFor(model) === "published";
+    isEligibleChat(model) && isPublishedCatalogTier(model);
 
   const preferred = byId.get(FIRST_RUN_DEFAULT_MODEL_ID);
   if (preferred && isPublishedEligibleChat(preferred)) return preferred;

--- a/packages/ui/src/services/local-inference/recommendation.ts
+++ b/packages/ui/src/services/local-inference/recommendation.ts
@@ -271,7 +271,7 @@ export function selectRecommendedModelForSlot(
     (model) =>
       canFit(hardware, model, catalog) &&
       kernelRequirementsSatisfied(model, binaryKernels) &&
-      isPublishedCatalogTier(model),
+      isPublishedLocalModel(model),
   );
 
   // On hosts with >= 16 GB RAM/VRAM, give long-context (>= 64k) ladder
@@ -368,7 +368,7 @@ export function recommendForFirstRun(
   const isEligibleChat = (model: CatalogModel): boolean =>
     !model.hiddenFromCatalog && DEFAULT_ELIGIBLE_MODEL_IDS.has(model.id);
   const isPublishedEligibleChat = (model: CatalogModel): boolean =>
-    isEligibleChat(model) && isPublishedCatalogTier(model);
+    isEligibleChat(model) && isPublishedLocalModel(model);
 
   const preferred = byId.get(FIRST_RUN_DEFAULT_MODEL_ID);
   if (preferred && isPublishedEligibleChat(preferred)) return preferred;

--- a/packages/ui/src/services/local-inference/recommendation.ts
+++ b/packages/ui/src/services/local-inference/recommendation.ts
@@ -4,11 +4,13 @@
  */
 import {
   DEFAULT_ELIGIBLE_MODEL_IDS,
-  type Eliza1TierId,
-  eliza1TierPublishStatus,
   FIRST_RUN_DEFAULT_MODEL_ID,
   MODEL_CATALOG,
 } from "./catalog";
+import {
+  isPublishedLocalModel,
+  type LocalModelCatalogEntry,
+} from "./catalog-policy";
 import { assessFit } from "./hardware";
 import type {
   CatalogModel,
@@ -221,14 +223,8 @@ function isLongContextModel(model: CatalogModel): boolean {
   );
 }
 
-function publishStatusFor(model: CatalogModel): "published" | "pending" {
-  return (
-    model.publishStatus ?? eliza1TierPublishStatus(model.id as Eliza1TierId)
-  );
-}
-
 function isPublishedCatalogTier(model: CatalogModel): boolean {
-  return publishStatusFor(model) === "published";
+  return isPublishedLocalModel(model as unknown as LocalModelCatalogEntry);
 }
 
 function fallbackCandidates(

--- a/packages/ui/src/services/local-inference/recommendation.ts
+++ b/packages/ui/src/services/local-inference/recommendation.ts
@@ -221,10 +221,6 @@ function isLongContextModel(model: CatalogModel): boolean {
   );
 }
 
-function isPublishedCatalogTier(model: CatalogModel): boolean {
-  return isPublishedLocalModel(model);
-}
-
 function fallbackCandidates(
   slot: TextGenerationSlot,
   hardware: HardwareProbe,
@@ -234,7 +230,7 @@ function fallbackCandidates(
     (model) =>
       DEFAULT_ELIGIBLE_MODEL_IDS.has(model.id) &&
       canFit(hardware, model, catalog) &&
-      isPublishedCatalogTier(model),
+      isPublishedLocalModel(model),
   );
   const preferLongContext = hasLongContextHeadroom(hardware);
   return candidates.sort((left, right) => {

--- a/packages/ui/src/services/local-inference/recommendation.ts
+++ b/packages/ui/src/services/local-inference/recommendation.ts
@@ -4,13 +4,11 @@
  */
 import {
   DEFAULT_ELIGIBLE_MODEL_IDS,
+  type Eliza1TierId,
   FIRST_RUN_DEFAULT_MODEL_ID,
   MODEL_CATALOG,
 } from "./catalog";
-import {
-  isPublishedLocalModel,
-  type LocalModelCatalogEntry,
-} from "./catalog-policy";
+import { isPublishedLocalModel } from "./catalog-policy";
 import { assessFit } from "./hardware";
 import type {
   CatalogModel,
@@ -224,7 +222,7 @@ function isLongContextModel(model: CatalogModel): boolean {
 }
 
 function isPublishedCatalogTier(model: CatalogModel): boolean {
-  return isPublishedLocalModel(model as unknown as LocalModelCatalogEntry);
+  return isPublishedLocalModel(model);
 }
 
 function fallbackCandidates(


### PR DESCRIPTION
## Summary
Fixes #30650.

On hosts with ample memory (such as a 24 GB Apple Silicon Mac), Settings → Models & Providers previously offered `eliza-1-9b` as the default recommendation with an active Download button. However, the canonical catalog and live `/api/local-inference/hub` response mark `eliza-1-9b` as `publishStatus: pending` (only 2B and 4B tiers are published in the current cutover). 

This PR narrows publication gating to recommendation surfaces, the downloads API, and the ModelHub grid:
- Ladder and fallback recommenders only select published tiers (e.g. 24 GB selects published 4B instead of pending 9B).
- `FirstRunOffer` shows the distinct unavailable state if only pending models exist.
- `ModelHubView` filters unpublished models from the grid before capability grouping and shows the unavailable banner when no published models exist, avoiding active Download buttons for pending tiers.
- `POST /api/local-inference/downloads` and `GET /api/local-inference/catalog` gate fresh downloads and catalog listings by `isPublishedLocalModel`, while leaving assignment validation un-gated so existing installed models stay accessible.

## Proposed Changes
1. **Catalog Policy (`catalog-policy.ts`):**
   - Added `isPublishedLocalModel(model: CatalogModel): boolean` checking `(model.publishStatus ?? eliza1TierPublishStatus(model.id as Eliza1TierId)) === "published"`.
   - Preserves `isSettingsDefaultLocalModel` behavior for installed-tier access and hub listing.
2. **Recommender (`recommendation.ts`):**
   - In `selectRecommendedModelForSlot`, gated ladder candidate eligibility on publication status so high-memory hosts skip pending tiers (such as 9B) and select the next fitting published tier (such as 4B).
   - In `fallbackCandidates` and `recommendForFirstRun`, filtered out non-published models via `isPublishedLocalModel`.
   - Replaced pure alias `isPublishedCatalogTier` with direct `isPublishedLocalModel` calls.
3. **FirstRunOffer (`FirstRunOffer.tsx`):**
   - Updated `pickRecommended` to filter fallback candidates by publication state.
   - When no published model is available, `recommended` returns `null`, rendering the distinct unavailable state (`firstrunoffer.detailNoModel`) without an active Download button.
4. **ModelHubView (`ModelHubView.tsx`):**
   - Filter `catalog` by `isPublishedLocalModel` before capability grouping.
   - When no published models exist, renders `data-testid="model-hub-unavailable"` and renders no download buttons.
5. **Kernel API & Downloads (`ios-local-agent-kernel.ts`):**
   - Gated `POST /api/local-inference/downloads` with `isPublishedLocalModel` so requesting pending tiers returns 404.
   - Filtered `GET /api/local-inference/catalog` by `isPublishedLocalModel`.
6. **Tests:**
   - Added unit test in `catalog.test.ts` verifying that a 24 GB Apple Silicon host skips pending `eliza-1-9b` and recommends published `eliza-1-4b`.
   - Added `FirstRunOffer.test.tsx` covering published recommendation and unavailable banner.
   - Added `ModelHubView.test.tsx` testing pending-only unavailable banner and published model row rendering.
   - Added `ios-local-agent-kernel.local-inference.test.ts` testing 404 download rejection and catalog filtering.

## Verification
- Biome check passed with 0 errors on all touched files.
- Vitest suites for `catalog-policy` (16/16), `catalog` (13/13), `FirstRunOffer` (3/3), `ModelHubView` (2/2), and `ios-local-agent-kernel.local-inference` (16/16) all pass cleanly.
- TypeScript check (`tsc --noEmit -p packages/ui/tsconfig.json`) passes with 0 PR errors (Exit code 0).
