### PR TITLE
fix(elizaos): reject unreadable migration sources before archive creation

### DIFF
--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -153,4 +153,7 @@ export { MIN_PASSWORD_LENGTH } from "./archive-format.js";
 export { assemblePayload } from "./archive-writer.js";
 export { mapToCharacter } from "./character-mapper.js";
 export { tierMemories } from "./memory-tiering.js";
-export { readOcAgentHome } from "./openclaw-reader.js";
+export {
+  MigrationSourceReadError,
+  readOcAgentHome,
+} from "./openclaw-reader.js";

--- a/packages/elizaos/src/migrate/openclaw-reader.test.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.test.ts
@@ -5,11 +5,17 @@
  * awareness preference order, daily/named memory classification and ordering,
  * non-file and non-markdown skips, CRLF normalization at the read boundary,
  * secrets-dir flagging, sqlite-store detection plus the detect-vs-ingest
- * warning contract, and the key-classification predicates.
+ * warning contract, the key-classification predicates, and the
+ * unreadable-vs-absent optional-source disposition (absent tolerated;
+ * wrong-type directory, FIFO, symlink-through-a-file (ENOTDIR), and EACCES
+ * rejected with the cause preserved).
  *
  * Drives the real exported reader against real temp directories (and real
- * sqlite bytes when this runtime exposes node:sqlite) — no mocks.
+ * sqlite bytes when this runtime exposes node:sqlite) — no mocks; unreadable
+ * cases use real filesystem shapes (directory, FIFO, symlink-through-a-file,
+ * chmod 000).
  */
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
@@ -20,10 +26,18 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   isPlaybookMemory,
   isSelfMemory,
+  MigrationSourceReadError,
   PLAYBOOK_MEMORY_KEYS,
   readOcAgentHome,
   SELF_MEMORY_KEYS,
 } from "./openclaw-reader.js";
+
+/** Root bypasses discretionary read bits, so the EACCES case is uid-gated. */
+const NON_ROOT =
+  typeof process.getuid === "function" ? process.getuid() !== 0 : false;
+
+/** `mkfifo` is POSIX-only, so the FIFO case is skipped on Windows runners. */
+const POSIX = process.platform !== "win32";
 
 const made: string[] = [];
 
@@ -401,6 +415,136 @@ describe("sqlite memory stores", () => {
       expect(source.warnings.join("\n")).not.toContain("other.sqlite");
     },
   );
