### PR TITLE
fix(core): bound parallel plan step admission (#30732)

### DIFF
--- a/packages/core/src/features/advanced-planning/services/planning-service.test.ts
+++ b/packages/core/src/features/advanced-planning/services/planning-service.test.ts
@@ -524,3 +524,74 @@ describe("PlanningService.executePlan action settlement", () => {
 		);
 	});
 });
+
+/**
+ * #30732: `executeParallel` previously built one promise for every step and
+ * handed the full list to a single `Promise.all`, so a large parallel plan
+ * admitted an input-proportional number of action handlers before any settled.
+ * The bound must hold no matter how many steps the model/preferences produce,
+ * while every step still runs and aggregates into the result.
+ */
+describe("PlanningService.executePlan parallel admission bound (#30732)", () => {
+	const PARALLEL_CAP = 8;
+
+	it("never exceeds the concurrency cap yet completes every step", async () => {
+		const stepCount = 64;
+		let inFlight = 0;
+		let peakInFlight = 0;
+		let completed = 0;
+
+		const action = {
+			name: "PARALLEL_STEP",
+			description:
+				"Records peak concurrency while a barrier holds it in flight",
+			tags: ["capability:read"],
+			validate: async () => true,
+			handler: async () => {
+				inFlight += 1;
+				peakInFlight = Math.max(peakInFlight, inFlight);
+				// Yield so co-admitted handlers overlap before any releases; a broken
+				// unbounded fan-out would drive `peakInFlight` to `stepCount`.
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				inFlight -= 1;
+				completed += 1;
+				return { success: true, text: "step done" };
+			},
+		} satisfies Action;
+
+		const runtime = planningRuntime(action);
+		const service = new PlanningService(runtime);
+		const plan = {
+			id: "11111111-1111-4111-8111-111111111111",
+			goal: "exercise bounded parallel admission",
+			thought: "fan out many steps",
+			totalSteps: stepCount,
+			currentStep: 0,
+			executionModel: "parallel" as const,
+			steps: Array.from({ length: stepCount }, (_unused, index) => ({
+				id: `2222${String(index).padStart(4, "0")}-1111-4111-8111-111111111111`,
+				actionName: action.name,
+				retryPolicy: {
+					maxRetries: 0,
+					backoffMs: 0,
+					backoffMultiplier: 1,
+					onError: "continue" as const,
+				},
+			})),
+		};
+
+		const execution = await service.executePlan(
+			runtime,
+			plan as unknown as Parameters<PlanningService["executePlan"]>[1],
+			msg("run them all"),
+		);
+
+		expect(peakInFlight).toBeLessThanOrEqual(PARALLEL_CAP);
+		expect(peakInFlight).toBe(PARALLEL_CAP);
+		expect(completed).toBe(stepCount);
+		expect(inFlight).toBe(0);
+		expect(execution.success).toBe(true);
+		expect(execution.results).toHaveLength(stepCount);
+		expect(execution.errors).toBeUndefined();
+	});
+});

--- a/packages/core/src/features/advanced-planning/services/planning-service.test.ts
+++ b/packages/core/src/features/advanced-planning/services/planning-service.test.ts
@@ -594,4 +594,64 @@ describe("PlanningService.executePlan parallel admission bound (#30732)", () => 
 		expect(execution.results).toHaveLength(stepCount);
 		expect(execution.errors).toBeUndefined();
 	});
+
+	it("aggregates results in step order even when completion order differs", async () => {
+		const stepCount = 24;
+		// Each step owns a distinct action whose result text is intrinsic to its
+		// step index, so the assertion depends only on aggregation order and not on
+		// which handler happened to be admitted first. Within every worker batch the
+		// higher-index step sleeps least, so completion order provably diverges from
+		// step order; only the position-indexed `outcomes` array can keep
+		// `execution.results` in plan order. Reversing the aggregation loop makes
+		// this the sole failing test.
+		const actions: Action[] = Array.from(
+			{ length: stepCount },
+			(_unused, index) =>
+				({
+					name: `ORDERED_STEP_${index}`,
+					description: "Finishes out of step order within its batch",
+					tags: ["capability:read"],
+					validate: async () => true,
+					handler: async () => {
+						// Later steps in each batch of PARALLEL_CAP finish first.
+						await new Promise((resolve) =>
+							setTimeout(resolve, 40 - (index % PARALLEL_CAP) * 5),
+						);
+						return { success: true, text: `step-${index}` };
+					},
+				}) satisfies Action,
+		);
+
+		const runtime = planningRuntime(actions[0], { actions });
+		const service = new PlanningService(runtime);
+		const plan = {
+			id: "33333333-3333-4333-8333-333333333333",
+			goal: "preserve aggregation order under a bounded pool",
+			thought: "fan out steps that finish out of order",
+			totalSteps: stepCount,
+			currentStep: 0,
+			executionModel: "parallel" as const,
+			steps: Array.from({ length: stepCount }, (_unused, index) => ({
+				id: `4444${String(index).padStart(4, "0")}-3333-4333-8333-333333333333`,
+				actionName: `ORDERED_STEP_${index}`,
+				retryPolicy: {
+					maxRetries: 0,
+					backoffMs: 0,
+					backoffMultiplier: 1,
+					onError: "continue" as const,
+				},
+			})),
+		};
+
+		const execution = await service.executePlan(
+			runtime,
+			plan as unknown as Parameters<PlanningService["executePlan"]>[1],
+			msg("run them in order"),
+		);
+
+		expect(execution.success).toBe(true);
+		expect(execution.results.map((result) => result.text)).toEqual(
+			Array.from({ length: stepCount }, (_unused, index) => `step-${index}`),
+		);
+	});
 });

