### PR TITLE
fix(cloud): preserve authorization audit logs without verbose logging

### DIFF
--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -22,6 +22,7 @@ import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 
 import {
+  inferenceAuthTailFailureCode,
   isCloudflarePlacement,
   sanitizeInferenceAuthTail,
   summarizeDeferredCacheWrites,
@@ -439,7 +440,7 @@ async function waitForSanitizedTail(rawPath, traceIds, deploySha) {
     }
   }
   throw new Error(
-    "Worker Tail did not yield complete sanitized auth evidence",
+    `Worker Tail did not yield complete sanitized auth evidence (${inferenceAuthTailFailureCode(lastFailure)})`,
     {
       cause: lastFailure,
     },

--- a/packages/cloud/scripts/inference-auth-latency.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.mjs
@@ -100,6 +100,33 @@ function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Categorizes failed Tail validation without exposing raw parser or IO errors. */
+export function inferenceAuthTailFailureCode(error) {
+  const message = error instanceof Error ? error.message : "";
+  const exact = new Map([
+    ["Worker Tail output ended mid-record", "incomplete_stream"],
+    ["Worker Tail returned duplicate auth traces", "duplicate_auth_records"],
+    [
+      "Worker Tail returned duplicate auth cache-write traces",
+      "duplicate_deferred_writes",
+    ],
+    [
+      "Worker Tail omitted a deferred auth cache-write trace",
+      "missing_deferred_write",
+    ],
+    [
+      "Worker Tail returned an unexpected auth cache-write trace",
+      "unexpected_deferred_write",
+    ],
+  ]);
+  if (exact.has(message)) return exact.get(message);
+  if (/^Worker Tail omitted \d+ retained auth traces$/.test(message))
+    return "missing_auth_records";
+  if (message.startsWith("Worker auth ")) return "schema_mismatch";
+  if (error instanceof SyntaxError) return "invalid_json";
+  return "unclassified_failure";
+}
+
 function hasExactKeys(value, keys) {
   const actual = Object.keys(value).sort();
   const expected = [...keys].sort();
@@ -678,6 +705,7 @@ export async function waitForInferenceAuthTail({
     throw new Error("Invalid Worker Tail readiness configuration");
   }
   let routePropagationPending = false;
+  let lastTailFailure;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     let sample;
     try {
@@ -707,7 +735,14 @@ export async function waitForInferenceAuthTail({
     routePropagationPending = false;
     for (let poll = 0; poll < pollsPerAttempt; poll++) {
       await sleep(pollIntervalMs);
-      if (readTail().includes(sample.traceId)) return attempt;
+      try {
+        sanitizeInferenceAuthTail(readTail(), [sample.traceId], deploySha);
+        return attempt;
+      } catch (error) {
+        // error-policy:J3 readiness requires a complete sanitized audit record;
+        // partial delivery and rejected records remain explicitly unready.
+        lastTailFailure = error;
+      }
     }
   }
   if (routePropagationPending) {
@@ -716,7 +751,7 @@ export async function waitForInferenceAuthTail({
     );
   }
   throw new Error(
-    "Worker Tail did not observe an authenticated readiness trace",
+    `Worker Tail did not observe an authenticated readiness trace (${inferenceAuthTailFailureCode(lastTailFailure)})`,
   );
 }
 

--- a/packages/cloud/scripts/inference-auth-latency.test.mjs
+++ b/packages/cloud/scripts/inference-auth-latency.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  inferenceAuthTailFailureCode,
   isCloudflarePlacement,
   parseArgs,
   parseAuthServerTiming,
@@ -41,6 +42,67 @@ function timingHeader(phase, resolveMs = 10) {
     ? shared
     : `${shared}, auth_key_lookup;dur=3, auth_user_org;dur=2, auth_moderation;dur=1`;
 }
+
+function warmTailRecord(traceId) {
+  return JSON.stringify({
+    outcome: "ok",
+    logs: [
+      {
+        message: [
+          "[InferenceAuth] trace",
+          {
+            v: 1,
+            traceId,
+            authSource: "x_api_key",
+            controlledProbe: "off",
+            cacheAvailability: "available",
+            cacheBackend: "cloudflare_kv",
+            cacheRead: "hit",
+            authoritative: "not_run",
+            cacheWrite: "not_run",
+            result: "authorized_cache",
+            timings: {
+              extractMs: 0,
+              cacheAvailabilityMs: 0,
+              cacheReadMs: 1,
+              keyLookupMs: null,
+              userOrgLookupMs: null,
+              moderationMs: null,
+              cacheWriteMs: null,
+              totalMs: 1,
+            },
+          },
+        ],
+      },
+    ],
+  });
+}
+
+test("Tail failure categories preserve diagnostic meaning without raw content", () => {
+  const traceId = "a".repeat(32);
+  const cases = [
+    ["", "missing_auth_records"],
+    [
+      warmTailRecord(traceId) + warmTailRecord(traceId),
+      "duplicate_auth_records",
+    ],
+    ['{"private":"raw-secret', "incomplete_stream"],
+    ['{"private": raw-secret}', "invalid_json"],
+  ];
+  for (const [raw, expected] of cases) {
+    assert.throws(
+      () => sanitizeInferenceAuthTail(raw, [traceId], SHA),
+      (error) => {
+        assert.equal(inferenceAuthTailFailureCode(error), expected);
+        return true;
+      },
+    );
+  }
+  assert.equal(
+    inferenceAuthTailFailureCode(new Error("private-token-or-url")),
+    "unclassified_failure",
+  );
+});
 
 test("parseArgs requires exact HTTPS deployment provenance and sample counts", () => {
   assert.deepEqual(
@@ -378,8 +440,12 @@ test("Tail readiness waits for an observed authenticated trace", async () => {
     readTail: () => {
       reads++;
       return traceIds.length > 1
-        ? JSON.stringify({ traceId: traceIds[1] })
-        : "";
+        ? warmTailRecord(traceIds[1])
+        : JSON.stringify({
+            event: {
+              request: { headers: { "x-eliza-trace-id": traceIds[0] } },
+            },
+          });
     },
     fetchImpl: async (_url, init) => {
       traceIds.push(init.headers["X-Eliza-Trace-Id"]);
@@ -412,7 +478,7 @@ test("Tail readiness retries a transient workers.dev propagation response", asyn
     pollsPerAttempt: 1,
     pollIntervalMs: 1,
     sleep: async () => {},
-    readTail: () => observedTraceId,
+    readTail: () => warmTailRecord(observedTraceId),
     fetchImpl: async (_url, init) => {
       requests++;
       if (requests === 1) return new Response(null, { status: 404 });

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -323,7 +323,7 @@ describe("resolveInferenceAuthContext", () => {
       await writeBarrier;
       return originalWrite(...args);
     });
-    const info = spyOn(logger, "info").mockImplementation(() => undefined);
+    const info = spyOn(logger, "audit").mockImplementation(() => undefined);
     const traces: import("./inference-auth-context").InferenceAuthTelemetry[] = [];
     const traceIds = ["a".repeat(32), "b".repeat(32)];
     try {
@@ -536,7 +536,7 @@ describe("resolveInferenceAuthContext", () => {
   });
 
   test("a cold request safely joins a refresh-created flight and retains its lease credential", async () => {
-    const info = spyOn(logger, "info").mockImplementation(() => undefined);
+    const info = spyOn(logger, "audit").mockImplementation(() => undefined);
     await writeInferenceAuthContext({
       v: 3,
       cachedAt: 1,
@@ -666,7 +666,7 @@ describe("resolveInferenceAuthContext", () => {
     const waited: Promise<unknown>[] = [];
     const cacheRead = spyOn(cache, "getWithOutcome");
     const errorSpy = spyOn(logger, "error").mockImplementation(() => undefined);
-    const infoSpy = spyOn(logger, "info").mockImplementation(() => undefined);
+    const infoSpy = spyOn(logger, "audit").mockImplementation(() => undefined);
     try {
       const result = await resolveInferenceAuthContext(reqWithApiKey(), {
         cacheOnly: true,

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -546,7 +546,7 @@ function observeHydrationProjection(
       // Projection failures are already reported by the hydration boundary.
       if (!completed) return;
       const telemetry = Object.freeze({ ...completed, traceId: boundedTraceId(options.traceId) });
-      if (canonical) logger.info("[InferenceAuth] trace", telemetry);
+      if (canonical) logger.audit("[InferenceAuth] trace", telemetry);
       options.onCacheWriteTelemetry?.(telemetry);
     })
     .catch((error) => {
@@ -1129,7 +1129,7 @@ export async function resolveInferenceAuthContext(
       const observedWrite = cacheWrite.then(
         (write) => {
           const telemetry = freezeCacheWriteTrace(options.traceId, write, cacheWriteStartedAt);
-          logger.info("[InferenceAuth] trace", telemetry);
+          logger.audit("[InferenceAuth] trace", telemetry);
           options.onCacheWriteTelemetry?.(telemetry);
         },
         (error) => {
@@ -1190,7 +1190,8 @@ export async function resolveInferenceAuthContext(
     const nested = (
       options as ResolveInferenceAuthOptions & { [SUPPRESS_STANDING_DENIAL_LOG]?: true }
     )[SUPPRESS_STANDING_DENIAL_LOG];
-    logger.info(nested ? "[InferenceAuth] hydration trace" : "[InferenceAuth] trace", telemetry);
+    if (nested) logger.info("[InferenceAuth] hydration trace", telemetry);
+    else logger.audit("[InferenceAuth] trace", telemetry);
     options.onTelemetry?.(telemetry);
   }
 }

--- a/packages/cloud/shared/src/lib/utils/logger.test.ts
+++ b/packages/cloud/shared/src/lib/utils/logger.test.ts
@@ -1,4 +1,4 @@
-// Exercises logger behavior with deterministic cloud-shared lib fixtures.
+/** Exercises the real cloud logging sink and redaction, including quiet-mode audit delivery. */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { logger } from "./logger";
 
@@ -51,5 +51,24 @@ describe("cloud logger sink redaction (#12229 M6)", () => {
     });
     expect(ctx.password).toBe("[REDACTED]");
     expect(ctx.count).toBe(3);
+  });
+
+  test("audit evidence survives quiet production logging without exposing secrets", () => {
+    const moduleUrl = new URL("./logger.ts", import.meta.url).href;
+    const script = `const { logger } = await import(${JSON.stringify(moduleUrl)});
+      logger.info("verbose-only-sentinel", { value: 1 });
+      logger.audit("[InferenceAuth] trace", { result: "authorized_cache", apiKey: "private-audit-secret" });`;
+    const child = Bun.spawnSync([process.execPath, "--eval", script], {
+      env: { ...process.env, NODE_ENV: "production", VERBOSE_LOGGING: "false" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(child.exitCode).toBe(0);
+    const output = child.stdout.toString();
+    expect(output).toContain("[InferenceAuth] trace");
+    expect(output).toContain("authorized_cache");
+    expect(output).toContain("[REDACTED]");
+    expect(output).not.toContain("private-audit-secret");
+    expect(output).not.toContain("verbose-only-sentinel");
   });
 });

--- a/packages/cloud/shared/src/lib/utils/logger.ts
+++ b/packages/cloud/shared/src/lib/utils/logger.ts
@@ -2,6 +2,8 @@
  * Conditional cloud logging utility with structural sensitive-data redaction.
  *
  * Debug/info logs only show when VERBOSE_LOGGING=true to reduce console noise.
+ * Audit records remain enabled independently so authorization evidence is not
+ * coupled to verbose diagnostics.
  * Every sink pipes its arguments through the core log-sink redactor
  * ({@link redactLogArgs}) before writing, so a secret is masked whether or not
  * the caller wrapped context in {@link redact.context}. Name-based redaction
@@ -159,6 +161,10 @@ export const redact = {
 };
 
 export const logger = {
+  /** Emits structured audit evidence independently of verbose diagnostics. */
+  audit: (message: string, context: object) => {
+    console.info(...redactLogArgs([message, context]));
+  },
   /**
    * Debug-level logs - only shown when VERBOSE_LOGGING=true
    */


### PR DESCRIPTION
## Summary

Refs #30685. Preserve redacted inference authorization audit records independently of verbose diagnostic logging, and require actual canonical records before declaring Worker Tail ready.

- Add an always-on structured `logger.audit` sink using the existing core redactor. Use it for outer authorization and deferred projection records; nested hydration remains verbose-only.
- Replace trace-ID substring readiness with the same strict sanitizer used by certification. Request metadata alone cannot prove audit delivery.
- Report bounded validation failure categories without copying raw Tail, parser, or I/O error text into workflow output.
- Preserve single standing-read behavior, deferred projection pairing, schema validation, authorization outcomes, and provider dispatch.

## Validation

Head: `acf88bccdda2425dfbc6154c78bd653984d80d29`.
Validated base: `8508c73dc14ae546717c30d47e5fc948fa436ced`.

- Pinned Bun 1.3.14 / Node 24.15.0 install passed after rebase.
- Probe and certification tests: 23 passed at this head.
- Final-head resolver, real logger, and HTTP telemetry tests: 78 passed, zero failed, 293 assertions across 3 files.
- Shared typecheck and scoped Biome passed. Full root `bun run verify` passed at this head: 376 workspace tasks succeeded and the final focused/skipped-test audit was clean.
- Independent read-only review passed with no blocker, including partial logger-mock compatibility. Live staging Tail certification remains required after normal merge and deployment.

## Evidence

<!-- evidence-head:acf88bccdda2425dfbc6154c78bd653984d80d29 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - server audit and protected diagnostic runner changes only.
<!-- evidence-row:backend-logs -->
- [x] Real quiet-production logger subprocess delivers the authorization audit record, suppresses ordinary verbose info, and redacts a credential-named field. Synthetic Tail boundary tests reject metadata-only readiness, incomplete records, duplicate records, and missing deferred-write evidence.

```text
node --test packages/cloud/scripts/inference-auth-latency.test.mjs packages/cloud/scripts/cloud-latency-certification.test.mjs
tests 23; pass 23; fail 0
PASS Tail failure categories preserve diagnostic meaning without raw content
PASS Worker Tail sanitizer retains only correlated bounded telemetry
PASS Tail readiness waits for an observed authenticated trace
bun test --coverage-reporter=lcov [resolver, logger, HTTP telemetry suites]
78 pass; 0 fail; 293 expect() calls; 3 files
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - frontend requests and response contracts are unchanged.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - model payload and provider dispatch behavior are unchanged. Existing live paired calls passed, but this patch has not yet been deployed and no live audit success is claimed.
<!-- evidence-row:domain-artifacts -->
- [x] Executed sanitizer tests inspect fixed-schema authorization evidence and safe failure categories, including privacy for unknown error text.

```text
Real parser invocation: sanitizeInferenceAuthTail(raw, [32-hex correlation], 40-hex deployment)
empty stream: missing_auth_records
invalid JSON: invalid_json
unknown parser error: unclassified_failure
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifacts changed.

## Remaining live acceptance

The prior staging certification completed all 44 provider calls and response-side auth assertions, then failed strict Tail validation. Raw logs were securely deleted, so the exact live cause is not asserted. This patch fixes an independently reproduced quiet-logging defect and exposes bounded failure categories for the next attempt. After normal merge, deploy the exact staging SHA and require full canonical auth plus deferred-write evidence; do not relax the schema or accept HTTP-only results.