+});
+
+describe("unreadable optional sources fail before archive creation", () => {
+  it("still tolerates a genuinely absent optional persona file", () => {
+    const home = makeHome();
+    // MEMORY.md present, SOUL/IDENTITY/AGENTS/USER/TOOLS all absent (ENOENT).
+    write(home, "MEMORY.md", "curated-only");
+    const source = readOcAgentHome(home, "kai");
+    expect(source.curatedMemory).toBe("curated-only");
+    expect(source.soul).toBeUndefined();
+    expect(source.identity).toBeUndefined();
+    expect(source.agents).toBeUndefined();
+    expect(source.user).toBeUndefined();
+    expect(source.tools).toBeUndefined();
+    // A curated home is not "empty", so no persona-missing warning fires.
+    expect(source.warnings.some((w) => w.includes("No persona"))).toBe(false);
+  });
+
+  it("rejects a persona path that exists but is the wrong type (directory)", () => {
+    const home = makeHome();
+    write(home, "MEMORY.md", "curated");
+    // SOUL.md is a directory, not a file: existing-but-wrong-type must fail
+    // rather than silently classify the persona as missing.
+    fs.mkdirSync(path.join(home, "SOUL.md"));
+    let caught: unknown;
+    try {
+      readOcAgentHome(home, "kai");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MigrationSourceReadError);
+    const error = caught as MigrationSourceReadError;
+    expect(error.context.path).toBe(path.join(home, "SOUL.md"));
+    expect(error.context.operation).toBe("read");
+    // The type-guard rejects before readFileSync; the cause names the wrong type.
+    expect((error.cause as Error).message).toContain("directory");
+    expect((error.cause as Error).message).toContain("regular file");
+  });
+
+  it.runIf(POSIX)(
+    "rejects a FIFO persona source instead of blocking migrate-agent",
+    () => {
+      const home = makeHome();
+      write(home, "MEMORY.md", "curated");
+      // A FIFO SOUL.md: readFileSync on a FIFO blocks forever waiting for a
+      // writer, hanging migrate-agent. The type-guard must reject it up front
+      // (regression for the reopened wrong-type case in #30754).
+      const soul = path.join(home, "SOUL.md");
+      execFileSync("mkfifo", [soul]);
+      let caught: unknown;
+      try {
+        readOcAgentHome(home, "kai");
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(MigrationSourceReadError);
+      const error = caught as MigrationSourceReadError;
+      expect(error.context.path).toBe(soul);
+      expect(error.context.operation).toBe("read");
+      expect((error.cause as Error).message).toContain("FIFO");
+      expect((error.cause as Error).message).toContain("regular file");
+    },
+  );
+
+  it("rejects an existing-but-unreadable persona path and preserves the cause (ENOTDIR)", () => {
+    const home = makeHome();
+    write(home, "MEMORY.md", "curated");
+    // A SOUL.md symlink whose target traverses a regular file yields a
+    // deterministic non-ENOENT errno (ENOTDIR) on stat regardless of the test
+    // uid: the path exists but cannot be inspected.
+    write(home, "blocker", "i am a file, not a directory");
+    fs.symlinkSync(
+      path.join(home, "blocker", "inner"),
+      path.join(home, "SOUL.md"),
+    );
+    let caught: unknown;
+    try {
+      readOcAgentHome(home, "kai");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(MigrationSourceReadError);
+    const error = caught as MigrationSourceReadError;
+    expect(error.context.path).toBe(path.join(home, "SOUL.md"));
+    // The underlying fs error is preserved as the cause, not discarded.
+    expect(error.cause).toBeInstanceOf(Error);
+    expect((error.cause as NodeJS.ErrnoException).code).toBe("ENOTDIR");
+  });
+
+  it.runIf(NON_ROOT)(
+    "rejects an EACCES-unreadable persona file and preserves the cause",
+    () => {
+      const home = makeHome();
+      write(home, "MEMORY.md", "curated");
+      const soul = path.join(home, "SOUL.md");
+      write(home, "SOUL.md", "secret persona");
+      fs.chmodSync(soul, 0o000);
+      try {
+        let caught: unknown;
+        try {
+          readOcAgentHome(home, "kai");
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(MigrationSourceReadError);
+        const error = caught as MigrationSourceReadError;
+        expect(error.context.path).toBe(soul);
+        expect(error.context.operation).toBe("read");
+        expect((error.cause as NodeJS.ErrnoException).code).toBe("EACCES");
+      } finally {
+        // Restore so afterEach cleanup can remove the temp home.
+        fs.chmodSync(soul, 0o644);
+      }
+    },
+  );
+
+  it("still surfaces the SQLite compatibility warning alongside the read split", () => {
+    const home = makeHome();
+    write(home, "SOUL.md", "soul");
+    // A non-database .sqlite store: readable-but-uningestable memory must keep
+    // emitting the explicit compatibility warning, unchanged by the new
+    // unreadable-source disposition.
+    write(home, "memory/broken.sqlite", "this is not a database");
+    const source = readOcAgentHome(home, "kai");
+    expect(source.soul).toBe("soul");
+    expect(source.sqliteUningested).toBe(true);
+    expect(source.warnings).toHaveLength(1);
+    expect(source.warnings[0]).toContain("DETECTED 1 sqlite memory store(s)");
+    expect(source.warnings[0]).toContain("could NOT read");
+  });
 });
 
 describe("key classification predicates", () => {

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -173,7 +173,40 @@ function readOptional<T>(
   }
 }
 
+/** Human-readable classification of a non-regular-file stat result. */
+function describeStatType(stat: fs.Stats): string {
+  if (stat.isDirectory()) return "directory";
+  if (stat.isBlockDevice()) return "block device";
+  if (stat.isCharacterDevice()) return "character device";
+  if (stat.isFIFO()) return "FIFO";
+  if (stat.isSocket()) return "socket";
+  return "non-file entry";
+}
+
+/**
+ * Read an OPTIONAL persona/memory source file, stat-guarding the type first.
+ *
+ * A genuinely absent path (`ENOENT`) is tolerated and returns `undefined`, so a
+ * partial home still migrates. A path that EXISTS is classified before the read:
+ * a non-regular-file source (directory, FIFO, socket, device) is rejected with
+ * `MigrationSourceReadError` instead of being handed to `readFileSync`. Without
+ * this guard a FIFO persona source blocks `readFileSync` waiting for a writer
+ * that never comes, hanging `migrate-agent` indefinitely; the guard converts
+ * that hang into an explicit typed failure before any archive artifact is
+ * written. `statSync` follows symlinks, so a symlink to a real file still reads.
+ */
 function readIfPresent(p: string): string | undefined {
+  const stat = statIfPresent(p);
+  if (stat === undefined) return undefined;
+  if (!stat.isFile()) {
+    // error-policy:J3 An existing non-regular-file source is invalid input, not
+    // absent data: reject it explicitly rather than blocking on readFileSync
+    // (a FIFO) or silently classifying the persona as missing.
+    throw new MigrationSourceReadError(
+      { path: p, operation: "read" },
+      new Error(`source is a ${describeStatType(stat)}, not a regular file`),
+    );
+  }
   return readOptional(p, "read", () =>
     normalizeEol(fs.readFileSync(p, "utf8")),
   );


### PR DESCRIPTION
# Relates to

Closes #30754

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; owning-package `test`/`typecheck`/`lint` gates pass (logs below). `bun run verify` is a repo-wide gate; the scoped, owning-package gates are attached and green.
- [x] A reviewer can confirm the change works without reading the code, from the before/after reproduction and failing-then-passing test logs below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`de30ecf38c`). The base merged the related fix #30777, which already introduced `MigrationSourceReadError`/`readOptional` and the absent-vs-unreadable split for `EACCES`/`ENOTDIR`/`EISDIR`. This PR was rebased onto that design and now carries **only** the remaining gap the maintainer reopened #30754 for.
- [x] Owning-package gates pass post-sync; see **Known gaps / failures** for the repo-wide `verify` note.

# Risks

Low. The change adds a single stat-based type guard inside the migration
reader's optional-read helper (`packages/elizaos/src/migrate/openclaw-reader.ts`).
It rejects a non-regular-file persona source (FIFO / socket / device /
directory) with the existing typed `MigrationSourceReadError` **before** handing
the path to `readFileSync`. Genuinely absent optional files and readable regular
files (including symlinks to regular files) behave exactly as before, so partial
homes still migrate. No public archive/CLI surface, dependency, or command flow
was restructured.

# Background

## What does this PR do?

Issue #30754 was reopened for one confirmed remaining case after #30777 merged:

> Reopening for the remaining confirmed wrong-type case: a FIFO persona source
> blocks migrate-agent.

After #30777, develop's `readIfPresent` calls `readOptional(p, "read", () => fs.readFileSync(p))`.
That correctly rejects `EACCES`/`ENOTDIR`/`EISDIR`, but a **FIFO** persona
source (e.g. `SOUL.md` created by `mkfifo`) passes `readFileSync`, whose
synchronous open blocks forever waiting for a writer that never arrives —
**hanging `migrate-agent` indefinitely** with no error and no archive.

This PR adds a narrow regular-file guard so `readIfPresent`:

- stats the path first (`statIfPresent`), tolerating a genuinely absent
  (`ENOENT`) path exactly as before — partial homes still migrate; and
- rejects any existing **non-regular-file** source (FIFO, socket, block/char
  device, directory) with `MigrationSourceReadError` carrying `context.path`,
  `context.operation`, and a `cause` naming the offending type — **before**
  the blocking `readFileSync`.

`statSync` follows symlinks, so a symlink to a real regular file still reads
normally (a legitimate persona layout). Because `buildMigrationPlan` calls
`readOcAgentHome` before any `printPlan`, `--json` output, or `archiveFromPlan`
call, the throw surfaces **before any CLI artifact or archive is produced**.
The typed error is exported from `src/migrate/index.ts` for callers.

## What kind of change is this?

Bug fix (non-breaking; converts an indefinite `migrate-agent` hang on a
non-regular-file persona source into an explicit typed failure).

# Documentation changes needed?

No product-doc change required. The `readIfPresent` contract doc in
`openclaw-reader.ts` was updated to describe the regular-file type guard.

# Testing

## Where should a reviewer start?

`packages/elizaos/src/migrate/openclaw-reader.test.ts`, describe block
"unreadable optional sources fail before archive creation" — specifically the
new `rejects a FIFO persona source instead of blocking migrate-agent` case,
plus the before/after reproduction below.

## Detailed testing steps

```bash
bun install
bun run --cwd packages/elizaos test        # 265 passed
bun run --cwd packages/elizaos typecheck    # clean
bun run --cwd packages/elizaos lint:check   # clean
```

Regression tests (real filesystem shapes, no mocks — the repo's no-vi-mocks
gate forbids `vi.mock`/`vi.spyOn`):

- absent optional persona file → still migrates, no error, no persona-missing warning;
- `SOUL.md` is a **FIFO** → `MigrationSourceReadError`, `cause` names the FIFO type (POSIX-gated; the exact reopened case);
- `SOUL.md` is a **directory** → `MigrationSourceReadError`, `cause` names the wrong type;
- `SOUL.md` is a **symlink through a regular file** → rejects with `ENOTDIR`, `cause` preserved;
- `SOUL.md` `chmod 000` → rejects with `EACCES`, `cause` preserved (uid-gated: root bypasses read bits);
- a non-database `.sqlite` store → the existing SQLite detect-and-warn path is unchanged.

# Evidence Gate

<!-- evidence-head:94eb10620742cf669decdf344f0332747298a7ad -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI/library migration-reader change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI/library migration-reader change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - non-interactive library/CLI code path; before/after reproduction and test logs attached instead.
<!-- evidence-row:backend-logs -->
- [x] Real code-path run at head `94eb106`: `readOcAgentHome` against a temp home (readable `MEMORY.md` + FIFO `SOUL.md`) plus the focused test run and owning-package gates. The typed throw fires before any plan/archive output.

<details><summary>1. FIFO rejection outcome (real run at head 94eb106)</summary>

```
=== WITH FIX (head 94eb106) : FIFO SOUL.md next to readable MEMORY.md ===
RESULT: threw before any plan/archive output.
  name        = MigrationSourceReadError
  code        = MIGRATION_SOURCE_READ_FAILED
  op          = read
  path        = <home>/SOUL.md
  causeMsg    = source is a FIFO, not a regular file
```

</details>

<details><summary>2. focused test run (real, head 94eb106)</summary>

```
> bun run --cwd packages/elizaos test openclaw-reader

unreadable optional sources fail before archive creation
 ✓ still tolerates a genuinely absent optional persona file
 ✓ rejects a persona path that exists but is the wrong type (directory)
 ✓ rejects a FIFO persona source instead of blocking migrate-agent
 ✓ rejects an existing-but-unreadable persona path and preserves the cause (ENOTDIR)
 ✓ rejects an EACCES-unreadable persona file and preserves the cause
 ✓ still surfaces the SQLite compatibility warning alongside the read split

 Test Files  2 passed (2)
      Tests  34 passed (34)
```

</details>

<details><summary>3. owning-package gates (real run)</summary>

```
> bun run --cwd packages/elizaos typecheck   # tsc --noEmit -> clean
> bun run --cwd packages/elizaos lint:check   # biome -> Checked 56/11/64 files, no fixes applied
> bun run --cwd packages/elizaos test         # Test Files 23 passed (23) | Tests 265 passed (265)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed; pure filesystem read-disposition.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: the failing-without-fix → passing-with-fix proof that the guard is load-bearing. Without the guard a FIFO persona source hangs the entire process (the exact `migrate-agent` hang); with the guard it is a clean typed rejection.

<details><summary>failing-WITHOUT the guard (real runs, head 94eb106 with the guard reverted)</summary>

```
--- FIFO case, guard reverted: readFileSync blocks the event loop ---
# `bunx vitest run openclaw-reader --testTimeout=6000` never completes; the
# synchronous readFileSync on the FIFO blocks the whole vitest process, so even
# vitest's per-test timeout cannot interrupt it. Killed by an external 120s
# timeout (exit 124). This IS the migrate-agent hang the guard prevents.

--- directory case, guard reverted (FIFO test excluded so the run can finish) ---
 × rejects a persona path that exists but is the wrong type (directory)
   → expected 'EISDIR: illegal operation on a directory, read' to contain 'regular file'
 Tests  1 failed | 33 skipped (34)
```

</details>

<details><summary>passing-WITH the guard (real run, head 94eb106)</summary>

```
 ✓ rejects a FIFO persona source instead of blocking migrate-agent
 ✓ rejects a persona path that exists but is the wrong type (directory)
 Test Files  2 passed (2)
      Tests  34 passed (34)
```

The FIFO no longer hangs and the directory rejection now carries the uniform
"not a regular file" classification, both before any archive output.

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

FIFO reproduction against a temp home (readable `MEMORY.md` + FIFO `SOUL.md`),
capturing what `readOcAgentHome` does at head `94eb106`:

```
=== WITH FIX (head 94eb106) : FIFO SOUL.md next to readable MEMORY.md ===
RESULT: threw before any plan/archive output.
  name     = MigrationSourceReadError
  code     = MIGRATION_SOURCE_READ_FAILED
  op       = read
  path     = <home>/SOUL.md
  causeMsg = source is a FIFO, not a regular file
```

Without the guard the same home does not throw: `readFileSync` blocks on the
FIFO forever, hanging `migrate-agent` with no error and no archive.

Owning-package gates:

<details><summary>test (265 passed)</summary>

```
> bun run --cwd packages/elizaos test

 Test Files  23 passed (23)
      Tests  265 passed (265)
   Duration  25.60s
```
</details>

Frontend: N/A - no frontend involved.

## Screenshots (before / after) + video walkthrough

N/A - CLI/library change with no rendered UI.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- Repo-wide `bun run verify` was not run to completion on this constrained
  worker; the scoped owning-package `test` (265 passed), `typecheck`, and
  `lint:check` gates are attached and green. The diff is confined to one package
  and adds no dependencies, so the risk of a cross-package `verify` regression is
  minimal.
- The FIFO test is POSIX-gated (`mkfifo` is not available on Windows runners).
  The EACCES test is uid-gated (`process.getuid() !== 0`) because root bypasses
  discretionary read bits; the directory and ENOTDIR cases run on every uid.

## Maintainer CI exception record

N/A - no exception requested

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@4cd6d837818d951267826f0b54e625580092ee68:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@4cd6d837818d951267826f0b54e625580092ee68:packages/skills/skills/contribute-to-eliza"} -->
