### PR TITLE
fix(app): align LifeOps ui-smoke filter contracts with the #29779 spatial controls

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -127,15 +127,16 @@ test("inbox decomposed view: channel filters toggle", async ({ page }) => {
   ).toBeVisible({ timeout: 15_000 });
 
   // Activating a channel chip narrows the server query (?channels=<channel>)
-  // and the rendered list: the active chip is renamed "* <Channel>", its
-  // thread stays, and the other channel's thread disappears.
+  // and the rendered list: the chip flips to its pressed state (aria-pressed,
+  // the solid primary variant since #29779), its thread stays, and the other
+  // channel's thread disappears.
   const emailChip = page
     .getByRole("button", { name: "Email", exact: true })
     .first();
   await expectTopmostAtCenter(emailChip, "Inbox Email filter chip");
   await emailChip.click();
   await expect(
-    page.getByRole("button", { name: "* Email", exact: true }),
+    page.getByRole("button", { name: "Email", exact: true, pressed: true }),
   ).toBeVisible({ timeout: 15_000 });
   await expect(page.getByText("Invoice #42 overdue").first()).toBeVisible({
     timeout: 15_000,
@@ -192,9 +193,11 @@ test("goals decomposed view: renders the goals scaffold", async ({ page }) => {
     timeout: 15_000,
   });
 
-  // Toggling the "Active" status chip narrows the groups: the paused goal
-  // disappears, the active goal stays.
-  await page.getByRole("button", { name: "Active", exact: true }).click();
+  // Filtering the Status select to "Active" narrows the groups: the paused
+  // goal disappears, the active goal stays. (#29779 replaced the per-status
+  // chip buttons with a Field select whose trigger is labeled "Status".)
+  await page.getByLabel("Status").click();
+  await page.getByRole("option", { name: "Active", exact: true }).click();
   await expect(page.getByText("Learn conversational Spanish")).toHaveCount(0, {
     timeout: 15_000,
   });


### PR DESCRIPTION
# Relates to

Tier-3 develop workflow health: repairs the reproducible `scenarios / Zero-Key app browser Pixel-7 real-touch lane` failure on `develop` (red at `8508c73d` job [101371457059](https://github.com/elizaOS/eliza/actions/runs/33990269930/job/101371457059) and `08f5532a` job [101377821784](https://github.com/elizaOS/eliza/actions/runs/33992655835/job/101377821784); green at `9e738793` run [33982927203](https://github.com/elizaOS/eliza/actions/runs/33982927203)). No open issue; surfaced by the Develop Full sweep.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (branch base = `08f5532a228a455c7941fd534f75d8d3ccbd2735` = `origin/develop` at authoring time).
- [x] Scoped checks: biome 2.5.8 clean on the changed file; full affected-spec red→green proof at the exact head (below). Full `bun run verify` was not run — the workspace-wide build is not executable in the evidence container; the diff touches only test expectations, no production code.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (single-file diff on top of `08f5532a`).
- [ ] `bun run verify` passes post-sync — not run (exact blocker above); biome + the affected suite green instead.

# Risks

Low. One test file changes; no production code, no schema, no exports. If the assertion update were wrong, the suite fails loudly (it is the same suite this PR turns green).

# Background

## What does this PR do?

`#29779` (`affd6aa463`, merged between `9e738793` and `8508c73d`) redesigned the LifeOps spatial-view controls: active inbox channel chips now carry `pressed` state (`aria-pressed`, `packages/ui/src/spatial/primitives.tsx:608`) instead of the `"* "` label prefix, and the goals per-status chip buttons became a `Field kind="select"` Status dropdown (`plugins/plugin-goals/src/components/goals/GoalsSpatialView.tsx:202-217`). That commit updated its unit tests and the focus expectation in this spec but missed two assertions, which is exactly why the Pixel-7 lane went red on every head since:

- `:138` asserted `getByRole("button", { name: "* Email" })` — the prefix no longer exists.
- `:197` clicked `getByRole("button", { name: "Active" })` — the chips are now a select.

This PR updates both to the new contracts while keeping the behavior each test proves (filter narrows the list; paused goal disappears, active goal stays). Tree-wide grep confirms these were the only two references to the old contract.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue) — restores a red-green control on a red CI lane.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts` — two hunks, both assertion-level.

## Detailed testing steps

Real-app Playwright run in a disposable container at exact `develop` head `08f5532a228a455c7941fd534f75d8d3ccbd2735` (spec md5-verified before each phase; full log rows below):

1. Pristine tree, `--project=chromium` on the spec:
   `2 failed, 7 passed (3.7m)` — failing exactly the two CI-red tests (`:118` inbox 17.7s, `:181` goals 3.0m), matching the lane's failure set.
2. Patched spec applied (container md5 `441c8d1d19ea545a864b8c0a98d98672` = branch file):
   `9 passed (29.2s)`, exit 0.

# Evidence Gate

<!-- evidence-head:6a9da31c9b1e625666f6ca074e3a7c0907a786f8 -->

- [ ] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - test-expectation update only; no rendered UI surface changes. The failing-state capture is the lane's own artifacts (screenshots/traces linked in the jobs above).`
<!-- evidence-row:after-screenshots -->
- [ ] N/A - production UI unchanged by this diff.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-flow change; the changed surface is the test suite itself.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend path touched; stack boot and API-stub logs are embedded in the frontend-logs section.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - fork token cannot upload to the upstream pr-evidence release; the complete RED/GREEN Playwright run output is quoted inline in the frontend-logs section of this body (pristine 08f5532a: 2 failed/7 passed; patched spec md5 441c8d1d19ea545a864b8c0a98d98672: 9 passed).

      RED (pristine `08f5532a`):
      ```
        ✘  3 [chromium] › test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts:118:1 › inbox decomposed view: channel filters toggle (17.7s)
        ✘  6 [chromium] › test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts:181:1 › goals decomposed view: renders the goals scaffold (3.0m)
        2 failed
        7 passed (3.7m)
      ```

      GREEN (patched spec, md5-verified):
      ```
        9 passed (29.2s)
      ```
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model path is touched.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact surface; the artifact of record is the inline test-run output.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface change.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-expectation update only; no rendered UI surface changes. Failing-state captures live in the lane artifacts of the linked jobs.



Compute receipt: 52011462 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: zai / glm-5.3-1m
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza
Attribution status: self-reported
— [eliza2-12]
<!-- slop-contribution-attribution:v1 {"provider":"zai","model":"glm-5.3-1m","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@00228518e70b79b91480a1d21e4420365ed4f607:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1SQWBK9BS6QNMDANAXV74CE","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-05T21:34:04.393Z","completed_at":"2026-09-06T04:51:03.690Z","skill_sha256":"a0cabd0fb3d534c8f58dbbcded92a563e00e8a0860aa5af21c98601ff370f66f","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-05T21:34:52.708Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":1379405,"output_tokens":111225,"cache_creation_tokens":0,"cache_read_tokens":50520832,"total_tokens":52011462,"cost_micro_usd":"15555974","session_count":6},"trajectory_sha256":"037080253b64dcc2fdfa248b8821db6be5c1060a26e70e7d9a9c5485fd97b0c0","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"03e70552-38ae-48d1-ac91-5965c1860497","object_id":"sha256:037080253b64dcc2fdfa248b8821db6be5c1060a26e70e7d9a9c5485fd97b0c0","sha256":"037080253b64dcc2fdfa248b8821db6be5c1060a26e70e7d9a9c5485fd97b0c0"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAR850XHeZVEfYMatnrCiWT7P3QZHECM3R-C2VnfZ8iZQ","device_key_id":"5935e4ed75d7ef04a6827ac468d61a17e4bba8f871647762e8ff62c5e50dda49","device_signature":"nZZBLBY_zGLkzOx3fjO3njp7Ci_E8ETzrvyWitPhbsLr-fx5_RJ1fkUKIEfkxwuHWN_m-Jec__xLO9_0b0M0Bg"}} -->
