### PR TITLE
fix(cloud): reject malformed configured Vast endpoint maps

### DIFF
--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
@@ -1,0 +1,172 @@
+// Verifies vast-endpoints map validation: malformed present config fails fast
+// with a redacted error, while absence and valid precedence/aliasing resolve
+// unchanged. Uses the real catalog with an injected env reader (deterministic).
+import { describe, expect, test } from "bun:test";
+import {
+  resolveVastEndpointConfig,
+  resolveVastFallbackModel,
+  VastEndpointConfigError,
+} from "./vast-endpoints";
+
+const SECRET = "sk-vast-super-secret-token-DO-NOT-LEAK";
+
+/** Build an env reader from a plain map; missing keys read as null. */
+function readerFrom(env: Record<string, string | undefined>): (name: string) => string | null {
+  return (name: string) => env[name] ?? null;
+}
+
+describe("resolveVastEndpointConfig endpoint-map validation", () => {
+  test("absent VAST_ENDPOINTS_JSON falls back to global config (unchanged)", () => {
+    const config = resolveVastEndpointConfig(
+      "vast/eliza-1-27b",
+      readerFrom({
+        VAST_BASE_URL: "https://global.example.com/",
+        VAST_API_KEY: "global-key",
+      }),
+    );
+    expect(config).not.toBeNull();
+    expect(config?.source).toBe("global");
+    expect(config?.baseUrl).toBe("https://global.example.com");
+    expect(config?.apiKey).toBe("global-key");
+  });
+
+  test("valid VAST_ENDPOINTS_JSON resolves dedicated endpoint precedence (unchanged)", () => {
+    const config = resolveVastEndpointConfig(
+      "vast/eliza-1-27b",
+      readerFrom({
+        VAST_ENDPOINTS_JSON: JSON.stringify({
+          "vast/eliza-1-27b": {
+            baseUrl: "https://dedicated.example.com/",
+            apiKey: "dedicated-key",
+            apiModelId: "eliza-27b-remote",
+          },
+        }),
+        VAST_BASE_URL: "https://global.example.com",
+        VAST_API_KEY: "global-key",
+      }),
+    );
+    expect(config?.source).toBe("json");
+    expect(config?.baseUrl).toBe("https://dedicated.example.com");
+    expect(config?.apiKey).toBe("dedicated-key");
+    expect(config?.apiModelId).toBe("eliza-27b-remote");
+  });
+
+  test("string endpoint entry is accepted and used as base URL (unchanged)", () => {
+    const config = resolveVastEndpointConfig(
+      "vast/eliza-1-27b",
+      readerFrom({
+        VAST_ENDPOINTS_JSON: JSON.stringify({
+          "vast/eliza-1-27b": "https://string-endpoint.example.com/",
+        }),
+        VAST_API_KEY: "global-key",
+      }),
+    );
+    expect(config?.source).toBe("json");
+    expect(config?.baseUrl).toBe("https://string-endpoint.example.com");
+  });
+
+  test("malformed JSON present throws an actionable VastEndpointConfigError", () => {
+    const reader = readerFrom({ VAST_ENDPOINTS_JSON: `{ "vast/eliza-1-27b": ${SECRET} }` });
+    expect(() => resolveVastEndpointConfig("vast/eliza-1-27b", reader)).toThrow(
+      VastEndpointConfigError,
+    );
+    try {
+      resolveVastEndpointConfig("vast/eliza-1-27b", reader);
+    } catch (error) {
+      expect(error).toBeInstanceOf(VastEndpointConfigError);
+      const message = (error as Error).message;
+      expect(message).toContain("VAST_ENDPOINTS_JSON");
+      expect(message).toContain("not valid JSON");
+      // Redaction: the raw (secret-bearing) value must never appear.
+      expect(message).not.toContain(SECRET);
+    }
+  });
+
+  test("valid JSON but non-object (array) throws a clear error", () => {
+    const reader = readerFrom({ VAST_ENDPOINTS_JSON: JSON.stringify(["not", "a", "map"]) });
+    expect(() => resolveVastEndpointConfig("vast/eliza-1-27b", reader)).toThrow(
+      /VAST_ENDPOINTS_JSON is set but is not a JSON object/,
+    );
+  });
+
+  test("valid JSON but entry value of wrong type throws a clear error", () => {
+    const reader = readerFrom({
+      VAST_ENDPOINTS_JSON: JSON.stringify({ "vast/eliza-1-27b": 12345 }),
+    });
+    expect(() => resolveVastEndpointConfig("vast/eliza-1-27b", reader)).toThrow(
+      /entry for "vast\/eliza-1-27b" must be a string base URL or an object/,
+    );
+  });
+
+  test("object entry with a non-string field throws and does not leak the value", () => {
+    const reader = readerFrom({
+      VAST_ENDPOINTS_JSON: JSON.stringify({
+        "vast/eliza-1-27b": { baseUrl: { host: SECRET } },
+      }),
+    });
+    try {
+      resolveVastEndpointConfig("vast/eliza-1-27b", reader);
+      throw new Error("expected VastEndpointConfigError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(VastEndpointConfigError);
+      const message = (error as Error).message;
+      expect(message).toContain('invalid "baseUrl" field');
+      expect(message).not.toContain(SECRET);
+    }
+  });
+});
+
+describe("resolveVastFallbackModel fallback-map validation", () => {
+  test("absent fallback map uses the built-in alias chain (unchanged)", () => {
+    const fallback = resolveVastFallbackModel(
+      "vast/eliza-1-27b",
+      readerFrom({
+        VAST_ENDPOINTS_JSON: JSON.stringify({
+          "vast/eliza-1-9b": "https://nine-b.example.com",
+        }),
+        VAST_API_KEY: "global-key",
+      }),
+    );
+    expect(fallback).toBe("vast/eliza-1-9b");
+  });
+
+  test("valid fallback map overrides the alias chain (unchanged)", () => {
+    const fallback = resolveVastFallbackModel(
+      "vast/eliza-1-27b",
+      readerFrom({
+        VAST_FALLBACK_MODEL_MAP_JSON: JSON.stringify({ "vast/eliza-1-27b": "vast/eliza-1-2b" }),
+        VAST_ENDPOINTS_JSON: JSON.stringify({
+          "vast/eliza-1-2b": "https://two-b.example.com",
+        }),
+        VAST_API_KEY: "global-key",
+      }),
+    );
+    expect(fallback).toBe("vast/eliza-1-2b");
+  });
+
+  test("malformed fallback map present throws VastEndpointConfigError", () => {
+    const reader = readerFrom({ VAST_FALLBACK_MODEL_MAP_JSON: "{ not json" });
+    expect(() => resolveVastFallbackModel("vast/eliza-1-27b", reader)).toThrow(
+      VastEndpointConfigError,
+    );
+  });
+
+  test("fallback map with non-string entry throws a clear error", () => {
+    const reader = readerFrom({
+      VAST_FALLBACK_MODEL_MAP_JSON: JSON.stringify({ "vast/eliza-1-27b": { model: "x" } }),
+    });
+    expect(() => resolveVastFallbackModel("vast/eliza-1-27b", reader)).toThrow(
+      /must map to a fallback model id string/,
+    );
+  });
+
+  test("empty-string env var is treated as absent (legal), not malformed", () => {
+    const reader = readerFrom({
+      VAST_ENDPOINTS_JSON: "   ",
+      VAST_BASE_URL: "https://global.example.com",
+      VAST_API_KEY: "global-key",
+    });
+    const config = resolveVastEndpointConfig("vast/eliza-1-27b", reader);
+    expect(config?.source).toBe("global");
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
@@ -23,6 +23,36 @@ type VastEndpointJsonValue =
       model?: string;
     };
 
+const VAST_ENDPOINT_STRING_FIELDS = [
+  "baseUrl",
+  "url",
+  "apiKey",
+  "apiKeyEnv",
+  "apiModelId",
+  "model",
+] as const;
+
+/**
+ * Raised when a Vast endpoint or fallback map env var is present but malformed.
+ * Thrown at parse time so the provider factory fails fast with an actionable,
+ * credential-free message instead of silently routing through the global
+ * default or surfacing an opaque low-level error deep in dispatch. Messages
+ * describe the offending env var, entry key, and value *type* only; raw values
+ * (which can embed API keys) are never echoed.
+ */
+export class VastEndpointConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VastEndpointConfigError";
+  }
+}
+
+function describeType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  return `a ${typeof value}`;
+}
+
 function trimTrailingSlash(url: string): string {
   return url.endsWith("/") ? url.slice(0, -1) : url;
 }
@@ -42,15 +72,80 @@ function defaultApiModelId(model: string): string {
   return translated;
 }
 
-function parseEndpointMap(raw: string | null): Record<string, VastEndpointJsonValue> {
-  if (!raw) return {};
+/**
+ * Parse a configured JSON map env var into a validated object. Absence (null or
+ * blank) is legal and yields an empty map. A present-but-malformed value throws
+ * a `VastEndpointConfigError` so misconfiguration fails fast before dispatch.
+ */
+function parseConfiguredMap(
+  envName: string,
+  raw: string | null,
+  validateEntry: (key: string, value: unknown) => void,
+): Record<string, unknown> {
+  if (raw === null || raw.trim().length === 0) return {};
+
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    return parsed as Record<string, VastEndpointJsonValue>;
+    parsed = JSON.parse(raw);
   } catch {
-    return {};
+    // error-policy:J3 present-but-invalid JSON is untrusted input; surface an
+    // explicit typed configuration error instead of a fake-empty map.
+    throw new VastEndpointConfigError(
+      `${envName} is set but is not valid JSON. Provide a JSON object mapping model ids to endpoint configuration, or unset the variable.`,
+    );
   }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new VastEndpointConfigError(
+      `${envName} is set but is not a JSON object (received ${describeType(parsed)}). Provide a JSON object mapping model ids to endpoint configuration, or unset the variable.`,
+    );
+  }
+
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    validateEntry(key, value);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function validateEndpointEntry(envName: string, key: string, value: unknown): void {
+  if (typeof value === "string") return;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new VastEndpointConfigError(
+      `${envName} entry for "${key}" must be a string base URL or an object, but received ${describeType(value)}.`,
+    );
+  }
+  const record = value as Record<string, unknown>;
+  for (const field of VAST_ENDPOINT_STRING_FIELDS) {
+    const fieldValue = record[field];
+    if (fieldValue !== undefined && typeof fieldValue !== "string") {
+      throw new VastEndpointConfigError(
+        `${envName} entry for "${key}" has an invalid "${field}" field: expected a string but received ${describeType(fieldValue)}.`,
+      );
+    }
+  }
+}
+
+function validateFallbackEntry(envName: string, key: string, value: unknown): void {
+  if (typeof value !== "string") {
+    throw new VastEndpointConfigError(
+      `${envName} entry for "${key}" must map to a fallback model id string, but received ${describeType(value)}.`,
+    );
+  }
+}
+
+function parseEndpointMap(
+  envName: string,
+  raw: string | null,
+): Record<string, VastEndpointJsonValue> {
+  return parseConfiguredMap(envName, raw, (key, value) =>
+    validateEndpointEntry(envName, key, value),
+  ) as Record<string, VastEndpointJsonValue>;
+}
+
+function parseFallbackModelMap(envName: string, raw: string | null): Record<string, string> {
+  return parseConfiguredMap(envName, raw, (key, value) =>
+    validateFallbackEntry(envName, key, value),
+  ) as Record<string, string>;
 }
 
 function readJsonEndpoint(
@@ -62,7 +157,7 @@ function readJsonEndpoint(
   baseUrl?: string;
   apiModelId?: string;
 } | null {
-  const endpointMap = parseEndpointMap(reader("VAST_ENDPOINTS_JSON"));
+  const endpointMap = parseEndpointMap("VAST_ENDPOINTS_JSON", reader("VAST_ENDPOINTS_JSON"));
   const config = endpointMap[model];
   if (!config) return null;
   if (typeof config === "string") {
@@ -143,10 +238,14 @@ export function resolveVastFallbackModel(
   reader: EnvReader = getProviderKey,
 ): string | null {
   if (!isVastNativeModel(model)) return null;
-  const rawMap = parseEndpointMap(reader("VAST_FALLBACK_MODEL_MAP_JSON"));
+  const rawMap = parseFallbackModelMap(
+    "VAST_FALLBACK_MODEL_MAP_JSON",
+    reader("VAST_FALLBACK_MODEL_MAP_JSON"),
+  );
+  const mapped = rawMap[model];
   const fallback =
-    typeof rawMap[model] === "string"
-      ? (rawMap[model] as string)
+    typeof mapped === "string"
+      ? mapped
       : model === "vast/eliza-1-27b-256k"
         ? "vast/eliza-1-27b"
         : model === "vast/eliza-1-27b"


### PR DESCRIPTION
# Relates to

Closes #30756

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and the owning-package + relevant repo gates were run after
      sync; the heavy full-monorepo `bun run verify` blocker is recorded under
      **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`dd77553` is one commit ahead of
      `origin/develop`, zero conflicts).
- [x] Focused package gates pass post-sync; the full-monorepo `bun run verify`
      blocker is documented in **Known gaps / failures**.

# Risks

Low. The change adds validation to a previously silent parser in
`packages/cloud/shared`. The only behavioral change is the malformed-**present**
branch: values that were silently dropped now raise a typed
`VastEndpointConfigError`. Absence (null/blank) and every valid
precedence/alias path are byte-for-byte unchanged, covered by regression tests.
A deployment that was *relying* on a malformed env var being silently ignored
would now fail fast — which is the intended correctness fix.

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/providers/vast-endpoints.ts` parsed
`VAST_ENDPOINTS_JSON` and `VAST_FALLBACK_MODEL_MAP_JSON` with a catch-all that
treated any present-but-malformed value as an empty map:

```ts
function parseEndpointMap(raw: string | null) {
  if (!raw) return {};
  try {
    const parsed = JSON.parse(raw);
    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
    return parsed;
  } catch {
    return {};   // <- malformed present value silently becomes "absent"
  }
}
```

Consequences of the silent-empty behavior:
1. A dedicated per-model endpoint typo (bad JSON, or an entry with the wrong
   shape) silently routed the model through the **global default** instead of
   erroring.
2. Malformed object fields (e.g. `baseUrl` set to a number/object) surfaced as
   opaque low-level errors deep in the provider factory rather than a clear
   configuration error.

This PR validates both maps at parse time:
- **Absence stays legal**: `null` or a blank/whitespace value yields an empty
  map (unchanged).
- **Present-but-malformed fails fast**: not valid JSON, not a JSON object, or an
  entry with the wrong shape now throws a typed `VastEndpointConfigError`
  **before dispatch**.
- **Credential-safe errors**: messages name only the env var, the entry key, and
  the value *type* (`describeType` → `"a number"`, `"an array"`, `"null"`, …).
  Raw values — which can embed API keys via `apiKey`/`apiKeyEnv` — are never
  echoed.
- **Valid precedence/aliasing preserved**: string entries, object entries,
  dedicated-endpoint precedence, the built-in 27b→9b→2b fallback chain, and
  explicit fallback-map overrides all resolve exactly as before.

## What kind of change is this?

Bug fix (non-breaking; fixes silent misconfiguration handling).

# Documentation changes needed?

No. Behavior for valid/absent config is unchanged; only malformed-present config
moves from silent-drop to an explicit typed error.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts` — 12 focused
tests exercising the real `resolveVastEndpointConfig` / `resolveVastFallbackModel`
contract with an injected env reader (no network, deterministic).

## Detailed testing steps

```bash
cd packages/cloud/shared
node scripts/run-bun-tests.mjs src/lib/providers/vast-endpoints.test.ts
bun test --isolate src/lib/providers/          # full provider suite
bun run typecheck
bun run lint:check
```

Covered paths: (a) absent maps → OK; (b) malformed JSON present → clear error;
(c) valid-JSON-but-wrong-shape (array root, non-string entry, non-string object
field) → clear error; (d) valid config → unchanged precedence/alias resolution;
(e) error messages do not leak secret-bearing raw values; plus blank-string env
treated as absent.

# Evidence Gate

<!-- evidence-head:dd77553bc9cfbea89f09d27099514f5db9bba801 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - server-only parser/validation change in @elizaos/cloud-shared; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - server-only parser/validation change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; behavior is env-config parsing verified by unit tests below.`
<!-- evidence-row:backend-logs -->
- [x] Real code path = the parser under test. Failing-first (old silent-empty behavior) vs passing (fixed) focused runs inline below; also archived as an immutable, revision-pinned GitHub gist permalink (captured at PR head `dd77553`): https://gist.github.com/agent-cortex/214a0ebf9849c51103f85df9b1bce471/91672d7ab99ca1d4926ad307dca2e2e238ea3801

<details>
<summary>Passing — fixed impl focused test output (12 pass / 0 fail)</summary>

```
bun test v1.3.14 (0d9b296a)

src/lib/providers/vast-endpoints.test.ts:
(pass) resolveVastEndpointConfig endpoint-map validation > absent VAST_ENDPOINTS_JSON falls back to global config (unchanged) [1.00ms]
(pass) resolveVastEndpointConfig endpoint-map validation > valid VAST_ENDPOINTS_JSON resolves dedicated endpoint precedence (unchanged) [0.35ms]
(pass) resolveVastEndpointConfig endpoint-map validation > string endpoint entry is accepted and used as base URL (unchanged) [0.16ms]
(pass) resolveVastEndpointConfig endpoint-map validation > malformed JSON present throws an actionable VastEndpointConfigError [0.57ms]
(pass) resolveVastEndpointConfig endpoint-map validation > valid JSON but non-object (array) throws a clear error [0.25ms]
(pass) resolveVastEndpointConfig endpoint-map validation > valid JSON but entry value of wrong type throws a clear error [0.33ms]
(pass) resolveVastEndpointConfig endpoint-map validation > object entry with a non-string field throws and does not leak the value [0.26ms]
(pass) resolveVastFallbackModel fallback-map validation > absent fallback map uses the built-in alias chain (unchanged) [0.28ms]
(pass) resolveVastFallbackModel fallback-map validation > valid fallback map overrides the alias chain (unchanged) [0.26ms]
(pass) resolveVastFallbackModel fallback-map validation > malformed fallback map present throws VastEndpointConfigError [0.12ms]
(pass) resolveVastFallbackModel fallback-map validation > fallback map with non-string entry throws a clear error [0.14ms]
(pass) resolveVastFallbackModel fallback-map validation > empty-string env var is treated as absent (legal), not malformed [0.08ms]

 12 pass
 0 fail
 25 expect() calls
Ran 12 tests across 1 file. [57.00ms]
```

</details>

<details>
<summary>Failing-first — old silent-empty behavior with export retained (6 fail / 6 pass): malformed-present inputs are silently dropped</summary>

```
bun test v1.3.14 (0d9b296a)

src/lib/providers/vast-endpoints.test.ts:
(pass) resolveVastEndpointConfig endpoint-map validation > absent VAST_ENDPOINTS_JSON falls back to global config (unchanged) [1.16ms]
(pass) resolveVastEndpointConfig endpoint-map validation > valid VAST_ENDPOINTS_JSON resolves dedicated endpoint precedence (unchanged) [0.20ms]
(pass) resolveVastEndpointConfig endpoint-map validation > string endpoint entry is accepted and used as base URL (unchanged) [0.17ms]
65 |     expect(config?.baseUrl).toBe("https://string-endpoint.example.com");
66 |   });
67 | 
68 |   test("malformed JSON present throws an actionable VastEndpointConfigError", () => {
69 |     const reader = readerFrom({ VAST_ENDPOINTS_JSON: `{ "vast/eliza-1-27b": ${SECRET} }` });
70 |     expect(() => resolveVastEndpointConfig("vast/eliza-1-27b", reader)).toThrow(
                                                                             ^
error: expect(received).toThrow(expected)

Expected constructor: VastEndpointConfigError

Received function did not throw
Received value: null

      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:70:73)
(fail) resolveVastEndpointConfig endpoint-map validation > malformed JSON present throws an actionable VastEndpointConfigError [1.00ms]
82 |     }
83 |   });
84 | 
85 |   test("valid JSON but non-object (array) throws a clear error", () => {
86 |     const reader = readerFrom({ VAST_ENDPOINTS_JSON: JSON.stringify(["not", "a", "map"]) });
87 |     expect(() => resolveVastEndpointConfig("vast/eliza-1-27b", reader)).toThrow(
                                                                             ^
error: expect(received).toThrow(expected)

Expected pattern: /VAST_ENDPOINTS_JSON is set but is not a JSON object/

Received function did not throw
Received value: null

      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:87:73)
(fail) resolveVastEndpointConfig endpoint-map validation > valid JSON but non-object (array) throws a clear error [0.38ms]
91 | 
92 |   test("valid JSON but entry value of wrong type throws a clear error", () => {
93 |     const reader = readerFrom({
94 |       VAST_ENDPOINTS_JSON: JSON.stringify({ "vast/eliza-1-27b": 12345 }),
95 |     });
96 |     expect(() => resolveVastEndpointConfig("vast/eliza-1-27b", reader)).toThrow(
                                                                             ^
error: expect(received).toThrow(expected)

Expected pattern: /entry for "vast\/eliza-1-27b" must be a string base URL or an object/

Received function did not throw
Received value: null

      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:96:73)
(fail) resolveVastEndpointConfig endpoint-map validation > valid JSON but entry value of wrong type throws a clear error [0.39ms]
106 |     });
107 |     try {
108 |       resolveVastEndpointConfig("vast/eliza-1-27b", reader);
109 |       throw new Error("expected VastEndpointConfigError");
110 |     } catch (error) {
111 |       expect(error).toBeInstanceOf(VastEndpointConfigError);
                          ^
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class VastEndpointConfigError extends Error]
Received value: 104 |         "vast/eliza-1-27b": { baseUrl: { host: SECRET } },
105 |       }),
106 |     });
107 |     try {
108 |       resolveVastEndpointConfig("vast/eliza-1-27b", reader);
109 |       throw new Error("expected VastEndpointConfigError");
                      ^
error: expected VastEndpointConfigError
      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:109:17)


      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:111:21)
