### PR TITLE
fix(cloud): secure billing settings and expose mail submission receipts

### DIFF
--- a/packages/cloud/api/v1/billing/settings/route.authorization.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.authorization.test.ts
@@ -26,6 +26,7 @@ const primaryReads = mock(async () => ({
   email: "owner@example.test",
   wallet_address: null,
 }));
+class MockUnavailableError extends Error {}
 mock.module("@/db/repositories/users", () => ({
   usersRepository: { findWithOrganizationForWrite: primaryReads },
 }));
@@ -65,6 +66,7 @@ mock.module("@/lib/services/auto-top-up", () => ({
   },
   AutoTopUpSettingsValidationError: ValidationError,
   AutoTopUpSettingsPolicyError: PolicyError,
+  AutoTopUpSettingsUnavailableError: MockUnavailableError,
   autoTopUpService: {
     getSettings: async () => ({
       enabled: false,

--- a/packages/cloud/api/v1/billing/settings/route.authorization.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.authorization.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Exercises billing-settings HTTP requests through the real session authority
+ * and cookie guard, with deterministic primary-storage and service boundaries.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv, AuthedUser } from "@/types/cloud-worker-env";
+
+let currentRole = "owner";
+let cachedRole = "owner";
+let currentTenant = "org-1";
+let validSession = true;
+let revokeDuringValidation = false;
+let organizationAvailable = true;
+const effects: Array<{ organizationId: string; settings: object }> = [];
+const primaryReads = mock(async () => ({
+  id: "user-1",
+  role: currentRole,
+  organization_id: currentTenant,
+  organization: { id: currentTenant, name: "Organization", is_active: true },
+  steward_user_id: "steward-1",
+  is_active: true,
+  is_anonymous: false,
+  deleted_at: null,
+  expires_at: null,
+  email: "owner@example.test",
+  wallet_address: null,
+}));
+mock.module("@/db/repositories/users", () => ({
+  usersRepository: { findWithOrganizationForWrite: primaryReads },
+}));
+mock.module("@/lib/auth/steward-client", () => ({
+  isStagingSessionTokenCandidate: () => false,
+  verifyStewardTokenCached: async () =>
+    validSession ? { userId: "steward-1" } : null,
+}));
+mock.module("@/lib/auth/staging-session-binding", () => ({
+  loadVerifiedStagingSessionUser: async () => null,
+}));
+mock.module("@/lib/services/account-lifecycle-authority", () => ({
+  readOrganizationLifecycleAuthority: async () => ({ state: "active" }),
+  organizationLifecycleAllowsNewWork: () => true,
+}));
+mock.module("@/db/repositories", () => ({
+  organizationsRepository: {
+    findById: async (organizationId: string) =>
+      organizationAvailable
+        ? {
+            id: organizationId,
+            pay_as_you_go_from_earnings: false,
+            stripe_customer_id: "must-not-leak",
+            stripe_default_payment_method: "must-not-leak",
+          }
+        : undefined,
+  },
+}));
+class ValidationError extends Error {}
+class PolicyError extends Error {}
+mock.module("@/lib/services/auto-top-up", () => ({
+  AUTO_TOP_UP_LIMITS: {
+    MIN_AMOUNT: 1,
+    MAX_AMOUNT: 1000,
+    MIN_THRESHOLD: 0,
+    MAX_THRESHOLD: 1000,
+  },
+  AutoTopUpSettingsValidationError: ValidationError,
+  AutoTopUpSettingsPolicyError: PolicyError,
+  autoTopUpService: {
+    getSettings: async () => ({
+      enabled: false,
+      amount: 0,
+      threshold: 0,
+      hasPaymentMethod: false,
+    }),
+    updateSettings: async (
+      organizationId: string,
+      settings: object,
+      authorize: () => Promise<void>,
+    ) => {
+      if (revokeDuringValidation) currentRole = "member";
+      await authorize();
+      effects.push({ organizationId, settings });
+    },
+  },
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
+}));
+
+const { default: route } = await import("./route");
+const { cookieMutationGuardMiddleware } = await import(
+  "../../../src/middleware/cookie-mutation-guard"
+);
+const app = new Hono<AppEnv>();
+app.use("*", async (c, next) => {
+  const user: AuthedUser = {
+    id: "user-1",
+    organization_id: "org-1",
+    organization: { id: "org-1", is_active: true },
+    role: cachedRole,
+    steward_id: "steward-1",
+    is_active: true,
+    is_anonymous: false,
+  };
+  c.set("user", user);
+  c.set("authMethod", "session");
+  await next();
+});
+app.use("*", cookieMutationGuardMiddleware);
+app.route("/api/v1/billing/settings", route);
+const url = "https://api.eliza.app/api/v1/billing/settings";
+const request = (headers: Record<string, string> = {}) =>
+  app.request(
+    url,
+    {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+        cookie: "steward-token=fixture",
+        origin: "https://api.eliza.app",
+        host: "api.eliza.app",
+        ...headers,
+      },
+      body: JSON.stringify({
+        autoTopUp: { enabled: false },
+        payAsYouGoFromEarnings: false,
+        organizationId: "org-other",
+      }),
+    },
+    {},
+  );
+
+beforeEach(() => {
+  currentRole = "owner";
+  cachedRole = "owner";
+  currentTenant = "org-1";
+  validSession = true;
+  revokeDuringValidation = false;
+  organizationAvailable = true;
+  effects.length = 0;
+  primaryReads.mockClear();
+});
+
+describe("billing settings current authority", () => {
+  test("owner/admin manage only their authenticated organization after two primary checks", async () => {
+    for (const role of ["owner", "admin"]) {
+      currentRole = role;
+      expect((await request()).status).toBe(200);
+    }
+    expect(effects.map((effect) => effect.organizationId)).toEqual([
+      "org-1",
+      "org-1",
+    ]);
+    expect(primaryReads).toHaveBeenCalledTimes(4);
+  });
+  test("member/guest and general API keys cannot reach persistence", async () => {
+    for (const role of ["member", "guest"]) {
+      currentRole = role;
+      expect((await request()).status).toBe(403);
+    }
+    currentRole = "owner";
+    expect((await request({ "x-api-key": "eliza_fixture" })).status).toBe(401);
+    expect(
+      (await request({ authorization: "Bearer eliza_fixture" })).status,
+    ).toBe(401);
+    expect(effects).toEqual([]);
+  });
+  test("stale membership and invalid session prevent effects", async () => {
+    currentTenant = "org-other";
+    expect((await request()).status).toBe(403);
+    currentTenant = "org-1";
+    validSession = false;
+    expect((await request()).status).toBe(401);
+    expect(effects).toEqual([]);
+  });
+  test("revocation during validation denies the final boundary", async () => {
+    revokeDuringValidation = true;
+    expect((await request()).status).toBe(403);
+    expect(primaryReads).toHaveBeenCalledTimes(2);
+    expect(effects).toEqual([]);
+  });
+  test("cross-origin and simple cookie mutations fail before primary authorization", async () => {
+    expect(
+      (await request({ origin: "https://untrusted.example" })).status,
+    ).toBe(403);
+    expect((await request({ "content-type": "text/plain" })).status).toBe(403);
+    expect(primaryReads).not.toHaveBeenCalled();
+    expect(effects).toEqual([]);
+  });
+  test("member reads remain uncached and do not disclose provider fields", async () => {
+    currentRole = "member";
+    cachedRole = "member";
+    const response = await app.request(
+      `${url}?organizationId=org-other`,
+      {},
+      {},
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.text()).not.toContain("must-not-leak");
+    expect(effects).toEqual([]);
+  });
+  test("missing organization is unavailable instead of a healthy default", async () => {
+    organizationAvailable = false;
+    const response = await app.request(url, {}, {});
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      code: "service_unavailable",
+    });
+  });
+});

--- a/packages/cloud/api/v1/billing/settings/route.availability.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.availability.test.ts
@@ -1,5 +1,5 @@
 /** Exercises unavailable billing settings through the real service and HTTP route with deterministic storage. */
-import { expect, mock, test } from "bun:test";
+import { beforeEach, expect, mock, test } from "bun:test";
 import type { Organization } from "@/db/repositories";
 
 const NOW = new Date("2026-08-17T00:00:00.000Z");
@@ -14,7 +14,18 @@ interface BillingAttributionFixture {
 }
 
 const findOrganizationById = mock(
-  async (): Promise<Organization | undefined> => undefined,
+  async (): Promise<
+    | Pick<
+        Organization,
+        | "id"
+        | "auto_top_up_enabled"
+        | "auto_top_up_amount"
+        | "auto_top_up_threshold"
+        | "stripe_default_payment_method"
+        | "pay_as_you_go_from_earnings"
+      >
+    | undefined
+  > => undefined,
 );
 const updateOrganization = mock(
   async (): Promise<Organization | undefined> => undefined,
@@ -124,3 +135,62 @@ test("real getSettings missing organization uses advertised unavailable response
   expect(updateOrganization).not.toHaveBeenCalled();
   expect(response.status).toBe(503);
 });
+
+beforeEach(() => {
+  findOrganizationById.mockResolvedValue(undefined);
+  updateOrganization.mockClear();
+  invalidateOrganizationCache.mockClear();
+  onOrganizationUpdated.mockClear();
+});
+
+test("real updateSettings missing organization returns PUT unavailable without mutations", async () => {
+  const response = await route.request("http://internal/", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ autoTopUp: { enabled: false } }),
+  });
+  expect(response.status).toBe(503);
+  expect(await response.json()).toMatchObject({
+    success: false,
+    code: "service_unavailable",
+    error: "Billing settings are unavailable",
+  });
+  expect(updateOrganization).not.toHaveBeenCalled();
+  expect(invalidateOrganizationCache).not.toHaveBeenCalled();
+  expect(onOrganizationUpdated).not.toHaveBeenCalled();
+});
+
+test.each([{}, { autoTopUp: {} }, { ignored: true }])(
+  "PUT with no recognized changes preserves storage and caches: %p",
+  async (body) => {
+    findOrganizationById.mockResolvedValue({
+      id: "org-1",
+      auto_top_up_enabled: false,
+      auto_top_up_amount: "10.00",
+      auto_top_up_threshold: "5.00",
+      stripe_default_payment_method: null,
+      pay_as_you_go_from_earnings: false,
+    });
+    const response = await route.request("http://internal/", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      success: true,
+      settings: {
+        autoTopUp: {
+          enabled: false,
+          amount: 10,
+          threshold: 5,
+          hasPaymentMethod: false,
+        },
+        payAsYouGoFromEarnings: false,
+      },
+    });
+    expect(updateOrganization).not.toHaveBeenCalled();
+    expect(invalidateOrganizationCache).not.toHaveBeenCalled();
+    expect(onOrganizationUpdated).not.toHaveBeenCalled();
+  },
+);

