### PR TITLE
fix(cloud): bind entitlement publication to current subscription authority

### DIFF
--- a/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts
+++ b/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.test.ts
@@ -27,7 +27,7 @@ describe("account deletion full-schema foreign-key policy", () => {
       .update(descriptors.map(serializeDescriptor).join("\n"))
       .digest("hex");
 
-    expect(descriptors).toHaveLength(253);
+    expect(descriptors).toHaveLength(254);
     expect(digest).toBe(ACCOUNT_DELETION_FOREIGN_KEY_SNAPSHOT_SHA256);
   });
 
@@ -37,7 +37,7 @@ describe("account deletion full-schema foreign-key policy", () => {
       action: classifyAccountDeletionForeignKey(descriptor),
     }));
 
-    expect(classified).toHaveLength(253);
+    expect(classified).toHaveLength(254);
     expect(classified.every(({ action }) => Boolean(action))).toBe(true);
     expect(classified.filter(({ action }) => action === "reconcile_external_resource").length).toBe(
       75,

--- a/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.ts
+++ b/packages/cloud/shared/src/db/account-deletion-foreign-key-policy.ts
@@ -23,9 +23,9 @@ export interface AccountDeletionForeignKeyDescriptor {
   targetColumns: string;
   onDelete: string;
 }
-/** SHA-256 of the 253 sorted direct user/organization FK descriptors. */
+/** SHA-256 of the 254 sorted direct user/organization FK descriptors. */
 export const ACCOUNT_DELETION_FOREIGN_KEY_SNAPSHOT_SHA256 =
-  "773c62bb7a60026260f8b4f90f58a7cdebf18fbf9a7ad66ab972c5cac4365af7";
+  "7cb2ab72048446d21a64edfde9e8a67d2000d104685e84152dc8fdc29d850ea7";
 
 function serializeDescriptor(descriptor: AccountDeletionForeignKeyDescriptor): string {
   return [

--- a/packages/cloud/shared/src/db/migrations/0379_subscription_account_authority.sql
+++ b/packages/cloud/shared/src/db/migrations/0379_subscription_account_authority.sql
@@ -1,0 +1,33 @@
+-- Retain account subscription identity through terminal lifecycle transitions.
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS subscription_authority_id uuid;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS subscription_authority_state text NOT NULL DEFAULT 'none';
+--> statement-breakpoint
+-- The unique live-subscription constraint establishes identity without timestamp ordering.
+UPDATE organizations o SET subscription_authority_id = s.id, subscription_authority_state = 'current'
+FROM billing_subscriptions s
+WHERE s.organization_id = o.id AND s.status IN ('pending','incomplete','active','grace','past_due','unpaid');
+--> statement-breakpoint
+-- A single historical source is unambiguous; multiple terminal sources require reconciliation.
+UPDATE organizations o SET subscription_authority_id = s.id, subscription_authority_state = 'current'
+FROM billing_subscriptions s
+WHERE s.organization_id = o.id AND o.subscription_authority_state = 'none'
+AND NOT EXISTS (SELECT 1 FROM billing_subscriptions other WHERE other.organization_id = o.id AND other.id <> s.id);
+UPDATE organizations o SET subscription_authority_state = 'unavailable'
+WHERE o.subscription_authority_state = 'none' AND EXISTS (SELECT 1 FROM billing_subscriptions s WHERE s.organization_id = o.id);
+--> statement-breakpoint
+ALTER TABLE organizations ADD CONSTRAINT organizations_subscription_authority_tenant_fk
+FOREIGN KEY (subscription_authority_id, id) REFERENCES billing_subscriptions (id, organization_id) ON DELETE RESTRICT;
+ALTER TABLE organizations ADD CONSTRAINT organizations_subscription_authority_check CHECK (
+  (subscription_authority_state = 'current' AND subscription_authority_id IS NOT NULL)
+  OR (subscription_authority_state IN ('none','unavailable') AND subscription_authority_id IS NULL)
+);
+--> statement-breakpoint
+-- Terminal projections retain the authoritative transition that produced Free.
+ALTER TABLE organization_entitlements DROP CONSTRAINT organization_entitlements_plan_state_check;
+ALTER TABLE organization_entitlements ADD CONSTRAINT organization_entitlements_plan_state_check CHECK (
+  plan_key IN ('free','plus_monthly','pro_monthly') AND state IN ('free','active','grace','past_due','unpaid')
+  AND ((plan_key = 'free' AND state = 'free' AND entitlement_effective
+        AND (source_subscription_id IS NULL) = (source_subscription_revision IS NULL))
+    OR (plan_key <> 'free' AND state <> 'free' AND source_subscription_id IS NOT NULL
+        AND source_subscription_revision IS NOT NULL AND (entitlement_effective = (state IN ('active','grace')))))
+);

--- a/packages/cloud/shared/src/db/migrations/0379_subscription_account_authority.sql
+++ b/packages/cloud/shared/src/db/migrations/0379_subscription_account_authority.sql
@@ -1,26 +1,37 @@
--- Retain account subscription identity through terminal lifecycle transitions.
-ALTER TABLE organizations ADD COLUMN IF NOT EXISTS subscription_authority_id uuid;
-ALTER TABLE organizations ADD COLUMN IF NOT EXISTS subscription_authority_state text NOT NULL DEFAULT 'none';
+-- Retain account identity without adding a reverse foreign key to the organization schema.
+CREATE TABLE IF NOT EXISTS organization_subscription_authorities (
+  organization_id uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  subscription_id uuid,
+  state text NOT NULL DEFAULT 'none',
+  CONSTRAINT organization_subscription_authorities_tenant_fk FOREIGN KEY (subscription_id, organization_id)
+    REFERENCES billing_subscriptions(id, organization_id) ON DELETE RESTRICT,
+  CONSTRAINT organization_subscription_authorities_state_check CHECK (
+    (state = 'current' AND subscription_id IS NOT NULL)
+    OR (state IN ('none','unavailable') AND subscription_id IS NULL))
+);
+INSERT INTO organization_subscription_authorities (organization_id) SELECT id FROM organizations;
 --> statement-breakpoint
 -- The unique live-subscription constraint establishes identity without timestamp ordering.
-UPDATE organizations o SET subscription_authority_id = s.id, subscription_authority_state = 'current'
+UPDATE organization_subscription_authorities a SET subscription_id = s.id, state = 'current'
 FROM billing_subscriptions s
-WHERE s.organization_id = o.id AND s.status IN ('pending','incomplete','active','grace','past_due','unpaid');
+WHERE s.organization_id = a.organization_id AND s.status IN ('pending','incomplete','active','grace','past_due','unpaid');
 --> statement-breakpoint
--- A single historical source is unambiguous; multiple terminal sources require reconciliation.
-UPDATE organizations o SET subscription_authority_id = s.id, subscription_authority_state = 'current'
+-- A sole historical identity is unambiguous; multiple terminal sources require reconciliation.
+UPDATE organization_subscription_authorities a SET subscription_id = s.id, state = 'current'
 FROM billing_subscriptions s
-WHERE s.organization_id = o.id AND o.subscription_authority_state = 'none'
-AND NOT EXISTS (SELECT 1 FROM billing_subscriptions other WHERE other.organization_id = o.id AND other.id <> s.id);
-UPDATE organizations o SET subscription_authority_state = 'unavailable'
-WHERE o.subscription_authority_state = 'none' AND EXISTS (SELECT 1 FROM billing_subscriptions s WHERE s.organization_id = o.id);
+WHERE s.organization_id = a.organization_id AND a.state = 'none'
+AND NOT EXISTS (SELECT 1 FROM billing_subscriptions other WHERE other.organization_id = a.organization_id AND other.id <> s.id);
+UPDATE organization_subscription_authorities a SET state = 'unavailable'
+WHERE a.state = 'none' AND EXISTS (SELECT 1 FROM billing_subscriptions s WHERE s.organization_id = a.organization_id);
 --> statement-breakpoint
-ALTER TABLE organizations ADD CONSTRAINT organizations_subscription_authority_tenant_fk
-FOREIGN KEY (subscription_authority_id, id) REFERENCES billing_subscriptions (id, organization_id) ON DELETE RESTRICT;
-ALTER TABLE organizations ADD CONSTRAINT organizations_subscription_authority_check CHECK (
-  (subscription_authority_state = 'current' AND subscription_authority_id IS NOT NULL)
-  OR (subscription_authority_state IN ('none','unavailable') AND subscription_authority_id IS NULL)
-);
+CREATE FUNCTION seed_organization_subscription_authority() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  INSERT INTO organization_subscription_authorities (organization_id) VALUES (NEW.id);
+  RETURN NEW;
+END
+$$;
+CREATE TRIGGER organizations_seed_subscription_authority AFTER INSERT ON organizations
+FOR EACH ROW EXECUTE FUNCTION seed_organization_subscription_authority();
 --> statement-breakpoint
 -- Terminal projections retain the authoritative transition that produced Free.
 ALTER TABLE organization_entitlements DROP CONSTRAINT organization_entitlements_plan_state_check;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2535,6 +2535,13 @@
       "when": 1796083200005,
       "tag": "0378_agent_backup_restore_v3_candidate_guards",
       "breakpoints": true
+    },
+    {
+      "idx": 362,
+      "version": "7",
+      "when": 1796083200006,
+      "tag": "0379_subscription_account_authority",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/subscription-account-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/migrations/subscription-account-authority.pglite.test.ts
@@ -53,30 +53,30 @@ describe("subscription account identity migration", () => {
     await database.exec(migration);
     const { rows } = await database.query<{
       id: string;
-      subscription_authority_id: string | null;
-      subscription_authority_state: string;
+      subscription_id: string | null;
+      state: string;
     }>(
-      "SELECT id, subscription_authority_id, subscription_authority_state FROM organizations ORDER BY id",
+      "SELECT organization_id AS id, subscription_id, state FROM organization_subscription_authorities ORDER BY organization_id",
     );
     expect(rows).toEqual([
-      { id: org(1), subscription_authority_id: null, subscription_authority_state: "none" },
-      { id: org(2), subscription_authority_id: sub(1), subscription_authority_state: "current" },
-      { id: org(3), subscription_authority_id: sub(3), subscription_authority_state: "current" },
-      { id: org(4), subscription_authority_id: null, subscription_authority_state: "unavailable" },
-      { id: org(5), subscription_authority_id: null, subscription_authority_state: "none" },
+      { id: org(1), subscription_id: null, state: "none" },
+      { id: org(2), subscription_id: sub(1), state: "current" },
+      { id: org(3), subscription_id: sub(3), state: "current" },
+      { id: org(4), subscription_id: null, state: "unavailable" },
+      { id: org(5), subscription_id: null, state: "none" },
     ]);
     await expect(
       database.query(
-        "UPDATE organizations SET subscription_authority_id=$1, subscription_authority_state='current' WHERE id=$2",
+        "UPDATE organization_subscription_authorities SET subscription_id=$1, state='current' WHERE organization_id=$2",
         [sub(1), org(1)],
       ),
-    ).rejects.toThrow("organizations_subscription_authority_tenant_fk");
+    ).rejects.toThrow("organization_subscription_authorities_tenant_fk");
     await expect(
       database.query(
-        "UPDATE organizations SET subscription_authority_state='current' WHERE id=$1",
+        "UPDATE organization_subscription_authorities SET state='current' WHERE organization_id=$1",
         [org(4)],
       ),
-    ).rejects.toThrow("organizations_subscription_authority_check");
+    ).rejects.toThrow("organization_subscription_authorities_state_check");
     expect(
       (
         await database.query(
@@ -87,13 +87,13 @@ describe("subscription account identity migration", () => {
     ).toEqual([{ plan_key: "free" }]);
   });
 
-  test("a failed migration transaction rolls back both columns and backfill", async () => {
+  test("a failed migration transaction rolls back both the association and backfill", async () => {
     await database.exec("BEGIN");
     await database.exec(migration);
     await expect(database.exec("SELECT 1 / 0")).rejects.toThrow();
     await database.exec("ROLLBACK");
     await expect(
-      database.query("SELECT subscription_authority_id FROM organizations"),
+      database.query("SELECT subscription_id FROM organization_subscription_authorities"),
     ).rejects.toThrow("does not exist");
     expect(
       (
@@ -105,10 +105,11 @@ describe("subscription account identity migration", () => {
     await database.exec(migration);
     expect(
       (
-        await database.query("SELECT subscription_authority_state FROM organizations WHERE id=$1", [
-          org(4),
-        ])
+        await database.query(
+          "SELECT state FROM organization_subscription_authorities WHERE organization_id=$1",
+          [org(4)],
+        )
       ).rows,
-    ).toEqual([{ subscription_authority_state: "unavailable" }]);
+    ).toEqual([{ state: "unavailable" }]);
   });
 });

--- a/packages/cloud/shared/src/db/migrations/subscription-account-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/migrations/subscription-account-authority.pglite.test.ts
@@ -1,0 +1,114 @@
+/** Exercises account subscription identity migration with a real in-memory PostgreSQL engine, including ambiguous history and transactional rollback. */
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+import { btree_gist } from "@electric-sql/pglite/contrib/btree_gist";
+
+setDefaultTimeout(120_000);
+
+let database: PGlite;
+const org = (n: number) => `81000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+const sub = (n: number) => `82000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+const migration = await readFile(
+  new URL("./0379_subscription_account_authority.sql", import.meta.url),
+  "utf8",
+);
+
+beforeEach(async () => {
+  database = new PGlite({ extensions: { btree_gist } });
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE credit_transactions (id uuid PRIMARY KEY, organization_id uuid REFERENCES organizations(id), CONSTRAINT credit_transactions_id_org_idx UNIQUE(id, organization_id));
+  `);
+  const prerequisite = await readFile(
+    new URL("./0373_subscription_authority.sql", import.meta.url),
+    "utf8",
+  );
+  await database.exec(prerequisite);
+  for (let n = 1; n <= 5; n++)
+    await database.query("INSERT INTO organizations(id) VALUES ($1)", [org(n)]);
+  const rows = [
+    [1, 2, "active"],
+    [2, 2, "canceled"],
+    [3, 3, "canceled"],
+    [4, 4, "canceled"],
+    [5, 4, "incomplete_expired"],
+  ] as const;
+  for (const [id, tenant, status] of rows) {
+    await database.query(
+      `INSERT INTO billing_subscriptions (id, organization_id, provider_environment, stripe_customer_id, stripe_subscription_id, stripe_subscription_item_id, plan_key, catalog_version, status, current_period_start, current_period_end, lifecycle_revision, provider_object_digest, created_at)
+      VALUES ($1,$2,'test',$3,$4,$5,'plus_monthly','v1',$6,'2026-08-01Z','2026-09-01Z',1,$7,'2026-08-01Z')`,
+      [sub(id), org(tenant), `cus_${tenant}`, `sub_${id}`, `si_${id}`, status, "a".repeat(64)],
+    );
+  }
+});
+
+afterEach(async () => {
+  await database.close();
+});
+
+describe("subscription account identity migration", () => {
+  test("backfills live identity without chronology and keeps missing history distinct from ambiguity", async () => {
+    await database.exec(migration);
+    const { rows } = await database.query<{
+      id: string;
+      subscription_authority_id: string | null;
+      subscription_authority_state: string;
+    }>(
+      "SELECT id, subscription_authority_id, subscription_authority_state FROM organizations ORDER BY id",
+    );
+    expect(rows).toEqual([
+      { id: org(1), subscription_authority_id: null, subscription_authority_state: "none" },
+      { id: org(2), subscription_authority_id: sub(1), subscription_authority_state: "current" },
+      { id: org(3), subscription_authority_id: sub(3), subscription_authority_state: "current" },
+      { id: org(4), subscription_authority_id: null, subscription_authority_state: "unavailable" },
+      { id: org(5), subscription_authority_id: null, subscription_authority_state: "none" },
+    ]);
+    await expect(
+      database.query(
+        "UPDATE organizations SET subscription_authority_id=$1, subscription_authority_state='current' WHERE id=$2",
+        [sub(1), org(1)],
+      ),
+    ).rejects.toThrow("organizations_subscription_authority_tenant_fk");
+    await expect(
+      database.query(
+        "UPDATE organizations SET subscription_authority_state='current' WHERE id=$1",
+        [org(4)],
+      ),
+    ).rejects.toThrow("organizations_subscription_authority_check");
+    expect(
+      (
+        await database.query(
+          "SELECT plan_key FROM organization_entitlements WHERE organization_id=$1",
+          [org(1)],
+        )
+      ).rows,
+    ).toEqual([{ plan_key: "free" }]);
+  });
+
+  test("a failed migration transaction rolls back both columns and backfill", async () => {
+    await database.exec("BEGIN");
+    await database.exec(migration);
+    await expect(database.exec("SELECT 1 / 0")).rejects.toThrow();
+    await database.exec("ROLLBACK");
+    await expect(
+      database.query("SELECT subscription_authority_id FROM organizations"),
+    ).rejects.toThrow("does not exist");
+    expect(
+      (
+        await database.query<{ count: number }>(
+          "SELECT count(*)::int AS count FROM billing_subscriptions",
+        )
+      ).rows[0].count,
+    ).toBe(5);
+    await database.exec(migration);
+    expect(
+      (
+        await database.query("SELECT subscription_authority_state FROM organizations WHERE id=$1", [
+          org(4),
+        ])
+      ).rows,
+    ).toEqual([{ subscription_authority_state: "unavailable" }]);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/subscription-authority.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-authority.postgres.integration.test.ts
@@ -27,6 +27,7 @@ const PURCHASED_ORG = "10000000-0000-4000-8000-000000000096";
 const PURCHASED_TRANSACTION = "13000000-0000-4000-8000-000000000096";
 
 let setupClient: Client | undefined;
+let entitlements: import("./subscription-entitlements").SubscriptionEntitlementsRepository;
 let allowanceRepository: import("./subscription-allowance").SubscriptionAllowanceRepository;
 let writeTransaction: typeof import("../helpers").writeTransaction;
 let microsToMoney: typeof import("./subscription-funding-reservations").microsToMoney;
@@ -62,6 +63,7 @@ describe.skipIf(!databaseUrl)("subscription authority PostgreSQL constraints", (
       [
         "../migrations/0373_subscription_authority.sql",
         "../migrations/0374_subscription_funding_transaction_uniqueness.sql",
+        "../migrations/0379_subscription_account_authority.sql",
       ].map((path) => readFile(new URL(path, import.meta.url), "utf8")),
     );
     for (const migration of migrations) {
@@ -85,6 +87,9 @@ describe.skipIf(!databaseUrl)("subscription authority PostgreSQL constraints", (
       "./subscription-allowance"
     ));
     ({ writeTransaction } = await import("../helpers"));
+    ({ subscriptionEntitlementsRepository: entitlements } = await import(
+      "./subscription-entitlements"
+    ));
     ({ microsToMoney } = await import("./subscription-funding-reservations"));
     ({ subscriptionFundingService } = await import("../../lib/services/subscription-funding"));
     ({ closeDatabaseConnectionsForTests } = await import("../client"));
@@ -547,6 +552,86 @@ describe.skipIf(!databaseUrl)("subscription authority PostgreSQL constraints", (
       expect(stamp.rows).toEqual([{ skewed: false }]);
     } finally {
       setSystemTime();
+      await locker.query("ROLLBACK");
+      await locker.end();
+    }
+  });
+  test("publication rechecks lifecycle authority after an independent transaction releases its lock", async () => {
+    const organizationId = randomUUID();
+    const subscriptionId = randomUUID();
+    await setupClient!.query("INSERT INTO organizations (id) VALUES ($1)", [organizationId]);
+    await setupClient!.query(
+      `INSERT INTO billing_subscriptions (
+      id, organization_id, provider_environment, stripe_customer_id, stripe_subscription_id,
+      stripe_subscription_item_id, plan_key, catalog_version, status, current_period_start,
+      current_period_end, lifecycle_revision, provider_object_digest
+    ) VALUES ($1,$2,'test','cus_projection','sub_projection','si_projection','plus_monthly','v1',
+      'active','2026-08-01Z','2026-09-01Z',1,$3)`,
+      [subscriptionId, organizationId, DIGEST],
+    );
+    const copyRevision = `INSERT INTO billing_subscription_revisions (
+      organization_id, subscription_id, revision, source, provider_environment,
+      stripe_customer_id, stripe_subscription_id, stripe_subscription_item_id,
+      plan_key, catalog_version, status, current_period_start, current_period_end,
+      cancel_at_period_end, provider_object_digest, dunning_started_at, grace_expires_at
+    ) SELECT organization_id, id, lifecycle_revision, 'webhook', provider_environment,
+      stripe_customer_id, stripe_subscription_id, stripe_subscription_item_id,
+      plan_key, catalog_version, status, current_period_start, current_period_end,
+      cancel_at_period_end, provider_object_digest, dunning_started_at, grace_expires_at
+      FROM billing_subscriptions WHERE id=$1`;
+    await setupClient!.query(copyRevision, [subscriptionId]);
+    await setupClient!.query(
+      "UPDATE organization_subscription_authorities SET subscription_id=$1, state='current' WHERE organization_id=$2",
+      [subscriptionId, organizationId],
+    );
+    const request = {
+      organizationId,
+      sourceSubscriptionId: subscriptionId,
+      sourceSubscriptionRevision: 1,
+      expectedProjectionRevision: 0,
+    };
+    await entitlements.rebuild(request);
+
+    const locker = await connect();
+    try {
+      await locker.query("BEGIN");
+      await locker.query("SELECT id FROM organizations WHERE id=$1 FOR UPDATE", [organizationId]);
+      await locker.query(
+        "UPDATE billing_subscriptions SET lifecycle_revision=2, status='grace', dunning_started_at='2026-08-20Z', grace_expires_at='2026-08-27Z' WHERE id=$1",
+        [subscriptionId],
+      );
+      await locker.query(copyRevision, [subscriptionId]);
+      const pending = entitlements.rebuild({ ...request, expectedProjectionRevision: 1 }).then(
+        (result) => ({ result }),
+        (error: unknown) => ({ error }),
+      );
+      let reachedOrganizationLock = false;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const waiting = await setupClient!.query<{ blocked: boolean }>(
+          `SELECT EXISTS (
+          SELECT 1 FROM pg_stat_activity WHERE datname=current_database() AND wait_event_type='Lock'
+          AND application_name=$1 AND query ILIKE '%organizations%FOR UPDATE%'
+        ) AS blocked`,
+          [schemaName],
+        );
+        reachedOrganizationLock = waiting.rows[0]?.blocked === true;
+        if (reachedOrganizationLock) break;
+        await Bun.sleep(10);
+      }
+      expect(reachedOrganizationLock).toBe(true);
+      await locker.query("COMMIT");
+      expect(await pending).toMatchObject({ error: { code: "SUBSCRIPTION_ENTITLEMENT_CONFLICT" } });
+      const current = await entitlements.rebuild({
+        ...request,
+        sourceSubscriptionRevision: 2,
+        expectedProjectionRevision: 1,
+      });
+      expect(current.entitlement).toMatchObject({
+        state: "grace",
+        source_subscription_revision: 2,
+      });
+      expect(current.entitlement.effective_until?.toISOString()).toBe("2026-08-27T00:00:00.000Z");
+    } finally {
       await locker.query("ROLLBACK");
       await locker.end();
     }

--- a/packages/cloud/shared/src/db/repositories/subscription-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-authority.ts
@@ -156,6 +156,24 @@ function requireActivationAllowed(
   }
 }
 
+function requireCurrentAccountAuthority(
+  organization: Pick<
+    typeof organizations.$inferSelect,
+    "subscription_authority_id" | "subscription_authority_state"
+  >,
+  subscriptionId: string,
+): void {
+  if (
+    organization.subscription_authority_state !== "current" ||
+    organization.subscription_authority_id !== subscriptionId
+  ) {
+    conflict("Subscription is not the current account authority", {
+      subscriptionId,
+      authorityState: organization.subscription_authority_state,
+    });
+  }
+}
+
 function isExactCreateReplay(row: BillingSubscription, values: SubscriptionCreateValues) {
   const { id: requestedId, organization_id: requestedOrganizationId, ...lifecycleValues } = values;
   return (
@@ -229,6 +247,8 @@ export class SubscriptionAuthorityRepository {
       const [organization] = await tx
         .select({
           id: organizations.id,
+          subscription_authority_id: organizations.subscription_authority_id,
+          subscription_authority_state: organizations.subscription_authority_state,
           account_lifecycle_state: organizations.account_lifecycle_state,
           paid_work_fenced_at: organizations.paid_work_fenced_at,
           stripe_customer_id: organizations.stripe_customer_id,
@@ -292,6 +312,7 @@ export class SubscriptionAuthorityRepository {
             revision: existing.lifecycle_revision,
           });
         }
+        requireCurrentAccountAuthority(organization, existing.id);
         return { subscription: existing, revision, replayed: true };
       }
 
@@ -340,6 +361,7 @@ export class SubscriptionAuthorityRepository {
             revision: subscription.lifecycle_revision,
           });
         }
+        requireCurrentAccountAuthority(organization, subscription.id);
         return { subscription, revision, replayed: true };
       }
 
@@ -353,6 +375,13 @@ export class SubscriptionAuthorityRepository {
           revision: 1,
         });
       }
+      await tx
+        .update(organizations)
+        .set({
+          subscription_authority_id: subscription.id,
+          subscription_authority_state: "current",
+        })
+        .where(eq(organizations.id, values.organization_id));
       return { subscription, revision, replayed: false };
     });
   }
@@ -362,6 +391,8 @@ export class SubscriptionAuthorityRepository {
       const [organization] = await tx
         .select({
           id: organizations.id,
+          subscription_authority_id: organizations.subscription_authority_id,
+          subscription_authority_state: organizations.subscription_authority_state,
           account_lifecycle_state: organizations.account_lifecycle_state,
           paid_work_fenced_at: organizations.paid_work_fenced_at,
           stripe_customer_id: organizations.stripe_customer_id,
@@ -376,6 +407,7 @@ export class SubscriptionAuthorityRepository {
           context: { organizationId: input.organizationId },
         });
       }
+      requireCurrentAccountAuthority(organization, input.subscriptionId);
       requireActivationAllowed(organization, input.values);
       const [current] = await tx
         .select()

--- a/packages/cloud/shared/src/db/repositories/subscription-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-authority.ts
@@ -5,6 +5,7 @@
  */
 import { ElizaError } from "@elizaos/core";
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import type { DbTransaction } from "../client";
 import { dbWrite, writeTransaction } from "../helpers";
 import {
   type BillingSubscription,
@@ -13,6 +14,7 @@ import {
   billingSubscriptionRevisions,
   billingSubscriptions,
   type NewBillingSubscription,
+  organizationSubscriptionAuthorities,
 } from "../schemas/billing-subscriptions";
 import { organizations } from "../schemas/organizations";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
@@ -156,20 +158,36 @@ function requireActivationAllowed(
   }
 }
 
+type AccountSubscriptionAuthority = Pick<
+  typeof organizationSubscriptionAuthorities.$inferSelect,
+  "subscription_id" | "state"
+>;
+
+async function readAccountAuthority(
+  tx: DbTransaction,
+  organizationId: string,
+): Promise<AccountSubscriptionAuthority> {
+  const [authority] = await tx
+    .select({
+      subscription_id: organizationSubscriptionAuthorities.subscription_id,
+      state: organizationSubscriptionAuthorities.state,
+    })
+    .from(organizationSubscriptionAuthorities)
+    .where(eq(organizationSubscriptionAuthorities.organization_id, organizationId))
+    .limit(1)
+    .for("update");
+  if (!authority) conflict("Account subscription authority is unavailable", { organizationId });
+  return authority;
+}
+
 function requireCurrentAccountAuthority(
-  organization: Pick<
-    typeof organizations.$inferSelect,
-    "subscription_authority_id" | "subscription_authority_state"
-  >,
+  authority: AccountSubscriptionAuthority,
   subscriptionId: string,
 ): void {
-  if (
-    organization.subscription_authority_state !== "current" ||
-    organization.subscription_authority_id !== subscriptionId
-  ) {
+  if (authority.state !== "current" || authority.subscription_id !== subscriptionId) {
     conflict("Subscription is not the current account authority", {
       subscriptionId,
-      authorityState: organization.subscription_authority_state,
+      authorityState: authority.state,
     });
   }
 }
@@ -239,16 +257,16 @@ export class SubscriptionAuthorityRepository {
       .orderBy(asc(billingSubscriptionRevisions.revision));
   }
 
+  /** The command captures the expected account identity before any provider work starts. */
   async create(
     values: SubscriptionCreateValues,
     source: BillingSubscriptionRevisionSource,
+    expectedAccountSubscriptionId: string | null,
   ): Promise<SubscriptionMutationResult> {
     return writeTransaction(async (tx) => {
       const [organization] = await tx
         .select({
           id: organizations.id,
-          subscription_authority_id: organizations.subscription_authority_id,
-          subscription_authority_state: organizations.subscription_authority_state,
           account_lifecycle_state: organizations.account_lifecycle_state,
           paid_work_fenced_at: organizations.paid_work_fenced_at,
           stripe_customer_id: organizations.stripe_customer_id,
@@ -263,6 +281,7 @@ export class SubscriptionAuthorityRepository {
           context: { organizationId: values.organization_id },
         });
       }
+      const accountAuthority = await readAccountAuthority(tx, values.organization_id);
       requireActivationAllowed(organization, values);
 
       const [currentForOrganization] = await tx
@@ -312,7 +331,7 @@ export class SubscriptionAuthorityRepository {
             revision: existing.lifecycle_revision,
           });
         }
-        requireCurrentAccountAuthority(organization, existing.id);
+        requireCurrentAccountAuthority(accountAuthority, existing.id);
         return { subscription: existing, revision, replayed: true };
       }
 
@@ -361,8 +380,20 @@ export class SubscriptionAuthorityRepository {
             revision: subscription.lifecycle_revision,
           });
         }
-        requireCurrentAccountAuthority(organization, subscription.id);
+        requireCurrentAccountAuthority(accountAuthority, subscription.id);
         return { subscription, revision, replayed: true };
+      }
+
+      if (
+        accountAuthority.state === "unavailable" ||
+        accountAuthority.subscription_id !== expectedAccountSubscriptionId
+      ) {
+        conflict("Subscription creation account authority changed since the command was accepted", {
+          organizationId: values.organization_id,
+          expectedAccountSubscriptionId,
+          currentAccountSubscriptionId: accountAuthority.subscription_id,
+          authorityState: accountAuthority.state,
+        });
       }
 
       const [revision] = await tx
@@ -376,14 +407,37 @@ export class SubscriptionAuthorityRepository {
         });
       }
       await tx
-        .update(organizations)
-        .set({
-          subscription_authority_id: subscription.id,
-          subscription_authority_state: "current",
-        })
-        .where(eq(organizations.id, values.organization_id));
+        .update(organizationSubscriptionAuthorities)
+        .set({ subscription_id: subscription.id, state: "current" })
+        .where(eq(organizationSubscriptionAuthorities.organization_id, values.organization_id));
       return { subscription, revision, replayed: false };
     });
+  }
+
+  /** Release the subscription identity only inside irreversible account erasure. */
+  async releaseForAccountDeletion(tx: DbTransaction, organizationId: string): Promise<void> {
+    const [organization] = await tx
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(
+        and(
+          eq(organizations.id, organizationId),
+          eq(organizations.account_lifecycle_state, "deletion_irreversible"),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!organization)
+      conflict("Subscription authority release requires irreversible account erasure", {
+        organizationId,
+      });
+    const released = await tx
+      .update(organizationSubscriptionAuthorities)
+      .set({ subscription_id: null, state: "unavailable" })
+      .where(eq(organizationSubscriptionAuthorities.organization_id, organizationId))
+      .returning({ organizationId: organizationSubscriptionAuthorities.organization_id });
+    if (released.length !== 1)
+      conflict("Account subscription authority is unavailable during erasure", { organizationId });
   }
 
   async advance(input: AdvanceSubscriptionInput): Promise<SubscriptionMutationResult> {
@@ -391,8 +445,6 @@ export class SubscriptionAuthorityRepository {
       const [organization] = await tx
         .select({
           id: organizations.id,
-          subscription_authority_id: organizations.subscription_authority_id,
-          subscription_authority_state: organizations.subscription_authority_state,
           account_lifecycle_state: organizations.account_lifecycle_state,
           paid_work_fenced_at: organizations.paid_work_fenced_at,
           stripe_customer_id: organizations.stripe_customer_id,
@@ -407,7 +459,8 @@ export class SubscriptionAuthorityRepository {
           context: { organizationId: input.organizationId },
         });
       }
-      requireCurrentAccountAuthority(organization, input.subscriptionId);
+      const accountAuthority = await readAccountAuthority(tx, input.organizationId);
+      requireCurrentAccountAuthority(accountAuthority, input.subscriptionId);
       requireActivationAllowed(organization, input.values);
       const [current] = await tx
         .select()

--- a/packages/cloud/shared/src/db/repositories/subscription-billing-operations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-billing-operations.pglite.test.ts
@@ -155,8 +155,8 @@ beforeEach(async () => {
     ) VALUES ('${ORG_A}', '${SUB_A}', 1, 'webhook', 'test', 'cus_repoa', 'sub_repoa', 'si_repoa',
       'plus_monthly', 'v1', 'active', '2026-08-01T00:00:00Z',
       '2026-09-01T00:00:00Z', false, '${DIGEST_A}');
-    UPDATE organizations SET subscription_authority_id = '${SUB_A}', subscription_authority_state = 'current' WHERE id = '${ORG_A}';
-    UPDATE organizations SET subscription_authority_id = '${SUB_B}', subscription_authority_state = 'current' WHERE id = '${ORG_B}';
+    UPDATE organization_subscription_authorities SET subscription_id = '${SUB_A}', state = 'current' WHERE organization_id = '${ORG_A}';
+    UPDATE organization_subscription_authorities SET subscription_id = '${SUB_B}', state = 'current' WHERE organization_id = '${ORG_B}';
   `);
 });
 

--- a/packages/cloud/shared/src/db/repositories/subscription-billing-operations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-billing-operations.pglite.test.ts
@@ -124,6 +124,7 @@ beforeAll(async () => {
     );
   `);
   await applyMigration("0373_subscription_authority.sql");
+  await applyMigration("0379_subscription_account_authority.sql");
 });
 
 beforeEach(async () => {
@@ -154,6 +155,8 @@ beforeEach(async () => {
     ) VALUES ('${ORG_A}', '${SUB_A}', 1, 'webhook', 'test', 'cus_repoa', 'sub_repoa', 'si_repoa',
       'plus_monthly', 'v1', 'active', '2026-08-01T00:00:00Z',
       '2026-09-01T00:00:00Z', false, '${DIGEST_A}');
+    UPDATE organizations SET subscription_authority_id = '${SUB_A}', subscription_authority_state = 'current' WHERE id = '${ORG_A}';
+    UPDATE organizations SET subscription_authority_id = '${SUB_B}', subscription_authority_state = 'current' WHERE id = '${ORG_B}';
   `);
 });
 
@@ -507,8 +510,8 @@ describe("SubscriptionBillingOperationsRepository", () => {
       state: "free",
       entitlement_effective: true,
       projection_revision: 2,
-      source_subscription_id: null,
-      source_subscription_revision: null,
+      source_subscription_id: SUB_A,
+      source_subscription_revision: 2,
     });
   });
 

--- a/packages/cloud/shared/src/db/repositories/subscription-entitlements-derivation.test.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-entitlements-derivation.test.ts
@@ -52,12 +52,20 @@ describe("subscription entitlement derivation", () => {
       state: "grace",
       entitlement_effective: true,
       effective_from: revision.current_period_start,
-      effective_until: revision.current_period_end,
+      effective_until: revision.grace_expires_at,
       catalog_version: "v1",
       source_digest: revision.provider_object_digest,
       source_subscription_id: revision.subscription_id,
       source_subscription_revision: 7,
     });
+  });
+
+  test("rejects missing, invalid, and reversed grace deadlines before publication", () => {
+    for (const grace_expires_at of [null, new Date(Number.NaN), revision.current_period_start]) {
+      expect(() => deriveSubscriptionEntitlementValues({ ...revision, grace_expires_at })).toThrow(
+        "requires a valid lifecycle deadline",
+      );
+    }
   });
 
   test("projects terminal lifecycle revisions back to Free", () => {
@@ -70,8 +78,8 @@ describe("subscription entitlement derivation", () => {
       entitlement_effective: true,
       effective_from: endedAt,
       effective_until: null,
-      source_subscription_id: null,
-      source_subscription_revision: null,
+      source_subscription_id: revision.subscription_id,
+      source_subscription_revision: 7,
     });
     expect(
       deriveSubscriptionEntitlementValues({ ...revision, status: "incomplete_expired" }),

--- a/packages/cloud/shared/src/db/repositories/subscription-entitlements.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-entitlements.pglite.test.ts
@@ -1,0 +1,256 @@
+/** Exercises entitlement publication against a real PGlite database, including replay, replacement and transaction rollback. */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { readFile } from "node:fs/promises";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+setDefaultTimeout(120_000);
+const ORG_A = "51000000-0000-4000-8000-000000000001";
+const ORG_B = "51000000-0000-4000-8000-000000000002";
+const USER = "52000000-0000-4000-8000-000000000001";
+const SUB_A = "53000000-0000-4000-8000-000000000001";
+const SUB_B = "53000000-0000-4000-8000-000000000002";
+const REPLACEMENT = "53000000-0000-4000-8000-000000000003";
+const DIGEST_A = "a".repeat(64);
+let client: typeof import("../client");
+let entitlements: import("./subscription-entitlements").SubscriptionEntitlementsRepository;
+let authority: import("./subscription-authority").SubscriptionAuthorityRepository;
+let writeTransaction: typeof import("../helpers").writeTransaction;
+function getPgliteClientForTests() {
+  return client.getPgliteClientForTests();
+}
+beforeAll(async () => {
+  client = await import("../client");
+  ({ subscriptionEntitlementsRepository: entitlements } = await import(
+    "./subscription-entitlements"
+  ));
+  ({ subscriptionAuthorityRepository: authority } = await import("./subscription-authority"));
+  ({ writeTransaction } = await import("../helpers"));
+  await getPgliteClientForTests().exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY, account_lifecycle_state text NOT NULL DEFAULT 'active', paid_work_fenced_at timestamptz, stripe_customer_id text);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE credit_transactions (id uuid PRIMARY KEY, organization_id uuid NOT NULL REFERENCES organizations(id), CONSTRAINT credit_transactions_id_org_idx UNIQUE (id, organization_id));
+  `);
+  const migration = await readFile(
+    new URL("../migrations/0373_subscription_authority.sql", import.meta.url),
+    "utf8",
+  );
+  for (const statement of migration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await getPgliteClientForTests().exec(statement);
+  }
+  const identityMigration = await readFile(
+    new URL("../migrations/0379_subscription_account_authority.sql", import.meta.url),
+    "utf8",
+  );
+  for (const statement of identityMigration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await getPgliteClientForTests().exec(statement);
+  }
+});
+beforeEach(async () => {
+  await getPgliteClientForTests().exec(`
+    ALTER TABLE billing_subscription_revisions DISABLE TRIGGER billing_subscription_revisions_immutable_guard;
+    ALTER TABLE subscription_allowance_transactions DISABLE TRIGGER subscription_allowance_transactions_immutable_guard;
+    TRUNCATE TABLE billing_subscriptions, users, organizations CASCADE;
+    ALTER TABLE billing_subscription_revisions ENABLE TRIGGER billing_subscription_revisions_immutable_guard;
+    ALTER TABLE subscription_allowance_transactions ENABLE TRIGGER subscription_allowance_transactions_immutable_guard;
+    INSERT INTO organizations (id) VALUES ('${ORG_A}'), ('${ORG_B}');
+    INSERT INTO users (id) VALUES ('${USER}');
+    INSERT INTO billing_subscriptions (
+      id, organization_id, provider_environment, stripe_customer_id,
+      stripe_subscription_id, stripe_subscription_item_id,
+      plan_key, catalog_version, status, current_period_start, current_period_end,
+      lifecycle_revision, provider_object_digest
+    ) VALUES
+      ('${SUB_A}', '${ORG_A}', 'test', 'cus_repoa', 'sub_repoa', 'si_repoa', 'plus_monthly', 'v1', 'active',
+       '2026-08-01T00:00:00Z', '2026-09-01T00:00:00Z', 1, '${DIGEST_A}'),
+      ('${SUB_B}', '${ORG_B}', 'test', 'cus_repob', 'sub_repob', 'si_repob', 'plus_monthly', 'v1', 'active',
+       '2026-08-01T00:00:00Z', '2026-09-01T00:00:00Z', 1, '${DIGEST_A}');
+    INSERT INTO billing_subscription_revisions (
+      organization_id, subscription_id, revision, source, provider_environment,
+      stripe_customer_id, stripe_subscription_id,
+      stripe_subscription_item_id, plan_key, catalog_version, status,
+      current_period_start, current_period_end, cancel_at_period_end,
+      provider_object_digest
+    ) VALUES ('${ORG_A}', '${SUB_A}', 1, 'webhook', 'test', 'cus_repoa', 'sub_repoa', 'si_repoa',
+      'plus_monthly', 'v1', 'active', '2026-08-01T00:00:00Z',
+      '2026-09-01T00:00:00Z', false, '${DIGEST_A}');
+    UPDATE organizations SET subscription_authority_id = '${SUB_A}', subscription_authority_state = 'current' WHERE id = '${ORG_A}';
+    UPDATE organizations SET subscription_authority_id = '${SUB_B}', subscription_authority_state = 'current' WHERE id = '${ORG_B}';
+  `);
+});
+
+afterAll(async () => {
+  await client.closeDatabaseConnectionsForTests();
+});
+const request = {
+  organizationId: ORG_A,
+  sourceSubscriptionId: SUB_A,
+  sourceSubscriptionRevision: 1,
+  expectedProjectionRevision: 0,
+};
+async function advanceToGrace(deadline: string) {
+  await getPgliteClientForTests().exec(`
+    UPDATE billing_subscriptions SET lifecycle_revision = 2, status = 'grace', dunning_started_at = '2026-08-20Z', grace_expires_at = '${deadline}' WHERE id = '${SUB_A}';
+    INSERT INTO billing_subscription_revisions (
+      organization_id, subscription_id, revision, source, provider_environment,
+      stripe_customer_id, stripe_subscription_id, stripe_subscription_item_id,
+      plan_key, catalog_version, status, current_period_start, current_period_end,
+      cancel_at_period_end, provider_object_digest, dunning_started_at, grace_expires_at
+    ) VALUES ('${ORG_A}', '${SUB_A}', 2, 'webhook', 'test', 'cus_repoa', 'sub_repoa', 'si_repoa', 'plus_monthly', 'v1', 'grace', '2026-08-01Z', '2026-09-01Z', false, '${DIGEST_A}', '2026-08-20Z', '${deadline}');
+  `);
+}
+describe("current-source entitlement publication", () => {
+  test("an old request cannot replay a projection after lifecycle authority advances", async () => {
+    const first = await entitlements.rebuild(request);
+    expect((await entitlements.rebuild(request)).replayed).toBe(true);
+    await advanceToGrace("2026-08-27Z");
+    await expect(entitlements.rebuild(request)).rejects.toMatchObject({
+      code: "SUBSCRIPTION_ENTITLEMENT_CONFLICT",
+    });
+    expect(await entitlements.find(ORG_A)).toEqual(first.entitlement);
+    const next = await entitlements.rebuild({
+      ...request,
+      sourceSubscriptionRevision: 2,
+      expectedProjectionRevision: 1,
+    });
+    expect(next.entitlement.effective_until?.toISOString()).toBe("2026-08-27T00:00:00.000Z");
+    expect(next.entitlement.state).toBe("grace");
+  });
+  test.each(["2026-08-27Z", "2026-09-10Z"])(
+    "publishes the actual grace deadline %s",
+    async (deadline) => {
+      await advanceToGrace(deadline);
+      const next = await entitlements.rebuild({ ...request, sourceSubscriptionRevision: 2 });
+      expect(next.entitlement.effective_until?.getTime()).toBe(Date.parse(deadline));
+    },
+  );
+  test("a missing grace deadline leaves the prior projection unchanged", async () => {
+    const first = await entitlements.rebuild(request);
+    await advanceToGrace("2026-08-27Z");
+    await getPgliteClientForTests().exec(
+      `UPDATE billing_subscriptions SET grace_expires_at = NULL, dunning_started_at = NULL WHERE id = '${SUB_A}';`,
+    );
+    await expect(
+      entitlements.rebuild({
+        ...request,
+        sourceSubscriptionRevision: 2,
+        expectedProjectionRevision: 1,
+      }),
+    ).rejects.toMatchObject({ code: "SUBSCRIPTION_ENTITLEMENT_CONFLICT" });
+    expect(await entitlements.find(ORG_A)).toEqual(first.entitlement);
+  });
+  test("tenant mismatch cannot publish another organization's subscription", async () => {
+    await expect(entitlements.rebuild({ ...request, organizationId: ORG_B })).rejects.toMatchObject(
+      { code: "SUBSCRIPTION_ENTITLEMENT_SOURCE_NOT_FOUND" },
+    );
+    expect((await entitlements.find(ORG_B))?.plan_key).toBe("free");
+  });
+  test("concurrent different source publications retain the current revision", async () => {
+    await advanceToGrace("2026-09-10Z");
+    const results = await Promise.allSettled([
+      entitlements.rebuild(request),
+      entitlements.rebuild({ ...request, sourceSubscriptionRevision: 2 }),
+    ]);
+    expect(results[0].status).toBe("rejected");
+    expect(results[1].status).toBe("fulfilled");
+    expect((await entitlements.find(ORG_A))?.source_subscription_revision).toBe(2);
+  });
+  test("projection and outer lifecycle work roll back in the same transaction", async () => {
+    await expect(
+      writeTransaction(async (tx) => {
+        await entitlements.rebuildInTransaction(tx, request);
+        throw new Error("outer operation failed");
+      }),
+    ).rejects.toThrow("outer operation failed");
+    expect((await entitlements.find(ORG_A))?.plan_key).toBe("free");
+    expect((await entitlements.rebuild(request)).entitlement.source_subscription_revision).toBe(1);
+  });
+  test.each(["active", "canceled"] as const)(
+    "retains explicit replacement %s identity even with equal creation timestamps",
+    async (status) => {
+      const original = await authority.findById(ORG_A, SUB_A);
+      if (!original) throw new Error("Missing seeded subscription");
+      const values = {
+        provider: original.provider,
+        provider_environment: original.provider_environment,
+        stripe_customer_id: original.stripe_customer_id,
+        stripe_subscription_id: original.stripe_subscription_id,
+        stripe_subscription_item_id: original.stripe_subscription_item_id,
+        catalog_version: original.catalog_version,
+        plan_key: original.plan_key,
+        status: "canceled" as const,
+        current_period_start: original.current_period_start,
+        current_period_end: original.current_period_end,
+        cancel_at_period_end: false,
+        canceled_at: new Date("2026-08-25Z"),
+        ended_at: new Date("2026-08-25Z"),
+        dunning_started_at: null,
+        grace_expires_at: null,
+        pending_plan_key: null,
+        last_provider_event_id: null,
+        last_provider_event_created_at: null,
+        provider_object_digest: DIGEST_A,
+      };
+      await authority.advance({
+        organizationId: ORG_A,
+        subscriptionId: SUB_A,
+        expectedRevision: 1,
+        source: "webhook",
+        observation: "authoritative_provider_retrieval",
+        values,
+      });
+      const replacement = await authority.create(
+        {
+          ...values,
+          id: REPLACEMENT,
+          organization_id: ORG_A,
+          stripe_subscription_id: "sub_replacement",
+          stripe_subscription_item_id: "si_replacement",
+          plan_key: "pro_monthly",
+          status,
+        },
+        "checkout",
+      );
+      await getPgliteClientForTests().exec(
+        `UPDATE billing_subscriptions SET created_at='2026-08-01Z' WHERE organization_id='${ORG_A}'`,
+      );
+      const current = await entitlements.rebuild({
+        ...request,
+        sourceSubscriptionId: replacement.subscription.id,
+        sourceSubscriptionRevision: 1,
+      });
+      expect(current.entitlement.source_subscription_id).toBe(REPLACEMENT);
+      expect(current.entitlement.plan_key).toBe(status === "active" ? "pro_monthly" : "free");
+      await expect(
+        entitlements.rebuild({
+          ...request,
+          sourceSubscriptionRevision: 2,
+          expectedProjectionRevision: 1,
+        }),
+      ).rejects.toMatchObject({ code: "SUBSCRIPTION_ENTITLEMENT_CONFLICT" });
+      await expect(
+        authority.advance({
+          organizationId: ORG_A,
+          subscriptionId: SUB_A,
+          expectedRevision: 2,
+          source: "webhook",
+          observation: "authoritative_provider_retrieval",
+          values,
+        }),
+      ).rejects.toMatchObject({ code: "SUBSCRIPTION_AUTHORITY_CONFLICT" });
+      await expect(
+        authority.create({ ...values, id: SUB_A, organization_id: ORG_A }, "checkout"),
+      ).rejects.toMatchObject({ code: "SUBSCRIPTION_AUTHORITY_CONFLICT" });
+      expect(await entitlements.find(ORG_A)).toEqual(current.entitlement);
+    },
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/subscription-entitlements.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-entitlements.pglite.test.ts
@@ -47,6 +47,13 @@ beforeAll(async () => {
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await getPgliteClientForTests().exec(statement);
   }
+  const eraseMigration = await readFile(
+    new URL("../migrations/0374_subscription_funding_transaction_uniqueness.sql", import.meta.url),
+    "utf8",
+  );
+  for (const statement of eraseMigration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await getPgliteClientForTests().exec(statement);
+  }
   const identityMigration = await readFile(
     new URL("../migrations/0379_subscription_account_authority.sql", import.meta.url),
     "utf8",
@@ -83,8 +90,8 @@ beforeEach(async () => {
     ) VALUES ('${ORG_A}', '${SUB_A}', 1, 'webhook', 'test', 'cus_repoa', 'sub_repoa', 'si_repoa',
       'plus_monthly', 'v1', 'active', '2026-08-01T00:00:00Z',
       '2026-09-01T00:00:00Z', false, '${DIGEST_A}');
-    UPDATE organizations SET subscription_authority_id = '${SUB_A}', subscription_authority_state = 'current' WHERE id = '${ORG_A}';
-    UPDATE organizations SET subscription_authority_id = '${SUB_B}', subscription_authority_state = 'current' WHERE id = '${ORG_B}';
+    UPDATE organization_subscription_authorities SET subscription_id = '${SUB_A}', state = 'current' WHERE organization_id = '${ORG_A}';
+    UPDATE organization_subscription_authorities SET subscription_id = '${SUB_B}', state = 'current' WHERE organization_id = '${ORG_B}';
   `);
 });
 
@@ -174,6 +181,41 @@ describe("current-source entitlement publication", () => {
     expect((await entitlements.find(ORG_A))?.plan_key).toBe("free");
     expect((await entitlements.rebuild(request)).entitlement.source_subscription_revision).toBe(1);
   });
+  test("account erasure releases the reverse pointer only behind the irreversible fence", async () => {
+    await expect(
+      writeTransaction((tx) => authority.releaseForAccountDeletion(tx, ORG_A)),
+    ).rejects.toMatchObject({ code: "SUBSCRIPTION_AUTHORITY_CONFLICT" });
+    await getPgliteClientForTests().exec(
+      `UPDATE organizations SET account_lifecycle_state='deletion_irreversible' WHERE id='${ORG_A}'`,
+    );
+    await expect(
+      writeTransaction(async (tx) => {
+        await authority.releaseForAccountDeletion(tx, ORG_A);
+        throw new Error("erase failed");
+      }),
+    ).rejects.toThrow("erase failed");
+    const rollback = await getPgliteClientForTests().query(
+      `SELECT subscription_id FROM organization_subscription_authorities WHERE organization_id='${ORG_A}'`,
+    );
+    expect(rollback.rows).toEqual([{ subscription_id: SUB_A }]);
+    await writeTransaction(async (tx) => {
+      await authority.releaseForAccountDeletion(tx, ORG_A);
+      const { sql } = await import("drizzle-orm");
+      await tx.execute(
+        sql`SELECT set_config('eliza.subscription_account_deletion_authority', 'on', true)`,
+      );
+      await tx.execute(sql`DELETE FROM organization_entitlements WHERE organization_id=${ORG_A}`);
+      await tx.execute(
+        sql`DELETE FROM billing_subscription_revisions WHERE organization_id=${ORG_A}`,
+      );
+      await tx.execute(sql`DELETE FROM billing_subscriptions WHERE organization_id=${ORG_A}`);
+      await tx.execute(sql`DELETE FROM organizations WHERE id=${ORG_A}`);
+    });
+    expect(await entitlements.find(ORG_A)).toBeUndefined();
+    expect(await authority.findById(ORG_A, SUB_A)).toBeUndefined();
+    expect(await authority.findById(ORG_B, SUB_B)).toBeDefined();
+  });
+
   test.each(["active", "canceled"] as const)(
     "retains explicit replacement %s identity even with equal creation timestamps",
     async (status) => {
@@ -219,6 +261,7 @@ describe("current-source entitlement publication", () => {
           status,
         },
         "checkout",
+        SUB_A,
       );
       await getPgliteClientForTests().exec(
         `UPDATE billing_subscriptions SET created_at='2026-08-01Z' WHERE organization_id='${ORG_A}'`,
@@ -248,8 +291,26 @@ describe("current-source entitlement publication", () => {
         }),
       ).rejects.toMatchObject({ code: "SUBSCRIPTION_AUTHORITY_CONFLICT" });
       await expect(
-        authority.create({ ...values, id: SUB_A, organization_id: ORG_A }, "checkout"),
+        authority.create({ ...values, id: SUB_A, organization_id: ORG_A }, "checkout", null),
       ).rejects.toMatchObject({ code: "SUBSCRIPTION_AUTHORITY_CONFLICT" });
+      if (status === "canceled") {
+        await expect(
+          authority.create(
+            {
+              ...values,
+              id: "53000000-0000-4000-8000-000000000004",
+              organization_id: ORG_A,
+              stripe_subscription_id: "sub_delayed",
+              stripe_subscription_item_id: "si_delayed",
+            },
+            "checkout",
+            SUB_A,
+          ),
+        ).rejects.toMatchObject({ code: "SUBSCRIPTION_AUTHORITY_CONFLICT" });
+        expect(
+          await authority.findById(ORG_A, "53000000-0000-4000-8000-000000000004"),
+        ).toBeUndefined();
+      }
       expect(await entitlements.find(ORG_A)).toEqual(current.entitlement);
     },
   );

--- a/packages/cloud/shared/src/db/repositories/subscription-entitlements.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-entitlements.ts
@@ -6,7 +6,8 @@
 import { ElizaError } from "@elizaos/core";
 import { and, eq } from "drizzle-orm";
 import { resolveSubscriptionPlanDefinition } from "../../lib/services/subscription-catalog";
-import { dbRead, writeTransaction } from "../helpers";
+import type { DbTransaction } from "../client";
+import { dbWrite, writeTransaction } from "../helpers";
 import {
   type BillingSubscriptionRevision,
   billingSubscriptionRevisions,
@@ -85,6 +86,8 @@ export function deriveSubscriptionEntitlementValues(
       ...FREE_ENTITLEMENT_VALUES,
       effective_from: revision.ended_at ?? revision.canceled_at ?? revision.recorded_at,
       source_digest: revision.provider_object_digest,
+      source_subscription_id: revision.subscription_id,
+      source_subscription_revision: revision.revision,
     };
   }
   if (
@@ -102,6 +105,19 @@ export function deriveSubscriptionEntitlementValues(
       },
     });
   }
