### PR TITLE
fix(cloud): cancel ambiguous billing leases after credential revocation

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -2012,6 +2012,36 @@ describe("InferenceAdmissionGate", () => {
     expect(recoverExpiredLease).not.toHaveBeenCalled();
   });
 
+  test.each(["/lease-dispatched", "/lease-dispatched-authorized"])(
+    "%s refuses a missing cancellation capability without reserving money",
+    async (path) => {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 10);
+      const response = await post(gate, path, {
+        organizationId: "org-a",
+        requestId: "missing-combined-capability",
+        balanceUsd: 10,
+        balanceRevision: "1",
+        estimatedCostUsd: 4,
+        recovery: organizationRecovery("missing-combined-capability"),
+        credential: {
+          kind: "api_key",
+          credentialId: "key-a",
+          userId: "user-a",
+        },
+      });
+      expect(response.status).toBe(400);
+      expect(
+        storage.read(storedLeaseKey("missing-combined-capability")),
+      ).toBeUndefined();
+      expect(storage.read("ledger")).toMatchObject({
+        availableUsd: 10,
+        activeLeaseCount: 0,
+      });
+    },
+  );
+
   test("prepared admission performs exactly one combined gate call before provider invocation", async () => {
     const storage = new TestStorage();
     const gate = createGate(storage);
@@ -2106,6 +2136,79 @@ describe("InferenceAdmissionGate", () => {
     ).toBeUndefined();
     expect(storage.read(storedLeaseKey("prepared-revoked"))).toBeUndefined();
   });
+
+  test.each(["transport", "malformed", "unavailable"] as const)(
+    "revocation after a %s combined acknowledgement still cancels the committed lease",
+    async (fault) => {
+      const storage = new TestStorage();
+      const gate = createGate(storage);
+      await hydrateGate(gate, 10);
+      let combinedCalls = 0;
+      const bindings = {
+        INFERENCE_ADMISSION_GATES: {
+          getByName: (_name: string) => ({
+            fetch: async (request: RequestInfo | URL, init?: RequestInit) => {
+              const incoming = new Request(request, init);
+              const path = new URL(incoming.url).pathname;
+              const response = await gate.fetch(incoming);
+              if (
+                path === "/lease-dispatched-authorized" &&
+                ++combinedCalls === 1
+              ) {
+                expect(response.status).toBe(200);
+                await post(gate, "/credential/revoke", {
+                  organizationId: "org-a",
+                  kind: "api_key",
+                  credentialId: "key-a",
+                });
+                if (fault === "malformed")
+                  return new Response("unreadable acknowledgement", {
+                    status: 200,
+                  });
+                if (fault === "unavailable")
+                  return new Response("unavailable acknowledgement", {
+                    status: 503,
+                  });
+                throw new Error(
+                  "injected lost acknowledgement before credential revocation",
+                );
+              }
+              return response;
+            },
+          }),
+        },
+      };
+      await runWithCloudBindingsAsync(bindings, async () => {
+        const lease = await acquireInferenceAdmissionLease({
+          organizationId: "org-a",
+          requestId: "prepared-revoked-after-commit",
+          balanceUsd: 10,
+          balanceRevision: "1",
+          estimatedCostUsd: 4,
+          recovery: organizationRecovery("prepared-revoked-after-commit"),
+          credential: {
+            kind: "api_key",
+            credentialId: "key-a",
+            userId: "user-a",
+          },
+          deferCommitUntilDispatch: true,
+        });
+        await expect(
+          markInferenceAdmissionLeaseDispatched(lease),
+        ).rejects.toBeInstanceOf(InferenceCredentialRevokedError);
+        await settleInferenceAdmissionLease(lease, 0, 0);
+      });
+      expect(combinedCalls).toBe(2);
+      expect(
+        storage.read(storedLeaseKey("prepared-revoked-after-commit")),
+      ).toBeUndefined();
+      expect(storage.read("ledger")).toMatchObject({
+        availableUsd: 10,
+        activeLeaseCount: 0,
+      });
+      expect(storage.alarm).toBeUndefined();
+    },
+  );
 
   test("lost combined acknowledgements release a committed lease before provider work", async () => {
     const storage = new TestStorage();

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -1477,12 +1477,24 @@ export class InferenceAdmissionGate {
     }
     if (path === "/lease-dispatched") {
       const dispatch = body as LeaseDispatchRequest;
+      if (!validTrimmedId(dispatch.preProviderCancellationToken)) {
+        return jsonError(
+          "Invalid inference admission dispatch capability",
+          400,
+        );
+      }
       return await this.serialize(() =>
         this.lease(dispatch, dispatch.preProviderCancellationToken),
       );
     }
     if (path === "/lease-dispatched-authorized") {
       const dispatch = body as AuthorizedLeaseDispatchRequest;
+      if (!validTrimmedId(dispatch.preProviderCancellationToken)) {
+        return jsonError(
+          "Invalid inference admission dispatch capability",
+          400,
+        );
+      }
       return await this.serializeRevocation(() =>
         this.serialize(() =>
           this.authorizedLease(dispatch, dispatch.preProviderCancellationToken),

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -748,6 +748,7 @@ export async function markInferenceAdmissionLeaseDispatched(
 
   let lastAmbiguousError: unknown;
   const prepared = lease.preparedDispatch;
+  let mayHaveCommitted = prepared?.state === "ambiguous";
   const path = prepared?.path ?? "/dispatch";
   const body = prepared
     ? { ...prepared.body, preProviderCancellationToken: cancellationToken }
@@ -767,12 +768,14 @@ export async function markInferenceAdmissionLeaseDispatched(
         AbortSignal.timeout(DISPATCH_GATE_TIMEOUT_MS),
       );
     } catch (error) {
+      mayHaveCommitted = true;
       lastAmbiguousError = error;
       if (attempt < DISPATCH_GATE_MAX_ATTEMPTS) continue;
       break;
     }
     if (prepared && response.status === 403) {
-      prepared.state = "rejected";
+      // A later denial cannot erase a prior acknowledgement-ambiguous commit.
+      if (!mayHaveCommitted) prepared.state = "rejected";
       let reason = "revoked";
       try {
         const payload = (await response.json()) as { reason?: unknown };
@@ -783,7 +786,7 @@ export async function markInferenceAdmissionLeaseDispatched(
       throw new InferenceCredentialRevokedError(reason);
     }
     if (prepared && response.status === 402) {
-      prepared.state = "rejected";
+      if (!mayHaveCommitted) prepared.state = "rejected";
       const payload = await parseLeaseResponse(response);
       throw new InferenceAdmissionLeaseRejectedError(payload.requiredUsd, payload.availableUsd);
     }
@@ -799,16 +802,20 @@ export async function markInferenceAdmissionLeaseDispatched(
       const error = new InferenceAdmissionDispatchMarkError(
         `Inference admission gate combined dispatch failed with status ${response.status}`,
       );
+      mayHaveCommitted = true;
       lastAmbiguousError = error;
       if (attempt < DISPATCH_GATE_MAX_ATTEMPTS) continue;
       break;
     }
     if (!response.ok) {
-      if (prepared && response.status < 500) prepared.state = "rejected";
+      if (prepared && response.status < 500 && !mayHaveCommitted) {
+        prepared.state = "rejected";
+      }
       const error = new InferenceAdmissionDispatchMarkError(
         `Inference admission gate dispatch failed with status ${response.status}`,
       );
       if (response.status < 500) throw error;
+      mayHaveCommitted = true;
       lastAmbiguousError = error;
       if (attempt < DISPATCH_GATE_MAX_ATTEMPTS) continue;
       break;
@@ -819,6 +826,7 @@ export async function markInferenceAdmissionLeaseDispatched(
     } catch (error) {
       // A valid 2xx transport with an unreadable body can still follow a
       // committed dispatch. Replaying the same capability resolves ambiguity.
+      mayHaveCommitted = true;
       lastAmbiguousError = error;
       if (attempt < DISPATCH_GATE_MAX_ATTEMPTS) continue;
       break;


### PR DESCRIPTION
A billing Durable Object can commit a lease and lose its acknowledgement. If the credential is revoked before the identical retry, the retry returns 403. The client previously discarded the earlier ambiguity, so zero settlement left the committed charge and active lease behind even though no provider request ran.

Preserve possible commitment across subsequent definitive denials so zero settlement uses the stable cancellation capability. Reject combined admission requests without a nonempty cancellation token before committing; those requests must not fall through to legacy lease behavior.

Refs #30635. Follow-up to #30641.

Validation at `899117c195fff4b537d88ca054a16b7b33d0a4b1`, based on develop `9e738793d1584`: pinned installation, all 376 root verification tasks and final audits passed. The admission gate suite passed 63 cases; app admission/recovery passed 24 cases; APNs and logger cases passed. All 595 isolated Cloud API test files also passed. API typecheck, 709-route contract validation, and production Worker bundle dry-run passed. The real SQLite Durable Object harness runs the production gate and client, injects lost transport, malformed acknowledgement, and 503 acknowledgement failures, then revokes the credential before retry. All three cases invoke no provider, restore the balance, remove the active lease, and clear its alarm. The successful control uses one billing request. External billing persistence and provider calls are explicitly outside this harness.

## Evidence Gate

<!-- evidence-head:899117c195fff4b537d88ca054a16b7b33d0a4b1 -->
<!-- evidence-row:before-screenshots -->
N/A - backend billing admission; no rendered surface changes.
<!-- evidence-row:after-screenshots -->
N/A - backend billing admission; no rendered surface changes.
<!-- evidence-row:walkthrough-video -->
N/A - the affected boundary is a SQLite Durable Object lease, exercised in the linked fault-injection result.
<!-- evidence-row:backend-logs -->
[Before regression, passing gate and recovery tests, API validation, and full root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30662-lease-cancellation-validation-899117c1.log).
[Full isolated Cloud API suite: 595 files passed](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30662-full-api-595-files-899117c1.log).
<!-- evidence-row:frontend-logs -->
N/A - no browser or renderer changes.
<!-- evidence-row:llm-trajectory -->
N/A - all three fault cases must stop before invoking a provider; no model prompt or behavior changes.
<!-- evidence-row:domain-artifacts -->
[Real SQLite Durable Object state, calls, balance, lease, and alarm results](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30662-lease-cancellation-workerd-899117c1.json). [Exact-head gate receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30662-lease-cancellation-gates-899117c1.json).