--- a/packages/cloud/api/v1/billing/settings/route.availability.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.availability.test.ts
@@ -1,0 +1,126 @@
+/** Exercises unavailable billing settings through the real service and HTTP route with deterministic storage. */
+import { expect, mock, test } from "bun:test";
+import type { Organization } from "@/db/repositories";
+
+const NOW = new Date("2026-08-17T00:00:00.000Z");
+
+interface BillingAttributionFixture {
+  userId: string | null;
+  affiliateCode: {
+    id: string;
+    user_id: string;
+    markup_percent: string;
+  } | null;
+}
+
+const findOrganizationById = mock(
+  async (): Promise<Organization | undefined> => undefined,
+);
+const updateOrganization = mock(
+  async (): Promise<Organization | undefined> => undefined,
+);
+const getControl = mock(async () => ({
+  mode: "durable" as const,
+  pausedAt: NOW,
+  legacyReconciledThrough: NOW,
+}));
+const findBlockingByOrganization = mock(async () => null);
+const findBlockingLegacyPaymentByOrganization = mock(async () => null);
+const listUsersByOrganization = mock(async () => []);
+const getBillingAttributionForOrganization = mock(
+  async (): Promise<BillingAttributionFixture> => ({
+    userId: null,
+    affiliateCode: null,
+  }),
+);
+
+mock.module("@/db/repositories", () => ({
+  affiliatesRepository: {
+    getBillingAttributionForOrganization,
+  },
+  autoTopUpAttemptsRepository: {
+    getControl,
+    findBlockingByOrganization,
+    findBlockingLegacyPaymentByOrganization,
+  },
+  organizationsRepository: {
+    findById: findOrganizationById,
+    update: updateOrganization,
+  },
+  usersRepository: {
+    listByOrganization: listUsersByOrganization,
+  },
+}));
+
+const onCreditMutation = mock(async () => undefined);
+const onOrganizationUpdated = mock(async () => undefined);
+mock.module("@/lib/cache/invalidation", () => ({
+  CacheInvalidation: {
+    onCreditMutation,
+    onOrganizationUpdated,
+  },
+}));
+
+const invalidateOrganizationCache = mock(async () => undefined);
+mock.module("@/lib/cache/organizations-cache", () => ({
+  invalidateOrganizationCache,
+}));
+
+const invalidateOrgTierCache = mock(async () => undefined);
+mock.module("@/lib/services/org-rate-limits", () => ({
+  invalidateOrgTierCache,
+}));
+
+const sendAutoTopUpSuccessEmail = mock(async () => true);
+const sendAutoTopUpDisabledEmail = mock(async () => true);
+mock.module("@/lib/services/email", () => ({
+  emailService: {
+    sendAutoTopUpSuccessEmail,
+    sendAutoTopUpDisabledEmail,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(),
+    error: mock(),
+    info: mock(),
+    warn: mock(),
+  },
+}));
+
+const ensureStripeCustomer = mock(async () => "cus_123");
+mock.module("@/lib/services/stripe-customer-authority", () => ({
+  stripeCustomerAuthorityService: { ensure: ensureStripeCustomer },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+  requireCurrentBillingManagerSession: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  moneyRateLimit: () => async (_c: unknown, next: () => Promise<void>) =>
+    next(),
+}));
+const { default: route } = await import("./route");
+test("real getSettings missing organization uses advertised unavailable response", async () => {
+  findOrganizationById.mockResolvedValue(undefined);
+  const response = await route.request("http://internal/");
+  expect(await response.json()).toEqual(
+    expect.objectContaining({
+      success: false,
+      code: "service_unavailable",
+      error: "Billing settings are unavailable",
+    }),
+  );
+  expect(updateOrganization).not.toHaveBeenCalled();
+  expect(response.status).toBe(503);
+});

--- a/packages/cloud/api/v1/billing/settings/route.json.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.json.test.ts
@@ -6,6 +6,7 @@ class MockPolicyError extends Error {}
 const updateSettings = mock(async () => undefined);
 class MockAutoTopUpSettingsValidationError extends Error {}
 
