### PR TITLE
fix(screencapture): share concurrent recording stop completion

### DIFF
--- a/plugins/plugin-native-screencapture/src/web.test.ts
+++ b/plugins/plugin-native-screencapture/src/web.test.ts
@@ -147,6 +147,82 @@ describe("ScreenCaptureWeb", () => {
     FakeMediaRecorder.instances = [];
   });
 
+  it("shares concurrent stop completion until metadata is ready, then allows another recording", async () => {
+    vi.useFakeTimers();
+    const { createElement } = installDocument();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+    const track = new FakeTrack("video");
+    const nextTrack = new FakeTrack("video");
+    const getDisplayMedia = vi
+      .fn()
+      .mockResolvedValueOnce(new FakeStream([track]))
+      .mockResolvedValueOnce(new FakeStream([nextTrack]));
+    setNavigator({
+      mediaDevices: { getDisplayMedia } as unknown as MediaDevices,
+    });
+    let completeMetadata: () => void = () => {
+      throw new Error("Metadata loading has not started");
+    };
+    createElement.mockImplementationOnce(() => ({
+      videoWidth: 1280,
+      videoHeight: 720,
+      set src(_value: string) {},
+      set onloadedmetadata(callback: () => void) {
+        completeMetadata = callback;
+      },
+      set onerror(_callback: () => void) {},
+    }));
+    const plugin = new ScreenCaptureWeb();
+    await plugin.startRecording();
+    const recorder = FakeMediaRecorder.instances[0];
+    recorder.stop.mockImplementation(() => undefined);
+
+    const first = plugin.stopRecording();
+    const second = plugin.stopRecording();
+    expect(recorder.stop).toHaveBeenCalledTimes(1);
+    recorder.onstop?.(new Event("stop"));
+    expect(track.stopped).toBe(true);
+    await expect(plugin.startRecording()).rejects.toThrow(
+      "already in progress",
+    );
+    expect(getDisplayMedia).toHaveBeenCalledTimes(1);
+    const duringMetadata = plugin.stopRecording();
+    completeMetadata();
+    const results = await Promise.all([first, second, duringMetadata]);
+    expect(results[0]).toEqual(results[1]);
+    expect(results[1]).toEqual(results[2]);
+
+    await plugin.startRecording();
+    await plugin.stopRecording();
+    expect(nextTrack.stopped).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("releases a rejected stop promise so the recorder can be stopped again", async () => {
+    vi.useFakeTimers();
+    installDocument();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+    const track = new FakeTrack("video");
+    setNavigator({
+      mediaDevices: {
+        getDisplayMedia: vi.fn(async () => new FakeStream([track])),
+      } as unknown as MediaDevices,
+    });
+    const plugin = new ScreenCaptureWeb();
+    await plugin.startRecording();
+    const recorder = FakeMediaRecorder.instances[0];
+    recorder.stop.mockImplementationOnce(() => {
+      throw new Error("Recorder stop failed");
+    });
+    await expect(plugin.stopRecording()).rejects.toThrow(
+      "Recorder stop failed",
+    );
+    await plugin.stopRecording();
+    expect(recorder.stop).toHaveBeenCalledTimes(2);
+    expect(track.stopped).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("reports unsupported cleanly when optional browser capture APIs are absent", async () => {
     setNavigator({});
     vi.stubGlobal("MediaRecorder", undefined);

--- a/plugins/plugin-native-screencapture/src/web.ts
+++ b/plugins/plugin-native-screencapture/src/web.ts
@@ -82,6 +82,7 @@ export class ScreenCaptureWeb extends WebPlugin {
    * any await and cleared in a finally that also covers the J2 rollback path.
    */
   private starting = false;
+  private recordingStop: Promise<ScreenRecordingResult> | null = null;
   private recordingStartTime = 0;
   private pausedDuration = 0;
   private pauseStartTime = 0;
@@ -197,7 +198,7 @@ export class ScreenCaptureWeb extends WebPlugin {
   async startRecording(options?: ScreenRecordingOptions): Promise<void> {
     // Latch synchronously before the first await so a concurrent second call
     // cannot slip past the guard while getDisplayMedia is still resolving.
-    if (this.isRecording || this.starting) {
+    if (this.isRecording || this.starting || this.recordingStop) {
       throw new Error("Recording already in progress");
     }
     this.starting = true;
@@ -350,11 +351,12 @@ export class ScreenCaptureWeb extends WebPlugin {
   }
 
   async stopRecording(): Promise<ScreenRecordingResult> {
+    if (this.recordingStop) return this.recordingStop;
     if (!this.isRecording || !this.mediaRecorder) {
       throw new Error("Not recording");
     }
 
-    return new Promise((resolve, reject) => {
+    const stopping = new Promise<ScreenRecordingResult>((resolve, reject) => {
       if (!this.mediaRecorder) {
         reject(new Error("MediaRecorder not initialized"));
         return;
@@ -412,6 +414,14 @@ export class ScreenCaptureWeb extends WebPlugin {
 
       this.mediaRecorder.stop();
     });
+    // Keep ownership through metadata loading so concurrent callers share the
+    // result and a new recording cannot replace its MIME type or chunk state.
+    this.recordingStop = stopping;
+    try {
+      return await stopping;
+    } finally {
+      if (this.recordingStop === stopping) this.recordingStop = null;
+    }
   }
 
   async pauseRecording(): Promise<void> {


### PR DESCRIPTION
# Relates to

Closes #30694. Recovers the concurrent-stop ownership portion of #30229 after #28962, without its unrelated consolidation.

Two callers stopping one browser screen recording previously installed competing completion handlers: one resolved, while the other waited forever. They now share one completion promise, including asynchronous metadata loading. New starts remain excluded until that result is ready, and a failed stop releases the promise so stopping can be retried.

# Sync with develop

Rebased on `08f5532a228a455c7941fd534f75d8d3ccbd2735`; verified head `f31709e1cc5432505946ae58703b645017c9b087`. Fresh pinned Bun 1.3.14 / Node 24.15.0 install. Full root `bun run verify` passed: 376/376 tasks plus all final repository audits.

# Risks

Low and confined to the browser recording API. The single-call completion format is unchanged. Ownership lasts through metadata loading to prevent a new recording from replacing state used to form the prior result.

# Background

This is a bug fix for the public Capacitor recording API. The new regression uses delayed recorder completion and delayed metadata, then starts and stops another recording. A second regression rejects one stop and verifies a successful retry. The concurrency regression fails on the previous implementation because the recorder receives two stop calls.

# Documentation changes needed?

No public API or setup change.

# Testing

The owning package passes 26 tests, typecheck, lint, and build. Real Chromium display capture and MediaRecorder on macOS arm64 reproduced the failure before and verified the built package after. The chooser selects a dedicated controlled browser tab; streams and recorders are real. This is browser implementation evidence, not a claim of native mobile or Electrobun OS-picker validation.

Before: one stop remains pending after recording and tracks end. After: both resolve to the same result and all tracks end. Screenshots, full API/track results, actual recorded video, and the reproduction harness are attached below. Product UI is unchanged; mobile screenshots and model trajectories are inapplicable.

# Evidence Gate

<!-- evidence-head:f31709e1cc5432505946ae58703b645017c9b087 -->
<!-- evidence-row:before-screenshots -->
- [x] [Before desktop reproduction](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30701-before-desktop.jpg).
<!-- evidence-row:after-screenshots -->
- [x] [After desktop reproduction](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30701-after-desktop.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] [Real browser walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30701-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend participates in this client-side recording method.
<!-- evidence-row:frontend-logs -->
- [x] [Complete before/after results and browser errors](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30701-browser-media-proof.json).
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Actual recorded video](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30701-recorded-output.mp4) and [reproduction harness](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30701-browser-harness.mjs).
<!-- evidence-row:ocr-review -->
- [ ] N/A - no product visual change. Controlled-fixture screenshots and recording frames were visually inspected; no OCR result is claimed.
