### PR TITLE
fix(cloud): collect privacy-safe distributed inference traces

### DIFF
--- a/.github/workflows/cloud-latency-certification.yml
+++ b/.github/workflows/cloud-latency-certification.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       expected_deploy_sha:
-        description: Exact 40-character develop SHA that staging must serve.
+        description: Exact 40-character develop ancestor that staging must serve.
         required: true
+        type: string
+      acknowledged_contract_digest:
+        description: Exact SHA-256 acknowledgement after reviewing verifier changes since the deployed revision; blank when unchanged.
+        required: false
+        default: ""
         type: string
       run_auth:
         description: Also run protected inference-auth hit, miss, non-standing guards, and sanitized Worker Tail proof.
@@ -35,6 +40,7 @@ jobs:
       BUN_VERSION: "1.3.14"
       NODE_VERSION: "24.15.0"
       EXPECTED_DEPLOY_SHA: ${{ inputs.expected_deploy_sha }}
+      ACKNOWLEDGED_CONTRACT_DIGEST: ${{ inputs.acknowledged_contract_digest }}
       RUN_AUTH: ${{ inputs.run_auth }}
       RUN_SUSPENDED: ${{ inputs.run_suspended }}
       CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
@@ -54,10 +60,6 @@ jobs:
           fi
           if [[ "$GITHUB_REF" != "refs/heads/develop" ]]; then
             echo "::error::Cloud latency certification must dispatch the trusted develop workflow definition."
-            exit 1
-          fi
-          if [[ "$EXPECTED_DEPLOY_SHA" != "$GITHUB_SHA" ]]; then
-            echo "::error::Dispatch must select develop at the exact expected_deploy_sha; refusing arbitrary checkout bytes."
             exit 1
           fi
           if [[ "$RUN_SUSPENDED" == "true" && "$RUN_AUTH" != "true" ]]; then
@@ -93,6 +95,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: false
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -112,6 +115,7 @@ jobs:
           args=(
             --deploy-sha "$EXPECTED_DEPLOY_SHA"
             --output-dir "$output_dir"
+            --acknowledged-contract-digest "$ACKNOWLEDGED_CONTRACT_DIGEST"
           )
           if [[ "$RUN_AUTH" == "true" ]]; then
             args+=(--auth)

--- a/.github/workflows/cloud-latency-certification.yml
+++ b/.github/workflows/cloud-latency-certification.yml
@@ -64,13 +64,14 @@ jobs:
             echo "::error::run_suspended is valid only when run_auth=true."
             exit 1
           fi
-          required=(CEREBRAS_API_KEY ELIZAOS_CLOUD_API_KEY)
+          required=(
+            CEREBRAS_API_KEY
+            ELIZAOS_CLOUD_API_KEY
+            CLOUDFLARE_API_TOKEN
+            CLOUDFLARE_ACCOUNT_ID
+          )
           if [[ "$RUN_AUTH" == "true" ]]; then
-            required+=(
-              INFERENCE_AUTH_PROBE_TOKEN
-              CLOUDFLARE_API_TOKEN
-              CLOUDFLARE_ACCOUNT_ID
-            )
+            required+=(INFERENCE_AUTH_PROBE_TOKEN)
           fi
           if [[ "$RUN_SUSPENDED" == "true" ]]; then
             required+=(ELIZA_STAGING_SUSPENDED_API_KEY)
@@ -120,14 +121,17 @@ jobs:
           fi
           node packages/cloud/scripts/cloud-latency-certification.mjs "${args[@]}"
 
-      - name: Remove private Worker Tail material
+      - name: Remove private Worker telemetry material
         if: ${{ always() }}
         shell: bash
         run: |
           set -euo pipefail
           shopt -s nullglob
-          private_tail_directories=("$RUNNER_TEMP"/eliza-inference-auth-tail-*)
-          for directory in "${private_tail_directories[@]}"; do
+          private_directories=(
+            "$RUNNER_TEMP"/eliza-inference-auth-tail-*
+            "$RUNNER_TEMP"/eliza-inference-trace-*
+          )
+          for directory in "${private_directories[@]}"; do
             if [[ ! -d "$directory" || -L "$directory" ]]; then
               echo "::error::Refusing unexpected private Tail cleanup target."
               exit 1
@@ -145,6 +149,7 @@ jobs:
             artifacts/cloud-latency-certification/paired.jsonl
             artifacts/cloud-latency-certification/inference-auth.jsonl
             artifacts/cloud-latency-certification/inference-auth-worker.jsonl
+            artifacts/cloud-latency-certification/inference-traces.json
             artifacts/cloud-latency-certification/summary.json
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/cloud-latency-certification.yml
+++ b/.github/workflows/cloud-latency-certification.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           name: cloud-latency-certification-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
+            artifacts/cloud-latency-certification/source.json
             artifacts/cloud-latency-certification/deployment.json
             artifacts/cloud-latency-certification/paired.jsonl
             artifacts/cloud-latency-certification/inference-auth.jsonl

--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -28,6 +28,10 @@ import {
   summarizeDeferredCacheWrites,
   waitForInferenceAuthTail,
 } from "./inference-auth-latency.mjs";
+import {
+  verifyCertificationSource,
+  withVerifiedDeployment,
+} from "./latency-certification-provenance.mjs";
 
 const STAGING_BASE_URL = "https://api-staging.eliza.app";
 const CEREBRAS_BASE_URL = "https://api.cerebras.ai";
