### PR TITLE
fix(openai): stop retrying exhausted provider credit

### DIFF
--- a/plugins/plugin-openai/__tests__/quota-retry-http.test.ts
+++ b/plugins/plugin-openai/__tests__/quota-retry-http.test.ts
@@ -25,7 +25,10 @@ async function fixture(
   code: string,
   recover: boolean,
   retryAfter?: string,
-  streamRecovery = false
+  streamRecovery = false,
+  structured = false,
+  status = 429,
+  failAfterOutput = false
 ) {
   let requests = 0;
   const requestTimes: number[] = [];
@@ -34,9 +37,9 @@ async function fixture(
     requests++;
     requestTimes.push(performance.now());
     response.setHeader("Content-Type", "application/json");
-    if (!recover || requests === 1) {
+    if (!failAfterOutput && (!recover || requests === 1)) {
       if (retryAfter) response.setHeader("Retry-After", retryAfter);
-      response.writeHead(429);
+      response.writeHead(status);
       response.end(
         JSON.stringify({ error: { message: "Provider rejected request", type: code, code } })
       );
@@ -52,8 +55,10 @@ async function fixture(
       };
       response.end(
         [
-          `data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: { role: "assistant", content: "Recovered" }, finish_reason: null }] })}\n\n`,
-          `data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } })}\n\n`,
+          `data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: structured ? { role: "assistant", tool_calls: [{ index: 0, id: "call_test", type: "function", function: { name: "reply", arguments: '{"text":"Recovered"}' } }] } : { role: "assistant", content: "Recovered" }, finish_reason: null }] })}\n\n`,
+          failAfterOutput
+            ? `data: ${JSON.stringify({ error: { message: "Stream failed after output", type: "server_error", code: "server_error" } })}\n\n`
+            : `data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: {}, finish_reason: structured ? "tool_calls" : "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } })}\n\n`,
           "data: [DONE]\n\n",
         ].join("")
       );
@@ -99,6 +104,8 @@ describe("provider quota retry HTTP boundary", () => {
     ["credit_balance_exhausted", "live"],
     ["insufficient_quota", "buffered"],
     ["credit_balance_exhausted", "buffered"],
+    ["insufficient_quota", "structured"],
+    ["credit_balance_exhausted", "structured"],
   ])(
     "does not retry %s in %s mode",
     async (code, mode) => {
@@ -109,6 +116,7 @@ describe("provider quota retry HTTP boundary", () => {
           prompt: "Reply briefly.",
           signal: AbortSignal.timeout(5000),
           stream: mode !== "generate",
+          streamStructured: mode === "structured",
         });
         if (typeof result !== "string") {
           for await (const chunk of result.textStream) {
@@ -151,11 +159,69 @@ describe("provider quota retry HTTP boundary", () => {
     expect(test.requests()).toBe(2);
   }, 10000);
 
-  it("cancels a provider-directed retry wait without another request", async () => {
-    const test = await fixture("rate_limit_exceeded", true, "30");
+  it.each([429, 500])(
+    "recovers structured live output after HTTP %s",
+    async (status) => {
+      const test = await fixture("rate_limit_exceeded", true, "0.01", true, true, status);
+      vi.stubEnv("ELIZA_PLANNER_FULL_ACTION_SURFACE", "0");
+      const result = await handleTextSmall(test.runtime, {
+        prompt: "Reply briefly.",
+        stream: true,
+        streamStructured: true,
+        tools: [
+          {
+            name: "reply",
+            description: "Return reply",
+            parameters: {
+              type: "object",
+              properties: { text: { type: "string" } },
+              required: ["text"],
+            },
+          },
+        ],
+      });
+      if (typeof result === "string") throw new Error("Expected streamed result");
+      let text = "";
+      for await (const chunk of result.textStream) text += chunk;
+      expect(text).toBe('{"text":"Recovered"}');
+      expect(test.requests()).toBe(2);
+    },
+    10000
+  );
+
+  it("never retries structured output after an argument delta reached the caller", async () => {
+    const test = await fixture("server_error", false, undefined, true, true, 500, true);
+    vi.stubEnv("ELIZA_PLANNER_FULL_ACTION_SURFACE", "0");
+    const result = await handleTextSmall(test.runtime, {
+      prompt: "Reply briefly.",
+      stream: true,
+      streamStructured: true,
+    });
+    if (typeof result === "string") throw new Error("Expected streamed result");
+    let text = "";
     await expect(
-      handleTextSmall(test.runtime, { prompt: "Reply briefly.", signal: AbortSignal.timeout(1000) })
+      (async () => {
+        for await (const chunk of result.textStream) text += chunk;
+      })()
     ).rejects.toThrow();
+    expect(text).toBe('{"text":"Recovered"}');
     expect(test.requests()).toBe(1);
   }, 10000);
+
+  it.each([false, true])(
+    "cancels provider-directed retry wait (structured=%s)",
+    async (structured) => {
+      const test = await fixture("rate_limit_exceeded", true, "30");
+      await expect(
+        handleTextSmall(test.runtime, {
+          prompt: "Reply briefly.",
+          signal: AbortSignal.timeout(1000),
+          stream: structured,
+          streamStructured: structured,
+        })
+      ).rejects.toThrow();
+      expect(test.requests()).toBe(1);
+    },
+    10000
+  );
 });

--- a/plugins/plugin-openai/__tests__/quota-retry-http.test.ts
+++ b/plugins/plugin-openai/__tests__/quota-retry-http.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Exercises the real text handler and AI SDK against a local HTTP provider.
+ * Permanent quota errors must reach the caller without redundant requests;
+ * transient rate limits must still recover on the next provider attempt.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { AgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleTextSmall } from "../models/text";
+
+let server: Server | undefined;
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  if (server) {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server?.close((error) => (error ? reject(error) : resolve()))
+    );
+    server = undefined;
+  }
+});
+
+async function fixture(
+  code: string,
+  recover: boolean,
+  retryAfter?: string,
+  streamRecovery = false
+) {
+  let requests = 0;
+  const requestTimes: number[] = [];
+  server = createServer((request, response) => {
+    request.resume();
+    requests++;
+    requestTimes.push(performance.now());
+    response.setHeader("Content-Type", "application/json");
+    if (!recover || requests === 1) {
+      if (retryAfter) response.setHeader("Retry-After", retryAfter);
+      response.writeHead(429);
+      response.end(
+        JSON.stringify({ error: { message: "Provider rejected request", type: code, code } })
+      );
+      return;
+    }
+    if (streamRecovery) {
+      response.setHeader("Content-Type", "text/event-stream");
+      const chunk = {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "latency-test",
+      };
+      response.end(
+        [
+          `data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: { role: "assistant", content: "Recovered" }, finish_reason: null }] })}\n\n`,
+          `data: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } })}\n\n`,
+          "data: [DONE]\n\n",
+        ].join("")
+      );
+      return;
+    }
+    response.end(
+      JSON.stringify({
+        id: "chatcmpl-test",
+        object: "chat.completion",
+        created: 1,
+        model: "latency-test",
+        choices: [
+          { index: 0, message: { role: "assistant", content: "Recovered" }, finish_reason: "stop" },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      })
+    );
+  });
+  await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
+  const baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}/v1`;
+  vi.stubEnv("OPENAI_API_KEY", "local-test-key");
+  vi.stubEnv("OPENAI_BASE_URL", baseURL);
+  vi.stubEnv("CEREBRAS_API_KEY", "");
+  vi.stubEnv("ELIZA_PROVIDER", "openai");
+  const runtime = new AgentRuntime({
+    character: {
+      name: "QuotaRetryTest",
+      settings: {
+        OPENAI_API_KEY: "local-test-key",
+        OPENAI_BASE_URL: baseURL,
+        OPENAI_SMALL_MODEL: "latency-test",
+      },
+    },
+  });
+  return { runtime, requests: () => requests, requestTimes };
+}
+
+describe("provider quota retry HTTP boundary", () => {
+  it.each([
+    ["insufficient_quota", "generate"],
+    ["credit_balance_exhausted", "generate"],
+    ["insufficient_quota", "live"],
+    ["credit_balance_exhausted", "live"],
+    ["insufficient_quota", "buffered"],
+    ["credit_balance_exhausted", "buffered"],
+  ])(
+    "does not retry %s in %s mode",
+    async (code, mode) => {
+      const test = await fixture(code, false);
+      vi.stubEnv("ELIZA_PLANNER_FULL_ACTION_SURFACE", mode === "buffered" ? "1" : "0");
+      const call = async () => {
+        const result = await handleTextSmall(test.runtime, {
+          prompt: "Reply briefly.",
+          signal: AbortSignal.timeout(5000),
+          stream: mode !== "generate",
+        });
+        if (typeof result !== "string") {
+          for await (const chunk of result.textStream) {
+            throw new Error(`Unexpected output before quota rejection: ${chunk}`);
+          }
+        }
+      };
+      await expect(call()).rejects.toMatchObject({ statusCode: 429 });
+      expect(test.requests()).toBe(1);
+    },
+    10000
+  );
+
+  it("retries a temporary rate limit and delivers the recovered response", async () => {
+    const test = await fixture("rate_limit_exceeded", true);
+    await expect(handleTextSmall(test.runtime, { prompt: "Reply briefly." })).resolves.toBe(
+      "Recovered"
+    );
+    expect(test.requests()).toBe(2);
+  }, 10000);
+
+  it("honors the provider retry delay before recovering", async () => {
+    const test = await fixture("rate_limit_exceeded", true, "0.8");
+    await expect(handleTextSmall(test.runtime, { prompt: "Reply briefly." })).resolves.toBe(
+      "Recovered"
+    );
+    expect(test.requests()).toBe(2);
+    expect(test.requestTimes[1] - test.requestTimes[0]).toBeGreaterThanOrEqual(790);
+  }, 10000);
+
+  it("recovers a buffered stream using the original rate-limit error", async () => {
+    const test = await fixture("rate_limit_exceeded", true, undefined, true);
+    vi.stubEnv("ELIZA_PLANNER_FULL_ACTION_SURFACE", "1");
+    const result = await handleTextSmall(test.runtime, { prompt: "Reply briefly.", stream: true });
+    expect(typeof result).not.toBe("string");
+    if (typeof result === "string") throw new Error("Expected streamed result");
+    let text = "";
+    for await (const chunk of result.textStream) text += chunk;
+    expect(text).toBe("Recovered");
+    expect(test.requests()).toBe(2);
+  }, 10000);
+
+  it("cancels a provider-directed retry wait without another request", async () => {
+    const test = await fixture("rate_limit_exceeded", true, "30");
+    await expect(
+      handleTextSmall(test.runtime, { prompt: "Reply briefly.", signal: AbortSignal.timeout(1000) })
+    ).rejects.toThrow();
+    expect(test.requests()).toBe(1);
+  }, 10000);
+});

--- a/plugins/plugin-openai/__tests__/streamstructured-tool-input-delta.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/streamstructured-tool-input-delta.shape.test.ts
@@ -8,6 +8,7 @@
  * the PR.
  */
 import { describe, expect, it, vi } from "vitest";
+import { handleTextSmall } from "../models/text";
 
 const aiMocks = vi.hoisted(() => ({
   generateText: vi.fn(),
@@ -96,7 +97,6 @@ describe("streamStructured tool-input-delta forwarding", () => {
     armToolForcedStream({ alsoText: true });
 
     const onStreamChunk = vi.fn();
-    const { handleTextSmall } = await import("../models/text");
     const stream = (await handleTextSmall(createRuntime(), {
       prompt: "stage-1",
       stream: true,
@@ -124,7 +124,6 @@ describe("streamStructured tool-input-delta forwarding", () => {
   it("streamStructured=true: non-delta fullStream parts (start/end/finish) are filtered out", async () => {
     armToolForcedStream();
 
-    const { handleTextSmall } = await import("../models/text");
     const stream = (await handleTextSmall(createRuntime(), {
       prompt: "stage-1",
       stream: true,
@@ -159,7 +158,6 @@ describe("streamStructured tool-input-delta forwarding", () => {
       usage: companion(),
     });
 
-    const { handleTextSmall } = await import("../models/text");
     const stream = (await handleTextSmall(createRuntime(), {
       prompt: "abort structured stream",
       stream: true,
@@ -193,7 +191,6 @@ describe("streamStructured tool-input-delta forwarding", () => {
       })
     );
 
-    const { handleTextSmall } = await import("../models/text");
     const stream = (await handleTextSmall(createRuntime(), {
       prompt: "plain stream",
       stream: true,

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -2013,8 +2013,8 @@ function enrichProviderCallError(error: unknown): unknown {
 
 /**
  * Whether a thrown model-call error is a transient provider hiccup that is
- * worth retrying. The AI SDK already retries clear-cut retryables (408/409/429/
- * 5xx) via its own `maxRetries`, but Cerebras under load returns its transient
+ * worth retrying. This layer owns retries for transient 408/409/429/5xx
+ * responses. Cerebras under load also returns its transient
  * "Encountered a server error, please try again" as an HTTP **400**, which the
  * SDK classifies as non-retryable and surfaces immediately — failing a coding
  * build that the very same request would complete on a second attempt (observed
@@ -2058,12 +2058,41 @@ function isSpuriousToolPairingRejection(error: unknown): boolean {
   return SPURIOUS_TOOL_PAIRING_400_RE.test(providerErrorSearchText(error));
 }
 
+function isPermanentQuotaError(error: unknown): boolean {
+  const codes = new Set(["insufficient_quota", "credit_balance_exhausted"]);
+  const inspect = (value: unknown): boolean => {
+    if (typeof value !== "object" || value === null) return false;
+    const record = value as Record<string, unknown>;
+    return (
+      (typeof record.code === "string" && codes.has(record.code)) ||
+      (typeof record.type === "string" && codes.has(record.type)) ||
+      (typeof record.error === "object" &&
+        record.error !== null &&
+        ["code", "type"].some((key) => {
+          const field = (record.error as Record<string, unknown>)[key];
+          return typeof field === "string" && codes.has(field);
+        }))
+    );
+  };
+  if (typeof error !== "object" || error === null) return false;
+  const record = error as Record<string, unknown>;
+  if (inspect(record) || inspect(record.data)) return true;
+  if (typeof record.responseBody !== "string") return false;
+  try {
+    return inspect(JSON.parse(record.responseBody));
+  } catch {
+    // error-policy:J3 malformed provider bodies cannot establish permanent quota exhaustion.
+    return false;
+  }
+}
+
 function isTransientProviderError(error: unknown): boolean {
   const e = error as
     | { statusCode?: number; status?: number; message?: string; data?: unknown }
     | undefined;
   if (!e) return false;
   const status = e.statusCode ?? e.status;
+  if (status === 429 && isPermanentQuotaError(error)) return false;
   if (status === 408 || status === 409 || status === 429) return true;
   if (typeof status === "number" && status >= 500 && status < 600) return true;
   // Include the raw response body: the AI SDK derives `message` from the
@@ -2160,6 +2189,23 @@ function describeRetryReason(error: unknown): string {
   return (error as { message?: string })?.message ?? String(error);
 }
 
+function providerRetryDelay(error: unknown, fallbackMs: number): number {
+  if (typeof error !== "object" || error === null) return fallbackMs;
+  const headers = (error as { responseHeaders?: Record<string, string> }).responseHeaders;
+  if (!headers) return fallbackMs;
+  const milliseconds = headers["retry-after-ms"];
+  const secondsOrDate = headers["retry-after"];
+  let delay = Number.NaN;
+  if (milliseconds?.trim()) delay = Number(milliseconds);
+  if (!Number.isFinite(delay) && secondsOrDate?.trim()) {
+    const seconds = Number(secondsOrDate);
+    delay = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(secondsOrDate) - Date.now();
+  }
+  // Retain the SDK's supported retry-header window while consolidating retry
+  // ownership. The same abort-aware wait handles server and local backoff.
+  return Number.isFinite(delay) && delay >= 0 && delay < 60_000 ? delay : fallbackMs;
+}
+
 /**
  * The single backoff seam every transient-retry lane goes through. Two jobs:
  *
@@ -2167,7 +2213,7 @@ function describeRetryReason(error: unknown): string {
  *    MODEL_USED and the result's `providerMetadata` surface, and emits one
  *    structured warn (lane/attempt/reason/model/backoff) per retry so a
  *    degraded provider is visible without wire captures.
- * 2. Abort-awareness — the exponential delay (capped at 3s + jitter) is where
+ * 2. Abort-awareness — the provider-directed or exponential delay is where
  *    a cancelled request would otherwise sit for seconds; an abort rejects the
  *    wait immediately with the caller's reason, so no attempt can start after
  *    cancellation.
@@ -2183,8 +2229,10 @@ async function waitForTransientRetry(opts: {
   const { lane, maxRetries, error, model, signal, state } = opts;
   state.retryCount += 1;
   state.lastRetryReason = describeRetryReason(error);
-  const backoffMs =
-    Math.min(3000, 300 * 2 ** (state.retryCount - 1)) + Math.floor(Math.random() * 200);
+  const backoffMs = providerRetryDelay(
+    error,
+    Math.min(3000, 300 * 2 ** (state.retryCount - 1)) + Math.floor(Math.random() * 200)
+  );
   logger.warn(
     {
       src: "plugin-openai",
@@ -2319,10 +2367,23 @@ async function consumeStreamWithTransientRetry(
         onChunk?.(chunk);
         text += chunk;
       }
-      const toolCalls = await result.toolCalls;
-      const usage = await result.usage;
-      const finishReason = (await result.finishReason) as string | undefined;
+      // Observe every companion before propagating the provider error. Failed
+      // requests can reject toolCalls with a generic NoOutputGeneratedError,
+      // which must not hide the captured failure from the retry classifier.
+      const [toolsOutcome, usageOutcome, finishOutcome, textOutcome] = await Promise.allSettled([
+        result.toolCalls,
+        result.usage,
+        result.finishReason,
+        result.text,
+      ]);
       if (capturedError) throw capturedError;
+      if (toolsOutcome.status === "rejected") throw toolsOutcome.reason;
+      if (usageOutcome.status === "rejected") throw usageOutcome.reason;
+      if (finishOutcome.status === "rejected") throw finishOutcome.reason;
+      if (textOutcome.status === "rejected") throw textOutcome.reason;
+      const toolCalls = toolsOutcome.value;
+      const usage = usageOutcome.value;
+      const finishReason = finishOutcome.value as string | undefined;
       return { text, toolCalls, usage, finishReason };
     } catch (rawError) {
       // error-policy:J2 context-adding rethrow — terminal, retry-exhausted, or
@@ -2493,6 +2554,9 @@ async function generateTextByModelType(
   const generateParams: NativeTextParams = {
     model,
     ...deepToWellFormedUnicode(promptOrMessages),
+    // This layer owns retries so the SDK cannot retry permanent quota failures
+    // before our provider-aware classifier observes the response.
+    maxRetries: 0,
     system: systemPrompt === undefined ? undefined : deepToWellFormedUnicode(systemPrompt),
     allowSystemInMessages: true,
     ...(params.signal ? { abortSignal: params.signal } : {}),

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -2679,8 +2679,8 @@ async function generateTextByModelType(
     // empty stream (or as a throw on the first pull), and at that point
     // nothing has reached the user, so a fresh attempt is invisible. Once a
     // token has been delivered a failure stays fatal — replaying a partial
-    // stream would double-deliver text. The first item is pre-pulled here and
-    // replayed by the generator below; abandoned attempts get their companion
+    // stream would double-deliver text. The prefix through the first forwarded
+    // delta is pre-pulled and replayed below; abandoned attempts get their companion
     // promises defused so an errored, unconsumed result cannot surface as an
     // unhandled rejection.
     let result!: Awaited<ReturnType<typeof streamText>>;
@@ -2693,8 +2693,10 @@ async function generateTextByModelType(
     let streamCompanions!: ReturnType<typeof observeStreamCompanions>;
     let streamIterator!: AsyncIterator<unknown>;
     let firstItem: IteratorResult<unknown> | undefined;
+    let attemptPrefix: unknown[] = [];
     for (let attempt = 0; ; attempt++) {
       capturedStreamError = undefined;
+      attemptPrefix = [];
       attestLlmInputSubstring(details);
       result = await streamText({
         ...generateParams,
@@ -2709,8 +2711,24 @@ async function generateTextByModelType(
       const source = params.streamStructured === true ? result.fullStream : result.textStream;
       streamIterator = (source as AsyncIterable<unknown>)[Symbol.asyncIterator]();
       try {
-        firstItem = await streamIterator.next();
+        for (;;) {
+          firstItem = await streamIterator.next();
+          if (firstItem.done) break;
+          attemptPrefix.push(firstItem.value);
+          if (params.streamStructured !== true) break;
+          // fullStream emits lifecycle frames before the HTTP request settles.
+          // Retain the prefix until an argument delta can reach the caller;
+          // otherwise a start frame would commit a still-retryable attempt.
+          const part = firstItem.value as {
+            type: string;
+            inputTextDelta?: string;
+            delta?: string;
+          };
+          if (part.type === "tool-input-delta" && (part.inputTextDelta ?? part.delta)) break;
+        }
       } catch (error) {
+        // error-policy:J2 the captured provider failure is classified below and
+        // rethrown by the stream boundary when recovery is not permitted.
         firstItem = undefined;
         capturedStreamError ??= error;
       }
@@ -2747,9 +2765,9 @@ async function generateTextByModelType(
         state: retryState,
       });
     }
-    // Replays the pre-pulled first item, then continues the committed attempt.
+    // Replay every retained frame of the selected attempt in its original order.
     const iterateStream = async function* (): AsyncGenerator<unknown> {
-      if (firstItem && !firstItem.done) yield firstItem.value;
+      yield* attemptPrefix;
       if (firstItem?.done) return;
       for (;;) {
         const next = await streamIterator.next();


### PR DESCRIPTION
Live provider calls returned HTTP 429 with `insufficient_quota` / `credit_balance_exhausted`, but the text handler and AI SDK both retried them. The handler now rejects these permanent failures after one request, owns the retry budget, preserves supported provider retry delays, and cancels pending backoff when the caller aborts.

Buffered streams now observe their companion promises and propagate the original provider error before a generic SDK no-output error can hide it. Structured live streams retain and replay their complete pre-output event prefix, so the SDK start event cannot commit an attempt before the provider accepts it. Temporary failures recover before output; failures after output are propagated without replay. The structured-stream test imports its handler before timed assertions so runtime module loading does not exhaust its behavior-test deadline.

Closes #30752.

Validation:
- Real handler + AI SDK + local HTTP server: permanent failures make one request in non-streaming, live-streaming, structured live-streaming, and buffered modes; temporary limits recover; provider delays and cancellation are exercised. Structured HTTP 429/500 recovery failed on the previous PR head and passes after retaining the pre-output prefix. A midstream failure after argument output rejects without a second request.
- On the unchanged base, all six quota cases made two requests and reached the five-second test deadline. The fixed seven-case suite completed in 629 ms after loading, versus 32.05 seconds of test execution on base. This measures the failure path, not successful inference speed.
- Full package suite: 442 tests pass across 32 files. Package typecheck and lint pass.
- Live Cerebras requests through the handler and isolated local conversation API return actual synthetic replies with persisted history. These samples establish integration behavior, not a controlled performance improvement.
- Repository-wide `bun run verify`: passed, including 376 Turbo tasks and final repository audits.

Scope: text-call failure latency only. No model context, credentials, billing settings, or deployment configuration changes. Frontend screenshots and video are N/A because no UI behavior changes. Full deployed agent and microphone-to-speaker latency remain outside this patch's acceptance evidence.
