### PR TITLE
fix(cloud): retain cleanup authority and require state-preserving recovery

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts
@@ -207,6 +207,7 @@ const oneShotModuleSpecifiers = [
   "@elizaos/cloud-shared/lib/utils/logger",
   "@elizaos/cloud-shared/lib/services/docker-node-manager",
   "@elizaos/cloud-shared/lib/services/containers/node-autoscaler",
+  "@elizaos/cloud-shared/lib/services/containers/hetzner-client",
   "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool",
   "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator",
   "@elizaos/cloud-shared/lib/config/containers-env",
@@ -431,8 +432,22 @@ describe("real one-shot daemon entrypoint", () => {
       "@elizaos/cloud-shared/lib/services/containers/node-autoscaler": {
         getNodeAutoscaler: () => ({
           evaluateCapacity,
+          reconcileRetirements: async () => ({
+            completed: 0,
+            retained: 0,
+            failed: 0,
+          }),
           provisionNode,
           drainNode,
+        }),
+      },
+      "@elizaos/cloud-shared/lib/services/containers/hetzner-client": {
+        getHetznerContainersClient: () => ({
+          reconcileCreateCleanup: async () => ({
+            checked: 0,
+            removed: 0,
+            pending: 0,
+          }),
         }),
       },
       "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool": {

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -39,6 +39,8 @@ type WorkerNodeManager =
   typeof import("@elizaos/cloud-shared/lib/services/docker-node-manager").dockerNodeManager;
 type WorkerNodeAutoscaler =
   typeof import("@elizaos/cloud-shared/lib/services/containers/node-autoscaler").getNodeAutoscaler;
+type WorkerContainersClient =
+  typeof import("@elizaos/cloud-shared/lib/services/containers/hetzner-client").getHetznerContainersClient;
 type WorkerWarmPoolManager =
   typeof import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool").WarmPoolManager;
 type WorkerEnvWarmPoolPolicy =
@@ -87,6 +89,7 @@ interface WorkerDeps {
   provisioningJobService: WorkerService;
   dockerNodeManager: WorkerNodeManager;
   getNodeAutoscaler: WorkerNodeAutoscaler;
+  getHetznerContainersClient: WorkerContainersClient;
   WarmPoolManager: WorkerWarmPoolManager;
   envWarmPoolPolicy: WorkerEnvWarmPoolPolicy;
   immutableImageReference: WorkerImmutableImageReference;
@@ -324,6 +327,7 @@ async function loadDeps(): Promise<WorkerDeps> {
       import("@elizaos/cloud-shared/lib/services/node-disk-manager"),
       import("@elizaos/cloud-shared/lib/services/agent-backup-verifier"),
       import("@elizaos/cloud-shared/lib/services/cloud-api-db-heartbeat"),
+      import("@elizaos/cloud-shared/lib/services/containers/hetzner-client"),
     ]).then(
       ([
         jobsModule,
@@ -342,11 +346,14 @@ async function loadDeps(): Promise<WorkerDeps> {
         nodeDiskManagerModule,
         backupVerifierModule,
         cloudApiDbHeartbeatModule,
+        containersClientModule,
       ]) => ({
         provisioningJobService: jobsModule.provisioningJobService,
         logger: loggerModule.logger,
         dockerNodeManager: nodeMgrModule.dockerNodeManager,
         getNodeAutoscaler: autoscalerModule.getNodeAutoscaler,
+        getHetznerContainersClient:
+          containersClientModule.getHetznerContainersClient,
         WarmPoolManager: warmPoolModule.WarmPoolManager,
         envWarmPoolPolicy: warmPoolModule.envWarmPoolPolicy,
         immutableImageReference: warmPoolModule.immutableImageReference,
@@ -944,6 +951,8 @@ interface PrePullImagesSummary {
 }
 
 interface NodeAutoscaleSummary {
+  createCleanup: { checked: number; removed: number; pending: number };
+  retirement: { completed: number; retained: number; failed: number };
   action:
     | "noop"
     | "scale_up"
@@ -1176,18 +1185,23 @@ export function prePullAllowsPoolImageRollout(
  * runs (decision + drain) but reports `scale_up_skipped`.
  */
 async function processNodeAutoscaleCycle(): Promise<NodeAutoscaleSummary> {
-  const { getNodeAutoscaler } = await loadDeps();
+  const { getNodeAutoscaler, getHetznerContainersClient } = await loadDeps();
+  const createCleanup =
+    await getHetznerContainersClient().reconcileCreateCleanup();
   const autoscaler = getNodeAutoscaler();
+  const retirement = await autoscaler.reconcileRetirements();
   const decision = await autoscaler.evaluateCapacity();
 
   if (!decision.shouldScaleUp && decision.shouldScaleDownNodeIds.length === 0) {
-    return { action: "noop" };
+    return { action: "noop", retirement, createCleanup };
   }
 
   if (decision.shouldScaleUp) {
     const publicKey = process.env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
     if (!publicKey) {
       return {
+        retirement,
+        createCleanup,
         action: "scale_up_skipped",
         detail: "CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY not set on daemon host",
       };
@@ -1202,11 +1216,15 @@ async function processNodeAutoscaleCycle(): Promise<NodeAutoscaleSummary> {
         },
       );
       return {
+        retirement,
+        createCleanup,
         action: "scale_up",
         detail: `${provisioned.nodeId} (${provisioned.hostname})`,
       };
     } catch (error) {
       return {
+        retirement,
+        createCleanup,
         action: "scale_up_failed",
         detail: formatErrorWithCause(error),
       };
@@ -1218,13 +1236,15 @@ async function processNodeAutoscaleCycle(): Promise<NodeAutoscaleSummary> {
   // up as idle simultaneously.
   const target = decision.shouldScaleDownNodeIds[0];
   if (!target) {
-    return { action: "noop" };
+    return { action: "noop", retirement, createCleanup };
   }
   try {
     await autoscaler.drainNode(target, { deprovision: true });
-    return { action: "scale_down", detail: target };
+    return { action: "scale_down", detail: target, retirement, createCleanup };
   } catch (error) {
     return {
+      retirement,
+      createCleanup,
       action: "drain_failed",
       detail: `${target}: ${formatErrorWithCause(error)}`,
     };

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -785,9 +785,11 @@ app.post("/api/v1/cron/agent-hot-pool", agentHotPoolResponse);
 function nodeAutoscaleResponse(c: Context) {
   return handleInternal(c, async () => {
     const autoscaler = getNodeAutoscaler();
+    const retirement = await autoscaler.reconcileRetirements();
     const decision = await autoscaler.evaluateCapacity();
     const result: Record<string, unknown> = {
       ...decision,
+      retirement,
       actions: [] as Array<Record<string, unknown>>,
       timestamp: new Date().toISOString(),
     };

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-repo.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-repo.test.ts
@@ -449,6 +449,28 @@ describe("stuck-provisioning owner predicates", () => {
     expect(await sandboxStatus(agentId)).toBe("running");
   });
 
+  test("health recovery cannot publish while a replacement owns unfinished restoration", async () => {
+    const { organizationId, userId } = await seedOrgAndUser();
+    const agentId = await seedProvisioningAgent(organizationId, userId);
+    const probed = await sandboxCapture(agentId);
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        replacement_cleanup_sandbox_id: "candidate-sandbox",
+        replacement_cleanup_node_id: "candidate-node",
+        replacement_cleanup_container_name: "candidate-container",
+        replacement_cleanup_attempt_id: crypto.randomUUID(),
+        replacement_cleanup_container_id: "a".repeat(64),
+        replacement_cleanup_allocation_counted: true,
+        replacement_cleanup_created_at: new Date(),
+      })
+      .where(eq(agentSandboxes.id, agentId));
+
+    expect(await repo.markRunningFromProvisioning(probed)).toBeUndefined();
+    expect(await repo.markRunningFromProvisioning(await sandboxCapture(agentId))).toBeUndefined();
+    expect(await sandboxStatus(agentId)).toBe("provisioning");
+  });
+
   test("recovery CAS never promotes forged Shared or unknown rows with container locators", async () => {
     for (const executionTier of ["shared", "future-container-tier"] as const) {
       const { organizationId, userId } = await seedOrgAndUser();

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-repo.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-repo.test.ts
@@ -25,7 +25,12 @@ import {
   PROVISIONING_STATUS_OWNER_JOB_TYPES,
   type ProvisioningJobType,
 } from "../../../lib/services/provisioning-job-types";
-import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
+import {
+  agentBackupCatalogAuthorities,
+  agentSandboxBackups,
+  agentSandboxes,
+} from "../../schemas/agent-sandboxes";
 import { apiKeys } from "../../schemas/api-keys";
 import { generations } from "../../schemas/generations";
 import { jobExecutionLeases } from "../../schemas/job-execution-leases";
@@ -193,6 +198,9 @@ beforeAll(async () => {
       users,
       userCharacters,
       agentSandboxes,
+      agentSandboxBackups,
+      agentBackupCatalogAuthorities,
+      agentNodeIncarnationHistories,
       apiKeys,
       usageRecords,
       generations,
@@ -448,6 +456,35 @@ describe("stuck-provisioning owner predicates", () => {
     );
     expect(await sandboxStatus(agentId)).toBe("running");
   });
+
+  test.each(["heartbeat", "backup-stamp", "backup-row"] as const)(
+    "health recovery cannot bypass retained state identified by %s",
+    async (evidence) => {
+      const { organizationId, userId } = await seedOrgAndUser();
+      const agentId = await seedProvisioningAgent(organizationId, userId);
+      const probed = await sandboxCapture(agentId);
+      if (evidence === "backup-row") {
+        await dbWrite.insert(agentSandboxBackups).values({
+          sandbox_record_id: agentId,
+          snapshot_type: "pre-shutdown",
+          state_data: { memories: [], config: {}, workspaceFiles: {} },
+          size_bytes: 2,
+          backup_kind: "full",
+        });
+      } else {
+        await dbWrite
+          .update(agentSandboxes)
+          .set(
+            evidence === "heartbeat"
+              ? { last_heartbeat_at: new Date() }
+              : { last_backup_at: new Date() },
+          )
+          .where(eq(agentSandboxes.id, agentId));
+      }
+      expect(await repo.markRunningFromProvisioning(probed)).toBeUndefined();
+      expect(await sandboxStatus(agentId)).toBe("provisioning");
+    },
+  );
 
   test("health recovery cannot publish while a replacement owns unfinished restoration", async () => {
     const { organizationId, userId } = await seedOrgAndUser();

--- a/packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/container-status.test.ts
@@ -17,6 +17,7 @@ const EVERY_STATUS: Record<ContainerStatus, true> = {
   running: true,
   stopped: true,
   failed: true,
+  cleanup_required: true,
   deleting: true,
   deleted: true,
 };

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1737,6 +1737,11 @@ export class AgentSandboxesRepository {
             isNull(agentSandboxes.pool_status),
             isNull(agentSandboxes.deleted_at),
             isNull(agentSandboxes.deletion_attempt_id),
+            // A created replacement can be reachable before restoration. Its
+            // owner must publish it; a health probe cannot settle that work.
+            isNull(agentSandboxes.replacement_cleanup_sandbox_id),
+            isNull(agentSandboxes.replacement_cleanup_attempt_id),
+            isNull(agentSandboxes.replacement_cleanup_container_id),
             hasNoProvisioningStatusOwnerJob(),
           ),
         )

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1742,6 +1742,15 @@ export class AgentSandboxesRepository {
             isNull(agentSandboxes.replacement_cleanup_sandbox_id),
             isNull(agentSandboxes.replacement_cleanup_attempt_id),
             isNull(agentSandboxes.replacement_cleanup_container_id),
+            // Transport-unresolved retries may have moved their handle into
+            // the primary row before restore. Prior state still requires the
+            // provisioning path; a health probe cannot prove it was applied.
+            isNull(agentSandboxes.last_heartbeat_at),
+            isNull(agentSandboxes.last_backup_at),
+            sql`NOT EXISTS (
+              SELECT 1 FROM ${agentSandboxBackups}
+              WHERE ${agentSandboxBackups.sandbox_record_id} = ${agentSandboxes.id}
+            )`,
             hasNoProvisioningStatusOwnerJob(),
           ),
         )

--- a/packages/cloud/shared/src/db/repositories/container-status.ts
+++ b/packages/cloud/shared/src/db/repositories/container-status.ts
@@ -21,6 +21,7 @@ export const CONTAINER_STATUSES = [
   "running",
   "stopped",
   "failed",
+  "cleanup_required",
   "deleting",
   "deleted",
 ] as const satisfies readonly ContainerStatus[];

--- a/packages/cloud/shared/src/db/repositories/containers.ts
+++ b/packages/cloud/shared/src/db/repositories/containers.ts
@@ -19,10 +19,15 @@ import {
   or,
   sql,
 } from "drizzle-orm";
+import { containersEnv } from "../../lib/config/containers-env";
 import {
   type ContainerLimitResolution,
   resolveMaxContainersForOrg,
 } from "../../lib/constants/pricing";
+import {
+  type CreatePlacementHost,
+  claimAppContainerNodeSlot,
+} from "../../lib/services/app-container-store-queries";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import { hydrateTextField, offloadTextField } from "../../lib/storage/object-store";
 import { type Database, dbRead, dbWrite } from "../helpers";
@@ -47,6 +52,7 @@ export type NewContainer = InferInsertModel<typeof containers>;
 export type ContainerStatus =
   | "pending"
   | "building"
+  | "cleanup_required"
   | "deploying"
   | "running"
   | "stopped"
@@ -196,6 +202,157 @@ export class DuplicateContainerNameError extends Error {
  * Write operations → dbWrite (primary)
  */
 export class ContainersRepository {
+  /** Read retryable failed-create ownership from the authoritative environment database. */
+  async findCreateCleanupCandidates(): Promise<Container[]> {
+    return dbWrite
+      .select()
+      .from(containers)
+      .where(
+        and(
+          eq(containers.status, "cleanup_required"),
+          sql`${containers.metadata}->>'provider' = 'hetzner-docker'`,
+          sql`${containers.metadata}->>'environment' = ${containersEnv.environment()}`,
+        ),
+      );
+  }
+
+  /** Persist node ownership before provider effects, serialized with node retirement. */
+  async reserveCreatePlacement(
+    id: string,
+    organizationId: string,
+    nodeId: string,
+    nodeRecordId: string,
+    expectedHost: CreatePlacementHost,
+  ): Promise<void> {
+    await claimAppContainerNodeSlot(
+      dbWrite,
+      id,
+      organizationId,
+      nodeId,
+      () =>
+        new ElizaError("Selected Docker node no longer admits container placement", {
+          code: "DOCKER_PLACEMENT_UNAVAILABLE",
+          context: { containerId: id, nodeId, nodeRecordId },
+          severity: "ephemeral",
+        }),
+      () =>
+        new ElizaError("Container create intent no longer admits placement", {
+          code: "CONTAINER_PLACEMENT_AUTHORITY_CHANGED",
+          context: { containerId: id, organizationId },
+        }),
+      { nodeRecordId, environment: containersEnv.environment(), expectedHost },
+    );
+  }
+
+  /** Commit observed create success only while the original placement still owns the row. */
+  async completeCreatePlacement(
+    id: string,
+    organizationId: string,
+    nodeRecordId: string,
+    data: Pick<
+      NewContainer,
+      | "metadata"
+      | "load_balancer_url"
+      | "public_hostname"
+      | "volume_path"
+      | "volume_size_gb"
+      | "hcloud_volume_id"
+      | "volume_location"
+    >,
+  ): Promise<Container> {
+    const [completed] = await dbWrite
+      .update(containers)
+      .set({
+        ...data,
+        status: "deploying",
+        metadata: sql`${containers.metadata} || ${JSON.stringify(data.metadata ?? {})}::jsonb`,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(containers.id, id),
+          eq(containers.organization_id, organizationId),
+          eq(containers.status, "building"),
+          sql`${containers.metadata}->>'nodeRecordId' = ${nodeRecordId}`,
+          sql`NOT jsonb_exists(${containers.metadata}, 'slotReleasedAt')`,
+        ),
+      )
+      .returning();
+    if (!completed)
+      throw new ElizaError("Container placement changed before create completion", {
+        code: "CONTAINER_PLACEMENT_AUTHORITY_CHANGED",
+        context: { containerId: id, organizationId, nodeRecordId },
+      });
+    return hydrateContainerDeploymentLog(completed);
+  }
+
+  /** Failed creates retain capacity until removal is proven; release and status commit together. */
+  async settleCreateFailure(
+    id: string,
+    organizationId: string,
+    nodeRecordId: string,
+    errorMessage: string,
+    removed: boolean,
+  ): Promise<void> {
+    await dbWrite.transaction(async (tx) => {
+      const [owner] = await tx
+        .select({
+          status: containers.status,
+          nodeId: containers.node_id,
+          metadata: containers.metadata,
+        })
+        .from(containers)
+        .where(and(eq(containers.id, id), eq(containers.organization_id, organizationId)))
+        .for("update");
+      if (
+        owner?.metadata.nodeRecordId === nodeRecordId &&
+        owner.status === "failed" &&
+        Object.hasOwn(owner.metadata, "slotReleasedAt")
+      )
+        return;
+      if (
+        !owner ||
+        !owner.nodeId ||
+        owner.metadata.nodeRecordId !== nodeRecordId ||
+        Object.hasOwn(owner.metadata, "slotReleasedAt") ||
+        !["building", "cleanup_required"].includes(owner.status)
+      ) {
+        throw new ElizaError("Container placement changed before failed-create settlement", {
+          code: "CONTAINER_PLACEMENT_AUTHORITY_CHANGED",
+          context: { containerId: id, organizationId, nodeRecordId },
+        });
+      }
+      if (removed) {
+        const [node] = await tx
+          .update(dockerNodes)
+          .set({
+            allocated_count: sql`GREATEST(${dockerNodes.allocated_count} - 1, 0)`,
+            updated_at: new Date(),
+          })
+          .where(and(eq(dockerNodes.id, nodeRecordId), eq(dockerNodes.node_id, owner.nodeId)))
+          .returning({ id: dockerNodes.id });
+        if (!node)
+          throw new ElizaError("Container cleanup lost its original node identity", {
+            code: "CONTAINER_PLACEMENT_AUTHORITY_CHANGED",
+            context: { containerId: id, nodeRecordId },
+          });
+      }
+      await tx
+        .update(containers)
+        .set({
+          status: removed ? "failed" : "cleanup_required",
+          error_message: errorMessage,
+          ...(removed
+            ? {
+                metadata: sql`jsonb_set(${containers.metadata}, '{slotReleasedAt}', to_jsonb(now()::text))`,
+              }
+            : {}),
+          updated_at: new Date(),
+        })
+        .where(eq(containers.id, id));
+    });
+  }
+
   // ============================================================================
   // READ OPERATIONS (use read-intent connection)
   // ============================================================================

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.ts
@@ -1,6 +1,7 @@
 /**
  * Persists Docker node records for cloud scheduling and control-plane health.
  */
+import { ElizaError } from "@elizaos/core";
 import { and, asc, eq, sql } from "drizzle-orm";
 import {
   type DockerNodeAllocationRecount,
@@ -15,6 +16,7 @@ import {
   type DockerNodeStatus,
   dockerNodes,
   type NewDockerNode,
+  NODE_RETIREMENT_METADATA_KEY,
   PLACEABLE_NODE_STATE,
 } from "../schemas/docker-nodes";
 import {
@@ -290,9 +292,24 @@ export class DockerNodesRepository {
 
   async update(id: string, data: DockerNodeMutableUpdate): Promise<DockerNode | null> {
     rejectDockerNodeIdentityMutation(data);
+    // Generic metadata edits cannot create or erase retirement intent. Re-enabling
+    // explicitly cancels it, even when the caller echoes stale metadata.
+    const replacementMetadata =
+      data.metadata === undefined
+        ? dockerNodes.metadata
+        : sql`${JSON.stringify(data.metadata)}::jsonb`;
+    const metadata =
+      data.enabled === true
+        ? sql`(${replacementMetadata} - ${NODE_RETIREMENT_METADATA_KEY})`
+        : data.metadata === undefined
+          ? undefined
+          : sql`(${replacementMetadata} - ${NODE_RETIREMENT_METADATA_KEY}) || CASE
+            WHEN ${dockerNodes.metadata} ? ${NODE_RETIREMENT_METADATA_KEY}
+            THEN jsonb_build_object(${NODE_RETIREMENT_METADATA_KEY}::text, ${dockerNodes.metadata}->${NODE_RETIREMENT_METADATA_KEY})
+            ELSE '{}'::jsonb END`;
     const [r] = await dbWrite
       .update(dockerNodes)
-      .set({ ...data, updated_at: new Date() })
+      .set({ ...data, ...(metadata === undefined ? {} : { metadata }), updated_at: new Date() })
       .where(eq(dockerNodes.id, id))
       .returning();
     return r ?? null;
@@ -560,14 +577,31 @@ export class DockerNodesRepository {
       .where(eq(dockerNodes.node_id, nodeId));
   }
 
-  async incrementAllocated(nodeId: string): Promise<void> {
-    await dbWrite
+  async incrementAllocated(nodeId: string, nodeRecordId: string): Promise<void> {
+    const [reserved] = await dbWrite
       .update(dockerNodes)
       .set({
         allocated_count: sql`${dockerNodes.allocated_count} + 1`,
         updated_at: new Date(),
       })
-      .where(eq(dockerNodes.node_id, nodeId));
+      .where(
+        and(
+          eq(dockerNodes.id, nodeRecordId),
+          eq(dockerNodes.node_id, nodeId),
+          eq(dockerNodes.enabled, true),
+          eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
+          eq(dockerNodes.status, "healthy"),
+          sql`${dockerNodes.allocated_count} < ${dockerNodes.capacity}`,
+        ),
+      )
+      .returning({ id: dockerNodes.id });
+    if (!reserved) {
+      throw new ElizaError("Selected Docker node no longer admits placement", {
+        code: "DOCKER_PLACEMENT_UNAVAILABLE",
+        context: { nodeId, nodeRecordId },
+        severity: "ephemeral",
+      });
+    }
   }
 
   async decrementAllocated(nodeId: string): Promise<void> {

--- a/packages/cloud/shared/src/db/schemas/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/schemas/docker-nodes.ts
@@ -1,4 +1,4 @@
-// Defines the docker nodes Drizzle table shape used by cloud repositories and services.
+/** Defines Docker node identity, placement state and persisted control-plane metadata. */
 import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
 import {
   boolean,
@@ -21,6 +21,9 @@ const pgXid8 = customType<{ data: string }>({
     return "xid8";
   },
 });
+
+/** Only the retirement authority writes this key; re-enablement cancels it. */
+export const NODE_RETIREMENT_METADATA_KEY = "requestedProviderRetirement";
 
 export type DockerNodeStatus = "healthy" | "degraded" | "offline" | "unknown";
 export type DockerNodeFleetKind = "robot" | "cloud";

--- a/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store-queries.ts
@@ -6,7 +6,12 @@
 import { and, eq, sql } from "drizzle-orm";
 import type { dbWrite } from "../../db/helpers";
 import { containers } from "../../db/schemas/containers";
-import { dockerNodes, PLACEABLE_NODE_STATE } from "../../db/schemas/docker-nodes";
+import { type DockerNode, dockerNodes, PLACEABLE_NODE_STATE } from "../../db/schemas/docker-nodes";
+
+export type CreatePlacementHost = Pick<
+  DockerNode,
+  "hostname" | "ssh_port" | "ssh_user" | "host_key_fingerprint" | "node_incarnation"
+>;
 
 export interface ProjectableContainerRow {
   id: string;
@@ -79,19 +84,28 @@ export function claimAppContainerNodeSlot(
   nodeId: string,
   capacityError: () => Error,
   conflictError: (existing: ExistingAppContainerNodeSlotClaim | null) => Error,
+  initialPlacement?: {
+    nodeRecordId: string;
+    environment: string;
+    expectedHost: CreatePlacementHost;
+  },
 ): Promise<AppContainerNodeSlotClaim> {
   return database.transaction(async (tx) => {
     const [claimed] = await tx
       .update(containers)
       .set({
         node_id: nodeId,
-        metadata: sql`jsonb_set(coalesce(${containers.metadata}, '{}'::jsonb), '{slotClaimedAt}', to_jsonb(now()::text))`,
+        ...(initialPlacement ? { status: "building" } : {}),
+        metadata: sql`jsonb_set(coalesce(${containers.metadata}, '{}'::jsonb), '{slotClaimedAt}', to_jsonb(now()::text)) || ${JSON.stringify(initialPlacement ? { nodeRecordId: initialPlacement.nodeRecordId, environment: initialPlacement.environment } : {})}::jsonb`,
         updated_at: new Date(),
       })
       .where(
         and(
           eq(containers.id, containerId),
           eq(containers.organization_id, organizationId),
+          ...(initialPlacement
+            ? [eq(containers.status, "pending"), sql`${containers.node_id} IS NULL`]
+            : []),
           sql`NOT jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotClaimedAt')`,
           sql`NOT jsonb_exists(coalesce(${containers.metadata}, '{}'::jsonb), 'slotReleasedAt')`,
         ),
@@ -110,6 +124,7 @@ export function claimAppContainerNodeSlot(
         .where(and(eq(containers.id, containerId), eq(containers.organization_id, organizationId)))
         .limit(1);
       if (
+        !initialPlacement &&
         existing?.nodeId === nodeId &&
         existing.slotClaimed &&
         !existing.slotReleased &&
@@ -129,6 +144,20 @@ export function claimAppContainerNodeSlot(
       .where(
         and(
           eq(dockerNodes.node_id, nodeId),
+          ...(initialPlacement
+            ? [
+                eq(dockerNodes.id, initialPlacement.nodeRecordId),
+                eq(dockerNodes.status, "healthy"),
+                sql`${dockerNodes.node_incarnation} IS NOT NULL`,
+                sql`length(trim(${dockerNodes.host_key_fingerprint})) > 0`,
+                sql`${dockerNodes.metadata}->>'environment' = ${initialPlacement.environment}`,
+                eq(dockerNodes.hostname, initialPlacement.expectedHost.hostname),
+                eq(dockerNodes.ssh_port, initialPlacement.expectedHost.ssh_port),
+                eq(dockerNodes.ssh_user, initialPlacement.expectedHost.ssh_user),
+                sql`${dockerNodes.host_key_fingerprint} = ${initialPlacement.expectedHost.host_key_fingerprint}`,
+                sql`${dockerNodes.node_incarnation} = ${initialPlacement.expectedHost.node_incarnation}::uuid`,
+              ]
+            : []),
           eq(dockerNodes.enabled, true),
           eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
           sql`${dockerNodes.allocated_count} < ${dockerNodes.capacity}`,
@@ -139,6 +168,24 @@ export function claimAppContainerNodeSlot(
     // The exception rolls back both attribution and the claim marker. The caller
     // supplies its domain error so this SQL-only module stays runtime-independent.
     if (!node) throw capacityError();
+    if (initialPlacement) {
+      // The node UPDATE still holds its row lock: snapshot the same host whose
+      // capacity was reserved, before another incarnation can be published.
+      await tx
+        .update(containers)
+        .set({
+          metadata: sql`${containers.metadata} || (
+          SELECT jsonb_build_object(
+            'createNodeIncarnation', ${dockerNodes.node_incarnation},
+            'createHostKeyFingerprint', ${dockerNodes.host_key_fingerprint},
+            'createHostname', ${dockerNodes.hostname},
+            'createSshPort', ${dockerNodes.ssh_port},
+            'createSshUser', ${dockerNodes.ssh_user}
+          ) FROM ${dockerNodes} WHERE ${dockerNodes.id} = ${initialPlacement.nodeRecordId}::uuid
+        )`,
+        })
+        .where(eq(containers.id, containerId));
+    }
     return "claimed";
   });
 }

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
@@ -434,6 +434,23 @@ describe("createContainer — placement and cleanup authority", () => {
     expect(completeCreatePlacement).not.toHaveBeenCalled();
   });
 
+  test("quiescent create without a candidate preserves a pre-existing container", async () => {
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
+    execStdinMock.mockRejectedValue(new Error("create rejected before a candidate was produced"));
+    let existingContainerPresent = true;
+    execMock.mockImplementation(async (command) => {
+      if (command.includes("attempt_cancelled"))
+        return `${getReplacementSecretArtifactsCleanupReceipt(ROW.id)}\n${getReplacementDockerCreateQuiescentReceipt(ROW.id)}\n`;
+      if (command.includes("docker rm -f")) existingContainerPresent = false;
+      return "";
+    });
+    await expect(getHetznerContainersClient().createContainer(NEW_CONTAINER_INPUT)).rejects.toThrow(
+      "create rejected before a candidate was produced",
+    );
+    expect(existingContainerPresent).toBe(true);
+    expect(settleCreateFailure.mock.calls[0]?.[4]).toBe(true);
+  });
+
   test("lost removal acknowledgement settles through explicit Docker absence", async () => {
     createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
     execStdinMock.mockRejectedValue(
@@ -441,7 +458,7 @@ describe("createContainer — placement and cleanup authority", () => {
     );
     execMock.mockImplementation(async (command) => {
       if (command.includes("attempt_cancelled"))
-        return `${getReplacementSecretArtifactsCleanupReceipt(ROW.id)}\n${getReplacementDockerCreateQuiescentReceipt(ROW.id)}\n`;
+        return `${getReplacementSecretArtifactsCleanupReceipt(ROW.id)}\n${getReplacementCandidateObservedReceipt(ROW.id, "a".repeat(64))}\n`;
       if (command.includes("docker rm -f")) throw new Error("SSH response lost");
       if (command.includes("docker inspect --format"))
         throw new Error(

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
@@ -10,9 +10,15 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 // afterAll so these stubs never leak into sibling files.
 import * as realContainersRepo from "../../../../db/repositories/containers";
 import * as realDockerNodesRepo from "../../../../db/repositories/docker-nodes";
+import { containersEnv } from "../../../config/containers-env";
 import * as realDockerNodeManager from "../../docker-node-manager";
 import * as realDockerPortAllocation from "../../docker-port-allocation";
-import { buildDockerEnvFileStdinTransport } from "../../docker-sandbox-utils";
+import {
+  buildDockerEnvFileStdinTransport,
+  getReplacementCandidateObservedReceipt,
+  getReplacementDockerCreateQuiescentReceipt,
+  getReplacementSecretArtifactsCleanupReceipt,
+} from "../../docker-sandbox-utils";
 import * as realDockerSsh from "../../docker-ssh";
 import * as realHetznerVolumes from "../hetzner-volumes";
 import * as realMetadata from "./metadata";
@@ -35,6 +41,11 @@ const tryReleaseNodeSlot = mock(async (): Promise<void> => {});
 const updateRow = mock(async (): Promise<unknown> => null);
 const updateStatus = mock(async (): Promise<void> => {});
 const prepareFundedRestart = mock(async (): Promise<void> => {});
+const reserveCreatePlacement = mock(async (..._args: unknown[]): Promise<void> => {});
+const completeCreatePlacement = mock(async (..._args: unknown[]) => ROW);
+const settleCreateFailure = mock(async (..._args: unknown[]): Promise<void> => {});
+const findCreateCleanupCandidates = mock(async (): Promise<unknown[]> => []);
+const findByIdOnPrimary = mock(async (_id: string): Promise<unknown> => null);
 const createWithProjectIntentAndQuotaCheck = mock(
   async (): Promise<unknown> => ({
     container: ROW,
@@ -75,6 +86,10 @@ mock.module("../../../../db/repositories/containers", () => ({
     update: updateRow,
     updateStatus,
     prepareFundedRestart,
+    reserveCreatePlacement,
+    completeCreatePlacement,
+    settleCreateFailure,
+    findCreateCleanupCandidates,
     createWithProjectIntentAndQuotaCheck,
   },
 }));
@@ -84,6 +99,7 @@ mock.module("../../../../db/repositories/docker-nodes", () => ({
   dockerNodesRepository: {
     ...realDockerNodesRepo.dockerNodesRepository,
     findByNodeId,
+    findByIdOnPrimary,
     incrementAllocated,
   },
 }));
@@ -129,14 +145,14 @@ const META = {
   provider: "hetzner-docker" as const,
   nodeId: "node-1",
   hostname: "10.0.0.1",
-  containerName: "app-ct1",
+  containerName: "app-11111111-1111-4111-8111-111111111111",
   hostPort: 8080,
   image: "ghcr.io/elizaos/eliza:stable",
   containerPort: 3000,
 };
 
 const ROW = {
-  id: "ct1",
+  id: "11111111-1111-4111-8111-111111111111",
   name: "existing",
   project_name: "project-one",
   organization_id: "org1",
@@ -159,11 +175,14 @@ const ROW = {
 };
 
 const NODE = {
+  id: "22222222-2222-4222-8222-222222222222",
+  node_incarnation: "33333333-3333-4333-8333-333333333333",
+  metadata: { environment: containersEnv.environment() },
   node_id: "node-create",
   hostname: "10.0.0.2",
   ssh_port: 22,
   ssh_user: "root",
-  host_key_fingerprint: null,
+  host_key_fingerprint: "SHA256:test-host-pin",
 };
 
 const NEW_CONTAINER_INPUT: CreateContainerInput = {
@@ -190,7 +209,7 @@ function dockerCreateCommands(): string[] {
 function assertSecretsAbsentFromCommands(secrets: readonly string[]): void {
   const commands = [...execMock.mock.calls.map((call) => call[0]), ...dockerCreateCommands()];
   for (const command of commands) {
-    expect(command).not.toMatch(/(?:^|\s)-e(?:\s|$)/);
+    expect(command).not.toMatch(/\bdocker\s+(?:create|run)\s[^;\n]*\s-e(?:\s|$)/);
     for (const secret of secrets) {
       if (secret.length > 0) expect(command).not.toContain(secret);
     }
@@ -217,6 +236,11 @@ beforeEach(() => {
     updateRow,
     updateStatus,
     prepareFundedRestart,
+    reserveCreatePlacement,
+    completeCreatePlacement,
+    settleCreateFailure,
+    findCreateCleanupCandidates,
+    findByIdOnPrimary,
     createWithProjectIntentAndQuotaCheck,
     readMetadata,
     execMock,
@@ -239,6 +263,11 @@ beforeEach(() => {
   updateRow.mockResolvedValue(null);
   updateStatus.mockResolvedValue(undefined);
   prepareFundedRestart.mockResolvedValue(undefined);
+  reserveCreatePlacement.mockResolvedValue(undefined);
+  completeCreatePlacement.mockResolvedValue(ROW);
+  settleCreateFailure.mockResolvedValue(undefined);
+  findCreateCleanupCandidates.mockResolvedValue([]);
+  findByIdOnPrimary.mockResolvedValue(NODE);
   createWithProjectIntentAndQuotaCheck.mockResolvedValue({
     container: ROW,
     created: false,
@@ -272,7 +301,10 @@ describe("createContainer — primary project intent", () => {
         cpu: 1024,
         memoryMb: 1024,
       }),
-    ).resolves.toMatchObject({ id: "ct1", projectName: "project-one" });
+    ).resolves.toMatchObject({
+      id: "11111111-1111-4111-8111-111111111111",
+      projectName: "project-one",
+    });
 
     expect(createWithProjectIntentAndQuotaCheck).toHaveBeenCalledTimes(1);
     expect(getClient).not.toHaveBeenCalled();
@@ -305,9 +337,157 @@ describe("createContainer — primary project intent", () => {
       }),
     ).rejects.toMatchObject({ code: "container_create_failed" });
 
-    expect(updateStatus).toHaveBeenCalledWith("ct1", "failed", "volume preflight unavailable");
+    expect(updateStatus).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "failed",
+      "volume preflight unavailable",
+    );
     expect(getClient).not.toHaveBeenCalled();
     expect(execMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("createContainer — placement and cleanup authority", () => {
+  test("background cleanup refuses a replacement boot but settles the original pinned host", async () => {
+    findCreateCleanupCandidates.mockResolvedValue([
+      {
+        ...ROW,
+        status: "cleanup_required",
+        node_id: NODE.node_id,
+        metadata: {
+          ...META,
+          nodeRecordId: NODE.id,
+          environment: containersEnv.environment(),
+          createNodeIncarnation: NODE.node_incarnation,
+          createHostKeyFingerprint: NODE.host_key_fingerprint,
+          createHostname: NODE.hostname,
+          createSshPort: NODE.ssh_port,
+          createSshUser: NODE.ssh_user,
+        },
+      },
+    ]);
+    findByIdOnPrimary.mockResolvedValue({
+      ...NODE,
+      node_incarnation: "44444444-4444-4444-8444-444444444444",
+    });
+    expect(await getHetznerContainersClient().reconcileCreateCleanup()).toEqual({
+      checked: 1,
+      removed: 0,
+      pending: 1,
+    });
+    expect(execMock).not.toHaveBeenCalled();
+    expect(settleCreateFailure).not.toHaveBeenCalled();
+    findByIdOnPrimary.mockResolvedValue(NODE);
+    execMock.mockImplementation(async (command) =>
+      command.includes("attempt_cancelled")
+        ? `${getReplacementSecretArtifactsCleanupReceipt(ROW.id)}\n${getReplacementDockerCreateQuiescentReceipt(ROW.id)}\n`
+        : "",
+    );
+    expect(await getHetznerContainersClient().reconcileCreateCleanup()).toEqual({
+      checked: 1,
+      removed: 1,
+      pending: 0,
+    });
+    expect(settleCreateFailure.mock.calls[0]?.[2]).toBe(NODE.id);
+  });
+
+  test("port inventory failure cannot leave a node reservation", async () => {
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
+    getUsedDockerHostPorts.mockRejectedValue(new Error("primary inventory unavailable"));
+    await expect(getHetznerContainersClient().createContainer(NEW_CONTAINER_INPUT)).rejects.toThrow(
+      "primary inventory unavailable",
+    );
+    expect(reserveCreatePlacement).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execStdinMock).not.toHaveBeenCalled();
+  });
+
+  test("rejected placement never reaches Docker", async () => {
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
+    reserveCreatePlacement.mockRejectedValue(new Error("node was retired"));
+    await expect(getHetznerContainersClient().createContainer(NEW_CONTAINER_INPUT)).rejects.toThrow(
+      "node was retired",
+    );
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execStdinMock).not.toHaveBeenCalled();
+    expect(completeCreatePlacement).not.toHaveBeenCalled();
+  });
+
+  test("unreachable cleanup keeps the capacity claim", async () => {
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
+    execStdinMock.mockRejectedValue(new Error("create acknowledgement lost"));
+    execMock.mockImplementation(async (command) => {
+      if (
+        command.includes("attempt_cancelled") ||
+        command.includes("docker rm -f") ||
+        command.includes("docker inspect --format")
+      ) {
+        throw new Error("SSH connection lost");
+      }
+      return "";
+    });
+    await expect(getHetznerContainersClient().createContainer(NEW_CONTAINER_INPUT)).rejects.toThrow(
+      "create acknowledgement lost",
+    );
+    expect(settleCreateFailure.mock.calls[0]?.[4]).toBe(false);
+    expect(incrementAllocated).not.toHaveBeenCalled();
+    expect(completeCreatePlacement).not.toHaveBeenCalled();
+  });
+
+  test("lost removal acknowledgement settles through explicit Docker absence", async () => {
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
+    execStdinMock.mockRejectedValue(
+      new Error("[docker-ssh] Command exited with code 1: create failed"),
+    );
+    execMock.mockImplementation(async (command) => {
+      if (command.includes("attempt_cancelled"))
+        return `${getReplacementSecretArtifactsCleanupReceipt(ROW.id)}\n${getReplacementDockerCreateQuiescentReceipt(ROW.id)}\n`;
+      if (command.includes("docker rm -f")) throw new Error("SSH response lost");
+      if (command.includes("docker inspect --format"))
+        throw new Error(
+          "Error: No such container: cloud-container-11111111-1111-4111-8111-111111111111",
+        );
+      return "";
+    });
+    await expect(getHetznerContainersClient().createContainer(NEW_CONTAINER_INPUT)).rejects.toThrow(
+      "create failed",
+    );
+    expect(settleCreateFailure.mock.calls[0]?.[4]).toBe(true);
+    expect(completeCreatePlacement).not.toHaveBeenCalled();
+  });
+
+  test("removal cannot release capacity while a timed-out create may still finish", async () => {
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
+    execStdinMock.mockRejectedValue(new Error("SSH create timed out"));
+    execMock.mockImplementation(async (command) =>
+      command.includes("attempt_cancelled")
+        ? `${getReplacementSecretArtifactsCleanupReceipt(ROW.id)}\n`
+        : "",
+    );
+    await expect(getHetznerContainersClient().createContainer(NEW_CONTAINER_INPUT)).rejects.toThrow(
+      "SSH create timed out",
+    );
+    expect(settleCreateFailure.mock.calls[0]?.[4]).toBe(false);
+  });
+
+  test("cleanup removes the recorded candidate ID instead of a reusable name", async () => {
+    const candidateId = "a".repeat(64);
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({ container: ROW, created: true });
+    execStdinMock.mockRejectedValue(new Error("SSH response lost"));
+    execMock.mockImplementation(async (command) =>
+      command.includes("attempt_cancelled")
+        ? `${getReplacementSecretArtifactsCleanupReceipt(ROW.id)}\n${getReplacementCandidateObservedReceipt(ROW.id, candidateId)}\n`
+        : "",
+    );
+    await expect(getHetznerContainersClient().createContainer(NEW_CONTAINER_INPUT)).rejects.toThrow(
+      "SSH response lost",
+    );
+    const removals = execMock.mock.calls
+      .map(([command]) => command)
+      .filter((command) => command.includes("docker rm -f"));
+    expect(removals).toHaveLength(1);
+    expect(removals[0]).toEndWith(`docker rm -f '${candidateId}'`);
+    expect(settleCreateFailure.mock.calls[0]?.[4]).toBe(true);
   });
 });
 
@@ -328,7 +508,7 @@ describe("createContainer — stdin-only environment transport", () => {
     const client = getHetznerContainersClient();
     await expect(
       client.createContainer({ ...NEW_CONTAINER_INPUT, environmentVars }),
-    ).resolves.toMatchObject({ id: "ct1" });
+    ).resolves.toMatchObject({ id: "11111111-1111-4111-8111-111111111111" });
 
     expect(createWithProjectIntentAndQuotaCheck).toHaveBeenCalledTimes(1);
     expect(createWithProjectIntentAndQuotaCheck.mock.calls[0]?.[0]).toMatchObject({
@@ -367,7 +547,7 @@ describe("createContainer — stdin-only environment transport", () => {
     const client = getHetznerContainersClient();
     await expect(
       client.createContainer({ ...NEW_CONTAINER_INPUT, environmentVars }),
-    ).resolves.toMatchObject({ id: "ct1" });
+    ).resolves.toMatchObject({ id: "11111111-1111-4111-8111-111111111111" });
 
     expect(execStdinMock).toHaveBeenCalledTimes(2);
     const firstCommand = execStdinMock.mock.calls[0]![0];
@@ -429,7 +609,7 @@ describe("setEnv — validate before mutation and recreate through stdin", () =>
     for (const environmentVars of invalidEnvironments) {
       let rejection: unknown;
       try {
-        await client.setEnv("ct1", "org1", environmentVars);
+        await client.setEnv("11111111-1111-4111-8111-111111111111", "org1", environmentVars);
       } catch (error) {
         rejection = error;
       }
@@ -473,12 +653,18 @@ describe("setEnv — validate before mutation and recreate through stdin", () =>
     });
 
     const client = getHetznerContainersClient();
-    await expect(client.setEnv("ct1", "org1", environmentVars)).resolves.toMatchObject({
-      id: "ct1",
+    await expect(
+      client.setEnv("11111111-1111-4111-8111-111111111111", "org1", environmentVars),
+    ).resolves.toMatchObject({
+      id: "11111111-1111-4111-8111-111111111111",
     });
 
     expect(events).toEqual(["funded", "stop", "rm", "network", "stdin-create", "start", "persist"]);
-    expect(prepareFundedRestart).toHaveBeenCalledWith("ct1", "org1", expect.any(Date));
+    expect(prepareFundedRestart).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "org1",
+      expect.any(Date),
+    );
     expect(execStdinMock).toHaveBeenCalledTimes(1);
     const [command, input, timeout] = execStdinMock.mock.calls[0]!;
     expect(command).toContain("docker create");
@@ -486,7 +672,7 @@ describe("setEnv — validate before mutation and recreate through stdin", () =>
     expect(input).toBe(expectedEnvironmentFrame(environmentVars));
     expect(timeout).toBe(60_000);
     expect(updateRow).toHaveBeenCalledWith(
-      "ct1",
+      "11111111-1111-4111-8111-111111111111",
       "org1",
       expect.objectContaining({
         environment_vars: environmentVars,
@@ -509,7 +695,7 @@ describe("setEnv — validate before mutation and recreate through stdin", () =>
     const client = getHetznerContainersClient();
     let rejection: unknown;
     try {
-      await client.setEnv("ct1", "org1", environmentVars);
+      await client.setEnv("11111111-1111-4111-8111-111111111111", "org1", environmentVars);
     } catch (error) {
       rejection = error;
     }
@@ -529,12 +715,14 @@ describe("setEnv — validate before mutation and recreate through stdin", () =>
 describe("deleteContainer — fail-closed host teardown", () => {
   test("happy path removes the container and then deletes the control-plane row", async () => {
     const client = getHetznerContainersClient();
-    await expect(client.deleteContainer("ct1", "org1")).resolves.toBeUndefined();
+    await expect(
+      client.deleteContainer("11111111-1111-4111-8111-111111111111", "org1"),
+    ).resolves.toBeUndefined();
 
     const cmds = execMock.mock.calls.map((c) => c[0]);
     expect(cmds.some((c) => c.includes("docker rm -f"))).toBe(true);
     expect(deleteRow).toHaveBeenCalledTimes(1);
-    expect(deleteRow.mock.calls[0]).toEqual(["ct1", "org1"]);
+    expect(deleteRow.mock.calls[0]).toEqual(["11111111-1111-4111-8111-111111111111", "org1"]);
   });
 
   test("authoritative `docker rm -f` failure PROPAGATES and the row is NOT deleted", async () => {
@@ -546,7 +734,9 @@ describe("deleteContainer — fail-closed host teardown", () => {
     });
 
     const client = getHetznerContainersClient();
-    await expect(client.deleteContainer("ct1", "org1")).rejects.toThrow("rm boom");
+    await expect(
+      client.deleteContainer("11111111-1111-4111-8111-111111111111", "org1"),
+    ).rejects.toThrow("rm boom");
     expect(deleteRow).not.toHaveBeenCalled();
   });
 
@@ -560,7 +750,9 @@ describe("deleteContainer — fail-closed host teardown", () => {
     });
 
     const client = getHetznerContainersClient();
-    await expect(client.deleteContainer("ct1", "org1")).resolves.toBeUndefined();
+    await expect(
+      client.deleteContainer("11111111-1111-4111-8111-111111111111", "org1"),
+    ).resolves.toBeUndefined();
     expect(deleteRow).toHaveBeenCalledTimes(1);
   });
 
@@ -572,7 +764,9 @@ describe("deleteContainer — fail-closed host teardown", () => {
     });
 
     const client = getHetznerContainersClient();
-    await expect(client.deleteContainer("ct1", "org1")).rejects.toMatchObject({
+    await expect(
+      client.deleteContainer("11111111-1111-4111-8111-111111111111", "org1"),
+    ).rejects.toMatchObject({
       code: "ssh_unreachable",
     });
     expect(deleteRow).not.toHaveBeenCalled();
@@ -582,7 +776,9 @@ describe("deleteContainer — fail-closed host teardown", () => {
 describe("billing stop — provider absence proof", () => {
   test("a successful docker removal reports a fresh provider acknowledgement", async () => {
     const client = getHetznerContainersClient();
-    await expect(client.stopContainerRuntimeForBilling("ct1", "org1", 7)).resolves.toEqual({
+    await expect(
+      client.stopContainerRuntimeForBilling("11111111-1111-4111-8111-111111111111", "org1", 7),
+    ).resolves.toEqual({
       nodeId: "node-1",
       alreadyAbsent: false,
     });
@@ -592,14 +788,16 @@ describe("billing stop — provider absence proof", () => {
     execMock.mockImplementation(async (cmd: string) => {
       if (cmd.includes("docker rm -f")) {
         throw new Error(
-          "[docker-ssh] Command exited with code 1 on 10.0.0.1: [stderr] Error response from daemon: No such container: app-ct1",
+          "[docker-ssh] Command exited with code 1 on 10.0.0.1: [stderr] Error response from daemon: No such container: app-11111111-1111-4111-8111-111111111111",
         );
       }
       return "";
     });
 
     const client = getHetznerContainersClient();
-    await expect(client.stopContainerRuntimeForBilling("ct1", "org1", 7)).resolves.toEqual({
+    await expect(
+      client.stopContainerRuntimeForBilling("11111111-1111-4111-8111-111111111111", "org1", 7),
+    ).resolves.toEqual({
       nodeId: "node-1",
       alreadyAbsent: true,
     });
@@ -608,7 +806,9 @@ describe("billing stop — provider absence proof", () => {
   test("malformed provider metadata cannot fabricate runtime absence", async () => {
     readMetadata.mockReturnValue(null);
     const client = getHetznerContainersClient();
-    await expect(client.stopContainerRuntimeForBilling("ct1", "org1", 7)).rejects.toMatchObject({
+    await expect(
+      client.stopContainerRuntimeForBilling("11111111-1111-4111-8111-111111111111", "org1", 7),
+    ).rejects.toMatchObject({
       code: "invalid_input",
     });
     expect(execMock).not.toHaveBeenCalled();
@@ -620,9 +820,9 @@ describe("billing stop — provider absence proof", () => {
       return "";
     });
     const client = getHetznerContainersClient();
-    await expect(client.stopContainerRuntimeForBilling("ct1", "org1", 7)).rejects.toThrow(
-      "docker helper binary not found",
-    );
+    await expect(
+      client.stopContainerRuntimeForBilling("11111111-1111-4111-8111-111111111111", "org1", 7),
+    ).rejects.toThrow("docker helper binary not found");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -21,8 +21,11 @@ import { dockerNodeManager } from "../../docker-node-manager";
 import { getUsedDockerHostPorts } from "../../docker-port-allocation";
 import {
   allocatePort,
+  buildDockerCreateAttemptCleanupCommand,
   buildDockerEnvFileStdinTransport,
   buildEnsureNetworkCmd,
+  buildExactRestoreBootFencedCommand,
+  parseDockerCreateAttemptCleanupReceipt,
   shellQuote,
   validateDockerEnvFileStdinEnvironment,
   WEBUI_PORT_MAX,
@@ -91,6 +94,63 @@ function validateContainerEnvironment(environment: Readonly<Record<string, strin
 }
 
 export class HetznerContainersClient {
+  /** Retry durable failed creates only on the original pinned host and boot incarnation. */
+  async reconcileCreateCleanup(): Promise<{ checked: number; removed: number; pending: number }> {
+    const candidates = await containersRepository.findCreateCleanupCandidates();
+    const result = { checked: candidates.length, removed: 0, pending: 0 };
+    for (const row of candidates) {
+      try {
+        const recordId = row.metadata.nodeRecordId;
+        const node =
+          typeof recordId === "string"
+            ? await dockerNodesRepository.findByIdOnPrimary(recordId)
+            : null;
+        if (
+          !node ||
+          node.node_id !== row.node_id ||
+          !node.node_incarnation ||
+          node.node_incarnation !== row.metadata.createNodeIncarnation ||
+          !node.host_key_fingerprint ||
+          node.host_key_fingerprint !== row.metadata.createHostKeyFingerprint ||
+          node.hostname !== row.metadata.createHostname ||
+          node.ssh_port !== row.metadata.createSshPort ||
+          node.ssh_user !== row.metadata.createSshUser ||
+          node.metadata.environment !== containersEnv.environment() ||
+          row.metadata.environment !== containersEnv.environment()
+        ) {
+          throw new HetznerClientError(
+            "container_create_failed",
+            "Original create host authority is unavailable or changed",
+          );
+        }
+        const ssh = DockerSSHClient.getClient(
+          node.hostname,
+          node.ssh_port,
+          node.host_key_fingerprint,
+          node.ssh_user,
+        );
+        if (await this.cleanupCreateAttempt(ssh, row.id, node.node_incarnation)) {
+          await containersRepository.settleCreateFailure(
+            row.id,
+            row.organization_id,
+            node.id,
+            row.error_message ?? "Container creation failed; remote cleanup confirmed",
+            true,
+          );
+          result.removed += 1;
+        } else result.pending += 1;
+      } catch (error) {
+        // error-policy:J6 one unresolved teardown retains ownership without blocking other retries.
+        result.pending += 1;
+        logger.warn("[hetzner-client] Create cleanup retry remains pending", {
+          containerId: row.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return result;
+  }
+
   // ----------------------------------------------------------------------
   // CRUD
   // ----------------------------------------------------------------------
@@ -223,29 +283,48 @@ export class HetznerContainersClient {
       throw new HetznerClientError("no_capacity", "No Hetzner-Docker capacity available");
     }
 
-    // 4. SSH into the node, pull the image, create + start the container.
-    const ssh = DockerSSHClient.getClient(
-      node.hostname,
-      node.ssh_port ?? 22,
-      node.host_key_fingerprint ?? undefined,
-      node.ssh_user ?? "root",
-    );
-
     const containerName = deriveContainerName(row.id);
-    const usedPorts = await getUsedDockerHostPorts(node.node_id);
+    const nodeIncarnation = node.node_incarnation;
+    let ssh: DockerSSHClient;
+    let usedPorts: Set<number>;
+    let volumePath: string | undefined;
+    try {
+      if (!nodeIncarnation)
+        throw new HetznerClientError("container_create_failed", "Docker node has no boot identity");
+      ssh = DockerSSHClient.getClient(
+        node.hostname,
+        node.ssh_port ?? 22,
+        node.host_key_fingerprint ?? undefined,
+        node.ssh_user ?? "root",
+      );
+      usedPorts = await getUsedDockerHostPorts(node.node_id);
+      volumePath =
+        input.persistVolume && !wantHcloudVolume
+          ? deriveVolumePath(input.organizationId, input.projectName)
+          : undefined;
+      await containersRepository.reserveCreatePlacement(
+        row.id,
+        input.organizationId,
+        node.node_id,
+        node.id,
+        node,
+      );
+    } catch (error) {
+      // error-policy:J2 local preparation and admission fail before any Docker effects.
+      const message = error instanceof Error ? error.message : String(error);
+      await containersRepository.updateStatus(row.id, "failed", message);
+      throw new HetznerClientError("container_create_failed", message, error);
+    }
 
-    // Local volume path - used for non-hcloud persistent volumes. For hcloud
-    // volumes this is set after the attach step below.
-    let volumePath: string | undefined =
-      input.persistVolume && !wantHcloudVolume
-        ? deriveVolumePath(input.organizationId, input.projectName)
-        : undefined;
     let bootstrapStats: { fileCount: number; totalBytes: number } | null = null;
 
     try {
       await containersRepository.update(row.id, input.organizationId, {
         status: "building",
         deployment_log: `Pulling image ${input.image} on ${node.node_id}...`,
+        volume_path: volumePath ?? null,
+        hcloud_volume_id: hcloudVolumeId ?? null,
+        volume_location: hcloudVolumeLocation ?? null,
       });
       await ensureRegistryAccess(ssh, input.image);
       await ssh.exec(`docker pull ${shellQuote(input.image)}`, 5 * 60 * 1000);
@@ -262,6 +341,9 @@ export class HetznerContainersClient {
           projectName: input.projectName,
         });
         volumePath = attached.mountPath;
+        await containersRepository.update(row.id, input.organizationId, {
+          volume_path: volumePath,
+        });
         // Confirm location matches what we stored from the volume record.
         hcloudVolumeLocation = attached.location;
       } else if (volumePath) {
@@ -305,11 +387,16 @@ export class HetznerContainersClient {
             ]
               .filter((part) => part.length > 0)
               .join(" "),
+          { replacementAttemptId: row.id },
         );
 
         try {
           await ssh.exec(buildEnsureNetworkCmd(DEFAULT_NODE_NETWORK), 30_000);
-          await ssh.execStdin(createTransport.command, createTransport.input, 60_000);
+          await ssh.execStdin(
+            buildExactRestoreBootFencedCommand(nodeIncarnation, createTransport.command),
+            createTransport.input,
+            60_000,
+          );
           break;
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
@@ -332,8 +419,13 @@ export class HetznerContainersClient {
       if (hostPort === undefined) {
         throw new HetznerClientError("container_create_failed", "Failed to allocate host port");
       }
-      await ssh.exec(`docker start ${shellQuote(containerName)}`, 60_000);
-      await dockerNodesRepository.incrementAllocated(node.node_id);
+      await ssh.exec(
+        buildExactRestoreBootFencedCommand(
+          nodeIncarnation,
+          `docker start ${shellQuote(containerName)}`,
+        ),
+        60_000,
+      );
 
       const meta: HetznerContainerMetadata = {
         provider: "hetzner-docker",
@@ -359,20 +451,22 @@ export class HetznerContainersClient {
 
       const metadata: Record<string, unknown> = { ...meta };
       if (bootstrapStats) metadata.bootstrapSource = bootstrapStats;
-      const updated = await containersRepository.update(row.id, input.organizationId, {
-        status: "deploying",
-        deployment_log: `Container started on ${node.node_id}; waiting for health check...`,
-        load_balancer_url: publicUrl,
-        public_hostname: publicHostname,
-        node_id: node.node_id,
-        volume_path: volumePath ?? null,
-        volume_size_gb: input.volumeSizeGb ?? null,
-        hcloud_volume_id: hcloudVolumeId ?? null,
-        volume_location: hcloudVolumeLocation ?? null,
-        metadata,
-      });
+      const updated = await containersRepository.completeCreatePlacement(
+        row.id,
+        input.organizationId,
+        node.id,
+        {
+          load_balancer_url: publicUrl,
+          public_hostname: publicHostname,
+          volume_path: volumePath ?? null,
+          volume_size_gb: input.volumeSizeGb ?? null,
+          hcloud_volume_id: hcloudVolumeId ?? null,
+          volume_location: hcloudVolumeLocation ?? null,
+          metadata,
+        },
+      );
 
-      return rowToSummary(updated ?? { ...row, metadata });
+      return rowToSummary(updated);
     } catch (err) {
       // error-policy:J2 translate the create failure into a typed provisioning
       // error (with `err` as cause) after marking the row `failed`; the throw
@@ -383,18 +477,14 @@ export class HetznerContainersClient {
         nodeId: node.node_id,
         error: message,
       });
-      // Best-effort deletion of the half-created Docker container. Leave the
-      // Hetzner Cloud volume intact; it may contain data if this is a
-      // redeploy and the container start failed after attach. Operators can
-      // retry because the volume is found by label on the next attempt.
-      // error-policy:J6 teardown-only; a cleanup failure is logged, never masks
-      // the create error rethrown below.
-      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, 30_000).catch((rmErr) =>
-        logger.warn(`[hetzner-client] cleanup rm failed for ${containerName}`, {
-          error: rmErr instanceof Error ? rmErr.message : String(rmErr),
-        }),
+      const removed = await this.cleanupCreateAttempt(ssh, row.id, nodeIncarnation);
+      await containersRepository.settleCreateFailure(
+        row.id,
+        input.organizationId,
+        node.id,
+        message,
+        removed,
       );
-      await containersRepository.updateStatus(row.id, "failed", message);
       throw new HetznerClientError("container_create_failed", message, err);
     }
   }
@@ -941,7 +1031,13 @@ export class HetznerContainersClient {
    * (`building`, `deploying`) and flip `running` / `failed` accordingly.
    * Called from the deployment-monitor cron handler.
    */
-  async monitorInflight(): Promise<{ checked: number; running: number; failed: number }> {
+  async monitorInflight(): Promise<{
+    checked: number;
+    running: number;
+    failed: number;
+    cleanup: { checked: number; removed: number; pending: number };
+  }> {
+    const cleanup = await this.reconcileCreateCleanup();
     const inflight = await dbRead
       .select()
       .from(containersTable)
@@ -1004,12 +1100,66 @@ export class HetznerContainersClient {
       }
     }
 
-    return { checked: inflight.length, running, failed };
+    return { checked: inflight.length, running, failed, cleanup };
   }
 
   // ----------------------------------------------------------------------
   // Internal helpers
   // ----------------------------------------------------------------------
+
+  /** Cancel the producer before deleting only its recorded candidate or proven-quiescent name. */
+  private async cleanupCreateAttempt(
+    ssh: DockerSSHClient,
+    attemptId: string,
+    nodeIncarnation: string,
+  ): Promise<boolean> {
+    try {
+      const output = await ssh.exec(
+        buildExactRestoreBootFencedCommand(
+          nodeIncarnation,
+          buildDockerCreateAttemptCleanupCommand(attemptId),
+        ),
+        30_000,
+      );
+      const receipt = parseDockerCreateAttemptCleanupReceipt(output, attemptId);
+      if (!receipt.quiescent && receipt.containerId === null) return false;
+      const target = receipt.containerId ?? deriveContainerName(attemptId);
+      try {
+        await ssh.exec(
+          buildExactRestoreBootFencedCommand(nodeIncarnation, `docker rm -f ${shellQuote(target)}`),
+          30_000,
+        );
+        return true;
+      } catch (removeError) {
+        // error-policy:J6 settle uncertain deletion only through a fresh exact-target absence response.
+        try {
+          await ssh.exec(
+            buildExactRestoreBootFencedCommand(
+              nodeIncarnation,
+              `docker inspect --format '{{.Id}}' ${shellQuote(target)}`,
+            ),
+            15_000,
+          );
+        } catch (inspectError) {
+          // error-policy:J6 transport failure is never an absence receipt.
+          if (
+            isContainerAbsentMessage(
+              inspectError instanceof Error ? inspectError.message : String(inspectError),
+            )
+          )
+            return true;
+        }
+        throw removeError;
+      }
+    } catch (error) {
+      // error-policy:J6 failed cleanup preserves the durable reservation for reconciliation.
+      logger.warn("[hetzner-client] Create cleanup remains unresolved", {
+        attemptId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
 
   private async requireRowWithMeta(
     containerId: string,

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -1107,7 +1107,7 @@ export class HetznerContainersClient {
   // Internal helpers
   // ----------------------------------------------------------------------
 
-  /** Cancel the producer before deleting only its recorded candidate or proven-quiescent name. */
+  /** Cancel the producer before deleting only its recorded candidate. */
   private async cleanupCreateAttempt(
     ssh: DockerSSHClient,
     attemptId: string,
@@ -1122,8 +1122,10 @@ export class HetznerContainersClient {
         30_000,
       );
       const receipt = parseDockerCreateAttemptCleanupReceipt(output, attemptId);
-      if (!receipt.quiescent && receipt.containerId === null) return false;
-      const target = receipt.containerId ?? deriveContainerName(attemptId);
+      // Quiescence without a candidate proves this attempt has nothing to remove.
+      // A reusable name cannot authorize deleting a container created elsewhere.
+      if (receipt.containerId === null) return receipt.quiescent;
+      const target = receipt.containerId;
       try {
         await ssh.exec(
           buildExactRestoreBootFencedCommand(nodeIncarnation, `docker rm -f ${shellQuote(target)}`),

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.error-policy.test.ts
@@ -13,17 +13,16 @@ import * as realDockerNodeWorkloadsNs from "../docker-node-workloads";
 import type { ComputeProvider } from "./compute-provider";
 import * as realHetznerCloudApiNs from "./hetzner-cloud-api";
 import * as realNodeBootstrapNs from "./node-bootstrap";
+import * as realRetirementNs from "./node-retirement-authority";
 
 const realDockerNodes = { ...realDockerNodesNs };
 const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
 const realHetznerCloudApi = { ...realHetznerCloudApiNs };
 const realNodeBootstrap = { ...realNodeBootstrapNs };
+const realRetirement = { ...realRetirementNs };
 const originalFirewallIds = process.env.CONTAINERS_HCLOUD_FIREWALL_IDS;
 const originalEnvironment = process.env.ENVIRONMENT;
 
-// The source narrows the swallow to `err instanceof HetznerCloudError &&
-// err.code === "not_found"`, so the thrown error must be an instance of the
-// SAME class the module-under-test imports — i.e. this mocked one.
 class FakeHetznerCloudError extends Error {
   constructor(
     public readonly code: string,
@@ -66,6 +65,20 @@ mock.module("./hetzner-cloud-api", () => ({
   isHetznerCloudConfigured: mocks.isConfigured,
 }));
 
+mock.module("./node-retirement-authority", () => ({
+  requestNodeRetirement: async () => {},
+  findRequestedNodeRetirements: async () => [],
+  withNodeRetirementAuthority: async (
+    nodeId: string,
+    retire: (node: DockerNode) => Promise<boolean>,
+  ) => {
+    const node = await mocks.findByNodeId(nodeId);
+    if (!(await retire(node))) return false;
+    await mocks.deleteNode(node.id);
+    return true;
+  },
+}));
+
 mock.module("./node-bootstrap", () => ({
   buildContainerNodeUserData: mock(() => "#cloud-config\n"),
 }));
@@ -75,6 +88,7 @@ afterAll(() => {
   mock.module("../docker-node-workloads", () => realDockerNodeWorkloads);
   mock.module("./hetzner-cloud-api", () => realHetznerCloudApi);
   mock.module("./node-bootstrap", () => realNodeBootstrap);
+  mock.module("./node-retirement-authority", () => realRetirement);
   if (originalFirewallIds === undefined) delete process.env.CONTAINERS_HCLOUD_FIREWALL_IDS;
   else process.env.CONTAINERS_HCLOUD_FIREWALL_IDS = originalFirewallIds;
   if (originalEnvironment === undefined) delete process.env.ENVIRONMENT;
@@ -181,9 +195,10 @@ describe("NodeAutoscaler drain deprovision — fail-closed error policy (#13415)
   });
 
   test("treats an idempotent not_found as designed success and removes the DB row", async () => {
-    mocks.deleteServer.mockRejectedValue(
-      new FakeHetznerCloudError("not_found", "server already deleted"),
-    );
+    mocks.deleteServer.mockImplementation(async () => {
+      mocks.getServer.mockResolvedValue(null);
+      throw new FakeHetznerCloudError("not_found", "server already deleted");
+    });
 
     await expect(drainDeprovision()).resolves.toBeUndefined();
 
@@ -195,7 +210,9 @@ describe("NodeAutoscaler drain deprovision — fail-closed error policy (#13415)
   });
 
   test("a clean delete removes the DB row (baseline distinct from failure)", async () => {
-    mocks.deleteServer.mockResolvedValue(undefined);
+    mocks.deleteServer.mockImplementation(async () => {
+      mocks.getServer.mockResolvedValue(null);
+    });
 
     await expect(drainDeprovision()).resolves.toBeUndefined();
 
@@ -224,6 +241,28 @@ describe("NodeAutoscaler drain deprovision — fail-closed error policy (#13415)
       "returned server 9999 for requested server 4242",
     );
     expect(mocks.deleteServer).not.toHaveBeenCalled();
+    expect(mocks.deleteNode).not.toHaveBeenCalled();
+  });
+  test("does not equate a successful delete response with completed deletion", async () => {
+    mocks.deleteServer.mockResolvedValue(undefined);
+    await expect(drainDeprovision()).rejects.toThrow("not yet confirmed absent");
+    expect(mocks.deleteNode).not.toHaveBeenCalled();
+  });
+
+  test("settles a lost deletion acknowledgement by observing provider absence", async () => {
+    mocks.deleteServer.mockImplementation(async () => {
+      mocks.getServer.mockResolvedValue(null);
+      throw new Error("lost response");
+    });
+    await expect(drainDeprovision()).resolves.toBeUndefined();
+    expect(mocks.deleteNode).toHaveBeenCalledWith("db-1");
+  });
+
+  test("keeps the record if absence readback fails", async () => {
+    mocks.deleteServer.mockImplementation(async () => {
+      mocks.getServer.mockRejectedValue(new Error("provider read unavailable"));
+    });
+    await expect(drainDeprovision()).rejects.toThrow("provider read unavailable");
     expect(mocks.deleteNode).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -12,6 +12,7 @@ import * as realDockerNodesNs from "../../../db/repositories/docker-nodes";
 import * as realDockerNodeWorkloadsNs from "../docker-node-workloads";
 import * as realHetznerCloudApiNs from "./hetzner-cloud-api";
 import * as realNodeBootstrapNs from "./node-bootstrap";
+import * as realRetirementNs from "./node-retirement-authority";
 
 // Snapshot the real exports into plain objects *before* the `mock.module` calls
 // below run. The `import * as` namespaces are live bindings — once `mock.module`
@@ -22,6 +23,7 @@ const realDockerNodes = { ...realDockerNodesNs };
 const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
 const realHetznerCloudApi = { ...realHetznerCloudApiNs };
 const realNodeBootstrap = { ...realNodeBootstrapNs };
+const realRetirement = { ...realRetirementNs };
 
 const AGENT_IMAGE = "ELIZA_AGENT_IMAGE";
 const AGENT_IMAGE_PLATFORM = "ELIZA_AGENT_IMAGE_PLATFORM";
@@ -97,6 +99,35 @@ mock.module("./node-provision-authority", () => ({
   ) => operation({ nodes: mocks.nodes, createNode: mocks.createNode }),
 }));
 
+// Retirement persistence is a stateful repository boundary in this autoscaler unit harness.
+mock.module("./node-retirement-authority", () => ({
+  requestNodeRetirement: async (nodeId: string) => {
+    const node = await mocks.findByNodeId(nodeId);
+    if (!node) throw new Error("Node missing");
+    await mocks.updateNode(node.id, {
+      enabled: false,
+      metadata: { ...node.metadata, requestedProviderRetirement: node.provider_server_id },
+    });
+  },
+  findRequestedNodeRetirements: async () =>
+    (await mocks.findAllNodes()).filter(
+      (node: DockerNode) =>
+        !node.enabled &&
+        node.provider_server_id !== null &&
+        node.metadata.requestedProviderRetirement === node.provider_server_id,
+    ),
+  withNodeRetirementAuthority: async (
+    nodeId: string,
+    retire: (node: DockerNode) => Promise<boolean>,
+  ) => {
+    const node = await mocks.findByNodeId(nodeId);
+    if (!node) return true;
+    if (!(await retire(node))) return false;
+    await mocks.deleteNode(node.id);
+    return true;
+  },
+}));
+
 mock.module("./node-bootstrap", () => ({
   buildContainerNodeUserData: mocks.buildUserData,
 }));
@@ -106,6 +137,7 @@ afterAll(() => {
   mock.module("../docker-node-workloads", () => realDockerNodeWorkloads);
   mock.module("./hetzner-cloud-api", () => realHetznerCloudApi);
   mock.module("./node-bootstrap", () => realNodeBootstrap);
+  mock.module("./node-retirement-authority", () => realRetirement);
 });
 
 import { InMemoryComputeProvider } from "./compute-provider-fake";
@@ -1241,5 +1273,58 @@ describe("NodeAutoscaler full provision\u2192healthy\u2192drain loop (#8920)", (
     const drained = await autoscaler.evaluateCapacity();
     expect(drained.healthyNodeCount).toBe(0);
     expect(drained.shouldScaleUp).toBe(true);
+  });
+  test("retries a failed retirement while preserving manual disablement and retained state", async () => {
+    class FailingDeleteProvider extends InMemoryComputeProvider {
+      failNextDelete = true;
+      override async deleteServer(id: number): Promise<void> {
+        if (this.failNextDelete) {
+          this.failNextDelete = false;
+          throw new Error("provider temporarily unavailable");
+        }
+        await super.deleteServer(id);
+      }
+    }
+    const fake = new FailingDeleteProvider({ serverActivateAfterTicks: 1 });
+    const autoscaler = new NodeAutoscaler(policy, () => NOW, fake);
+    const provisioned = await autoscaler.provisionNode(
+      { nodeId: "retry-node", capacity: 8, prePullImages: [] },
+      { controlPlanePublicKey: "ssh-ed25519 AAAAcontrol" },
+    );
+    fake.tick(1);
+    store[0].status = "healthy";
+    delete store[0].metadata.capacityProvisional;
+    await expect(autoscaler.drainNode("retry-node", { deprovision: true })).rejects.toThrow(
+      "provider temporarily unavailable",
+    );
+    expect(await fake.getServer(provisioned.hcloudServerId)).not.toBeNull();
+    expect(store[0].enabled).toBe(false);
+
+    // A later process cycle uses persisted intent, even when no enabled node is drainable.
+    const restarted = new NodeAutoscaler(policy, () => NOW, fake);
+    mocks.countRetained.mockResolvedValue(1);
+    expect(await restarted.reconcileRetirements()).toEqual({
+      completed: 0,
+      retained: 1,
+      failed: 0,
+    });
+    expect(await fake.getServer(provisioned.hcloudServerId)).not.toBeNull();
+    mocks.countRetained.mockResolvedValue(0);
+    expect(await restarted.reconcileRetirements()).toEqual({
+      completed: 1,
+      retained: 0,
+      failed: 0,
+    });
+    expect(await fake.getServer(provisioned.hcloudServerId)).toBeNull();
+    expect(store).toHaveLength(0);
+
+    const manual = await autoscaler.provisionNode(
+      { nodeId: "manual-node", capacity: 8, prePullImages: [] },
+      { controlPlanePublicKey: "ssh-ed25519 AAAAcontrol" },
+    );
+    fake.tick(1);
+    await autoscaler.drainNode("manual-node");
+    await restarted.reconcileRetirements();
+    expect(await fake.getServer(manual.hcloudServerId)).not.toBeNull();
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
@@ -42,10 +42,16 @@ import {
   attestHetznerCloudNode,
   type HetznerServerAuthority,
   isTypedHetznerCloudNode,
+  requireHetznerNodeAuthority,
   requireSafeHetznerServerId,
 } from "./hetzner-node-attestation";
 import { buildContainerNodeUserData, type NodeBootstrapInput } from "./node-bootstrap";
 import { withNodeProvisionAuthority } from "./node-provision-authority";
+import {
+  findRequestedNodeRetirements,
+  requestNodeRetirement,
+  withNodeRetirementAuthority,
+} from "./node-retirement-authority";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -540,63 +546,70 @@ export class NodeAutoscaler {
    * useful message.
    */
   async drainNode(nodeId: string, options: DrainOptions = {}): Promise<void> {
-    const node = await dockerNodesRepository.findByNodeId(nodeId);
-    if (!node) {
-      throw new HetznerCloudError("not_found", `node ${nodeId} not registered`);
-    }
-
-    if (node.enabled) {
+    if (options.deprovision !== true) {
+      const node = await dockerNodesRepository.findByNodeId(nodeId);
+      if (!node) throw new HetznerCloudError("not_found", `node ${nodeId} not registered`);
       await dockerNodesRepository.update(node.id, { enabled: false });
-      logger.info("[autoscaler] Disabled node for drain", { nodeId });
-    }
-
-    const retainedWorkloads = await countRetainedWorkloadsOnNode(nodeId);
-    if (retainedWorkloads > 0) {
-      logger.info("[autoscaler] Node still has retained workloads, leaving disabled until empty", {
-        nodeId,
-        remaining: retainedWorkloads,
-      });
       return;
     }
+    await requestNodeRetirement(nodeId);
+    await this.completeRequestedRetirement(nodeId);
+  }
 
-    if (options.deprovision !== true) return;
-
-    const hcloudServerId = getHcloudServerId(node);
-    if (!hcloudServerId) {
-      logger.warn("[autoscaler] Cannot deprovision: no hcloudServerId on node metadata", {
-        nodeId,
-      });
-      return;
-    }
-
-    if (!isHetznerCloudConfigured()) {
-      throw new HetznerCloudError(
-        "missing_token",
-        `Cannot attest or delete Hetzner server ${hcloudServerId} without HCLOUD_TOKEN`,
-      );
-    }
-
-    const client = this.computeProvider();
-    try {
-      const attested = await attestHetznerCloudNode(node, client);
-      await client.deleteServer(attested.serverId);
-    } catch (err) {
-      // error-policy:J6 idempotent teardown — a not_found means the server is
-      // already deprovisioned (the desired end state), so the DB row is safe to
-      // delete below. Every other outbound-API failure (auth/rate-limit/5xx)
-      // rethrows so a live server is never orphaned by a silently-dropped delete.
-      if (err instanceof HetznerCloudError && err.code === "not_found") {
-        logger.info("[autoscaler] Hetzner server already gone", {
-          nodeId,
-          hcloudServerId,
+  /** Retry committed retirements even when the scheduling pool needs no capacity change. */
+  async reconcileRetirements(): Promise<{ completed: number; retained: number; failed: number }> {
+    const summary = { completed: 0, retained: 0, failed: 0 };
+    for (const node of await findRequestedNodeRetirements()) {
+      try {
+        if (await this.completeRequestedRetirement(node.node_id)) summary.completed += 1;
+        else summary.retained += 1;
+      } catch (error) {
+        // error-policy:J6 failed teardown retains its committed request for the next cycle.
+        summary.failed += 1;
+        logger.warn("[autoscaler] Requested node retirement remains pending", {
+          nodeId: node.node_id,
+          error,
         });
-      } else {
-        throw err;
       }
     }
+    return summary;
+  }
 
-    await dockerNodesRepository.delete(node.id);
-    logger.info("[autoscaler] Deprovisioned node", { nodeId, hcloudServerId });
+  private async completeRequestedRetirement(nodeId: string): Promise<boolean> {
+    return withNodeRetirementAuthority(nodeId, async (node) => {
+      const retainedWorkloads = await countRetainedWorkloadsOnNode(nodeId);
+      if (retainedWorkloads > 0) {
+        logger.info("[autoscaler] Retirement waits for retained workloads", {
+          nodeId,
+          remaining: retainedWorkloads,
+        });
+        return false;
+      }
+      const serverId = getHcloudServerId(node);
+      if (!serverId || !isHetznerCloudConfigured()) {
+        throw new HetznerCloudError(
+          "missing_token",
+          "Node retirement requires provider identity and credentials",
+        );
+      }
+      const client = this.computeProvider();
+      const existing = await client.getServer(serverId);
+      if (existing) {
+        assertAuthoritativeHetznerServer(existing, requireHetznerNodeAuthority(node));
+        try {
+          await client.deleteServer(serverId);
+        } catch (error) {
+          // error-policy:J6 lost deletion acknowledgements settle only through a fresh absence read.
+          if (await client.getServer(serverId)) throw error;
+          return true;
+        }
+        if (await client.getServer(serverId)) {
+          throw new HetznerCloudError("server_error", "Node deletion is not yet confirmed absent");
+        }
+      }
+      logger.info("[autoscaler] Provider node absence confirmed", { nodeId, serverId });
+      return true;
+    });
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/containers/node-retirement-authority.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-retirement-authority.test.ts
@@ -1,0 +1,252 @@
+/** Exercises committed retirement intent and rollback using a real isolated PGlite database. */
+
+import { afterAll, beforeAll, beforeEach, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.ENVIRONMENT = "local";
+process.env.CONTAINERS_HCLOUD_FIREWALL_IDS = "8101";
+
+const EXPECTED_HOST = {
+  hostname: "192.0.2.1",
+  ssh_port: 22,
+  ssh_user: "root",
+  host_key_fingerprint: "SHA256:test-host-pin",
+  node_incarnation: "00000000-0000-4000-8000-000000000099",
+};
+const { dbWrite } = await import("../../../db/helpers");
+const { closeDatabaseConnectionsForTests } = await import("../../../db/client");
+const { requestNodeRetirement, findRequestedNodeRetirements, withNodeRetirementAuthority } =
+  await import("./node-retirement-authority");
+
+beforeAll(async () => {
+  // This fixture owns only the node persistence boundary; source-history and
+  // workload constraints are exercised by their existing schema integration lanes.
+  await dbWrite.execute(sql`CREATE TABLE docker_nodes (
+    id uuid PRIMARY KEY, node_id text UNIQUE NOT NULL, hostname text NOT NULL,
+    ssh_port integer NOT NULL DEFAULT 22, capacity integer NOT NULL DEFAULT 8,
+    enabled boolean NOT NULL DEFAULT true, placement_state text NOT NULL DEFAULT 'open',
+    status text NOT NULL DEFAULT 'healthy', allocated_count integer NOT NULL DEFAULT 0,
+    last_health_check timestamptz, ssh_user text NOT NULL DEFAULT 'root',
+    host_key_fingerprint text, fleet_kind text, infrastructure_provider text,
+    provider_server_id text, node_incarnation uuid, current_node_history_id uuid,
+    backup_admission_xid xid8 NOT NULL DEFAULT pg_current_xact_id(),
+    metadata jsonb NOT NULL DEFAULT '{}', created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+  )`);
+  await dbWrite.execute(sql`CREATE TABLE containers (
+    id uuid PRIMARY KEY, organization_id uuid NOT NULL, status text NOT NULL,
+    node_id text, metadata jsonb NOT NULL DEFAULT '{}', updated_at timestamptz,
+    error_message text
+  )`);
+});
+
+beforeEach(async () => {
+  await dbWrite.execute(sql`DELETE FROM containers`);
+  await dbWrite.execute(sql`DELETE FROM docker_nodes`);
+  await dbWrite.execute(sql`INSERT INTO docker_nodes
+    (id, node_id, hostname, fleet_kind, infrastructure_provider, provider_server_id, metadata, node_incarnation, host_key_fingerprint)
+    VALUES ('00000000-0000-4000-8000-000000000001', 'node-1', '192.0.2.1',
+      'cloud', 'hetzner', '42', '{"environment":"local","unrelated":"preserved"}',
+      '00000000-0000-4000-8000-000000000099', 'SHA256:test-host-pin')`);
+});
+
+test("app placement commits its owner with capacity and cannot reserve twice", async () => {
+  const { containersRepository } = await import("../../../db/repositories/containers");
+  const id = "00000000-0000-4000-8000-000000000010";
+  const org = "00000000-0000-4000-8000-000000000020";
+  const nodeRecordId = "00000000-0000-4000-8000-000000000001";
+  await dbWrite.execute(sql`INSERT INTO containers (id, organization_id, status)
+    VALUES (${id}::uuid, ${org}::uuid, 'pending')`);
+  await expect(
+    containersRepository.reserveCreatePlacement(id, id, "node-1", nodeRecordId, EXPECTED_HOST),
+  ).rejects.toThrow("no longer admits placement");
+  await requestNodeRetirement("node-1");
+  await expect(
+    containersRepository.reserveCreatePlacement(id, org, "node-1", nodeRecordId, EXPECTED_HOST),
+  ).rejects.toThrow("no longer admits container placement");
+  const unchanged = await dbWrite.execute(sql`SELECT status, node_id FROM containers`);
+  expect(unchanged.rows).toEqual([{ status: "pending", node_id: null }]);
+  await dbWrite.execute(sql`UPDATE docker_nodes SET enabled=true, placement_state='open'`);
+  await containersRepository.reserveCreatePlacement(id, org, "node-1", nodeRecordId, EXPECTED_HOST);
+  await expect(
+    containersRepository.reserveCreatePlacement(id, org, "node-1", nodeRecordId, EXPECTED_HOST),
+  ).rejects.toThrow("no longer admits placement");
+  const placed = await dbWrite.execute(sql`SELECT c.status, c.node_id, n.allocated_count
+    FROM containers c JOIN docker_nodes n ON n.node_id=c.node_id`);
+  expect(placed.rows).toEqual([{ status: "building", node_id: "node-1", allocated_count: 1 }]);
+});
+
+test("placement rejects a changed host and retains its original pin after admission", async () => {
+  const { containersRepository } = await import("../../../db/repositories/containers");
+  const id = "00000000-0000-4000-8000-000000000010";
+  const org = "00000000-0000-4000-8000-000000000020";
+  const nodeRecordId = "00000000-0000-4000-8000-000000000001";
+  await dbWrite.execute(sql`INSERT INTO containers (id, organization_id, status)
+    VALUES (${id}::uuid, ${org}::uuid, 'pending')`);
+  await dbWrite.execute(sql`UPDATE docker_nodes SET hostname='192.0.2.2'`);
+  await expect(
+    containersRepository.reserveCreatePlacement(id, org, "node-1", nodeRecordId, EXPECTED_HOST),
+  ).rejects.toThrow("no longer admits container placement");
+  const rejected = await dbWrite.execute(sql`SELECT allocated_count FROM docker_nodes`);
+  expect(rejected.rows).toEqual([{ allocated_count: 0 }]);
+  await dbWrite.execute(sql`UPDATE docker_nodes SET hostname='192.0.2.1'`);
+  await containersRepository.reserveCreatePlacement(id, org, "node-1", nodeRecordId, EXPECTED_HOST);
+  await dbWrite.execute(
+    sql`UPDATE docker_nodes SET host_key_fingerprint='SHA256:replacement-host'`,
+  );
+  const original = await dbWrite.execute(sql`SELECT metadata->>'createHostKeyFingerprint' AS pin,
+    metadata->>'createNodeIncarnation' AS incarnation FROM containers`);
+  expect(original.rows).toEqual([
+    { pin: EXPECTED_HOST.host_key_fingerprint, incarnation: EXPECTED_HOST.node_incarnation },
+  ]);
+});
+
+test("existing app claim retries and rollback keep one capacity owner", async () => {
+  const { claimAppContainerNodeSlot, rollbackAppContainerNodeSlotClaim } = await import(
+    "../app-container-store-queries"
+  );
+  const id = "00000000-0000-4000-8000-000000000010";
+  const org = "00000000-0000-4000-8000-000000000020";
+  await dbWrite.execute(sql`INSERT INTO containers (id, organization_id, status)
+    VALUES (${id}::uuid, ${org}::uuid, 'pending')`);
+  const claim = () =>
+    claimAppContainerNodeSlot(
+      dbWrite,
+      id,
+      org,
+      "node-1",
+      () => new Error("capacity unavailable"),
+      () => new Error("claim conflict"),
+    );
+  expect(await claim()).toBe("claimed");
+  expect(await claim()).toBe("already-claimed");
+  const reserved = await dbWrite.execute(sql`SELECT allocated_count FROM docker_nodes`);
+  expect(reserved.rows).toEqual([{ allocated_count: 1 }]);
+  expect(await rollbackAppContainerNodeSlotClaim(dbWrite, id, org, "node-1")).toBe(true);
+  expect(await rollbackAppContainerNodeSlotClaim(dbWrite, id, org, "node-1")).toBe(false);
+  const released = await dbWrite.execute(sql`SELECT allocated_count FROM docker_nodes`);
+  expect(released.rows).toEqual([{ allocated_count: 0 }]);
+});
+
+test("uncertain create cleanup retains capacity; proven removal releases it once", async () => {
+  const { containersRepository } = await import("../../../db/repositories/containers");
+  const id = "00000000-0000-4000-8000-000000000010";
+  const org = "00000000-0000-4000-8000-000000000020";
+  const nodeRecordId = "00000000-0000-4000-8000-000000000001";
+  await dbWrite.execute(sql`INSERT INTO containers (id, organization_id, status)
+    VALUES (${id}::uuid, ${org}::uuid, 'pending')`);
+  await containersRepository.reserveCreatePlacement(id, org, "node-1", nodeRecordId, EXPECTED_HOST);
+  await containersRepository.settleCreateFailure(id, org, nodeRecordId, "connection lost", false);
+  const pending = await dbWrite.execute(sql`SELECT c.status, n.allocated_count
+    FROM containers c JOIN docker_nodes n ON n.node_id=c.node_id`);
+  expect(pending.rows).toEqual([{ status: "cleanup_required", allocated_count: 1 }]);
+  await containersRepository.settleCreateFailure(id, org, nodeRecordId, "create failed", true);
+  await containersRepository.settleCreateFailure(id, org, nodeRecordId, "create failed", true);
+  const released = await dbWrite.execute(sql`SELECT c.status, n.allocated_count
+    FROM containers c JOIN docker_nodes n ON n.node_id=c.node_id`);
+  expect(released.rows).toEqual([{ status: "failed", allocated_count: 0 }]);
+});
+
+test("cleanup cannot decrement a slot already released by another lifecycle owner", async () => {
+  const { containersRepository } = await import("../../../db/repositories/containers");
+  const id = "00000000-0000-4000-8000-000000000010";
+  const org = "00000000-0000-4000-8000-000000000020";
+  const nodeRecordId = "00000000-0000-4000-8000-000000000001";
+  await dbWrite.execute(sql`INSERT INTO containers (id, organization_id, status)
+    VALUES (${id}::uuid, ${org}::uuid, 'pending')`);
+  await containersRepository.reserveCreatePlacement(id, org, "node-1", nodeRecordId, EXPECTED_HOST);
+  await dbWrite.execute(
+    sql`UPDATE containers SET metadata=metadata || '{"slotReleasedAt":"2026-09-05T00:00:00Z"}'::jsonb`,
+  );
+  await expect(
+    containersRepository.settleCreateFailure(id, org, nodeRecordId, "late cleanup", true),
+  ).rejects.toThrow("placement changed");
+  const remaining = await dbWrite.execute(sql`SELECT allocated_count FROM docker_nodes`);
+  expect(remaining.rows).toEqual([{ allocated_count: 1 }]);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+test("provider failure rolls back deletion but preserves the separately committed request", async () => {
+  await requestNodeRetirement("node-1");
+  await expect(
+    withNodeRetirementAuthority("node-1", async () => {
+      throw new Error("provider unavailable");
+    }),
+  ).rejects.toThrow("provider unavailable");
+  const pending = await findRequestedNodeRetirements();
+  expect(pending.map((node) => node.node_id)).toEqual(["node-1"]);
+  expect(pending[0].metadata.unrelated).toBe("preserved");
+  expect(pending[0].placement_state).toBe("cordoned");
+  expect(await withNodeRetirementAuthority("node-1", async () => false)).toBe(false);
+  expect(await findRequestedNodeRetirements()).toHaveLength(1);
+  expect(await withNodeRetirementAuthority("node-1", async () => true)).toBe(true);
+  expect(await findRequestedNodeRetirements()).toHaveLength(0);
+  expect(
+    await withNodeRetirementAuthority("node-1", async () => {
+      throw new Error("already deleted node must not call provider");
+    }),
+  ).toBe(true);
+});
+
+test("manual disablement and foreign environment never grant retirement authority", async () => {
+  await dbWrite.execute(sql`UPDATE docker_nodes SET enabled=false`);
+  expect(await findRequestedNodeRetirements()).toHaveLength(0);
+  await expect(withNodeRetirementAuthority("node-1", async () => true)).rejects.toThrow(
+    "no matching retirement request",
+  );
+  await dbWrite.execute(sql`UPDATE docker_nodes SET metadata='{"environment":"production"}'`);
+  await expect(requestNodeRetirement("node-1")).rejects.toThrow("active environment");
+  expect(await findRequestedNodeRetirements()).toHaveLength(0);
+});
+
+test("metadata refresh preserves intent; re-enabling cancels it permanently", async () => {
+  const { dockerNodesRepository } = await import("../../../db/repositories/docker-nodes");
+  const id = "00000000-0000-4000-8000-000000000001";
+  await requestNodeRetirement("node-1");
+  await dockerNodesRepository.update(id, { metadata: { environment: "local", refreshed: true } });
+  const [pending] = await findRequestedNodeRetirements();
+  expect(pending.metadata.refreshed).toBe(true);
+  expect(pending.metadata.requestedProviderRetirement).toBe("42");
+  await dockerNodesRepository.update(id, { enabled: true, metadata: pending.metadata });
+  await dockerNodesRepository.update(id, { enabled: false });
+  expect(await findRequestedNodeRetirements()).toHaveLength(0);
+  await expect(withNodeRetirementAuthority("node-1", async () => true)).rejects.toThrow(
+    "no matching retirement request",
+  );
+});
+
+test("a selection made before retirement cannot reserve capacity after the cordon", async () => {
+  const { dockerNodesRepository } = await import("../../../db/repositories/docker-nodes");
+  const id = "00000000-0000-4000-8000-000000000001";
+  await requestNodeRetirement("node-1");
+  await expect(dockerNodesRepository.incrementAllocated("node-1", id)).rejects.toThrow(
+    "no longer admits placement",
+  );
+  await dockerNodesRepository.update(id, { enabled: true });
+  await expect(dockerNodesRepository.incrementAllocated("node-1", id)).rejects.toThrow(
+    "no longer admits placement",
+  );
+  await dockerNodesRepository.update(id, { placement_state: "open", capacity: 1 });
+  await dockerNodesRepository.incrementAllocated("node-1", id);
+  await expect(dockerNodesRepository.incrementAllocated("node-1", id)).rejects.toThrow(
+    "no longer admits placement",
+  );
+  expect((await dockerNodesRepository.findByIdOnPrimary(id))?.allocated_count).toBe(1);
+});
+
+test("reusing a logical node name cannot admit a stale selection onto its replacement", async () => {
+  const { dockerNodesRepository } = await import("../../../db/repositories/docker-nodes");
+  const previousId = "00000000-0000-4000-8000-000000000001";
+  const replacementId = "00000000-0000-4000-8000-000000000002";
+  await dbWrite.execute(sql`UPDATE docker_nodes SET id=${replacementId}::uuid`);
+  await expect(dockerNodesRepository.incrementAllocated("node-1", previousId)).rejects.toThrow(
+    "no longer admits placement",
+  );
+  expect((await dockerNodesRepository.findByIdOnPrimary(replacementId))?.allocated_count).toBe(0);
+  await dockerNodesRepository.incrementAllocated("node-1", replacementId);
+  expect((await dockerNodesRepository.findByIdOnPrimary(replacementId))?.allocated_count).toBe(1);
+});

--- a/packages/cloud/shared/src/lib/services/containers/node-retirement-authority.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-retirement-authority.ts
@@ -1,0 +1,100 @@
+/**
+ * Persists explicit node retirement independently of capacity selection.
+ * Provider failure must leave the committed request discoverable. The node row
+ * lock serializes retirement with node mutations. Workload admission must persist
+ * its ownership before remote effects; a node lock alone cannot establish that.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { and, eq, sql } from "drizzle-orm";
+import { dbWrite } from "../../../db/helpers";
+import {
+  type DockerNode,
+  dockerNodes,
+  NODE_RETIREMENT_METADATA_KEY,
+} from "../../../db/schemas/docker-nodes";
+import { containersEnv } from "../../config/containers-env";
+import { requireHetznerNodeAuthority } from "./hetzner-node-attestation";
+
+const RETIREMENT_KEY = NODE_RETIREMENT_METADATA_KEY;
+
+/** Only a request for this exact typed provider identity permits automatic retry. */
+export function hasNodeRetirementRequest(node: DockerNode): boolean {
+  return (
+    !node.enabled &&
+    node.fleet_kind === "cloud" &&
+    node.infrastructure_provider === "hetzner" &&
+    node.provider_server_id !== null &&
+    node.metadata[RETIREMENT_KEY] === node.provider_server_id
+  );
+}
+
+/** Commit the request before starting any fallible provider operation. */
+export async function requestNodeRetirement(nodeId: string): Promise<void> {
+  await dbWrite.transaction(async (tx) => {
+    const [node] = await tx
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.node_id, nodeId))
+      .for("update");
+    if (!node) {
+      throw new ElizaError("Cannot retire an unregistered Docker node", {
+        code: "NODE_RETIREMENT_NOT_FOUND",
+        context: { nodeId },
+      });
+    }
+    requireHetznerNodeAuthority(node);
+    const patch = JSON.stringify({ [RETIREMENT_KEY]: node.provider_server_id });
+    await tx
+      .update(dockerNodes)
+      .set({
+        enabled: false,
+        placement_state: "cordoned",
+        metadata: sql`${dockerNodes.metadata} || ${patch}::jsonb`,
+        updated_at: new Date(),
+      })
+      .where(eq(dockerNodes.id, node.id));
+  });
+}
+
+/** Read retirement intent from the primary; replica lag cannot hide failed cleanup. */
+export async function findRequestedNodeRetirements(): Promise<DockerNode[]> {
+  return dbWrite
+    .select()
+    .from(dockerNodes)
+    .where(
+      and(
+        eq(dockerNodes.enabled, false),
+        eq(dockerNodes.fleet_kind, "cloud"),
+        eq(dockerNodes.infrastructure_provider, "hetzner"),
+        sql`${dockerNodes.metadata}->>'environment' = ${containersEnv.environment()}`,
+        sql`${dockerNodes.metadata}->>${RETIREMENT_KEY} = ${dockerNodes.provider_server_id}`,
+      ),
+    )
+    .orderBy(dockerNodes.updated_at);
+}
+
+/** The callback returns true only after retained-workload checks and provider absence proof. */
+export async function withNodeRetirementAuthority(
+  nodeId: string,
+  retire: (node: DockerNode) => Promise<boolean>,
+): Promise<boolean> {
+  return dbWrite.transaction(async (tx) => {
+    const [node] = await tx
+      .select()
+      .from(dockerNodes)
+      .where(eq(dockerNodes.node_id, nodeId))
+      .for("update");
+    if (!node) return true;
+    if (!hasNodeRetirementRequest(node)) {
+      throw new ElizaError("Docker node has no matching retirement request", {
+        code: "NODE_RETIREMENT_AUTHORITY_CHANGED",
+        context: { nodeId },
+      });
+    }
+    requireHetznerNodeAuthority(node);
+    if (!(await retire(node))) return false;
+    await tx.delete(dockerNodes).where(eq(dockerNodes.id, node.id));
+    return true;
+  });
+}

--- a/packages/cloud/shared/src/lib/services/docker-env-file-stdin-transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-env-file-stdin-transport.test.ts
@@ -4,11 +4,25 @@
  */
 import { describe, expect, test } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildDockerCreateAttemptCleanupCommand,
   buildDockerEnvFileStdinTransport,
+  buildExactRestoreBootFencedCommand,
+  getReplacementCandidateObservedReceipt,
+  getReplacementDockerCreateQuiescentReceipt,
+  getReplacementSecretArtifactsCleanupReceipt,
+  parseDockerCreateAttemptCleanupReceipt,
   shellQuote,
   validateDockerEnvFileStdinEnvironment,
 } from "./docker-sandbox-utils";
@@ -42,6 +56,140 @@ function makeTemporaryDirectory(prefix: string): string {
 }
 
 describe("generic Docker env-file stdin transport", () => {
+  test("remote boot mismatch or unreadability prevents the wrapped command", async () => {
+    const root = makeTemporaryDirectory("eliza-remote-boot-");
+    const marker = join(root, "executed");
+    const expected = "33333333-3333-4333-8333-333333333333";
+    const command = buildExactRestoreBootFencedCommand(
+      expected,
+      `printf executed > ${shellQuote(marker)}`,
+    );
+    try {
+      expect((await runShell(`cat() { printf '%s' other-boot; }; ${command}`, "")).code).toBe(78);
+      expect(existsSync(marker)).toBe(false);
+      expect((await runShell(`cat() { return 1; }; ${command}`, "")).code).toBe(78);
+      expect(existsSync(marker)).toBe(false);
+      expect(
+        (await runShell(`cat() { printf '%s' ${shellQuote(expected)}; }; ${command}`, "")).code,
+      ).toBe(0);
+      expect(readFileSync(marker, "utf8")).toBe("executed");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("cleanup receipt parser rejects wrong owners, partial IDs and ambiguous extra records", () => {
+    const attempt = "33333333-3333-4333-8333-333333333333";
+    const base = getReplacementSecretArtifactsCleanupReceipt(attempt);
+    const candidate = getReplacementCandidateObservedReceipt(attempt, "a".repeat(64));
+    expect(parseDockerCreateAttemptCleanupReceipt(`${base}\n${candidate}\n`, attempt)).toEqual({
+      quiescent: false,
+      containerId: "a".repeat(64),
+    });
+    for (const output of [
+      "",
+      `${base}\n${base}`,
+      `${base}\n${candidate}\nextra`,
+      `${base}\n${getReplacementCandidateObservedReceipt(attempt, "a".repeat(12))}`,
+      getReplacementSecretArtifactsCleanupReceipt("44444444-4444-4444-8444-444444444444"),
+    ]) {
+      expect(() => parseDockerCreateAttemptCleanupReceipt(output, attempt)).toThrow(
+        "receipt is invalid",
+      );
+    }
+  });
+  test("fenced stdin persists one candidate and rejects replay or cancellation", async () => {
+    // Real shell and file effects; stat/flock stand in for Linux root ownership
+    // and locking on macOS. This is not a cross-process exclusion proof.
+    const root = makeTemporaryDirectory("eliza-framed-attempt-");
+    const bin = join(root, "bin");
+    const attempts = join(root, "attempts");
+    const attemptId = "33333333-3333-4333-8333-333333333333";
+    const attempt = join(attempts, attemptId);
+    const capture = join(root, "captured-secret");
+    const capturedEnv = join(root, "captured-env");
+    const containerId = "a".repeat(64);
+    mkdirSync(bin, { mode: 0o700 });
+    writeFileSync(join(bin, "flock"), "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    writeFileSync(
+      join(bin, "stat"),
+      '#!/bin/sh\ncase "$2" in "%u") printf 0 ;; "%a") if test -d "$4"; then printf 700; else printf 600; fi ;; "%h") printf 1 ;; *) exit 64 ;; esac\n',
+      { mode: 0o700 },
+    );
+    const secret = "first line\nsecond 'quoted' line\n";
+    const transport = buildDockerEnvFileStdinTransport(
+      {
+        APP_SECRET: secret,
+        attempt_dir: "/untrusted-value",
+        candidate_id: "untrusted-candidate",
+      },
+      (envPath) =>
+        [
+          `printf '%s' "$APP_SECRET" > ${shellQuote(capture)}`,
+          `cp ${envPath} ${shellQuote(capturedEnv)}`,
+          `printf '%s\\n' ${shellQuote(containerId)}`,
+        ].join("; "),
+      { replacementAttemptId: attemptId },
+    );
+    const remap = (command: string) =>
+      command
+        .replaceAll("/var/lib/eliza/replacement-attempts", attempts)
+        .replaceAll("chmod 700 --", "chmod 700")
+        .replaceAll("chmod 600 --", "chmod 600")
+        .replaceAll("cat -- ", "cat ")
+        .replaceAll("mv -- ", "mv ");
+    const command = remap(transport.command);
+    const env = { ...process.env, PATH: `${bin}:${process.env.PATH}` };
+    try {
+      expect(await runShell(command, transport.input, env)).toEqual({
+        code: 0,
+        output: `${containerId}\n`,
+      });
+      expect(readFileSync(capture, "utf8")).toBe(secret);
+      expect(readFileSync(capturedEnv, "utf8")).toContain("attempt_dir=/untrusted-value\n");
+      expect(readFileSync(join(attempt, "candidate-id"), "utf8")).toBe(`${containerId}\n`);
+      for (const name of ["container-env", "container-env.body", "container-env.end", "active"]) {
+        expect(existsSync(join(attempt, name))).toBe(false);
+      }
+      expect((await runShell(command, transport.input, env)).code).toBe(75);
+      rmSync(join(attempt, "candidate-id"));
+      const cleanup = await runShell(
+        remap(buildDockerCreateAttemptCleanupCommand(attemptId)),
+        "",
+        env,
+      );
+      expect(cleanup.code).toBe(0);
+      expect(cleanup.output).toContain(getReplacementSecretArtifactsCleanupReceipt(attemptId));
+      expect(cleanup.output).toContain(getReplacementDockerCreateQuiescentReceipt(attemptId));
+      expect((await runShell(command, transport.input, env)).code).toBe(75);
+
+      expect(existsSync(join(attempt, "candidate-id"))).toBe(false);
+      rmSync(join(attempt, "cancelled"));
+      const ambiguous = buildDockerEnvFileStdinTransport(
+        { APP_SECRET: secret },
+        () => "printf 'daemon request failed' >&2; exit 1",
+        { replacementAttemptId: attemptId },
+      );
+      expect((await runShell(remap(ambiguous.command), ambiguous.input, env)).code).toBe(1);
+      expect(existsSync(join(attempt, "active"))).toBe(true);
+      expect(existsSync(join(attempt, "container-env"))).toBe(false);
+      expect(existsSync(join(attempt, "container-env.body"))).toBe(false);
+      expect(existsSync(join(attempt, "container-env.end"))).toBe(false);
+      expect((await runShell(command, transport.input, env)).code).toBe(75);
+      const unresolved = await runShell(
+        remap(buildDockerCreateAttemptCleanupCommand(attemptId)),
+        "",
+        env,
+      );
+      expect(unresolved.code).toBe(0);
+      expect(unresolved.output).not.toContain(
+        getReplacementDockerCreateQuiescentReceipt(attemptId),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("keeps arbitrary keys and values out of command argv", () => {
     const environment = Object.fromEntries([
       ["ARGV_SENTINEL_KEY", "argv-sentinel-value with spaces = and 'quotes'"],

--- a/packages/cloud/shared/src/lib/services/docker-env-file-stdin-transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-env-file-stdin-transport.test.ts
@@ -165,6 +165,23 @@ describe("generic Docker env-file stdin transport", () => {
 
       expect(existsSync(join(attempt, "candidate-id"))).toBe(false);
       rmSync(join(attempt, "cancelled"));
+      const rejected = buildDockerEnvFileStdinTransport(
+        { APP_SECRET: secret },
+        () => "sh -c 'printf \"invalid reference format\" >&2; exit 1'",
+        { replacementAttemptId: attemptId },
+      );
+      expect((await runShell(remap(rejected.command), rejected.input, env)).code).toBe(1);
+      const rejectedCleanup = await runShell(
+        remap(buildDockerCreateAttemptCleanupCommand(attemptId)),
+        "",
+        env,
+      );
+      expect(rejectedCleanup.code).toBe(0);
+      expect(parseDockerCreateAttemptCleanupReceipt(rejectedCleanup.output, attemptId)).toEqual({
+        quiescent: true,
+        containerId: null,
+      });
+      rmSync(join(attempt, "cancelled"));
       const ambiguous = buildDockerEnvFileStdinTransport(
         { APP_SECRET: secret },
         () => "printf 'daemon request failed' >&2; exit 1",

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.retained.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.retained.pglite.test.ts
@@ -19,6 +19,8 @@ beforeAll(async () => {
     CREATE TABLE containers (
       id uuid PRIMARY KEY,
       node_id text,
+      volume_path text,
+      hcloud_volume_id integer,
       status text NOT NULL
     );
     CREATE TABLE agent_sandboxes (
@@ -49,6 +51,19 @@ beforeEach(async () => {
 });
 
 describe("countRetainedWorkloadsOnNodeWithDatabase", () => {
+  test("failed stateful creates retain their host until explicit volume cleanup", async () => {
+    await client.query(
+      `INSERT INTO containers (id, node_id, status, volume_path)
+      VALUES ('40000000-0000-4000-8000-000000000001', $1, 'failed', '/srv/tenant-data')`,
+      [NODE_ID],
+    );
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, NODE_ID)).toBe(1);
+    await client.exec("UPDATE containers SET volume_path=NULL, hcloud_volume_id=42");
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, NODE_ID)).toBe(1);
+    await client.exec("UPDATE containers SET hcloud_volume_id=NULL");
+    expect(await countRetainedWorkloadsOnNodeWithDatabase(database, NODE_ID)).toBe(0);
+  });
+
   test("keeps rolling deploys functional before the replacement table exists", async () => {
     const legacyClient = new PGlite();
     try {
@@ -56,6 +71,8 @@ describe("countRetainedWorkloadsOnNodeWithDatabase", () => {
         CREATE TABLE containers (
           id uuid PRIMARY KEY,
           node_id text,
+          volume_path text,
+          hcloud_volume_id integer,
           status text NOT NULL
         );
         CREATE TABLE agent_sandboxes (

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -402,7 +402,10 @@ export async function countRetainedWorkloadsOnNodeWithDatabase(
         SELECT count(*)::int
         FROM ${containers}
         WHERE ${containers.node_id} = ${nodeId}
-          AND ${containers.status} not in ('failed','deleted')
+          AND ${containers.status} <> 'deleted'
+          AND (${containers.status} <> 'failed'
+            OR ${containers.volume_path} IS NOT NULL
+            OR ${containers.hcloud_volume_id} IS NOT NULL)
       )`,
     agentCount: sql<number>`(
         SELECT count(*)::int

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -8,6 +8,16 @@
  * Reference: eliza-cloud/backend/services/container-orchestrator.ts
  */
 
+import {
+  buildExactRestoreBootFencedCommand,
+  buildExactRestoreDockerBootFencedCommand,
+} from "./docker-sandbox-utils";
+
+export {
+  buildExactRestoreBootFencedCommand,
+  buildExactRestoreDockerBootFencedCommand,
+} from "./docker-sandbox-utils";
+
 import { ElizaError } from "@elizaos/core";
 import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
@@ -241,8 +251,6 @@ const EXACT_RESTORE_NODE_INCARNATION_LABEL = "ai.elizaos.restore-node-incarnatio
 const EXACT_RESTORE_NODE_HISTORY_LABEL = "ai.elizaos.restore-node-history-id";
 const EXACT_RESTORE_IMAGE_DIGEST_LABEL = "ai.elizaos.restore-image-digest";
 const EXACT_RESTORE_QUARANTINE_LABEL = "ai.elizaos.restore-quarantine";
-const REMOTE_NODE_BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
-const EXACT_RESTORE_REMOTE_BOOT_FENCE_EXIT_CODE = 78;
 const REPLACEMENT_VPN_SETTLE_OBSERVATIONS = 4;
 const REPLACEMENT_VPN_SETTLE_INTERVAL_MS = 750;
 const REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS = 30_000;
@@ -410,50 +418,6 @@ function isExactRestoreContainerName(value: string): boolean {
     // error-policy:J3 canonical validation translates rejected input to false.
     return false;
   }
-}
-
-export function buildExactRestoreBootFencedCommand(
-  expectedNodeIncarnation: string,
-  exactCommand: string,
-): string {
-  return [
-    `observed_boot_id=$(cat ${shellQuote(REMOTE_NODE_BOOT_ID_PATH)} 2>/dev/null) || { printf '%s\\n' 'ELIZA_RESTORE_BOOT_ID_UNREADABLE' >&2; exit ${EXACT_RESTORE_REMOTE_BOOT_FENCE_EXIT_CODE}; }`,
-    `if [ "$observed_boot_id" != ${shellQuote(expectedNodeIncarnation)} ]; then printf '%s\\n' 'ELIZA_RESTORE_BOOT_ID_MISMATCH' >&2; exit ${EXACT_RESTORE_REMOTE_BOOT_FENCE_EXIT_CODE}; fi`,
-    exactCommand,
-  ].join("; ");
-}
-
-/** Boot-fence and isolate every exact Docker CLI call from ambient client state. */
-export function buildExactRestoreDockerBootFencedCommand(
-  expectedNodeIncarnation: string,
-  exactDockerCommand: string,
-): string {
-  const configTemplate = "/tmp/eliza-exact-docker.XXXXXXXXXX";
-  const cleanup =
-    "cleanup_exact_docker_config() { cleanup_status=$?; trap - EXIT; " +
-    'case "$exact_docker_config" in /tmp/eliza-exact-docker.?*) ' +
-    'rm -rf -- "$exact_docker_config" || cleanup_status=70 ;; *) cleanup_status=70 ;; esac; ' +
-    'exit "$cleanup_status"; }';
-  const isolatedCommand = [
-    "set -eu",
-    "umask 077",
-    `exact_docker_config=$(mktemp -d ${shellQuote(configTemplate)})`,
-    cleanup,
-    "trap cleanup_exact_docker_config EXIT",
-    "trap 'exit 129' HUP",
-    "trap 'exit 130' INT",
-    "trap 'exit 143' TERM",
-    'chmod 700 -- "$exact_docker_config"',
-    `printf '%s\\n' ${shellQuote('{"auths":{},"proxies":{}}')} > "$exact_docker_config/config.json"`,
-    'chmod 600 -- "$exact_docker_config/config.json"',
-    "unset DOCKER_CONTEXT DOCKER_TLS_VERIFY DOCKER_CERT_PATH DOCKER_CONFIG DOCKER_DEFAULT_PLATFORM DOCKER_API_VERSION",
-    'DOCKER_HOST="unix:///var/run/docker.sock"',
-    'DOCKER_CONFIG="$exact_docker_config"',
-    "export DOCKER_HOST DOCKER_CONFIG",
-    'docker() { command docker --host unix:///var/run/docker.sock --config "$exact_docker_config" "$@"; }',
-    `(${exactDockerCommand})`,
-  ].join("; ");
-  return buildExactRestoreBootFencedCommand(expectedNodeIncarnation, isolatedCommand);
 }
 
 function buildExactRestoreAnonymousPullCommand(
@@ -3285,7 +3249,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       // one service transaction. Ordinary creates retain provider-owned
       // accounting because they have no durable replacement fence.
       if (providerManagesCapacity) {
-        await dockerNodesRepository.incrementAllocated(nodeId);
+        await dockerNodesRepository.incrementAllocated(nodeId, dbNode.id);
       }
     } else {
       const registeredNodes = await dockerNodesRepository.findAll();

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -813,7 +813,9 @@ describe("secret container environment transport (#22060)", () => {
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
-  }, 10_000);
+    // This fixture starts many real shells; process startup on shared hosts is
+    // not the Docker timeout contract exercised by its assertions.
+  }, 60_000);
 
   test("derives exact cleanup paths from the canonical container name only", () => {
     const attemptId = "33333333-3333-4333-8333-333333333333";

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.test.ts
@@ -1559,18 +1559,17 @@ describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
     fs.rmSync(volume, { recursive: true, force: true });
   });
 
-  test("rejects raw control bytes before remote mutation and permits later recovery", async () => {
-    const fs = await import("node:fs");
-    const invalidOverrides = [
-      "operator-key\0suffix",
-      "operator-key\x7fsuffix",
-      "operator-key\nsuffix",
-      "operator-key\rsuffix",
-      "operator-key\tsuffix",
-      "operator-key\x01suffix",
-    ];
-
-    for (const invalidOverride of invalidOverrides) {
+  test.each([
+    "operator-key\0suffix",
+    "operator-key\x7fsuffix",
+    "operator-key\nsuffix",
+    "operator-key\rsuffix",
+    "operator-key\tsuffix",
+    "operator-key\x01suffix",
+  ])(
+    "rejects control bytes in %j before remote mutation and permits recovery",
+    async (invalidOverride) => {
+      const fs = await import("node:fs");
       const volume = await makeVolume();
       let remoteCalls = 0;
       const trackedExec: typeof shExecStdin = async (...args) => {
@@ -1591,8 +1590,8 @@ describe("volume-persisted vault passphrase (#18080 / #19225 / #22060)", () => {
         "valid-operator-key",
       );
       fs.rmSync(volume, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
   test("an empty or whitespace-only override falls through to the volume lifecycle", async () => {
     const fs = await import("node:fs");

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -10,6 +10,54 @@ import { ElizaError } from "@elizaos/core";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 
+const REMOTE_NODE_BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
+const EXACT_RESTORE_REMOTE_BOOT_FENCE_EXIT_CODE = 78;
+
+/** Reject remote work when the host boot no longer matches its admitted incarnation. */
+export function buildExactRestoreBootFencedCommand(
+  expectedNodeIncarnation: string,
+  exactCommand: string,
+): string {
+  return [
+    `observed_boot_id=$(cat ${shellQuote(REMOTE_NODE_BOOT_ID_PATH)} 2>/dev/null) || { printf '%s\\n' 'ELIZA_RESTORE_BOOT_ID_UNREADABLE' >&2; exit ${EXACT_RESTORE_REMOTE_BOOT_FENCE_EXIT_CODE}; }`,
+    `if [ "$observed_boot_id" != ${shellQuote(expectedNodeIncarnation)} ]; then printf '%s\\n' 'ELIZA_RESTORE_BOOT_ID_MISMATCH' >&2; exit ${EXACT_RESTORE_REMOTE_BOOT_FENCE_EXIT_CODE}; fi`,
+    exactCommand,
+  ].join("; ");
+}
+
+/** Boot-fence and isolate every exact Docker CLI call from ambient client state. */
+export function buildExactRestoreDockerBootFencedCommand(
+  expectedNodeIncarnation: string,
+  exactDockerCommand: string,
+): string {
+  const configTemplate = "/tmp/eliza-exact-docker.XXXXXXXXXX";
+  const cleanup =
+    "cleanup_exact_docker_config() { cleanup_status=$?; trap - EXIT; " +
+    'case "$exact_docker_config" in /tmp/eliza-exact-docker.?*) ' +
+    'rm -rf -- "$exact_docker_config" || cleanup_status=70 ;; *) cleanup_status=70 ;; esac; ' +
+    'exit "$cleanup_status"; }';
+  const isolatedCommand = [
+    "set -eu",
+    "umask 077",
+    `exact_docker_config=$(mktemp -d ${shellQuote(configTemplate)})`,
+    cleanup,
+    "trap cleanup_exact_docker_config EXIT",
+    "trap 'exit 129' HUP",
+    "trap 'exit 130' INT",
+    "trap 'exit 143' TERM",
+    'chmod 700 -- "$exact_docker_config"',
+    `printf '%s\\n' ${shellQuote('{"auths":{},"proxies":{}}')} > "$exact_docker_config/config.json"`,
+    'chmod 600 -- "$exact_docker_config/config.json"',
+    "unset DOCKER_CONTEXT DOCKER_TLS_VERIFY DOCKER_CERT_PATH DOCKER_CONFIG DOCKER_DEFAULT_PLATFORM DOCKER_API_VERSION",
+    'DOCKER_HOST="unix:///var/run/docker.sock"',
+    'DOCKER_CONFIG="$exact_docker_config"',
+    "export DOCKER_HOST DOCKER_CONFIG",
+    'docker() { command docker --host unix:///var/run/docker.sock --config "$exact_docker_config" "$@"; }',
+    `(${exactDockerCommand})`,
+  ].join("; ");
+  return buildExactRestoreBootFencedCommand(expectedNodeIncarnation, isolatedCommand);
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -315,6 +363,8 @@ export interface DockerEnvFileStdinTransport {
 export interface DockerEnvFileStdinTransportOptions {
   /** Override for isolated tests; production callers use restrictive files under `/tmp`. */
   temporaryDirectory?: string;
+  /** Persist create/cancellation authority using the existing root-owned attempt directory. */
+  replacementAttemptId?: string;
 }
 
 const CONTAINER_SECRET_ENV_STDIN_SENTINEL = "ELIZA_SECRET_ENV_STDIN_V1_END";
@@ -379,6 +429,8 @@ const DOCKER_CLIENT_CONTROL_ENV_KEYS = new Set([
 
 function isDockerClientControlEnvKey(key: string): boolean {
   if (
+    /^(?:attempt_|secure_|candidate_)/.test(key) ||
+    ["docker_status", "control_parent", "cleanup_status"].includes(key) ||
     /^(?:DOCKER_|LD_|DYLD_|XDG_|LC_|MALLOC_)/.test(key) ||
     /^(?:GODEBUG|GOMAXPROCS|GOMEMLIMIT|GOTRACEBACK)$/.test(key)
   ) {
@@ -497,6 +549,12 @@ export function buildDockerEnvFileStdinTransport(
   options: DockerEnvFileStdinTransportOptions = {},
 ): DockerEnvFileStdinTransport {
   const input = buildDockerEnvironmentFrame(environment);
+  const attemptId = options.replacementAttemptId;
+  if (attemptId !== undefined) assertCanonicalReplacementPathAttemptId(attemptId);
+  if (attemptId && options.temporaryDirectory !== undefined) {
+    throw new Error("Fenced Docker stdin transport requires its canonical attempt directory.");
+  }
+  const controlEnvPath = attemptId ? getReplacementControlSecretEnvPath(attemptId) : undefined;
   const temporaryDirectory = options.temporaryDirectory ?? "/tmp";
   validateVolumePath(temporaryDirectory);
 
@@ -515,13 +573,34 @@ export function buildDockerEnvFileStdinTransport(
       "env_frame_file=",
       "env_file=",
       "env_end_file=",
-      'cleanup_env_files() { test -z "$env_frame_file" || rm -f "$env_frame_file"; test -z "$env_end_file" || rm -f "$env_end_file"; test -z "$env_file" || rm -f "$env_file"; }',
+      ...(attemptId
+        ? [
+            ...replacementAttemptControlPrelude(attemptId),
+            'test ! -e "$attempt_cancelled" && test ! -L "$attempt_cancelled" || exit 75',
+            'test ! -e "$attempt_active" && test ! -L "$attempt_active" || exit 75',
+            'test ! -e "$attempt_candidate_id" && test ! -L "$attempt_candidate_id" || exit 75',
+          ]
+        : []),
+      attemptId
+        ? 'cleanup_env_files() { cleanup_status=$?; if ! rm -f -- "$env_frame_file" "$env_end_file" "$env_file"; then cleanup_status=70; fi; for secure_path in "$env_frame_file" "$env_end_file" "$env_file"; do if test -e "$secure_path" || test -L "$secure_path"; then cleanup_status=70; fi; done; if test "$cleanup_status" -eq 0; then rm -f -- "$attempt_active" || cleanup_status=70; fi; trap - EXIT; exit "$cleanup_status"; }'
+        : 'cleanup_env_files() { test -z "$env_frame_file" || rm -f "$env_frame_file"; test -z "$env_end_file" || rm -f "$env_end_file"; test -z "$env_file" || rm -f "$env_file"; }',
       "trap cleanup_env_files EXIT",
       "trap 'exit 1' HUP INT TERM",
       "umask 077",
-      `env_frame_file=$(mktemp ${envFrameTemplate})`,
-      `env_file=$(mktemp ${envFileTemplate})`,
-      `env_end_file=$(mktemp ${envEndFileTemplate})`,
+      ...(controlEnvPath
+        ? [
+            `env_frame_file=${shellQuote(`${controlEnvPath}.body`)}`,
+            `env_file=${shellQuote(controlEnvPath)}`,
+            `env_end_file=${shellQuote(`${controlEnvPath}.end`)}`,
+            'secure_reset_control_file "$env_frame_file"',
+            'secure_reset_control_file "$env_file"',
+            'secure_reset_control_file "$env_end_file"',
+          ]
+        : [
+            `env_frame_file=$(mktemp ${envFrameTemplate})`,
+            `env_file=$(mktemp ${envFileTemplate})`,
+            `env_end_file=$(mktemp ${envEndFileTemplate})`,
+          ]),
       'chmod 600 "$env_frame_file" "$env_end_file" "$env_file"',
       `dd bs=1 count=${DOCKER_ENV_FILE_STDIN_HEADER_BYTES} of="$env_frame_file" status=none`,
       `test "$(wc -c < "$env_frame_file" | tr -d ' ')" = ${DOCKER_ENV_FILE_STDIN_HEADER_BYTES}`,
@@ -541,7 +620,14 @@ export function buildDockerEnvFileStdinTransport(
       "test \"$(dd bs=1 count=1 status=none | wc -c | tr -d ' ')\" = 0",
       '. "$env_frame_file"',
       'chmod 600 "$env_file"',
-      dockerCommand,
+      ...(attemptId
+        ? [
+            'secure_reset_control_file "$attempt_docker_error"',
+            'secure_reset_control_file "$attempt_active"',
+            buildDockerCreateAttemptInvocation(dockerCommand, true, true),
+            'printf "%s\\n" "$candidate_id"',
+          ]
+        : [dockerCommand]),
     ].join("; "),
   };
 }
@@ -876,6 +962,35 @@ export function getReplacementCandidateObservedReceipt(
 export function getReplacementDockerCreateQuiescentReceipt(replacementAttemptId: string): string {
   assertCanonicalReplacementPathAttemptId(replacementAttemptId);
   return `${REPLACEMENT_DOCKER_CREATE_QUIESCENT_RECEIPT} ${replacementAttemptId}`;
+}
+
+/** Validate the complete cleanup response before it can authorize capacity release. */
+export function parseDockerCreateAttemptCleanupReceipt(
+  output: string,
+  replacementAttemptId: string,
+): { quiescent: boolean; containerId: string | null } {
+  const lines = output.trim().split(/\r?\n/);
+  const invalid = () =>
+    new ElizaError("Docker create cleanup receipt is invalid", {
+      code: "DOCKER_CREATE_CLEANUP_RECEIPT_INVALID",
+      context: { replacementAttemptId },
+    });
+  if (lines.shift() !== getReplacementSecretArtifactsCleanupReceipt(replacementAttemptId)) {
+    throw invalid();
+  }
+  const quiescent = lines[0] === getReplacementDockerCreateQuiescentReceipt(replacementAttemptId);
+  if (quiescent) lines.shift();
+  if (lines.length === 0) return { quiescent, containerId: null };
+  if (lines.length !== 1) throw invalid();
+  const containerId = lines[0].split(" ").at(-1);
+  if (
+    !containerId ||
+    !/^[0-9a-f]{64}$/.test(containerId) ||
+    lines[0] !== getReplacementCandidateObservedReceipt(replacementAttemptId, containerId)
+  ) {
+    throw invalid();
+  }
+  return { quiescent, containerId };
 }
 
 /** Exact non-secret receipt proving one abandoned restore staging path is absent. */
@@ -1302,6 +1417,7 @@ export function buildReplacementSecretArtifactsCleanupCommand(
   const artifactPaths = [
     secretEnvPath,
     secretEnvBodyPath,
+    `${secretEnvPath}.end`,
     getReplacementControlVaultPassphrasePath(replacementAttemptId),
     ...(["stdin", "override", "generated", "normalized"] as const).map((kind) =>
       getReplacementControlVaultArtifactPath(replacementAttemptId, kind),
@@ -1313,6 +1429,24 @@ export function buildReplacementSecretArtifactsCleanupCommand(
     ),
     getVolumeVaultPassphrasePublicationCandidatePath(volumePath, replacementAttemptId),
   ];
+  return buildAttemptArtifactsCleanupCommand(replacementAttemptId, artifactPaths);
+}
+
+/** Cancel a framed Docker create and prove only its canonical transient files absent. */
+export function buildDockerCreateAttemptCleanupCommand(replacementAttemptId: string): string {
+  const envPath = getReplacementControlSecretEnvPath(replacementAttemptId);
+  return buildAttemptArtifactsCleanupCommand(replacementAttemptId, [
+    envPath,
+    `${envPath}.body`,
+    `${envPath}.end`,
+  ]);
+}
+
+/** Keep cancellation, path validation, and receipts identical across plaintext producers. */
+function buildAttemptArtifactsCleanupCommand(
+  replacementAttemptId: string,
+  artifactPaths: readonly string[],
+): string {
   const existingArtifactProof = artifactPaths
     .map(
       (path) =>
@@ -1472,6 +1606,59 @@ export function buildReplacementCreatedContainerIdProofCommand(
   ].join("; ");
 }
 
+/** Build one create invocation using the shared attempt markers and exact candidate receipt. */
+function buildDockerCreateAttemptInvocation(
+  command: string,
+  fenced: boolean,
+  recordContainerId: boolean,
+): string {
+  const definitiveDockerFailurePatterns = [
+    "Conflict. The container name",
+    "is already in use by container",
+    "invalid reference format",
+    "No such image",
+    "invalid mount config",
+    "invalid volume specification",
+    "unknown flag:",
+  ]
+    .map((marker) => `-e ${shellQuote(marker)}`)
+    .join(" ");
+  const clearDefinitiveDockerFailure = fenced
+    ? `secure_private_regular_file_proof "$attempt_docker_error"; if grep -F ${definitiveDockerFailurePatterns} -- "$attempt_docker_error" >/dev/null 2>&1; then rm -f -- "$attempt_active" || exit 70; test ! -e "$attempt_active" && test ! -L "$attempt_active" || exit 70; fi`
+    : ":";
+  return recordContainerId
+    ? [
+        'exec 8>>"$attempt_docker_error"',
+        `if candidate_id=$(${command} 2>&8); then docker_status=0; else docker_status=$?; fi`,
+        "exec 8>&-",
+        'secure_private_regular_file_proof "$attempt_docker_error"',
+        `if test "$docker_status" -ne 0; then ${clearDefinitiveDockerFailure}; rm -f -- "$attempt_docker_error"; exit "$docker_status"; fi`,
+        'rm -f -- "$attempt_docker_error"',
+        'test ! -e "$attempt_docker_error" && test ! -L "$attempt_docker_error" || exit 70',
+        'case "$candidate_id" in ""|*[!0-9a-f]*) exit 70 ;; esac',
+        'test "${#candidate_id}" = 64',
+        'candidate_tmp="$attempt_dir/candidate-id.tmp"',
+        'secure_reset_control_file "$candidate_tmp"',
+        'exec 8>>"$candidate_tmp"',
+        'printf "%s\\n" "$candidate_id" >&8',
+        "exec 8>&-",
+        'secure_private_regular_file_proof "$candidate_tmp"',
+        'mv -- "$candidate_tmp" "$attempt_candidate_id"',
+        'secure_private_regular_file_proof "$attempt_candidate_id"',
+      ].join("; ")
+    : fenced
+      ? [
+          'exec 8>>"$attempt_docker_error"',
+          `if ${command} 2>&8; then docker_status=0; else docker_status=$?; fi`,
+          "exec 8>&-",
+          'secure_private_regular_file_proof "$attempt_docker_error"',
+          `if test "$docker_status" -ne 0; then ${clearDefinitiveDockerFailure}; rm -f -- "$attempt_docker_error"; exit "$docker_status"; fi`,
+          'rm -f -- "$attempt_docker_error"',
+          'test ! -e "$attempt_docker_error" && test ! -L "$attempt_docker_error" || exit 70',
+        ].join("; ")
+      : command;
+}
+
 /**
  * Wrap `docker create` so stdin becomes a 0600 env file, the persisted vault
  * value is appended without being read by the caller, and every shell exit
@@ -1541,51 +1728,11 @@ export function buildDockerCreateWithSecretEnvCommand(options: {
       ? 'if test "$cleanup_status" -eq 0; then if ! rm -f -- "$attempt_active"; then cleanup_status=70; elif test -e "$attempt_active" || test -L "$attempt_active"; then cleanup_status=70; fi; fi; '
       : "") +
     'trap - EXIT; exit "$cleanup_status"; }';
-  const definitiveDockerFailurePatterns = [
-    "Conflict. The container name",
-    "is already in use by container",
-    "invalid reference format",
-    "No such image",
-    "invalid mount config",
-    "invalid volume specification",
-    "unknown flag:",
-  ]
-    .map((marker) => `-e ${shellQuote(marker)}`)
-    .join(" ");
-  const clearDefinitiveDockerFailure = fenced
-    ? `secure_private_regular_file_proof "$attempt_docker_error"; if grep -F ${definitiveDockerFailurePatterns} -- "$attempt_docker_error" >/dev/null 2>&1; then rm -f -- "$attempt_active" || exit 70; test ! -e "$attempt_active" && test ! -L "$attempt_active" || exit 70; fi`
-    : ":";
-  const dockerCreateCommand = options.exactReplacement?.recordContainerId
-    ? [
-        'exec 8>>"$attempt_docker_error"',
-        `if candidate_id=$(${options.dockerCreateCommand} 2>&8); then docker_status=0; else docker_status=$?; fi`,
-        "exec 8>&-",
-        'secure_private_regular_file_proof "$attempt_docker_error"',
-        `if test "$docker_status" -ne 0; then ${clearDefinitiveDockerFailure}; rm -f -- "$attempt_docker_error"; exit "$docker_status"; fi`,
-        'rm -f -- "$attempt_docker_error"',
-        'test ! -e "$attempt_docker_error" && test ! -L "$attempt_docker_error" || exit 70',
-        'case "$candidate_id" in ""|*[!0-9a-f]*) exit 70 ;; esac',
-        'test "${#candidate_id}" = 64',
-        'candidate_tmp="$attempt_dir/candidate-id.tmp"',
-        'secure_reset_control_file "$candidate_tmp"',
-        'exec 8>>"$candidate_tmp"',
-        'printf "%s\\n" "$candidate_id" >&8',
-        "exec 8>&-",
-        'secure_private_regular_file_proof "$candidate_tmp"',
-        'mv -- "$candidate_tmp" "$attempt_candidate_id"',
-        'secure_private_regular_file_proof "$attempt_candidate_id"',
-      ].join("; ")
-    : fenced
-      ? [
-          'exec 8>>"$attempt_docker_error"',
-          `if ${options.dockerCreateCommand} 2>&8; then docker_status=0; else docker_status=$?; fi`,
-          "exec 8>&-",
-          'secure_private_regular_file_proof "$attempt_docker_error"',
-          `if test "$docker_status" -ne 0; then ${clearDefinitiveDockerFailure}; rm -f -- "$attempt_docker_error"; exit "$docker_status"; fi`,
-          'rm -f -- "$attempt_docker_error"',
-          'test ! -e "$attempt_docker_error" && test ! -L "$attempt_docker_error" || exit 70',
-        ].join("; ")
-      : options.dockerCreateCommand;
+  const dockerCreateCommand = buildDockerCreateAttemptInvocation(
+    options.dockerCreateCommand,
+    fenced,
+    options.exactReplacement?.recordContainerId === true,
+  );
   return [
     "set -eu",
     `env_file=${envFile}`,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -14,7 +14,6 @@ import {
   test,
 } from "bun:test";
 import { readFileSync } from "node:fs";
-import { KeyNotFoundError, KmsError, orgKey } from "@elizaos/core/security/kms";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
@@ -56,8 +55,7 @@ import {
   SandboxReplacementCleanupUnresolvedError,
 } from "./sandbox-provider-types";
 
-// Drive the real core KMS stack so the errors the snapshot-degrade
-// path classifies are genuine (`AeadError`, `KeyNotFoundError`) — not hand-rolled
+// Drive the real core KMS stack so restore failures are genuine (`AeadError`, `KeyNotFoundError`) — not hand-rolled
 // stand-ins. In NODE_ENV=test, getKmsClient() resolves the in-process memory
 // backend, which is exactly what orphans keys across a restart in prod.
 const KMS_TEST_ORG = "org-test-1";
@@ -912,24 +910,6 @@ describe("ElizaSandboxService state restore auth", () => {
     expect(fetchCalls).toBe(0);
   });
 
-  test("the oversized refusal is neither unrecoverable nor permanently lost (#17172)", async () => {
-    // Both classifiers must say no. "Unrecoverable" authorises the fresh-boot
-    // degrade, and an oversized chain is intact and decryptable — degrading it
-    // would discard recoverable state because of a limit we chose. "Permanently
-    // lost" additionally authorises pruning, which would destroy that chain.
-    // The refusal gets its own terminal branch at each restore site instead.
-    const { isUnrecoverableSnapshotError, isPermanentlyLostSnapshot } = await import(
-      "./eliza-sandbox.ts?actual"
-    );
-    const { SnapshotPayloadTooLargeError } = await import("@elizaos/shared/agent-backup-limits");
-    const err = new SnapshotPayloadTooLargeError(200, 100);
-
-    expect(isUnrecoverableSnapshotError(err)).toBe(false);
-    expect(isPermanentlyLostSnapshot(err)).toBe(false);
-    expect(err.payloadBytes).toBe(200);
-    expect(err.limitBytes).toBe(100);
-  });
-
   test("pushes a restore payload that fits the v1 restorable limit (#17172)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     let fetchCalls = 0;
@@ -1288,7 +1268,7 @@ describe("ElizaSandboxService shared runtime bridge", () => {
 
 describe("ElizaSandboxService wake", () => {
   test.skipIf(process.platform === "win32")(
-    "skips missing state restore endpoint for web-only custom images",
+    "refuses wake when a custom image cannot restore retained state",
     async () => {
       const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
       const now = new Date("2026-06-04T12:05:00.000Z");
@@ -1346,6 +1326,7 @@ describe("ElizaSandboxService wake", () => {
           },
         })),
         stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+        stopForReplacement: mock(async () => {}),
         checkHealth: mock(async () => true),
       };
       const requests: string[] = [];
@@ -1360,6 +1341,10 @@ describe("ElizaSandboxService wake", () => {
         }
         return Response.json({ ok: true });
       });
+      const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(
+        sleepingSandbox,
+      );
+      const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups");
       const originalFindByIdAndOrg = agentSandboxesRepository.findByIdAndOrg;
       const originalFindByIdAndOrgForWrite = agentSandboxesRepository.findByIdAndOrgForWrite;
       const originalTrySetProvisioning = agentSandboxesRepository.trySetProvisioning;
@@ -1436,17 +1421,14 @@ describe("ElizaSandboxService wake", () => {
           sleepingSandbox.organization_id,
         );
 
-        expect(result).toEqual({
-          success: true,
-          reprovisioned: true,
-          restoredBackupId: backup.id,
-        });
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("State restore failed: HTTP 404");
         expect(requests).toContain("https://runtime.example/api/restore");
-        expect(updateSpy).toHaveBeenCalledWith(
-          sleepingSandbox.id,
-          expect.objectContaining({ status: "running" }),
-        );
+        expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+        expect(pruneSpy).not.toHaveBeenCalled();
       } finally {
+        findByIdSpy.mockRestore();
+        pruneSpy.mockRestore();
         agentSandboxesRepository.findByIdAndOrg = originalFindByIdAndOrg;
         agentSandboxesRepository.findByIdAndOrgForWrite = originalFindByIdAndOrgForWrite;
         agentSandboxesRepository.trySetProvisioning = originalTrySetProvisioning;
@@ -1509,13 +1491,14 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
   }
 
   async function armFromBackupProvision(opts: {
+    initialStatus?: AgentSandbox["status"];
     backupSandboxRecordId?: string;
     reconstructError?: Error;
     restoreHttpStatus?: number;
     createError?: Error;
   }) {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const rec = sleepingSandboxRec();
+    const rec = { ...sleepingSandboxRec(), status: opts.initialStatus ?? "sleeping" };
     const backup = backupRow(opts.backupSandboxRecordId ?? rec.id);
     const provider: SandboxProvider = {
       create: mock(async () => {
@@ -1601,6 +1584,90 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
     };
   }
 
+  test.each(["sleeping", "stopped", "disconnected"] as const)(
+    "refuses empty recovery of a %s agent whose backup is missing",
+    async (initialStatus) => {
+      const h = await armFromBackupProvision({ initialStatus });
+      const latest = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+        undefined,
+      );
+      try {
+        const result = await h.svc.provision(h.rec.id, h.rec.organization_id);
+        expect(result.success).toBe(false);
+        expect(result.failureCause).toMatchObject({
+          code: "SNAPSHOT_RESTORE_FAILED",
+          cause: { code: "SNAPSHOT_RECOVERY_BACKUP_MISSING" },
+        });
+        expect(h.updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+        expect(h.pruneSpy).not.toHaveBeenCalled();
+      } finally {
+        latest.mockRestore();
+        h.restore();
+      }
+    },
+  );
+
+  test.each(["first-create", "explicit-consent"] as const)(
+    "permits an empty runtime only for %s",
+    async (mode) => {
+      const h = await armFromBackupProvision({
+        initialStatus: mode === "first-create" ? "pending" : "sleeping",
+      });
+      const latest = spyOn(agentSandboxesRepository, "getLatestBackup");
+      if (mode === "first-create") latest.mockResolvedValue(undefined);
+      else
+        latest.mockRejectedValue(
+          new Error("retained backup must not be read for consented fresh boot"),
+        );
+      try {
+        const result = await h.svc.provision(
+          h.rec.id,
+          h.rec.organization_id,
+          mode === "explicit-consent" ? { kind: "fresh-boot" } : undefined,
+        );
+        expect(result.success).toBe(true);
+        expect(result.sandboxRecord?.status).toBe("running");
+        expect(h.reconstructMock).not.toHaveBeenCalled();
+        expect(h.pruneSpy).not.toHaveBeenCalled();
+        if (mode === "explicit-consent") expect(latest).not.toHaveBeenCalled();
+        else expect(latest).toHaveBeenCalledWith(h.rec.id);
+      } finally {
+        latest.mockRestore();
+        h.restore();
+      }
+    },
+  );
+
+  test("publishes the primary runtime only after the restore endpoint acknowledges state", async () => {
+    const h = await armFromBackupProvision({});
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = fetchUrl(input);
+      if (url.endsWith("/api/agents"))
+        return Response.json({ error: "Not found" }, { status: 404 });
+      if (url.endsWith("/api/restore")) {
+        entered.resolve();
+        await release.promise;
+      }
+      return Response.json({ ok: true });
+    });
+    const pending = h.svc.provision(h.rec.id, h.rec.organization_id);
+    try {
+      await entered.promise;
+      expect(h.updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+      release.resolve();
+      const result = await pending;
+      expect(result.success).toBe(true);
+      expect(result.sandboxRecord?.status).toBe("running");
+      expect(h.updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(true);
+    } finally {
+      release.resolve();
+      await pending;
+      h.restore();
+    }
+  });
+
   test("provider creation failures preserve the original cause for the job boundary", async () => {
     const transport = new Error("provider socket failed");
     const creation = new Error("RequestTimeoutError", { cause: transport });
@@ -1619,7 +1686,7 @@ describe("ElizaSandboxService provision — from-backup override (#15603 B6)", (
 
   test("an unreconstructable explicit backup FAILS the provision — no fresh boot, no prune", async () => {
     // A REAL AeadError: without the override this exact error is classified
-    // unrecoverable and degrades to a fresh boot + pruneBackups(rec.id, 0).
+    // inaccessible; the backup must remain available for a later recovery.
     const aead = await realAeadDecryptError();
     const h = await armFromBackupProvision({ reconstructError: aead });
     try {
@@ -6925,7 +6992,8 @@ describe("failed warm-claim replacement teardown", () => {
     const failed = failedWarmClaim();
     const resetRow: AgentSandbox = {
       ...failed,
-      status: "stopped",
+      status: "pending",
+      last_heartbeat_at: null,
       claimed_at: null,
       warm_claim_credential_state: null,
       warm_claim_source_pool_id: null,
@@ -7037,7 +7105,8 @@ describe("failed warm-claim replacement teardown", () => {
     const failed = failedWarmClaim();
     const resetRow: AgentSandbox = {
       ...failed,
-      status: "stopped",
+      status: "pending",
+      last_heartbeat_at: null,
       claimed_at: null,
       warm_claim_credential_state: null,
       warm_claim_source_pool_id: null,
@@ -7483,7 +7552,8 @@ describe("ElizaSandboxService.provision execution-tier admission", () => {
         id: AGENT,
         organization_id: ORG,
         execution_tier: executionTier,
-        status: "stopped",
+        status: "pending",
+        last_heartbeat_at: null,
         bridge_url: null,
         health_url: null,
         claimed_at: null,
@@ -7515,7 +7585,8 @@ describe("ElizaSandboxService.provision execution-tier admission", () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row: AgentSandbox = {
       ...rejectedRow("shared"),
-      status: "stopped",
+      status: "pending",
+      last_heartbeat_at: null,
       claimed_at: null,
       warm_claim_credential_state: null,
       replacement_cleanup_sandbox_id: null,
@@ -7589,9 +7660,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       health_url: null,
       database_uri: "postgres://shared.example/railway",
       database_status: "ready",
-      // Custom-tier so the post-create backup-restore HTTP 404 is tolerated and
-      // ensureRuntimeAgentStarted's list endpoint is not the gating factor (it
-      // is spied to a no-op below regardless).
+      // These fixtures isolate provisioning from runtime startup; individual
+      // restore tests exercise the custom-image endpoint contract explicitly.
       execution_tier: "custom",
     };
   }
@@ -8283,13 +8353,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  test("(8) status='running' persists BEFORE the backup-restore push (#14038 wake-lag)", async () => {
-    // The status column is the reachability gate: the dedicated-agent proxy
-    // synthesizes 202 "starting" for every request (including the launcher's
-    // /api/status poll) until status='running'. The container serves the moment
-    // the health check + runtime-agent start succeed, so the flip must not wait
-    // for the (potentially long) state restore — that ordering is exactly the
-    // "agent answers in ~8s but launcher says waking for 90s+" prod window.
+  test("(8) restores retained state before publishing running", async () => {
+    // The proxy uses running as its reachability gate. A healthy container
+    // must finish restoring retained state before that gate opens.
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
     const backup: AgentSandboxBackup = {
@@ -8351,7 +8417,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     try {
       const res = await svc.provision(AGENT, ORG);
       expect(res.success).toBe(true);
-      expect(order).toEqual(["status-running", "push-state"]);
+      expect(order).toEqual(["push-state", "status-running"]);
     } finally {
       findSpy.mockRestore();
       lockSpy.mockRestore();
@@ -8365,10 +8431,9 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  test("(9) restore failure after the early running-write still ends in markError", async () => {
-    // 'running' must never stick on a failed provision: a restore failure takes
-    // the same catch as before (ghost cleanup → markError), so the early
-    // reachability flip cannot leave a broken agent advertised as running.
+  test("(9) restore failure reports an error without publishing running", async () => {
+    // Failed restoration retains the existing error and cleanup path without
+    // exposing an intermediate running state.
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row: AgentSandbox = {
       ...provisioningReadyRow(),
@@ -8433,14 +8498,14 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       "getProvider",
     ).mockResolvedValue({
       create: mock(async () => providerHandle()),
-      stop,
+      stopForReplacement: stop,
       checkHealth: async () => true,
     } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       expect(res.success).toBe(false);
       expect(res.error).toBe("State restore failed: HTTP 500");
-      expect(runningWrites).toBe(1);
+      expect(runningWrites).toBe(0);
       expect(markErrorSpy).toHaveBeenCalledTimes(1);
       // Ghost cleanup still stops the container whose restore failed.
       expect(stop).toHaveBeenCalledWith("sandbox-blue-1");
@@ -8463,25 +8528,20 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  // The KMS timebomb (HQ #14308): a provisioning worker misconfigured with the
-  // ephemeral `memory` KMS backend rotates its key on every restart, orphaning
-  // the pre-upgrade snapshot it wrote — decrypt then throws KeyNotFoundError on
-  // resume. That must degrade to a FRESH boot (agent comes up without prior
-  // in-memory state), NOT brick the whole provision closed. Drives the REAL
-  // provision() body; the thrown error is from the real core KMS
-  // KeyNotFoundError.
-  test("(10) an orphaned snapshot (KeyNotFoundError on getLatestBackup) degrades to a fresh boot", async () => {
+  // A missing encryption key must preserve the backup for key recovery.
+  test("(10) backup recovery failure preserves state and refuses success", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();
     const finalRow: AgentSandbox = { ...row, status: "running" };
     const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
     const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
       ...row,
       status: "provisioning",
     });
     // The org DEK that encrypted the snapshot is gone (memory backend restart).
     const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockRejectedValue(
-      new KeyNotFoundError(orgKey(ORG, "dek"), 1),
+      await realKeyRotatedAwayError(),
     );
     const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(1);
     const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
@@ -8498,7 +8558,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
       "ensureRuntimeAgentStarted",
     ).mockResolvedValue(null);
-    // A fresh boot must NOT push any restore state.
+    // A failed backup read must not dispatch partial state.
     const pushStateSpy = spyOn(
       svc as unknown as { pushState: () => Promise<unknown> },
       "pushState",
@@ -8508,24 +8568,21 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stopForReplacement: stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
-      // Fresh boot: the provision SUCCEEDS instead of bricking.
-      expect(res.success).toBe(true);
-      expect(res.sandboxRecord).toBe(finalRow);
-      expect(create).toHaveBeenCalledTimes(1);
-      // Orphaned snapshot discarded (never pushed) and its dead chain dropped so
-      // the next resume does not re-hit it.
+      expect(res.success).toBe(false);
+      expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+      expect(res.failureCause).toMatchObject({ code: "SNAPSHOT_RESTORE_FAILED" });
+      expect(pruneSpy).not.toHaveBeenCalled();
       expect(pushStateSpy).not.toHaveBeenCalled();
-      expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
-      // The degrade is logged with context, never silent.
-      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
-      // A degrade is not a container failure — no ghost cleanup.
-      expect(stop).not.toHaveBeenCalled();
     } finally {
       findSpy.mockRestore();
+      findByIdSpy.mockRestore();
       lockSpy.mockRestore();
       backupSpy.mockRestore();
       pruneSpy.mockRestore();
@@ -8538,89 +8595,96 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  // The other undecryptable shape: a corrupt / wrong-key snapshot whose AEAD auth
-  // tag will not verify surfaces as a real AeadError from reconstruction. Same
-  // degrade-to-fresh-boot outcome.
-  test("(11) a corrupt snapshot (AeadError on reconstruction) degrades to a fresh boot", async () => {
-    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const aeadError = await realAeadDecryptError();
-    expect(aeadError.name).toBe("AeadError"); // guard: a genuine crypto failure
-    const row = provisioningReadyRow();
-    const finalRow: AgentSandbox = { ...row, status: "running" };
-    const backup: AgentSandboxBackup = {
-      id: "55555555-5555-4555-8555-555555555555",
-      sandbox_record_id: row.id,
-      snapshot_type: "pre-upgrade",
-      state_data: { memories: [], config: {}, workspaceFiles: {} },
-      state_data_storage: "inline",
-      state_data_key: null,
-      size_bytes: 2,
-      backup_kind: "full",
-      parent_backup_id: null,
-      content_hash: null,
-      created_at: new Date("2026-06-04T12:05:00.000Z"),
-    };
-    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
-    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
-      ...row,
-      status: "provisioning",
-    });
-    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
-    const reconstructedSpy = spyOn(
-      agentSandboxesRepository,
-      "getReconstructedBackupState",
-    ).mockRejectedValue(aeadError);
-    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(2);
-    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
-      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
-    );
-    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
-      id: "22222222-2222-4222-8222-222222222222",
-      plainKey: "eliza_test_agent_key",
-      prefix: "eliza_test",
-    });
-    const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
-    const svc = new ElizaSandboxService();
-    const ensureStartedSpy = spyOn(
-      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
-      "ensureRuntimeAgentStarted",
-    ).mockResolvedValue(null);
-    const pushStateSpy = spyOn(
-      svc as unknown as { pushState: () => Promise<unknown> },
-      "pushState",
-    ).mockResolvedValue(null);
-    const create = mock(async () => providerHandle());
-    const getProviderSpy = spyOn(
-      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
-      "getProvider",
-    ).mockResolvedValue({
-      create,
-      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
-      stopForReplacement: mock(async () => {}),
-      checkHealth: async () => true,
-    } as SandboxProvider);
-    try {
-      const res = await svc.provision(AGENT, ORG);
-      expect(res.success).toBe(true);
-      expect(res.sandboxRecord).toBe(finalRow);
-      expect(pushStateSpy).not.toHaveBeenCalled();
-      expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
-      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
-    } finally {
-      findSpy.mockRestore();
-      lockSpy.mockRestore();
-      backupSpy.mockRestore();
-      reconstructedSpy.mockRestore();
-      pruneSpy.mockRestore();
-      updateSpy.mockRestore();
-      apiKeySpy.mockRestore();
-      errorLogSpy.mockRestore();
-      ensureStartedSpy.mockRestore();
-      pushStateSpy.mockRestore();
-      getProviderSpy.mockRestore();
-    }
-  });
+  // Corrupt or wrong-key bytes must not authorize an empty boot.
+  test.each(["decrypt", "missing"] as const)(
+    "(11) backup recovery failure preserves state and refuses success: %s",
+    async (mode) => {
+      const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+      const aeadError = await realAeadDecryptError();
+      expect(aeadError.name).toBe("AeadError"); // guard: a genuine crypto failure
+      const row = provisioningReadyRow();
+      const finalRow: AgentSandbox = { ...row, status: "running" };
+      const backup: AgentSandboxBackup = {
+        id: "55555555-5555-4555-8555-555555555555",
+        sandbox_record_id: row.id,
+        snapshot_type: "pre-upgrade",
+        state_data: { memories: [], config: {}, workspaceFiles: {} },
+        state_data_storage: "inline",
+        state_data_key: null,
+        size_bytes: 2,
+        backup_kind: "full",
+        parent_backup_id: null,
+        content_hash: null,
+        created_at: new Date("2026-06-04T12:05:00.000Z"),
+      };
+      const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+      const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
+      const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+        ...row,
+        status: "provisioning",
+      });
+      const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+        backup,
+      );
+      const reconstructedSpy = spyOn(
+        agentSandboxesRepository,
+        "getReconstructedBackupState",
+      ).mockImplementation(async () => {
+        if (mode === "missing") return null;
+        throw aeadError;
+      });
+      const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(2);
+      const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+        async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+      );
+      const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+        id: "22222222-2222-4222-8222-222222222222",
+        plainKey: "eliza_test_agent_key",
+        prefix: "eliza_test",
+      });
+      const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
+      const svc = new ElizaSandboxService();
+      const ensureStartedSpy = spyOn(
+        svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+        "ensureRuntimeAgentStarted",
+      ).mockResolvedValue(null);
+      const pushStateSpy = spyOn(
+        svc as unknown as { pushState: () => Promise<unknown> },
+        "pushState",
+      ).mockResolvedValue(null);
+      const create = mock(async () => providerHandle());
+      const getProviderSpy = spyOn(
+        svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+        "getProvider",
+      ).mockResolvedValue({
+        create,
+        stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+        stopForReplacement: mock(async () => {}),
+        checkHealth: async () => true,
+      } as SandboxProvider);
+      try {
+        const res = await svc.provision(AGENT, ORG);
+        expect(res.success).toBe(false);
+        expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+        expect(res.failureCause).toMatchObject({ code: "SNAPSHOT_RESTORE_FAILED" });
+        expect(pruneSpy).not.toHaveBeenCalled();
+        expect(pushStateSpy).not.toHaveBeenCalled();
+      } finally {
+        findSpy.mockRestore();
+        findByIdSpy.mockRestore();
+        lockSpy.mockRestore();
+        backupSpy.mockRestore();
+        reconstructedSpy.mockRestore();
+        pruneSpy.mockRestore();
+        updateSpy.mockRestore();
+        apiKeySpy.mockRestore();
+        errorLogSpy.mockRestore();
+        ensureStartedSpy.mockRestore();
+        pushStateSpy.mockRestore();
+        getProviderSpy.mockRestore();
+      }
+    },
+  );
 
   // The load-bearing distinction: a transient (non-crypto) backup-read failure —
   // a DB blip, network hiccup — must NOT be swallowed. Degrading on it would
@@ -8666,7 +8730,11 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stopForReplacement: stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
       // A transient failure fails the provision (the resume job retries), rather
@@ -8695,16 +8763,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  // The HQ 14308 incident, end to end: the restore push to the new container is
-  // rejected 401 Unauthorized (bridge URL routing to a dead/rotated container),
-  // which is deterministic on every attempt — retrying only burned the
-  // provision attempts and bricked agent 23766030 into status=error
-  // ("Provisioning failed after 1 attempt (not retryable): State restore failed: HTTP 401
-  // {"error":"Unauthorized"}"). It must instead degrade to a fresh boot on the
-  // FIRST detection. Drives the REAL pushState (fetch intercepted with the
-  // incident's exact response) so the classified error is the code's own throw
-  // shape, not a hand-rolled string.
-  test("(13) restore push rejected 401 (dead/rotated container) degrades to a fresh boot on the first attempt", async () => {
+  // Exercise the real restore transport against an authentication refusal.
+  test("(13) backup recovery failure preserves state and refuses success", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row: AgentSandbox = { ...provisioningReadyRow(), execution_tier: "dedicated-lazy" };
     const finalRow: AgentSandbox = { ...row, status: "running" };
@@ -8722,6 +8782,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
     const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
     const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
       ...row,
       status: "provisioning",
@@ -8763,29 +8824,21 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stopForReplacement: stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
-      // Fresh boot: the provision SUCCEEDS instead of bricking the agent.
-      expect(res.success).toBe(true);
-      expect(res.sandboxRecord).toBe(finalRow);
-      // The restore POST really went to the new container's bridge.
+      expect(res.success).toBe(false);
+      expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+      expect(res.failureCause).toMatchObject({ code: "SNAPSHOT_RESTORE_FAILED" });
+      expect(pruneSpy).not.toHaveBeenCalled();
       expect(restoreCalls).toEqual(["https://runtime-blue.example/api/restore"]);
-      // Degrade on FIRST detection: one create, no retry burn, no ghost
-      // cleanup of the healthy container, no markError.
-      expect(create).toHaveBeenCalledTimes(1);
-      expect(stop).not.toHaveBeenCalled();
-      expect(markErrorSpy).not.toHaveBeenCalled();
-      // A 401 is an AUTH failure — RECOVERABLE (#15263), not a permanently-lost
-      // snapshot. It degrades to a fresh boot so the agent never bricks, but the
-      // backup chain is PRESERVED so a later token-corrected resume can restore
-      // it. Pruning here would be silent, permanent data loss (#15274), so the
-      // chain-nuking `pruneBackups(agentId, 0)` must NOT fire on this path.
-      expect(pruneSpy).not.toHaveBeenCalledWith(AGENT, 0);
-      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
     } finally {
       findSpy.mockRestore();
+      findByIdSpy.mockRestore();
       lockSpy.mockRestore();
       backupSpy.mockRestore();
       reconstructedSpy.mockRestore();
@@ -8799,10 +8852,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  // A restore-endpoint 404 on a NON-custom tier is equally deterministic (the
-  // image will never grow the endpoint mid-provision) — same degrade, via the
-  // real pushState throw shape.
-  test("(14) restore push rejected 404 on a non-custom tier degrades to a fresh boot", async () => {
+  // A missing restore endpoint must preserve state and fail recovery.
+  test("(14) backup recovery failure preserves state and refuses success", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row: AgentSandbox = { ...provisioningReadyRow(), execution_tier: "dedicated-lazy" };
     const finalRow: AgentSandbox = { ...row, status: "running" };
@@ -8820,6 +8871,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
     const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
     const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
       ...row,
       status: "provisioning",
@@ -8854,17 +8906,20 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     const getProviderSpy = spyOn(
       svc as unknown as { getProvider: () => Promise<SandboxProvider> },
       "getProvider",
-    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    ).mockResolvedValue({
+      create,
+      stopForReplacement: stop,
+      checkHealth: async () => true,
+    } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
-      expect(res.success).toBe(true);
-      expect(markErrorSpy).not.toHaveBeenCalled();
-      expect(stop).not.toHaveBeenCalled();
-      expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
-      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
+      expect(res.success).toBe(false);
+      expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+      expect(res.failureCause).toMatchObject({ code: "SNAPSHOT_RESTORE_FAILED" });
+      expect(pruneSpy).not.toHaveBeenCalled();
     } finally {
       findSpy.mockRestore();
+      findByIdSpy.mockRestore();
       lockSpy.mockRestore();
       backupSpy.mockRestore();
       reconstructedSpy.mockRestore();
@@ -8878,11 +8933,8 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
-  // Custom-tier images legitimately lack /api/restore: that 404 stays the
-  // designed benign skip — the snapshot is KEPT (no prune) for a future image
-  // that has the endpoint. Guards the branch ordering: the skip must win over
-  // the unrecoverable degrade.
-  test("(15) restore push 404 on a custom tier stays a benign skip — snapshot kept, no degrade", async () => {
+  // Custom images also require successful restoration when a backup exists.
+  test("(15) backup recovery failure preserves state and refuses success", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow(); // execution_tier: "custom"
     const finalRow: AgentSandbox = { ...row, status: "running" };
@@ -8900,6 +8952,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       created_at: new Date("2026-06-04T12:05:00.000Z"),
     };
     const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
     const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
       ...row,
       status: "provisioning",
@@ -8938,15 +8991,13 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     } as SandboxProvider);
     try {
       const res = await svc.provision(AGENT, ORG);
-      expect(res.success).toBe(true);
-      // Benign skip, not a degrade: chain untouched, no error-level log.
+      expect(res.success).toBe(false);
+      expect(updateSpy.mock.calls.some(([, data]) => data.status === "running")).toBe(false);
+      expect(res.failureCause).toMatchObject({ code: "SNAPSHOT_RESTORE_FAILED" });
       expect(pruneSpy).not.toHaveBeenCalled();
-      const info = infoLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(info).toContain("custom image has no restore endpoint");
-      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).not.toContain("Unrecoverable snapshot");
     } finally {
       findSpy.mockRestore();
+      findByIdSpy.mockRestore();
       lockSpy.mockRestore();
       backupSpy.mockRestore();
       reconstructedSpy.mockRestore();
@@ -9346,176 +9397,6 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       ensureStartedSpy.mockRestore();
       getProviderSpy.mockRestore();
     }
-  });
-});
-
-// Snapshot-degrade error classification (`isUnrecoverableSnapshotError`), proven
-// against real core KMS errors produced by the crypto stack — the
-// precise crypto-vs-transient distinction the degrade path keys on.
-describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)", () => {
-  test("classifies a real KeyNotFoundError (memory-KMS key rotated away) as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
-    const err = await realKeyRotatedAwayError();
-    // The exact prod incident: the memory backend restart orphaned the key.
-    expect(err).toBeInstanceOf(KeyNotFoundError);
-    expect(isUnrecoverableSnapshotError(err)).toBe(true);
-  });
-
-  test("classifies a real AeadError (auth-tag failure) as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
-    const err = await realAeadDecryptError();
-    expect(err.name).toBe("AeadError");
-    expect(isUnrecoverableSnapshotError(err)).toBe(true);
-  });
-
-  test("classifies permanent snapshot HTTP rejections (401/403/404/410) as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
-    // The exact HQ 14308 incident string, as pushState throws it (status +
-    // first 200 bytes of the response body).
-    expect(
-      isUnrecoverableSnapshotError(
-        new Error('State restore failed: HTTP 401 {"error":"Unauthorized"}'),
-      ),
-    ).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 403 "))).toBe(true);
-    expect(
-      isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 404 Not Found")),
-    ).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 410 Gone"))).toBe(
-      true,
-    );
-    // fetchSnapshotState's shape (no body suffix). Its 404 is mapped to the
-    // SNAPSHOT_ENDPOINT_UNSUPPORTED sentinel before ever surfacing, but the
-    // auth statuses surface verbatim.
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 401"))).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 403"))).toBe(true);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 410"))).toBe(true);
-  });
-
-  test("does NOT classify transient snapshot HTTP failures — those must retry", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
-    // 5xx (container mid-boot / overloaded), 408 (timeout), 429 (throttled):
-    // all can heal on the next attempt, so degrading would discard restorable
-    // state.
-    expect(
-      isUnrecoverableSnapshotError(
-        new Error("State restore failed: HTTP 500 Internal Server Error"),
-      ),
-    ).toBe(false);
-    expect(
-      isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 502 Bad Gateway")),
-    ).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 503 "))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 408 "))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 429 "))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 500"))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 503"))).toBe(false);
-    // #18228: a diagnostic body suffix must not change transient-vs-permanent
-    // classification — the regex is anchored at the status prefix.
-    expect(
-      isUnrecoverableSnapshotError(
-        new Error("Snapshot fetch failed: HTTP 500 Durable Object storage quota exceeded"),
-      ),
-    ).toBe(false);
-  });
-
-  test("matches only this file's snapshot throw shapes — anchored, exact status", async () => {
-    const { isUnrecoverableSnapshotError, SNAPSHOT_ENDPOINT_UNSUPPORTED } = await import(
-      "./eliza-sandbox.ts?actual"
-    );
-    // Network-level fetch failures carry no HTTP status and must propagate.
-    expect(isUnrecoverableSnapshotError(new TypeError("fetch failed"))).toBe(false);
-    // A message that merely EMBEDS the wrapper (e.g. the markError re-wrap) is
-    // not the raw restore-path error the degrade classifies.
-    expect(
-      isUnrecoverableSnapshotError(
-        new Error(
-          'Provisioning failed after 1 attempt (not retryable): State restore failed: HTTP 401 {"error":"Unauthorized"}',
-        ),
-      ),
-    ).toBe(false);
-    // The "image has no snapshot endpoint" sentinel is a benign skip elsewhere,
-    // never a degrade.
-    expect(isUnrecoverableSnapshotError(new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED))).toBe(false);
-    expect(isUnrecoverableSnapshotError(new Error("Sandbox is not running"))).toBe(false);
-  });
-
-  test("does NOT classify transient / non-crypto failures as unrecoverable", async () => {
-    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
-    // A DB/network blip, a base Steward KmsError (HTTP 5xx transient), and
-    // non-Errors must all propagate — degrading on them would discard state a
-    // retry would have restored.
-    expect(isUnrecoverableSnapshotError(new Error("connection terminated unexpectedly"))).toBe(
-      false,
-    );
-    expect(
-      isUnrecoverableSnapshotError(
-        new KmsError("Steward KMS decrypt failed (503 Service Unavailable)"),
-      ),
-    ).toBe(false);
-    expect(isUnrecoverableSnapshotError("AEAD decrypt failed")).toBe(false);
-    expect(isUnrecoverableSnapshotError(null)).toBe(false);
-    expect(isUnrecoverableSnapshotError(undefined)).toBe(false);
-  });
-});
-
-// Snapshot PRUNE-gating classification (`isPermanentlyLostSnapshot`, #15274).
-// A strict SUBSET of `isUnrecoverableSnapshotError`: an auth 401/403 is
-// unrecoverable for THIS provision (boot fresh) but the snapshot is NOT
-// permanently lost — a token-corrected resume (#15263) can still restore it —
-// so it must NEVER gate a `pruneBackups(agentId, 0)`. Only crypto-loss and
-// HTTP 404/410 are permanently lost and safe to prune.
-describe("isPermanentlyLostSnapshot (prune-vs-preserve gating)", () => {
-  test("classifies crypto-loss shapes (KeyNotFoundError / AeadError) as permanently lost", async () => {
-    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
-    const keyGone = await realKeyRotatedAwayError();
-    expect(keyGone).toBeInstanceOf(KeyNotFoundError);
-    expect(isPermanentlyLostSnapshot(keyGone)).toBe(true);
-    const corrupt = await realAeadDecryptError();
-    expect(corrupt.name).toBe("AeadError");
-    expect(isPermanentlyLostSnapshot(corrupt)).toBe(true);
-  });
-
-  test("classifies HTTP 404/410 (snapshot gone) as permanently lost — safe to prune", async () => {
-    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
-    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 404 Not Found"))).toBe(
-      true,
-    );
-    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 410 Gone"))).toBe(true);
-    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 410"))).toBe(true);
-  });
-
-  test("does NOT classify auth 401/403 as permanently lost — recoverable, must PRESERVE the chain (#15274)", async () => {
-    const { isPermanentlyLostSnapshot, isUnrecoverableSnapshotError } = await import(
-      "./eliza-sandbox.ts?actual"
-    );
-    // The exact HQ 14308 incident string. It IS unrecoverable-for-this-provision
-    // (degrade to fresh boot) but NOT permanently lost: PR #15263 shows the 401
-    // was a healthy container missing the agent token, which a corrected resume
-    // restores. Pruning here = silent permanent data loss.
-    const auth401 = new Error('State restore failed: HTTP 401 {"error":"Unauthorized"}');
-    expect(isUnrecoverableSnapshotError(auth401)).toBe(true);
-    expect(isPermanentlyLostSnapshot(auth401)).toBe(false);
-    const auth403 = new Error("State restore failed: HTTP 403 ");
-    expect(isUnrecoverableSnapshotError(auth403)).toBe(true);
-    expect(isPermanentlyLostSnapshot(auth403)).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 401"))).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 403"))).toBe(false);
-  });
-
-  test("does NOT classify transient / non-matching errors as permanently lost", async () => {
-    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
-    // Transient HTTP and network/DB errors were never unrecoverable to begin
-    // with; they must never prune.
-    expect(
-      isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 500 Internal Server Error")),
-    ).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 503 "))).toBe(false);
-    expect(isPermanentlyLostSnapshot(new Error("connection terminated unexpectedly"))).toBe(false);
-    expect(isPermanentlyLostSnapshot(new TypeError("fetch failed"))).toBe(false);
-    expect(isPermanentlyLostSnapshot("AEAD decrypt failed")).toBe(false);
-    expect(isPermanentlyLostSnapshot(null)).toBe(false);
-    expect(isPermanentlyLostSnapshot(undefined)).toBe(false);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -487,11 +487,9 @@ function containerBackedServiceRejection(
 }
 
 /**
- * Restore-source override for `provision()`. `from-backup` restores a specific
- * backup instead of the latest and disables unrecoverable-snapshot degradation;
- * manual restore additionally sets `requireRestoreEndpoint` so the custom-image
- * 404 compatibility skip cannot fabricate success. `fresh-boot` skips restore
- * entirely. Callers that omit an override keep latest-backup auto-restore.
+ * Selects the retained backup for provisioning, or records explicit consent
+ * to skip restoration. Every selected backup requires a working restore
+ * endpoint. Omitted overrides restore the latest backup when one exists.
  */
 export type ProvisionRestoreOverride =
   | {
@@ -1667,101 +1665,6 @@ export function computeManagedAgentDbEnv(
   return callerSuppliedDatabaseUrl || wantsLocalState
     ? { ELIZA_MANAGED_DATABASE_URL: dbUri }
     : { DATABASE_URL: dbUri };
-}
-
-// HTTP statuses that make a snapshot fetch/restore fail for THIS snapshot in a
-// way the current provision cannot retry away, so it must degrade to a fresh
-// boot instead of bricking the agent (#15210): 401/403 (auth — a dead/rotated
-// container or an unauthenticated/rotating token rejects every retry
-// identically), 404 (endpoint or snapshot gone), 410 (gone). Everything else —
-// 5xx, 408/429, network/timeout — can heal on a retry and must NOT appear here.
-const UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES = new Set([401, 403, 404, 410]);
-// The subset that is also PERMANENTLY LOST — the snapshot itself is gone and no
-// later resume can restore it, so the dead backup chain should be pruned: 404
-// (endpoint or snapshot gone) and 410 (gone). 401/403 are auth failures, which
-// are RECOVERABLE (missing/rotating token — see #15263, where the incident 401
-// was a healthy container whose restore push simply omitted the agent token),
-// so they must degrade-but-PRESERVE the chain: never prune a snapshot a
-// token-corrected resume could still restore (#15274).
-const PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES = new Set([404, 410]);
-
-// Anchored on the exact `fetchSnapshotState` / `pushState` throw shapes so only
-// this file's snapshot HTTP throw sites classify — an unrelated error that
-// merely embeds one of these strings does not.
-const SNAPSHOT_HTTP_ERROR_SHAPE =
-  /^(?:Snapshot fetch failed|State restore failed): HTTP (\d{3})(?:\s|$)/;
-
-/**
- * True only when a stored backup snapshot can never be applied, no matter how
- * many times the provision retries. An agent's identity, config, and durable
- * data live in the DB record; a snapshot holds only volatile in-memory session
- * state — so the designed degrade for an unrecoverable snapshot (#15210) is
- * "boot fresh, lose only the volatile session", never "brick the whole agent".
- * Two shapes qualify:
- *
- * - UNDECRYPTABLE: the AEAD auth tag fails to verify (corruption / wrong key /
- *   wrong AAD, surfaced by the core KMS as `AeadError`) or the KMS key
- *   version that encrypted it no longer exists (`KeyNotFoundError` — thrown
- *   only by the ephemeral `memory` KMS backend, which derives a fresh
- *   per-process key on every restart and thus orphans everything it previously
- *   encrypted). Matched by error class NAME rather than `instanceof` because
- *   `AeadError` is internal to the core KMS submodule (not exported) and this code
- *   runs bundled, where a cross-realm `instanceof` on a dependency's error
- *   class is unreliable.
- * - UNRETRIEVABLE / UNRESTORABLE: the snapshot fetch or restore push was
- *   rejected with an unrecoverable-for-this-provision HTTP status (see
- *   `UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES`). The incident shape (HQ 14308, agent
- *   23766030): `State restore failed: HTTP 401 {"error":"Unauthorized"}` from a
- *   bridge URL — deterministic on every attempt of THIS provision, so retrying
- *   only re-failed it into status=error.
- *
- * Deliberately NARROW so it never swallows a recoverable failure: HTTP 5xx /
- * 408 / 429, network/timeout errors, a transient KMS error (the Steward
- * backend surfaces HTTP 5xx as a base `KmsError`, not `KeyNotFoundError`), and
- * DB/IO errors are NOT matched and still propagate — degrading on one of those
- * would silently discard state that a retry would have restored.
- *
- * NOTE: "unrecoverable for this provision" (boot fresh) is a strictly WIDER
- * classification than "permanently lost" (also prune the chain). A 401/403 is
- * unrecoverable here but the snapshot is NOT permanently lost — an auth failure
- * heals once the token is attached/rotated correctly (#15263), so
- * `isPermanentlyLostSnapshot` must gate any pruning, never this predicate.
- */
-export function isUnrecoverableSnapshotError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
-  // A size refusal is deliberately NOT unrecoverable-for-this-provision. It is
-  // deterministic, so retrying is pointless — but the chain is intact and
-  // restorable in principle, and the only reason it cannot be applied is a
-  // limit WE chose. Degrading it to a fresh boot would discard recoverable
-  // state; it gets its own terminal branch at each restore site instead, and
-  // the one way past it is wake's explicit `forceFreshBoot` consent.
-  const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
-  return match !== null && UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
-}
-
-/**
- * True only when the snapshot is PERMANENTLY LOST — no later resume, on any
- * container with any token, can ever restore it — so the dead backup chain is
- * safe to prune. A strict SUBSET of `isUnrecoverableSnapshotError`:
- *
- * - The crypto shapes (`AeadError` / `KeyNotFoundError`): the bytes can never
- *   be decrypted again (corruption, or the ephemeral `memory` KMS key that
- *   encrypted them is gone), so the chain is genuinely dead.
- * - HTTP 404 (endpoint or snapshot gone) / 410 (gone): the snapshot resource
- *   itself no longer exists to fetch.
- *
- * Excludes 401/403: those are AUTH failures (missing/rotating token), which are
- * RECOVERABLE — pruning on one would silently, permanently discard a snapshot a
- * token-corrected resume could still restore (#15274 regression class). On an
- * auth failure we still degrade to a fresh boot (never brick), but we PRESERVE
- * the chain and let the next authenticated resume restore it.
- */
-export function isPermanentlyLostSnapshot(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
-  const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
-  return match !== null && PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
 }
 
 /**
@@ -3903,13 +3806,9 @@ export class ElizaSandboxService {
   // Provision
 
   /**
-   * `restoreOverride` narrows step 5's backup restore for callers that have
-   * already decided the restore source: `executeWake` (#15603 B6) and manual
-   * `restore()`. `from-backup` restores a specific validated backup and NEVER
-   * degrades an unrecoverable restore error to a fresh boot; manual restore also
-   * requires the endpoint, while wake retains its custom-image 404 compatibility
-   * skip. `fresh-boot` skips restore after explicit data-loss consent. Omitted:
-   * latest-backup auto-restore with the designed unrecoverable-snapshot degrade.
+   * Provisions a runtime and restores the selected or latest retained backup.
+   * Restoration failure preserves the chain and fails the operation. Only an
+   * explicit fresh-boot override permits skipping retained state.
    */
   async provision(
     agentId: string,
@@ -4359,18 +4258,10 @@ export class ElizaSandboxService {
 
         await this.ensureRuntimeAgentStarted(runtimeRec);
 
-        // 4. Persist the reachable container and provider-specific metadata.
-        //
-        // User rows flip to `running` before restore because that status is the
-        // proxy reachability gate; delaying it made a responsive agent render
-        // as "waking" throughout restore (#14038). Unclaimed pool rows are the
-        // exception: exposing them as claimable before the restore tail
-        // succeeds recreates the readiness crash window, so they stay
-        // `provisioning` until the final status+stamp CAS below.
+        // Prepare the final publication while the replacement ledger retains
+        // ownership. Restoration must succeed before routing can use this row.
         const updateData: Parameters<typeof agentSandboxesRepository.update>[1] = {
-          // Pool rows stay non-claimable until the entire provision tail
-          // succeeds. Their final status+readiness stamp is one repository CAS
-          // below; user rows retain the early reachability flip.
+          // Pool entries require their separate readiness-stamp CAS below.
           status: recoveringPendingWarmClaim || isWarmPoolProvision ? "provisioning" : "running",
           sandbox_id: handle.sandboxId,
           bridge_url: handle.bridgeUrl,
@@ -4410,41 +4301,9 @@ export class ElizaSandboxService {
           updateData.image_digest = dockerMeta.imageDigest;
         }
 
-        const updated = await this.transferReplacementToPrimary(
-          rec.id,
-          rec.organization_id,
-          handle,
-          rec.environment_revision,
-          updateData,
-        );
-
-        // Re-enter the billable set on every successful provision. A
-        // credit-suspended agent (billing_status='suspended') that a user tops
-        // up and resumes/wakes via the user-facing routes would otherwise run
-        // (status='running') permanently EXCLUDED from listBillableSandboxes =
-        // free dedicated compute forever. The service-key resume/restart routes
-        // already reactivate; do it here so ALL provision paths re-enter billing.
-        // Idempotent + exempt-guarded (ne billing_status 'exempt').
-        await agentBillingRepository.reactivateSandboxBillingAfterFunding(rec.id, new Date());
-
-        // 5. Restore from backup (reconstructs incrementals back to a full).
-        //
-        // The snapshot holds only volatile in-memory session state — the agent's
-        // identity, config, and durable data live in the DB record — so an
-        // UNRECOVERABLE snapshot degrades to a FRESH boot instead of failing the
-        // whole provision closed (error-policy:J4 designed degrade — the state is
-        // unrestorable regardless of retries, so booting without prior in-memory
-        // state is correct, not a fabricated success). Two unrecoverable shapes,
-        // classified by `isUnrecoverableSnapshotError`: UNDECRYPTABLE (the org
-        // DEK that encrypted it is gone — the ephemeral `memory` KMS backend
-        // rotates its key on every restart — or the bytes are corrupt) and
-        // UNRESTORABLE (the restore push is rejected with a permanent HTTP
-        // status; HQ 14308 bricked an agent on a deterministic 401). Degrading on
-        // FIRST detection matters: these failures re-fail identically on every
-        // attempt, so retrying only burns the provision attempts and lands in
-        // markError. A transient DB/IO/network/5xx error is rethrown so the
-        // provision fails and the resume job retries rather than silently
-        // discarding recoverable state.
+        // Restore the complete retained state before reporting success. Missing
+        // keys, inaccessible objects and unsupported endpoints do not authorize
+        // an empty boot or deletion of the backup chain.
         let backup: Awaited<ReturnType<typeof agentSandboxesRepository.getLatestBackup>>;
         let restoreState: Awaited<
           ReturnType<typeof agentSandboxesRepository.getReconstructedBackupState>
@@ -4477,28 +4336,35 @@ export class ElizaSandboxService {
                 );
               }
             }
+            if (
+              !backup &&
+              (["running", "stopped", "sleeping", "disconnected"].includes(previousStatus) ||
+                rec.last_backup_at !== null || rec.last_heartbeat_at !== null)
+            ) {
+              throw new ElizaError(
+                "Recovery requires retained state, but no backup is available. Restore the missing backup or explicitly authorize a fresh boot.",
+                {
+                  code: "SNAPSHOT_RECOVERY_BACKUP_MISSING",
+                  context: { agentId: rec.id, previousStatus },
+                },
+              );
+            }
             restoreState = reviewedRestore
               ? reviewedRestore.state
               : backup
                 ? await agentSandboxesRepository.getReconstructedBackupState(backup.id)
                 : undefined;
-            if (isExplicitBackupRestore(restoreOverride) && !restoreState) {
+            if (backup && !restoreState) {
               // The exact row can disappear or leave the legacy-visible lane
-              // between lookup and chain reconstruction. An explicit restore
-              // must fail closed instead of booting a reachable empty runtime.
-              throw new Error(
-                `Restore backup ${restoreOverride.backupId} could not be reconstructed`,
-              );
+              // between lookup and reconstruction. A known backup requires
+              // complete state even when no explicit restore point was chosen.
+              throw new ElizaError(`Restore backup ${backup.id} could not be reconstructed`, {
+                code: "SNAPSHOT_RESTORE_STATE_UNAVAILABLE",
+                context: { agentId: rec.id, backupId: backup.id },
+              });
             }
           } catch (error) {
-            // An explicitly-requested backup must NEVER silently degrade to a
-            // fresh boot — the caller opted into THAT restore point, so a
-            // failure here fails the provision (retryable by the wake job)
-            // instead of booting empty (#15603 B6).
-            // Ordered before the from-backup rethrow: the gated wake ALWAYS
-            // passes `from-backup`, so checking that first would swallow the
-            // consent sentence on the one path where the consent mechanism
-            // exists.
+            // Size refusal retains the existing explicit-consent response.
             if (error instanceof SnapshotPayloadTooLargeError) {
               // Size refusal fails CLOSED even on an ordinary provision: the
               // chain is intact, only too large — booting empty would silently
@@ -4518,11 +4384,12 @@ export class ElizaSandboxService {
                 },
               );
             }
-            if (isExplicitBackupRestore(restoreOverride)) throw error;
-            if (!isUnrecoverableSnapshotError(error)) throw error;
-            await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
-            backup = undefined;
-            restoreState = undefined;
+            // error-policy:J2 preserve the restore failure and retained state.
+            throw new ElizaError(error instanceof Error ? error.message : "Backup recovery failed; retained state was not discarded", {
+              code: "SNAPSHOT_RESTORE_FAILED",
+              cause: error,
+              context: { agentId: rec.id },
+            });
           }
         }
         if (restoreState) {
@@ -4569,14 +4436,8 @@ export class ElizaSandboxService {
               });
             }
           } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            const missingCustomRestoreEndpoint =
-              rec.execution_tier === "custom" &&
-              message.startsWith("State restore failed: HTTP 404");
             if (error instanceof SnapshotPayloadTooLargeError) {
-              // Ordered before the from-backup rethrow for the same reason as
-              // the fetch branch: a gated wake would otherwise never see the
-              // consent sentence.
+              // Preserve the explicit-consent response for a size refusal.
               throw new ElizaError(
                 `Restore refused: ${error.message}. Booting empty would discard this agent's state; wake with forceFreshBoot to explicitly accept the data loss.`,
                 {
@@ -4590,41 +4451,32 @@ export class ElizaSandboxService {
                   severity: "fatal",
                 },
               );
-            } else if (
-              isExplicitBackupRestore(restoreOverride) &&
-              (restoreOverride.kind === "from-reviewed-backup" ||
-                restoreOverride.requireRestoreEndpoint ||
-                !missingCustomRestoreEndpoint)
-            ) {
-              // Same no-silent-fresh-boot rule as the fetch above: an explicit
-              // restore point that cannot be pushed fails the provision. A
-              // manual restore requires the endpoint because restore() reports
-              // that exact point as applied; the historical wake lane alone
-              // keeps its custom-image 404 compatibility skip (#15603 B6).
-              throw error;
-            } else if (missingCustomRestoreEndpoint) {
-              // Ordinary custom-image provisions may legitimately lack the
-              // restore endpoint. Keep the snapshot intact for a future image;
-              // manual restores opt into strict endpoint enforcement above.
-              logger.info(
-                "[agent-sandbox] Backup restore skipped: custom image has no restore endpoint",
-                {
-                  agentId: rec.id,
-                  backupId: backup?.id,
-                },
-              );
-            } else if (isUnrecoverableSnapshotError(error)) {
-              await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
-            } else {
-              throw error;
             }
+            // error-policy:J2 a reachable runtime is not proof of restored state.
+            throw new ElizaError(error instanceof Error ? error.message : "Backup recovery failed; retained state was not discarded", {
+              code: "SNAPSHOT_RESTORE_FAILED",
+              cause: error,
+              context: { agentId: rec.id, backupId: backup?.id },
+            });
           }
-        } else if (backup) {
-          logger.warn("[agent-sandbox] Backup restore skipped: reconstructed state was null", {
-            agentId: rec.id,
-            backupId: backup.id,
-          });
         }
+
+        const updated = await this.transferReplacementToPrimary(
+          rec.id,
+          rec.organization_id,
+          handle,
+          rec.environment_revision,
+          updateData,
+        );
+
+        // Re-enter the billable set on every successful provision. A
+        // credit-suspended agent (billing_status='suspended') that a user tops
+        // up and resumes/wakes via the user-facing routes would otherwise run
+        // (status='running') permanently EXCLUDED from listBillableSandboxes =
+        // free dedicated compute forever. The service-key resume/restart routes
+        // already reactivate; do it here so ALL provision paths re-enter billing.
+        // Idempotent + exempt-guarded (ne billing_status 'exempt').
+        await agentBillingRepository.reactivateSandboxBillingAfterFunding(rec.id, new Date());
 
         let completed = updated;
         if (isWarmPoolProvision) {
@@ -6009,10 +5861,14 @@ export class ElizaSandboxService {
           };
         }
       }
+      // A failed credential handoff never activated this user agent. Reset
+      // initial provisioning and discard only the pool heartbeat, preserving
+      // any backup history that still requires restoration.
       const reset = await tx.execute<{ id: string }>(sql`
         UPDATE ${agentSandboxes}
         SET
-          status = 'stopped',
+          status = 'pending',
+          last_heartbeat_at = NULL,
           claimed_at = NULL,
           warm_claim_credential_state = NULL,
           warm_claim_source_pool_id = NULL,
@@ -13262,50 +13118,6 @@ export class ElizaSandboxService {
       bytes: backup.size_bytes ?? sizeBytes,
     });
     return { backupId: backup.id, lifecycleRevision: sandbox.lifecycleRevision };
-  }
-
-  /**
-   * The single degrade path for a snapshot `isUnrecoverableSnapshotError`
-   * cannot restore on THIS provision (#15210): log it loudly, then boot fresh
-   * instead of bricking the agent. Never throws — the caller continues to a
-   * fresh boot, which must not be derailed by cleanup.
-   *
-   * Pruning the backup chain is gated on `isPermanentlyLostSnapshot` (#15274):
-   * only drop it when the snapshot can NEVER be restored (crypto corruption /
-   * gone-key, or HTTP 404/410). For a RECOVERABLE auth failure (401/403) we
-   * still boot fresh but PRESERVE the chain, so a later token-corrected resume
-   * (#15263) can restore it — pruning a recoverable snapshot on a transient 401
-   * is silent, permanent data loss (`pruneBackups(agentId, 0)` deletes the
-   * whole chain and there is no undo).
-   */
-  private async degradeUnrecoverableSnapshot(
-    agentId: string,
-    backupId: string | undefined,
-    error: unknown,
-  ): Promise<void> {
-    const permanentlyLost = isPermanentlyLostSnapshot(error);
-    logger.error("[agent-sandbox] Unrecoverable snapshot, booting fresh", {
-      agentId,
-      backupId,
-      permanentlyLost,
-      // A recoverable auth failure keeps the chain for the next authenticated
-      // resume; a permanent loss drops it so the next resume boots clean.
-      backupChain: permanentlyLost ? "pruned" : "preserved",
-      error: error instanceof Error ? error.message : String(error),
-    });
-    // Preserve the chain on a recoverable failure (auth 401/403): a
-    // token-corrected resume can still restore it, so pruning here would be
-    // silent, permanent data loss (#15274).
-    if (!permanentlyLost) return;
-    // error-policy:J6 best-effort — a failed prune only means we warn + degrade
-    // again next boot, never that we fail to boot fresh, so it must not throw
-    // out of the provision.
-    await agentSandboxesRepository.pruneBackups(agentId, 0).catch((pruneErr) => {
-      logger.warn("[agent-sandbox] Failed to drop orphaned snapshot after degrade", {
-        agentId,
-        error: pruneErr instanceof Error ? pruneErr.message : String(pruneErr),
-      });
-    });
   }
 
   private async markError(rec: AgentSandbox, msg: string) {


### PR DESCRIPTION
Failed provider deletion must remain retryable after a node is disabled, and replacement creation must retain enough identity to clean up an uncertain outcome. This change persists retirement intent, verifies provider absence before ownership removal, and retains exact failed-create cleanup authority. Recovery also fails closed when prior state cannot be restored and publishes readiness only after restoration succeeds.

Refs #30675 and #30697. This PR covers lifecycle cleanup and state-preserving recovery. Funded automatic resume, backup activation, environment separation and live fleet cleanup remain separate work.

# Relates to

#30675 and #30697. Targets `develop`.

# Sync with develop

Rebased without conflicts onto `e8cfcd6914e`; pinned install and root verification both passed afterward.

# Risks

Medium/high operational impact: affects provider retirement, failed-create cleanup, and recovery publication. Retains unresolved resource ownership and prior state; restore failures now remain visible instead of silently fresh-booting. Requires a staging failure/restore drill before deployment.

# Background

## What does this PR do?

Persists cleanup/retirement authority and requires prior state restoration before recovery publishes a usable agent.

## What kind of change is this?

Bug fixes to existing cloud lifecycle behavior.

# Documentation changes needed?

Deployment runbooks and live activation belong to the broader cloud production plan; this draft does not claim them complete.

# Testing

## Where should a reviewer start?

Start with node retirement retry, exact failed-create cleanup, and ordinary recovery failure/restore tests. Review the evidence limits below before approving deployment.

## Detailed testing steps

Run shared package tests, control-plane tests, daemon focused tests, shared typecheck/lint, and root verification. On staging, exercise failed provider deletion, an uncertain create acknowledgement, and a stateful restore failure followed by successful recovery; inspect both database receipts and provider resources.

## Validation

- Candidate: `9e8479d5f1496d260f0e8002a956b123100d3f56`; rebased base: `e8cfcd6914edfc1675450ce0a1bbea685e0a08be`.
- Pinned Bun 1.3.14 / Node 24.15.0 install passed after rebase.
- All 26 changed files are byte-identical to the cloud changes validated at `20b05250d7e`; the three upstream commits affect installation tooling and screen recording.
- Shared package test coverage: 12,574 pass, 208 skip across the same 347-batch inventory. Batches 1–238 passed; batch239 hung after a hook timeout and was terminated after verifying the exact process and worktree. Its 37 tests passed in an independent 4.55-second recheck; batches240–347 all passed through the existing wrapper. This is combined coverage, not a passing claim for the interrupted invocation.
- Owning control-plane tests: 23 pass. Daemon focused tests: 74 pass. Shared lint/typecheck passed during implementation. Post-rebase `bun run verify` passed (exit 0).
- Behavioral checks exercise actual PostgreSQL-compatible transactions in PGlite, the real provisioning body with substituted provider/transport boundaries, backup decryption and HTTP restoration, ambiguous create cleanup, node retirement retry and stale-generation rejection.

## Evidence and remaining verification

| Surface | Evidence |
| --- | --- |
| Database/lifecycle behavior | Real PGlite tests verify exact cleanup settlement, retained workload protection, and readiness compare-and-set rejection while backup restoration is unresolved. |
| Provider failure handling | Deterministic provider/SSH boundary tests cover lost acknowledgements, failed deletion retry, stale node boot identity, and preservation of cleanup authority. These are not live Hetzner evidence. |
| Stateful recovery | Real provisioning-path tests preserve prior backups on authentication/decryption/missing-state errors and delay primary publication until transfer/restore succeeds. |
| UI/screenshots/video | N/A — no rendered UI changed. |
| Live model trajectories | N/A — no prompt or model behavior changed. |
| Live Hetzner/Docker and restore drill | Pending existing host/control-plane database operator access. No fleet resource was deleted and no production configuration was changed. |

Keep this PR in draft until live provider/state recovery evidence and final required checks are complete. The production-readiness plan is not complete.

# Evidence Gate

<!-- evidence-head:9644125f30b73de52772c4b6c99da2456d86efa7 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend-testable flow changed.
<!-- evidence-row:backend-logs -->
- [ ] Live provider end-to-end logs remain unavailable pending existing operator access; draft is not deployment-ready.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompts, model calls or reasoning behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] PGlite transaction assertions and provider boundary tests passed; live Docker/Hetzner/database recovery receipts remain required.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior changed.

## Backend + frontend logs

Frontend: N/A - no frontend changes. Backend live integration logs remain required; deterministic tests do not substitute for a real provider drill.

<details><summary>Recorded shared test coverage</summary>

```text
Unchanged cloud source: 20b05250d7e → 9e8479d5f1496d260f0e8002a956b123100d3f56
Original batches 1–238: 10611 pass, 160 skip
Batch239 independent recheck: 37 pass, 0 fail, 199 assertions, 4.55 seconds
Original batches240–347: 1926 pass, 48 skip, exit0
Combined successful coverage: 12574 pass, 208 skip
Post-rebase bun install: exit0
Post-rebase bun run verify: exit0
```

The initial broad run timed out in a credits-test hook; its failed process and successful exact-file recheck are reported above. No failed test was hidden or counted as passing.
</details>

### Before

N/A - no UI changed.

### After

N/A - no UI changed.

### Walkthrough video

N/A - no frontend flow changed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

The interrupted credits-test invocation is recorded above. No live Docker/Hetzner/DB access is available for the required staging failure and restoration drill. That gap blocks readiness and deployment; this PR remains draft.

## Maintainer CI exception record

N/A - no exception requested. No check bypass or repository rule change is requested by this PR.

# Deploy Notes

Keep draft pending live failure/recovery evidence. No infrastructure resources or production configuration have been changed. This is one source-code part of the cloud production plan, not a production-readiness declaration.


## Independent review update

Reviewed candidate `9644125f30b73de52772c4b6c99da2456d86efa7`, based on `b676280384b15df54204276e34bb8740db26936f`. Cleanup no longer falls back to a derived container name when a quiescent receipt has no recorded container ID; that fallback could remove an unrelated replacement. Removal remains bound to the recorded provider identity. The regression failed before the repair and passed afterward.

Validation: 26 cleanup tests; 288 database/recovery contract tests; 64 sandbox utility tests with one real-Docker skip; and 10 shell-transport tests with one real-Docker skip passed. A six-operation control-byte test exceeded its aggregate deadline, so each operation now has its own test and retains the original deadline; all six cases passed. These runs overlap and are not an additive coverage count.

The normal [full repository Quality job](https://github.com/elizaOS/eliza/actions/runs/34015199191/job/101437645557) passed on this exact candidate: 376 workspace tasks and repository audits. The broader CI run is not entirely green; scripts and UI failures remain. This update is not merge or deployment approval. The existing live staging failure/restore drill remains required, and the PR stays draft.