@@ -67,6 +71,7 @@ export function parseCertificationArgs(argv) {
     options: {
       "deploy-sha": { type: "string" },
       "output-dir": { type: "string" },
+      "acknowledged-contract-digest": { type: "string", default: "" },
       auth: { type: "boolean", default: false },
       suspended: { type: "boolean", default: false },
     },
@@ -85,6 +90,7 @@ export function parseCertificationArgs(argv) {
   return {
     deploySha,
     outputDir: resolve(outputDir),
+    acknowledgedContractDigest: values["acknowledged-contract-digest"],
     runAuth: values.auth,
     runSuspended: values.suspended,
   };
@@ -150,7 +156,7 @@ export async function verifyExactDeployment(deploySha, fetchImpl = fetch) {
   return { kind: "deployment", deploySha, environment: "staging" };
 }
 
-export function validatePairedEvidence(text, deploySha) {
+export function validatePairedEvidence(text, deploySha, sourceSha = deploySha) {
   const records = parseJsonLines(text, "Paired latency evidence");
   if (records.length !== EXPECTED_PAIRED_RECORDS) {
     throw new Error(
@@ -170,9 +176,12 @@ export function validatePairedEvidence(text, deploySha) {
     ) {
       throw new Error("Paired latency evidence contains a failed proof");
     }
-    if (record.ci?.sha !== deploySha) {
+    if (
+      record.ci?.sha !== sourceSha ||
+      record.ci?.gatewayDeploySha !== deploySha
+    ) {
       throw new Error(
-        "Paired latency evidence is not bound to the dispatch SHA",
+        "Paired latency evidence is not bound to source and deployment SHAs",
       );
     }
     const placement = record.headers?.["cf-placement"];
@@ -472,7 +481,7 @@ async function waitForSanitizedTail(rawPath, traceIds, deploySha) {
   );
 }
 
-async function runPaired({ deploySha, outputDir, env }) {
+async function runPaired({ deploySha, sourceSha, outputDir, env }) {
   requirePairedSecrets(env);
   const outputPath = join(outputDir, "paired.jsonl");
   const stderrPath = join(outputDir, ".paired.stderr");
@@ -511,6 +520,7 @@ async function runPaired({ deploySha, outputDir, env }) {
     return validatePairedEvidence(
       await readFile(outputPath, "utf8"),
       deploySha,
+      sourceSha,
     );
   } finally {
     await rm(stderrPath, { force: true });
@@ -642,57 +652,82 @@ export async function runCertification(
   options,
   { env = process.env, fetchImpl = fetch } = {},
 ) {
+  const source = await verifyCertificationSource({
+    sourceRef: env.GITHUB_REF,
+    sourceSha: env.GITHUB_SHA,
+    deploySha: options.deploySha,
+    acknowledgedContractDigest: options.acknowledgedContractDigest,
+  });
   await mkdir(options.outputDir, { recursive: true, mode: 0o700 });
-  const deployment = await verifyExactDeployment(options.deploySha, fetchImpl);
   await writeFile(
-    join(options.outputDir, "deployment.json"),
-    `${JSON.stringify(deployment)}\n`,
+    join(options.outputDir, "source.json"),
+    `${JSON.stringify(source)}\n`,
     { mode: 0o600, flag: "wx" },
   );
-  const paired = await runPaired({ ...options, env });
-  // Start trace lookup immediately after the paired calls. Its rejection is
-  // observed here so a slower auth failure cannot create an unhandled promise;
-  // the finally below still waits for private-response cleanup and evidence.
-  const traceOutcomePromise = runTraces({
-    ...options,
-    env,
-    pairedRecords: paired.records,
-  }).then(
-    (value) => ({ value, error: null }),
-    (error) => ({ value: null, error }),
+  const { paired, auth, traces } = await withVerifiedDeployment(
+    options.deploySha,
+    (sha) => verifyExactDeployment(sha, fetchImpl),
+    async (deployment) => {
+      await writeFile(
+        join(options.outputDir, "deployment.json"),
+        `${JSON.stringify(deployment)}\n`,
+        { mode: 0o600, flag: "wx" },
+      );
+      const paired = await runPaired({
+        ...options,
+        sourceSha: source.sourceSha,
+        env,
+      });
+      // Start trace lookup immediately after the paired calls. Its rejection is
+      // observed here so a slower auth failure cannot create an unhandled promise;
+      // the finally below still waits for private-response cleanup and evidence.
+      const traceOutcomePromise = runTraces({
+        ...options,
+        env,
+        pairedRecords: paired.records,
+      }).then(
+        (value) => ({ value, error: null }),
+        (error) => ({ value: null, error }),
+      );
+      let auth = {
+        skipped: true,
+        reason: "not_requested",
+        suspendedGuard: "not_requested",
+      };
+      let authFailure;
+      let traceOutcome;
+      try {
+        if (options.runAuth) auth = await runAuth({ ...options, env });
+      } catch (error) {
+        // error-policy:J5 the same auth failure is rethrown after the concurrent
+        // trace capture has finished and removed all raw telemetry.
+        authFailure = error;
+      } finally {
+        traceOutcome = await traceOutcomePromise;
+      }
+      if (authFailure && traceOutcome.error) {
+        // error-policy:J2 neither boundary may hide the other; retain both causes
+        // privately while the CLI emits only this bounded category.
+        throw new Error(
+          "Auth probe and distributed trace collection both failed",
+          {
+            cause: new AggregateError([authFailure, traceOutcome.error]),
+          },
+        );
+      }
+      if (authFailure) throw authFailure;
+      if (traceOutcome.error) throw traceOutcome.error;
+      return { paired, auth, traces: traceOutcome.value };
+    },
   );
-  let auth = {
-    skipped: true,
-    reason: "not_requested",
-    suspendedGuard: "not_requested",
-  };
-  let authFailure;
-  let traceOutcome;
-  try {
-    if (options.runAuth) auth = await runAuth({ ...options, env });
-  } catch (error) {
-    // error-policy:J5 the same auth failure is rethrown after the concurrent
-    // trace capture has finished and removed all raw telemetry.
-    authFailure = error;
-  } finally {
-    traceOutcome = await traceOutcomePromise;
-  }
-  if (authFailure && traceOutcome.error) {
-    // error-policy:J2 neither boundary may hide the other; retain both causes
-    // privately while the CLI emits only this bounded category.
-    throw new Error("Auth probe and distributed trace collection both failed", {
-      cause: new AggregateError([authFailure, traceOutcome.error]),
-    });
-  }
-  if (authFailure) throw authFailure;
-  if (traceOutcome.error) throw traceOutcome.error;
   const summary = {
     kind: "cloud_latency_certification",
     deploySha: options.deploySha,
+    source,
     environment: "staging",
     paired: { records: paired.records.length, counts: paired.counts },
     auth,
-    traces: traceOutcome.value,
+    traces,
   };
   await writeFile(
     join(options.outputDir, "summary.json"),

--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -20,7 +20,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
-
+import { collectInferenceTraceEvidence } from "./cloudflare-inference-trace-evidence.mjs";
 import {
   inferenceAuthTailFailureCode,
   isCloudflarePlacement,
@@ -100,6 +100,13 @@ export function requirePairedSecrets(env) {
   return {
     directApiKey: requireSecret(env, "CEREBRAS_API_KEY"),
     gatewayApiKey: requireSecret(env, "ELIZAOS_CLOUD_API_KEY"),
+  };
+}
+
+export function requireTraceSecrets(env) {
+  return {
+    cloudflareApiToken: requireSecret(env, "CLOUDFLARE_API_TOKEN"),
+    cloudflareAccountId: requireSecret(env, "CLOUDFLARE_ACCOUNT_ID"),
   };
 }
 
@@ -283,27 +290,45 @@ export function validateAuthEvidence(text, deploySha, runSuspended = false) {
   return { records, traceIds };
 }
 
-export async function withPrivateTailDirectory(task, root = tmpdir()) {
-  const directory = await mkdtemp(join(root, "eliza-inference-auth-tail-"));
+async function withPrivateCaptureDirectory({ prefix, label, task, root }) {
+  const directory = await mkdtemp(join(root, prefix));
   await chmod(directory, 0o700);
   let result;
   let failure;
   try {
     result = await task(directory);
   } catch (error) {
-    // error-policy:J5 the same failure is rethrown immediately after the raw
-    // Tail directory has been removed.
+    // error-policy:J5 the same failure is rethrown immediately after its raw
+    // private capture directory has been removed.
     failure = error;
   }
   try {
     await rm(directory, { recursive: true, force: true });
   } catch (cause) {
-    // error-policy:J2 raw Tail cleanup is a security boundary and therefore
+    // error-policy:J2 raw capture cleanup is a security boundary and therefore
     // cannot degrade to a warning or a successful certification.
-    throw new Error("Private Worker Tail cleanup failed", { cause });
+    throw new Error(`Private ${label} cleanup failed`, { cause });
   }
   if (failure) throw failure;
   return result;
+}
+
+export async function withPrivateTailDirectory(task, root = tmpdir()) {
+  return await withPrivateCaptureDirectory({
+    prefix: "eliza-inference-auth-tail-",
+    label: "Worker Tail",
+    task,
+    root,
+  });
+}
+
+export async function withPrivateTraceDirectory(task, root = tmpdir()) {
+  return await withPrivateCaptureDirectory({
+    prefix: "eliza-inference-trace-",
+    label: "Cloudflare trace",
+    task,
+    root,
+  });
 }
 
 async function runCommandToFile({
@@ -492,6 +517,30 @@ async function runPaired({ deploySha, outputDir, env }) {
   }
 }
 
+async function runTraces({ deploySha, outputDir, env, pairedRecords }) {
+  const secrets = requireTraceSecrets(env);
+  const privateRoot = env.RUNNER_TEMP?.trim() || tmpdir();
+  return await withPrivateTraceDirectory(async (directory) => {
+    const evidence = await collectInferenceTraceEvidence({
+      pairedRecords,
+      deploySha,
+      accountId: secrets.cloudflareAccountId,
+      apiToken: secrets.cloudflareApiToken,
+      privateDirectory: directory,
+    });
+    await writeFile(
+      join(outputDir, "inference-traces.json"),
+      `${JSON.stringify(evidence)}\n`,
+      { mode: 0o600, flag: "wx" },
+    );
+    return {
+      status: evidence.status,
+      reason: evidence.reason,
+      coverage: evidence.coverage,
+    };
+  }, privateRoot);
+}
+
 async function runAuth({ deploySha, outputDir, env, runSuspended }) {
   const secrets = requireAuthSecrets(env, runSuspended);
   const privateRoot = env.RUNNER_TEMP?.trim() || tmpdir();
@@ -601,19 +650,49 @@ export async function runCertification(
     { mode: 0o600, flag: "wx" },
   );
   const paired = await runPaired({ ...options, env });
-  const auth = options.runAuth
-    ? await runAuth({ ...options, env })
-    : {
-        skipped: true,
-        reason: "not_requested",
-        suspendedGuard: "not_requested",
-      };
+  // Start trace lookup immediately after the paired calls. Its rejection is
+  // observed here so a slower auth failure cannot create an unhandled promise;
+  // the finally below still waits for private-response cleanup and evidence.
+  const traceOutcomePromise = runTraces({
+    ...options,
+    env,
+    pairedRecords: paired.records,
+  }).then(
+    (value) => ({ value, error: null }),
+    (error) => ({ value: null, error }),
+  );
+  let auth = {
+    skipped: true,
+    reason: "not_requested",
+    suspendedGuard: "not_requested",
+  };
+  let authFailure;
+  let traceOutcome;
+  try {
+    if (options.runAuth) auth = await runAuth({ ...options, env });
+  } catch (error) {
+    // error-policy:J5 the same auth failure is rethrown after the concurrent
+    // trace capture has finished and removed all raw telemetry.
+    authFailure = error;
+  } finally {
+    traceOutcome = await traceOutcomePromise;
+  }
+  if (authFailure && traceOutcome.error) {
+    // error-policy:J2 neither boundary may hide the other; retain both causes
+    // privately while the CLI emits only this bounded category.
+    throw new Error("Auth probe and distributed trace collection both failed", {
+      cause: new AggregateError([authFailure, traceOutcome.error]),
+    });
+  }
+  if (authFailure) throw authFailure;
+  if (traceOutcome.error) throw traceOutcome.error;
   const summary = {
     kind: "cloud_latency_certification",
     deploySha: options.deploySha,
     environment: "staging",
     paired: { records: paired.records.length, counts: paired.counts },
     auth,
+    traces: traceOutcome.value,
   };
   await writeFile(
     join(options.outputDir, "summary.json"),

--- a/packages/cloud/scripts/cloud-latency-certification.test.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.test.mjs
@@ -5,7 +5,7 @@
 
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -15,10 +15,12 @@ import {
   parseCertificationArgs,
   requireAuthSecrets,
   requirePairedSecrets,
+  requireTraceSecrets,
   validateAuthEvidence,
   validatePairedEvidence,
   verifyExactDeployment,
   withPrivateTailDirectory,
+  withPrivateTraceDirectory,
 } from "./cloud-latency-certification.mjs";
 
 const SHA = "a".repeat(40);
@@ -387,5 +389,50 @@ test("private Tail directory is deleted when capture fails", async () => {
     assert.equal(existsSync(observedDirectory), false);
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("trace capture removes private raw bytes on success and failure", async () => {
+  const root = await mkdtemp(join(tmpdir(), "eliza-trace-cleanup-test-"));
+  try {
+    for (const fail of [false, true]) {
+      let observedDirectory;
+      const capture = withPrivateTraceDirectory(async (directory) => {
+        observedDirectory = directory;
+        assert.equal((await stat(directory)).mode & 0o777, 0o700);
+        await writeFile(join(directory, "raw.json"), '{"private":"sentinel"}', {
+          mode: 0o600,
+        });
+        if (fail) throw new Error("trace boundary failed");
+        return { status: "inconclusive_sampling" };
+      }, root);
+      if (fail) await assert.rejects(capture, /trace boundary failed/);
+      else assert.equal((await capture).status, "inconclusive_sampling");
+      assert.equal(existsSync(observedDirectory), false);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("trace credentials fail closed without exposing configured values", () => {
+  const configured = {
+    CLOUDFLARE_API_TOKEN: "private-trace-token",
+    CLOUDFLARE_ACCOUNT_ID: "private-account",
+  };
+  assert.equal(
+    requireTraceSecrets(configured).cloudflareApiToken,
+    configured.CLOUDFLARE_API_TOKEN,
+  );
+  for (const missing of Object.keys(configured)) {
+    assert.throws(
+      () => requireTraceSecrets({ ...configured, [missing]: " " }),
+      (error) => {
+        assert.ok(error.message.includes(missing));
+        assert.ok(!error.message.includes("private-trace-token"));
+        assert.ok(!error.message.includes("private-account"));
+        return true;
+      },
+    );
   }
 });

--- a/packages/cloud/scripts/cloud-latency-certification.test.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.test.mjs
@@ -32,7 +32,7 @@ function pairedRecord(index, overrides = {}) {
     ok: true,
     transportOk: true,
     proofMatched: true,
-    ci: { sha: SHA },
+    ci: { sha: SHA, gatewayDeploySha: SHA },
     headers: index % 2 === 0 ? {} : { "cf-placement": "local-ORD" },
     ...overrides,
   };
@@ -126,6 +126,7 @@ test("parseCertificationArgs requires an exact SHA and explicit output directory
     {
       deploySha: SHA,
       outputDir: join(process.cwd(), "artifacts/cert"),
+      acknowledgedContractDigest: "",
       runAuth: true,
       runSuspended: false,
     },
@@ -308,6 +309,32 @@ test("paired certification requires exactly 44 balanced successful proofs", () =
           SHA,
         ),
       /invalid Worker placement/,
+    );
+  }
+});
+
+test("paired evidence keeps trusted verifier and deployed identities distinct", () => {
+  const sourceSha = "b".repeat(40);
+  const records = Array.from({ length: 44 }, (_, index) =>
+    pairedRecord(index, {
+      ci: { sha: sourceSha, gatewayDeploySha: SHA },
+    }),
+  );
+  assert.equal(
+    validatePairedEvidence(jsonl(records), SHA, sourceSha).records.length,
+    44,
+  );
+  for (const ci of [
+    { sha: SHA, gatewayDeploySha: SHA },
+    { sha: sourceSha, gatewayDeploySha: sourceSha },
+    { sha: sourceSha },
+  ]) {
+    const invalid = records.map((record, index) =>
+      index === 0 ? { ...record, ci } : record,
+    );
+    assert.throws(
+      () => validatePairedEvidence(jsonl(invalid), SHA, sourceSha),
+      /source and deployment SHAs/,
     );
   }
 });

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
@@ -1,0 +1,664 @@
+/**
+ * Collects Cloudflare Worker-to-Durable-Object traces for a completed staging
+ * latency matrix and emits only coarse placement and rounded phase durations.
+ * Raw telemetry and correlation identifiers never cross the private capture
+ * directory boundary.
+ */
+
+import { writeFile } from "node:fs/promises";
+
+const API_ORIGIN = "https://api.cloudflare.com/client/v4";
+const STAGING_WORKER = "eliza-cloud-api-staging";
+const GATE_ORIGIN = "https://inference-admission.internal";
+const QUERY_TIMEOUT_MS = 30_000;
+const QUERY_ATTEMPTS = 8;
+const QUERY_RETRY_MS = 2_500;
+const MAX_EVENTS = 2_000;
+const MAX_TRACE_DURATION_MS = 300_000;
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+const EVENT_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,256}$/;
+const CF_RAY_PATTERN = /^([0-9a-f]{16,32})-([A-Z]{3})$/i;
+const COLO_PATTERN = /^[A-Z]{3}$/;
+const REQUIRED_KEYS = new Map([
+  ["$metadata.duration", "number"],
+  ["$metadata.parentSpanId", "string"],
+  ["$metadata.rayId", "string"],
+  ["$metadata.region", "string"],
+  ["$metadata.service", "string"],
+  ["$metadata.spanId", "string"],
+  ["$metadata.spanName", "string"],
+  ["$metadata.traceId", "string"],
+  ["$metadata.url", "string"],
+]);
+const PHASE_BY_PATH = new Map([
+  ["/rate-limit", "rate"],
+  ["/lease-dispatched", "billing"],
+  ["/lease-dispatched-authorized", "billing"],
+]);
+
+export class CloudflareTraceSchemaError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "CloudflareTraceSchemaError";
+  }
+}
+
+function object(value) {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : null;
+}
+
+function roundDuration(value, label) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value > MAX_TRACE_DURATION_MS
+  ) {
+    throw new CloudflareTraceSchemaError(
+      `Cloudflare trace ${label} is invalid`,
+    );
+  }
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function optionalDuration(value, label) {
+  return value === undefined ? null : roundDuration(value, label);
+}
+
+function coarseColo(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.toUpperCase();
+  return COLO_PATTERN.test(normalized) ? normalized : null;
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (cause) {
+    // error-policy:J2 retain the parser cause privately while the public error
+    // contains no response bytes.
+    throw new CloudflareTraceSchemaError(
+      `Cloudflare ${label} response is not valid JSON`,
+      { cause },
+    );
+  }
+}
+
+function readEnvelope(text, label, arrayResult = false) {
+  const envelope = object(parseJson(text, label));
+  if (
+    envelope?.success !== true ||
+    !Array.isArray(envelope.errors) ||
+    envelope.errors.length !== 0 ||
+    !(arrayResult ? Array.isArray(envelope.result) : object(envelope.result))
+  ) {
+    throw new CloudflareTraceSchemaError(
+      `Cloudflare ${label} response failed its envelope contract`,
+    );
+  }
+  return envelope.result;
+}
+
+export function pairedGatewayTraceWindow(records) {
+  const references = [];
+  const seenRays = new Set();
+  for (const record of records) {
+    if (record?.target !== "gateway") continue;
+    const observedAt = Date.parse(record.observedAt);
+    const rayHeader = record.headers?.["cf-ray"];
+    const match =
+      typeof rayHeader === "string" ? CF_RAY_PATTERN.exec(rayHeader) : null;
+    if (
+      !match ||
+      !Number.isSafeInteger(record.sequence) ||
+      record.sequence < 0 ||
+      !Number.isFinite(observedAt)
+    ) {
+      throw new CloudflareTraceSchemaError(
+        "Gateway latency evidence lacks trace correlation metadata",
+      );
+    }
+    const rayId = match[1].toLowerCase();
+    if (seenRays.has(rayId)) {
+      throw new CloudflareTraceSchemaError(
+        "Gateway latency evidence reused a Cloudflare Ray",
+      );
+    }
+    seenRays.add(rayId);
+    references.push({
+      rayId,
+      sequence: record.sequence,
+      workerColo: match[2].toUpperCase(),
+      observedAt,
+    });
+  }
+  if (references.length !== 22) {
+    throw new CloudflareTraceSchemaError(
+      "Gateway latency evidence must contain 22 traceable requests",
+    );
+  }
+  const observed = references.map((reference) => reference.observedAt);
+  return {
+    references,
+    timeframe: {
+      from: Math.floor(Math.min(...observed) - 30_000),
+      to: Math.ceil(Math.max(...observed) + 30_000),
+    },
+  };
+}
+
+export function buildTraceKeysRequest(timeframe) {
+  return {
+    from: timeframe.from,
+    to: timeframe.to,
+    keyNeedle: { value: "$metadata.", isRegex: false, matchCase: true },
+    limit: 1_000,
+  };
+}
+
+export function validateTraceKeysResponse(text) {
+  const result = readEnvelope(text, "trace keys", true);
+  if (!Array.isArray(result)) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare trace keys response has no key list",
+    );
+  }
+  const discovered = new Map();
+  for (const item of result) {
+    const entry = object(item);
+    if (
+      entry &&
+      typeof entry.key === "string" &&
+      (entry.type === "string" ||
+        entry.type === "number" ||
+        entry.type === "boolean")
+    ) {
+      discovered.set(entry.key, entry.type);
+    }
+  }
+  for (const [key, type] of REQUIRED_KEYS) {
+    if (discovered.get(key) !== type) {
+      throw new CloudflareTraceSchemaError(
+        `Cloudflare trace key contract changed for ${key}`,
+      );
+    }
+  }
+  return Object.fromEntries(REQUIRED_KEYS);
+}
+
+function filter(key, value) {
+  return { kind: "filter", key, operation: "eq", type: "string", value };
+}
+
+export function buildRootTraceQuery(timeframe, references) {
+  return {
+    queryId: "eliza-inference-trace-roots-v1",
+    timeframe,
+    dry: true,
+    limit: 100,
+    view: "traces",
+    parameters: {
+      filterCombination: "and",
+      filters: [
+        filter("$metadata.service", STAGING_WORKER),
+        {
+          kind: "group",
+          filterCombination: "or",
+          filters: references.map((reference) =>
+            filter("$metadata.rayId", reference.rayId),
+          ),
+        },
+      ],
+    },
+  };
+}
+
+export function buildTraceEventsQuery(timeframe, traceId) {
+  if (!TRACE_ID_PATTERN.test(traceId)) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare returned an invalid trace correlation identifier",
+    );
+  }
+  return {
+    queryId: "eliza-inference-trace-events-v1",
+    timeframe,
+    dry: true,
+    limit: MAX_EVENTS,
+    view: "events",
+    parameters: {
+      filterCombination: "and",
+      filters: [
+        filter("$metadata.service", STAGING_WORKER),
+        filter("$metadata.traceId", traceId),
+      ],
+    },
+  };
+}
+
+function readCompletedRun(result, label) {
+  const run = object(result.run);
+  if (!run || (run.status !== "STARTED" && run.status !== "COMPLETED")) {
+    throw new CloudflareTraceSchemaError(
+      `Cloudflare ${label} response has an invalid run state`,
+    );
+  }
+  return run.status === "COMPLETED";
+}
+
+export function parseRootTraceResponse(text) {
+  const result = readEnvelope(text, "root trace query");
+  if (!readCompletedRun(result, "root trace query")) {
+    return { completed: false, traceIds: [] };
+  }
+  if (!Array.isArray(result.traces)) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare root trace query has no trace summaries",
+    );
+  }
+  const traceIds = [];
+  const seen = new Set();
+  for (const value of result.traces) {
+    const trace = object(value);
+    if (
+      !trace ||
+      !TRACE_ID_PATTERN.test(trace.traceId) ||
+      !Array.isArray(trace.service) ||
+      !trace.service.includes(STAGING_WORKER)
+    ) {
+      throw new CloudflareTraceSchemaError(
+        "Cloudflare root trace summary changed schema",
+      );
+    }
+    if (!seen.has(trace.traceId)) {
+      seen.add(trace.traceId);
+      traceIds.push(trace.traceId);
+    }
+  }
+  if (traceIds.length > 22) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare root trace query exceeded the request matrix",
+    );
+  }
+  return { completed: true, traceIds };
+}
+
+export function parseTraceEventsResponse(text) {
+  const result = readEnvelope(text, "trace events query");
+  if (!readCompletedRun(result, "trace events query")) {
+    return { completed: false, events: [] };
+  }
+  const events = object(result.events);
+  if (!events || !Array.isArray(events.events)) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare trace events query has no event list",
+    );
+  }
+  if (
+    events.count !== undefined &&
+    (!Number.isSafeInteger(events.count) || events.count < events.events.length)
+  ) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare trace events query returned an invalid total",
+    );
+  }
+  if (events.events.length > MAX_EVENTS) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare trace events query exceeded its page limit",
+    );
+  }
+  return {
+    completed: true,
+    events: events.events,
+    total: events.count ?? null,
+  };
+}
+
+function phaseForEvent(event) {
+  const metadata = object(event?.$metadata);
+  if (metadata?.spanName !== "durable_object_subrequest") return null;
+  if (typeof metadata.url !== "string") {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare Durable Object subrequest has no URL classification",
+    );
+  }
+  let url;
+  try {
+    url = new URL(metadata.url);
+  } catch (cause) {
+    // error-policy:J2 retain URL parser context without exposing the raw URL.
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare Durable Object subrequest URL is invalid",
+      { cause },
+    );
+  }
+  if (url.origin !== GATE_ORIGIN) return null;
+  const phase = PHASE_BY_PATH.get(url.pathname);
+  if (!phase) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare inference admission trace contains an unknown phase",
+    );
+  }
+  return phase;
+}
+
+function requireMetadata(event) {
+  const metadata = object(event?.$metadata);
+  if (
+    !metadata ||
+    typeof metadata.id !== "string" ||
+    !EVENT_ID_PATTERN.test(metadata.id) ||
+    typeof metadata.traceId !== "string" ||
+    !TRACE_ID_PATTERN.test(metadata.traceId) ||
+    typeof metadata.service !== "string" ||
+    metadata.service !== STAGING_WORKER
+  ) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare trace event changed its metadata schema",
+    );
+  }
+  return metadata;
+}
+
+function isDescendant(metadata, ancestorSpanId, bySpanId) {
+  const visited = new Set();
+  let parent = metadata.parentSpanId;
+  while (typeof parent === "string" && !visited.has(parent)) {
+    if (parent === ancestorSpanId) return true;
+    visited.add(parent);
+    parent = bySpanId.get(parent)?.parentSpanId;
+  }
+  return false;
+}
+
+function sanitizePhase(subrequest, phase, events, bySpanId) {
+  const metadata = requireMetadata(subrequest);
+  if (typeof metadata.spanId !== "string") {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare Durable Object subrequest has no span identity",
+    );
+  }
+  const roots = events.filter((event) => {
+    const childMetadata = requireMetadata(event);
+    const workers = object(event.$workers);
+    return (
+      childMetadata.parentSpanId === metadata.spanId &&
+      workers?.entrypoint === "InferenceAdmissionGate" &&
+      workers.executionModel === "durableObject"
+    );
+  });
+  if (roots.length !== 1) return null;
+  const root = roots[0];
+  const rootMetadata = requireMetadata(root);
+  if (typeof rootMetadata.spanId !== "string") return null;
+  const workers = object(root.$workers);
+  const doColo = coarseColo(rootMetadata.region);
+  if (!doColo) return null;
+  const storage = events.filter((event) => {
+    const candidate = requireMetadata(event);
+    return (
+      typeof candidate.spanName === "string" &&
+      candidate.spanName.startsWith("durable_object_storage_") &&
+      isDescendant(candidate, rootMetadata.spanId, bySpanId)
+    );
+  });
+  let storageMs = 0;
+  for (const event of storage) {
+    storageMs += roundDuration(
+      requireMetadata(event).duration,
+      "storage duration",
+    );
+  }
+  return {
+    phase,
+    workerColo: coarseColo(metadata.region),
+    doColo,
+    subrequestMs: roundDuration(metadata.duration, "subrequest duration"),
+    doWallMs: optionalDuration(
+      workers.wallTimeMs ?? rootMetadata.duration,
+      "Durable Object wall duration",
+    ),
+    storageMs: Math.round(storageMs * 100) / 100,
+    storageSpans: storage.length,
+  };
+}
+
+export function sanitizeTraceEvents(rawEvents, references) {
+  const events = rawEvents.map((event) => {
+    const value = object(event);
+    if (!value) {
+      throw new CloudflareTraceSchemaError(
+        "Cloudflare trace event is not an object",
+      );
+    }
+    requireMetadata(value);
+    return value;
+  });
+  const bySpanId = new Map();
+  for (const event of events) {
+    const metadata = requireMetadata(event);
+    if (typeof metadata.spanId === "string")
+      bySpanId.set(metadata.spanId, metadata);
+  }
+  const rayRoots = events.filter((event) => {
+    const metadata = requireMetadata(event);
+    return typeof metadata.rayId === "string";
+  });
+  const matchedReferences = new Set();
+  for (const event of rayRoots) {
+    const rayId = requireMetadata(event).rayId.toLowerCase();
+    const reference = references.find((candidate) => candidate.rayId === rayId);
+    if (reference) matchedReferences.add(reference);
+  }
+  if (matchedReferences.size !== 1) return null;
+  const [reference] = matchedReferences;
+  const subrequests = events
+    .map((event) => ({ event, phase: phaseForEvent(event) }))
+    .filter((candidate) => candidate.phase !== null);
+  const counts = new Map();
+  for (const candidate of subrequests) {
+    counts.set(candidate.phase, (counts.get(candidate.phase) ?? 0) + 1);
+  }
+  if (counts.get("rate") !== 1 || counts.get("billing") !== 1) return null;
+  const phases = subrequests.map(({ event, phase }) =>
+    sanitizePhase(event, phase, events, bySpanId),
+  );
+  if (phases.some((phase) => phase === null)) return null;
+  return {
+    sample: reference.sequence,
+    workerColo: reference.workerColo,
+    phases: Object.fromEntries(phases.map((phase) => [phase.phase, phase])),
+  };
+}
+
+async function writeRaw(directory, sequence, label, text) {
+  const path = `${directory}/${String(sequence).padStart(3, "0")}-${label}.json`;
+  await writeFile(path, text, { mode: 0o600, flag: "wx" });
+}
+
+async function apiRequest({
+  accountId,
+  apiToken,
+  endpoint,
+  body,
+  privateDirectory,
+  rawSequence,
+  rawLabel,
+  fetchImpl,
+}) {
+  let response;
+  try {
+    response = await fetchImpl(
+      `${API_ORIGIN}/accounts/${encodeURIComponent(accountId)}/workers/observability/telemetry/${endpoint}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(QUERY_TIMEOUT_MS),
+      },
+    );
+  } catch (cause) {
+    // error-policy:J2 preserve the transport cause without copying its URL or
+    // credential-bearing request into the bounded diagnostic message.
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare trace telemetry request failed",
+      { cause },
+    );
+  }
+  const text = await response.text();
+  await writeRaw(privateDirectory, rawSequence, rawLabel, text);
+  if (!response.ok) {
+    throw new CloudflareTraceSchemaError(
+      `Cloudflare trace telemetry returned HTTP ${response.status}`,
+    );
+  }
+  return text;
+}
+
+async function completedQuery(options, body, parser, label, state) {
+  for (let attempt = 0; attempt < QUERY_ATTEMPTS; attempt++) {
+    if (attempt > 0) await options.sleepImpl(QUERY_RETRY_MS);
+    const text = await apiRequest({
+      ...options,
+      endpoint: "query",
+      body,
+      rawSequence: state.rawSequence++,
+      rawLabel: `${label}-${attempt + 1}`,
+    });
+    const parsed = parser(text);
+    if (parsed.completed) return parsed;
+  }
+  throw new CloudflareTraceSchemaError(
+    `Cloudflare ${label} query did not complete`,
+  );
+}
+
+async function completeTraceEvents(options, body, state) {
+  const events = [];
+  const seenIds = new Set();
+  let offset;
+  let total = null;
+  // Bound diagnostic work explicitly; never report partial pages as a trace.
+  for (let page = 0; page < 20; page++) {
+    const response = await completedQuery(
+      options,
+      { ...body, ...(offset === undefined ? {} : { offset }) },
+      parseTraceEventsResponse,
+      "events",
+      state,
+    );
+    if (total !== null && response.total !== null && total !== response.total) {
+      throw new CloudflareTraceSchemaError(
+        "Cloudflare trace total changed during pagination",
+      );
+    }
+    total = response.total ?? total;
+    for (const event of response.events) {
+      const metadata = requireMetadata(event);
+      if (
+        metadata.traceId !== body.parameters.filters[1].value ||
+        seenIds.has(metadata.id)
+      ) {
+        throw new CloudflareTraceSchemaError(
+          "Cloudflare trace pagination returned unrelated or repeated events",
+        );
+      }
+      seenIds.add(metadata.id);
+      events.push(event);
+    }
+    if (total !== null && events.length > total) {
+      throw new CloudflareTraceSchemaError(
+        "Cloudflare trace pagination exceeded its total",
+      );
+    }
+    if (
+      total !== null
+        ? events.length === total
+        : response.events.length < MAX_EVENTS
+    )
+      return events;
+    if (response.events.length === 0) {
+      throw new CloudflareTraceSchemaError(
+        "Cloudflare trace pagination ended before its total",
+      );
+    }
+    offset = requireMetadata(response.events.at(-1)).id;
+  }
+  throw new CloudflareTraceSchemaError(
+    "Cloudflare trace pagination exceeded its diagnostic budget",
+  );
+}
+
+export async function collectInferenceTraceEvidence({
+  pairedRecords,
+  deploySha,
+  accountId,
+  apiToken,
+  privateDirectory,
+  fetchImpl = fetch,
+  sleepImpl = (duration) =>
+    new Promise((resolvePromise) => setTimeout(resolvePromise, duration)),
+}) {
+  const { references, timeframe } = pairedGatewayTraceWindow(pairedRecords);
+  const state = { rawSequence: 1 };
+  const requestOptions = {
+    accountId,
+    apiToken,
+    privateDirectory,
+    fetchImpl,
+    sleepImpl,
+  };
+  const keysText = await apiRequest({
+    ...requestOptions,
+    endpoint: "keys",
+    body: buildTraceKeysRequest(timeframe),
+    rawSequence: state.rawSequence++,
+    rawLabel: "keys",
+  });
+  validateTraceKeysResponse(keysText);
+  const rootQuery = await completedQuery(
+    requestOptions,
+    buildRootTraceQuery(timeframe, references),
+    parseRootTraceResponse,
+    "roots",
+    state,
+  );
+  const complete = [];
+  let incompleteTraces = 0;
+  for (const traceId of rootQuery.traceIds) {
+    const events = await completeTraceEvents(
+      requestOptions,
+      buildTraceEventsQuery(timeframe, traceId),
+      state,
+    );
+    const sample = sanitizeTraceEvents(events, references);
+    if (sample) complete.push(sample);
+    else incompleteTraces++;
+  }
+  complete.sort((left, right) => left.sample - right.sample);
+  const status = complete.length > 0 ? "observed" : "inconclusive_sampling";
+  return {
+    schemaVersion: 1,
+    kind: "inference_distributed_trace_evidence",
+    deploySha,
+    environment: "staging",
+    status,
+    reason:
+      status === "observed"
+        ? null
+        : rootQuery.traceIds.length === 0
+          ? "no_sampled_traces"
+          : "sampled_traces_incomplete",
+    coverage: {
+      gatewayRequests: references.length,
+      sampledTraces: rootQuery.traceIds.length,
+      completeTraces: complete.length,
+      incompleteTraces,
+    },
+    samples: complete,
+  };
+}

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
@@ -6,6 +6,7 @@
  */
 
 import { writeFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 
 const API_ORIGIN = "https://api.cloudflare.com/client/v4";
 const STAGING_WORKER = "eliza-cloud-api-staging";
@@ -13,6 +14,9 @@ const GATE_ORIGIN = "https://inference-admission.internal";
 const QUERY_TIMEOUT_MS = 30_000;
 const QUERY_ATTEMPTS = 8;
 const QUERY_RETRY_MS = 2_500;
+const SEMANTIC_SETTLE_ROUNDS = 8;
+const DISCOVERY_SLICE_MS = 10_000;
+const MIN_DISCOVERY_SLICE_MS = 5_000;
 const MAX_EVENTS = 2_000;
 const MAX_TRACE_DURATION_MS = 300_000;
 const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
@@ -147,6 +151,30 @@ export function pairedGatewayTraceWindow(records) {
       to: Math.ceil(Math.max(...observed) + 30_000),
     },
   };
+}
+
+/** Divide a trace window into the bounded slices required by repository policy. */
+export function traceDiscoverySlices(timeframe) {
+  if (
+    !Number.isSafeInteger(timeframe?.from) ||
+    !Number.isSafeInteger(timeframe?.to) ||
+    timeframe.from >= timeframe.to ||
+    timeframe.to - timeframe.from < MIN_DISCOVERY_SLICE_MS
+  ) {
+    throw new CloudflareTraceSchemaError(
+      "Cloudflare trace discovery timeframe is invalid",
+    );
+  }
+  const duration = timeframe.to - timeframe.from;
+  const sliceCount = Math.ceil(duration / DISCOVERY_SLICE_MS);
+  const slices = [];
+  for (let index = 0; index < sliceCount; index++) {
+    slices.push({
+      from: Math.floor(timeframe.from + (duration * index) / sliceCount),
+      to: Math.floor(timeframe.from + (duration * (index + 1)) / sliceCount),
+    });
+  }
+  return slices;
 }
 
 export function buildTraceKeysRequest(timeframe) {
@@ -319,9 +347,7 @@ function phaseForEvent(event) {
   const metadata = object(event?.$metadata);
   if (metadata?.spanName !== "durable_object_subrequest") return null;
   if (typeof metadata.url !== "string") {
-    throw new CloudflareTraceSchemaError(
-      "Cloudflare Durable Object subrequest has no URL classification",
-    );
+    return undefined;
   }
   let url;
   try {
@@ -403,9 +429,9 @@ function sanitizePhase(subrequest, phase, events, bySpanId) {
       isDescendant(candidate, rootMetadata.spanId, bySpanId)
     );
   });
-  let storageMs = 0;
+  let storageInclusiveSumMs = 0;
   for (const event of storage) {
-    storageMs += roundDuration(
+    storageInclusiveSumMs += roundDuration(
       requireMetadata(event).duration,
       "storage duration",
     );
@@ -419,7 +445,7 @@ function sanitizePhase(subrequest, phase, events, bySpanId) {
       workers.wallTimeMs ?? rootMetadata.duration,
       "Durable Object wall duration",
     ),
-    storageMs: Math.round(storageMs * 100) / 100,
+    storageInclusiveSumMs: Math.round(storageInclusiveSumMs * 100) / 100,
     storageSpans: storage.length,
   };
 }
@@ -467,6 +493,9 @@ export function sanitizeTraceEvents(rawEvents, references) {
   const subrequests = events
     .map((event) => ({ event, phase: phaseForEvent(event) }))
     .filter((candidate) => candidate.phase !== null);
+  if (subrequests.some((candidate) => candidate.phase === undefined)) {
+    return null;
+  }
   const counts = new Map();
   for (const candidate of subrequests) {
     counts.set(candidate.phase, (counts.get(candidate.phase) ?? 0) + 1);
@@ -562,7 +591,10 @@ async function completeTraceEvents(options, body, state) {
   for (let page = 0; page < 20; page++) {
     const response = await completedQuery(
       options,
-      { ...body, ...(offset === undefined ? {} : { offset }) },
+      {
+        ...body,
+        ...(offset === undefined ? {} : { offset, offsetDirection: "next" }),
+      },
       parseTraceEventsResponse,
       "events",
       state,
@@ -609,6 +641,90 @@ async function completeTraceEvents(options, body, state) {
   );
 }
 
+async function discoverSettledRootTraces(
+  options,
+  timeframe,
+  references,
+  state,
+) {
+  const slices = traceDiscoverySlices(timeframe);
+  const traceIds = new Set();
+  const traceIdsBySlice = slices.map(() => new Set());
+  for (let round = 0; round < SEMANTIC_SETTLE_ROUNDS; round++) {
+    if (round > 0) await options.sleepImpl(QUERY_RETRY_MS);
+    for (let sliceIndex = 0; sliceIndex < slices.length; sliceIndex++) {
+      const response = await completedQuery(
+        options,
+        buildRootTraceQuery(slices[sliceIndex], references),
+        parseRootTraceResponse,
+        `roots-s${sliceIndex + 1}-r${round + 1}`,
+        state,
+      );
+      for (const traceId of response.traceIds) {
+        traceIds.add(traceId);
+        traceIdsBySlice[sliceIndex].add(traceId);
+      }
+    }
+  }
+  return {
+    traceIds: [...traceIds],
+    discoverySlices: slices.map((slice, index) => ({
+      fromUtc: new Date(slice.from).toISOString(),
+      toUtc: new Date(slice.to).toISOString(),
+      sampledTraces: traceIdsBySlice[index].size,
+    })),
+    settleRounds: SEMANTIC_SETTLE_ROUNDS,
+  };
+}
+
+async function settleTraceSample(options, body, references, state) {
+  const slices = traceDiscoverySlices(body.timeframe);
+  const eventsById = new Map();
+  const eventIdsBySlice = slices.map(() => new Set());
+  for (let round = 0; round < SEMANTIC_SETTLE_ROUNDS; round++) {
+    if (round > 0) await options.sleepImpl(QUERY_RETRY_MS);
+    for (let sliceIndex = 0; sliceIndex < slices.length; sliceIndex++) {
+      const events = await completeTraceEvents(
+        options,
+        { ...body, timeframe: slices[sliceIndex] },
+        state,
+      );
+      for (const event of events) {
+        const metadata = requireMetadata(event);
+        const prior = eventsById.get(metadata.id);
+        if (prior && !isDeepStrictEqual(prior, event)) {
+          throw new CloudflareTraceSchemaError(
+            "Cloudflare trace slices returned conflicting event records",
+          );
+        }
+        eventsById.set(metadata.id, event);
+        eventIdsBySlice[sliceIndex].add(metadata.id);
+      }
+    }
+    const sample = sanitizeTraceEvents([...eventsById.values()], references);
+    const eventSweep = {
+      settleRounds: round + 1,
+      slices: slices.map((slice, index) => ({
+        fromUtc: new Date(slice.from).toISOString(),
+        toUtc: new Date(slice.to).toISOString(),
+        eventCount: eventIdsBySlice[index].size,
+      })),
+    };
+    if (sample) return { sample, eventSweep };
+  }
+  return {
+    sample: null,
+    eventSweep: {
+      settleRounds: SEMANTIC_SETTLE_ROUNDS,
+      slices: slices.map((slice, index) => ({
+        fromUtc: new Date(slice.from).toISOString(),
+        toUtc: new Date(slice.to).toISOString(),
+        eventCount: eventIdsBySlice[index].size,
+      })),
+    },
+  };
+}
+
 export async function collectInferenceTraceEvidence({
   pairedRecords,
   deploySha,
@@ -636,23 +752,24 @@ export async function collectInferenceTraceEvidence({
     rawLabel: "keys",
   });
   validateTraceKeysResponse(keysText);
-  const rootQuery = await completedQuery(
+  const rootDiscovery = await discoverSettledRootTraces(
     requestOptions,
-    buildRootTraceQuery(timeframe, references),
-    parseRootTraceResponse,
-    "roots",
+    timeframe,
+    references,
     state,
   );
   const complete = [];
+  const eventSweeps = [];
   let incompleteTraces = 0;
-  for (const traceId of rootQuery.traceIds) {
-    const events = await completeTraceEvents(
+  for (const traceId of rootDiscovery.traceIds) {
+    const settled = await settleTraceSample(
       requestOptions,
       buildTraceEventsQuery(timeframe, traceId),
+      references,
       state,
     );
-    const sample = sanitizeTraceEvents(events, references);
-    if (sample) complete.push(sample);
+    eventSweeps.push(settled.eventSweep);
+    if (settled.sample) complete.push(settled.sample);
     else incompleteTraces++;
   }
   complete.sort((left, right) => left.sample - right.sample);
@@ -666,14 +783,17 @@ export async function collectInferenceTraceEvidence({
     reason:
       status === "observed"
         ? null
-        : rootQuery.traceIds.length === 0
+        : rootDiscovery.traceIds.length === 0
           ? "no_sampled_traces"
           : "sampled_traces_incomplete",
     coverage: {
       gatewayRequests: references.length,
-      sampledTraces: rootQuery.traceIds.length,
+      sampledTraces: rootDiscovery.traceIds.length,
       completeTraces: complete.length,
       incompleteTraces,
+      settleRounds: rootDiscovery.settleRounds,
+      discoverySlices: rootDiscovery.discoverySlices,
+      eventSweeps,
     },
     samples: complete,
   };

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
@@ -453,6 +453,17 @@ export function sanitizeTraceEvents(rawEvents, references) {
   }
   if (matchedReferences.size !== 1) return null;
   const [reference] = matchedReferences;
+  const workerRoots = rayRoots.filter((event) => {
+    const metadata = requireMetadata(event);
+    return (
+      metadata.rayId.toLowerCase() === reference.rayId &&
+      metadata.spanName === "fetch" &&
+      object(event.$workers)?.executionModel === "stateless"
+    );
+  });
+  if (workerRoots.length !== 1) return null;
+  const workerColo = coarseColo(requireMetadata(workerRoots[0]).region);
+  if (!workerColo) return null;
   const subrequests = events
     .map((event) => ({ event, phase: phaseForEvent(event) }))
     .filter((candidate) => candidate.phase !== null);
@@ -467,7 +478,12 @@ export function sanitizeTraceEvents(rawEvents, references) {
   if (phases.some((phase) => phase === null)) return null;
   return {
     sample: reference.sequence,
-    workerColo: reference.workerColo,
+    ingressColo: reference.workerColo,
+    workerColo,
+    workerWallMs: roundDuration(
+      requireMetadata(workerRoots[0]).duration,
+      "Worker root duration",
+    ),
     phases: Object.fromEntries(phases.map((phase) => [phase.phase, phase])),
   };
 }

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
@@ -1,0 +1,640 @@
+/**
+ * Exercises the real Cloudflare Observability response boundary with synthetic
+ * API envelopes; no network, credentials, or provider calls are used.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  buildRootTraceQuery,
+  buildTraceEventsQuery,
+  buildTraceKeysRequest,
+  CloudflareTraceSchemaError,
+  collectInferenceTraceEvidence,
+  pairedGatewayTraceWindow,
+  parseRootTraceResponse,
+  parseTraceEventsResponse,
+  sanitizeTraceEvents,
+  validateTraceKeysResponse,
+} from "./cloudflare-inference-trace-evidence.mjs";
+
+const SHA = "a".repeat(40);
+const TRACE_A = "1".repeat(32);
+const TRACE_B = "2".repeat(32);
+const REQUIRED_KEYS = [
+  ["$metadata.duration", "number"],
+  ["$metadata.parentSpanId", "string"],
+  ["$metadata.rayId", "string"],
+  ["$metadata.region", "string"],
+  ["$metadata.service", "string"],
+  ["$metadata.spanId", "string"],
+  ["$metadata.spanName", "string"],
+  ["$metadata.traceId", "string"],
+  ["$metadata.url", "string"],
+];
+
+function apiEnvelope(result) {
+  return JSON.stringify({ success: true, errors: [], messages: [], result });
+}
+
+function keysEnvelope(overrides = REQUIRED_KEYS) {
+  return apiEnvelope(
+    overrides.map(([key, type], index) => ({
+      key,
+      type,
+      lastSeenAt: 1_780_000_000_000 + index,
+    })),
+  );
+}
+
+function pairedRecords() {
+  const records = [];
+  for (let index = 0; index < 22; index++) {
+    records.push({
+      target: "gateway",
+      sequence: index + 1,
+      observedAt: new Date(1_780_000_000_000 + index * 500).toISOString(),
+      headers: {
+        "cf-ray": `${(index + 1).toString(16).padStart(16, "0")}-ORD`,
+      },
+    });
+    records.push({ target: "direct", sequence: index + 1 });
+  }
+  return records;
+}
+
+function event({
+  id,
+  traceId = TRACE_A,
+  spanId,
+  parentSpanId,
+  spanName,
+  duration,
+  region,
+  rayId,
+  url,
+  workers,
+  privateValue = "private-request-value",
+}) {
+  return {
+    $metadata: {
+      id,
+      traceId,
+      service: "eliza-cloud-api-staging",
+      spanId,
+      ...(parentSpanId && { parentSpanId }),
+      spanName,
+      duration,
+      region,
+      ...(rayId && { rayId }),
+      ...(url && { url }),
+      secretMetadata: privateValue,
+    },
+    dataset: "cloudflare-workers",
+    timestamp: 1_780_000_000_000,
+    source: {
+      headers: { authorization: privateValue },
+      requestBody: privateValue,
+      url: `https://private.invalid/${privateValue}`,
+    },
+    ...(workers
+      ? {
+          $workers: {
+            ...workers,
+            durableObjectId: privateValue,
+            event: { body: privateValue },
+            requestId: privateValue,
+          },
+        }
+      : {}),
+  };
+}
+
+function completeTraceEvents({
+  traceId = TRACE_A,
+  rayId = "0000000000000001",
+  privateValue,
+} = {}) {
+  return [
+    event({
+      id: "root",
+      traceId,
+      spanId: "span-root",
+      spanName: "fetch",
+      duration: 185,
+      region: "ORD",
+      rayId,
+      url: "https://api-staging.eliza.app/api/v1/chat/completions",
+      workers: {
+        eventType: "fetch",
+        scriptName: "eliza-cloud-api-staging",
+        executionModel: "stateless",
+      },
+      privateValue,
+    }),
+    event({
+      id: "rate-subrequest",
+      traceId,
+      spanId: "span-rate-subrequest",
+      parentSpanId: "span-root",
+      spanName: "durable_object_subrequest",
+      duration: 58.123,
+      region: "ORD",
+      url: "https://inference-admission.internal/rate-limit",
+      privateValue,
+    }),
+    event({
+      id: "rate-root",
+      traceId,
+      spanId: "span-rate-root",
+      parentSpanId: "span-rate-subrequest",
+      spanName: "fetch",
+      duration: 4.5,
+      region: "EWR",
+      workers: {
+        eventType: "fetch",
+        scriptName: "eliza-cloud-api-staging",
+        executionModel: "durableObject",
+        entrypoint: "InferenceAdmissionGate",
+        wallTimeMs: 4.456,
+      },
+      privateValue,
+    }),
+    event({
+      id: "rate-storage",
+      traceId,
+      spanId: "span-rate-storage",
+      parentSpanId: "span-rate-root",
+      spanName: "durable_object_storage_kv_put",
+      duration: 1.255,
+      region: "EWR",
+      privateValue,
+    }),
+    event({
+      id: "billing-subrequest",
+      traceId,
+      spanId: "span-billing-subrequest",
+      parentSpanId: "span-root",
+      spanName: "durable_object_subrequest",
+      duration: 49.987,
+      region: "ORD",
+      url: "https://inference-admission.internal/lease-dispatched-authorized",
+      privateValue,
+    }),
+    event({
+      id: "billing-root",
+      traceId,
+      spanId: "span-billing-root",
+      parentSpanId: "span-billing-subrequest",
+      spanName: "fetch",
+      duration: 5.5,
+      region: "IAD",
+      workers: {
+        eventType: "fetch",
+        scriptName: "eliza-cloud-api-staging",
+        executionModel: "durableObject",
+        entrypoint: "InferenceAdmissionGate",
+        wallTimeMs: 5.444,
+      },
+      privateValue,
+    }),
+    event({
+      id: "billing-storage-one",
+      traceId,
+      spanId: "span-billing-storage-one",
+      parentSpanId: "span-billing-root",
+      spanName: "durable_object_storage_kv_put",
+      duration: 1.1,
+      region: "IAD",
+      privateValue,
+    }),
+    event({
+      id: "billing-storage-two",
+      traceId,
+      spanId: "span-billing-storage-two",
+      parentSpanId: "span-billing-storage-one",
+      spanName: "durable_object_storage_alarms_setAlarm",
+      duration: 0.25,
+      region: "IAD",
+      privateValue,
+    }),
+  ];
+}
+
+function queryEnvelope(view, value, status = "COMPLETED") {
+  return apiEnvelope({
+    run: { status },
+    statistics: { bytes_read: 1, elapsed: 0.01, rows_read: 1 },
+    ...(view === "traces" ? { traces: value } : {}),
+    ...(view === "events"
+      ? {
+          events: {
+            count: value.length,
+            events: value,
+            fields: [],
+            series: [],
+          },
+        }
+      : {}),
+  });
+}
+
+test("gateway references produce one bounded exact request window", () => {
+  const result = pairedGatewayTraceWindow(pairedRecords());
+  assert.equal(result.references.length, 22);
+  assert.deepEqual(result.references[0], {
+    rayId: "0000000000000001",
+    sequence: 1,
+    workerColo: "ORD",
+    observedAt: 1_780_000_000_000,
+  });
+  assert.deepEqual(result.timeframe, {
+    from: 1_779_999_970_000,
+    to: 1_780_000_040_500,
+  });
+  assert.throws(
+    () =>
+      pairedGatewayTraceWindow(
+        pairedRecords().map((record, index) =>
+          index === 0
+            ? { ...record, headers: { "cf-ray": "invalid" } }
+            : record,
+        ),
+      ),
+    CloudflareTraceSchemaError,
+  );
+});
+
+test("request builders use only official ad-hoc telemetry query fields", () => {
+  const { references, timeframe } = pairedGatewayTraceWindow(pairedRecords());
+  assert.deepEqual(buildTraceKeysRequest(timeframe), {
+    from: timeframe.from,
+    to: timeframe.to,
+    keyNeedle: { value: "$metadata.", isRegex: false, matchCase: true },
+    limit: 1_000,
+  });
+  const roots = buildRootTraceQuery(timeframe, references);
+  assert.equal(roots.view, "traces");
+  assert.equal(roots.dry, true);
+  assert.equal(roots.parameters.filters[1].filters.length, 22);
+  const events = buildTraceEventsQuery(timeframe, TRACE_A);
+  assert.equal(events.view, "events");
+  assert.deepEqual(events.parameters.filters[1], {
+    kind: "filter",
+    key: "$metadata.traceId",
+    operation: "eq",
+    type: "string",
+    value: TRACE_A,
+  });
+});
+
+test("key discovery validates every filter and sanitizer field before querying", () => {
+  assert.equal(
+    validateTraceKeysResponse(keysEnvelope())["$metadata.traceId"],
+    "string",
+  );
+  assert.throws(
+    () => validateTraceKeysResponse(keysEnvelope(REQUIRED_KEYS.slice(1))),
+    /key contract changed/,
+  );
+  assert.throws(
+    () =>
+      validateTraceKeysResponse(
+        keysEnvelope(
+          REQUIRED_KEYS.map(([key, type]) => [
+            key,
+            key === "$metadata.duration" ? "string" : type,
+          ]),
+        ),
+      ),
+    /duration/,
+  );
+});
+
+test("query parsers distinguish incomplete runs, zero samples, and multiple samples", () => {
+  assert.deepEqual(
+    parseRootTraceResponse(queryEnvelope("traces", [], "STARTED")),
+    { completed: false, traceIds: [] },
+  );
+  assert.deepEqual(parseRootTraceResponse(queryEnvelope("traces", [])), {
+    completed: true,
+    traceIds: [],
+  });
+  assert.deepEqual(
+    parseRootTraceResponse(
+      queryEnvelope(
+        "traces",
+        [TRACE_A, TRACE_B].map((traceId) => ({
+          rootSpanName: "fetch",
+          rootTransactionName: "POST /api/v1/chat/completions",
+          service: ["eliza-cloud-api-staging"],
+          spans: 8,
+          traceDurationMs: 185,
+          traceStartMs: 1_780_000_000_000,
+          traceEndMs: 1_780_000_000_185,
+          traceId,
+        })),
+      ),
+    ),
+    { completed: true, traceIds: [TRACE_A, TRACE_B] },
+  );
+  assert.equal(
+    parseTraceEventsResponse(queryEnvelope("events", completeTraceEvents()))
+      .events.length,
+    8,
+  );
+  assert.throws(
+    () =>
+      parseTraceEventsResponse(
+        apiEnvelope({
+          run: { status: "COMPLETED" },
+          events: { count: 7, events: completeTraceEvents() },
+        }),
+      ),
+    /invalid total/,
+  );
+});
+
+test("sanitizer emits only phase, coarse colo, rounded duration, and coverage inputs", () => {
+  const privateValue = "secret-account-request-object-id";
+  const { references } = pairedGatewayTraceWindow(pairedRecords());
+  const sample = sanitizeTraceEvents(
+    completeTraceEvents({ privateValue }),
+    references,
+  );
+  assert.deepEqual(sample, {
+    sample: 1,
+    workerColo: "ORD",
+    phases: {
+      rate: {
+        phase: "rate",
+        workerColo: "ORD",
+        doColo: "EWR",
+        subrequestMs: 58.12,
+        doWallMs: 4.46,
+        storageMs: 1.26,
+        storageSpans: 1,
+      },
+      billing: {
+        phase: "billing",
+        workerColo: "ORD",
+        doColo: "IAD",
+        subrequestMs: 49.99,
+        doWallMs: 5.44,
+        storageMs: 1.35,
+        storageSpans: 2,
+      },
+    },
+  });
+  const serialized = JSON.stringify(sample);
+  assert.equal(serialized.includes(privateValue), false);
+  for (const forbidden of [
+    "traceId",
+    "spanId",
+    "rayId",
+    "requestId",
+    "durableObjectId",
+    "authorization",
+    "headers",
+    "source",
+    "url",
+  ]) {
+    assert.equal(serialized.includes(forbidden), false);
+  }
+});
+
+test("unknown admission paths fail closed while missing sampled spans remain inconclusive", () => {
+  const { references } = pairedGatewayTraceWindow(pairedRecords());
+  const unknown = completeTraceEvents();
+  unknown.find(
+    (value) => value.$metadata.id === "rate-subrequest",
+  ).$metadata.url = "https://inference-admission.internal/unreviewed-operation";
+  assert.throws(
+    () => sanitizeTraceEvents(unknown, references),
+    /unknown phase/,
+  );
+  assert.equal(
+    sanitizeTraceEvents(
+      completeTraceEvents().filter(
+        (value) => value.$metadata.id !== "billing-root",
+      ),
+      references,
+    ),
+    null,
+  );
+});
+
+test("collector reports zero sampled traces explicitly and removes no privacy fields", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
+  const calls = [];
+  try {
+    const evidence = await collectInferenceTraceEvidence({
+      pairedRecords: pairedRecords(),
+      deploySha: SHA,
+      accountId: "private-account-id",
+      apiToken: "private-api-token",
+      privateDirectory: directory,
+      sleepImpl: async () => {},
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return new Response(
+          calls.length === 1 ? keysEnvelope() : queryEnvelope("traces", []),
+        );
+      },
+    });
+    assert.equal(evidence.status, "inconclusive_sampling");
+    assert.equal(evidence.reason, "no_sampled_traces");
+    assert.deepEqual(evidence.coverage, {
+      gatewayRequests: 22,
+      sampledTraces: 0,
+      completeTraces: 0,
+      incompleteTraces: 0,
+    });
+    assert.deepEqual(evidence.samples, []);
+    assert.equal(calls.length, 2);
+    assert.match(calls[0].url, /\/telemetry\/keys$/);
+    assert.equal(calls[0].init.method, "POST");
+    assert.equal(
+      calls[0].init.headers.Authorization,
+      "Bearer private-api-token",
+    );
+    const serialized = JSON.stringify(evidence);
+    assert.equal(serialized.includes("private-account-id"), false);
+    assert.equal(serialized.includes("private-api-token"), false);
+    assert.equal(
+      (await readFile(join(directory, "001-keys.json"), "utf8")).length > 0,
+      true,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("collector sanitizes one complete sampled trace and polls STARTED runs", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
+  const responses = [
+    keysEnvelope(),
+    queryEnvelope("traces", [], "STARTED"),
+    queryEnvelope("traces", [
+      {
+        rootSpanName: "fetch",
+        rootTransactionName: "POST /api/v1/chat/completions",
+        service: ["eliza-cloud-api-staging"],
+        spans: 8,
+        traceDurationMs: 185,
+        traceStartMs: 1_780_000_000_000,
+        traceEndMs: 1_780_000_000_185,
+        traceId: TRACE_A,
+      },
+    ]),
+    queryEnvelope("events", completeTraceEvents()),
+  ];
+  let sleeps = 0;
+  try {
+    const evidence = await collectInferenceTraceEvidence({
+      pairedRecords: pairedRecords(),
+      deploySha: SHA,
+      accountId: "private-account-id",
+      apiToken: "private-api-token",
+      privateDirectory: directory,
+      sleepImpl: async () => {
+        sleeps++;
+      },
+      fetchImpl: async () => new Response(responses.shift()),
+    });
+    assert.equal(evidence.status, "observed");
+    assert.equal(evidence.reason, null);
+    assert.equal(evidence.samples.length, 1);
+    assert.equal(evidence.coverage.sampledTraces, 1);
+    assert.equal(evidence.coverage.completeTraces, 1);
+    assert.equal(sleeps, 1);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("collector returns sampled-trace incompleteness without fabricating placement", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
+  const incomplete = completeTraceEvents().filter(
+    (value) => value.$metadata.id !== "billing-root",
+  );
+  const responses = [
+    keysEnvelope(),
+    queryEnvelope("traces", [
+      {
+        rootSpanName: "fetch",
+        rootTransactionName: "POST /api/v1/chat/completions",
+        service: ["eliza-cloud-api-staging"],
+        spans: incomplete.length,
+        traceDurationMs: 185,
+        traceStartMs: 1_780_000_000_000,
+        traceEndMs: 1_780_000_000_185,
+        traceId: TRACE_A,
+      },
+    ]),
+    queryEnvelope("events", incomplete),
+  ];
+  try {
+    const evidence = await collectInferenceTraceEvidence({
+      pairedRecords: pairedRecords(),
+      deploySha: SHA,
+      accountId: "private-account-id",
+      apiToken: "private-api-token",
+      privateDirectory: directory,
+      sleepImpl: async () => {},
+      fetchImpl: async () => new Response(responses.shift()),
+    });
+    assert.equal(evidence.status, "inconclusive_sampling");
+    assert.equal(evidence.reason, "sampled_traces_incomplete");
+    assert.deepEqual(evidence.samples, []);
+    assert.equal(evidence.coverage.incompleteTraces, 1);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("API failures never copy private response content into errors", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
+  try {
+    const error = await collectInferenceTraceEvidence({
+      pairedRecords: pairedRecords(),
+      deploySha: SHA,
+      accountId: "private-account-id",
+      apiToken: "private-api-token",
+      privateDirectory: directory,
+      fetchImpl: async () =>
+        new Response('{"secret":"do-not-echo"}', { status: 403 }),
+    }).then(
+      () => null,
+      (failure) => failure,
+    );
+    assert.match(error.message, /HTTP 403/);
+    assert.equal(error.message.includes("do-not-echo"), false);
+    assert.equal(error.message.includes("private-account-id"), false);
+    assert.equal(error.message.includes("private-api-token"), false);
+    assert.equal(existsSync(join(directory, "001-keys.json")), true);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("collector follows event cursors and rejects incomplete or repeated pages", async () => {
+  for (const mode of ["complete", "repeated", "empty", "mixed"]) {
+    const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
+    const events = completeTraceEvents();
+    const secondPage =
+      mode === "empty"
+        ? []
+        : mode === "repeated"
+          ? events.slice(0, 4)
+          : events.slice(4);
+    if (mode === "mixed") secondPage[0].$metadata.traceId = TRACE_B;
+    const responses = [
+      keysEnvelope(),
+      queryEnvelope("traces", [
+        { traceId: TRACE_A, service: ["eliza-cloud-api-staging"] },
+      ]),
+      apiEnvelope({
+        run: { status: "COMPLETED" },
+        events: { count: 8, events: events.slice(0, 4) },
+      }),
+      apiEnvelope({
+        run: { status: "COMPLETED" },
+        events: { count: 8, events: secondPage },
+      }),
+    ];
+    const bodies = [];
+    try {
+      const capture = collectInferenceTraceEvidence({
+        pairedRecords: pairedRecords(),
+        deploySha: SHA,
+        accountId: "private-account",
+        apiToken: "private-token",
+        privateDirectory: directory,
+        fetchImpl: async (_url, init) => {
+          bodies.push(JSON.parse(init.body));
+          assert.ok(
+            responses.length > 0,
+            "collector must terminate within supplied pages",
+          );
+          return new Response(responses.shift());
+        },
+      });
+      if (mode === "complete") {
+        const result = await capture;
+        assert.equal(result.status, "observed");
+        assert.equal(result.samples[0].phases.billing.doColo, "IAD");
+      } else {
+        await assert.rejects(capture, /pagination/);
+      }
+      assert.equal(bodies[3].offset, events[3].$metadata.id);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+});

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
@@ -369,7 +369,9 @@ test("sanitizer emits only phase, coarse colo, rounded duration, and coverage in
   );
   assert.deepEqual(sample, {
     sample: 1,
+    ingressColo: "ORD",
     workerColo: "ORD",
+    workerWallMs: 185,
     phases: {
       rate: {
         phase: "rate",
@@ -581,6 +583,17 @@ test("API failures never copy private response content into errors", async () =>
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+test("trace placement uses the Worker span rather than the ingress Ray colo", () => {
+  const { references } = pairedGatewayTraceWindow(pairedRecords());
+  const events = completeTraceEvents();
+  events[0].$metadata.region = "SJC";
+  const sample = sanitizeTraceEvents(events, references);
+  assert.equal(sample.ingressColo, "ORD");
+  assert.equal(sample.workerColo, "SJC");
+  delete events[0].$metadata.region;
+  assert.equal(sanitizeTraceEvents(events, references), null);
 });
 
 test("collector follows event cursors and rejects incomplete or repeated pages", async () => {

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
@@ -20,12 +20,14 @@ import {
   parseRootTraceResponse,
   parseTraceEventsResponse,
   sanitizeTraceEvents,
+  traceDiscoverySlices,
   validateTraceKeysResponse,
 } from "./cloudflare-inference-trace-evidence.mjs";
 
 const SHA = "a".repeat(40);
 const TRACE_A = "1".repeat(32);
 const TRACE_B = "2".repeat(32);
+const SETTLE_ROUNDS = 8;
 const REQUIRED_KEYS = [
   ["$metadata.duration", "number"],
   ["$metadata.parentSpanId", "string"],
@@ -244,6 +246,25 @@ function queryEnvelope(view, value, status = "COMPLETED") {
   });
 }
 
+function traceSummary(traceId = TRACE_A) {
+  return {
+    rootSpanName: "fetch",
+    rootTransactionName: "POST /api/v1/chat/completions",
+    service: ["eliza-cloud-api-staging"],
+    spans: 8,
+    traceDurationMs: 185,
+    traceStartMs: 1_780_000_000_000,
+    traceEndMs: 1_780_000_000_185,
+    traceId,
+  };
+}
+
+function containsFirstGatewayRequest(timeframe) {
+  return (
+    timeframe.from <= 1_780_000_000_000 && timeframe.to > 1_780_000_000_000
+  );
+}
+
 test("gateway references produce one bounded exact request window", () => {
   const result = pairedGatewayTraceWindow(pairedRecords());
   assert.equal(result.references.length, 22);
@@ -268,6 +289,19 @@ test("gateway references produce one bounded exact request window", () => {
       ),
     CloudflareTraceSchemaError,
   );
+});
+
+test("trace discovery divides the complete window into consecutive 5-10 second slices", () => {
+  const { timeframe } = pairedGatewayTraceWindow(pairedRecords());
+  const slices = traceDiscoverySlices(timeframe);
+  assert.equal(slices.length, 8);
+  assert.equal(slices[0].from, timeframe.from);
+  assert.equal(slices.at(-1).to, timeframe.to);
+  for (let index = 0; index < slices.length; index++) {
+    if (index > 0) assert.equal(slices[index - 1].to, slices[index].from);
+    assert.ok(slices[index].to - slices[index].from >= 5_000);
+    assert.ok(slices[index].to - slices[index].from <= 10_000);
+  }
 });
 
 test("request builders use only official ad-hoc telemetry query fields", () => {
@@ -379,7 +413,7 @@ test("sanitizer emits only phase, coarse colo, rounded duration, and coverage in
         doColo: "EWR",
         subrequestMs: 58.12,
         doWallMs: 4.46,
-        storageMs: 1.26,
+        storageInclusiveSumMs: 1.26,
         storageSpans: 1,
       },
       billing: {
@@ -388,7 +422,7 @@ test("sanitizer emits only phase, coarse colo, rounded duration, and coverage in
         doColo: "IAD",
         subrequestMs: 49.99,
         doWallMs: 5.44,
-        storageMs: 1.35,
+        storageInclusiveSumMs: 1.35,
         storageSpans: 2,
       },
     },
@@ -429,6 +463,10 @@ test("unknown admission paths fail closed while missing sampled spans remain inc
     ),
     null,
   );
+  const missingUrl = completeTraceEvents();
+  delete missingUrl.find((value) => value.$metadata.id === "rate-subrequest")
+    .$metadata.url;
+  assert.equal(sanitizeTraceEvents(missingUrl, references), null);
 });
 
 test("collector reports zero sampled traces explicitly and removes no privacy fields", async () => {
@@ -444,21 +482,29 @@ test("collector reports zero sampled traces explicitly and removes no privacy fi
       sleepImpl: async () => {},
       fetchImpl: async (url, init) => {
         calls.push({ url, init });
-        return new Response(
-          calls.length === 1 ? keysEnvelope() : queryEnvelope("traces", []),
-        );
+        if (url.endsWith("/keys")) return new Response(keysEnvelope());
+        assert.equal(JSON.parse(init.body).view, "traces");
+        return new Response(queryEnvelope("traces", []));
       },
     });
     assert.equal(evidence.status, "inconclusive_sampling");
     assert.equal(evidence.reason, "no_sampled_traces");
-    assert.deepEqual(evidence.coverage, {
-      gatewayRequests: 22,
-      sampledTraces: 0,
-      completeTraces: 0,
-      incompleteTraces: 0,
-    });
+    assert.equal(evidence.coverage.gatewayRequests, 22);
+    assert.equal(evidence.coverage.sampledTraces, 0);
+    assert.equal(evidence.coverage.completeTraces, 0);
+    assert.equal(evidence.coverage.incompleteTraces, 0);
+    assert.equal(evidence.coverage.settleRounds, SETTLE_ROUNDS);
+    assert.equal(evidence.coverage.discoverySlices.length, 8);
+    assert.ok(
+      evidence.coverage.discoverySlices.every(
+        (slice) =>
+          typeof slice.fromUtc === "string" &&
+          typeof slice.toUtc === "string" &&
+          slice.sampledTraces === 0,
+      ),
+    );
     assert.deepEqual(evidence.samples, []);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 1 + 8 * SETTLE_ROUNDS);
     assert.match(calls[0].url, /\/telemetry\/keys$/);
     assert.equal(calls[0].init.method, "POST");
     assert.equal(
@@ -479,23 +525,8 @@ test("collector reports zero sampled traces explicitly and removes no privacy fi
 
 test("collector sanitizes one complete sampled trace and polls STARTED runs", async () => {
   const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
-  const responses = [
-    keysEnvelope(),
-    queryEnvelope("traces", [], "STARTED"),
-    queryEnvelope("traces", [
-      {
-        rootSpanName: "fetch",
-        rootTransactionName: "POST /api/v1/chat/completions",
-        service: ["eliza-cloud-api-staging"],
-        spans: 8,
-        traceDurationMs: 185,
-        traceStartMs: 1_780_000_000_000,
-        traceEndMs: 1_780_000_000_185,
-        traceId: TRACE_A,
-      },
-    ]),
-    queryEnvelope("events", completeTraceEvents()),
-  ];
+  const rootCallsBySlice = new Map();
+  let eventCalls = 0;
   let sleeps = 0;
   try {
     const evidence = await collectInferenceTraceEvidence({
@@ -507,40 +538,92 @@ test("collector sanitizes one complete sampled trace and polls STARTED runs", as
       sleepImpl: async () => {
         sleeps++;
       },
-      fetchImpl: async () => new Response(responses.shift()),
+      fetchImpl: async (url, init) => {
+        if (url.endsWith("/keys")) return new Response(keysEnvelope());
+        const body = JSON.parse(init.body);
+        if (body.view === "events") {
+          eventCalls++;
+          const events = completeTraceEvents();
+          const sweepRound = Math.floor((eventCalls - 1) / 8) + 1;
+          const isFollowingSlice =
+            body.timeframe.from > 1_780_000_000_000 &&
+            body.timeframe.from - 1_780_000_000_000 <= 10_000;
+          const sliceEvents = containsFirstGatewayRequest(body.timeframe)
+            ? events.slice(0, 4)
+            : isFollowingSlice
+              ? [events[2], ...events.slice(4)]
+              : [];
+          return new Response(
+            queryEnvelope(
+              "events",
+              sweepRound === 1
+                ? sliceEvents.filter(
+                    (value) => value.$metadata.id !== "billing-root",
+                  )
+                : sliceEvents,
+            ),
+          );
+        }
+        const sliceKey = `${body.timeframe.from}:${body.timeframe.to}`;
+        const sliceCalls = (rootCallsBySlice.get(sliceKey) ?? 0) + 1;
+        rootCallsBySlice.set(sliceKey, sliceCalls);
+        if (containsFirstGatewayRequest(body.timeframe) && sliceCalls === 1) {
+          return new Response(queryEnvelope("traces", [], "STARTED"));
+        }
+        const isPriorBoundarySlice =
+          body.timeframe.to < 1_780_000_000_000 &&
+          1_780_000_000_000 - body.timeframe.to <= 10_000;
+        const traceIsVisible =
+          (containsFirstGatewayRequest(body.timeframe) && sliceCalls >= 3) ||
+          (isPriorBoundarySlice && sliceCalls >= 2);
+        return new Response(
+          queryEnvelope("traces", traceIsVisible ? [traceSummary()] : []),
+        );
+      },
     });
     assert.equal(evidence.status, "observed");
     assert.equal(evidence.reason, null);
     assert.equal(evidence.samples.length, 1);
     assert.equal(evidence.coverage.sampledTraces, 1);
     assert.equal(evidence.coverage.completeTraces, 1);
-    assert.equal(sleeps, 1);
+    assert.equal(evidence.coverage.incompleteTraces, 0);
+    assert.equal(eventCalls, 16);
+    assert.equal(evidence.coverage.eventSweeps.length, 1);
+    assert.equal(evidence.coverage.eventSweeps[0].settleRounds, 2);
+    assert.equal(evidence.coverage.eventSweeps[0].slices.length, 8);
+    assert.ok(
+      evidence.coverage.eventSweeps[0].slices.every(
+        (slice) =>
+          typeof slice.fromUtc === "string" &&
+          typeof slice.toUtc === "string" &&
+          Number.isSafeInteger(slice.eventCount),
+      ),
+    );
+    assert.deepEqual(
+      evidence.coverage.eventSweeps[0].slices
+        .map((slice) => slice.eventCount)
+        .filter((count) => count > 0),
+      [4, 5],
+    );
+    assert.equal(JSON.stringify(evidence).includes(TRACE_A), false);
+    assert.equal(
+      evidence.coverage.discoverySlices.filter(
+        (slice) => slice.sampledTraces === 1,
+      ).length,
+      2,
+    );
+    assert.equal(sleeps, 9);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 });
 
-test("collector returns sampled-trace incompleteness without fabricating placement", async () => {
+test("collector reports a sampled trace with an unclassifiable URL as inconclusive", async () => {
   const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
-  const incomplete = completeTraceEvents().filter(
-    (value) => value.$metadata.id !== "billing-root",
-  );
-  const responses = [
-    keysEnvelope(),
-    queryEnvelope("traces", [
-      {
-        rootSpanName: "fetch",
-        rootTransactionName: "POST /api/v1/chat/completions",
-        service: ["eliza-cloud-api-staging"],
-        spans: incomplete.length,
-        traceDurationMs: 185,
-        traceStartMs: 1_780_000_000_000,
-        traceEndMs: 1_780_000_000_185,
-        traceId: TRACE_A,
-      },
-    ]),
-    queryEnvelope("events", incomplete),
-  ];
+  const incomplete = completeTraceEvents();
+  delete incomplete.find((value) => value.$metadata.id === "rate-subrequest")
+    .$metadata.url;
+  let eventCalls = 0;
   try {
     const evidence = await collectInferenceTraceEvidence({
       pairedRecords: pairedRecords(),
@@ -549,12 +632,32 @@ test("collector returns sampled-trace incompleteness without fabricating placeme
       apiToken: "private-api-token",
       privateDirectory: directory,
       sleepImpl: async () => {},
-      fetchImpl: async () => new Response(responses.shift()),
+      fetchImpl: async (url, init) => {
+        if (url.endsWith("/keys")) return new Response(keysEnvelope());
+        const body = JSON.parse(init.body);
+        if (body.view === "events") {
+          eventCalls++;
+          return new Response(
+            queryEnvelope(
+              "events",
+              containsFirstGatewayRequest(body.timeframe) ? incomplete : [],
+            ),
+          );
+        }
+        return new Response(
+          queryEnvelope(
+            "traces",
+            containsFirstGatewayRequest(body.timeframe) ? [traceSummary()] : [],
+          ),
+        );
+      },
     });
     assert.equal(evidence.status, "inconclusive_sampling");
     assert.equal(evidence.reason, "sampled_traces_incomplete");
     assert.deepEqual(evidence.samples, []);
     assert.equal(evidence.coverage.incompleteTraces, 1);
+    assert.equal(eventCalls, 8 * SETTLE_ROUNDS);
+    assert.equal(evidence.coverage.eventSweeps[0].settleRounds, SETTLE_ROUNDS);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -596,8 +699,14 @@ test("trace placement uses the Worker span rather than the ingress Ray colo", ()
   assert.equal(sanitizeTraceEvents(events, references), null);
 });
 
-test("collector follows event cursors and rejects incomplete or repeated pages", async () => {
-  for (const mode of ["complete", "repeated", "empty", "mixed"]) {
+test("collector follows event cursors and rejects incomplete, repeated, or conflicting pages", async () => {
+  for (const mode of [
+    "complete",
+    "repeated",
+    "empty",
+    "mixed",
+    "conflicting",
+  ]) {
     const directory = await mkdtemp(join(tmpdir(), "eliza-trace-boundary-"));
     const events = completeTraceEvents();
     const secondPage =
@@ -607,21 +716,8 @@ test("collector follows event cursors and rejects incomplete or repeated pages",
           ? events.slice(0, 4)
           : events.slice(4);
     if (mode === "mixed") secondPage[0].$metadata.traceId = TRACE_B;
-    const responses = [
-      keysEnvelope(),
-      queryEnvelope("traces", [
-        { traceId: TRACE_A, service: ["eliza-cloud-api-staging"] },
-      ]),
-      apiEnvelope({
-        run: { status: "COMPLETED" },
-        events: { count: 8, events: events.slice(0, 4) },
-      }),
-      apiEnvelope({
-        run: { status: "COMPLETED" },
-        events: { count: 8, events: secondPage },
-      }),
-    ];
     const bodies = [];
+    let targetEventPage = 0;
     try {
       const capture = collectInferenceTraceEvidence({
         pairedRecords: pairedRecords(),
@@ -629,23 +725,59 @@ test("collector follows event cursors and rejects incomplete or repeated pages",
         accountId: "private-account",
         apiToken: "private-token",
         privateDirectory: directory,
-        fetchImpl: async (_url, init) => {
-          bodies.push(JSON.parse(init.body));
-          assert.ok(
-            responses.length > 0,
-            "collector must terminate within supplied pages",
+        sleepImpl: async () => {},
+        fetchImpl: async (url, init) => {
+          if (url.endsWith("/keys")) return new Response(keysEnvelope());
+          const body = JSON.parse(init.body);
+          bodies.push(body);
+          if (body.view === "traces") {
+            return new Response(
+              queryEnvelope(
+                "traces",
+                containsFirstGatewayRequest(body.timeframe)
+                  ? [traceSummary()]
+                  : [],
+              ),
+            );
+          }
+          if (!containsFirstGatewayRequest(body.timeframe)) {
+            if (
+              mode === "conflicting" &&
+              body.timeframe.from > 1_780_000_000_000 &&
+              body.timeframe.from - 1_780_000_000_000 <= 10_000
+            ) {
+              const conflicting = structuredClone(events[0]);
+              conflicting.$metadata.duration++;
+              return new Response(queryEnvelope("events", [conflicting]));
+            }
+            return new Response(queryEnvelope("events", []));
+          }
+          targetEventPage++;
+          return new Response(
+            apiEnvelope({
+              run: { status: "COMPLETED" },
+              events: {
+                count: 8,
+                events: targetEventPage === 1 ? events.slice(0, 4) : secondPage,
+              },
+            }),
           );
-          return new Response(responses.shift());
         },
       });
       if (mode === "complete") {
         const result = await capture;
         assert.equal(result.status, "observed");
         assert.equal(result.samples[0].phases.billing.doColo, "IAD");
+      } else if (mode === "conflicting") {
+        await assert.rejects(capture, /conflicting/);
       } else {
         await assert.rejects(capture, /pagination/);
       }
-      assert.equal(bodies[3].offset, events[3].$metadata.id);
+      const eventBodies = bodies.filter((body) => body.view === "events");
+      const continuation = eventBodies.find(
+        (body) => body.offset === events[3].$metadata.id,
+      );
+      assert.equal(continuation.offsetDirection, "next");
     } finally {
       await rm(directory, { recursive: true, force: true });
     }

--- a/packages/cloud/scripts/latency-certification-provenance.mjs
+++ b/packages/cloud/scripts/latency-certification-provenance.mjs
@@ -1,0 +1,117 @@
+/**
+ * Binds a trusted develop verifier to a served ancestor without checking out
+ * older code. Changed verifier contracts require an exact operator acknowledgement;
+ * source and deployment identities remain distinct throughout the evidence.
+ */
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promisify } from "node:util";
+
+const execute = promisify(execFile);
+const SHA = /^[a-f0-9]{40}$/;
+const CONTRACT_PATHS = [
+  ".github/workflows/cloud-latency-certification.yml",
+  "packages/cloud/scripts/chat-latency.mjs",
+  "packages/cloud/scripts/inference-auth-latency.mjs",
+  "packages/cloud/scripts/cloud-latency-certification.mjs",
+  "packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs",
+  "packages/cloud/scripts/latency-certification-provenance.mjs",
+];
+
+async function git(args, cwd) {
+  try {
+    const result = await execute("git", args, {
+      cwd,
+      env: { ...process.env, GIT_NO_REPLACE_OBJECTS: "1" },
+      timeout: 60_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return result.stdout;
+  } catch (cause) {
+    // error-policy:J2 never expose git stderr, remote URLs, or subprocess environment.
+    throw new Error("Certification source ancestry could not be proven", {
+      cause,
+    });
+  }
+}
+
+export async function verifyCertificationSource(
+  { sourceRef, sourceSha, deploySha, acknowledgedContractDigest = "" },
+  { cwd = process.cwd() } = {},
+) {
+  if (
+    sourceRef !== "refs/heads/develop" ||
+    !SHA.test(sourceSha) ||
+    !SHA.test(deploySha)
+  ) {
+    throw new Error(
+      "Certification requires trusted develop source and exact commit identities",
+    );
+  }
+  if (
+    acknowledgedContractDigest !== "" &&
+    !/^[a-f0-9]{64}$/.test(acknowledgedContractDigest)
+  ) {
+    throw new Error("Invalid verifier contract acknowledgement");
+  }
+  if ((await git(["rev-parse", "HEAD"], cwd)).trim() !== sourceSha) {
+    throw new Error(
+      "Certification checkout does not match trusted workflow source",
+    );
+  }
+  if ((await git(["cat-file", "-t", deploySha], cwd)).trim() !== "commit") {
+    throw new Error("Deployment identity is not a commit");
+  }
+  await git(["merge-base", "--is-ancestor", deploySha, sourceSha], cwd);
+  const changes = await git(
+    [
+      "diff",
+      "--raw",
+      "--full-index",
+      "--no-abbrev",
+      "--no-renames",
+      "--no-ext-diff",
+      "--no-textconv",
+      deploySha,
+      sourceSha,
+      "--",
+      ...CONTRACT_PATHS,
+    ],
+    cwd,
+  );
+  const contractDigest = createHash("sha256").update(changes).digest("hex");
+  const changedVerifierPaths = changes
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split("\t")[1]);
+  if (changedVerifierPaths.some((path) => !CONTRACT_PATHS.includes(path))) {
+    throw new Error("Unexpected verifier contract path");
+  }
+  const contractChanged = changes.length > 0;
+  if (contractChanged && acknowledgedContractDigest !== contractDigest) {
+    throw new Error(
+      `Verifier contract changes require acknowledgement: ${contractDigest}`,
+    );
+  }
+  if (!contractChanged && acknowledgedContractDigest !== "") {
+    throw new Error("Verifier contract acknowledgement is not applicable");
+  }
+  return {
+    kind: "certification_source",
+    sourceSha,
+    deploySha,
+    relationship: sourceSha === deploySha ? "identical" : "develop_ancestor",
+    verifierContractChanged: contractChanged,
+    verifierContractDigest: contractDigest,
+    changedVerifierPaths,
+    verifierContractAcknowledged: contractChanged,
+  };
+}
+
+/** A successful measurement is valid only while its deployment remains unchanged. */
+export async function withVerifiedDeployment(deploySha, verify, measure) {
+  const before = await verify(deploySha);
+  const result = await measure(before);
+  await verify(deploySha);
+  return result;
+}

--- a/packages/cloud/scripts/latency-certification-provenance.test.mjs
+++ b/packages/cloud/scripts/latency-certification-provenance.test.mjs
@@ -1,0 +1,145 @@
+/** Exercises provenance against real temporary Git history and deployment boundaries. */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { verifyExactDeployment } from "./cloud-latency-certification.mjs";
+import {
+  verifyCertificationSource,
+  withVerifiedDeployment,
+} from "./latency-certification-provenance.mjs";
+
+test("real Git ancestry rejects untrusted revisions and binds changed verifier contracts", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "latency-provenance-test-"));
+  const git = (...args) =>
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=fixture@example.invalid",
+        ...args,
+      ],
+      { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    ).trim();
+  const commit = async (file, value) => {
+    await writeFile(join(cwd, file), value);
+    git("add", file);
+    git("commit", "-m", "fixture");
+    return git("rev-parse", "HEAD");
+  };
+  try {
+    git("init");
+    const base = await commit("ordinary.txt", "base");
+    const sourceSha = await commit("ordinary.txt", "later");
+    const config = {
+      sourceRef: "refs/heads/develop",
+      sourceSha,
+      deploySha: base,
+    };
+    assert.equal(
+      (await verifyCertificationSource(config, { cwd })).relationship,
+      "develop_ancestor",
+    );
+    assert.equal(
+      (
+        await verifyCertificationSource(
+          { ...config, deploySha: sourceSha },
+          { cwd },
+        )
+      ).relationship,
+      "identical",
+    );
+    const unrelated = git("commit-tree", "HEAD^{tree}", "-m", "unrelated");
+    const descendant = git(
+      "commit-tree",
+      "HEAD^{tree}",
+      "-p",
+      sourceSha,
+      "-m",
+      "descendant",
+    );
+    for (const change of [
+      { sourceRef: "refs/heads/feature" },
+      { sourceSha: base },
+      { deploySha: "not-a-sha" },
+      { deploySha: "a".repeat(40) },
+      { deploySha: unrelated },
+      { deploySha: descendant },
+      { acknowledgedContractDigest: "b".repeat(64) },
+    ])
+      await assert.rejects(
+        verifyCertificationSource({ ...config, ...change }, { cwd }),
+      );
+
+    await mkdir(join(cwd, "packages/cloud/scripts"), { recursive: true });
+    const changedSha = await commit(
+      "packages/cloud/scripts/chat-latency.mjs",
+      "export const changed = true;\n",
+    );
+    const changed = { ...config, sourceSha: changedSha };
+    let digest;
+    await assert.rejects(
+      verifyCertificationSource(changed, { cwd }),
+      (error) => {
+        digest = /acknowledgement: ([a-f0-9]{64})$/.exec(error.message)?.[1];
+        return Boolean(digest);
+      },
+    );
+    const receipt = await verifyCertificationSource(
+      { ...changed, acknowledgedContractDigest: digest },
+      { cwd },
+    );
+    assert.equal(receipt.verifierContractChanged, true);
+    assert.equal(receipt.verifierContractAcknowledged, true);
+    assert.deepEqual(receipt.changedVerifierPaths, [
+      "packages/cloud/scripts/chat-latency.mjs",
+    ]);
+    assert.equal(receipt.sourceSha, changedSha);
+    assert.equal(receipt.deploySha, base);
+    await assert.rejects(
+      verifyCertificationSource(
+        { ...changed, acknowledgedContractDigest: "c".repeat(64) },
+        { cwd },
+      ),
+    );
+    const newerSha = await commit(
+      "packages/cloud/scripts/chat-latency.mjs",
+      "export const changed = false;\n",
+    );
+    await assert.rejects(
+      verifyCertificationSource(
+        { ...changed, sourceSha: newerSha, acknowledgedContractDigest: digest },
+        { cwd },
+      ),
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("deployment movement rejects measured evidence and initial mismatch prevents measurement", async () => {
+  const sha = "a".repeat(40);
+  for (const mismatchAt of [0, 1, -1]) {
+    let checks = 0;
+    let measurements = 0;
+    const verify = (expected) =>
+      verifyExactDeployment(expected, async () =>
+        Response.json({
+          commit: checks++ === mismatchAt ? "b".repeat(40) : sha,
+          environment: "staging",
+        }),
+      );
+    const run = withVerifiedDeployment(sha, verify, async () => {
+      measurements++;
+      return "measured";
+    });
+    if (mismatchAt === -1) assert.equal(await run, "measured");
+    else await assert.rejects(run, /expected commit/);
+    assert.equal(measurements, mismatchAt === 0 ? 0 : 1);
+    assert.equal(checks, mismatchAt === 0 ? 1 : 2);
+  }
+});


### PR DESCRIPTION
## Summary

Refs #30671 and #30706. Add privacy-safe distributed trace evidence to the protected staging latency workflow, so regional admission overhead can be attributed to Worker and Durable Object execution rather than inferred from the ingress Ray alone. Bind the trusted verifier separately from the exact served develop ancestor so parallel merges do not force repeated deployments merely to take a measurement.

- Query only the paired gateway request window and exact Ray correlations through Cloudflare Observability. Discover indexed keys before querying; paginate event results using the documented event cursor.
- Sweep both trace discovery and event graphs in consecutive 5–10 second slices, retry delayed ingestion for bounded settle rounds, and preserve sanitized slice bounds/counts. Deduplicate identical boundary events and reject conflicting records.
- Emit only deployment provenance, coverage counts, ingress/Worker/DO airport codes, and rounded root/subrequest/storage durations. Never upload raw telemetry, account/object/request/trace IDs, URLs, headers, or payloads.
- Keep raw responses in a mode-0700 temporary directory with mode-0600 files, remove it after success or failure, and retain workflow-level unconditional cleanup as a second boundary.
- Treat a sampled Durable Object span without a classification URL as inconclusive. Report storage as inclusive summed span duration, not exclusive elapsed time.
- Run trace capture after paired calls even when the concurrent strict auth probe fails. Zero samples and incomplete sampled traces remain explicitly inconclusive, not evidence of zero overhead.
- Keep protected develop checkout and prove the served revision is its Git ancestor before paid requests. Record both source and deployment SHAs without rewriting CI identity. When verifier files differ, require an exact SHA-256 acknowledgement after operator review; record the changed verifier paths.
- Bracket paired/auth/trace work with exact staging health checks, reject deployment movement, and preserve standing/auth probe assertions. No placement, billing, tenant, provider-routing, or production mutations are introduced.

## Validation state

Head: `3e13f64fef08300f708fbc98cd486dbc27c0a233`.
Base: `e8cfcd6914edfc1675450ce0a1bbea685e0a08be`.

- Pinned Bun 1.3.14 / Node 24.15.0 install completed successfully.
- Integrated real Git ancestry and parser/collector boundary tests: 26 passed, zero failed. Network responses are synthetic boundary fixtures; no live capture is claimed. Ancestry fixtures include unrelated, descendant, missing, and malformed identities, changed-verifier acknowledgements, and deployment movement.
- Scoped Biome and `git diff --check` passed.
- Final-head install and full `bun run verify` passed after fresh fetch/rebase: 376 successful workspace tasks and 11,446 test files audited without focused or orphaned skips. Independent review caught the missing `source.json` upload entry; that sanitized receipt is now retained on failure too and is included in this final-head gate.
- Independent review reran all 26 tests and reviewed the collector, provenance module, wrapper integration, and workflow with no remaining source blocker reported.
- A read-only live attempt reused the existing 22 gateway correlations through locally authenticated Wrangler credentials. The configured Cloudflare account is visible, but the telemetry endpoint returned HTTP 403. No new model calls were made, and private raw cleanup was verified. This proves failure handling and cleanup, not successful live trace schema or completeness; protected workflow token access remains unproven.
- Independent review identified and drove the slicing, semantic settling, and missing-URL handling fixes. Protected live capture remains required; API permission availability and sampled event data have not been proven live.

## Evidence

<!-- evidence-head:3e13f64fef08300f708fbc98cd486dbc27c0a233 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this change adds a protected diagnostic collector, not an interactive surface.
<!-- evidence-row:backend-logs -->
- [x] Synthetic API boundary evidence, not live Cloudflare proof.

```text
node --test packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs packages/cloud/scripts/cloud-latency-certification.test.mjs packages/cloud/scripts/latency-certification-provenance.test.mjs
tests 26; pass 26; fail 0
Covered: zero sampling, complete and incomplete traces, cursor pagination,
repeated/empty/mixed-trace page rejection, private-field exclusion,
transport failure sanitization, raw-file cleanup, credential failure,
late ingestion, full-window sliced graph assembly and conflicting duplicates.
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or response contract changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model request or provider-dispatch behavior changed; the existing paired benchmark is unchanged.
<!-- evidence-row:domain-artifacts -->
- [x] Parser output and private-directory lifecycle inspected through executed boundary tests.

```text
Ingress ORD with Worker span SJC emits ingressColo=ORD and workerColo=SJC.
Missing Worker region yields inconclusive sampling rather than inferred placement.
Raw capture directory is mode 0700 and absent after both success and failure.
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels or visual surface changed.

## Remaining acceptance

After source review and normal merge, run the protected workflow on an exact staging deployment. Inspect the sanitized artifact and any failure category. Sampling absence is inconclusive. Do not change placement or admission topology based only on this collector's unit tests; require actual per-hop observations first.

## External boundary references

- [Cloudflare telemetry query API](https://developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/query/): ad-hoc queries, event cursors, metadata duration units and Worker execution-model fields.
- [Indexed telemetry keys API](https://developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/keys/): array-shaped key/type discovery response.
- [Automatic spans and attributes](https://developers.cloudflare.com/workers/observability/traces/spans-and-attributes/): Worker roots, Durable Object subrequests and storage spans. The REST event execution-model vocabulary differs from OpenTelemetry attributes; the collector uses the REST contract.
