### PR TITLE
test(agent): pin every serving-truth diagnostic report to a case that reaches it

### DIFF
--- a/packages/agent/src/api/provider-serving-truth.test.ts
+++ b/packages/agent/src/api/provider-serving-truth.test.ts
@@ -27,6 +27,14 @@ function cerebrasConfig(credential?: string): ElizaConfig {
   } as unknown as ElizaConfig;
 }
 
+function openAiConfig(): ElizaConfig {
+  return {
+    serviceRouting: {
+      llmText: { transport: "direct", backend: "openai" },
+    },
+  } as unknown as ElizaConfig;
+}
+
 function runtimeWith(options: {
   credential?: string | null;
   openAiCredential?: string | null;
@@ -137,7 +145,11 @@ describe("provider serving truth", () => {
     ).toBeNull();
   });
 
-  it("reports failed runtime credential lookup without falling back to an env key", () => {
+  it("reports a throwing settings lookup inside the cerebras-mode gate without falling back to an env key", () => {
+    // `CEREBRAS_API_KEY` is first read by `isCerebrasMode` through the
+    // cerebras-mode gate, so the throw is reported from that catch and the
+    // credential loop below it is never reached. The two cases that follow
+    // pin the loop and the registration lookup on a path with no such gate.
     const runtime = runtimeWith({ throwOnSetting: "CEREBRAS_API_KEY" });
     expect(
       resolveActiveChat(
@@ -149,6 +161,46 @@ describe("provider serving truth", () => {
     expect(runtime.reportError).toHaveBeenCalledWith(
       "model-config.serving-truth",
       expect.objectContaining({ message: "lookup unavailable" }),
+    );
+  });
+
+  it("reports a throwing credential lookup on the openai path, which has no cerebras-mode gate", () => {
+    const runtime = {
+      reportError: vi.fn(),
+      getSetting: (key: string) => {
+        if (key === "OPENAI_API_KEY") throw new Error("lookup unavailable");
+        return null;
+      },
+      getModelRegistrations: () => [
+        { modelType: ModelType.TEXT_SMALL, provider: "openai" },
+      ],
+    } as unknown as AgentRuntime;
+    expect(
+      resolveActiveChat(
+        openAiConfig(),
+        { OPENAI_API_KEY: "deterministic-env-credential" },
+        runtime,
+      ),
+    ).toBeNull();
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "model-config.serving-truth",
+      expect.objectContaining({ message: "lookup unavailable" }),
+      { credentialKey: "OPENAI_API_KEY" },
+    );
+  });
+
+  it("reports a throwing model-registration lookup instead of claiming a handler", () => {
+    const runtime = {
+      reportError: vi.fn(),
+      getSetting: () => "deterministic-credential",
+      getModelRegistrations: () => {
+        throw new Error("registrations unavailable");
+      },
+    } as unknown as AgentRuntime;
+    expect(resolveActiveChat(openAiConfig(), {}, runtime)).toBeNull();
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "model-config.serving-truth",
+      expect.objectContaining({ message: "registrations unavailable" }),
     );
   });
 


### PR DESCRIPTION
Follow-through on #30001 (merged as `4653dbf102`). That PR turned the three catches in the serving-truth resolver from silent swallows into `runtime.reportError("model-config.serving-truth", …)` calls, per error-policy J7. Only one of the three reports is pinned by the merged suite, and the one test that asserts a report is named for a path it never reaches. Test-only; no runtime source is touched.

## What was unpinned (reproduced on clean develop before the fix)

| mutant (line deleted from `model-config-routes.ts`) | develop suite | with this PR |
| --- | --- | --- |
| report in `hasTextHandlerRegistered`'s catch | 10 pass | **1 failed** |
| report in `isConfiguredCerebrasMode`'s catch | 1 failed (already pinned) | 1 failed |
| report in the credential-loop catch of `hasDirectProviderServingEvidence` | 10 pass | **1 failed** |

## Why the merged test could not see two of them

The merged case `reports failed runtime credential lookup without falling back to an env key` throws from `getSetting("CEREBRAS_API_KEY")` on a cerebras config. But `hasDirectProviderServingEvidence` consults `isConfiguredCerebrasMode` before its credential loop, and `isCerebrasMode` reads `CEREBRAS_API_KEY` through that gate first — so the throw is caught and reported by the cerebras-mode catch, and the credential loop is never entered. Deleting the credential-loop report leaves the case green; deleting the cerebras-mode report is what reddens it. The registration-lookup catch had no case at all.

This PR renames that case to what it pins (a throwing settings lookup inside the cerebras-mode gate) and adds two cases on the `openai` path, which has no cerebras-mode gate: a throwing `OPENAI_API_KEY` lookup, asserted with the `{ credentialKey }` context the loop attaches, and a throwing `getModelRegistrations`. Each of the three report calls now fails exactly one named test when deleted.

## Verification

- `cd packages/agent && bunx vitest run src/api/provider-serving-truth.test.ts src/api/model-config-routes.test.ts` — 57/57 pass at this head (the agent package's `test` script batches every file, so the focused run goes through vitest directly)
- Each of the three mutants above re-applied at this head: exactly the intended test fails, nothing else
- `biome check` on the changed file; `packages/agent` typecheck
- Environment: disposable worktree at `origin/develop` (`8fea4f94c2`, rebased from `4653dbf102`), Bun 1.3.14, `bun install --frozen-lockfile`, plus the two workspace prerequisites unrelated to this change (`generate-keywords.mjs`, `packages/prompts` build)

## Test-only gate

- **Realistic regression prevented:** a later edit that drops or reorders either unpinned `reportError` call (a J7 catch reverting to a silent `return false`) currently leaves every suite green.
- **Observing consumer:** `runtime.reportError` feeds `EventType.ERROR_REPORTED`, `RECENT_ERRORS`, and owner escalation; a swallowed lookup failure in the serving-truth resolver reads as "provider not serving" with no diagnostic anywhere, which is the failure #30001 set out to make visible.
- **Why existing coverage does not own it:** demonstrated by mutation above — two of the three reports can be deleted with the merged suite green, and the one asserting case is attributed to the wrong catch.

Refs: #30001 (merged), #29989.

<!-- evidence-head:c89248608a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; no rendered UI surface exists before or after.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no rendered UI surface exists before or after.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow changes; the deliverable is the mutation-kill matrix below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real suites at this head:

```text
$ cd packages/agent && bunx vitest run src/api/provider-serving-truth.test.ts src/api/model-config-routes.test.ts
 Test Files  2 passed (2)
      Tests  57 passed (57)
```

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend runtime code is touched; the only edit is a test file.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model call, prompt, or planner path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — mutation-kill matrix, each mutant applied and reverted independently, before (clean develop) and after (this head):

```text
MUTANT A - delete the reportError call in hasTextHandlerRegistered's catch
  develop:   Tests  10 passed (10)                    <- survives
  this head: × reports a throwing model-registration lookup instead of claiming a handler
             Tests  1 failed | 11 passed (12)         <- killed

MUTANT B - delete the reportError call in isConfiguredCerebrasMode's catch
  develop:   × reports failed runtime credential lookup without falling back to an env key
             Tests  1 failed | 9 passed (10)          <- already killed, by the case named for the other catch
  this head: × reports a throwing settings lookup inside the cerebras-mode gate without falling back to an env key
             Tests  1 failed | 11 passed (12)         <- killed, now by its own name

MUTANT C - delete the reportError call (3 lines) in the credential-loop catch
  develop:   Tests  10 passed (10)                    <- survives
  this head: × reports a throwing credential lookup on the openai path, which has no cerebras-mode gate
             Tests  1 failed | 11 passed (12)         <- killed
```

<!-- evidence-row:surface-ocr -->
- [x] OCR visual text review: `N/A - test-only change has no rendered visual surface to review.`

Compute receipt: 9818722 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza
Attribution status: self-reported
— [kenjohnscreates]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M1TGETQS28G1QJNHP96H2CXS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-06T04:43:35.545Z","completed_at":"2026-09-06T05:14:00.994Z","skill_sha256":"ede00e21ecb0e86f710c76ab00ab60f9c39e0f33cb3a4ab8514af38585385c0e","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-06T04:43:37.590Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":1448,"output_tokens":17598,"cache_creation_tokens":28275,"cache_read_tokens":9771401,"total_tokens":9818722,"cost_micro_usd":"3902730","session_count":1},"trajectory_sha256":"372473038e20b5f0afb98e44119fafd9d64931864de893ff67ab629de8e1b0d5","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"2eb18321-94a2-4116-a82c-01cb6fdb5264","object_id":"sha256:372473038e20b5f0afb98e44119fafd9d64931864de893ff67ab629de8e1b0d5","sha256":"372473038e20b5f0afb98e44119fafd9d64931864de893ff67ab629de8e1b0d5"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAHBoGfBNRJEhRkQvHY6AcB2oVJyScySjClifWLRVPl28","device_key_id":"e6f31ab600bfb4b6612dfa8af8aec495ea789bb7fa02be582d03179b4a835899","device_signature":"1z9-DNjYrr5-LLJ2DDJEP2V7wjueeKxBAVXYNbjTOt02JZ0Yf2a3kcagQNd-NbsAoqkZ--lMehXcBJ262HL_Cw"}} -->