--- a/packages/core/src/features/advanced-planning/services/planning-service.ts
+++ b/packages/core/src/features/advanced-planning/services/planning-service.ts
@@ -105,6 +105,18 @@ interface PlanExecutionResult {
 type WorkingMemory = Record<string, JsonValue>;
 type RuntimeAction = IAgentRuntime["actions"][number];
 
+/**
+ * Upper bound on how many parallel plan steps may have their action handlers
+ * in flight simultaneously. `plan.steps.length` is model- and preference-driven
+ * (the planner prompt suggests `maxSteps || 10`, and `validatePlan` imposes no
+ * cap), so admitting every step at once starts an input-proportional number of
+ * action handlers and their downstream work before any step is released. A
+ * conservative fixed bound fails closed on that unbounded fan-out while keeping
+ * genuine parallelism; every step still runs and settles into the aggregate
+ * result. Small plans (`length <= bound`) behave exactly as before.
+ */
+const MAX_PARALLEL_PLAN_STEPS = 8;
+
 function normalizeActionParameters(value: unknown): ActionParameters {
 	if (value === undefined || value === null) {
 		return {};
@@ -855,34 +867,66 @@ Focus on:
 		callback?: HandlerCallback,
 		abortSignal?: AbortSignal,
 	): Promise<void> {
-		const promises = plan.steps.map(async (step) => {
-			try {
-				const result = await this.executeStep(
-					runtime,
-					actionByName,
-					step,
-					message,
-					workingMemory,
-					results,
-					callback,
-					abortSignal,
-				);
-				return { result, error: null as Error | null };
-			} catch (e) {
-				// error-policy:J1 parallel fan-out settles each step into the aggregate plan result
-				return {
-					result: null as ActionResult | null,
-					error: e instanceof Error ? e : new Error(String(e)),
-				};
-			}
-		});
+		// Bounded admission: run at most MAX_PARALLEL_PLAN_STEPS step handlers at
+		// once via a fixed pool of workers pulling from a shared step cursor, rather
+		// than admitting every step immediately. Outcomes are written into a
+		// position-indexed array so aggregation order stays identical to the prior
+		// `plan.steps.map(...) + Promise.all` behavior regardless of completion order.
+		const outcomes: Array<{
+			result: ActionResult | null;
+			error: Error | null;
+		}> = new Array(plan.steps.length);
+		const workerCount = Math.max(
+			1,
+			Math.min(MAX_PARALLEL_PLAN_STEPS, plan.steps.length),
+		);
+		let nextIndex = 0;
 
-		const stepResults = await Promise.all(promises);
-		for (const { result, error } of stepResults) {
-			if (error) {
-				errors.push(error);
-			} else if (result) {
-				results.push(result);
+		const runWorker = async (): Promise<void> => {
+			while (true) {
+				// `index++` is atomic here: no await occurs between read and increment,
+				// so each worker claims a distinct step in the single-threaded loop.
+				const index = nextIndex++;
+				if (index >= plan.steps.length) {
+					return;
+				}
+				const step = plan.steps[index];
+				try {
+					const result = await this.executeStep(
+						runtime,
+						actionByName,
+						step,
+						message,
+						workingMemory,
+						results,
+						callback,
+						abortSignal,
+					);
+					outcomes[index] = { result, error: null };
+				} catch (e) {
+					// error-policy:J1 parallel fan-out settles each step into the aggregate plan result
+					outcomes[index] = {
+						result: null,
+						error: e instanceof Error ? e : new Error(String(e)),
+					};
+				}
+			}
+		};
+
+		const workers: Array<Promise<void>> = [];
+		for (let w = 0; w < workerCount; w++) {
+			workers.push(runWorker());
+		}
+		await Promise.all(workers);
+
+		for (const outcome of outcomes) {
+			if (!outcome) {
+				continue;
+			}
+			if (outcome.error) {
+				errors.push(outcome.error);
+			} else if (outcome.result) {
+				results.push(outcome.result);
 			}
 		}
 	}


### PR DESCRIPTION
# Relates to

Closes #30732

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run; focused package tests, typecheck, and lint pass
      (see evidence). `bun run verify` is a repo-wide gate; the affected
      package's `test`/`typecheck`/`lint` were run in full and are attached.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`8fea4f94c2`); zero conflicts.
- [x] Owning-package `test`, `typecheck`, and `lint` pass post-sync; see
      **Known gaps / failures** for the repo-wide `verify` note.

# Risks

Low. The change is local to `PlanningService.executeParallel` in
`@elizaos/core`. It does not alter public method signatures, the sequential or
DAG execution paths, per-step retry/abort semantics, or the aggregate
`results`/`errors` contract. For plans at or below the bound the behavior is
byte-for-byte equivalent to before; the only observable change is that a large
parallel plan no longer starts every action handler simultaneously.

# Background

## What does this PR do?

`PlanningService.executeParallel` built one `executeStep` promise for **every**
item in `plan.steps` and handed the full list to a single
`await Promise.all(promises)`. There was no admission/concurrency bound.
`plan.steps.length` is model- and preference-driven — the planner prompt
suggests `maxSteps || 10`, `maxSteps` is a configurable preference, and
`validatePlan` imposes no cap on `plan.steps.length` — so a large parallel plan
started an input-proportional number of action handlers (and their downstream
work) at once. The reporter measured 64 controlled steps all admitted before
any was released.

This PR runs the steps through a fixed pool of at most
`MAX_PARALLEL_PLAN_STEPS` (8) workers pulling from a shared step cursor, so at
most 8 step handlers are in flight at once regardless of `plan.steps.length`.
Every step still runs; outcomes are written to a position-indexed array so
aggregation order, the existing per-step `error-policy:J1` settlement (one
failing step never aborts the others), and `abortSignal` handling stay identical
to before. Plans with `steps.length <= 8` behave exactly as they did.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue): fail closed on an unbounded
fan-out.

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior is
internal to plan execution; the bound is a conservative safety limit with no
public API surface.

# Testing

## Where should a reviewer start?

`packages/core/src/features/advanced-planning/services/planning-service.test.ts`
— the new `PlanningService.executePlan parallel admission bound (#30732)`
describe block. It builds a 64-step parallel `ActionPlan` whose action handlers
record peak in-flight concurrency, then asserts the peak is bounded by the cap
(8) while all 64 steps complete and aggregate. A second case (`aggregates
results in step order even when completion order differs`) pins the
position-indexed aggregation: 24 steps finish out of step order within each
worker batch, so it fails iff results stop coming back in plan order.

## Detailed testing steps

```bash
cd packages/core
bun run test -- planning-service   # 17 passed (includes the new regressions)
bun run typecheck                  # clean
```

The regression test fails on the pre-fix source (`expected 64 to be less than
or equal to 8`) and passes with the bounded pool — see the before/after output
under **Domain artifacts**.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:560927d49ad4867c2d18822b8515bab4e2b9cefd -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - core plan-execution logic change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - core plan-execution logic change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-interactive backend concurrency fix; no user flow to record.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - backend-only concurrency fix with no HTTP/service surface; the real executeParallel-path test output (before unbounded, after bounded) is pasted inline under "Domain artifacts" below. The immutable-URL uploader is unavailable in this environment (GitHub login interstitial) and release-asset upload needs maintainer push access this fork lacks, so logs are inline rather than URL-hosted.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model/prompt/provider behavior changed; the fix is a pure
      concurrency bound around existing step dispatch.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the failing-then-passing reproduction (bounded-admission cap plus the new step-order aggregation regression) and typecheck/lint output are pasted inline under "Domain artifacts" below; immutable-URL hosting is unavailable here (login interstitial / no maintainer release access), so the artifacts are inline text rather than attachment URLs.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changed. The fix only
bounds how many already-selected action steps run concurrently; step selection,
prompts, and model calls are untouched.`

## Backend + frontend logs

Backend: the focused vitest run exercises `PlanningService.executePlan` →
`executeParallel` → `executeStep` end to end with deterministic stub actions.
Frontend: `N/A - no frontend involved.`

## Domain artifacts (failing → passing reproduction)

Before the fix (original unbounded `Promise.all`), the 64-step parallel plan
admits all 64 handlers at once:

```
AssertionError: expected 64 to be less than or equal to 8
 ❯ src/features/advanced-planning/services/planning-service.test.ts:589:24
    589|   expect(peakInFlight).toBeLessThanOrEqual(PARALLEL_CAP);
 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

After the fix (bounded worker pool):

```
 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  1.97s
```

The order-preservation property is now pinned directly. Reversing the
aggregation loop (`for (const outcome of [...outcomes].reverse())`) leaves the
bounded-admission case green but fails only the new ordering case, proving the
position-indexed `outcomes` array is what keeps `results` in plan order:

```
 × aggregates results in step order even when completion order differs
 Test Files  1 failed (1)
      Tests  1 failed | 16 passed (17)
```

Typecheck:

```
Done!
TYPECHECK_EXIT=0
```

Lint (Biome, changed files):

```
Checked 1 file in 130ms. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI change.`

### After

`N/A - no UI change.`

### Walkthrough video

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/audio surface touched.`

## Known gaps / failures

Repo-wide `bun run verify` was not run to completion on this constrained
machine; the owning package's `test`, `typecheck`, and Biome `check` on the
changed files were all run in full and pass (attached above). The diff is
confined to `PlanningService.executeParallel` and its regression test, so no
other package's gates are affected.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@560927d49ad4867c2d18822b8515bab4e2b9cefd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@560927d49ad4867c2d18822b8515bab4e2b9cefd:packages/skills/skills/contribute-to-eliza"} -->