+  const effectiveUntil =
+    revision.status === "grace" ? revision.grace_expires_at : revision.current_period_end;
+  if (
+    effectiveUntil === null ||
+    !Number.isFinite(effectiveUntil.getTime()) ||
+    !Number.isFinite(revision.current_period_start.getTime()) ||
+    effectiveUntil <= revision.current_period_start
+  ) {
+    throw new ElizaError("Subscription entitlement requires a valid lifecycle deadline", {
+      code: SUBSCRIPTION_ENTITLEMENT_SOURCE_NOT_FOUND,
+      context: { subscriptionId: revision.subscription_id, status: revision.status },
+    });
+  }
   const plan = resolveSubscriptionPlanDefinition(revision.plan_key, revision.catalog_version);
   return {
     completions_rpm: plan.rateLimits.completionsRpm,
@@ -117,7 +133,7 @@ export function deriveSubscriptionEntitlementValues(
     state: revision.status,
     entitlement_effective: revision.status === "active" || revision.status === "grace",
     effective_from: revision.current_period_start,
-    effective_until: revision.current_period_end,
+    effective_until: effectiveUntil,
     catalog_version: revision.catalog_version,
     source_digest: revision.provider_object_digest,
     source_subscription_id: revision.subscription_id,
@@ -127,7 +143,7 @@ export function deriveSubscriptionEntitlementValues(
 
 export class SubscriptionEntitlementsRepository {
   async find(organizationId: string): Promise<OrganizationEntitlement | undefined> {
-    const [row] = await dbRead
+    const [row] = await dbWrite
       .select()
       .from(organizationEntitlements)
       .where(eq(organizationEntitlements.organization_id, organizationId))
@@ -138,132 +154,182 @@ export class SubscriptionEntitlementsRepository {
   async rebuild(
     input: RebuildSubscriptionEntitlementInput,
   ): Promise<RebuildSubscriptionEntitlementResult> {
-    return writeTransaction(async (tx) => {
-      const [organization] = await tx
-        .select({ id: organizations.id })
-        .from(organizations)
-        .where(eq(organizations.id, input.organizationId))
-        .limit(1)
-        .for("update");
-      if (!organization) {
-        throw new ElizaError("Entitlement organization does not exist", {
-          code: SUBSCRIPTION_ENTITLEMENT_TENANT_NOT_FOUND,
-          context: { organizationId: input.organizationId },
-        });
-      }
+    return writeTransaction((tx) => this.rebuildInTransaction(tx, input));
+  }
 
-      let values: RebuildValues;
-      {
-        const [subscription] = await tx
-          .select({ id: billingSubscriptions.id })
-          .from(billingSubscriptions)
-          .where(
-            and(
-              eq(billingSubscriptions.organization_id, input.organizationId),
-              eq(billingSubscriptions.id, input.sourceSubscriptionId),
-            ),
-          )
-          .limit(1)
-          .for("update");
-        if (!subscription) {
-          throw new ElizaError("Entitlement source subscription does not exist", {
-            code: SUBSCRIPTION_ENTITLEMENT_SOURCE_NOT_FOUND,
-            context: {
-              organizationId: input.organizationId,
-              subscriptionId: input.sourceSubscriptionId,
-            },
-          });
-        }
-        const [revision] = await tx
-          .select()
-          .from(billingSubscriptionRevisions)
-          .where(
-            and(
-              eq(billingSubscriptionRevisions.organization_id, input.organizationId),
-              eq(billingSubscriptionRevisions.subscription_id, input.sourceSubscriptionId),
-              eq(billingSubscriptionRevisions.revision, input.sourceSubscriptionRevision),
-            ),
-          )
-          .limit(1);
-        if (!revision) {
-          throw new ElizaError("Entitlement source revision does not exist", {
-            code: SUBSCRIPTION_ENTITLEMENT_SOURCE_NOT_FOUND,
-            context: {
-              subscriptionId: input.sourceSubscriptionId,
-              revision: input.sourceSubscriptionRevision,
-            },
-          });
-        }
-        values = deriveSubscriptionEntitlementValues(revision);
-      }
+  /** Compose publication with lifecycle writes; the transaction owns organization-first locks. */
+  async rebuildInTransaction(
+    tx: DbTransaction,
+    input: RebuildSubscriptionEntitlementInput,
+  ): Promise<RebuildSubscriptionEntitlementResult> {
+    const [organization] = await tx
+      .select({
+        id: organizations.id,
+        subscriptionAuthorityId: organizations.subscription_authority_id,
+        subscriptionAuthorityState: organizations.subscription_authority_state,
+      })
+      .from(organizations)
+      .where(eq(organizations.id, input.organizationId))
+      .limit(1)
+      .for("update");
+    if (!organization) {
+      throw new ElizaError("Entitlement organization does not exist", {
+        code: SUBSCRIPTION_ENTITLEMENT_TENANT_NOT_FOUND,
+        context: { organizationId: input.organizationId },
+      });
+    }
 
-      const [current] = await tx
+    let values: RebuildValues;
+    {
+      const [subscription] = await tx
         .select()
-        .from(organizationEntitlements)
-        .where(eq(organizationEntitlements.organization_id, input.organizationId))
+        .from(billingSubscriptions)
+        .where(
+          and(
+            eq(billingSubscriptions.organization_id, input.organizationId),
+            eq(billingSubscriptions.id, input.sourceSubscriptionId),
+          ),
+        )
         .limit(1)
         .for("update");
-      if (
-        current &&
-        Object.entries(values).every(([key, requested]) =>
-          sameEntitlementValue(current[key as keyof OrganizationEntitlement], requested),
-        )
-      ) {
-        return { entitlement: current, replayed: true };
-      }
-
-      const actualRevision = current?.projection_revision ?? null;
-      if (actualRevision !== input.expectedProjectionRevision) {
-        entitlementConflict("Entitlement projection compare-and-swap failed", {
-          organizationId: input.organizationId,
-          expectedRevision: input.expectedProjectionRevision,
-          actualRevision,
+      if (!subscription) {
+        throw new ElizaError("Entitlement source subscription does not exist", {
+          code: SUBSCRIPTION_ENTITLEMENT_SOURCE_NOT_FOUND,
+          context: {
+            organizationId: input.organizationId,
+            subscriptionId: input.sourceSubscriptionId,
+          },
         });
       }
-      const nextRevision = (actualRevision ?? -1) + 1;
-      const now = await readPostLockDatabaseNow(tx);
-      if (!current) {
-        const [entitlement] = await tx
-          .insert(organizationEntitlements)
-          .values({
-            ...values,
-            organization_id: input.organizationId,
-            projection_revision: nextRevision,
-            rebuilt_at: now,
-            updated_at: now,
-          })
-          .returning();
-        if (!entitlement) {
-          entitlementConflict("Entitlement insert returned no row", {
+      if (subscription.lifecycle_revision !== input.sourceSubscriptionRevision) {
+        entitlementConflict("Entitlement source is not the current lifecycle revision", {
+          organizationId: input.organizationId,
+          subscriptionId: subscription.id,
+          requestedRevision: input.sourceSubscriptionRevision,
+          currentRevision: subscription.lifecycle_revision,
+        });
+      }
+      if (
+        organization.subscriptionAuthorityState !== "current" ||
+        organization.subscriptionAuthorityId !== subscription.id
+      ) {
+        entitlementConflict(
+          "Entitlement source is not the current account subscription authority",
+          {
             organizationId: input.organizationId,
+            subscriptionId: subscription.id,
+            authorityState: organization.subscriptionAuthorityState,
+          },
+        );
+      }
+      const [revision] = await tx
+        .select()
+        .from(billingSubscriptionRevisions)
+        .where(
+          and(
+            eq(billingSubscriptionRevisions.organization_id, input.organizationId),
+            eq(billingSubscriptionRevisions.subscription_id, input.sourceSubscriptionId),
+            eq(billingSubscriptionRevisions.revision, input.sourceSubscriptionRevision),
+          ),
+        )
+        .limit(1);
+      if (!revision) {
+        throw new ElizaError("Entitlement source revision does not exist", {
+          code: SUBSCRIPTION_ENTITLEMENT_SOURCE_NOT_FOUND,
+          context: {
+            subscriptionId: input.sourceSubscriptionId,
+            revision: input.sourceSubscriptionRevision,
+          },
+        });
+      }
+      for (const field of [
+        "plan_key",
+        "catalog_version",
+        "status",
+        "current_period_start",
+        "current_period_end",
+        "grace_expires_at",
+        "provider_object_digest",
+        "canceled_at",
+        "ended_at",
+      ] as const) {
+        if (!sameEntitlementValue(subscription[field], revision[field])) {
+          entitlementConflict("Entitlement source differs from committed lifecycle authority", {
+            organizationId: input.organizationId,
+            subscriptionId: subscription.id,
+            field,
           });
         }
-        return { entitlement, replayed: false };
       }
+      values = deriveSubscriptionEntitlementValues(revision);
+    }
 
+    const [current] = await tx
+      .select()
+      .from(organizationEntitlements)
+      .where(eq(organizationEntitlements.organization_id, input.organizationId))
+      .limit(1)
+      .for("update");
+    if (
+      current &&
+      Object.entries(values).every(([key, requested]) =>
+        sameEntitlementValue(current[key as keyof OrganizationEntitlement], requested),
+      )
+    ) {
+      return { entitlement: current, replayed: true };
+    }
+
+    const actualRevision = current?.projection_revision ?? null;
+    if (actualRevision !== input.expectedProjectionRevision) {
+      entitlementConflict("Entitlement projection compare-and-swap failed", {
+        organizationId: input.organizationId,
+        expectedRevision: input.expectedProjectionRevision,
+        actualRevision,
+      });
+    }
+    const nextRevision = (actualRevision ?? -1) + 1;
+    const now = await readPostLockDatabaseNow(tx);
+    if (!current) {
       const [entitlement] = await tx
-        .update(organizationEntitlements)
-        .set({
+        .insert(organizationEntitlements)
+        .values({
           ...values,
+          organization_id: input.organizationId,
           projection_revision: nextRevision,
           rebuilt_at: now,
           updated_at: now,
         })
-        .where(
-          and(
-            eq(organizationEntitlements.organization_id, input.organizationId),
-            eq(organizationEntitlements.projection_revision, input.expectedProjectionRevision!),
-          ),
-        )
         .returning();
       if (!entitlement) {
-        entitlementConflict("Entitlement projection compare-and-swap lost", {
+        entitlementConflict("Entitlement insert returned no row", {
           organizationId: input.organizationId,
-          expectedRevision: input.expectedProjectionRevision,
         });
       }
       return { entitlement, replayed: false };
-    });
+    }
+
+    const [entitlement] = await tx
+      .update(organizationEntitlements)
+      .set({
+        ...values,
+        projection_revision: nextRevision,
+        rebuilt_at: now,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(organizationEntitlements.organization_id, input.organizationId),
+          eq(organizationEntitlements.projection_revision, input.expectedProjectionRevision!),
+        ),
+      )
+      .returning();
+    if (!entitlement) {
+      entitlementConflict("Entitlement projection compare-and-swap lost", {
+        organizationId: input.organizationId,
+        expectedRevision: input.expectedProjectionRevision,
+      });
+    }
+    return { entitlement, replayed: false };
   }
 }
 

--- a/packages/cloud/shared/src/db/repositories/subscription-entitlements.ts
+++ b/packages/cloud/shared/src/db/repositories/subscription-entitlements.ts
@@ -12,6 +12,7 @@ import {
   type BillingSubscriptionRevision,
   billingSubscriptionRevisions,
   billingSubscriptions,
+  organizationSubscriptionAuthorities,
 } from "../schemas/billing-subscriptions";
 import {
   type NewOrganizationEntitlement,
@@ -163,11 +164,7 @@ export class SubscriptionEntitlementsRepository {
     input: RebuildSubscriptionEntitlementInput,
   ): Promise<RebuildSubscriptionEntitlementResult> {
     const [organization] = await tx
-      .select({
-        id: organizations.id,
-        subscriptionAuthorityId: organizations.subscription_authority_id,
-        subscriptionAuthorityState: organizations.subscription_authority_state,
-      })
+      .select({ id: organizations.id })
       .from(organizations)
       .where(eq(organizations.id, input.organizationId))
       .limit(1)
@@ -178,6 +175,13 @@ export class SubscriptionEntitlementsRepository {
         context: { organizationId: input.organizationId },
       });
     }
+
+    const [accountAuthority] = await tx
+      .select()
+      .from(organizationSubscriptionAuthorities)
+      .where(eq(organizationSubscriptionAuthorities.organization_id, input.organizationId))
+      .limit(1)
+      .for("update");
 
     let values: RebuildValues;
     {
@@ -201,6 +205,19 @@ export class SubscriptionEntitlementsRepository {
           },
         });
       }
+      if (
+        !accountAuthority ||
+        accountAuthority.state !== "current" ||
+        accountAuthority.subscription_id !== input.sourceSubscriptionId
+      ) {
+        entitlementConflict(
+          "Entitlement source is not the current account subscription authority",
+          {
+            organizationId: input.organizationId,
+            subscriptionId: input.sourceSubscriptionId,
+          },
+        );
+      }
       if (subscription.lifecycle_revision !== input.sourceSubscriptionRevision) {
         entitlementConflict("Entitlement source is not the current lifecycle revision", {
           organizationId: input.organizationId,
@@ -208,19 +225,6 @@ export class SubscriptionEntitlementsRepository {
           requestedRevision: input.sourceSubscriptionRevision,
           currentRevision: subscription.lifecycle_revision,
         });
-      }
-      if (
-        organization.subscriptionAuthorityState !== "current" ||
-        organization.subscriptionAuthorityId !== subscription.id
-      ) {
-        entitlementConflict(
-          "Entitlement source is not the current account subscription authority",
-          {
-            organizationId: input.organizationId,
-            subscriptionId: subscription.id,
-            authorityState: organization.subscriptionAuthorityState,
-          },
-        );
       }
       const [revision] = await tx
         .select()

--- a/packages/cloud/shared/src/db/schemas/billing-subscriptions.ts
+++ b/packages/cloud/shared/src/db/schemas/billing-subscriptions.ts
@@ -1,5 +1,5 @@
 /**
- * Defines tenant-scoped subscription authority and its immutable lifecycle revisions.
+ * Defines tenant-scoped subscription authority, immutable lifecycle revisions, and canonical account identity.
  */
 import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
 import {
@@ -227,3 +227,26 @@ export type BillingSubscriptionRevision = Readonly<
   InferSelectModel<typeof billingSubscriptionRevisions>
 >;
 export type NewBillingSubscriptionRevision = InferInsertModel<typeof billingSubscriptionRevisions>;
+
+/** Canonical account identity association, owned by the existing lifecycle repository. */
+export const organizationSubscriptionAuthorities = pgTable(
+  "organization_subscription_authorities",
+  {
+    organization_id: uuid("organization_id")
+      .primaryKey()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    subscription_id: uuid("subscription_id"),
+    state: text("state").$type<"none" | "current" | "unavailable">().notNull().default("none"),
+  },
+  (table) => ({
+    subscription_tenant_fk: foreignKey({
+      columns: [table.subscription_id, table.organization_id],
+      foreignColumns: [billingSubscriptions.id, billingSubscriptions.organization_id],
+      name: "organization_subscription_authorities_tenant_fk",
+    }).onDelete("restrict"),
+    state_check: check(
+      "organization_subscription_authorities_state_check",
+      sql`(${table.state} = 'current' AND ${table.subscription_id} IS NOT NULL) OR (${table.state} IN ('none', 'unavailable') AND ${table.subscription_id} IS NULL)`,
+    ),
+  }),
+);

--- a/packages/cloud/shared/src/db/schemas/organization-entitlements.ts
+++ b/packages/cloud/shared/src/db/schemas/organization-entitlements.ts
@@ -78,7 +78,7 @@ export const organizationEntitlements = pgTable(
     }).onDelete("restrict"),
     plan_state_check: check(
       "organization_entitlements_plan_state_check",
-      sql`${table.plan_key} IN ('free','plus_monthly','pro_monthly') AND ${table.state} IN ('free','active','grace','past_due','unpaid') AND ((${table.plan_key} = 'free' AND ${table.state} = 'free' AND ${table.entitlement_effective} AND ${table.source_subscription_id} IS NULL AND ${table.source_subscription_revision} IS NULL) OR (${table.plan_key} <> 'free' AND ${table.state} <> 'free' AND ${table.source_subscription_id} IS NOT NULL AND ${table.source_subscription_revision} IS NOT NULL AND (${table.entitlement_effective} = (${table.state} IN ('active','grace')))))`,
+      sql`${table.plan_key} IN ('free','plus_monthly','pro_monthly') AND ${table.state} IN ('free','active','grace','past_due','unpaid') AND ((${table.plan_key} = 'free' AND ${table.state} = 'free' AND ${table.entitlement_effective} AND (${table.source_subscription_id} IS NULL) = (${table.source_subscription_revision} IS NULL)) OR (${table.plan_key} <> 'free' AND ${table.state} <> 'free' AND ${table.source_subscription_id} IS NOT NULL AND ${table.source_subscription_revision} IS NOT NULL AND (${table.entitlement_effective} = (${table.state} IN ('active','grace')))))`,
     ),
     effective_bounds_check: check(
       "organization_entitlements_effective_bounds_check",

--- a/packages/cloud/shared/src/db/schemas/organizations.ts
+++ b/packages/cloud/shared/src/db/schemas/organizations.ts
@@ -7,9 +7,11 @@ import {
   bigint,
   boolean,
   check,
+  foreignKey,
   index,
   jsonb,
   numeric,
+  type PgTableExtraConfig,
   pgSequence,
   pgTable,
   text,
@@ -17,6 +19,8 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+
+import { billingSubscriptions } from "./billing-subscriptions";
 
 export const organizationBalanceRevisionSequence = pgSequence("organization_balance_revision_seq");
 
@@ -38,6 +42,14 @@ export const organizations = pgTable(
   "organizations",
   {
     id: uuid("id").defaultRandom().primaryKey(),
+    // Lifecycle creation establishes this identity; cancellation retains it so
+    // an older subscription cannot regain authority after its replacement ends.
+    // Historical backfill ambiguity is distinct from having no subscription.
+    subscription_authority_id: uuid("subscription_authority_id"),
+    subscription_authority_state: text("subscription_authority_state")
+      .$type<"none" | "current" | "unavailable">()
+      .notNull()
+      .default("none"),
     name: text("name").notNull(),
     slug: text("slug").notNull().unique(),
     credit_balance: numeric("credit_balance", { precision: 16, scale: 6 })
@@ -108,7 +120,16 @@ export const organizations = pgTable(
     created_at: timestamp("created_at").notNull().defaultNow(),
     updated_at: timestamp("updated_at").notNull().defaultNow(),
   },
-  (table) => ({
+  (table): PgTableExtraConfig => ({
+    subscription_authority_tenant_fk: foreignKey({
+      columns: [table.subscription_authority_id, table.id],
+      foreignColumns: [billingSubscriptions.id, billingSubscriptions.organization_id],
+      name: "organizations_subscription_authority_tenant_fk",
+    }).onDelete("restrict"),
+    subscription_authority_check: check(
+      "organizations_subscription_authority_check",
+      sql`(${table.subscription_authority_state} = 'current' AND ${table.subscription_authority_id} IS NOT NULL) OR (${table.subscription_authority_state} IN ('none', 'unavailable') AND ${table.subscription_authority_id} IS NULL)`,
+    ),
     slug_idx: index("organizations_slug_idx").on(table.slug),
     stripe_customer_authority_unique: uniqueIndex("organizations_stripe_customer_authority_unique")
       .on(table.stripe_customer_id)

--- a/packages/cloud/shared/src/db/schemas/organizations.ts
+++ b/packages/cloud/shared/src/db/schemas/organizations.ts
@@ -7,11 +7,9 @@ import {
   bigint,
   boolean,
   check,
-  foreignKey,
   index,
   jsonb,
   numeric,
-  type PgTableExtraConfig,
   pgSequence,
   pgTable,
   text,
@@ -19,8 +17,6 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
-
-import { billingSubscriptions } from "./billing-subscriptions";
 
 export const organizationBalanceRevisionSequence = pgSequence("organization_balance_revision_seq");
 
@@ -42,14 +38,6 @@ export const organizations = pgTable(
   "organizations",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    // Lifecycle creation establishes this identity; cancellation retains it so
-    // an older subscription cannot regain authority after its replacement ends.
-    // Historical backfill ambiguity is distinct from having no subscription.
-    subscription_authority_id: uuid("subscription_authority_id"),
-    subscription_authority_state: text("subscription_authority_state")
-      .$type<"none" | "current" | "unavailable">()
-      .notNull()
-      .default("none"),
     name: text("name").notNull(),
     slug: text("slug").notNull().unique(),
     credit_balance: numeric("credit_balance", { precision: 16, scale: 6 })
@@ -120,16 +108,7 @@ export const organizations = pgTable(
     created_at: timestamp("created_at").notNull().defaultNow(),
     updated_at: timestamp("updated_at").notNull().defaultNow(),
   },
-  (table): PgTableExtraConfig => ({
-    subscription_authority_tenant_fk: foreignKey({
-      columns: [table.subscription_authority_id, table.id],
-      foreignColumns: [billingSubscriptions.id, billingSubscriptions.organization_id],
-      name: "organizations_subscription_authority_tenant_fk",
-    }).onDelete("restrict"),
-    subscription_authority_check: check(
-      "organizations_subscription_authority_check",
-      sql`(${table.subscription_authority_state} = 'current' AND ${table.subscription_authority_id} IS NOT NULL) OR (${table.subscription_authority_state} IN ('none', 'unavailable') AND ${table.subscription_authority_id} IS NULL)`,
-    ),
+  (table) => ({
     slug_idx: index("organizations_slug_idx").on(table.slug),
     stripe_customer_authority_unique: uniqueIndex("organizations_stripe_customer_authority_unique")
       .on(table.stripe_customer_id)

--- a/packages/cloud/shared/src/lib/services/account-deletion-provider-adapters.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/account-deletion-provider-adapters.pglite.test.ts
@@ -1,18 +1,26 @@
 /** Proves the restrictive-grant inventory reaches real SQL terminal absence on isolated PGlite. */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+setDefaultTimeout(120_000);
 
 process.env.DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 import { sql } from "drizzle-orm";
-import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import {
+  closeDatabaseConnectionsForTests,
+  dbWrite,
+  getPgliteClientForTests,
+} from "../../db/client";
 import {
   ACCOUNT_DELETION_LOCAL_GRANT_INVENTORY,
   createAccountDeletionProviderAdapters,
 } from "./account-deletion-provider-adapters";
 import type { AccountDeletionProviderContext } from "./account-deletion-saga";
 
+const SUBSCRIPTION_ID = "30000000-0000-4000-8000-000000000001";
 const USER_ID = "20000000-0000-4000-8000-000000000001";
 const ORGANIZATION_ID = "10000000-0000-4000-8000-000000000001";
 
@@ -27,6 +35,29 @@ const context = {
 } as AccountDeletionProviderContext;
 
 beforeAll(async () => {
+  await getPgliteClientForTests().exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY, account_lifecycle_state text NOT NULL DEFAULT 'active');
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE credit_transactions (id uuid PRIMARY KEY, organization_id uuid REFERENCES organizations(id), CONSTRAINT credit_transactions_id_org_idx UNIQUE(id, organization_id));
+  `);
+  for (const name of [
+    "0373_subscription_authority.sql",
+    "0374_subscription_funding_transaction_uniqueness.sql",
+    "0379_subscription_account_authority.sql",
+  ]) {
+    const migration = await readFile(
+      new URL(`../../db/migrations/${name}`, import.meta.url),
+      "utf8",
+    );
+    await getPgliteClientForTests().transaction(async (tx) => {
+      await tx.exec(migration);
+    });
+  }
+
+  const migrated = await getPgliteClientForTests().query<{ tablename: string }>(
+    "SELECT tablename FROM pg_tables WHERE schemaname='public'",
+  );
+  const migratedTables = new Set(migrated.rows.map((row) => row.tablename));
   const columnsByTable = new Map<string, Set<string>>();
   for (const { table, column } of ACCOUNT_DELETION_LOCAL_GRANT_INVENTORY) {
     const columns = columnsByTable.get(table) ?? new Set<string>();
@@ -34,6 +65,7 @@ beforeAll(async () => {
     columnsByTable.set(table, columns);
   }
   for (const [table, columns] of columnsByTable) {
+    if (migratedTables.has(table)) continue;
     const columnDefinitions = [...columns].map((column) => sql`${sql.raw(column)} uuid`);
     await dbWrite.execute(
       sql`CREATE TABLE ${sql.raw(table)} (
@@ -42,33 +74,22 @@ beforeAll(async () => {
       )`,
     );
   }
-  await dbWrite.execute(sql`
-    CREATE FUNCTION reject_subscription_append_only_mutation()
-    RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-    BEGIN
-      IF current_setting('eliza.subscription_account_deletion_authority', true) = 'on' THEN
-        RETURN NULL;
-      END IF;
-      RAISE EXCEPTION '% is append-only', TG_TABLE_NAME USING ERRCODE = '23514';
-    END;
-    $$
-  `);
-  for (const table of ["billing_subscription_revisions", "subscription_allowance_transactions"]) {
-    await dbWrite.execute(
-      sql`CREATE TRIGGER ${sql.raw(`${table}_immutable_guard`)}
-          BEFORE UPDATE OR DELETE OR TRUNCATE ON ${sql.raw(table)}
-          FOR EACH STATEMENT EXECUTE FUNCTION reject_subscription_append_only_mutation()`,
-    );
-  }
   for (const entry of ACCOUNT_DELETION_LOCAL_GRANT_INVENTORY) {
+    if (migratedTables.has(entry.table)) continue;
     const subject = entry.subject === "user" ? USER_ID : ORGANIZATION_ID;
     await dbWrite.execute(
       sql`INSERT INTO ${sql.raw(entry.table)} (id, ${sql.raw(entry.column)})
           VALUES (${crypto.randomUUID()}, ${subject})`,
     );
   }
+  await getPgliteClientForTests().exec(`
+    INSERT INTO organizations(id) VALUES ('${ORGANIZATION_ID}');
+    INSERT INTO billing_subscriptions (id, organization_id, provider_environment, stripe_customer_id, stripe_subscription_id, stripe_subscription_item_id, plan_key, catalog_version, status, current_period_start, current_period_end, lifecycle_revision, provider_object_digest)
+    VALUES ('${SUBSCRIPTION_ID}', '${ORGANIZATION_ID}', 'test', 'cus_erasure', 'sub_erasure', 'si_erasure', 'plus_monthly', 'v1', 'active', '2026-08-01Z', '2026-09-01Z', 1, '${"a".repeat(64)}');
+    INSERT INTO billing_subscription_revisions (organization_id, subscription_id, revision, source, provider_environment, stripe_customer_id, stripe_subscription_id, stripe_subscription_item_id, plan_key, catalog_version, status, current_period_start, current_period_end, cancel_at_period_end, provider_object_digest)
+    VALUES ('${ORGANIZATION_ID}', '${SUBSCRIPTION_ID}', 1, 'webhook', 'test', 'cus_erasure', 'sub_erasure', 'si_erasure', 'plus_monthly', 'v1', 'active', '2026-08-01Z', '2026-09-01Z', false, '${"a".repeat(64)}');
+    UPDATE organization_subscription_authorities SET state='current', subscription_id='${SUBSCRIPTION_ID}' WHERE organization_id='${ORGANIZATION_ID}';
+  `);
 });
 
 afterAll(async () => {
@@ -80,9 +101,19 @@ describe("account deletion restrictive-grant terminal absence", () => {
     const adapter = createAccountDeletionProviderAdapters().other_grants;
 
     await expect(adapter.inspect(context)).resolves.toEqual({ state: "needs_execution" });
+    await expect(adapter.execute(context, "before-irreversible-fence")).rejects.toMatchObject({
+      code: "SUBSCRIPTION_AUTHORITY_CONFLICT",
+    });
+    await dbWrite.execute(
+      sql`UPDATE organizations SET account_lifecycle_state='deletion_irreversible' WHERE id=${ORGANIZATION_ID}`,
+    );
     await adapter.execute(context, "delete-local-grants-once");
     await expect(adapter.inspect(context)).resolves.toMatchObject({ state: "complete" });
 
+    const association = await dbWrite.execute(
+      sql`SELECT subscription_id, state FROM organization_subscription_authorities WHERE organization_id=${ORGANIZATION_ID}`,
+    );
+    expect(association.rows).toEqual([{ subscription_id: null, state: "unavailable" }]);
     for (const entry of ACCOUNT_DELETION_LOCAL_GRANT_INVENTORY) {
       const result = await dbWrite.execute(
         sql`SELECT count(*)::int AS count FROM ${sql.raw(entry.table)}
@@ -90,5 +121,10 @@ describe("account deletion restrictive-grant terminal absence", () => {
       );
       expect(result.rows[0]?.count).toBe(0);
     }
+    await dbWrite.execute(sql`DELETE FROM organizations WHERE id=${ORGANIZATION_ID}`);
+    const remaining = await dbWrite.execute(
+      sql`SELECT organization_id FROM organization_subscription_authorities WHERE organization_id=${ORGANIZATION_ID}`,
+    );
+    expect(remaining.rows).toEqual([]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/account-deletion-provider-adapters.ts
+++ b/packages/cloud/shared/src/lib/services/account-deletion-provider-adapters.ts
@@ -8,6 +8,7 @@ import { createHash } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
 import { and, eq, inArray, ne, or, sql } from "drizzle-orm";
 import { dbWrite } from "../../db/helpers";
+import { subscriptionAuthorityRepository } from "../../db/repositories/subscription-authority";
 import {
   agentBackupGcOutbox,
   agentBackupObjects,
@@ -508,6 +509,7 @@ async function countLocalRestrictiveRows(context: AccountDeletionProviderContext
 
 async function deleteLocalRestrictiveRows(context: AccountDeletionProviderContext): Promise<void> {
   await dbWrite.transaction(async (tx) => {
+    await subscriptionAuthorityRepository.releaseForAccountDeletion(tx, context.organizationId);
     await tx.execute(
       sql`SELECT set_config('eliza.subscription_account_deletion_authority', 'on', true)`,
     );


### PR DESCRIPTION
# Relates to

Prerequisite for #23094; does not close it.

# Background

Entitlement publication now verifies the organization's canonical subscription identity and current immutable lifecycle revision before replay or projection CAS. A historical subscription cannot overwrite or replay the current account's projection. Grace uses its actual deadline; canceled/free projections retain the transition that produced them.

A canonical account association is owned by the existing lifecycle repository. New identities require the command-captured expected identity. Migration chooses the unique live subscription or sole historical identity; ambiguous terminal history becomes unavailable rather than being ordered by timestamps. Irreversible account erasure releases the association in the same transaction before deleting history.

# Sync with develop

Head `09d3fa484a47f4fc3beaa6f19b7dc1498c9afe44`, base `cd821540d73c4e7370a9407c07be19020a3b810b`. The prerequisite patch remains unchanged after rebase. Pinned Bun 1.3.14 install passed. Exact-head root `bun run verify` passed 376/376 tasks and all subsequent repository audits, exit 0.

Live merge-target readback at evidence publication: `65a4f5216421ba74a75b1bc9bc98de0ae2d1ceb1`. That later develop tip is not mislabeled as the base used for the local root run; GitHub reports the exact PR head conflict-free. No bypass is requested.

# Risks

This adds a billing-authority migration. Ambiguous existing terminal history requires reconciliation; no guessed identity is chosen. Paid resource ceilings remain nullable, not unlimited. Full enforcement, generic trial/payer/access policy and real Dedicated continuity are outside this prerequisite.

No production migration, deployed provider or money operation is claimed. Local PGlite tests exercise real database constraints and transaction rollback; they do not substitute for independent PostgreSQL sessions. All five exact-head hosted checks passed in [run 34020529015](https://github.com/elizaOS/eliza/actions/runs/34020529015), including the real PostgreSQL authority job, billing replay E2E, Windows security, source smoke and aggregate gate. A readiness-triggered run, if created, must also finish before merge.

# Documentation changes needed?

No rendered UI or public endpoint changes. Remaining full-issue acceptance is tracked in #23094.

# Testing

- Root independent exact-head review: no actionable finding; four owning PGlite/derivation files passed 17 tests, 93 assertions.
- Author exact-head verification: seven files passed 34 tests, 168 assertions; six local PostgreSQL suite entries skipped because no DSN is available. This is not labeled independent review.
- Exact-head full shared package rerun: `bun run --cwd packages/cloud/shared test`, exit 0. All 348 sequential child processes completed over 1,181 files: **12,566 passed, 209 skipped, 0 failed; 80,529 assertions**. These totals are the sum of all 348 terminal Bun summaries, not a partial or mixed-state sweep.
- The first exact-head full attempt stopped at ordinary batch 25 on an unrelated restore-v3 timing assertion: the test expected `AgentBackupRestoreV3StreamError` but its operation deadline produced `AgentBackupRestoreV3ControlError` after 276 ms. No source changes were made to mask it. The same 16-file batch passed in isolation (256 tests, 1,928 assertions), then the full exact-head rerun above passed. The initial failure remains disclosed; neither isolated success nor the older mixed-state run is substituted for the complete rerun.
- Hosted exact-head [Subscription authority PostgreSQL](https://github.com/elizaOS/eliza/actions/runs/34020529015/job/101452155504) passed with independent database sessions; local missing-DSN skips are not represented as that proof.

# Evidence Gate

<!-- evidence-head:09d3fa484a47f4fc3beaa6f19b7dc1498c9afe44 -->
<!-- evidence-row:before-screenshots -->
N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
N/A - database authority and migration; no interactive UI flow.
<!-- evidence-row:backend-logs -->
<details><summary>Independent current-head execution</summary>

```text
bun test v1.3.14 (d1632b29)
(pass) current-source entitlement publication > an old request cannot replay a projection after lifecycle authority advances [45.18ms]
17 pass
0 fail
93 expect() calls
Ran 17 tests across 4 files. [6.26s]
```

</details>
<details><summary>Exact-head repository gate</summary>

```text
$ bun run verify
Tasks: 376 successful, 376 total
[anti-larp] scanned 11452 test files — 0 focused, 0 orphaned skip(s)
exit 0
```

</details>
<details><summary>Full shared package and first-attempt disclosure</summary>

```text
$ bun run --cwd packages/cloud/shared test
[run-bun-tests] sequential process sharding: 1181 file(s), 348 child process(es)
348 terminal child summaries aggregated:
12566 pass
209 skip
0 fail
80529 expect() calls
process exit 0

First attempt: ordinary batch25 stopped on an existing restore-v3 operation-deadline assertion.
Isolated unchanged batch25: 256 pass, 0 fail, 1928 expect() calls, exit0.
Complete unchanged-head rerun: totals above, exit0.
```

</details>
<!-- evidence-row:frontend-logs -->
N/A - no frontend flow changed.
<!-- evidence-row:llm-trajectory -->
N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
Real migration/readback and repository tests verify ambiguous history, tenant constraints, source provenance, lifecycle freshness and erasure fencing. Selected observed current-head output:

<details><summary>Persisted authority and rollback outcomes</summary>

```text
(pass) subscription account identity migration > backfills live identity without chronology and keeps missing history distinct from ambiguity [926.16ms]
(pass) subscription account identity migration > a failed migration transaction rolls back both the association and backfill [651.01ms]
(pass) current-source entitlement publication > an old request cannot replay a projection after lifecycle authority advances [45.18ms]
(pass) current-source entitlement publication > tenant mismatch cannot publish another organization's subscription [20.38ms]
(pass) current-source entitlement publication > account erasure releases the reverse pointer only behind the irreversible fence [26.50ms]
(pass) current-source entitlement publication > retains explicit replacement canceled identity even with equal creation timestamps [36.19ms]
```

</details>
<!-- evidence-row:ocr-review -->
N/A - no rendered text.
