### PR TITLE
fix: reject native streams missing HTTP response headers

### DIFF
--- a/packages/ui/src/api/ios-local-agent-fetch.test.ts
+++ b/packages/ui/src/api/ios-local-agent-fetch.test.ts
@@ -243,3 +243,33 @@ it("uses buffered compatibility before dispatch when stream events are unavailab
   expect(native.call).toHaveBeenCalledTimes(1);
   expect(native.call.mock.calls[0][0].method).toBe("http_request");
 });
+
+it.each(["event", "promise"])(
+  "rejects a missing native response head completed by %s without replay",
+  async (completionKind) => {
+    await install();
+    const completion = Promise.withResolvers<{ result: unknown }>();
+    native.call.mockReturnValue(completion.promise);
+    const request = fetch(endpoint, {
+      method: "POST",
+      headers: { accept: "text/event-stream" },
+      body: "one message",
+    });
+    const rejected = expect(request).rejects.toMatchObject({
+      code: "NATIVE_STREAM_RESPONSE_MISSING",
+    });
+    await vi.waitFor(() => expect(native.listeners.size).toBe(3));
+    const streamId = native.call.mock.calls[0][0].args.streamId;
+    native.listeners.get("agentStreamChunk")?.({
+      streamId,
+      dataBase64: btoa("The server refused this message"),
+    });
+    if (completionKind === "event") {
+      native.listeners.get("agentStreamComplete")?.({ streamId });
+    } else completion.resolve({ result: { streamId, done: true } });
+    await rejected;
+    expect(native.call).toHaveBeenCalledTimes(1);
+    expect(native.call.mock.calls[0][0].method).toBe("http_request_stream");
+    expect(native.listeners.size).toBe(0);
+  },
+);

--- a/packages/ui/src/api/native-agent-stream.test.ts
+++ b/packages/ui/src/api/native-agent-stream.test.ts
@@ -237,27 +237,34 @@ describe("createNativeStreamingResponse", () => {
     }
   });
 
