### PR TITLE
fix(cloud): expose safe retained-image evidence for staging provisioning

### DIFF
--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
@@ -41,6 +41,8 @@ const snapshot = {
     error_message: null,
     sandbox_id: null,
     bridge_url: null,
+    docker_image: null,
+    image_digest: null,
   }),
 };
 
@@ -107,6 +109,8 @@ describe("personal Dedicated staging re-review operator", () => {
       error_message: `Headscale routing is required but HEADSCALE_API_KEY is not configured ${privateLocator}`,
       sandbox_id: "private-container-id",
       bridge_url: privateLocator,
+      docker_image: "private.registry.invalid/private-agent:secret-tag",
+      image_digest: "private-digest-value",
     });
     const result = await runRereviewOperator(
       config("preview"),
@@ -119,6 +123,10 @@ describe("personal Dedicated staging re-review operator", () => {
     );
     expect(JSON.stringify(result)).not.toContain(privateLocator);
     expect(JSON.stringify(result)).not.toContain("private-container-id");
+    expect(JSON.stringify(result)).not.toContain("private.registry.invalid");
+    expect(JSON.stringify(result)).not.toContain("secret-tag");
+    expect(JSON.stringify(result)).not.toContain("private-digest-value");
+    expect(result.selectedTarget.imageFamily).toBe("custom");
     expect(() =>
       diagnoseRereviewTarget({
         status: privateLocator,
@@ -126,8 +134,94 @@ describe("personal Dedicated staging re-review operator", () => {
         error_message: null,
         sandbox_id: null,
         bridge_url: null,
+        docker_image: null,
+        image_digest: null,
       }),
     ).toThrow("selected_target_status_invalid");
+  });
+
+  test("publishes only validated official image digests through the operator evidence", async () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    for (const [image, family, referenceDigest, recordedDigest] of [
+      [`ghcr.io/elizaos/eliza@${digest}`, "canonical", digest, digest],
+      ["ghcr.io/elizaos/eliza-demo:develop", "demo", null, digest],
+      ["ghcr.io/elizaos/eliza-private:secret", "custom", null, null],
+      ["ghcr.io/elizaos/eliza@sha256:private-value", "custom", null, null],
+      ["ghcr.io/elizaos/eliza:tag/private-value", "custom", null, null],
+      [null, "unconfigured", null, null],
+    ] as const) {
+      const selectedTarget = diagnoseRereviewTarget({
+        status: "error",
+        database_status: "ready",
+        error_message: "Provisioning timeout",
+        sandbox_id: null,
+        bridge_url: null,
+        docker_image: image,
+        image_digest: digest,
+      });
+      const result = await runRereviewOperator(
+        config("preview"),
+        dependencies({
+          snapshot: async () => ({ ...snapshot, selectedTarget }),
+        }).value,
+      );
+      expect(result.selectedTarget.imageFamily).toBe(family);
+      expect(result.selectedTarget.publicImageReferenceDigest).toBe(
+        referenceDigest,
+      );
+      expect(result.selectedTarget.publicRecordedImageDigest).toBe(
+        recordedDigest,
+      );
+      expect(JSON.stringify(result)).not.toContain("private-value");
+      expect(JSON.stringify(result)).not.toContain("secret");
+    }
+    const invalidRecordedDigest = diagnoseRereviewTarget({
+      status: "error",
+      database_status: "ready",
+      error_message: null,
+      sandbox_id: null,
+      bridge_url: null,
+      docker_image: "ghcr.io/elizaos/eliza:develop",
+      image_digest: "private-invalid-digest",
+    });
+    expect(JSON.stringify(invalidRecordedDigest)).not.toContain(
+      "private-invalid-digest",
+    );
+    expect(invalidRecordedDigest.publicRecordedImageDigest).toBeNull();
+  });
+
+  test("distinguishes sandbox readiness expiry without interpreting stack paths as failures", async () => {
+    for (const [error, expected] of [
+      [
+        "Sandbox health check timed out; private-host.invalid/private-agent",
+        true,
+      ],
+      ["Provision failed\ncaused by: Sandbox health check timed out", true],
+      [
+        "Job execution timeout\n    at Sandbox health check timed out (/private/path)",
+        false,
+      ],
+      [null, false],
+    ] as const) {
+      const selectedTarget = diagnoseRereviewTarget({
+        status: "error",
+        database_status: "ready",
+        error_message: error,
+        sandbox_id: null,
+        bridge_url: null,
+        docker_image: null,
+        image_digest: null,
+      });
+      const result = await runRereviewOperator(
+        config("preview"),
+        dependencies({
+          snapshot: async () => ({ ...snapshot, selectedTarget }),
+        }).value,
+      );
+      expect(result.selectedTarget.sandboxHealthCheckTimedOut).toBe(expected);
+      expect(JSON.stringify(result)).not.toContain("private-host");
+      expect(JSON.stringify(result)).not.toContain("/private/path");
+    }
   });
 
   test("classifies zero, one, and invariant-breaking receipt counts", () => {

--- a/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
+++ b/packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts
@@ -61,15 +61,21 @@ interface RereviewTargetDiagnostic {
   provisionFailure: ManagedDedicatedProvisionFailureCode;
   hasContainer: boolean;
   hasBridge: boolean;
+  sandboxHealthCheckTimedOut: boolean;
+  imageFamily: "canonical" | "demo" | "custom" | "unconfigured";
+  publicImageReferenceDigest: string | null;
+  publicRecordedImageDigest: string | null;
 }
 
-/** Emits only lifecycle vocabulary and presence flags from the retained row. */
+/** Emits lifecycle vocabulary and public image digests, never private image references. */
 export function diagnoseRereviewTarget(target: {
   status: string;
   database_status: string;
   error_message: string | null;
   sandbox_id: string | null;
   bridge_url: string | null;
+  docker_image: string | null;
+  image_digest: string | null;
 }): RereviewTargetDiagnostic {
   if (
     ![
@@ -89,15 +95,44 @@ export function diagnoseRereviewTarget(target: {
       "selected_target_status_invalid",
     );
   }
+  // Only official public repositories may reveal digests. Private repositories,
+  // tags, malformed references and arbitrary database text never cross this boundary.
+  const publicImage = target.docker_image?.match(
+    /^ghcr\.io\/elizaos\/(eliza|eliza-demo)(?::[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}|@(sha256:[0-9a-f]{64}))?$/,
+  );
+  const imageFamily = publicImage
+    ? publicImage[1] === "eliza"
+      ? "canonical"
+      : "demo"
+    : target.docker_image === null
+      ? "unconfigured"
+      : "custom";
   return {
     status: target.status,
     databaseStatus: target.database_status,
+    imageFamily,
+    publicImageReferenceDigest: publicImage?.[2] ?? null,
+    publicRecordedImageDigest:
+      publicImage &&
+      target.image_digest !== null &&
+      /^sha256:[0-9a-f]{64}$/.test(target.image_digest)
+        ? target.image_digest
+        : null,
     provisionFailure: classifyManagedDedicatedProvisionFailure(
       target.error_message,
       "selected target error",
     ),
     hasContainer: Boolean(target.sandbox_id),
     hasBridge: Boolean(target.bridge_url),
+    sandboxHealthCheckTimedOut:
+      target.error_message !== null &&
+      target.error_message
+        .split(/\r?\n/)
+        .some(
+          (line, index) =>
+            (index === 0 || line.startsWith("caused by:")) &&
+            line.includes("Sandbox health check timed out"),
+        ),
   };
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #30552.

<!--
Link the issue, ticket, or Project card. For agent/kanban work, follow
CONTRIBUTING.md and keep the Project item status current.
-->

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. This extends the staging-only operator evidence with a closed image family, validated official image digests, and a sandbox health-expiry observation. It does not change selection authority, provisioning behavior, or the preview/execute gates. Arbitrary image references and raw errors remain private.

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

A successful worker rollout does not prove which image a retained Personal Dedicated row will use. Reprovisioning preserves a stored image from another repository, so a staging operator pin can be bypassed while the existing diagnostic reports only a generic timeout.

Report the retained image family and strictly validated digests only for the two official repositories. Also distinguish the exact sandbox health-check timeout from other timeout families without returning raw error text. Private repositories, tags, malformed digests, locators, and stack paths are withheld.

## What kind of change is this?

Bug fix to the protected operational diagnostic.

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

No separate product documentation change. The operator output and exported diagnostic contract describe the added fields.

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

Compare protected preview 33991463648, which confirms a terminal three-attempt timeout but cannot identify the selected image, with the serialized operator evidence exercised by the tests. After merge, the same protected read-only preview will verify the new fields against the staging row; this PR does not claim that provisioning is repaired.

## Detailed testing steps

- After synchronization, operator and workflow contracts: 29 passed.
- Real dependency-import preflight: 27 passed with `bun test --timeout 30000`, for 56 focused checks total. No source timeout was changed.
- Pinned Bun install after sync: no dependency changes.
- Prior exact head `330209c551cb489a35904481185d85ff21c966dd`: local `bun run verify` passed, all 376 Turbo tasks and every final repository audit. This is historical evidence only.
- Prior refreshed head `f810ec059273eea121221aa9b65366729ab54` passed hosted Quality 33996648740, including the pinned install and full repository verification.
- Current head `049cf8aa82085c62f009b100a689f43a4c95a25f` is rebased on `e8cfcd6914edfc1675450ce0a1bbea685e0a08be`; pinned install and all 56 focused checks passed. [Hosted Quality 33997529649](https://github.com/elizaOS/eliza/actions/runs/33997529649/job/101390551167) passed the pinned install and full repository verification. Live develop readback immediately before publication still matched that base.
- Biome check and `git diff --check` completed; one existing optional-chain suggestion does not alter the required boolean diagnostic contract.

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:049cf8aa82085c62f009b100a689f43a4c95a25f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - staging operator diagnostic has no rendered UI

<!-- evidence-row:after-screenshots -->
- [x] N/A - staging operator diagnostic has no rendered UI

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered user flow changed

<!-- evidence-row:backend-logs -->
- [x] [30719-eliza-provision-image-049-contracts.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30719-eliza-provision-image-049-contracts.log)

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or requests changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - read-only operator serialization changes no persisted domain artifacts; focused serialization evidence is in backend logs and added-field staging readback follows merge under #30552

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface


# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

Link the JSON report, run viewer, native jsonl, or write `N/A - <reason>`.

## Backend + frontend logs

Backend: structured logger lines ([ClassName] …) showing the code path firing end to end.
Frontend: console + network trace showing the request/response and state change.
Paste here inline (wrap long output in a `<details>` block), or write
`N/A - <reason>`.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

### Before

### After

### Walkthrough video

Or write `N/A - <reason>`.

## Audio / voice walkthrough

For voice / transcript / TTS / STT / omnivoice changes, attach captured audio of
the real round-trip plus a narrated walkthrough. Or write `N/A - <reason>`.

## Known gaps / failures

The added fields cannot be read from the protected staging operator until this change reaches develop. The post-merge preview remains a required operational follow-through under #30552. Existing preview 33991463648 established the terminal three-attempt failure; this diagnostic does not claim provisioning is repaired.

No rendered UI, voice, or model path changes. Their evidence rows are N/A. The current exact-head hosted proof is 049cf8aa on develop e8cfcd; historical local results above are identified separately.

## Maintainer CI exception record

Write `N/A - no exception requested` unless a maintainer is invoking the narrow
[Maintainer CI exception](../CONTRIBUTING.md#maintainer-ci-exception). When it
applies, preserve every field below and link the exact evidence.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<details><summary>Exact-head focused operator, workflow, and real dependency-preflight checks</summary>

```text
bun test v1.3.14 (0d9b296a)

packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts:
(pass) personal Dedicated staging re-review operator > reports lifecycle before a missing selection prevents review [0.74ms]
(pass) personal Dedicated staging re-review operator > reports a provisioning failure without returning raw errors or locators [0.84ms]
(pass) personal Dedicated staging re-review operator > publishes only validated official image digests through the operator evidence [0.66ms]
(pass) personal Dedicated staging re-review operator > distinguishes sandbox readiness expiry without interpreting stack paths as failures [0.19ms]
(pass) personal Dedicated staging re-review operator > classifies zero, one, and invariant-breaking receipt counts [0.04ms]
(pass) personal Dedicated staging re-review operator > bootstraps only one canonical restore authority in ambiguous inventory [0.23ms]
(pass) personal Dedicated staging re-review operator > reports expected preview decisions neutrally without weakening execute [0.05ms]
(pass) personal Dedicated staging re-review operator > returns identifier-free preview evidence and does not execute [0.12ms]
(pass) personal Dedicated staging re-review operator > requires the prior exact preview digest and reviewed confirmation [0.14ms]
(pass) personal Dedicated staging re-review operator > uses a distinct digest-bound confirmation for missing-receipt bootstrap [0.10ms]
(pass) personal Dedicated staging re-review operator > binds every resolved selector and replacement decision into approval [0.12ms]
(pass) personal Dedicated staging re-review operator > rejects a preview for a different operation before snapshot or execute [0.04ms]
(pass) personal Dedicated staging re-review operator > binds approval to current inventory and refuses compute or job drift [0.08ms]
(pass) personal Dedicated staging re-review operator > rejects deployment mismatch before resolving account identity [0.05ms]
(pass) personal Dedicated staging re-review operator > requires explicit staging opt-in and validates execute authority inputs [0.07ms]

packages/cloud/scripts/admin/personal-dedicated-rereview-staging-workflow.test.ts:
(pass) personal Dedicated staging re-review workflow > is manual, staging protected, serialized, and GitHub read-only [0.04ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for preview of the currently served older commit [1429.44ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for execution against an older commit [223.39ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for preview from main [894.76ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for malformed preview commit [58.87ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for unknown operation [109.14ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for execution without a prior digest [21.51ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for execution without confirmation [23.25ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for execution without a reviewed reason [24.53ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for approved exact-head re-review [23.81ms]
(pass) personal Dedicated staging re-review workflow > enforces shell admission for approved exact-head backup selection [23.59ms]
(pass) personal Dedicated staging re-review workflow > binds protected identity and smoke account authorities without artifacts [0.18ms]
(pass) personal Dedicated staging re-review workflow > materializes the linked runtime required by fresh-checkout imports [0.07ms]
(pass) personal Dedicated staging re-review workflow > uses primary database authority for identity and mutation observations [0.14ms]

packages/cloud/scripts/admin/preflight-database-identity.test.ts:
(pass) database identity preflight > is inert by default and requires an explicit environment [0.11ms]
(pass) database identity preflight > emits stable hashes without raw database identity fields [0.34ms]
(pass) database identity preflight > report mode records mismatch classes without failing [0.15ms]
(pass) database identity preflight > report mode never labels an unreviewed receipt as a match [0.08ms]
(pass) database identity preflight > off mode ignores prepared digests without touching the database [0.05ms]
(pass) database identity preflight > report mode ignores malformed expectations and sanitizes query failures [0.11ms]
(pass) database identity preflight > classifies setup failures with a bounded non-sensitive category [0.06ms]
(pass) database identity preflight > probes fixed dependencies in order and reports only the failed label [0.29ms]
(pass) database identity preflight > enforce mode requires both authorities and fails closed on mismatch [0.07ms]
(pass) database identity preflight > enforce mode accepts the exact cluster and authority receipts [0.04ms]
(pass) database identity preflight > rejects malformed query rows and authority digests [0.09ms]
(pass) standalone database identity reporter > the manual CLI exits nonzero when DATABASE_URL is absent [68.13ms]
(pass) standalone database identity reporter > the dependency-probe CLI flag bypasses reporter configuration [6502.17ms]
(pass) standalone database identity reporter > a dependency probe failure is bounded and stops before client creation [0.69ms]
(pass) standalone database identity reporter > connection failures are redacted, nonzero, and close the client [2.78ms]
(pass) standalone database identity reporter > client error events during a query fail before success publication [0.51ms]
(pass) standalone database identity reporter > client error events remain bounded through teardown [0.21ms]
(pass) standalone database identity reporter > client error events queued after close remain bounded before publication [4.64ms]
(pass) standalone database identity reporter > client error events after publication fail the process boundary [32.50ms]
[database-identity] warning: database client close failed
(pass) standalone database identity reporter > a client close rejection fails report mode before publication [1.81ms]
[database-identity] warning: database client close failed
(pass) standalone database identity reporter > a client close rejection fails enforcement with a bounded error [0.28ms]
[database-identity] warning: database client close failed
(pass) standalone database identity reporter > a client close rejection preserves an earlier query failure [0.16ms]
(pass) standalone database identity reporter > an unavailable query status is nonzero without leaking its cause [0.11ms]
(pass) standalone database identity reporter > publication failures are redacted, nonzero, and close the client [0.12ms]
(pass) standalone database identity reporter > a published reported receipt exits successfully [0.13ms]
(pass) standalone database identity reporter > a published mismatch receipt exits successfully [0.03ms]
(pass) standalone database identity reporter > a published match receipt exits successfully [0.03ms]
------------------------------------------------------------------------|---------|---------|-------------------
File                                                                    | % Funcs | % Lines | Uncovered Line #s
------------------------------------------------------------------------|---------|---------|-------------------
All files                                                               |   61.02 |   64.10 |
 packages/cloud/scripts/admin/database-identity-receipt.ts              |  100.00 |   94.34 | 72-74
 packages/cloud/scripts/admin/managed-dedicated-provision-diagnostic.ts |   25.00 |   35.71 | 150-153,157-168,172-186,190-191,195-205,209-214,226,228-258,273-274,296,299,305-306,312-313,319-320,326-327,333-334,337,340,347-348,354-355,359-360,366-367,373-374,380-381,386-387,390,393,396,399,402,405,408,411,414,417,422-435,438,441,447-448,452-453,456,459,462,468-469,473-474,484,490-491,497-498,504-505,511-512,515,522-523,529-530,534,540-541,548-771,775-782,786-794,799-805
 packages/cloud/scripts/admin/personal-dedicated-rereview-staging.ts    |   59.09 |   46.40 | 353-363,367-369,507-518,522-571,575-692,696-741,745-851,859-884,887-908
 packages/cloud/scripts/admin/preflight-database-identity.ts            |   60.00 |   79.95 | 94,298-310,314-317,322-340,345-368,387,494-501,507-509,512-515
------------------------------------------------------------------------|---------|---------|-------------------

 56 pass
 0 fail
 257 expect() calls
Ran 56 tests across 3 files. [10.69s]
```

</details>