+class MockUnavailableError extends Error {}
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireCurrentBillingManagerSession: async () => ({
     id: "user-1",
@@ -33,6 +34,7 @@ mock.module("@/lib/services/auto-top-up", () => ({
   },
   AutoTopUpSettingsValidationError: MockAutoTopUpSettingsValidationError,
   AutoTopUpSettingsPolicyError: MockPolicyError,
+  AutoTopUpSettingsUnavailableError: MockUnavailableError,
   autoTopUpService: {
     getSettings: async () => ({
       enabled: false,

--- a/packages/cloud/api/v1/billing/settings/route.json.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.json.test.ts
@@ -1,10 +1,16 @@
 /** Verifies the billing-settings JSON boundary with deterministic service mocks. */
 import { describe, expect, mock, test } from "bun:test";
 
+class MockPolicyError extends Error {}
+
 const updateSettings = mock(async () => undefined);
 class MockAutoTopUpSettingsValidationError extends Error {}
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireCurrentBillingManagerSession: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
   requireUserOrApiKeyWithOrg: async () => ({
     id: "user-1",
     organization_id: "org-1",
@@ -26,6 +32,7 @@ mock.module("@/lib/services/auto-top-up", () => ({
     MAX_THRESHOLD: 1000,
   },
   AutoTopUpSettingsValidationError: MockAutoTopUpSettingsValidationError,
+  AutoTopUpSettingsPolicyError: MockPolicyError,
   autoTopUpService: {
     getSettings: async () => ({
       enabled: false,

--- a/packages/cloud/api/v1/billing/settings/route.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.test.ts
@@ -4,6 +4,8 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+class MockPolicyError extends Error {}
+
 const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000207";
 const STANDARD_RATE_LIMIT = { windowMs: 60_000, maxRequests: 100 } as const;
 const rateLimitConfigs: Array<Record<string, unknown>> = [];
@@ -25,7 +27,10 @@ const getSettings = mock(async () => ({
   threshold: null,
   hasPaymentMethod: true,
 }));
-const updateSettings = mock(async () => undefined);
+const updateSettings = mock(
+  async (_id: string, _settings: object, authorize: () => Promise<void>) =>
+    authorize(),
+);
 const findOrganizationById = mock(async () => ({
   id: ORGANIZATION_ID,
   pay_as_you_go_from_earnings: false,
@@ -34,6 +39,7 @@ const updateOrganization = mock(async () => undefined);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
+  requireCurrentBillingManagerSession: requireUserOrApiKeyWithOrg,
 }));
 
 mock.module("@/db/repositories", () => ({
@@ -51,6 +57,7 @@ mock.module("@/lib/services/auto-top-up", () => ({
     MAX_THRESHOLD: 1000,
   },
   AutoTopUpSettingsValidationError,
+  AutoTopUpSettingsPolicyError: MockPolicyError,
   autoTopUpService: { getSettings, updateSettings },
 }));
 
@@ -91,7 +98,9 @@ beforeEach(() => {
     hasPaymentMethod: true,
   });
   updateSettings.mockClear();
-  updateSettings.mockResolvedValue(undefined);
+  updateSettings.mockImplementation(async (_id, _settings, authorize) =>
+    authorize(),
+  );
   findOrganizationById.mockClear();
   findOrganizationById.mockResolvedValue({
     id: ORGANIZATION_ID,
@@ -134,11 +143,15 @@ describe("billing settings cutover safety", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(updateSettings).toHaveBeenCalledWith(ORGANIZATION_ID, {
-      enabled: false,
-      amount: undefined,
-      threshold: undefined,
-    });
+    expect(updateSettings).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+      {
+        enabled: false,
+        amount: undefined,
+        payAsYouGoFromEarnings: undefined,
+      },
+      expect.any(Function),
+    );
     await expect(response.json()).resolves.toMatchObject({
       success: true,
       settings: {

--- a/packages/cloud/api/v1/billing/settings/route.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.test.ts
@@ -37,6 +37,7 @@ const findOrganizationById = mock(async () => ({
 }));
 const updateOrganization = mock(async () => undefined);
 
+class MockUnavailableError extends Error {}
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
   requireCurrentBillingManagerSession: requireUserOrApiKeyWithOrg,
@@ -58,6 +59,7 @@ mock.module("@/lib/services/auto-top-up", () => ({
   },
   AutoTopUpSettingsValidationError,
   AutoTopUpSettingsPolicyError: MockPolicyError,
+  AutoTopUpSettingsUnavailableError: MockUnavailableError,
   autoTopUpService: { getSettings, updateSettings },
 }));
 

--- a/packages/cloud/api/v1/billing/settings/route.ts
+++ b/packages/cloud/api/v1/billing/settings/route.ts
@@ -24,6 +24,7 @@ import {
 import {
   AUTO_TOP_UP_LIMITS,
   AutoTopUpSettingsPolicyError,
+  AutoTopUpSettingsUnavailableError,
   AutoTopUpSettingsValidationError,
   autoTopUpService,
 } from "@/lib/services/auto-top-up";
@@ -89,6 +90,16 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
     });
   } catch (error) {
     // error-policy:J1 transport boundary returns a sanitized failure.
+    if (error instanceof AutoTopUpSettingsUnavailableError) {
+      return failureResponse(
+        c,
+        new ApiError(
+          503,
+          "service_unavailable",
+          "Billing settings are unavailable",
+        ),
+      );
+    }
     logger.error("[Billing Settings API] Error getting settings:", error);
     return failureResponse(c, error);
   }
@@ -184,6 +195,16 @@ app.put("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
       return c.json(
         { success: false, error: error.message, code: "validation_error" },
         400,
+      );
+    }
+    if (error instanceof AutoTopUpSettingsUnavailableError) {
+      return failureResponse(
+        c,
+        new ApiError(
+          503,
+          "service_unavailable",
+          "Billing settings are unavailable",
+        ),
       );
     }
     logger.error("[Billing Settings API] Error updating settings:", error);

--- a/packages/cloud/api/v1/billing/settings/route.ts
+++ b/packages/cloud/api/v1/billing/settings/route.ts
@@ -1,19 +1,21 @@
 /**
- * Billing Settings API (v1)
- *
- * GET/PUT /api/v1/billing/settings
- * Manage auto-top-up and billing settings.
- *
- * Auto-top-up powers autonomous-agent continuity: when balance falls below
- * threshold, the saved Stripe payment method is charged. Configuring this via
- * API lets agents/integrators tune their own billing without the dashboard.
+ * Reads tenant billing settings and admits session-only manager changes.
+ * The service rechecks current authority after validation and persists the
+ * auto-top-up and earnings changes together before invalidating billing caches.
  */
 
 import { Hono } from "hono";
 import { z } from "zod";
 import { organizationsRepository } from "@/db/repositories";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import {
+  ApiError,
+  ForbiddenError,
+  failureResponse,
+} from "@/lib/api/cloud-worker-errors";
+import {
+  requireCurrentBillingManagerSession,
+  requireUserOrApiKeyWithOrg,
+} from "@/lib/auth/workers-hono-auth";
 import {
   moneyRateLimit,
   RateLimitPresets,
@@ -21,6 +23,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   AUTO_TOP_UP_LIMITS,
+  AutoTopUpSettingsPolicyError,
   AutoTopUpSettingsValidationError,
   autoTopUpService,
 } from "@/lib/services/auto-top-up";
@@ -58,6 +61,14 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
       organizationsRepository.findById(user.organization_id),
     ]);
 
+    if (!org) {
+      throw new ApiError(
+        503,
+        "service_unavailable",
+        "Billing settings are unavailable",
+      );
+    }
+    c.header("Cache-Control", "no-store");
     return c.json({
       success: true,
       settings: {
@@ -67,7 +78,7 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
           threshold: autoTopUpSettings.threshold,
           hasPaymentMethod: autoTopUpSettings.hasPaymentMethod,
         },
-        payAsYouGoFromEarnings: org?.pay_as_you_go_from_earnings ?? true,
+        payAsYouGoFromEarnings: org.pay_as_you_go_from_earnings,
         limits: {
           minAmount: AUTO_TOP_UP_LIMITS.MIN_AMOUNT,
           maxAmount: AUTO_TOP_UP_LIMITS.MAX_AMOUNT,
@@ -77,6 +88,7 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
       },
     });
   } catch (error) {
+    // error-policy:J1 transport boundary returns a sanitized failure.
     logger.error("[Billing Settings API] Error getting settings:", error);
     return failureResponse(c, error);
   }
@@ -84,7 +96,7 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
 
 app.put("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+    const user = await requireCurrentBillingManagerSession(c);
 
     const decodedBody = await decodeRequestJson(c.req);
     if (!decodedBody.ok) {
@@ -107,71 +119,41 @@ app.put("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
 
     const { autoTopUp, payAsYouGoFromEarnings } = validation.data;
 
-    if (autoTopUp) {
-      try {
-        await autoTopUpService.updateSettings(user.organization_id, {
-          enabled: autoTopUp.enabled,
-          amount: autoTopUp.amount,
-          threshold: autoTopUp.threshold,
-        });
-      } catch (err) {
-        if (err instanceof AutoTopUpSettingsValidationError) {
-          return c.json(
-            {
-              success: false,
-              error:
-                "Valid auto top-up values are required to replace corrupt settings.",
-              code: "validation_error" as const,
-            },
-            400,
-          );
-        }
-        // Allow domain-specific validation messages through (e.g. "Cannot
-        // enable auto-top-up without a payment method") — they don't leak
-        // internals.
-        const message = err instanceof Error ? err.message : "";
-        const isValidationError =
-          message.includes("Cannot enable") ||
-          message.includes("must be") ||
-          message.includes("cannot exceed");
-        if (isValidationError) {
-          return c.json(
-            {
-              success: false,
-              error: message,
-              code: "validation_error" as const,
-            },
-            400,
-          );
-        }
-        throw err;
+    const authorizeMutation = async (): Promise<void> => {
+      const current = await requireCurrentBillingManagerSession(c);
+      if (
+        current.id !== user.id ||
+        current.organization_id !== user.organization_id
+      ) {
+        throw ForbiddenError("Organization billing authority changed");
       }
-
-      logger.info("[Billing Settings API] Updated auto-top-up settings", {
-        organizationId: user.organization_id,
-        userId: user.id,
-        settings: autoTopUp,
-      });
-    }
-
-    if (payAsYouGoFromEarnings !== undefined) {
-      await organizationsRepository.update(user.organization_id, {
-        pay_as_you_go_from_earnings: payAsYouGoFromEarnings,
-        updated_at: new Date(),
-      });
-
-      logger.info("[Billing Settings API] Updated pay-as-you-go toggle", {
-        organizationId: user.organization_id,
-        userId: user.id,
-        enabled: payAsYouGoFromEarnings,
-      });
-    }
+    };
+    await autoTopUpService.updateSettings(
+      user.organization_id,
+      { ...autoTopUp, payAsYouGoFromEarnings },
+      authorizeMutation,
+    );
+    logger.info("[Billing Settings API] Updated billing settings", {
+      organizationId: user.organization_id,
+      userId: user.id,
+      command: "billing.settings.update",
+      decision: "authorized",
+      outcome: "persisted",
+    });
 
     const [updatedSettings, org] = await Promise.all([
       autoTopUpService.getSettings(user.organization_id),
       organizationsRepository.findById(user.organization_id),
     ]);
 
+    if (!org) {
+      throw new ApiError(
+        503,
+        "service_unavailable",
+        "Billing settings are unavailable",
+      );
+    }
+    c.header("Cache-Control", "no-store");
     return c.json({
       success: true,
       message: "Billing settings updated successfully",
@@ -182,10 +164,28 @@ app.put("/", moneyRateLimit(RateLimitPresets.STANDARD), async (c) => {
           threshold: updatedSettings.threshold,
           hasPaymentMethod: updatedSettings.hasPaymentMethod,
         },
-        payAsYouGoFromEarnings: org?.pay_as_you_go_from_earnings ?? true,
+        payAsYouGoFromEarnings: org.pay_as_you_go_from_earnings,
       },
     });
   } catch (error) {
+    // error-policy:J1 transport boundary maps typed settings validation safely.
+    if (error instanceof AutoTopUpSettingsValidationError) {
+      return c.json(
+        {
+          success: false,
+          error:
+            "Valid auto top-up values are required to replace corrupt settings.",
+          code: "validation_error",
+        },
+        400,
+      );
+    }
+    if (error instanceof AutoTopUpSettingsPolicyError) {
+      return c.json(
+        { success: false, error: error.message, code: "validation_error" },
+        400,
+      );
+    }
     logger.error("[Billing Settings API] Error updating settings:", error);
     return failureResponse(c, error);
   }

--- a/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
@@ -1953,12 +1953,69 @@ describe("AutoTopUpService settings compatibility", () => {
     });
   });
 
-  test("persists validated decimal settings", async () => {
-    await new AutoTopUpService().updateSettings("org-1", {
-      enabled: true,
-      amount: 25,
-      threshold: 10,
+  test("rechecks authority after validation and commits both billing toggles together", async () => {
+    const order: string[] = [];
+    findBlockingByOrganization.mockImplementationOnce(async () => {
+      order.push("validation");
+      return null;
     });
+    const authorize = mock(async () => {
+      order.push("authority");
+      expect(updateOrganization).not.toHaveBeenCalled();
+    });
+    await new AutoTopUpService().updateSettings(
+      "org-1",
+      {
+        enabled: true,
+        amount: 25,
+        threshold: 10,
+        payAsYouGoFromEarnings: false,
+      },
+      authorize,
+    );
+    expect(order).toEqual(["validation", "authority"]);
+    expect(updateOrganization).toHaveBeenCalledTimes(1);
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        auto_top_up_enabled: true,
+        auto_top_up_amount: "25.00",
+        pay_as_you_go_from_earnings: false,
+      }),
+    );
+  });
+
+  test("a revoked manager after asynchronous validation cannot persist either setting", async () => {
+    const denial = new Error("Current authority denied");
+    await expect(
+      new AutoTopUpService().updateSettings(
+        "org-1",
+        {
+          enabled: true,
+          amount: 25,
+          threshold: 10,
+          payAsYouGoFromEarnings: false,
+        },
+        async () => {
+          throw denial;
+        },
+      ),
+    ).rejects.toBe(denial);
+    expect(findBlockingByOrganization).toHaveBeenCalledWith("org-1");
+    expect(updateOrganization).not.toHaveBeenCalled();
+    expect(onOrganizationUpdated).not.toHaveBeenCalled();
+  });
+
+  test("persists validated decimal settings", async () => {
+    await new AutoTopUpService().updateSettings(
+      "org-1",
+      {
+        enabled: true,
+        amount: 25,
+        threshold: 10,
+      },
+      async () => undefined,
+    );
 
     expect(updateOrganization).toHaveBeenCalledWith(
       "org-1",
@@ -1976,9 +2033,9 @@ describe("AutoTopUpService settings compatibility", () => {
       makeOrganization({ stripe_default_payment_method: null }),
     );
 
-    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
-      "Cannot enable auto top-up without a default payment method",
-    );
+    await expect(
+      new AutoTopUpService().updateSettings("org-1", { enabled: true }, async () => undefined),
+    ).rejects.toThrow("Cannot enable auto top-up without a default payment method");
     expect(updateOrganization).not.toHaveBeenCalled();
   });
 
@@ -1988,7 +2045,9 @@ describe("AutoTopUpService settings compatibility", () => {
       status: "manual_review",
     });
 
-    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
+    await expect(
+      new AutoTopUpService().updateSettings("org-1", { enabled: true }, async () => undefined),
+    ).rejects.toThrow(
       "Cannot enable auto top-up while an earlier card payment requires reconciliation",
     );
     expect(updateOrganization).not.toHaveBeenCalled();
@@ -2000,7 +2059,9 @@ describe("AutoTopUpService settings compatibility", () => {
       status: "manual_review",
     });
 
-    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
+    await expect(
+      new AutoTopUpService().updateSettings("org-1", { enabled: true }, async () => undefined),
+    ).rejects.toThrow(
       "Cannot enable auto top-up while an earlier card payment requires reconciliation",
     );
     expect(updateOrganization).not.toHaveBeenCalled();
@@ -2016,7 +2077,11 @@ describe("AutoTopUpService settings compatibility", () => {
     );
 
     await expect(
-      new AutoTopUpService().updateSettings("org-1", { enabled: true, amount: 25 }),
+      new AutoTopUpService().updateSettings(
+        "org-1",
+        { enabled: true, amount: 25 },
+        async () => undefined,
+      ),
     ).rejects.toThrow("Valid auto top-up values are required to replace corrupt settings");
     expect(updateOrganization).not.toHaveBeenCalled();
   });
@@ -2030,10 +2095,14 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await new AutoTopUpService().updateSettings("org-1", {
-      enabled: true,
-      amount: 25,
-    });
+    await new AutoTopUpService().updateSettings(
+      "org-1",
+      {
+        enabled: true,
+        amount: 25,
+      },
+      async () => undefined,
+    );
 
     expect(updateOrganization).toHaveBeenCalledWith(
       "org-1",
@@ -2054,10 +2123,14 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await new AutoTopUpService().updateSettings("org-1", {
-      enabled: true,
-      threshold: 8,
-    });
+    await new AutoTopUpService().updateSettings(
+      "org-1",
+      {
+        enabled: true,
+        threshold: 8,
+      },
+      async () => undefined,
+    );
 
     expect(updateOrganization).toHaveBeenCalledWith(
       "org-1",
@@ -2078,11 +2151,15 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await new AutoTopUpService().updateSettings("org-1", {
-      enabled: true,
-      amount: 25,
-      threshold: 10,
-    });
+    await new AutoTopUpService().updateSettings(
+      "org-1",
+      {
+        enabled: true,
+        amount: 25,
+        threshold: 10,
+      },
+      async () => undefined,
+    );
 
     expect(updateOrganization).toHaveBeenCalledWith(
       "org-1",
@@ -2103,9 +2180,9 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
-      "Auto top-up amount must be at least $1",
-    );
+    await expect(
+      new AutoTopUpService().updateSettings("org-1", { enabled: true }, async () => undefined),
+    ).rejects.toThrow("Auto top-up amount must be at least $1");
     expect(updateOrganization).not.toHaveBeenCalled();
   });
 
@@ -2118,7 +2195,7 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await new AutoTopUpService().updateSettings("org-1", { enabled: true });
+    await new AutoTopUpService().updateSettings("org-1", { enabled: true }, async () => undefined);
 
     expect(updateOrganization).toHaveBeenCalledWith(
       "org-1",
@@ -2138,7 +2215,7 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await new AutoTopUpService().updateSettings("org-1", { amount: 10 });
+    await new AutoTopUpService().updateSettings("org-1", { amount: 10 }, async () => undefined);
 
     expect(updateOrganization).toHaveBeenCalledWith(
       "org-1",
@@ -2155,9 +2232,9 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await expect(new AutoTopUpService().updateSettings("org-1", { amount: 25 })).rejects.toThrow(
-      "Valid auto top-up values are required to replace corrupt settings",
-    );
+    await expect(
+      new AutoTopUpService().updateSettings("org-1", { amount: 25 }, async () => undefined),
+    ).rejects.toThrow("Valid auto top-up values are required to replace corrupt settings");
     expect(updateOrganization).not.toHaveBeenCalled();
   });
 
@@ -2169,7 +2246,7 @@ describe("AutoTopUpService settings compatibility", () => {
       }),
     );
 
-    await new AutoTopUpService().updateSettings("org-1", { enabled: false });
+    await new AutoTopUpService().updateSettings("org-1", { enabled: false }, async () => undefined);
 
     expect(updateOrganization).toHaveBeenCalledWith(
       "org-1",

--- a/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
@@ -1908,6 +1908,23 @@ describe("AutoTopUpService settings compatibility", () => {
   beforeEach(() => {
     findOrganizationById.mockResolvedValue(makeOrganization());
   });
+  test("missing organization rejects settings updates as unavailable", async () => {
+    findOrganizationById.mockResolvedValueOnce(undefined);
+    await expect(
+      new AutoTopUpService().updateSettings("org-1", { enabled: false }, async () => undefined),
+    ).rejects.toMatchObject({ code: "BILLING_SETTINGS_UNAVAILABLE" });
+    expect(updateOrganization).not.toHaveBeenCalled();
+    expect(invalidateOrganizationCache).not.toHaveBeenCalled();
+    expect(onOrganizationUpdated).not.toHaveBeenCalled();
+  });
+
+  test("empty settings preserve storage and cache state", async () => {
+    await new AutoTopUpService().updateSettings("org-1", {}, async () => undefined);
+    expect(updateOrganization).not.toHaveBeenCalled();
+    expect(invalidateOrganizationCache).not.toHaveBeenCalled();
+    expect(onOrganizationUpdated).not.toHaveBeenCalled();
+  });
+
   test("reads the existing billing settings without unsealing charging", async () => {
     const result = await new AutoTopUpService().getSettings("org-1");
 

--- a/packages/cloud/shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud/shared/src/lib/services/auto-top-up.ts
@@ -148,6 +148,16 @@ export class AutoTopUpSettingsValidationError extends Error {
   }
 }
 
+/** Missing account settings are unavailable, never a healthy empty configuration. */
+export class AutoTopUpSettingsUnavailableError extends ElizaError {
+  constructor(organizationId: string) {
+    super("Billing settings are unavailable", {
+      code: "BILLING_SETTINGS_UNAVAILABLE",
+      context: { organizationId },
+    });
+  }
+}
+
 /** Public validation failure with a safe, actionable settings message. */
 export class AutoTopUpSettingsPolicyError extends ElizaError {
   constructor(message: string) {
@@ -1556,7 +1566,7 @@ export class AutoTopUpService {
   }> {
     const organization = await organizationsRepository.findById(organizationId);
     if (!organization) {
-      throw new Error("Organization not found");
+      throw new AutoTopUpSettingsUnavailableError(organizationId);
     }
 
     return {

--- a/packages/cloud/shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud/shared/src/lib/services/auto-top-up.ts
@@ -1595,7 +1595,15 @@ export class AutoTopUpService {
   ): Promise<void> {
     const organization = await organizationsRepository.findById(organizationId);
     if (!organization) {
-      throw new Error("Organization not found");
+      throw new AutoTopUpSettingsUnavailableError(organizationId);
+    }
+    if (
+      settings.enabled === undefined &&
+      settings.amount === undefined &&
+      settings.threshold === undefined &&
+      settings.payAsYouGoFromEarnings === undefined
+    ) {
+      return;
     }
 
     if (settings.enabled === true && !organization.stripe_default_payment_method) {

--- a/packages/cloud/shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud/shared/src/lib/services/auto-top-up.ts
@@ -4,7 +4,7 @@
  * retries reuse that attempt's stable idempotency key and fenced lease.
  */
 
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { ElizaError, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import Decimal from "decimal.js";
 import type Stripe from "stripe";
 import type {
@@ -145,6 +145,13 @@ export class AutoTopUpSettingsValidationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "AutoTopUpSettingsValidationError";
+  }
+}
+
+/** Public validation failure with a safe, actionable settings message. */
+export class AutoTopUpSettingsPolicyError extends ElizaError {
+  constructor(message: string) {
+    super(message, { code: "BILLING_SETTINGS_INVALID" });
   }
 }
 
@@ -433,21 +440,27 @@ export class AutoTopUpService {
 
   validateSettings(amount: number, threshold: number): void {
     if (!Number.isFinite(amount) || !Number.isFinite(threshold)) {
-      throw new Error("Auto top-up settings must be valid numbers");
+      throw new AutoTopUpSettingsPolicyError("Auto top-up settings must be valid numbers");
     }
     if (amount < AUTO_TOP_UP_LIMITS.MIN_AMOUNT) {
-      throw new Error(`Auto top-up amount must be at least $${AUTO_TOP_UP_LIMITS.MIN_AMOUNT}`);
+      throw new AutoTopUpSettingsPolicyError(
+        `Auto top-up amount must be at least $${AUTO_TOP_UP_LIMITS.MIN_AMOUNT}`,
+      );
     }
     if (amount > AUTO_TOP_UP_LIMITS.MAX_AMOUNT) {
-      throw new Error(`Auto top-up amount cannot exceed $${AUTO_TOP_UP_LIMITS.MAX_AMOUNT}`);
+      throw new AutoTopUpSettingsPolicyError(
+        `Auto top-up amount cannot exceed $${AUTO_TOP_UP_LIMITS.MAX_AMOUNT}`,
+      );
     }
     if (threshold < AUTO_TOP_UP_LIMITS.MIN_THRESHOLD) {
-      throw new Error(
+      throw new AutoTopUpSettingsPolicyError(
         `Auto top-up threshold must be at least $${AUTO_TOP_UP_LIMITS.MIN_THRESHOLD}`,
       );
     }
     if (threshold > AUTO_TOP_UP_LIMITS.MAX_THRESHOLD) {
-      throw new Error(`Auto top-up threshold cannot exceed $${AUTO_TOP_UP_LIMITS.MAX_THRESHOLD}`);
+      throw new AutoTopUpSettingsPolicyError(
+        `Auto top-up threshold cannot exceed $${AUTO_TOP_UP_LIMITS.MAX_THRESHOLD}`,
+      );
     }
   }
 
@@ -1566,7 +1579,9 @@ export class AutoTopUpService {
       enabled?: boolean;
       amount?: number;
       threshold?: number;
+      payAsYouGoFromEarnings?: boolean;
     },
+    authorizeMutation: () => Promise<void>,
   ): Promise<void> {
     const organization = await organizationsRepository.findById(organizationId);
     if (!organization) {
@@ -1574,7 +1589,7 @@ export class AutoTopUpService {
     }
 
     if (settings.enabled === true && !organization.stripe_default_payment_method) {
-      throw new Error(
+      throw new AutoTopUpSettingsPolicyError(
         "Cannot enable auto top-up without a default payment method. Please add a payment method first.",
       );
     }
@@ -1584,7 +1599,7 @@ export class AutoTopUpService {
         autoTopUpAttemptsRepository.findBlockingLegacyPaymentByOrganization(organizationId),
       ]);
       if (blockingAttempt || blockingLegacyPayment) {
-        throw new Error(
+        throw new AutoTopUpSettingsPolicyError(
           "Cannot enable auto top-up while an earlier card payment requires reconciliation.",
         );
       }
@@ -1638,6 +1653,11 @@ export class AutoTopUpService {
       updates.auto_top_up_threshold = "0.00";
     }
 
+    if (settings.payAsYouGoFromEarnings !== undefined) {
+      updates.pay_as_you_go_from_earnings = settings.payAsYouGoFromEarnings;
+    }
+    // Recheck after all asynchronous validation and immediately before persistence.
+    await authorizeMutation();
     await organizationsRepository.update(organizationId, updates);
     await Promise.all([
       invalidateOrganizationCache(organizationId),

--- a/packages/cloud/shared/src/lib/services/email.dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/email.dispatch.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Exercises submission receipts through the real SMTP adapter on loopback and
+ * the SendGrid response boundary. No messages leave the local test process.
+ */
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { createServer, type Server, type Socket } from "node:net";
+import sgMail from "@sendgrid/mail";
+import { EmailService } from "./email";
+
+const keys = [
+  "SMTP_HOST",
+  "SMTP_PORT",
+  "SMTP_PASSWORD",
+  "SMTP_USERNAME",
+  "SENDGRID_API_KEY",
+] as const;
+const prior = new Map(keys.map((key) => [key, process.env[key]]));
+const sockets = new Set<Socket>();
+let server: Server | null = null;
+let submissions = 0;
+const restores: Array<() => void> = [];
+const mail = {
+  to: "recipient@example.test",
+  subject: "Receipt contract",
+  text: "Local fixture",
+  html: "<p>Local fixture</p>",
+};
+
+beforeEach(() => {
+  for (const key of keys) delete process.env[key];
+  submissions = 0;
+});
+afterEach(async () => {
+  for (const restore of restores.splice(0)) restore();
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  if (server) {
+    const closing = server;
+    server = null;
+    await new Promise<void>((resolve, reject) =>
+      closing.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+  for (const [key, value] of prior) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+async function smtp(
+  mode: "accept" | "disconnect" | "reject" | "partial" | "reject_all",
+): Promise<void> {
+  server = createServer((socket) => {
+    sockets.add(socket);
+    let pending = "";
+    let data = false;
+    socket.write("220 localhost ESMTP\r\n");
+    socket.on("data", (chunk) => {
+      pending += chunk.toString();
+      let end: number;
+      while ((end = pending.indexOf("\r\n")) >= 0) {
+        const line = pending.substring(0, end);
+        pending = pending.substring(end + 2);
+        if (data) {
+          if (line !== ".") continue;
+          data = false;
+          submissions += 1;
+          if (mode === "disconnect") socket.destroy();
+          else socket.write(mode === "reject" ? "550 Message rejected\r\n" : "250 queued\r\n");
+        } else if (line.startsWith("EHLO")) socket.write("250-localhost\r\n250 AUTH PLAIN\r\n");
+        else if (line.startsWith("AUTH")) socket.write("235 authenticated\r\n");
+        else if (line.startsWith("DATA")) {
+          data = true;
+          socket.write("354 continue\r\n");
+        } else if (line.startsWith("QUIT")) socket.end("221 bye\r\n");
+        else if (mode === "reject_all" && line.startsWith("RCPT"))
+          socket.write("550 recipient rejected\r\n");
+        else if (mode === "partial" && line.includes("reject@example.test"))
+          socket.write("550 recipient rejected\r\n");
+        else socket.write("250 ok\r\n");
+      }
+    });
+  });
+  const listening = server;
+  await new Promise<void>((resolve, reject) => {
+    listening.once("error", reject);
+    listening.listen(0, "127.0.0.1", resolve);
+  });
+  const address = listening.address();
+  if (!address || typeof address === "string") throw new Error("Missing loopback listener");
+  process.env.SMTP_HOST = "127.0.0.1";
+  process.env.SMTP_PORT = String(address.port);
+  process.env.SMTP_USERNAME = "fixture";
+  process.env.SMTP_PASSWORD = "fixture-password";
+}
+
+describe("EmailService durable submission receipt", () => {
+  test("makes unavailable configuration explicit and retains legacy false", async () => {
+    const service = new EmailService();
+    expect(await service.dispatch(mail)).toEqual({
+      status: "unavailable",
+      reason: "not_configured",
+    });
+    expect(await service.send(mail)).toBe(false);
+  });
+  test("records SMTP acceptance without claiming recipient delivery", async () => {
+    await smtp("accept");
+    const result = await new EmailService().dispatch(mail);
+    expect(result).toMatchObject({ status: "accepted", provider: "smtp" });
+    if (result.status !== "accepted") throw new Error("Expected SMTP acceptance");
+    expect(result.messageId).toContain("@");
+    expect(submissions).toBe(1);
+    expect(JSON.stringify(result)).not.toContain(mail.to);
+    expect(JSON.stringify(result)).not.toContain(mail.text);
+  });
+  test("disconnect after submission remains uncertain and is never retried", async () => {
+    await smtp("disconnect");
+    expect(await new EmailService().dispatch(mail)).toEqual({
+      status: "uncertain",
+      provider: "smtp",
+      reason: "transport_error",
+      messageId: null,
+    });
+    expect(submissions).toBe(1);
+  });
+  test("partial recipient acceptance cannot claim one complete receipt", async () => {
+    await smtp("partial");
+    expect(
+      await new EmailService().dispatch({ ...mail, to: [mail.to, "reject@example.test"] }),
+    ).toMatchObject({ status: "uncertain", provider: "smtp", reason: "partial_acceptance" });
+    expect(submissions).toBe(1);
+  });
+  test("explicit SMTP rejection is distinct from uncertain acceptance", async () => {
+    await smtp("reject");
+    expect(await new EmailService().dispatch(mail)).toEqual({
+      status: "rejected",
+      provider: "smtp",
+      reason: "provider_rejected",
+    });
+    expect(submissions).toBe(1);
+  });
+  test("all recipients rejected never submit a message", async () => {
+    await smtp("reject_all");
+    expect(await new EmailService().dispatch(mail)).toEqual({
+      status: "rejected",
+      provider: "smtp",
+      reason: "provider_rejected",
+    });
+    expect(submissions).toBe(0);
+  });
+  test("legacy transport failure continues to reject", async () => {
+    await smtp("reject");
+    await expect(new EmailService().send(mail)).rejects.toThrow();
+    expect(submissions).toBe(1);
+  });
+  test("malformed configured port is unavailable without opening a connection", async () => {
+    process.env.SMTP_HOST = "127.0.0.1";
+    process.env.SMTP_PORT = "invalid";
+    process.env.SMTP_PASSWORD = "fixture-password";
+    expect(await new EmailService().dispatch(mail)).toEqual({
+      status: "unavailable",
+      reason: "invalid_configuration",
+    });
+    expect(submissions).toBe(0);
+  });
+  test("maps SendGrid receipt, missing receipt, rejection and ambiguous failure separately", async () => {
+    process.env.SENDGRID_API_KEY = "SG.test.fake";
+    const setKey = spyOn(sgMail, "setApiKey").mockImplementation(() => undefined);
+    const send = spyOn(sgMail, "send");
+    restores.push(
+      () => send.mockRestore(),
+      () => setKey.mockRestore(),
+    );
+    send.mockResolvedValue([
+      { statusCode: 202, headers: { "x-message-id": "receipt-123" }, body: {} },
+      {},
+    ]);
+    expect(await new EmailService().dispatch(mail)).toEqual({
+      status: "accepted",
+      provider: "sendgrid",
+      messageId: "receipt-123",
+    });
+    send.mockResolvedValue([{ statusCode: 202, headers: {}, body: {} }, {}]);
+    expect(await new EmailService().dispatch(mail)).toMatchObject({
+      status: "uncertain",
+      reason: "missing_receipt",
+    });
+    send.mockRejectedValue(Object.assign(new Error("private transport payload"), { code: 401 }));
+    expect(await new EmailService().dispatch(mail)).toEqual({
+      status: "rejected",
+      provider: "sendgrid",
+      reason: "provider_rejected",
+    });
+    send.mockRejectedValue(Object.assign(new Error("private transport payload"), { code: 503 }));
+    expect(await new EmailService().dispatch(mail)).toEqual({
+      status: "uncertain",
+      provider: "sendgrid",
+      reason: "transport_error",
+      messageId: null,
+    });
+    send.mockRejectedValue(Object.assign(new Error("private timeout payload"), { code: 408 }));
+    expect(await new EmailService().dispatch(mail)).toMatchObject({
+      status: "uncertain",
+      reason: "transport_error",
+    });
+    send.mockResolvedValue([
+      {
+        statusCode: 202,
+        headers: { "x-message-id": "private\r\nAuthorization: bearer-secret" },
+        body: {},
+      },
+      {},
+    ]);
+    const unsafeReceipt = await new EmailService().dispatch(mail);
+    expect(unsafeReceipt).toMatchObject({
+      status: "uncertain",
+      reason: "missing_receipt",
+      messageId: null,
+    });
+    expect(JSON.stringify(unsafeReceipt)).not.toContain("bearer-secret");
+    expect(send).toHaveBeenCalledTimes(6);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/email.ts
+++ b/packages/cloud/shared/src/lib/services/email.ts
@@ -64,6 +64,24 @@ export function resolveSmtpPort(raw: string | undefined | null): number {
   return parsed;
 }
 
+/** Submission receipts are server-only; acceptance never proves recipient delivery. */
+export type EmailDispatchResult =
+  | { status: "unavailable"; reason: "not_configured" | "invalid_configuration" }
+  | { status: "accepted"; provider: "smtp" | "sendgrid"; messageId: string }
+  | { status: "rejected"; provider: "smtp" | "sendgrid"; reason: "provider_rejected" }
+  | {
+      status: "uncertain";
+      provider: "smtp" | "sendgrid";
+      reason: "transport_error" | "missing_receipt" | "partial_acceptance";
+      messageId: string | null;
+    };
+
+function receiptId(value: unknown): string | null {
+  // Transport metadata is untrusted. Never persist response bodies or headers
+  // masquerading as a message ID, and never truncate a correlation identifier.
+  return typeof value === "string" && /^[A-Za-z0-9._:@<>+=/-]{1,256}$/.test(value) ? value : null;
+}
+
 /**
  * Email service supporting SendGrid API and SMTP.
  */
@@ -111,21 +129,56 @@ export class EmailService {
   }
 
   /**
-   * Sends an email using the configured provider (SendGrid or SMTP).
-   *
-   * @param options - Email options including recipient, subject, and content.
-   * @returns True if sent successfully, false otherwise.
+   * Compatibility API: resolves false when unconfigured and true after a
+   * resolved transport submission; transport failures continue to reject.
+   * New durable callers must use dispatch and persist its typed receipt.
    */
   async send(options: EmailOptions): Promise<boolean> {
-    this.initialize();
+    const result = await this.submit(options);
+    return result.status !== "unavailable";
+  }
 
-    if (!this.initialized) {
-      logger.warn("[EmailService] Not initialized, skipping email send");
-      return false;
+  /**
+   * Submits once and records what the provider actually acknowledged. An
+   * uncertain result requires reconciliation, never an automatic resend.
+   */
+  async dispatch(options: EmailOptions): Promise<EmailDispatchResult> {
+    try {
+      return await this.submit(options);
+    } catch (error) {
+      // error-policy:J1 the mail boundary reports acceptance uncertainty without
+      // leaking recipients, credentials, transport responses, or message bodies.
+      if (error instanceof SmtpPortConfigError) {
+        return { status: "unavailable", reason: "invalid_configuration" };
+      }
+      const provider = this.useSmtp ? "smtp" : "sendgrid";
+      const responseCode =
+        error !== null && typeof error === "object"
+          ? this.useSmtp && "responseCode" in error
+            ? error.responseCode
+            : "code" in error
+              ? error.code
+              : null
+          : null;
+      if (
+        typeof responseCode === "number" &&
+        responseCode >= 400 &&
+        responseCode < 600 &&
+        (this.useSmtp || (responseCode < 500 && responseCode !== 408))
+      ) {
+        return { status: "rejected", provider, reason: "provider_rejected" };
+      }
+      return { status: "uncertain", provider, reason: "transport_error", messageId: null };
     }
+  }
 
+  private async submit(options: EmailOptions): Promise<EmailDispatchResult> {
+    this.initialize();
+    if (!this.initialized) {
+      return { status: "unavailable", reason: "not_configured" };
+    }
     if (this.useSmtp && this.smtpTransporter) {
-      await this.smtpTransporter.sendMail({
+      const result = await this.smtpTransporter.sendMail({
         from: options.from || this.fromEmail!,
         to: options.to,
         subject: options.subject,
@@ -138,33 +191,41 @@ export class EmailService {
           contentType: att.type,
         })),
       });
-
-      logger.info("[EmailService] Email sent via SMTP", {
-        to: options.to,
-        subject: options.subject,
-      });
-
-      return true;
-    } else {
-      const msg = {
-        to: options.to,
-        from: options.from || this.fromEmail!,
-        subject: options.subject,
-        text: options.text,
-        html: options.html,
-        replyTo: options.replyTo,
-        attachments: options.attachments,
-      };
-
-      await sgMail.send(msg);
-
-      logger.info("[EmailService] Email sent via API", {
-        to: options.to,
-        subject: options.subject,
-      });
-
-      return true;
+      const messageId = receiptId(result.messageId);
+      if (result.rejected?.length > 0 || result.pending?.length > 0) {
+        return {
+          status: "uncertain",
+          provider: "smtp",
+          reason: "partial_acceptance",
+          messageId,
+        };
+      }
+      if (
+        !messageId ||
+        !result.accepted?.length ||
+        result.accepted.length !== result.envelope?.to.length
+      ) {
+        return { status: "uncertain", provider: "smtp", reason: "missing_receipt", messageId };
+      }
+      return { status: "accepted", provider: "smtp", messageId };
     }
+    const [response] = await sgMail.send({
+      to: options.to,
+      from: options.from || this.fromEmail!,
+      subject: options.subject,
+      text: options.text,
+      html: options.html,
+      replyTo: options.replyTo,
+      attachments: options.attachments,
+    });
+    const messageId = receiptId(response.headers?.["x-message-id"]);
+    if (response.statusCode >= 400 && response.statusCode < 600) {
+      return { status: "rejected", provider: "sendgrid", reason: "provider_rejected" };
+    }
+    if (response.statusCode !== 202 || !messageId) {
+      return { status: "uncertain", provider: "sendgrid", reason: "missing_receipt", messageId };
+    }
+    return { status: "accepted", provider: "sendgrid", messageId };
   }
 
   /**


### PR DESCRIPTION
Billing settings now require current organization manager authority for updates, recheck it before persistence, and save auto-top-up and earnings settings together. Missing organizations return a sanitized HTTP 503 for both GET and PUT. Empty or unknown-only updates return persisted settings without a write, timestamp change, or cache invalidation.

The mail boundary exposes typed unavailable, accepted, rejected, and uncertain submission receipts while preserving legacy send behavior. Provider acceptance is distinct from recipient delivery; uncertain submission is never treated as a reason to resend automatically.

References #23095. This prerequisite does not close the issue. Coherent subscription status, durable notices, policy approval and real recipient/deployed acceptance remain separate work.

Validation targets `65fe8b2ef6752c5d679ae5863790efae7bdc29ff`, rebased onto `65a4f5216421ba74a75b1bc9bc98de0ae2d1ceb1`. All three issue patches are range-diff identical to independently reviewed `d2c4e156d349d045e9ba9dac96ffa962ba80405f`.

- Pinned Bun 1.3.14 install passed on the current head.
- Independent review on d2c4e156 found no actionable P1/P2 issue: 105 tests passed with 363 assertions. The four API files ran in separate processes, matching the package's canonical runner. This is source-equivalent review evidence, not a new-head execution claim.
- Root independent current-head review found no actionable finding after inspecting the rebased repair and unchanged affected base paths. Current-head verification passed: 77 service tests / 271 assertions, 9 mail tests / 27 assertions, and all four API files / 19 tests / 65 assertions (105 tests, 363 assertions total).
- Current-head root verification passed all 376 tasks and subsequent repository audits, exit 0. The full owning API suite passed all 598 files in isolated Bun processes, exit 0.
- Historical full API sweep on 494f811a passed all 597 files. That sweep predates the additional PUT/no-op repair and is not claimed as full-package proof of the repair.
- Current hosted run34023755788 passed source static smoke, payment replay, PostgreSQL authority, Windows security and the final aggregate. The superseded push-triggered run34023749259 was canceled when readiness triggered this run; its failed aggregate is not a source-test failure.

The reported missing-organization PUT and unnecessary no-op persistence findings are fixed. The mock-isolation review concern is addressed by the canonical isolated API runner and independent execution of all four affected route files. No external email, Stripe mutation or deployment was performed.

## Evidence Gate

<!-- evidence-head:65fe8b2ef6752c5d679ae5863790efae7bdc29ff -->
<!-- evidence-row:before-screenshots -->
N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
N/A - HTTP and mail adapter changes with no interactive UI surface.
<!-- evidence-row:backend-logs -->
<details><summary>Independent execution on source-equivalent d2c4e156</summary>

```text
Settings service: 77 pass, 0 fail, 271 assertions
API authorization: 7 pass, 0 fail, 25 assertions
API availability: 5 pass, 0 fail, 23 assertions
API malformed JSON: 2 pass, 0 fail, 5 assertions
API settings: 5 pass, 0 fail, 12 assertions
Mail receipt: 9 pass, 0 fail, 27 assertions
Total: 105 pass, 0 fail, 363 assertions
```

Each API file ran in its own Bun process. Service and mail suites also ran separately.
</details>
<!-- evidence-row:frontend-logs -->
N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
N/A - no model behavior change.
<!-- evidence-row:domain-artifacts -->
Inspected real service, HTTP and loopback SMTP outcomes are included below.

<details><summary>Inspected boundary outcomes</summary>

Real settings-service tests verify typed unavailable on missing organization and no persistence/cache invalidation for empty updates. HTTP tests inspect sanitized 503 responses and manager/session/tenant authorization. Loopback SMTP tests inspect accepted submission, disconnect after submission, rejection and partial recipient acceptance. SMTP acceptance is not delivery proof; SendGrid response tests use a deterministic adapter fixture.

Observed test output:
```text
(pass) real getSettings missing organization uses advertised unavailable response [2.69ms]
(pass) real updateSettings missing organization returns PUT unavailable without mutations [1.22ms]
(pass) PUT with no recognized changes preserves storage and caches: {} [0.38ms]
(pass) EmailService durable submission receipt > records SMTP acceptance without claiming recipient delivery [15.15ms]
(pass) EmailService durable submission receipt > disconnect after submission remains uncertain and is never retried [3.84ms]
(pass) EmailService durable submission receipt > partial recipient acceptance cannot claim one complete receipt [3.11ms]
```

Current-head root gate:
```text
Tasks: 376 successful, 376 total
[anti-larp] scanned 11458 test files — 0 focused, 0 orphaned skip(s)
exit 0
```
</details>
<!-- evidence-row:ocr-review -->
N/A - no rendered text.