-  it("settles the head to a closed 200 when completion arrives before any response", async () => {
-    vi.useFakeTimers();
-    try {
-      const { agent, emit, listenerCount } = makeFakeAgent();
+  it.each(["event", "promise"])(
+    "rejects missing response headers when native completion arrives by %s",
+    async (completionKind) => {
+      let complete!: () => void;
+      const completion = new Promise<void>((resolve) => {
+        complete = resolve;
+      });
+      const { agent, emit, listenerCount } = makeFakeAgent("s1", completion);
       const responsePromise = createNativeStreamingResponse(agent, {
         path: "/x",
       });
-      await vi.advanceTimersByTimeAsync(0);
-      emit("agentStreamComplete", { streamId: "s1" });
-      const response = await responsePromise;
-      expect(response.status).toBe(200);
-      const reader = (response.body as ReadableStream<Uint8Array>).getReader();
-      const r = await reader.read();
-      expect(r.done).toBe(true);
+      const rejected = expect(responsePromise).rejects.toMatchObject({
+        code: "NATIVE_STREAM_RESPONSE_MISSING",
+      });
+      await flush();
+      emit("agentStreamChunk", {
+        streamId: "s1",
+        dataBase64: b64("The server denied this request"),
+      });
+      if (completionKind === "event") {
+        emit("agentStreamComplete", { streamId: "s1" });
+      } else complete();
+      await rejected;
       expect(listenerCount()).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+    },
+  );
 
-  it("rejects the head on the head timeout so the caller falls back", async () => {
+  it("rejects the head on the head timeout without fabricating a response", async () => {
     vi.useFakeTimers();
     try {
       const { agent, listenerCount } = makeFakeAgent();

--- a/packages/ui/src/api/native-agent-stream.ts
+++ b/packages/ui/src/api/native-agent-stream.ts
@@ -12,6 +12,7 @@
  * Pure transport glue — the plugin is passed in, so it unit-tests with a fake.
  */
 
+import { ElizaError } from "@elizaos/core/errors";
 import { reportRendererDiagnostic } from "../utils/renderer-diagnostics";
 import { abortableResponse } from "./abortable-request";
 
@@ -208,15 +209,19 @@ export async function createNativeStreamingResponse(
     }
   };
 
-  // Terminal on a SUCCESSFUL native completion (the resolution, not just the
-  // rejection failStream handles): if the head never arrived, settle it with a
-  // 200 so the caller gets a Response, then close the body. Idempotent — a
-  // later `agentStreamComplete` sees `detached` and no-ops.
+  const missingResponseError = (): ElizaError =>
+    new ElizaError("Native stream completed without HTTP response headers", {
+      code: "NATIVE_STREAM_RESPONSE_MISSING",
+      context: { streamId, path: options.path },
+    });
+
+  // Native completion confirms transport completion, not an HTTP status. A
+  // missing response event cannot establish whether the server accepted the request.
   const finishStream = (): void => {
     if (detached) return;
     if (!headSettled) {
-      headSettled = true;
-      resolveHead(new Response(body, { status: 200 }));
+      failStream(missingResponseError());
+      return;
     }
     if (controller) {
       controller.close();
@@ -272,19 +277,11 @@ export async function createNativeStreamingResponse(
   const onComplete = (event: unknown): void => {
     const e = event as NativeStreamCompleteEvent;
     if (!e || e.streamId !== streamId || detached) return;
-    // Always settle the head before touching the body — a terminal event that
-    // beats the response (empty stream completing head-first, or a dropped head
-    // event) must still resolve/reject the caller's promise, never leave it
-    // hanging. A failure can't yield a Response, so it rejects; a success
-    // resolves a 200 and falls through to close the body.
+    // A terminal event without response metadata must fail promptly rather
+    // than hang or turn an unknown server status into an apparent success.
     if (!headSettled) {
-      headSettled = true;
-      if (e.error) {
-        rejectHead(new Error(e.error));
-        detach();
-        return;
-      }
-      resolveHead(new Response(body, { status: 200 }));
+      failStream(e.error ? new Error(e.error) : missingResponseError());
+      return;
     }
     if (controller) {
       if (e.error) controller.error(new Error(e.error));


### PR DESCRIPTION
Native stream completion could arrive without HTTP response headers. The adapter then fabricated HTTP 200 even when the server had rejected the request. It now rejects with `NATIVE_STREAM_RESPONSE_MISSING`, closes the stream, and removes listeners. It preserves received HTTP statuses and never replays the request.

Closes #30678.

## Validation and risk

Head `e2e77e0b4f1d0cd5fd819cebfa83ce8a3f86c0be` is based on `8fea4f94c29c7712ce3caf303e3350150622d048`. Normal `bun install`, root `bun run verify` (376 tasks plus final audits), 31 focused tests, a real TCP POST refusal fixture, and a rebuilt/installed iOS native smoke all passed. Independent source review covered completion ordering, status preservation, listener cleanup, and duplicate-request prevention.

The before/after fixture sends an actual POST returning 403, then deliberately drops the bridge response-head event. The baseline exposes fabricated 200; this head rejects with the typed missing-response error. Both invoke the bridge once and remove listeners. A delivered head still exposes 403. Risk is confined to incomplete native HTTP responses now rejecting rather than appearing successful; no public API or rendered UI changes.

The installed iOS smoke records real native model generation and response delivery. Its repeated streaming request can replay the cached conversation result; this is not proof of incremental native token generation or a full planner turn. Earlier app audit passed 219 checks on byte-identical transport changes. Manual desktop, portrait, and tablet chat captures were clear; landscape Today cards had baseline clipping independently reproduced by the UI reviewer. That existing layout issue is outside this transport change. No documentation changes are needed and no CI exception is requested.

## Evidence Gate

<!-- evidence-head:e2e77e0b4f1d0cd5fd819cebfa83ce8a3f86c0be -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - protocol adapter and regression tests only; no rendered UI changes. Actual before HTTP behavior is recorded below.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - protocol adapter and regression tests only; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no changed interactive or visual flow; actual HTTP and installed native transport evidence is linked below.

<!-- evidence-row:backend-logs -->
- [x] [30678-install-e2e77e0b.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-install-e2e77e0b.log) [30678-verify-e2e77e0b.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-verify-e2e77e0b.log) [30678-native-smoke-e2e77e0b.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-native-smoke-e2e77e0b.log)

<!-- evidence-row:frontend-logs -->
- [x] [30678-focused-e2e77e0b.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-focused-e2e77e0b.log) [30678-missing-head-e2e77e0b.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-missing-head-e2e77e0b.json) [30678-missing-head-before-e8cf.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-missing-head-before-e8cf.json)

<!-- evidence-row:llm-trajectory -->
- [x] [30678-native-trajectory-e2e77e0b.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-native-trajectory-e2e77e0b.json) — real native generation and transport; cached stream replay limitation described above.

<!-- evidence-row:domain-artifacts -->
- [x] [30678-before-source-provenance.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-before-source-provenance.json) [30678-review-receipt-e2e77e0b.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-review-receipt-e2e77e0b.json) [30678-native-build-e2e77e0b.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-native-build-e2e77e0b.log) [30678-app-audit-0e50d544.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-app-audit-0e50d544.log) [30678-proof-scope-0e50d544.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30678-proof-scope-0e50d544.json)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or visual surface changes. Prior audit and manual-review limitations are disclosed above.