(fail) resolveVastEndpointConfig endpoint-map validation > object entry with a non-string field throws and does not leak the value [0.29ms]
(pass) resolveVastFallbackModel fallback-map validation > absent fallback map uses the built-in alias chain (unchanged) [0.25ms]
(pass) resolveVastFallbackModel fallback-map validation > valid fallback map overrides the alias chain (unchanged) [0.08ms]
144 |     expect(fallback).toBe("vast/eliza-1-2b");
145 |   });
146 | 
147 |   test("malformed fallback map present throws VastEndpointConfigError", () => {
148 |     const reader = readerFrom({ VAST_FALLBACK_MODEL_MAP_JSON: "{ not json" });
149 |     expect(() => resolveVastFallbackModel("vast/eliza-1-27b", reader)).toThrow(
                                                                             ^
error: expect(received).toThrow(expected)

Expected constructor: VastEndpointConfigError

Received function did not throw
Received value: null

      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:149:72)
(fail) resolveVastFallbackModel fallback-map validation > malformed fallback map present throws VastEndpointConfigError [0.81ms]
153 | 
154 |   test("fallback map with non-string entry throws a clear error", () => {
155 |     const reader = readerFrom({
156 |       VAST_FALLBACK_MODEL_MAP_JSON: JSON.stringify({ "vast/eliza-1-27b": { model: "x" } }),
157 |     });
158 |     expect(() => resolveVastFallbackModel("vast/eliza-1-27b", reader)).toThrow(
                                                                             ^
error: expect(received).toThrow(expected)

Expected pattern: /must map to a fallback model id string/

Received function did not throw
Received value: null

      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:158:72)
(fail) resolveVastFallbackModel fallback-map validation > fallback map with non-string entry throws a clear error [0.23ms]
(pass) resolveVastFallbackModel fallback-map validation > empty-string env var is treated as absent (legal), not malformed [0.09ms]

 6 pass
 6 fail
 19 expect() calls
Ran 12 tests across 1 file. [70.00ms]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior change; this is endpoint-map config validation, not a model call.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - config-map validation has no DB/wallet/file/scheduled-task artifacts; the parse-time behavior is fully covered by the inline failing-first vs passing unit tests linked in backend-logs.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior change.`

## Backend + frontend logs

Backend = the parser under test. Failing-first (old silent-empty behavior with
the new export retained) vs passing (fixed) focused runs:

<details>
<summary>Failing-first (6 fail / 6 pass) — malformed-present inputs are silently dropped</summary>

```
(pass) resolveVastFallbackModel fallback-map validation > absent fallback map uses the built-in alias chain (unchanged) [0.25ms]
(pass) resolveVastFallbackModel fallback-map validation > valid fallback map overrides the alias chain (unchanged) [0.08ms]
144 |     expect(fallback).toBe("vast/eliza-1-2b");
145 |   });
146 | 
147 |   test("malformed fallback map present throws VastEndpointConfigError", () => {
148 |     const reader = readerFrom({ VAST_FALLBACK_MODEL_MAP_JSON: "{ not json" });
149 |     expect(() => resolveVastFallbackModel("vast/eliza-1-27b", reader)).toThrow(
                                                                             ^
error: expect(received).toThrow(expected)

Expected constructor: VastEndpointConfigError

Received function did not throw
Received value: null

      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:149:72)
(fail) resolveVastFallbackModel fallback-map validation > malformed fallback map present throws VastEndpointConfigError [0.81ms]
153 | 
154 |   test("fallback map with non-string entry throws a clear error", () => {
155 |     const reader = readerFrom({
156 |       VAST_FALLBACK_MODEL_MAP_JSON: JSON.stringify({ "vast/eliza-1-27b": { model: "x" } }),
157 |     });
158 |     expect(() => resolveVastFallbackModel("vast/eliza-1-27b", reader)).toThrow(
                                                                             ^
error: expect(received).toThrow(expected)

Expected pattern: /must map to a fallback model id string/

Received function did not throw
Received value: null

      at <anonymous> (/home/home/Developer/eliza-swarm/state/worktrees/issue-30756/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts:158:72)
(fail) resolveVastFallbackModel fallback-map validation > fallback map with non-string entry throws a clear error [0.23ms]
(pass) resolveVastFallbackModel fallback-map validation > empty-string env var is treated as absent (legal), not malformed [0.09ms]

 6 pass
 6 fail
 19 expect() calls
Ran 12 tests across 1 file. [70.00ms]
```
</details>

<details>
<summary>Passing (12 pass / 0 fail) — fixed impl via package runner (bun --isolate)</summary>

```
bun test v1.3.14 (0d9b296a)

src/lib/providers/vast-endpoints.test.ts:
(pass) resolveVastEndpointConfig endpoint-map validation > absent VAST_ENDPOINTS_JSON falls back to global config (unchanged) [1.00ms]
(pass) resolveVastEndpointConfig endpoint-map validation > valid VAST_ENDPOINTS_JSON resolves dedicated endpoint precedence (unchanged) [0.35ms]
(pass) resolveVastEndpointConfig endpoint-map validation > string endpoint entry is accepted and used as base URL (unchanged) [0.16ms]
(pass) resolveVastEndpointConfig endpoint-map validation > malformed JSON present throws an actionable VastEndpointConfigError [0.57ms]
(pass) resolveVastEndpointConfig endpoint-map validation > valid JSON but non-object (array) throws a clear error [0.25ms]
(pass) resolveVastEndpointConfig endpoint-map validation > valid JSON but entry value of wrong type throws a clear error [0.33ms]
(pass) resolveVastEndpointConfig endpoint-map validation > object entry with a non-string field throws and does not leak the value [0.26ms]
(pass) resolveVastFallbackModel fallback-map validation > absent fallback map uses the built-in alias chain (unchanged) [0.28ms]
(pass) resolveVastFallbackModel fallback-map validation > valid fallback map overrides the alias chain (unchanged) [0.26ms]
(pass) resolveVastFallbackModel fallback-map validation > malformed fallback map present throws VastEndpointConfigError [0.12ms]
(pass) resolveVastFallbackModel fallback-map validation > fallback map with non-string entry throws a clear error [0.14ms]
(pass) resolveVastFallbackModel fallback-map validation > empty-string env var is treated as absent (legal), not malformed [0.08ms]

 12 pass
 0 fail
 25 expect() calls
Ran 12 tests across 1 file. [57.00ms]
```
</details>

<details>
<summary>Full provider suite under --isolate (as run-bun-tests.mjs runs it): 220 pass / 2 skip / 0 fail</summary>

```
(skip) adaptive thinking live OpenRouter trajectory > sends adaptive thinking without a manual budget and returns a live response
(skip) Atlas Cloud video provider live > generates a real Atlas-hosted video

 220 pass
 2 skip
 0 fail
 531 expect() calls
Ran 222 tests across 27 files. [11.23s]
```
</details>

Frontend: `N/A - no frontend surface.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - server-only change, no UI.`

### After

`N/A - server-only change, no UI.`

### Walkthrough video

`N/A - server-only change, no UI.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- Root `bun run verify` was **not** run to completion: it drives Turbo
  `typecheck`+`lint:check` across the entire ~150-package monorepo plus ~20
  audits, which is impractical to finish on this 16 GB Raspberry Pi host in a
  bounded session. Instead the owning-package and relevant repo gates were run
  and pass:
  - `packages/cloud/shared` `typecheck` — clean (no `tsc` errors).
  - `packages/cloud/shared` `lint:check` (Biome) — `Checked 2627 files … No fixes applied.`
  - `bun run check:biome-version` — `Biome version consistency passed.`
  - `bun run audit:focused-tests` — `clean — no focused tests, no untracked skips.`
  - `bun run audit:test-lane-membership` — passes; `packages/cloud/shared`
    covered by the cloud bespoke `test-cloud-run.mjs` roots.
  This blocker is environmental (host scale), not a code failure in this diff.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@b676280384b15df54204276e34bb8740db26936f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@b676280384b15df54204276e34bb8740db26936f:packages/skills/skills/contribute-to-eliza"} -->



