### PR TITLE
fix(setup): verify complete fused libraries and live embeddings on install

### DIFF
--- a/packages/app-core/README.md
+++ b/packages/app-core/README.md
@@ -40,3 +40,19 @@ bun run --cwd packages/app-core lint         # Biome
 ```
 
 This package is consumed by `@elizaos/agent`, `@elizaos/ui`, `@elizaos/shared`, the `packages/app` shell, and most `plugins/*` app plugins. It targets Node `>=24`, with `react`/`react-dom`/`three` as peer dependencies and the `@elizaos/capacitor-*` mobile bridges as optional dependencies.
+
+## Native inference setup
+
+A normal root `bun install` initializes the pinned fused inference submodule,
+ensures the host library and its companion libraries are current, and provisions
+the hash-verified default embedding model. The runtime discovers these artifacts
+under the same state directory without additional environment configuration.
+Relative `ELIZA_STATE_DIR` paths resolve from the current working directory;
+`~` expands to the user's home directory.
+
+Reuse checks cover every staged native library, host architecture, and native
+source changes. Missing or altered companions trigger a rebuild on install;
+setup failures fail the install instead of reporting inference as ready.
+`ELIZA_SKIP_FUSED_INFERENCE_SETUP=1` is an explicit escape hatch and does not
+establish runtime readiness. Android and iOS packaging use their platform build
+lanes to produce the corresponding NDK or Apple artifacts.

--- a/packages/app-core/README.md
+++ b/packages/app-core/README.md
@@ -45,7 +45,8 @@ This package is consumed by `@elizaos/agent`, `@elizaos/ui`, `@elizaos/shared`, 
 
 A normal root `bun install` initializes the pinned fused inference submodule,
 ensures the host library and its companion libraries are current, and provisions
-the hash-verified default embedding model. The runtime discovers these artifacts
+the hash-verified default embedding model. Setup then loads the native library
+and computes a local embedding before reporting readiness. The runtime discovers these artifacts
 under the same state directory without additional environment configuration.
 Relative `ELIZA_STATE_DIR` paths resolve from the current working directory;
 `~` expands to the user's home directory.

--- a/packages/app-core/scripts/ensure-fused-inference-install.mjs
+++ b/packages/app-core/scripts/ensure-fused-inference-install.mjs
@@ -16,9 +16,9 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveSetupStateDir } from "./lib/setup-state-dir.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const defaultRepoRoot = path.resolve(scriptDir, "..", "..", "..");
@@ -61,23 +61,6 @@ function runChecked(command, args, options = {}) {
   }
 }
 
-function resolveStateDir(env) {
-  const explicit = env.ELIZA_STATE_DIR?.trim();
-  if (explicit) {
-    return path.isAbsolute(explicit)
-      ? explicit
-      : path.join(os.homedir(), explicit);
-  }
-  const namespace = env.ELIZA_NAMESPACE?.trim() || "eliza";
-  const xdg = env.XDG_STATE_HOME?.trim();
-  if (xdg) {
-    return path.isAbsolute(xdg)
-      ? path.join(xdg, namespace)
-      : path.join(os.homedir(), xdg, namespace);
-  }
-  return path.join(os.homedir(), ".local", "state", namespace);
-}
-
 export function resolveEmbeddingArtifactPath({
   env = process.env,
   repoRoot = defaultRepoRoot,
@@ -85,7 +68,7 @@ export function resolveEmbeddingArtifactPath({
   const configured = env.MODELS_DIR?.trim();
   const modelsDir = configured
     ? path.resolve(repoRoot, configured)
-    : path.join(resolveStateDir(env), "models");
+    : path.join(resolveSetupStateDir(env), "models");
   return path.join(modelsDir, FUSED_EMBEDDING_ARTIFACT.filename);
 }
 

--- a/packages/app-core/scripts/ensure-fused-inference-install.mjs
+++ b/packages/app-core/scripts/ensure-fused-inference-install.mjs
@@ -250,6 +250,18 @@ export async function ensureFusedInferenceInstall({
   );
   run(bunExecutable, [stageScript, "--ensure"], { cwd: repoRoot, env });
   const embedding = await ensureEmbedding({ env, repoRoot, fetchImpl });
+  run(
+    bunExecutable,
+    [
+      "--conditions=eliza-source",
+      path.join(
+        repoRoot,
+        "packages/app-core/scripts/verify-fused-embedding.mjs",
+      ),
+      embedding.path,
+    ],
+    { cwd: repoRoot, env },
+  );
   log("fused desktop inference and embedding model are installed and current");
   return { status: "ready", embedding };
 }

--- a/packages/app-core/scripts/ensure-fused-inference-install.test.mjs
+++ b/packages/app-core/scripts/ensure-fused-inference-install.test.mjs
@@ -75,7 +75,7 @@ test("CI is not an implicit escape hatch", async () => {
   });
 
   assert.equal(result.status, "ready");
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 3);
 });
 
 test("missing Linux prerequisites are provisioned before the native build", async () => {
@@ -98,6 +98,7 @@ test("missing Linux prerequisites are provisioned before the native build", asyn
   assert.deepEqual(events, [
     ["run", "git"],
     ["provision", "cmake", "build-essential"],
+    ["run", "/bun"],
     ["run", "/bun"],
   ]);
 });

--- a/packages/app-core/scripts/ensure-fused-inference-install.test.mjs
+++ b/packages/app-core/scripts/ensure-fused-inference-install.test.mjs
@@ -239,3 +239,23 @@ test("a corrupt download is rejected without replacing the existing artifact", a
     rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+test("relative state directories stage embedding bytes where the runtime resolves them", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "fused-relative-state-"));
+  const relativeState = path.relative(process.cwd(), root);
+  const bytes = Buffer.from("runtime-visible embedding fixture");
+  try {
+    const result = await ensureEmbeddingArtifact({
+      env: { ELIZA_STATE_DIR: relativeState },
+      artifact: fixtureArtifact(bytes),
+      fetchImpl: async () => fixtureResponse(bytes),
+    });
+    assert.deepEqual(
+      readFileSync(path.join(root, "models", "gte-small_fp16.gguf")),
+      bytes,
+    );
+    assert.equal(result.path, path.join(root, "models", "gte-small_fp16.gguf"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/app-core/scripts/lib/fused-artifact-integrity.mjs
+++ b/packages/app-core/scripts/lib/fused-artifact-integrity.mjs
@@ -1,0 +1,127 @@
+/** Verifies the complete staged native library set before install or build reuse. */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export function isNativeLibrary(name) {
+  return /\.(?:dylib|dll|so(?:\.\d+)*)$/.test(name);
+}
+
+export function nativeLibraryInventory(directory) {
+  return Object.fromEntries(
+    readdirSync(directory)
+      .filter(isNativeLibrary)
+      .sort()
+      .map((name) => [
+        name,
+        createHash("sha256")
+          .update(readFileSync(path.join(directory, name)))
+          .digest("hex"),
+      ]),
+  );
+}
+
+export function nativeLibraryIntegrityProblems(
+  directory,
+  stamp,
+  { platform, arch, backend, fusedName },
+) {
+  const problems = [];
+  if (stamp?.platform !== platform || stamp?.arch !== arch)
+    problems.push("native host target changed or is unstamped");
+  if (backend !== "auto" && stamp?.backend !== backend)
+    problems.push("requested native backend changed");
+  const expected = stamp?.libraries;
+  if (
+    !expected ||
+    typeof expected !== "object" ||
+    Array.isArray(expected) ||
+    typeof expected[fusedName] !== "string" ||
+    Object.entries(expected).some(
+      ([name, hash]) =>
+        path.basename(name) !== name ||
+        !isNativeLibrary(name) ||
+        typeof hash !== "string" ||
+        !/^[a-f0-9]{64}$/.test(hash),
+    )
+  ) {
+    problems.push("complete native library inventory is missing or invalid");
+    return problems;
+  }
+  let actual;
+  try {
+    actual = nativeLibraryInventory(directory);
+  } catch (error) {
+    // error-policy:J3 unreadable artifacts are explicitly stale, never reusable.
+    problems.push(`native library inventory cannot be read: ${error.message}`);
+    return problems;
+  }
+  for (const name of new Set([
+    ...Object.keys(expected),
+    ...Object.keys(actual),
+  ])) {
+    if (actual[name] !== expected[name])
+      problems.push(
+        `native companion missing, changed, or unexpected: ${name}`,
+      );
+  }
+  return problems;
+}
+
+export function nativeSourceFingerprint(forkSrc) {
+  // Hash changed bytes, not porcelain filenames: a second edit to the same
+  // dirty source file must invalidate the prior native build as well.
+  const scopes = [
+    "tools",
+    "src",
+    "ggml",
+    "common",
+    "include",
+    "cmake",
+    "vendor",
+    "CMakeLists.txt",
+  ];
+  const options = { maxBuffer: 128 * 1024 * 1024 };
+  const diff = execFileSync(
+    "git",
+    [
+      "-C",
+      forkSrc,
+      "diff",
+      "--binary",
+      "--submodule=diff",
+      "HEAD",
+      "--",
+      ...scopes,
+    ],
+    options,
+  );
+  const untracked = execFileSync(
+    "git",
+    [
+      "-C",
+      forkSrc,
+      "ls-files",
+      "--others",
+      "--exclude-standard",
+      "-z",
+      "--",
+      ...scopes,
+    ],
+    options,
+  )
+    .toString()
+    .split("\0")
+    .filter(Boolean)
+    .sort();
+  if (!diff.length && !untracked.length) return "";
+  const hash = createHash("sha256").update(diff);
+  for (const name of untracked)
+    hash
+      .update(name)
+      .update("\0")
+      .update(readFileSync(path.join(forkSrc, name)))
+      .update("\0");
+  return hash.digest("hex");
+}

