### PR TITLE
fix(cloud): consolidate A2A history validation and reject invalid Vast routing maps

### DIFF
--- a/packages/cloud/shared/src/lib/api/a2a/handlers.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/handlers.ts
@@ -9,7 +9,10 @@ import { a2aTaskStoreService, type TaskStoreEntry } from "../../services/a2a-tas
 import { contentModerationService } from "../../services/content-moderation";
 import { resolveOutboundMessageStanding } from "../../services/outbound-message-standing";
 import { logger } from "../../utils/logger";
-import { parseUntrustedA2AMessageSendParams } from "./request-validation";
+import {
+  parseUntrustedA2AMessageSendParams,
+  UntrustedA2ATaskGetParamsSchema,
+} from "./request-validation";
 import {
   executeSkillBrowserSession,
   executeSkillChatCompletion,
@@ -29,6 +32,7 @@ import {
   executeSkillVideoGeneration,
   executeSkillWebSearch,
 } from "./skills";
+import { projectTaskHistory } from "./task-history";
 import {
   type A2AContext,
   type Artifact,
@@ -180,20 +184,15 @@ export async function handleMessageSend(
   await addMessageToHistory(taskId, ctx.user.organization_id, message);
 
   // Process the message
-  const result = await processA2AMessage(task, message, ctx, configuration);
+  const result = await processA2AMessage(task, message, ctx);
 
-  return result;
+  return projectTaskHistory(result, configuration?.historyLength);
 }
 
 /**
  * Process an A2A message and dispatch to appropriate skill
  */
-async function processA2AMessage(
-  task: Task,
-  message: Message,
-  ctx: A2AContext,
-  _configuration?: MessageSendParams["configuration"],
-): Promise<Task> {
+async function processA2AMessage(task: Task, message: Message, ctx: A2AContext): Promise<Task> {
   const textParts = message.parts.filter(
     (p): p is { type: "text"; text: string } => p.type === "text",
   );
@@ -317,20 +316,14 @@ async function processA2AMessage(
  * tasks/get - Get task status and history
  */
 export async function handleTasksGet(params: TaskGetParams, ctx: A2AContext): Promise<Task> {
-  const { id, historyLength } = params;
+  const { id, historyLength } = UntrustedA2ATaskGetParamsSchema.parse(params);
 
   const store = await getTaskStore(id, ctx.user.organization_id);
   if (!store) {
     throw new Error(`Task not found: ${id}`);
   }
 
-  const task = { ...store.task };
-
-  if (historyLength !== undefined && task.history) {
-    task.history = task.history.slice(-historyLength);
-  }
-
-  return task;
+  return projectTaskHistory(store.task, historyLength);
 }
 
 /**

--- a/packages/cloud/shared/src/lib/api/a2a/platform-cloud.test.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/platform-cloud.test.ts
@@ -18,6 +18,7 @@ const executeCloudCapabilityRest = mock();
 const requireCurrentBillingManagerSession = mock();
 const requireUserOrApiKeyWithOrg = mock();
 const taskStoreSet = mock();
+const taskStoreGet = mock();
 const loggerError = mock();
 const requestCancellation = mock();
 
@@ -72,7 +73,7 @@ mock.module("../../services/containers", () => ({
 mock.module("../../services/a2a-task-store", () => ({
   a2aTaskStoreService: {
     set: taskStoreSet,
-    get: mock(),
+    get: taskStoreGet,
     updateTaskState: mock(),
   },
 }));
@@ -122,6 +123,7 @@ beforeEach(() => {
   requireUserOrApiKeyWithOrg.mockReset();
   requireCurrentBillingManagerSession.mockReset();
   taskStoreSet.mockReset();
+  taskStoreGet.mockReset();
   requestCancellation.mockReset();
   loggerError.mockReset();
 
@@ -305,5 +307,65 @@ describe("Cloud platform A2A billing cancellation authority", () => {
 
     expect(requestCancellation).not.toHaveBeenCalled();
     expect(taskStoreSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("A2A response history selection", () => {
+  test("limits send responses without discarding persisted history", async () => {
+    const response = (await handlePlatformA2aJsonRpc(context, {
+      jsonrpc: "2.0",
+      id: "send-history",
+      method: "message/send",
+      params: {
+        message: {
+          role: "user",
+          parts: [{ type: "data", data: { skill: "cloud.capabilities.list" } }],
+        },
+        configuration: { historyLength: 1 },
+      },
+    })) as JSONRPCSuccessResponse<Task>;
+    const persisted = taskStoreSet.mock.calls[0][1].task as Task;
+    expect(response.result.history).toEqual([persisted.status.message!]);
+    expect(persisted.history?.[0].role).toBe("user");
+    taskStoreGet.mockResolvedValue({ task: persisted });
+    for (const historyLength of [undefined, 0]) {
+      const readback = (await handlePlatformA2aJsonRpc(context, {
+        jsonrpc: "2.0",
+        id: "get-history",
+        method: "tasks/get",
+        params: { id: persisted.id, ...(historyLength === undefined ? {} : { historyLength }) },
+      })) as JSONRPCSuccessResponse<Task>;
+      expect(readback.result.history).toEqual(persisted.history);
+      expect(readback.result.history?.map((message) => message.role)).toEqual(["user", "agent"]);
+    }
+    const latest = (await handlePlatformA2aJsonRpc(context, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tasks/get",
+      params: { id: persisted.id, historyLength: 1 },
+    })) as JSONRPCSuccessResponse<Task>;
+    expect(latest.result.history).toEqual([persisted.status.message!]);
+    expect(persisted.history?.[0].role).toBe("user");
+  });
+
+  test("rejects malformed task queries before auth and storage", async () => {
+    for (const historyLength of [-1, 1.5, "1", null, Number.MAX_SAFE_INTEGER + 1]) {
+      const response = (await handlePlatformA2aJsonRpc(context, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tasks/get",
+        params: { id: "task", historyLength },
+      })) as JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32602);
+    }
+    const missingId = (await handlePlatformA2aJsonRpc(context, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tasks/get",
+      params: { historyLength: 1 },
+    })) as JSONRPCErrorResponse;
+    expect(missingId.error.code).toBe(-32602);
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(taskStoreGet).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/api/a2a/platform-cloud.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/platform-cloud.ts
@@ -29,7 +29,9 @@ import {
   jsonRpcError,
   jsonRpcSuccess,
   type Message,
+  type MessageSendParams,
   type Task,
+  type TaskGetParams,
   type TaskState,
 } from "../../types/a2a";
 import { logger } from "../../utils/logger";
@@ -38,7 +40,10 @@ import {
   A2AJsonRpcRequestSchema,
   jsonRpcIdFromUnknown,
   UntrustedA2AMessageSendParamsSchema,
+  UntrustedA2ATaskGetParamsSchema,
 } from "./request-validation";
+
+import { projectTaskHistory } from "./task-history";
 
 function getBaseUrl(c: AppContext): string {
   return c.env.NEXT_PUBLIC_APP_URL || new URL(c.req.url).origin;
@@ -237,7 +242,10 @@ async function executePlatformSkill(c: AppContext, skill: string, args: Record<s
 }
 
 export async function handlePlatformMessageSend(c: AppContext, params: unknown) {
-  const validated = UntrustedA2AMessageSendParamsSchema.parse(params);
+  return sendValidatedPlatformMessage(c, UntrustedA2AMessageSendParamsSchema.parse(params));
+}
+
+async function sendValidatedPlatformMessage(c: AppContext, validated: MessageSendParams) {
   const { message } = validated;
   const paramsMetadata = validated.metadata ?? {};
   const data = { ...extractData(message), ...paramsMetadata };
@@ -272,22 +280,20 @@ export async function handlePlatformMessageSend(c: AppContext, params: unknown) 
     }),
   ];
   if (user) await storePlatformTask(task, user);
-  return task;
+  return projectTaskHistory(task, validated.configuration?.historyLength);
 }
 
 export async function handlePlatformTasksGet(c: AppContext, params: Record<string, unknown>) {
+  return getValidatedPlatformTask(c, UntrustedA2ATaskGetParamsSchema.parse(params));
+}
+
+async function getValidatedPlatformTask(c: AppContext, { id, historyLength }: TaskGetParams) {
   const user = await requireUserOrApiKeyWithOrg(c);
-  const id = typeof params.id === "string" ? params.id : "";
   const entry = await a2aTaskStoreService.get(id, user.organization_id);
   if (!entry) {
     throw new Error(`Task not found: ${id}`);
   }
-  const task = { ...entry.task };
-  const historyLength = typeof params.historyLength === "number" ? params.historyLength : undefined;
-  if (historyLength !== undefined && task.history) {
-    task.history = task.history.slice(-historyLength);
-  }
-  return task;
+  return projectTaskHistory(entry.task, historyLength);
 }
 
 export async function handlePlatformTasksCancel(c: AppContext, params: Record<string, unknown>) {
@@ -325,10 +331,13 @@ export async function handlePlatformA2aJsonRpc(c: AppContext, input: unknown) {
       case "message/send": {
         const params = UntrustedA2AMessageSendParamsSchema.safeParse(request.params);
         if (!params.success) return jsonRpcError(-32602, "Invalid params", id);
-        return jsonRpcSuccess(await handlePlatformMessageSend(c, params.data), id);
+        return jsonRpcSuccess(await sendValidatedPlatformMessage(c, params.data), id);
       }
-      case "tasks/get":
-        return jsonRpcSuccess(await handlePlatformTasksGet(c, request.params ?? {}), id);
+      case "tasks/get": {
+        const params = UntrustedA2ATaskGetParamsSchema.safeParse(request.params);
+        if (!params.success) return jsonRpcError(-32602, "Invalid params", id);
+        return jsonRpcSuccess(await getValidatedPlatformTask(c, params.data), id);
+      }
       case "tasks/cancel":
         return jsonRpcSuccess(await handlePlatformTasksCancel(c, request.params ?? {}), id);
       case "agent/getAuthenticatedExtendedCard":

--- a/packages/cloud/shared/src/lib/api/a2a/request-validation.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/request-validation.ts
@@ -134,10 +134,20 @@ const PushNotificationConfigSchema = z
   })
   .strict();
 
+const HistoryLengthSchema = z.number().int().nonnegative();
+
+export const UntrustedA2ATaskGetParamsSchema = z
+  .object({
+    id: z.string().min(1),
+    historyLength: HistoryLengthSchema.optional(),
+    metadata: MetadataSchema.optional(),
+  })
+  .strict();
+
 const MessageSendConfigurationSchema = z
   .object({
     acceptedOutputModes: z.array(z.string()).optional(),
-    historyLength: z.number().int().nonnegative().optional(),
+    historyLength: HistoryLengthSchema.optional(),
     pushNotificationConfig: PushNotificationConfigSchema.optional(),
     blocking: z.boolean().optional(),
   })

--- a/packages/cloud/shared/src/lib/api/a2a/task-history.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/task-history.ts
@@ -1,0 +1,14 @@
+/**
+ * Projects caller-requested A2A v0.3 task history without changing stored tasks.
+ * Zero and omitted counts retain the existing unlimited-history contract.
+ */
+import type { Task } from "../../types/a2a";
+
+export function projectTaskHistory(task: Task, historyLength?: number): Task {
+  return {
+    ...task,
+    ...(task.history
+      ? { history: historyLength ? task.history.slice(-historyLength) : [...task.history] }
+      : {}),
+  };
+}

--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import { ElizaError } from "@elizaos/core";
-import { getVastProvider } from "./index";
+import { getProviderForModelWithFallback, getVastProvider } from "./index";
 import { resolveVastEndpointConfig, resolveVastFallbackModel } from "./vast-endpoints";
 
 const model = "vast/eliza-1-27b";
@@ -118,6 +118,7 @@ test("provider factory rejects malformed routing before dispatch and preserves v
   });
   const keys = [
     "VAST_ENDPOINTS_JSON",
+    "VAST_FALLBACK_MODEL_MAP_JSON",
     "VAST_BASE_URL",
     "VAST_API_KEY",
     "VAST_BASE_URL_ELIZA_1_27B",
@@ -129,11 +130,20 @@ test("provider factory rejects malformed routing before dispatch and preserves v
     process.env.VAST_ENDPOINTS_JSON = "{broken";
     process.env.VAST_BASE_URL = `http://127.0.0.1:${server.port}`;
     process.env.VAST_API_KEY = "synthetic-test-key";
-    expect(() => getVastProvider(model)).toThrow("VAST_ENDPOINTS_JSON");
-    expect(calls).toEqual([]);
+    for (const raw of ["{broken", "{placeholder broken", "{your_model broken"]) {
+      process.env.VAST_ENDPOINTS_JSON = raw;
+      expect(() => getVastProvider(model)).toThrow("VAST_ENDPOINTS_JSON");
+      expect(calls).toEqual([]);
+    }
     process.env.VAST_ENDPOINTS_JSON = JSON.stringify({
-      [model]: { url: process.env.VAST_BASE_URL, model: "local-model" },
+      [model]: { url: process.env.VAST_BASE_URL, model: "your_placeholder_model" },
     });
+    for (const raw of ["{placeholder broken", "{your_model broken"]) {
+      process.env.VAST_FALLBACK_MODEL_MAP_JSON = raw;
+      expect(() => getProviderForModelWithFallback(model)).toThrow("VAST_FALLBACK_MODEL_MAP_JSON");
+      expect(calls).toEqual([]);
+    }
+    delete process.env.VAST_FALLBACK_MODEL_MAP_JSON;
     const messages = [{ role: "user" as const, content: "Complete routing request payload" }];
     const response = await getVastProvider(model).chatCompletions({
       model,
@@ -144,7 +154,10 @@ test("provider factory rejects malformed routing before dispatch and preserves v
       choices: [{ message: { role: "assistant", content: "local receipt" } }],
     });
     expect(calls).toEqual([
-      { path: "/v1/chat/completions", body: { model: "local-model", messages, stream: false } },
+      {
+        path: "/v1/chat/completions",
+        body: { model: "your_placeholder_model", messages, stream: false },
+      },
     ]);
   } finally {
     keys.forEach((key, index) => {

--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Exercises Vast routing configuration through its resolver and actual HTTP provider.
+ * Local HTTP records dispatch; credentials and endpoint maps are synthetic.
+ */
+import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import { getVastProvider } from "./index";
+import { resolveVastEndpointConfig, resolveVastFallbackModel } from "./vast-endpoints";
+
+const model = "vast/eliza-1-27b";
+const reader = (env: Record<string, string>) => (name: string) => env[name] ?? null;
+const base = { VAST_API_KEY: "synthetic", VAST_BASE_URL: "https://global.example" };
+
+describe("Vast configured routing maps", () => {
+  test("rejects invalid configured maps with redacted actionable errors", () => {
+    for (const raw of [
+      '{"secret":"sensitive-audit-value",',
+      "[]",
+      "null",
+      "42",
+      '{"vast/eliza-1-27b":{}}',
+      '{"vast/eliza-1-27b":{"baseURL":"https://typo.example"}}',
+      '{"vast/eliza-1-27b":42}',
+      '{"vast/eliza-1-27b":{"baseUrl":7}}',
+    ]) {
+      try {
+        resolveVastEndpointConfig(model, reader({ ...base, VAST_ENDPOINTS_JSON: raw }));
+        throw new Error("invalid configuration was accepted");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ElizaError);
+        expect((error as ElizaError).code).toBe("INVALID_VAST_ROUTING_CONFIG");
+        expect((error as Error).message).toContain("VAST_ENDPOINTS_JSON");
+        expect(String((error as Error).cause)).not.toContain("sensitive-audit-value");
+        expect(JSON.stringify(error)).not.toContain("sensitive-audit-value");
+      }
+    }
+  });
+
+  test("preserves absent maps, valid aliases and explicit model environment precedence", () => {
+    expect(resolveVastEndpointConfig(model, reader(base))?.baseUrl).toBe(base.VAST_BASE_URL);
+    expect(resolveVastEndpointConfig(model, reader({}))).toBeNull();
+    expect(
+      resolveVastEndpointConfig(model, reader({ ...base, VAST_ENDPOINTS_JSON: "" }))?.baseUrl,
+    ).toBe(base.VAST_BASE_URL);
+    expect(
+      resolveVastEndpointConfig(model, reader({ ...base, VAST_ENDPOINTS_JSON: "  " }))?.baseUrl,
+    ).toBe(base.VAST_BASE_URL);
+    for (const config of [
+      "https://dedicated.example/",
+      { url: "https://dedicated.example/", apiKeyEnv: "DEDICATED_KEY", model: "served-model" },
+    ]) {
+      const result = resolveVastEndpointConfig(
+        model,
+        reader({
+          ...base,
+          DEDICATED_KEY: "dedicated",
+          VAST_ENDPOINTS_JSON: JSON.stringify({ [model]: config }),
+        }),
+      );
+      expect(result?.baseUrl).toBe("https://dedicated.example");
+      expect(result?.source).toBe("json");
+      if (typeof config !== "string") {
+        expect(result?.apiKey).toBe("dedicated");
+        expect(result?.apiModelId).toBe("served-model");
+      }
+    }
+    expect(
+      resolveVastEndpointConfig(
+        model,
+        reader({
+          ...base,
+          VAST_ENDPOINTS_JSON: "{invalid",
+          VAST_BASE_URL_ELIZA_1_27B: "https://explicit.example",
+        }),
+      )?.baseUrl,
+    ).toBe("https://explicit.example");
+  });
+
+  test("validates fallback maps separately from endpoint entries", () => {
+    const env = {
+      ...base,
+      VAST_BASE_URL_ELIZA_1_9B: "https://nine.example",
+      VAST_BASE_URL_ELIZA_1_2B: "https://two.example",
+    };
+    expect(resolveVastFallbackModel(model, reader(env))).toBe("vast/eliza-1-9b");
+    expect(
+      resolveVastFallbackModel(
+        model,
+        reader({
+          ...env,
+          VAST_FALLBACK_MODEL_MAP_JSON: JSON.stringify({ [model]: "vast/eliza-1-2b" }),
+        }),
+      ),
+    ).toBe("vast/eliza-1-2b");
+    for (const raw of [
+      "{invalid",
+      "[]",
+      JSON.stringify({ [model]: { url: "https://invalid.example" } }),
+    ]) {
+      expect(() =>
+        resolveVastFallbackModel(model, reader({ ...env, VAST_FALLBACK_MODEL_MAP_JSON: raw })),
+      ).toThrow("VAST_FALLBACK_MODEL_MAP_JSON");
+    }
+  });
+});
+
+test("provider factory rejects malformed routing before dispatch and preserves valid HTTP requests", async () => {
+  const calls: unknown[] = [];
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(request) {
+      calls.push({ path: new URL(request.url).pathname, body: await request.json() });
+      return Response.json({
+        choices: [{ message: { role: "assistant", content: "local receipt" } }],
+      });
+    },
+  });
+  const keys = [
+    "VAST_ENDPOINTS_JSON",
+    "VAST_BASE_URL",
+    "VAST_API_KEY",
+    "VAST_BASE_URL_ELIZA_1_27B",
+    "VAST_ENDPOINT_URL_ELIZA_1_27B",
+  ];
+  const prior = keys.map((key) => process.env[key]);
+  try {
+    for (const key of keys) delete process.env[key];
+    process.env.VAST_ENDPOINTS_JSON = "{broken";
+    process.env.VAST_BASE_URL = `http://127.0.0.1:${server.port}`;
+    process.env.VAST_API_KEY = "synthetic-test-key";
+    expect(() => getVastProvider(model)).toThrow("VAST_ENDPOINTS_JSON");
+    expect(calls).toEqual([]);
+    process.env.VAST_ENDPOINTS_JSON = JSON.stringify({
+      [model]: { url: process.env.VAST_BASE_URL, model: "local-model" },
+    });
+    const messages = [{ role: "user" as const, content: "Complete routing request payload" }];
+    const response = await getVastProvider(model).chatCompletions({
+      model,
+      messages,
+      stream: false,
+    });
+    expect(await response.json()).toEqual({
+      choices: [{ message: { role: "assistant", content: "local receipt" } }],
+    });
+    expect(calls).toEqual([
+      { path: "/v1/chat/completions", body: { model: "local-model", messages, stream: false } },
+    ]);
+  } finally {
+    keys.forEach((key, index) => {
+      if (prior[index] === undefined) delete process.env[key];
+      else process.env[key] = prior[index];
+    });
+    server.stop(true);
+  }
+});

--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.test.ts
@@ -144,6 +144,16 @@ test("provider factory rejects malformed routing before dispatch and preserves v
       expect(calls).toEqual([]);
     }
     delete process.env.VAST_FALLBACK_MODEL_MAP_JSON;
+    for (const endpoint of ["   ", "not-a-url", "/relative", "ftp://example.com", "https://"]) {
+      for (const config of [endpoint, { baseUrl: endpoint }, { url: endpoint }]) {
+        process.env.VAST_ENDPOINTS_JSON = JSON.stringify({ [model]: config });
+        expect(() => getVastProvider(model)).toThrow("VAST_ENDPOINTS_JSON");
+        expect(calls).toEqual([]);
+      }
+    }
+    process.env.VAST_ENDPOINTS_JSON = JSON.stringify({
+      [model]: { url: process.env.VAST_BASE_URL, model: "your_placeholder_model" },
+    });
     const messages = [{ role: "user" as const, content: "Complete routing request payload" }];
     const response = await getVastProvider(model).chatCompletions({
       model,

--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
@@ -1,4 +1,9 @@
-// Defines cloud shared vast endpoints behavior for backend service consumers.
+/**
+ * Resolves configured Vast model endpoints and fallback routing for provider factories.
+ * Present malformed maps fail explicitly; absent maps retain environment/default routing.
+ */
+import { ElizaError } from "@elizaos/core";
+import { z } from "zod";
 import { getVastApiModelId, isVastNativeModel, VAST_NATIVE_MODELS } from "../models";
 import { getProviderKey } from "./provider-env";
 
@@ -12,16 +17,23 @@ export interface VastEndpointConfig {
 
 type EnvReader = (name: string) => string | null;
 
-type VastEndpointJsonValue =
-  | string
-  | {
-      baseUrl?: string;
-      url?: string;
-      apiKey?: string;
-      apiKeyEnv?: string;
-      apiModelId?: string;
-      model?: string;
-    };
+const EndpointEntrySchema = z.union([
+  z.string().min(1),
+  z
+    .object({
+      baseUrl: z.string().min(1).optional(),
+      url: z.string().min(1).optional(),
+      apiKey: z.string().min(1).optional(),
+      apiKeyEnv: z.string().min(1).optional(),
+      apiModelId: z.string().min(1).optional(),
+      model: z.string().min(1).optional(),
+    })
+    .strict()
+    .refine((value) => Boolean(value.baseUrl || value.url)),
+]);
+const EndpointMapSchema = z.record(z.string(), EndpointEntrySchema);
+const FallbackMapSchema = z.record(z.string(), z.string().min(1));
+type VastEndpointJsonValue = z.infer<typeof EndpointEntrySchema>;
 
 function trimTrailingSlash(url: string): string {
   return url.endsWith("/") ? url.slice(0, -1) : url;
@@ -42,15 +54,29 @@ function defaultApiModelId(model: string): string {
   return translated;
 }
 
-function parseEndpointMap(raw: string | null): Record<string, VastEndpointJsonValue> {
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    return parsed as Record<string, VastEndpointJsonValue>;
-  } catch {
-    return {};
+function parseConfiguredMap<T>(raw: string | null, variable: string, schema: z.ZodType<T>): T {
+  let parsed: unknown = {};
+  if (raw?.trim()) {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // error-policy:J3 configuration is invalid; parser messages can contain credentials.
+      throw new ElizaError(`Invalid JSON in ${variable}`, {
+        code: "INVALID_VAST_ROUTING_CONFIG",
+        context: { variable },
+        cause: new SyntaxError("Configured routing map contains invalid JSON"),
+      });
+    }
   }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    throw new ElizaError(`Invalid routing map in ${variable}`, {
+      code: "INVALID_VAST_ROUTING_CONFIG",
+      context: { variable },
+      cause: new TypeError("Configured routing map does not match its expected field types"),
+    });
+  }
+  return result.data;
 }
 
 function readJsonEndpoint(
@@ -62,7 +88,11 @@ function readJsonEndpoint(
   baseUrl?: string;
   apiModelId?: string;
 } | null {
-  const endpointMap = parseEndpointMap(reader("VAST_ENDPOINTS_JSON"));
+  const endpointMap = parseConfiguredMap(
+    reader("VAST_ENDPOINTS_JSON"),
+    "VAST_ENDPOINTS_JSON",
+    EndpointMapSchema,
+  );
   const config = endpointMap[model];
   if (!config) return null;
   if (typeof config === "string") {
@@ -143,17 +173,20 @@ export function resolveVastFallbackModel(
   reader: EnvReader = getProviderKey,
 ): string | null {
   if (!isVastNativeModel(model)) return null;
-  const rawMap = parseEndpointMap(reader("VAST_FALLBACK_MODEL_MAP_JSON"));
+  const rawMap = parseConfiguredMap(
+    reader("VAST_FALLBACK_MODEL_MAP_JSON"),
+    "VAST_FALLBACK_MODEL_MAP_JSON",
+    FallbackMapSchema,
+  );
   const fallback =
-    typeof rawMap[model] === "string"
-      ? (rawMap[model] as string)
-      : model === "vast/eliza-1-27b-256k"
-        ? "vast/eliza-1-27b"
-        : model === "vast/eliza-1-27b"
-          ? "vast/eliza-1-9b"
-          : model === "vast/eliza-1-9b"
-            ? "vast/eliza-1-2b"
-            : null;
+    rawMap[model] ??
+    (model === "vast/eliza-1-27b-256k"
+      ? "vast/eliza-1-27b"
+      : model === "vast/eliza-1-27b"
+        ? "vast/eliza-1-9b"
+        : model === "vast/eliza-1-9b"
+          ? "vast/eliza-1-2b"
+          : null);
 
   if (!fallback || fallback === model || !isVastNativeModel(fallback)) return null;
   return hasDedicatedVastEndpointConfigured(fallback, reader) ? fallback : null;

--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
@@ -5,6 +5,7 @@
 import { ElizaError } from "@elizaos/core";
 import { z } from "zod";
 import { getVastApiModelId, isVastNativeModel, VAST_NATIVE_MODELS } from "../models";
+import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { getProviderKey } from "./provider-env";
 
 export interface VastEndpointConfig {
@@ -16,6 +17,15 @@ export interface VastEndpointConfig {
 }
 
 type EnvReader = (name: string) => string | null;
+
+function readVastConfiguration(name: string): string | null {
+  // JSON maps contain model names and URLs, not just credentials. Filtering
+  // their whole value as a provider key can hide invalid configured maps.
+  if (name === "VAST_ENDPOINTS_JSON" || name === "VAST_FALLBACK_MODEL_MAP_JSON") {
+    return getCloudAwareEnv()[name]?.trim() || null;
+  }
+  return getProviderKey(name);
+}
 
 const EndpointEntrySchema = z.union([
   z.string().min(1),
@@ -110,7 +120,7 @@ function readJsonEndpoint(
 
 export function resolveVastEndpointConfig(
   model: string,
-  reader: EnvReader = getProviderKey,
+  reader: EnvReader = readVastConfiguration,
 ): VastEndpointConfig | null {
   if (!isVastNativeModel(model)) return null;
 
@@ -156,13 +166,13 @@ export function resolveVastEndpointConfig(
   };
 }
 
-export function hasAnyVastProviderConfigured(reader: EnvReader = getProviderKey): boolean {
+export function hasAnyVastProviderConfigured(reader: EnvReader = readVastConfiguration): boolean {
   return VAST_NATIVE_MODELS.some((model) => resolveVastEndpointConfig(model.id, reader));
 }
 
 export function hasDedicatedVastEndpointConfigured(
   model: string,
-  reader: EnvReader = getProviderKey,
+  reader: EnvReader = readVastConfiguration,
 ): boolean {
   const config = resolveVastEndpointConfig(model, reader);
   return Boolean(config && config.source !== "global");
@@ -170,7 +180,7 @@ export function hasDedicatedVastEndpointConfigured(
 
 export function resolveVastFallbackModel(
   model: string,
-  reader: EnvReader = getProviderKey,
+  reader: EnvReader = readVastConfiguration,
 ): string | null {
   if (!isVastNativeModel(model)) return null;
   const rawMap = parseConfiguredMap(

--- a/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
+++ b/packages/cloud/shared/src/lib/providers/vast-endpoints.ts
@@ -27,12 +27,13 @@ function readVastConfiguration(name: string): string | null {
   return getProviderKey(name);
 }
 
+const EndpointUrlSchema = z.url({ protocol: /^https?$/ });
 const EndpointEntrySchema = z.union([
-  z.string().min(1),
+  EndpointUrlSchema,
   z
     .object({
-      baseUrl: z.string().min(1).optional(),
-      url: z.string().min(1).optional(),
+      baseUrl: EndpointUrlSchema.optional(),
+      url: EndpointUrlSchema.optional(),
       apiKey: z.string().min(1).optional(),
       apiKeyEnv: z.string().min(1).optional(),
       apiModelId: z.string().min(1).optional(),


### PR DESCRIPTION
Closes #30755. Closes #30756.

A2A send/get now share validated, caller-requested history projection. Positive lengths select response history after complete persistence; zero and omitted lengths retain the existing unlimited-history contract. Stored history and individual messages remain complete.

Vast routing configuration rejects malformed endpoint and fallback maps with typed, redacted errors. Endpoint strings and both URL aliases must be absolute HTTP(S) URLs. The production provider-factory regression reproduces the previously accepted whitespace endpoint, rejects malformed URLs before dispatch, and verifies valid requests through a real local HTTP server. Per-model environment precedence and supported aliases remain intact.

Validated head: `816826a9810450e7fe38d16dd74357a468a1ed9e`, rebased onto `b8aa904a64a0fa80b5ee7a7167807b687fd935bd`.

Validation with Bun 1.3.14 and Node 24.15.0:

- Supported Cloud installation (`ELIZA_SKIP_FUSED_INFERENCE_SETUP=1 bun install`): passed.
- Owning focused A2A/Vast tests: 14 passed, 143 assertions, zero failures. The new URL regression failed before repair.
- Cloud-shared typecheck: passed. Read-only lint: 2,632 files checked, no fixes.
- Root `bun run verify`: passed, exit 0; final audit scanned 11,501 test files with zero focused tests or orphaned skips.

The tests use controlled authentication/storage and a real local HTTP provider. They do not establish live Redis persistence or Vast inference. Broad suite attempts are not claimed as passing: one encountered generated-package resolution errors during overlapping builds; a source-conditioned rerun was interrupted by a tool-host restart. Focused tests were rerun successfully on the final committed source.

<!-- evidence-head:816826a9810450e7fe38d16dd74357a468a1ed9e -->
<!-- evidence-row:before-screenshots -->
N/A - backend protocol/configuration change.
<!-- evidence-row:after-screenshots -->
N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
N/A - protocol behavior is exercised through HTTP and response assertions.
<!-- evidence-row:backend-logs -->
```text
14 pass, 0 fail, 143 assertions
cloud-shared typecheck: exit 0
cloud-shared lint:check: 2632 files, exit 0
bun run verify: exit 0
[anti-larp] scanned 11501 test files — 0 focused, 0 orphaned skips
```
<!-- evidence-row:frontend-logs -->
N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
N/A - routing configuration and response selection; no model reasoning change or live inference claim.
<!-- evidence-row:domain-artifacts -->
Tests inspect persisted versus returned history, invalid parameter errors, redacted routing errors, rejected pre-dispatch configurations, and the exact request/response at the local HTTP server.
<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface.
