### PR TITLE
fix(ui): clear the develop lint baseline in consent and voice-event tests

### DIFF
--- a/packages/ui/src/cloud/account-security/data/consent-store.test.ts
+++ b/packages/ui/src/cloud/account-security/data/consent-store.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for consent-store: validates privacy-by-default false values
  * and localStorage write/read roundtrip.
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getTrajectoryLoggingEnabled,
   getVisionEnabled,
@@ -15,18 +15,15 @@ describe("consent-store", () => {
 
   beforeEach(() => {
     storage.clear();
-    (globalThis as any).window = {
+    vi.stubGlobal("window", {
       localStorage: {
         getItem: (key: string) => storage.get(key) ?? null,
         setItem: (key: string, val: string) => storage.set(key, val),
         removeItem: (key: string) => storage.delete(key),
         clear: () => storage.clear(),
       },
-    };
-  });
-
-  afterEach(() => {
-    delete (globalThis as any).window;
+    });
+    return () => vi.unstubAllGlobals();
   });
 
   it("defaults to false for vision and trajectory logging", () => {

--- a/packages/ui/src/native-transcript/voice-event-adapter.test.ts
+++ b/packages/ui/src/native-transcript/voice-event-adapter.test.ts
@@ -2,6 +2,7 @@
  * Coverage for voice-event-adapter.
  */
 import { describe, expect, it } from "vitest";
+import type { ServerControlFrame } from "../voice/voice-session-protocol";
 import { nativeTranscriptInputFromVoiceServerEvent } from "./voice-event-adapter.js";
 
 describe("voice-event-adapter", () => {
@@ -10,19 +11,22 @@ describe("voice-event-adapter", () => {
       t: "stt_partial",
       traceId: "t1",
       text: "hello",
-    } as any);
+    });
     expect(r?.type).toBe("stt.partial");
   });
   it("maps speaking_start", () => {
     const r = nativeTranscriptInputFromVoiceServerEvent({
       t: "speaking_start",
       traceId: "t2",
-    } as any);
+    });
     expect(r?.type).toBe("tts.audio");
   });
   it("returns null for unknown", () => {
     expect(
-      nativeTranscriptInputFromVoiceServerEvent({ t: "unknown" } as any),
+      // Deliberately outside the known frame union: the adapter must guard.
+      nativeTranscriptInputFromVoiceServerEvent({
+        t: "unknown",
+      } as ServerControlFrame),
     ).toBeNull();
   });
 });

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -466,7 +466,6 @@ body.pwa-standalone textarea {
 
 .custom-scrollbar,
 .chat-native-scrollbar,
-/* biome-ignore lint/style/noDescendingSpecificity: universal scrollbar styling is intentional. */
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb-mid) var(--scrollbar-track);
@@ -642,7 +641,6 @@ kbd {
 
 /* Reduced motion - universal override is intentional for accessibility */
 @media (prefers-reduced-motion: reduce) {
-  /* biome-ignore lint/style/noDescendingSpecificity: a11y override must apply to every element regardless of prior class-level specificity. */
   *,
   /* biome-ignore lint/style/noDescendingSpecificity: a11y override must apply to every pseudo-element. */
   *::before,


### PR DESCRIPTION
## Summary

`packages/ui`'s `lint:check` has been red on develop since #26786, #26500, and #29150 landed (Aug 24–26): five `noExplicitAny` findings across two test files and two biome suppression comments that no longer suppress anything. Because the PR smoke lane runs this check, **every same-repo-branch PR's source-smoke has failed on this baseline since** (most recently PR #30229's run 33979037189, job 101340779697).

Three mechanical repairs, no behavior change:

- `consent-store.test.ts` — stub `window` through `vi.stubGlobal` with `vi.unstubAllGlobals()` teardown instead of `(globalThis as any)` writes.
- `voice-event-adapter.test.ts` — drop the `as any` casts: the two valid frame literals type directly as `ServerControlFrame` members; the adversarial unknown-frame case keeps an explicit `ServerControlFrame` cast (the guard's job is exactly this input).
- `styles.css` — remove the two `noDescendingSpecificity` suppression comments biome 2.5.8 reports as unused (the identical suppressions on `*::before`/`*::after` still fire and stay).

## Evidence

<!-- evidence-row:backend-logs -->
- [x] Disposable container (bun 1.3.14 image, frozen lockfile `--ignore-scripts`, core+shared+prompts dist built, generated i18n keywords):
  - **RED control at clean develop `beccdfaf2f`**: `bunx @biomejs/biome check src scripts/*.ts` reports exactly the 7 baseline findings (consent-store 18:20/29:27, voice-event-adapter 13:10/20:10/25:69 noExplicitAny; styles.css 469:1/645:3 suppressions/unused) — identical to the hosted job-101340779697 failure set.
  - **GREEN at fix head `ddc3e2877`**: full `bun run --cwd packages/ui lint:check` chain (biome + all five design-graph/coverage gate stages) exits 0.
  - Changed suites still pass: consent-store + voice-event-adapter vitest **6/6**.
  - `typecheck`: the only errors are 354 pre-existing `lucide-react` workspace-link errors reproduced identically at clean develop in the same container (container artifact); zero errors reference the changed files.

<!-- evidence-head:ddc3e28771f11e2fdd1cd0e32bb2f9c9109df14f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no visual change: two test files and two deleted comment lines in CSS; no rendered surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no visual change.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive surface changed; the lint chain transcript is the acceptance artifact.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no live browser session; no runtime behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - lint/transcript evidence inline above; no domain artifact produced.

---

Compute receipt: 34382957 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: zai / glm-5.3-1m
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-review]
<!-- slop-contribution-attribution:v1 {"provider":"zai","model":"glm-5.3-1m","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1S8BDSYQF10FQBD2PTCBG6V","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-05T17:02:40.959Z","completed_at":"2026-09-05T17:52:46.547Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-05T17:02:51.297Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":148429,"output_tokens":72992,"cache_creation_tokens":0,"cache_read_tokens":34161536,"total_tokens":34382957,"cost_micro_usd":"9410964","session_count":3},"trajectory_sha256":"92af3e4b061ac095697f543fe25834e3a9799b15e7cac217c7d73e96cdaeaa35","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"680e8d92-ee30-45ea-94ef-cb2cbe595aee","object_id":"sha256:92af3e4b061ac095697f543fe25834e3a9799b15e7cac217c7d73e96cdaeaa35","sha256":"92af3e4b061ac095697f543fe25834e3a9799b15e7cac217c7d73e96cdaeaa35"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAR850XHeZVEfYMatnrCiWT7P3QZHECM3R-C2VnfZ8iZQ","device_key_id":"5935e4ed75d7ef04a6827ac468d61a17e4bba8f871647762e8ff62c5e50dda49","device_signature":"mZdKwiHZ6N5xvpUoSoI0IUj48XMbiWxkZrO7_MkhcISynW9YzRmoMyWXF8tF6REbTHFp9CQri_USGfojZ-87AA"}} -->