--- a/packages/app-core/scripts/lib/fused-artifact-integrity.test.mjs
+++ b/packages/app-core/scripts/lib/fused-artifact-integrity.test.mjs
@@ -1,0 +1,136 @@
+/** Exercises native-set reuse against real staged files, corruption and target changes. */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  nativeLibraryIntegrityProblems,
+  nativeLibraryInventory,
+  nativeSourceFingerprint,
+} from "./fused-artifact-integrity.mjs";
+
+function fixture() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "fused-set-"));
+  const fusedName = "libelizainference.so";
+  fs.writeFileSync(path.join(directory, fusedName), "fused artifact");
+  fs.writeFileSync(path.join(directory, "libggml.so.0"), "dependency artifact");
+  const target = {
+    platform: "linux",
+    arch: "arm64",
+    backend: "cpu",
+    fusedName,
+  };
+  const stamp = { ...target, libraries: nativeLibraryInventory(directory) };
+  return { directory, target, stamp };
+}
+
+test("reuse rejects missing, altered, and unexpected companions even when the fused file is unchanged", () => {
+  const { directory, target, stamp } = fixture();
+  try {
+    assert.deepEqual(
+      nativeLibraryIntegrityProblems(directory, stamp, target),
+      [],
+    );
+    fs.unlinkSync(path.join(directory, "libggml.so.0"));
+    assert.match(
+      nativeLibraryIntegrityProblems(directory, stamp, target).join("\n"),
+      /libggml.so.0/,
+    );
+    fs.writeFileSync(
+      path.join(directory, "libggml.so.0"),
+      "changed dependency",
+    );
+    assert.match(
+      nativeLibraryIntegrityProblems(directory, stamp, target).join("\n"),
+      /libggml.so.0/,
+    );
+    fs.writeFileSync(
+      path.join(directory, "libggml.so.0"),
+      "dependency artifact",
+    );
+    assert.deepEqual(
+      nativeLibraryIntegrityProblems(directory, stamp, target),
+      [],
+    );
+    fs.writeFileSync(path.join(directory, "libggml-cuda.so"), "old backend");
+    assert.match(
+      nativeLibraryIntegrityProblems(directory, stamp, target).join("\n"),
+      /libggml-cuda.so/,
+    );
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("reuse rejects another architecture, explicit backend, or legacy incomplete stamp", () => {
+  const { directory, target, stamp } = fixture();
+  try {
+    assert.ok(
+      nativeLibraryIntegrityProblems(directory, stamp, {
+        ...target,
+        arch: "x64",
+      }).length,
+    );
+    assert.ok(
+      nativeLibraryIntegrityProblems(directory, stamp, {
+        ...target,
+        backend: "cuda",
+      }).length,
+    );
+    assert.ok(
+      nativeLibraryIntegrityProblems(
+        directory,
+        { ...stamp, libraries: undefined },
+        target,
+      ).length,
+    );
+    assert.deepEqual(
+      nativeLibraryIntegrityProblems(directory, stamp, {
+        ...target,
+        backend: "auto",
+      }),
+      [],
+    );
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a second edit to an already-dirty native source invalidates reuse", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "fused-source-"));
+  const git = (...args) =>
+    execFileSync("git", ["-C", directory, ...args], { stdio: "pipe" });
+  try {
+    git("init");
+    fs.mkdirSync(path.join(directory, "src"));
+    const source = path.join(directory, "src", "engine.c");
+    fs.writeFileSync(source, "original");
+    git("add", ".");
+    git(
+      "-c",
+      "user.name=Fixture",
+      "-c",
+      "user.email=fixture@example.invalid",
+      "commit",
+      "-m",
+      "fixture",
+    );
+    assert.equal(nativeSourceFingerprint(directory), "");
+    fs.writeFileSync(source, "first edit");
+    const first = nativeSourceFingerprint(directory);
+    fs.writeFileSync(source, "second edit");
+    assert.notEqual(nativeSourceFingerprint(directory), first);
+    fs.writeFileSync(source, "original");
+    assert.equal(nativeSourceFingerprint(directory), "");
+    fs.writeFileSync(
+      path.join(directory, "src", "new.c"),
+      "new implementation",
+    );
+    assert.notEqual(nativeSourceFingerprint(directory), "");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/app-core/scripts/lib/setup-state-dir.mjs
+++ b/packages/app-core/scripts/lib/setup-state-dir.mjs
@@ -1,0 +1,16 @@
+/** Resolves bootstrap artifact storage before workspace packages can be imported. */
+import os from "node:os";
+import path from "node:path";
+
+export function resolveSetupStateDir(env = process.env) {
+  const explicit = env.ELIZA_STATE_DIR?.trim();
+  if (explicit)
+    return path.resolve(explicit.replace(/^~(?=$|[\\/])/, os.homedir()));
+  const namespace = env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const xdg = env.XDG_STATE_HOME?.trim();
+  if (xdg)
+    return path.isAbsolute(xdg)
+      ? path.join(xdg, namespace)
+      : path.join(os.homedir(), xdg, namespace);
+  return path.join(os.homedir(), ".local", "state", namespace);
+}

--- a/packages/app-core/scripts/stage-desktop-fused-lib-staleness.test.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib-staleness.test.mjs
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { nativeLibraryInventory } from "./lib/fused-artifact-integrity.mjs";
 
 // Exercises the desktop fused-lib staleness guard (`--check`): a stale or
 // unstamped staged lib must exit non-zero (2) so build/deploy flows never ship
@@ -87,6 +88,9 @@ test("--check: stamp matching the current fork + lib hash is FRESH → exit 0", 
     fs.writeFileSync(
       path.join(dir, STAMP),
       JSON.stringify({
+        platform: process.platform,
+        arch: process.arch,
+        libraries: nativeLibraryInventory(dir),
         forkCommit: currentFork(),
         forkDirty: "",
         backend: "test",
@@ -110,6 +114,9 @@ test("--check: stamp from a DIFFERENT fork commit is STALE → exit 2", () => {
     fs.writeFileSync(
       path.join(dir, STAMP),
       JSON.stringify({
+        platform: process.platform,
+        arch: process.arch,
+        libraries: nativeLibraryInventory(dir),
         forkCommit: "0000000000000000000000000000000000000000",
         forkDirty: "",
         backend: "test",
@@ -134,6 +141,9 @@ test("--check: staged lib whose bytes don't match the stamp hash is STALE → ex
     fs.writeFileSync(
       path.join(dir, STAMP),
       JSON.stringify({
+        platform: process.platform,
+        arch: process.arch,
+        libraries: nativeLibraryInventory(dir),
         forkCommit: currentFork(),
         forkDirty: "",
         backend: "test",
@@ -156,6 +166,9 @@ test("--check: a host-native stamp is stale for a portable CPU request", () => {
     fs.writeFileSync(
       path.join(dir, STAMP),
       JSON.stringify({
+        platform: process.platform,
+        arch: process.arch,
+        libraries: nativeLibraryInventory(dir),
         forkCommit: currentFork(),
         forkDirty: "",
         backend: "cpu",
@@ -179,6 +192,9 @@ test("--check: a portable CPU stamp is fresh for a portable CPU request", () => 
     fs.writeFileSync(
       path.join(dir, STAMP),
       JSON.stringify({
+        platform: process.platform,
+        arch: process.arch,
+        libraries: nativeLibraryInventory(dir),
         forkCommit: currentFork(),
         forkDirty: "",
         backend: "cpu",

--- a/packages/app-core/scripts/stage-desktop-fused-lib.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib.mjs
@@ -49,6 +49,12 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  nativeLibraryIntegrityProblems,
+  nativeLibraryInventory,
+  nativeSourceFingerprint,
+} from "./lib/fused-artifact-integrity.mjs";
+import { resolveSetupStateDir } from "./lib/setup-state-dir.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..", "..", "..");
@@ -131,30 +137,7 @@ function forkCommit() {
     return "unknown";
   }
 }
-function forkDirtyHash() {
-  try {
-    const s = execFileSync(
-      "git",
-      [
-        "-C",
-        forkSrc,
-        "status",
-        "--porcelain",
-        "--untracked-files=no",
-        "--",
-        "tools",
-        "src",
-        "ggml",
-        "common",
-        "CMakeLists.txt",
-      ],
-      { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
-    ).trim();
-    return s ? createHash("sha256").update(s).digest("hex").slice(0, 16) : "";
-  } catch {
-    return "";
-  }
-}
+
 function sha256File(p) {
   try {
     return createHash("sha256").update(readFileSync(p)).digest("hex");
@@ -198,22 +181,6 @@ function parseArgs(argv) {
 
 /** Resolve the state dir the same way @elizaos/core resolveStateDir does, so
  *  the default output dir matches where the runtime searches. */
-function resolveStateDir() {
-  const explicit = process.env.ELIZA_STATE_DIR?.trim();
-  if (explicit) {
-    return path.isAbsolute(explicit)
-      ? explicit
-      : path.join(os.homedir(), explicit);
-  }
-  const ns = process.env.ELIZA_NAMESPACE?.trim() || "eliza";
-  const xdg = process.env.XDG_STATE_HOME?.trim();
-  if (xdg) {
-    return path.isAbsolute(xdg)
-      ? path.join(xdg, ns)
-      : path.join(os.homedir(), xdg, ns);
-  }
-  return path.join(os.homedir(), ".local", "state", ns);
-}
 
 /** Autodetect the best available GPU backend for the host. */
 function detectBackend() {
@@ -351,16 +318,29 @@ const {
 } = parseArgs(process.argv.slice(2));
 
 const stagedOutDir =
-  outOverride || path.join(resolveStateDir(), "local-inference", "lib");
+  outOverride || path.join(resolveSetupStateDir(), "local-inference", "lib");
+if (
+  !existsSync(path.join(forkSrc, ".git")) ||
+  !existsSync(path.join(forkSrc, "CMakeLists.txt"))
+) {
+  die(
+    "Native submodule is not initialized. Run bun install to synchronize the pinned fused source.",
+  );
+}
 const currentFork = forkCommit();
-const currentDirty = forkDirtyHash();
+const currentDirty = nativeSourceFingerprint(forkSrc);
 
 // Shared staleness verdict for --check / --ensure. Returns the reasons the
 // staged fused lib is stale ([] = fresh).
 function stagedStalenessReasons() {
   const stamp = readStamp(stagedOutDir);
   const stagedSha = sha256File(path.join(stagedOutDir, FUSED_LIB_NAME));
-  const reasons = [];
+  const reasons = nativeLibraryIntegrityProblems(stagedOutDir, stamp, {
+    platform: process.platform,
+    arch: process.arch,
+    backend: variant,
+    fusedName: FUSED_LIB_NAME,
+  });
   if (!stagedSha) reasons.push(`staged ${FUSED_LIB_NAME} is missing`);
   if (!stamp) reasons.push("no build stamp (built by an older/raw cmake path)");
   if (stamp && stamp.forkCommit !== currentFork)
@@ -591,6 +571,9 @@ const buildStamp = JSON.stringify(
     forkCommit: currentFork,
     forkDirty: currentDirty,
     backend,
+    platform: process.platform,
+    arch: process.arch,
+    libraries: nativeLibraryInventory(outDir),
     cpuNative: !portableCpu,
     fusedLib: fusedName,
     fusedSha256: sha256File(path.join(outDir, fusedName)),

--- a/packages/app-core/scripts/verify-fused-embedding.mjs
+++ b/packages/app-core/scripts/verify-fused-embedding.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+/** Proves the installed fused library can load its companions and compute a local embedding. */
+import path from "node:path";
+import { resolveFusedEmbeddingBundleRoot } from "../../../plugins/plugin-local-inference/src/runtime/fused-embedding-bundle.ts";
+import { resolveFusedLibraryPath } from "../../../plugins/plugin-local-inference/src/services/desktop-fused-ffi-backend-runtime.ts";
+import { loadElizaInferenceFfi } from "../../../plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts";
+
+const model = process.argv[2];
+if (!model) throw new Error("The verified embedding model path is required");
+const bundle = resolveFusedEmbeddingBundleRoot({
+  modelsDir: path.dirname(model),
+  model: path.basename(model),
+});
+if (!bundle)
+  throw new Error(`Installed embedding model is unavailable: ${model}`);
+const library = resolveFusedLibraryPath(bundle);
+if (!library)
+  throw new Error("Installed fused inference library is unavailable");
+const ffi = loadElizaInferenceFfi(library);
+let context;
+try {
+  if (!ffi.embedSupported() || typeof ffi.embed !== "function")
+    throw new Error(
+      "Installed fused inference library lacks embedding support",
+    );
+  context = ffi.create(bundle);
+  const embedding = ffi.embed({
+    ctx: context,
+    text: "Verify local embedding availability.",
+    pooling: 1,
+  });
+  if (
+    embedding.length !== 384 ||
+    !embedding.every(Number.isFinite) ||
+    !embedding.some((value) => value !== 0)
+  ) {
+    throw new Error(
+      "Installed fused inference returned an invalid default embedding",
+    );
+  }
+  console.log(
+    `[verify-fused-embedding] ready: ${library}; ${embedding.length} finite local dimensions`,
+  );
+} finally {
+  try {
+    if (context) ffi.destroy(context);
+  } finally {
+    ffi.close();
+  }
+}


### PR DESCRIPTION
Normal `bun install` now verifies the complete fused inference library set and computes a local embedding before reporting setup as ready. A missing GGML/llama companion previously passed the freshness check while the real loader failed. Reuse now checks all staged library hashes, the host architecture, and native source bytes, including repeated edits to already-dirty files. An explicit backend change invalidates reuse.

The installer and native stage command share state-directory resolution, so relative and home-relative paths match the runtime. Native source must be initialized, and the existing pinned submodule and hash-verified embedding-model setup remain automatic. An explicit setup skip does not establish readiness.

Closes #30673.

Validation: 19 focused setup tests pass. A real Metal build produced the complete library set. Actual native embeddings returned three finite, nonzero 384-dimensional vectors; related sentences had cosine similarity 0.8954 versus 0.6785 for unrelated sentences. Removing `libllama.0.dylib` from a copied otherwise-current set makes the new check fail, while the old check reported success and the actual loader failed. Normal install, 19 focused setup tests, and the full root verification gate pass on 69ed4e1a20bf5e50fe58e4d651fa3b1ce76a9647. Hosted checks must pass before merge. Native execution evidence is macOS arm64; Android packaging/routing defects found during separate device testing are tracked in #30692.

Additional regression readbacks: [Old false freshness result](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-missing-companion-before-check.log); [New complete-set success](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-complete-set-fresh.log).

## Evidence Gate

<!-- evidence-head:69ed4e1a20bf5e50fe58e4d651fa3b1ce76a9647 -->
<!-- evidence-row:before-screenshots -->
N/A — repository setup and native loader changes; no rendered product surface changes.
<!-- evidence-row:after-screenshots -->
N/A — repository setup and native loader changes; complete CLI and native artifacts are provided.
<!-- evidence-row:walkthrough-video -->
N/A — no interactive UI flow changes; before/after native loader and embedding execution is recorded in logs.
<!-- evidence-row:backend-logs -->
[Normal install and actual embedding probe](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-install-69ed4e1a.log); [376 tasks and final audits](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-verify-69ed4e1a.log).
<!-- evidence-row:frontend-logs -->
N/A — no frontend changes or browser requests.
<!-- evidence-row:llm-trajectory -->
N/A — no generative agent or LLM behavior changes. Real embedding model inputs and outputs are supplied as native domain artifacts below.
<!-- evidence-row:domain-artifacts -->
[Final source hashes and proof provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-review-receipt-69ed4e1a.json); [Real Metal build](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-native-ensure-first.log); [Native library inventory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-companion-regression.json); [Actual old loader failure](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-missing-companion-before-load.log); [New missing-companion rejection](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-complete-set-missing.log).
[19 setup tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-setup-tests-69ed4e1a.log); [Native embedding inputs and complete vectors before rebuild](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-live-embedding-before.log); [Native embedding inputs and complete vectors after rebuild](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30698-30673-live-embedding-after.log). Native before/after executions predate the final rebase; the final install log records the current product embedding probe.
<!-- evidence-row:ocr-review -->
N/A — no screenshots or rendered text changed.
