### PR TITLE
fix(native-gateway): restore macOS verification without weakening lint

### DIFF
--- a/plugins/plugin-native-gateway/ios/Sources/GatewayPlugin/GatewayPlugin.swift
+++ b/plugins/plugin-native-gateway/ios/Sources/GatewayPlugin/GatewayPlugin.swift
@@ -1,15 +1,12 @@
+/**
+ * Connects the Capacitor app to an Eliza Gateway through Bonjour discovery
+ * and authenticated WebSocket RPC. Same-file extensions share private session
+ * state while separating discovery, public calls, and transport lifecycle.
+ */
 import Foundation
 import Capacitor
 import Network
 
-/**
- * Gateway Plugin for Capacitor
- *
- * Provides WebSocket connectivity to an Eliza Gateway server.
- * This implementation handles authentication, reconnection, and RPC-style
- * request/response as well as event streaming. Also supports gateway
- * discovery via Bonjour/mDNS.
- */
 @objc(GatewayPlugin)
 public class GatewayPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "GatewayPlugin"
@@ -46,7 +43,9 @@ public class GatewayPlugin: CAPPlugin, CAPBridgedPlugin {
     private var backoffMs: TimeInterval = 0.8
     private var reconnectTimer: Timer?
     private var connectContinuation: CheckedContinuation<JSObject, Error>?
+}
 
+extension GatewayPlugin {
     // MARK: - Discovery Methods
 
     @objc func startDiscovery(_ call: CAPPluginCall) {
@@ -211,6 +210,9 @@ public class GatewayPlugin: CAPPlugin, CAPBridgedPlugin {
         ]
     }
 
+}
+
+extension GatewayPlugin {
     // MARK: - Connection Methods
 
     @objc func connect(_ call: CAPPluginCall) {
@@ -310,6 +312,9 @@ public class GatewayPlugin: CAPPlugin, CAPBridgedPlugin {
         ])
     }
 
+}
+
+extension GatewayPlugin {
     // MARK: - Private Methods
 
     private func establishConnection(url: URL, options: JSObject) async throws -> JSObject {

--- a/turbo.json
+++ b/turbo.json
@@ -199,6 +199,14 @@
     "lint": {
       "outputs": []
     },
+    "@elizaos/capacitor-gateway#lint": {
+      "env": ["DEVELOPER_DIR"],
+      "outputs": []
+    },
+    "@elizaos/capacitor-gateway#lint:check": {
+      "env": ["DEVELOPER_DIR"],
+      "outputs": []
+    },
     "@elizaos/ui#lint:check": {
       "inputs": [
         "$TURBO_DEFAULT$",
@@ -280,10 +288,7 @@
       "outputs": []
     },
     "@elizaos/plugin-calendar#typecheck": {
-      "dependsOn": [
-        "@elizaos/ui#build",
-        "@elizaos/plugin-scheduling#build"
-      ],
+      "dependsOn": ["@elizaos/ui#build", "@elizaos/plugin-scheduling#build"],
       "outputs": []
     },
     "@elizaos/plugin-personal-assistant#typecheck": {


### PR DESCRIPTION
# Relates to

Closes #30774. Prerequisite for Guardian Project 19 verification.

The required macOS verification gate failed before reviewing unrelated work: SwiftLint rejected the gateway's 506-line class, and Turbo's strict environment removed `DEVELOPER_DIR`, causing SourceKitten to crash loading the selected Xcode framework. This separates existing methods into same-file extensions and preserves the selected developer directory for gateway lint tasks. No lint rule is relaxed.

- [x] Targets develop; fetched and rebased with zero conflicts.
- [x] Post-sync bun install completed with the documented native-inference skip (this change does not require local inference).
- [x] Final post-sync root verification passed.

# Sync with develop

Head `39b7d51bbb84943499536ff2111882638b6e89b4`; validated base `b676280384b15df54204276e34bb8740db26936f`.

# Risks

Low: stored properties, registered Objective-C selectors, access modifiers, and executable method bodies remain unchanged. Same-file Swift extensions retain access to the class's private state. Turbo cache identity now includes the selected developer directory.

# Background

Bug fix to required validation. The Swift header now precedes imports and states responsibility. Existing unrelated Swift warnings remain warnings; no suppression was added.

# Documentation changes needed?

No user-facing documentation change; commands and plugin APIs remain unchanged.

# Testing

- `bun run --cwd plugins/plugin-native-gateway test`: 29/29 pass.
- Package `typecheck` and `lint:check`: pass; SwiftLint reports zero serious violations.
- `xcrun swiftc -parse .../GatewayPlugin.swift`: pass.
- Actual Xcode simulator framework build using the source file and installed Capacitor/CapacitorCordova 8.5.0: pass for arm64 and x86_64, with signing disabled.
- Actual `node packages/scripts/run-turbo.mjs run lint:check --filter=@elizaos/capacitor-gateway --force`: before env declaration 0/1 and SourceKitten crash; after 1/1 pass.
- `git diff --check` and changed JSON Biome: pass.

# Evidence Gate

<!-- evidence-head:39b7d51bbb84943499536ff2111882638b6e89b4 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI or visual behavior changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI or visual behavior changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - code organization and build-task environment only; no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend execution behavior changed; native compile/lint execution is recorded under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state transition, or rendering change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] Native framework architecture and SHA-256 receipts:

```text
Actual Xcode simulator build: BUILD SUCCEEDED
Architectures in GatewayCompile.framework/GatewayCompile: x86_64 arm64
Source SHA-256: 3f0bec7d9dbcbfd61493d6c21b1656706e622353b9b9ac3c3e5bfea31f062cdb
Framework SHA-256: 8fabfb55f63dc016812f0f4d12c7c6a63b1ddd999f43ca3ae9a3737871b0e68f
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Native compiler artifact

Compiled the real source with a temporary CocoaPods framework project referencing installed dependencies. The package's documented verify:ios project/workspace is absent in this checkout, so the temporary project supplies build scaffolding without replacing the source or Capacitor implementation. This proves compilation/linking, not real-device networking acceptance.

```text
xcodebuild -workspace /tmp/guardian-gateway-native/GatewayCompile.xcworkspace -scheme GatewayCompile -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/guardian-gateway-native/DerivedData -jobs 2 CODE_SIGNING_ALLOWED=NO build
** BUILD SUCCEEDED **
Architectures: x86_64 arm64
Source SHA-256: 3f0bec7d9dbcbfd61493d6c21b1656706e622353b9b9ac3c3e5bfea31f062cdb
Framework SHA-256: 8fabfb55f63dc016812f0f4d12c7c6a63b1ddd999f43ca3ae9a3737871b0e68f
```

## Before / after Turbo execution

Before preserving DEVELOPER_DIR (with the Swift split already applied):

```text
SourceKittenFramework/library_wrapper.swift:58: Fatal error: Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed
Tasks: 0 successful, 1 total
```

After preserving it:

```text
Done linting! Found 14 violations, 0 serious in 1 file.
Tasks: 1 successful, 1 total
```

## Real LLM, screenshots, video, audio

N/A - no model or rendered/voice behavior changed.

## Known gaps / failures

`bun run verify` passed at `39b7d51bbb84943499536ff2111882638b6e89b4`: all 376 Turbo tasks passed, followed by all repository audits. No failed required local gate remains for this PR.

Native device networking was not exercised because method implementations are unchanged. The actual native compiler boundary was exercised as described above. No runtime connectivity certification is claimed.

## Maintainer CI exception record

N/A - no exception requested.
