### PR TITLE
fix(cloud): isolate infrastructure tiers and protect tenant database bootstrap

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -16,7 +16,7 @@ on:
         required: true
         default: staging
         type: choice
-        options: [staging, production]
+        options: [development, staging, production]
       operation:
         description: Terraform operation
         required: true
@@ -69,8 +69,19 @@ jobs:
         env:
           SOURCE_REF: ${{ github.ref }}
           TARGET_ENVIRONMENT: ${{ inputs.environment }}
+          TARGET_COMPONENT: ${{ inputs.component }}
         run: |
           set -euo pipefail
+          case "$TARGET_ENVIRONMENT" in
+            development|staging|production) ;;
+            *) echo "::error::Unknown infrastructure environment"; exit 1 ;;
+          esac
+          if [ "$TARGET_ENVIRONMENT" = "development" ]; then
+            case "$TARGET_COMPONENT" in
+              control-plane|apps-shared|apps-data-plane) ;;
+              *) echo "::error::Development support for this component is not configured"; exit 1 ;;
+            esac
+          fi
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
             expected_ref="refs/heads/main"
           else
@@ -90,14 +101,12 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       TF_IN_AUTOMATION: "true"
-      HCLOUD_TOKEN: ${{ (inputs.component == 'control-plane' || inputs.component == 'prod-ops') && secrets.HCLOUD_TOKEN || secrets.HCLOUD_APPS_TOKEN }}
-      # Pages-domain plans need DNS, Pages, and SSL Certificates access. Prefer
-      # the environment-scoped credential for that root while preserving the
-      # shared credential contract for every other component and as a rollout
-      # fallback where the dedicated secret has not yet been provisioned.
-      CLOUDFLARE_API_TOKEN: ${{ inputs.component == 'pages-domains' && secrets.CLOUDFLARE_PAGES_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATE_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATE_SECRET_ACCESS_KEY }}
+      HCLOUD_TOKEN: ${{ secrets[(inputs.component == 'control-plane' || inputs.component == 'prod-ops') && (inputs.environment == 'development' && 'DEVELOPMENT_HCLOUD_TOKEN' || 'HCLOUD_TOKEN') || (inputs.environment == 'development' && 'DEVELOPMENT_HCLOUD_APPS_TOKEN' || 'HCLOUD_APPS_TOKEN')] }}
+      # Select the credential name before lookup: missing tier/root credentials
+      # must not fall back to another tier's token.
+      CLOUDFLARE_API_TOKEN: ${{ secrets[inputs.environment == 'development' && 'DEVELOPMENT_CLOUDFLARE_API_TOKEN' || (inputs.component == 'pages-domains' && 'CLOUDFLARE_PAGES_API_TOKEN' || 'CLOUDFLARE_API_TOKEN')] }}
+      AWS_ACCESS_KEY_ID: ${{ secrets[inputs.environment == 'development' && 'DEVELOPMENT_R2_STATE_ACCESS_KEY_ID' || 'R2_STATE_ACCESS_KEY_ID'] }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets[inputs.environment == 'development' && 'DEVELOPMENT_R2_STATE_SECRET_ACCESS_KEY' || 'R2_STATE_SECRET_ACCESS_KEY'] }}
       TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY: ${{ vars.TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY }}
       TERRAFORM_PLAN_SCOPE: ${{ inputs.plan_scope }}
       TF_VAR_environment: ${{ inputs.environment }}
@@ -107,11 +116,11 @@ jobs:
       TF_VAR_elizacloud_ai_zone_id: ${{ secrets.APPS_CLOUDFLARE_ZONE_ID || vars.APPS_CLOUDFLARE_ZONE_ID }}
       TF_VAR_ssh_public_keys: ${{ inputs.component == 'prod-ops' && format('["{0}"]', vars.PROD_OPS_OPERATOR_SSH_KEY) || inputs.component == 'apps-shared' && format('["{0}"]', vars.APPS_SHARED_OPERATOR_SSH_KEY) || format('["{0}"]', vars.APPS_OPERATOR_SSH_KEY) }}
       TF_VAR_operator_ingress_cidrs: ${{ inputs.component == 'apps-shared' && vars.APPS_SHARED_OPERATOR_INGRESS_CIDRS || vars.OPERATOR_INGRESS_CIDRS }}
-      TF_VAR_apps_base_domain: ${{ inputs.environment == 'production' && 'apps.eliza.app' || 'apps-staging.eliza.app' }}
-      TF_VAR_legacy_apps_base_domain: ${{ inputs.environment == 'production' && 'apps.elizacloud.ai' || 'apps-staging.elizacloud.ai' }}
-      TF_VAR_cloud_api_origin: ${{ inputs.environment == 'production' && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
-      TF_VAR_headscale_hostname: ${{ inputs.environment == 'production' && 'headscale.elizacloud.ai' || 'headscale-staging.elizacloud.ai' }}
-      TF_VAR_canonical_headscale_hostname: ${{ inputs.environment == 'production' && 'headscale.eliza.app' || 'headscale-staging.eliza.app' }}
+      TF_VAR_apps_base_domain: ${{ inputs.environment == 'production' && 'apps.eliza.app' || format('apps-{0}.eliza.app', inputs.environment) }}
+      TF_VAR_legacy_apps_base_domain: ${{ inputs.environment == 'production' && 'apps.elizacloud.ai' || format('apps-{0}.elizacloud.ai', inputs.environment) }}
+      TF_VAR_cloud_api_origin: ${{ inputs.environment == 'production' && 'https://api.eliza.app' || format('https://api-{0}.eliza.app', inputs.environment) }}
+      TF_VAR_headscale_hostname: ${{ inputs.environment == 'production' && 'headscale.elizacloud.ai' || format('headscale-{0}.elizacloud.ai', inputs.environment) }}
+      TF_VAR_canonical_headscale_hostname: ${{ inputs.environment == 'production' && 'headscale.eliza.app' || format('headscale-{0}.eliza.app', inputs.environment) }}
       # Branch selection is part of the environment contract, not mutable
       # operator inventory. Derive it here so a stale or missing GitHub variable
       # can never bootstrap production from develop (or staging from main).
@@ -281,11 +290,7 @@ jobs:
             prod-ops) directory="packages/cloud/infra/cloud/terraform/hetzner/prod-ops" ;;
             *) echo "::error::Unsupported component: $COMPONENT"; exit 1 ;;
           esac
-          if [ "$COMPONENT" = "apps-shared" ]; then
-            backend="backend.hcl"
-          else
-            backend="backend-${ENVIRONMENT}.hcl"
-          fi
+          backend="backend-${ENVIRONMENT}.hcl"
           echo "directory=$directory" >> "$GITHUB_OUTPUT"
           echo "backend=$backend" >> "$GITHUB_OUTPUT"
 
@@ -382,9 +387,9 @@ jobs:
             require_exact TF_VAR_canonical_headscale_hostname "$TF_VAR_canonical_headscale_hostname" "headscale.eliza.app"
           else
             require_exact TF_VAR_deploy_branch "$TF_VAR_deploy_branch" "develop"
-            require_exact TF_VAR_apps_base_domain "$TF_VAR_apps_base_domain" "apps-staging.eliza.app"
-            require_exact TF_VAR_cloud_api_origin "$TF_VAR_cloud_api_origin" "https://api-staging.eliza.app"
-            require_exact TF_VAR_canonical_headscale_hostname "$TF_VAR_canonical_headscale_hostname" "headscale-staging.eliza.app"
+            require_exact TF_VAR_apps_base_domain "$TF_VAR_apps_base_domain" "apps-${TARGET_ENVIRONMENT}.eliza.app"
+            require_exact TF_VAR_cloud_api_origin "$TF_VAR_cloud_api_origin" "https://api-${TARGET_ENVIRONMENT}.eliza.app"
+            require_exact TF_VAR_canonical_headscale_hostname "$TF_VAR_canonical_headscale_hostname" "headscale-${TARGET_ENVIRONMENT}.eliza.app"
           fi
 
       - name: Format and initialize
@@ -393,6 +398,7 @@ jobs:
           terraform fmt -check -recursive
           terraform init -input=false -lockfile=readonly -backend-config="${{ steps.root.outputs.backend }}"
           terraform validate -no-color
+          if [ -d tests ]; then terraform test -no-color; fi
 
       - name: Plan
         if: inputs.operation == 'plan'

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/README.md
@@ -1,112 +1,49 @@
-# Eliza Cloud Apps - per-env data plane (Hetzner)
+# elizaOS Cloud Apps — environment worker infrastructure
 
-> The IaC half of "Eliza Cloud Apps" (Product 2). This terraform stands up the
-> per-env worker nodes and wildcard DNS. Shared resources (private network and
-> tenant Postgres) live in the sibling [`apps-shared`](../apps-shared/) module;
-> apply that one first.
+This root provisions app Docker hosts, network attachments, firewalls and
+wildcard ingress for one environment. The corresponding `apps-shared` root
+must first publish its network and database into that environment's state
+bucket. A missing or different `environment` output stops planning before
+workers can attach to that network.
 
-## Launch status
+Use `backend-<environment>.hcl` and the matching tfvars example with a Hetzner
+apps project token and R2 state credentials scoped to that environment.
+Development, staging and production each use a separate
+`eliza-terraform-state-<environment>` bucket. Canonical and legacy app domains
+and the cloud API origin must match the selected environment.
 
-- Apps deploy mechanics are CI-proven by
-  [PR #8430](https://github.com/elizaOS/eliza/pull/8430): build a real app
-  image, provision a per-tenant DB, run an isolated container, verify own-DB
-  access, verify cross-tenant rejection, and verify no public egress.
-- eDad is the all-features test app after
-  [PR #8433](https://github.com/elizaOS/eliza/pull/8433): when deployed with
-  `databaseMode: "isolated"`, it persists chat history through the injected
-  `DATABASE_URL`.
-- Production deploy remains behind the draft cutover switch
-  [PR #8425](https://github.com/elizaOS/eliza/pull/8425) until this module has
-  been applied for production and the production daemon is armed.
+## Existing-fleet migration
 
-**Why:** `APPS_DEPLOY_ENABLED` on the Worker only enqueues app deploy jobs. The
-daemon still needs a real app node, registry/build settings, and the tenant DB
-admin DSN; merging the Worker flag early can leave apps stuck in `building`.
+The per-environment backends are new isolated destinations. Do not use
+`terraform init -migrate-state` to move old worker ownership or the shared tenant
+DB into them: that would not move data or separate projects. Keep the old fleet
+and state available under its reviewed historical configuration while executing
+the [database migration](../apps-shared/README.md#migration-and-admission).
 
-## What this provisions
+Provision and verify candidate hosts before DNS cutover. Existing wildcard
+records must be adopted into the intended state through an exact-ID reviewed
+import and routing plan; do not delete or recreate DNS by reusable name to
+resolve a duplicate-record error. Coordinate the final authority switch with
+the database write fence, Caddy routes, daemon node registrations and tenant
+DSNs. Preserve the old host and database until the replacement passes restore
+and rollback checks.
 
-The **per-env** pieces of the apps data plane:
+Each planned worker receives its environment's database host and cloud API
+origin. After provisioning, validate its SSH identity, kernel isolation,
+per-app database access and egress policy before enabling customer workloads.
+For multiple hosts, complete load balancing and route reconciliation; the
+wildcard resource currently targets host 1 and does not by itself distribute
+traffic across workers.
 
-| Resource | Purpose |
-|---|---|
-| `hcloud_server.app_node[*]` | Docker host(s) for **untrusted** user containers (per-app `--internal` net + cap-drop + egress proxy). |
-| `hcloud_server_network.app_node[*]` | Attaches each app node to the SHARED `apps-shared` private network. |
-| `hcloud_firewall.app_node` | SSH + 80/443. |
-| `cloudflare_dns_record.apps_wildcard` | `*.<apps_base_domain>` → app node (use an LB for >1 node). |
-
-Runtime-created burst nodes are separate from these Terraform-managed app
-nodes. Their authoritative reconciler is
-`packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts`, backed
-by `docker_nodes` provider IDs plus provider environment/tier labels. The
-control-plane environment must set one reviewed firewall set in
-`CONTAINERS_HCLOUD_FIREWALL_IDS`; creation fails closed when it is absent,
-malformed, duplicated, or when an existing provider attachment drifts from the
-exact set. Names and age alone never authorize adoption or deletion. Existing
-host convergence remains a protected, plan-reviewed operator action rather
-than an autoscaler mutation.
-
-The shared private network, tenant Postgres node, and `random_password` admin
-secret live in [`../apps-shared`](../apps-shared/). This module reads them via
-a `terraform_remote_state` data source pointed at
-`hetzner/apps-shared/shared.tfstate`.
-
-## How it connects to the code
-1. Apply `../apps-shared` once → `outputs.tenant_db_admin_dsn` (sensitive) +
-   `tenant_db_private_ip`.
-2. Encrypt the admin DSN, seed it into **`tenant_db_clusters`** (`provider='direct_pg'`,
-   `host=tenant_db_private_ip`). The runtime `ClusterPool` allocates from it;
-   the daemon's `DirectPgExecutor` runs the per-tenant `CREATE ROLE/DATABASE/REVOKE CONNECT`.
-3. Apply THIS module per env → `outputs.app_node_ips`.
-4. Set daemon/Worker env: `CONTAINERS_DOCKER_NODES` (= `app_node_ips`),
-   `CONTAINERS_PUBLIC_BASE_DOMAIN` (= `apps_base_domain`), `CONTAINERS_EGRESS_PROXY_URL`,
-   the image registry.
-5. Wire the two gated boot one-liners: cloud-api `configureAppsDeployTrigger()` +
-   daemon `configureAppsDeployBackend({ registry, buildExec })`.
-6. Flip the feature gate for an allowlist; **on-node kernel re-check** (throwaway
-   `--internal` scratch net) before opening to users.
-
-## Apply (after review)
-
-**One-shot setup on a fresh `apps` Hetzner project**:
-
-1. **Generate a Hetzner API token** scoped to the `apps` project (Console →
-   Security → API Tokens). Store it as the repo-level GitHub secret
-   `HCLOUD_APPS_TOKEN` (shared across staging + production — the apps data
-   plane is one project, see `../ARCHITECTURE.md`).
-2. **Register the operator SSH public key** in the `apps` project (Console →
-   Security → SSH Keys → Add). cloud-init still seeds `authorized_keys` from
-   `var.ssh_public_keys` for the `deploy` user — but the hcloud-managed key
-   is the canonical fallback for root-level `hcloud server reset` flows.
-3. **Apply `../apps-shared` first** — this module's `terraform_remote_state`
-   data source will fail until that state file exists.
-
-Then plan/apply from CI:
+## Verification
 
 ```bash
-gh workflow run terraform-apps-data-plane.yml --ref develop \
-  -f environment=staging -f action=plan
-# Review the plan in the run logs, then:
-gh workflow run terraform-apps-data-plane.yml --ref develop \
-  -f environment=staging -f action=apply
+terraform init -backend=false -input=false
+terraform validate
+terraform test
 ```
 
-Or locally for debugging:
-
-```bash
-cd packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane
-cp tfvars/staging.tfvars.example staging.tfvars   # fill in real values
-export HCLOUD_TOKEN=...      # the HCLOUD_APPS_TOKEN value
-terraform init -backend-config=backend-staging.hcl
-terraform plan  -var-file=staging.tfvars
-terraform apply -var-file=staging.tfvars
-```
-
-## STAN — must confirm before production
-- **SSH surface:** `operator_ingress_cidrs` — tighten.
-- **Untrusted-image hardening:** gVisor (runsc) / Kata / userns-remap + seccomp on
-  the app node — the draft uses stock docker + `--cap-drop=ALL` + `--internal`
-  (the verified baseline, not defense-in-depth vs a kernel 0-day).
-- **Ingress/TLS:** install Caddy (or reuse the existing ingress-map → Caddyfile
-  emitter) on the app node; front multiple app nodes with `hcloud_load_balancer`.
-- **Egress allowlist:** `squid` default-deny on the app node currently allows only
-  ghcr.io + githubusercontent — extend to what apps legitimately need.
+These tests exercise the actual Terraform plan and remote-state identity
+postcondition with substituted providers and state transport. They prove
+configuration rejection, not live project isolation, data migration or cloud
+readiness. Reviewed provider plans and runtime evidence remain required.

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/backend-development.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/backend-development.hcl
@@ -1,7 +1,7 @@
 # Environment state uses a separate R2 bucket and bucket-scoped credentials.
-# Provision this bucket before init; use credentials scoped only to production state.
-bucket                      = "eliza-terraform-state-production"
-key                         = "hetzner/apps-data-plane/production.tfstate"
+# Provision this bucket before init; use credentials scoped only to development state.
+bucket                      = "eliza-terraform-state-development"
+key                         = "hetzner/apps-data-plane/development.tfstate"
 region                      = "auto"
 endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
 skip_credentials_validation = true

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/backend-staging.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/backend-staging.hcl
@@ -1,11 +1,6 @@
-# Cloudflare R2 backend (S3-compatible) for terraform state — apps data-plane,
-# staging. Mirrors control-plane/backend-staging.hcl (same bucket + R2 account).
-#
-# Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY to an R2 API token with
-# read/write on the bucket, then:
-#   terraform init -backend-config=backend-staging.hcl
-
-bucket                      = "eliza-terraform-state"
+# Environment state uses a separate R2 bucket and bucket-scoped credentials.
+# Provision this bucket before init; use credentials scoped only to staging state.
+bucket                      = "eliza-terraform-state-staging"
 key                         = "hetzner/apps-data-plane/staging.tfstate"
 region                      = "auto"
 endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
@@ -14,6 +9,4 @@ skip_metadata_api_check     = true
 skip_region_validation      = true
 skip_requesting_account_id  = true
 use_path_style              = true
-
-# Native S3 backend lockfile (requires TF 1.10+). No DynamoDB needed.
 use_lockfile                = true

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -1,24 +1,5 @@
-###############################################################################
-# Eliza Cloud Apps (Product 2) — per-env data plane (Hetzner)
-#
-# This module owns the PER-ENV pieces of the apps data plane: the app worker
-# node(s) (Docker hosts for untrusted user images) and the Cloudflare wildcard
-# record routing per-app URLs at them.
-#
-# The SHARED pieces (private network, tenant Postgres node) live in
-# ../apps-shared and are read here via a `terraform_remote_state` data source.
-#
-# Topology:
-#   - SHARED (one private network, one tenant Postgres node) — owned by
-#     ../apps-shared/, single backend, no env suffix on resource names;
-#   - PER-ENV (app worker node(s) + wildcard DNS) — this module, one tfstate
-#     per env (backend-staging.hcl / backend-production.hcl).
-#
-# Security items to keep in mind (search "STAN:"):
-#   - tighten operator_ingress_cidrs (SSH);
-#   - gVisor/Kata/userns hardening on the app node for untrusted images;
-#   - egress proxy allowlist for app containers.
-###############################################################################
+# Provisions app workers and ingress for one environment. The database/network
+# state must report the same environment before any worker can attach to it.
 
 locals {
   common_labels = {
@@ -28,15 +9,12 @@ locals {
   }
 }
 
-# ── Shared infra (private network + tenant DB) lives in ../apps-shared ────────
-# Read its outputs so app nodes attach to the same network the tenant DB lives
-# on. The shared state has a single backend (no env suffix); both staging and
-# production app-node applies point at it.
+# Read only this environment's tenant database and network state.
 data "terraform_remote_state" "apps_shared" {
   backend = "s3"
   config = {
-    bucket                      = "eliza-terraform-state"
-    key                         = "hetzner/apps-shared/shared.tfstate"
+    bucket                      = "eliza-terraform-state-${var.environment}"
+    key                         = "hetzner/apps-shared/${var.environment}.tfstate"
     region                      = "auto"
     endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
     skip_credentials_validation = true
@@ -44,6 +22,12 @@ data "terraform_remote_state" "apps_shared" {
     skip_region_validation      = true
     skip_requesting_account_id  = true
     use_path_style              = true
+  }
+  lifecycle {
+    postcondition {
+      condition     = try(self.outputs.environment, null) == var.environment
+      error_message = "Tenant database state has no matching environment identity; refusing cross-tier network and database attachment."
+    }
   }
 }
 
@@ -121,13 +105,10 @@ resource "hcloud_server_network" "app_node" {
 
   server_id  = each.value.id
   network_id = local.apps_network_id
-  # staging + production app nodes share the apps-shared subnet, so the private-IP
-  # offset MUST be partitioned per environment or the prod node #1 collides with
-  # the staging node #1 (both at host 21 → "API request failed" on attach).
-  # staging → 21,22,…  production → 31,32,… (DB node is host 10).
+  # Each environment has its own subnet; database host 10 remains reserved.
   ip = cidrhost(
     local.apps_subnet_cidr,
-    (var.environment == "production" ? 30 : 20) + tonumber(each.key),
+    20 + tonumber(each.key),
   )
 }
 

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
@@ -1,6 +1,4 @@
-# tenant_db_* outputs now live in ../apps-shared (one tenant DB, shared across
-# staging + production app nodes). Read them via terraform_remote_state if you
-# need them in another module.
+# Publishes this environment app worker addresses and ingress to operators.
 
 output "app_node_ips" {
   description = "Public IPs of the app worker nodes (the daemon SSHes here to run app containers; ingress also lands here)."

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
@@ -1,11 +1,5 @@
 provider "hcloud" {
-  # Token resolution order:
-  #   1. var.hcloud_token (passed via tfvars or -var)
-  #   2. HCLOUD_TOKEN env var (the GHA pattern — sourced from the REPO-level
-  #      secret HCLOUD_APPS_TOKEN; both staging + production applies share it
-  #      because the apps data-plane lives in a single shared Hetzner Cloud
-  #      Project, NOT split per environment like the control-plane is).
-  # See ../ARCHITECTURE.md § "Multi-project layout" for the topology.
+  # HCLOUD_TOKEN must be scoped to this environment apps project.
   token = var.hcloud_token
 }
 

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/tests/environment-state.tftest.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/tests/environment-state.tftest.hcl
@@ -1,0 +1,71 @@
+# Exercises remote-state identity admission through actual Terraform planning.
+# Providers and remote-state transport are substituted; no cloud effects run.
+mock_provider "hcloud" {}
+mock_provider "cloudflare" {}
+variables {
+  environment             = "development"
+  cloudflare_zone_id      = "00000000000000000000000000000001"
+  eliza_app_zone_id       = "00000000000000000000000000000002"
+  legacy_apps_base_domain = "apps-development.elizacloud.ai"
+  apps_base_domain        = "apps-development.eliza.app"
+  cloud_api_origin        = "https://api-development.eliza.app"
+  operator_ingress_cidrs  = ["192.0.2.1/32"]
+}
+run "matching_database" {
+  command = plan
+  override_data {
+    target = data.terraform_remote_state.apps_shared
+    values = {
+      outputs = {
+        environment          = "development"
+        apps_network_id      = 1001
+        apps_subnet_cidr     = "10.30.1.0/24"
+        tenant_db_private_ip = "10.30.1.10"
+      }
+    }
+  }
+}
+run "reject_production_database" {
+  command = plan
+  override_data {
+    target = data.terraform_remote_state.apps_shared
+    values = {
+      outputs = {
+        environment          = "production"
+        apps_network_id      = 1001
+        apps_subnet_cidr     = "10.30.1.0/24"
+        tenant_db_private_ip = "10.30.1.10"
+      }
+    }
+  }
+  expect_failures = [data.terraform_remote_state.apps_shared]
+}
+run "reject_staging_database" {
+  command = plan
+  override_data {
+    target = data.terraform_remote_state.apps_shared
+    values = {
+      outputs = {
+        environment          = "staging"
+        apps_network_id      = 1001
+        apps_subnet_cidr     = "10.30.1.0/24"
+        tenant_db_private_ip = "10.30.1.10"
+      }
+    }
+  }
+  expect_failures = [data.terraform_remote_state.apps_shared]
+}
+run "reject_unattested_database" {
+  command = plan
+  override_data {
+    target = data.terraform_remote_state.apps_shared
+    values = {
+      outputs = {
+        apps_network_id      = 1001
+        apps_subnet_cidr     = "10.30.1.0/24"
+        tenant_db_private_ip = "10.30.1.10"
+      }
+    }
+  }
+  expect_failures = [data.terraform_remote_state.apps_shared]
+}

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/tfvars/development.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/tfvars/development.tfvars.example
@@ -1,0 +1,23 @@
+# Copy to development.tfvars (gitignored) and fill in real values.
+
+environment        = "development"
+hcloud_location    = "fsn1"
+cloudflare_zone_id = "<legacy-zone-id-for-elizacloud.ai>"
+eliza_app_zone_id  = "<canonical-zone-id-for-eliza.app>"
+legacy_apps_base_domain = "apps-development.elizacloud.ai"
+apps_base_domain   = "apps-development.eliza.app"
+
+# Sizing — start small for the allowlist beta.
+app_node_count       = 1
+app_node_server_type = "ccx23"
+
+# Tight operator IPs only; module validation rejects 0.0.0.0/0 / ::/0.
+operator_ingress_cidrs = ["<operator-ip>/32"]
+
+# Operator SSH public keys (NEVER paste private keys here).
+ssh_public_keys = [
+  # "ssh-ed25519 AAAA... operator@laptop"
+]
+
+# cloud-api origin for this env (the on-demand-TLS ask endpoint lives under it)
+cloud_api_origin         = "https://api-development.eliza.app"

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -1,25 +1,16 @@
 variable "environment" {
-  description = "Deployment environment (staging, production)"
+  description = "Deployment environment (development, staging, production)"
   type        = string
   validation {
-    condition     = contains(["staging", "production"], var.environment)
-    error_message = "Environment must be 'staging' or 'production'"
+    condition     = contains(["development", "staging", "production"], var.environment)
+    error_message = "Environment must be 'development', 'staging', or 'production'"
   }
 }
 
-# ── Shared apps-project credentials ──────────────────────────────────────────
-# The apps data-plane lives in a SINGLE SHARED Hetzner Cloud Project (one
-# quota, one set of SSH keys, one private network). The shared network +
-# tenant Postgres node are owned by ../apps-shared/. This module is per-env
-# (one tfstate per env) and only manages app worker nodes + the wildcard
-# Cloudflare record.
-#
-# The provider picks up the token from this variable OR the HCLOUD_TOKEN env
-# var. GitHub Actions wires the REPO-LEVEL secret HCLOUD_APPS_TOKEN as
-# HCLOUD_TOKEN for both staging and production runs.
-# See ARCHITECTURE.md § "Multi-project layout" for the topology.
+# Use a project token scoped to this environment's apps infrastructure.
+# Worker and database roots share that project's network within one tier only.
 variable "hcloud_token" {
-  description = "Hetzner Cloud API token for the shared apps Hetzner project. Leave null to pick up from HCLOUD_TOKEN env var (the GHA pattern, sourced from repo-level secret HCLOUD_APPS_TOKEN)."
+  description = "Hetzner token for this environment apps project; null uses HCLOUD_TOKEN."
   type        = string
   default     = null
   sensitive   = true
@@ -49,12 +40,9 @@ variable "app_node_count" {
   type        = number
   default     = 1
   validation {
-    # Per-env private-IP windows in the shared subnet are 10 apart (staging base
-    # 20, production base 30 — see hcloud_server_network.app_node). Capping at 9
-    # keeps staging's top host (20+9=29) strictly below production's base (31) so
-    # the two windows can never overlap as either env scales.
+    # Bound this operator-managed pool; runtime capacity has its own admission.
     condition     = var.app_node_count >= 1 && var.app_node_count <= 9
-    error_message = "app_node_count must be between 1 and 9 (per-env private-IP windows are 10 apart in the shared subnet)"
+    error_message = "app_node_count must be an integer between 1 and 9"
   }
 }
 
@@ -78,8 +66,8 @@ variable "legacy_apps_base_domain" {
   description = "Legacy per-app base domain kept as proxied redirect ingress during migration."
   type        = string
   validation {
-    condition     = endswith(var.legacy_apps_base_domain, ".elizacloud.ai")
-    error_message = "legacy_apps_base_domain must be under elizacloud.ai"
+    condition     = var.legacy_apps_base_domain == (var.environment == "production" ? "apps.elizacloud.ai" : "apps-${var.environment}.elizacloud.ai")
+    error_message = "legacy_apps_base_domain must belong to the selected environment"
   }
 }
 
@@ -91,8 +79,8 @@ variable "apps_base_domain" {
     error_message = "apps_base_domain must be a non-empty hostname (no whitespace)"
   }
   validation {
-    condition     = var.environment != "staging" || var.apps_base_domain == "apps-staging.eliza.app"
-    error_message = "staging apps_base_domain must be apps-staging.eliza.app"
+    condition     = var.apps_base_domain == (var.environment == "production" ? "apps.eliza.app" : "apps-${var.environment}.eliza.app")
+    error_message = "apps_base_domain must belong to the selected environment"
   }
 }
 
@@ -102,6 +90,10 @@ variable "cloud_api_origin" {
   validation {
     condition     = can(regex("^https://[^/\\s]+$", var.cloud_api_origin))
     error_message = "cloud_api_origin must be an https:// origin with no trailing slash or path (e.g. https://api-staging.eliza.app)"
+  }
+  validation {
+    condition     = var.cloud_api_origin == (var.environment == "production" ? "https://api.eliza.app" : "https://api-${var.environment}.eliza.app")
+    error_message = "cloud_api_origin must belong to the selected environment"
   }
 }
 

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/README.md
@@ -1,67 +1,82 @@
-# Eliza Cloud Apps - shared infra (Hetzner)
+# elizaOS Cloud Apps — environment database infrastructure
 
-The **shared** half of the Apps (Product 2) data plane. Owns the resources
-that are physically a single piece of infrastructure across staging + production
-app worker nodes:
+This root provisions one private network, PostgreSQL host, PGDATA volume,
+firewall and database credentials for **one** of development, staging or
+production. Its name remains `apps-shared` because workers within that
+environment share the database host; environments must not share it.
 
-| Resource | Purpose |
-|---|---|
-| `hcloud_network.apps` (+ subnet) | Private network for apps + their tenant DB. **No overlap with the agent net.** |
-| `hcloud_server.tenant_db` (+ volume) | One self-managed Postgres holding thousands of per-tenant `DATABASE`+`ROLE` (`REVOKE CONNECT FROM PUBLIC` per tenant). Reachable **only** on the private net. |
-| `hcloud_firewall.tenant_db` | SSH from operators only — Postgres stays private-net only. |
-| `random_password.tenant_db_admin` | The tenant DB superuser password, used to build the admin DSN output. |
-| `random_password.pgbouncer_auth` | The pgbouncer `auth_user` credential (resolves per-tenant SCRAM via `auth_query`). |
+Use a separate Hetzner apps project and `eliza-terraform-state-<environment>`
+R2 bucket for each environment. Copy the matching
+`tfvars/<environment>.tfvars.example` and initialize with
+`backend-<environment>.hcl`. The required `environment` input is published
+in state; `apps-data-plane` rejects any missing or mismatched identity.
 
-Per-env app worker nodes + the `*.<apps_base_domain>` Cloudflare record live in
-the sibling [`apps-data-plane`](../apps-data-plane/) module, which consumes
-this module's outputs through a `terraform_remote_state` data source.
+The historical `backend.hcl` records the prior shared state location for
+migration readback. Do not initialize the current root against it or migrate
+that state into a new environment backend. Use the reviewed historical source
+for legacy resource administration until retirement.
 
-## Launch role
+## Migration and admission
 
-This module is the shared dependency for both staging and production app
-workers. It must exist before `apps-data-plane` can be applied in either
-environment, and its sensitive `tenant_db_admin_dsn` is what the apps daemon
-uses to create per-tenant roles and databases.
+1. Inventory and back up the existing shared tenant databases, roles, volume,
+   encryption keys and routing authority. Prove a restore before cutover.
+2. Provision new environment projects and bucket-scoped state credentials.
+   Plan this root against each new backend; the reviewed plan must create
+   isolated resources without modifying the old database, volume or network.
+3. Copy each environment's data and roles to its new database. Re-encrypt DSNs
+   with that environment's secrets and seed only its `tenant_db_clusters` rows.
+4. Validate own-tenant reads/writes, cross-tenant and cross-environment rejection,
+   backup capture and an isolated restore. Fence writes for final synchronization.
+5. Switch database authority and app routing under the existing lifecycle
+   controls. Preserve the old resources for a verified rollback window; their
+   retirement requires a separate ownership and retention review.
 
-**Why:** isolated app DB mode is only real when every deployed app receives a
-tenant-specific DSN created from this shared cluster. Without this state, the
-Worker can accept deploy requests but the daemon cannot provision isolated
-database access.
+Changing Terraform state does not move data or rewrite deployed credentials.
+The nightly backup implementation below does not meet the production plan's
+five-minute PITR target; continuous WAL backup and measured recovery remain
+required before production acceptance.
 
-## State
+Run `terraform init -backend=false`, `terraform validate`, and `terraform test`
+for local configuration checks. Tests use mocked provider effects; live
+provider plans, connectivity and recovery evidence remain separate requirements.
 
-Single shared backend file (`backend.hcl`) — there is no staging vs production
-copy of these resources, only one. Both env apply rounds of `apps-data-plane`
-read the same `hetzner/apps-shared/shared.tfstate`.
+## Bootstrap and empty-cluster initialization
 
-## Apply
+The host installs PostgreSQL 16 for the Ubuntu 24.04 image and validates the
+existing cluster's major before starting it. Bootstrap uses the exact volume
+ID supplied by Terraform, requires an ext4 filesystem, and verifies the mounted
+block-device identity. It never formats a volume. Missing attachment or package
+readiness is a failure retried by systemd, rather than a healthy empty host.
+
+A new empty volume needs a one-use authorization after its creation and identity
+have been verified in the reviewed plan/provider receipt. On that candidate host,
+use the new volume ID from that receipt in this root command:
 
 ```bash
-cd packages/cloud/infra/cloud/terraform/hetzner/apps-shared
-cp tfvars/shared.tfvars.example shared.tfvars   # fill in real values
-export HCLOUD_TOKEN=...      # the HCLOUD_APPS_TOKEN value
-export AWS_ACCESS_KEY_ID=... # R2 token for the tf state backend
-export AWS_SECRET_ACCESS_KEY=...
-terraform init -backend-config=backend.hcl
-terraform plan  -var-file=shared.tfvars
-terraform apply -var-file=shared.tfvars
+sudo bash -s -- /dev/disk/by-id/scsi-0HC_Volume_REPLACE_WITH_NEW_VOLUME_ID <<'SH'
+set -euo pipefail
+volume_device="$1"
+[[ "$volume_device" =~ ^/dev/disk/by-id/scsi-0HC_Volume_[0-9]+$ ]]
+test -b "$volume_device"
+systemctl stop tenant-db-init.service
+test ! -L /run/eliza-tenant-db-init
+install -d -m 0700 -o root -g root /run/eliza-tenant-db-init
+test ! -e /run/eliza-tenant-db-init/authorization.consumed
+umask 077
+set -o noclobber
+printf '%s\n' "$volume_device" > /run/eliza-tenant-db-init/authorization
+systemctl start tenant-db-init.service
+SH
 ```
 
-Or from CI:
-
-```bash
-gh workflow run terraform-apps-shared.yml --ref develop -f action=plan
-gh workflow run terraform-apps-shared.yml --ref develop -f action=apply
-```
-
-## After apply
-
-1. Encrypt `tenant_db_admin_dsn` and seed it into `tenant_db_clusters`
-   (`provider='direct_pg'`, `host=tenant_db_private_ip`). The runtime
-   `ClusterPool` allocates from it; the daemon's `DirectPgExecutor` runs
-   the per-tenant `CREATE ROLE/DATABASE/REVOKE CONNECT`.
-2. Run the `apps-data-plane` apply (staging then production) so app worker
-   nodes attach to the shared network published here.
+The receipt expires after five minutes, is bound to that exact volume and is
+consumed atomically before `initdb`. It is not recreated on reboot. A failed
+initialization leaves its consumed receipt and partial data intact; inspect and
+recover them instead of issuing another authorization blindly. Existing clusters
+do not need this receipt. Unknown directories, mismatched versions and recovered
+filesystem entries stop initialization and require the appropriate restore or
+migration path. Systemd/SSH/database readiness still needs a real host drill;
+local shell tests substitute those external boundaries.
 
 ## Connection pooling (pgbouncer) — #8321 P0 #2
 
@@ -119,8 +134,8 @@ gates every connection.
 
 ### Authority and data classification
 
-This module's tenant Postgres node is the single authority for every deployed
-app's tenant database (per-tenant `DATABASE`+`ROLE`, `REVOKE CONNECT FROM
+This module's tenant Postgres node is the authority for this environment's
+app tenant databases (per-tenant `DATABASE`+`ROLE`, `REVOKE CONNECT FROM
 PUBLIC`). The data is customer-owned application data — treat it as
 confidential. This README, the terraform files, and all job logs must never
 carry credentials, DSN values, host secrets, or tenant identifiers; tenant

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend-development.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend-development.hcl
@@ -1,7 +1,7 @@
 # Environment state uses a separate R2 bucket and bucket-scoped credentials.
-# Provision this bucket before init; use credentials scoped only to production state.
-bucket                      = "eliza-terraform-state-production"
-key                         = "hetzner/apps-data-plane/production.tfstate"
+# Provision this bucket before init; use credentials scoped only to development state.
+bucket                      = "eliza-terraform-state-development"
+key                         = "hetzner/apps-shared/development.tfstate"
 region                      = "auto"
 endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
 skip_credentials_validation = true

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend-production.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend-production.hcl
@@ -1,7 +1,7 @@
 # Environment state uses a separate R2 bucket and bucket-scoped credentials.
 # Provision this bucket before init; use credentials scoped only to production state.
 bucket                      = "eliza-terraform-state-production"
-key                         = "hetzner/apps-data-plane/production.tfstate"
+key                         = "hetzner/apps-shared/production.tfstate"
 region                      = "auto"
 endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
 skip_credentials_validation = true

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend-staging.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend-staging.hcl
@@ -1,7 +1,7 @@
 # Environment state uses a separate R2 bucket and bucket-scoped credentials.
-# Provision this bucket before init; use credentials scoped only to production state.
-bucket                      = "eliza-terraform-state-production"
-key                         = "hetzner/apps-data-plane/production.tfstate"
+# Provision this bucket before init; use credentials scoped only to staging state.
+bucket                      = "eliza-terraform-state-staging"
+key                         = "hetzner/apps-shared/staging.tfstate"
 region                      = "auto"
 endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
 skip_credentials_validation = true

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/backend.hcl
@@ -1,3 +1,5 @@
+# Legacy shared-state location, retained for migration readback only.
+# The current module uses backend-<environment>.hcl for new isolated resources.
 # Cloudflare R2 backend (S3-compatible) for terraform state — apps-shared.
 # Single shared backend file: this module is NOT per-env (one private network +
 # one tenant Postgres node are shared across staging + production app nodes).

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
@@ -1,48 +1,9 @@
 #cloud-config
-# Tenant Postgres node for Eliza Cloud Apps (Product 2).
-#
-# Stands up ONE self-managed Postgres that holds thousands of per-tenant
-# DATABASE+ROLE (each app gets its own DB + LOGIN role with REVOKE CONNECT FROM
-# PUBLIC — the hard isolation boundary). The per-tenant DDL is run at deploy time
-# by the node daemon (DirectPgExecutor over the admin DSN); this only stands up
-# the cluster + the admin superuser + locks the network surface.
-#
-# Reachable ONLY on the private apps network (the firewall opens no public 5432).
-#
-# The cluster setup is wrapped in a systemd oneshot service (tenant-db-init)
-# rather than cloud-init runcmd, because runcmd is per-instance: it only fires
-# on first boot. After a Hetzner rescale (server_type change), the cloud
-# refreshes user_data + reboots but cloud-init treats it as the same instance,
-# so runcmd never runs again — and we end up with an empty volume and dead
-# Postgres. The systemd unit runs on every boot, every step is grep-/path-
-# guarded, so it's a no-op after first successful run.
-#
-# Connection scaling (#8321 P0 #2): the default Postgres ceiling is 100
-# connections, which the apps data plane exhausts at ~5 apps under load. This
-# node now (a) raises max_connections + sizes shared_buffers to the box, and
-# (b) runs pgbouncer in SESSION pool_mode on :6432 so app sessions are
-# multiplexed onto a bounded set of server backends. SESSION mode (not
-# transaction) is required because plugin-sql's migrator takes SESSION-scoped
-# advisory locks (pg_advisory_lock, not the _xact_ variants) across independent
-# pool checkouts — transaction pooling would orphan those locks and wedge
-# migrations. The pooler is INERT until an operator points the cluster's
-# app-facing host at :6432 (see README + tenant_db_pooler_endpoint output);
-# admin/DDL keeps using :5432 directly.
-#
-# Off-host recovery (#21729): a nightly systemd timer (tenant-db-backup) takes
-# an application-consistent logical backup (pg_dumpall globals + per-database
-# pg_dump -Fc), encrypts the archive locally with AES-256 before it leaves the
-# node, ships it to an S3-compatible bucket outside the Hetzner failure domain
-# via rclone, and prunes sets older than the retention window. The pipeline is
-# INERT until terraform renders /etc/eliza/tenant-db-backup.env (all backup_*
-# variables set). Job logs carry counts/bytes/durations only — never DSNs,
-# credentials, or tenant database names (names live inside the encrypted
-# archive's dbmap). Restore drills run through
-# packages/cloud/scripts/admin/apps-tenant-db-recovery.ts.
-#
-# STAN: generate a server TLS cert for hostssl (until then the pg_hba lines
-# below stay 'host' and the admin DSN uses sslmode=disable); tighten pgbouncer
-# listen_addr to the private IP.
+# Converges one environment's PostgreSQL host on its assigned persistent volume.
+# Bootstrap never formats disks or initializes a populated/unknown cluster.
+# A new empty cluster requires a short-lived root-issued authorization; normal
+# recovery starts only matching existing data. Nightly encrypted logical backups
+# are installed but require the complete backup credential bundle to run.
 
 hostname: ${hostname}
 manage_etc_hosts: true
@@ -65,7 +26,7 @@ users:
 package_update: true
 package_upgrade: false
 packages:
-  - postgresql
+  - postgresql-16
   - postgresql-contrib
   - pgbouncer
   - jq
@@ -120,47 +81,109 @@ write_files:
       set -euo pipefail
       log() { echo "[tenant-db-init] $*"; }
 
-      # 1. Locate the Hetzner data volume by stable scsi id.
-      VOL="$(ls /dev/disk/by-id/scsi-0HC_Volume_* 2>/dev/null | head -1 || true)"
-      if [ -z "$VOL" ]; then
-        log "no Hetzner data volume attached yet; deferring (next boot will retry)."
-        exit 0
+      # Bind initialization to the volume recorded by Terraform. The provider
+      # formats newly created volumes; bootstrap must never format or choose a
+      # different attached disk when this volume is unavailable.
+      VOL="${tenant_db_volume_device}"
+      if ! test -b "$VOL"; then
+        log "the assigned data volume is unavailable; initialization must retry."
+        exit 75
       fi
-      log "data volume = $VOL"
-
-      # 2. Format only if no filesystem detected. blkid is the gate — never -F.
-      if ! blkid "$VOL" >/dev/null 2>&1; then
-        log "no fs on $VOL — formatting ext4."
-        mkfs.ext4 "$VOL"
+      fs_type="$(blkid -p -s TYPE -o value "$VOL")" || {
+        log "unable to verify the assigned data volume filesystem."
+        exit 1
+      }
+      if [ "$fs_type" != "ext4" ]; then
+        log "the assigned data volume must contain the expected ext4 filesystem."
+        exit 1
+      fi
+      expected_device="$(lsblk --raw --nodeps --noheadings --output MAJ:MIN "$VOL")"
+      if [[ ! "$expected_device" =~ ^[0-9]+:[0-9]+$ ]]; then
+        log "unable to identify the assigned data volume block device."
+        exit 1
       fi
 
-      # 3. fstab + mount, grep-guarded so we don't accumulate duplicate lines.
+      # This service mounts its exact volume on every boot. Avoid mount -a and
+      # fstab edits, which could operate on unrelated or stale volume entries.
       mkdir -p /mnt/tenant-pgdata
-      if ! grep -qE "^[^#]*[[:space:]]/mnt/tenant-pgdata[[:space:]]" /etc/fstab; then
-        echo "$VOL /mnt/tenant-pgdata ext4 defaults,nofail 0 2" >> /etc/fstab
+      if ! mountpoint -q /mnt/tenant-pgdata; then
+        mount --source "$VOL" --target /mnt/tenant-pgdata
       fi
-      mountpoint -q /mnt/tenant-pgdata || mount -a
+      observed_device="$(findmnt --raw --noheadings --output MAJ:MIN --mountpoint /mnt/tenant-pgdata)"
+      if [ "$observed_device" != "$expected_device" ]; then
+        log "the database mount is backed by a different block device; refusing initialization."
+        exit 1
+      fi
 
-      # 4. Postgres version detection. The package may not be installed on the
-      # very first boot if cloud-init hasn't reached the package stage yet —
-      # defer cleanly; the next boot will pick it up.
-      PGVER="$(ls /etc/postgresql 2>/dev/null | head -1 || true)"
-      if [ -z "$PGVER" ]; then
-        log "postgresql package not installed yet; deferring."
-        exit 0
+      # 4. Postgres version detection. Pin the supported Ubuntu 24.04 major
+      # instead of selecting whichever configuration directory sorts first.
+      PGVER=16
+      if ! test -x "/usr/lib/postgresql/$PGVER/bin/postgres" || ! test -f "/etc/postgresql/$PGVER/main/postgresql.conf"; then
+        log "the supported PostgreSQL package is not ready; initialization must retry."
+        exit 75
       fi
       PGDATA="/mnt/tenant-pgdata/$PGVER/main"
       CONF="/etc/postgresql/$PGVER/main/postgresql.conf"
       HBA="/etc/postgresql/$PGVER/main/pg_hba.conf"
       log "PGVER=$PGVER PGDATA=$PGDATA"
 
-      # 5. initdb if PGDATA doesn't exist or isn't an initialised cluster.
-      if [ ! -f "$PGDATA/PG_VERSION" ]; then
-        log "no cluster at $PGDATA — initdb."
-        systemctl stop "postgresql@$PGVER-main" 2>/dev/null || true
+      # Existing clusters must match the installed PostgreSQL major. A missing
+      # marker is not evidence of a new database: refuse populated volumes and
+      # require a fresh, root-issued one-use authorization for empty volumes.
+      if test -L "/mnt/tenant-pgdata/$PGVER" || test -L "$PGDATA"; then
+        log "the database directory must not redirect outside its assigned volume."
+        exit 1
+      fi
+      if [ -f "$PGDATA/PG_VERSION" ]; then
+        if [ "$(cat "$PGDATA/PG_VERSION")" != "$PGVER" ]; then
+          log "the database major does not match the installed PostgreSQL version."
+          exit 1
+        fi
+      else
+        existing_entry="$(find /mnt/tenant-pgdata -mindepth 1 -maxdepth 1 ! -name lost+found -print -quit)"
+        if [ -n "$existing_entry" ]; then
+          log "the volume contains data without the expected cluster; restore or migration is required."
+          exit 1
+        fi
+        if test -e /mnt/tenant-pgdata/lost+found; then
+          if ! test -d /mnt/tenant-pgdata/lost+found || test -L /mnt/tenant-pgdata/lost+found || [ -n "$(find /mnt/tenant-pgdata/lost+found -mindepth 1 -print -quit)" ]; then
+            log "filesystem recovery entries require inspection before initialization."
+            exit 1
+          fi
+        fi
+        authorization=/run/eliza-tenant-db-init/authorization
+        if test -L /run/eliza-tenant-db-init || [ "$(stat -c '%u:%a' /run/eliza-tenant-db-init)" != "0:700" ]; then
+          log "the initialization authorization directory must be root-owned and private."
+          exit 1
+        fi
+        if ! test -f "$authorization" || test -L "$authorization"; then
+          log "an empty volume requires a one-use initialization authorization."
+          exit 1
+        fi
+        if [ "$(stat -c '%u:%a' "$authorization")" != "0:600" ] || [ "$(cat "$authorization")" != "$VOL" ]; then
+          log "the initialization authorization does not belong to this volume and root operator."
+          exit 1
+        fi
+        issued_at="$(stat -c '%Y' "$authorization")"
+        now="$(date +%s)"
+        if [[ ! "$issued_at" =~ ^[0-9]+$ ]] || (( issued_at > now || now - issued_at > 300 )); then
+          log "the initialization authorization is expired or has an invalid timestamp."
+          exit 1
+        fi
+        # Atomic hard-link creation excludes a competing initializer; the
+        # consumed receipt remains in /run for this boot, including on failure.
+        ln "$authorization" "$authorization.consumed"
+        rm "$authorization"
+        systemctl stop "postgresql@$PGVER-main"
         mkdir -p "$PGDATA"
         chown -R postgres:postgres /mnt/tenant-pgdata
         runuser -u postgres -- "/usr/lib/postgresql/$PGVER/bin/initdb" -D "$PGDATA" --auth-host=scram-sha-256
+      fi
+
+      data_device="$(findmnt --raw --noheadings --output MAJ:MIN --target "$PGDATA")"
+      if [ "$data_device" != "$expected_device" ]; then
+        log "the database directory is on a different block device; refusing startup."
+        exit 1
       fi
 
       # 6. postgresql.conf — sed pattern matches both commented and uncommented
@@ -478,17 +501,19 @@ write_files:
       # restart us "to break ordering cycle"). network-online is enough.
       After=network-online.target
       Wants=network-online.target
-      # Run BEFORE postgresql so the script's restart isn't fighting the
-      # default unit. The script itself enables + starts postgresql once
-      # data_directory is wired.
-      Before=postgresql.service
+      # The script restarts PostgreSQL after verifying its volume. Ordering
+      # this oneshot before PostgreSQL would make that restart wait on itself.
+      After=postgresql.service
+      StartLimitIntervalSec=0
 
       [Service]
       Type=oneshot
       RemainAfterExit=yes
       ExecStart=/usr/local/bin/tenant-db-init.sh
-      # Keep the unit's own state simple: success = postgres up; failure leaves
-      # it for the operator to inspect via `journalctl -u tenant-db-init`.
+      # Volume attachment can complete after cloud-init. Failed initialization
+      # remains visible and retries without requiring another host reboot.
+      Restart=on-failure
+      RestartSec=15s
       StandardOutput=journal
       StandardError=journal
 

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/main.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/main.tf
@@ -1,32 +1,13 @@
-###############################################################################
-# Eliza Cloud Apps (Product 2) — SHARED data-plane resources (Hetzner)
-#
-# This module owns the resources that are shared across staging + production
-# app nodes:
-#   - the PRIVATE network + subnet (10.30.0.0/16 — no overlap with agents);
-#   - the TENANT POSTGRES node (thousands of DATABASE+ROLE, REVOKE CONNECT per
-#     tenant) reachable ONLY on the private net — never public;
-#   - admin DSN for the tenant DB.
-#
-# Per-env app worker nodes (and their wildcard DNS record) live in the
-# apps-data-plane module, which reads this module's outputs via a
-# `terraform_remote_state` data source.
-#
-# Why split? The tenant DB + private net are physically a single shared piece
-# of infra in the apps Hetzner project — one network, one Postgres node holds
-# both staging and production tenant DBs (alpha scale). Keeping them in their
-# own state file means:
-#   - staging vs prod apply rounds can't accidentally rebuild the tenant DB;
-#   - app-node-only changes don't touch the shared backend.
-#
-# The Hetzner server name is intentionally "eliza-app-tenant" (no env suffix)
-# because the resource is shared — there is one tenant DB, not two.
-###############################################################################
+# Owns the network, persistent database volume and PostgreSQL host for one
+# environment. App workers consume its environment-attested state separately.
+# Existing shared databases require data migration before routing cutover;
+# applying this root to a new backend does not copy their data.
 
 locals {
   common_labels = {
-    "managed-by" = "eliza-cloud"
-    "tier"       = "apps-shared"
+    "managed-by"  = "eliza-cloud"
+    "tier"        = "apps-shared"
+    "environment" = var.environment
   }
 
   # Off-host backup pipeline (#21729): armed only when the full credential set
@@ -59,15 +40,10 @@ resource "random_password" "pgbouncer_auth" {
   special = false
 }
 
-# Operator/daemon SSH access is provisioned by cloud-init: each node's `deploy`
-# user gets `var.ssh_public_keys` in its authorized_keys (see cloud-init/*.tftpl).
-# We do NOT register an `hcloud_ssh_key` here: the apps Hetzner project is
-# shared, and registering the key out-of-band via Hetzner Console keeps both
-# this module + apps-data-plane from racing on the same `eliza-op-*` key.
-
-# ── Private network: apps + tenant DB only; isolated from the agent plane ─────
+# Cloud-init installs the supplied operator keys for the deploy account.
+# The private network belongs to this environment's apps project.
 resource "hcloud_network" "apps" {
-  name              = "eliza-apps"
+  name              = "eliza-apps-${var.environment}"
   ip_range          = var.network_cidr
   labels            = local.common_labels
   delete_protection = true
@@ -90,7 +66,7 @@ resource "hcloud_network_subnet" "apps" {
 
 # ── Block storage for all tenant databases (PGDATA) ───────────────────────────
 resource "hcloud_volume" "tenant_db_data" {
-  name              = "eliza-app-tenant-data"
+  name              = "eliza-app-tenant-${var.environment}-data"
   size              = var.tenant_db_volume_size_gb
   location          = var.hcloud_location
   format            = "ext4"
@@ -113,7 +89,7 @@ resource "hcloud_volume" "tenant_db_data" {
 # Tenant DB node: NO public Postgres. SSH from operators only; Postgres (5432)
 # is reachable solely on the private network (no firewall rule opens it publicly).
 resource "hcloud_firewall" "tenant_db" {
-  name   = "eliza-app-tenant"
+  name   = "eliza-app-tenant-${var.environment}"
   labels = local.common_labels
 
   rule {
@@ -131,14 +107,8 @@ resource "hcloud_firewall" "tenant_db" {
   }
 }
 
-# ── Tenant Postgres node ──────────────────────────────────────────────────────
-# Name is intentionally bare `eliza-app-tenant` — no env suffix — because this
-# server is shared across staging + production. lifecycle.ignore_changes
-# includes `name` so Hetzner-side renames (e.g. legacy `eliza-apps-tenantdb-
-# staging` left over from the pre-shared layout) don't cause drift; operators
-# can rename via the Hetzner Console at their discretion (cosmetic only).
 resource "hcloud_server" "tenant_db" {
-  name               = "eliza-app-tenant"
+  name               = "eliza-app-tenant-${var.environment}"
   location           = var.hcloud_location
   server_type        = var.tenant_db_server_type
   image              = var.hcloud_image
@@ -149,7 +119,8 @@ resource "hcloud_server" "tenant_db" {
   labels             = merge(local.common_labels, { "role" = "tenant-db" })
 
   user_data = templatefile("${path.module}/cloud-init/tenant-db.yaml.tftpl", {
-    hostname                = "eliza-app-tenant"
+    hostname                = "eliza-app-tenant-${var.environment}"
+    tenant_db_volume_device = "/dev/disk/by-id/scsi-0HC_Volume_${hcloud_volume.tenant_db_data.id}"
     admin_password          = random_password.tenant_db_admin.result
     pgbouncer_auth_password = random_password.pgbouncer_auth.result
     operator_ssh_keys       = var.ssh_public_keys

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/outputs.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/outputs.tf
@@ -11,7 +11,7 @@ output "apps_subnet_id" {
 }
 
 output "apps_subnet_cidr" {
-  description = "CIDR of the shared apps subnet. apps-data-plane computes app_node private IPs per env via cidrhost(subnet, base + i) where base = 20 (staging) / 30 (production); tenant DB is host 10."
+  description = "CIDR of this environment apps subnet. App workers start at host 21; the tenant database uses host 10."
   value       = var.subnet_cidr
 }
 
@@ -41,4 +41,9 @@ output "tenant_db_backup_configured" {
 output "tenant_db_pooler_endpoint" {
   description = "Host:port of the pgbouncer SESSION-mode pooler (#8321 P0 #2). To route per-tenant APP connections through the pooler, set tenant_db_clusters.host to THIS value (the app-facing per-tenant DSN host) once the tenant-db node has been (re)rolled with the pgbouncer cloud-init. The admin DSN above stays on :5432. Leaving host at :5432 keeps the pooler inert."
   value       = "${cidrhost(var.subnet_cidr, 10)}:6432"
+}
+
+output "environment" {
+  description = "Environment identity checked by app workers before using this network and database."
+  value       = var.environment
 }

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/providers.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/providers.tf
@@ -1,9 +1,4 @@
 provider "hcloud" {
-  # Token resolution order:
-  #   1. var.hcloud_token (passed via tfvars or -var)
-  #   2. HCLOUD_TOKEN env var (the GHA pattern — sourced from the REPO-level
-  #      secret HCLOUD_APPS_TOKEN; the apps Hetzner project is one shared
-  #      project across staging + production).
-  # See ../ARCHITECTURE.md § "Multi-project layout" for the topology.
+  # HCLOUD_TOKEN must be scoped to this environment apps project.
   token = var.hcloud_token
 }

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tests/environments.tftest.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tests/environments.tftest.hcl
@@ -1,0 +1,26 @@
+# Plans the actual tenant infrastructure with provider effects mocked.
+mock_provider "hcloud" {}
+mock_provider "random" {}
+variables {
+  environment            = "development"
+  operator_ingress_cidrs = ["192.0.2.1/32"]
+}
+run "development_database" { command = plan }
+run "staging_database" {
+  command = plan
+  variables { environment = "staging" }
+}
+run "production_database" {
+  command = plan
+  variables { environment = "production" }
+}
+run "reject_shared_environment" {
+  command = plan
+  variables { environment = "shared" }
+  expect_failures = [var.environment]
+}
+run "reject_environment_state_bucket_for_backup" {
+  command = plan
+  variables { backup_s3_bucket = "eliza-terraform-state-development" }
+  expect_failures = [var.backup_s3_bucket]
+}

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tfvars/development.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tfvars/development.tfvars.example
@@ -1,0 +1,35 @@
+# Copy to development.tfvars (gitignored) and fill in real values.
+environment = "development"
+
+hcloud_location = "fsn1"
+
+# Sizing — start small for the allowlist beta.
+# tenant_db_server_type omitted: inherit the module default (cpx42, shared CPU,
+# no dedicated-vCPU quota cost). Add an explicit override here when you need
+# more headroom (e.g. ccx33 for dedicated 8 vCPU / 32 GB).
+tenant_db_volume_size_gb = 200
+
+# MUST NOT overlap the agent data-plane network.
+network_cidr = "10.30.0.0/16"
+subnet_cidr  = "10.30.1.0/24"
+
+# Tight operator IPs only; module validation rejects 0.0.0.0/0 / ::/0.
+operator_ingress_cidrs = ["<operator-ip>/32"]
+
+# Operator SSH public keys (NEVER paste private keys here).
+ssh_public_keys = [
+  # "ssh-ed25519 AAAA... operator@laptop"
+]
+
+# Off-host encrypted backups (#21729). All-or-nothing: set every value below
+# together or leave them all unset to keep the pipeline inert. The bucket must
+# be OUTSIDE the Hetzner apps project and never the terraform state bucket.
+# The passphrase (>= 32 chars) lives in the org password manager; losing it
+# makes every off-host backup unreadable.
+# backup_s3_endpoint           = "https://<account>.r2.cloudflarestorage.com"
+# backup_s3_bucket             = "eliza-tenant-db-backups-development"
+# backup_s3_prefix             = "tenant-db"
+# backup_s3_access_key         = "<r2-access-key-id>"
+# backup_s3_secret_key         = "<r2-secret-access-key>"
+# backup_encryption_passphrase = "<32+ char passphrase from the ops vault>"
+# backup_retention_days        = 14

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tfvars/production.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tfvars/production.tfvars.example
@@ -1,5 +1,5 @@
-# Copy to shared.tfvars (gitignored) and fill in real values.
-# Single shared tfvars: this module is NOT per-env.
+# Copy to production.tfvars (gitignored) and fill in real values.
+environment = "production"
 
 hcloud_location = "fsn1"
 
@@ -27,7 +27,7 @@ ssh_public_keys = [
 # The passphrase (>= 32 chars) lives in the org password manager; losing it
 # makes every off-host backup unreadable.
 # backup_s3_endpoint           = "https://<account>.r2.cloudflarestorage.com"
-# backup_s3_bucket             = "eliza-tenant-db-backups"
+# backup_s3_bucket             = "eliza-tenant-db-backups-production"
 # backup_s3_prefix             = "tenant-db"
 # backup_s3_access_key         = "<r2-access-key-id>"
 # backup_s3_secret_key         = "<r2-secret-access-key>"

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tfvars/staging.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/tfvars/staging.tfvars.example
@@ -1,0 +1,35 @@
+# Copy to staging.tfvars (gitignored) and fill in real values.
+environment = "staging"
+
+hcloud_location = "fsn1"
+
+# Sizing — start small for the allowlist beta.
+# tenant_db_server_type omitted: inherit the module default (cpx42, shared CPU,
+# no dedicated-vCPU quota cost). Add an explicit override here when you need
+# more headroom (e.g. ccx33 for dedicated 8 vCPU / 32 GB).
+tenant_db_volume_size_gb = 200
+
+# MUST NOT overlap the agent data-plane network.
+network_cidr = "10.30.0.0/16"
+subnet_cidr  = "10.30.1.0/24"
+
+# Tight operator IPs only; module validation rejects 0.0.0.0/0 / ::/0.
+operator_ingress_cidrs = ["<operator-ip>/32"]
+
+# Operator SSH public keys (NEVER paste private keys here).
+ssh_public_keys = [
+  # "ssh-ed25519 AAAA... operator@laptop"
+]
+
+# Off-host encrypted backups (#21729). All-or-nothing: set every value below
+# together or leave them all unset to keep the pipeline inert. The bucket must
+# be OUTSIDE the Hetzner apps project and never the terraform state bucket.
+# The passphrase (>= 32 chars) lives in the org password manager; losing it
+# makes every off-host backup unreadable.
+# backup_s3_endpoint           = "https://<account>.r2.cloudflarestorage.com"
+# backup_s3_bucket             = "eliza-tenant-db-backups-staging"
+# backup_s3_prefix             = "tenant-db"
+# backup_s3_access_key         = "<r2-access-key-id>"
+# backup_s3_secret_key         = "<r2-secret-access-key>"
+# backup_encryption_passphrase = "<32+ char passphrase from the ops vault>"
+# backup_retention_days        = 14

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/variables.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/variables.tf
@@ -1,14 +1,16 @@
-# ── Shared apps-project credentials ──────────────────────────────────────────
-# The apps-shared module owns the resources that are SHARED across staging +
-# production app nodes: the private network + the tenant Postgres node.
-# Per-env app worker nodes live in apps-data-plane and consume this module's
-# outputs via a `terraform_remote_state` data source.
-#
-# The provider picks up the token from this variable OR the HCLOUD_TOKEN env
-# var. GitHub Actions wires the REPO-LEVEL secret HCLOUD_APPS_TOKEN as
-# HCLOUD_TOKEN.
+variable "environment" {
+  description = "The single environment owning this network and tenant database."
+  type        = string
+  validation {
+    condition     = contains(["development", "staging", "production"], var.environment)
+    error_message = "Select development, staging, or production; shared tenant database state is not an environment."
+  }
+}
+
+# Use a project token scoped to this environment's apps infrastructure.
+# Worker and database roots share that project's network within one tier only.
 variable "hcloud_token" {
-  description = "Hetzner Cloud API token for the shared apps Hetzner project. Leave null to pick up from HCLOUD_TOKEN env var (the GHA pattern, sourced from repo-level secret HCLOUD_APPS_TOKEN)."
+  description = "Hetzner token for this environment apps project; null uses HCLOUD_TOKEN."
   type        = string
   default     = null
   sensitive   = true
@@ -87,7 +89,7 @@ variable "backup_s3_bucket" {
   type        = string
   default     = ""
   validation {
-    condition     = var.backup_s3_bucket != "eliza-terraform-state"
+    condition     = !startswith(var.backup_s3_bucket, "eliza-terraform-state")
     error_message = "backup_s3_bucket must be a dedicated backup bucket, never the terraform state bucket"
   }
 }

--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/versions.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/versions.tf
@@ -15,9 +15,6 @@ terraform {
     }
   }
 
-  # State backend uses Cloudflare R2 (S3-compatible), same as apps-data-plane.
-  # Single shared backend file — this module is NOT per-env (one private network +
-  # one tenant Postgres are shared across staging + production app nodes).
-  #   terraform init -backend-config=backend.hcl
+  # Select backend-<environment>.hcl with credentials scoped to its R2 bucket.
   backend "s3" {}
 }

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/README.md
@@ -54,6 +54,32 @@ scp packages/cloud/shared/.env.local root@<vm-ip>:/opt/eliza/cloud/.env.local
 #    (workflow: deploy-eliza-provisioning-worker.yml, manual dispatch).
 ```
 
+## Development control-plane provisioning
+
+Development uses `tfvars/development.tfvars.example`, its own Hetzner project,
+and `backend-development.hcl`. Create the dedicated
+`eliza-terraform-state-development` R2 bucket and use credentials scoped to that
+bucket before initializing state. Never initialize development against an
+existing staging or production state key.
+
+The module creates development Headscale DNS records without importing a
+legacy record from another tier. Both Headscale hostnames must match the selected
+environment, and a development host must follow `develop`. Development workflow
+admission and service configuration must be wired before operational use; this
+module alone does not establish a working cloud tier.
+
+Run the Terraform boundary tests without cloud credentials:
+
+```bash
+terraform init -backend=false -input=false
+terraform validate
+terraform test
+```
+
+These tests exercise the real Terraform graph with mocked provider operations;
+they do not provision hosts or prove live routing, database, or credential
+isolation. A real reviewed plan and subsequent runtime readback remain required.
+
 ## Adopt the existing production VM into Terraform
 
 The current prod manager VM (`89.167.63.246`, a legacy hand-assigned

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/backend-development.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/backend-development.hcl
@@ -1,7 +1,7 @@
-# Environment state uses a separate R2 bucket and bucket-scoped credentials.
-# Provision this bucket before init; use credentials scoped only to production state.
-bucket                      = "eliza-terraform-state-production"
-key                         = "hetzner/apps-data-plane/production.tfstate"
+# Development state uses a separate R2 bucket and bucket-scoped credentials.
+# Provision this bucket before init; do not reuse staging/production state tokens.
+bucket                      = "eliza-terraform-state-development"
+key                         = "hetzner/control-plane/development.tfstate"
 region                      = "auto"
 endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
 skip_credentials_validation = true

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/import.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/import.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 import {
-  for_each = { "1" = local.adopt_headscale_record_id[var.environment] }
+  for_each = { for environment, record_id in local.adopt_headscale_record_id : "1" => record_id if environment == var.environment }
   to       = cloudflare_dns_record.headscale[each.key]
   id       = "${var.cloudflare_zone_id}/${each.value}"
 }

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/tests/development.tftest.hcl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/tests/development.tftest.hcl
@@ -1,0 +1,42 @@
+# Exercises the real Terraform graph and input validation with provider effects
+# mocked. This proves planning behavior, not live provider or tier isolation.
+mock_provider "hcloud" {}
+mock_provider "cloudflare" {}
+
+variables {
+  environment                  = "development"
+  cloudflare_zone_id           = "00000000000000000000000000000001"
+  eliza_app_zone_id            = "00000000000000000000000000000002"
+  headscale_hostname           = "headscale-development.elizacloud.ai"
+  canonical_headscale_hostname = "headscale-development.eliza.app"
+  deploy_branch                = "develop"
+}
+
+run "development_creates_without_legacy_import" {
+  command = plan
+
+}
+
+run "reject_production_canonical_headscale" {
+  command = plan
+  variables {
+    canonical_headscale_hostname = "headscale.eliza.app"
+  }
+  expect_failures = [var.canonical_headscale_hostname]
+}
+
+run "reject_staging_legacy_headscale" {
+  command = plan
+  variables {
+    headscale_hostname = "headscale-staging.elizacloud.ai"
+  }
+  expect_failures = [var.headscale_hostname]
+}
+
+run "reject_development_production_branch" {
+  command = plan
+  variables {
+    deploy_branch = "main"
+  }
+  expect_failures = [var.deploy_branch]
+}

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/tfvars/development.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/tfvars/development.tfvars.example
@@ -1,0 +1,12 @@
+# Development requires its own Hetzner project token and operator access.
+# Copy to development.tfvars and fill the zone IDs and authorized public keys.
+environment                  = "development"
+hcloud_location              = "fsn1"
+hcloud_server_type           = "cpx32"
+control_plane_count          = 1
+cloudflare_zone_id           = "<legacy-zone-id-for-elizacloud.ai>"
+eliza_app_zone_id            = "<canonical-zone-id-for-eliza.app>"
+headscale_hostname           = "headscale-development.elizacloud.ai"
+canonical_headscale_hostname = "headscale-development.eliza.app"
+deploy_branch                = "develop"
+ssh_public_keys              = []

--- a/packages/cloud/infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud/infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -1,9 +1,9 @@
 variable "environment" {
-  description = "Deployment environment (staging, production)"
+  description = "Deployment environment (development, staging, production)"
   type        = string
   validation {
-    condition     = contains(["staging", "production"], var.environment)
-    error_message = "Environment must be 'staging' or 'production'"
+    condition     = contains(["development", "staging", "production"], var.environment)
+    error_message = "Environment must be 'development', 'staging', or 'production'"
   }
 }
 
@@ -99,8 +99,8 @@ variable "headscale_hostname" {
   description = "Legacy headscale FQDN retained during migration (prod: headscale.elizacloud.ai, staging: headscale-staging.elizacloud.ai)."
   type        = string
   validation {
-    condition     = endswith(var.headscale_hostname, ".elizacloud.ai")
-    error_message = "headscale_hostname must be a subdomain of elizacloud.ai (the zone this module manages)"
+    condition     = var.headscale_hostname == (var.environment == "production" ? "headscale.elizacloud.ai" : "headscale-${var.environment}.elizacloud.ai")
+    error_message = "headscale_hostname must match the selected environment; cross-tier Headscale DNS is forbidden"
   }
 }
 
@@ -108,8 +108,8 @@ variable "canonical_headscale_hostname" {
   description = "Canonical public FQDN for headscale (prod: headscale.eliza.app, staging: headscale-staging.eliza.app). Must match HEADSCALE_PUBLIC_URL."
   type        = string
   validation {
-    condition     = endswith(var.canonical_headscale_hostname, ".eliza.app")
-    error_message = "canonical_headscale_hostname must be a subdomain of eliza.app"
+    condition     = var.canonical_headscale_hostname == (var.environment == "production" ? "headscale.eliza.app" : "headscale-${var.environment}.eliza.app")
+    error_message = "canonical_headscale_hostname must match the selected environment; cross-tier Headscale DNS is forbidden"
   }
 }
 
@@ -117,6 +117,10 @@ variable "deploy_branch" {
   description = "Git branch the host's auto-deploy workflow follows. Staging defaults to 'develop'; production MUST be 'main' (enforced by the validation below) so a staging fix doesn't accidentally land in prod via the wrong branch pin."
   type        = string
   default     = "develop"
+  validation {
+    condition     = var.environment != "development" || var.deploy_branch == "develop"
+    error_message = "Development control planes must follow develop"
+  }
   validation {
     condition     = var.environment != "production" || var.deploy_branch == "main"
     error_message = "deploy_branch must be 'main' when environment='production' — set it explicitly via the workflow to prevent prod tracking develop"

--- a/packages/cloud/infra/tests/tenant-db-bootstrap.test.ts
+++ b/packages/cloud/infra/tests/tenant-db-bootstrap.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Exercises the actual bootstrap shell gates with temporary files and substituted
+ * block-device commands. Initialization races use real filesystem hard links;
+ * PostgreSQL, mounts and systemd remain external boundary fixtures.
+ */
+import { afterEach, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const template = readFileSync(
+  new URL(
+    "../cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl",
+    import.meta.url,
+  ),
+  "utf8",
+);
+function section(start: string, end: string): string {
+  const begin = template.indexOf(start);
+  const finish = template.indexOf(end, begin);
+  if (begin < 0 || finish < 0)
+    throw new Error("Bootstrap protocol boundaries changed");
+  return template
+    .substring(begin, finish)
+    .split("\n")
+    .map((line) => line.replace(/^ {6}/, ""))
+    .join("\n");
+}
+const volumeGate = section(
+  "      # Bind initialization",
+  "      # 4. Postgres version detection",
+).replace(
+  "${tenant_db_volume_device}",
+  "/dev/disk/by-id/scsi-0HC_Volume_12345",
+);
+const clusterGate = section(
+  "      # Existing clusters must match",
+  "      # 6. postgresql.conf",
+);
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+const volume = "/dev/disk/by-id/scsi-0HC_Volume_12345";
+const volumePrelude = `set -euo pipefail
+log() { :; }
+test() { if [ "$1" = '-b' ]; then [ "$BLOCK_PRESENT" = '1' ]; else builtin test "$@"; fi; }
+blkid() { [ "$PROBE_OK" = '1' ] || return 2; printf '%s\\n' "$FS_TYPE"; }
+lsblk() { printf '%s\\n' "$EXPECTED_DEVICE"; }
+mkdir() { :; }
+mountpoint() { [ "$ALREADY_MOUNTED" = '1' ]; }
+mount() { printf '%s\\n' "$*" >> "$EFFECTS"; [ "$MOUNT_OK" = '1' ]; }
+findmnt() { printf '%s\\n' "$OBSERVED_DEVICE"; }
+`;
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "tenant-bootstrap-"));
+  roots.push(root);
+  const data = join(root, "data");
+  const authorizationRoot = join(root, "authorization");
+  mkdirSync(data);
+  mkdirSync(authorizationRoot);
+  return {
+    root,
+    data,
+    authorizationRoot,
+    receipt: join(authorizationRoot, "authorization"),
+    effects: join(root, "effects"),
+  };
+}
+function effects(path: string) {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+const volumeCases: Array<[string, Record<string, string>, boolean, boolean]> = [
+  ["missing volume", { BLOCK_PRESENT: "0" }, false, false],
+  ["failed filesystem probe", { PROBE_OK: "0" }, false, false],
+  ["unexpected filesystem", { FS_TYPE: "xfs" }, false, false],
+  [
+    "ambiguous device identity",
+    { EXPECTED_DEVICE: "8:16\n8:17" },
+    false,
+    false,
+  ],
+  ["correct existing mount", {}, true, false],
+  ["wrong existing mount", { OBSERVED_DEVICE: "8:17" }, false, false],
+  ["mount assigned volume", { ALREADY_MOUNTED: "0" }, true, true],
+  ["lost mount response", { ALREADY_MOUNTED: "0", MOUNT_OK: "0" }, false, true],
+  [
+    "mismatched mount readback",
+    { ALREADY_MOUNTED: "0", OBSERVED_DEVICE: "8:17" },
+    false,
+    true,
+  ],
+];
+for (const [name, overrides, allowed, mounted] of volumeCases) {
+  test(`volume admission: ${name}`, () => {
+    const f = fixture();
+    const result = spawnSync(
+      "bash",
+      ["-c", `${volumePrelude}${volumeGate}\necho INITIALIZATION_ALLOWED\n`],
+      {
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH,
+          BLOCK_PRESENT: "1",
+          PROBE_OK: "1",
+          FS_TYPE: "ext4",
+          EXPECTED_DEVICE: "8:16",
+          ALREADY_MOUNTED: "1",
+          MOUNT_OK: "1",
+          OBSERVED_DEVICE: "8:16",
+          EFFECTS: f.effects,
+          ...overrides,
+        },
+      },
+    );
+    expect(result.status === 0).toBe(allowed);
+    expect(result.stdout.includes("INITIALIZATION_ALLOWED")).toBe(allowed);
+    expect(effects(f.effects)).toBe(
+      mounted ? `--source ${volume} --target /mnt/tenant-pgdata\n` : "",
+    );
+  });
+}
+function cluster(
+  f: ReturnType<typeof fixture>,
+  overrides: Record<string, string> = {},
+) {
+  const source = clusterGate
+    .replaceAll("/mnt/tenant-pgdata", f.data)
+    .replaceAll("/run/eliza-tenant-db-init", f.authorizationRoot);
+  const prelude = `set -euo pipefail
+log() { :; }
+stat() { if [ "$3" = "$AUTH_ROOT" ]; then echo "$AUTH_ROOT_MODE"; elif [ "$2" = '%Y' ]; then echo "$ISSUED_AT"; else echo "$AUTH_MODE"; fi; }
+systemctl() { :; }
+chown() { :; }
+runuser() { echo INITIALIZED >> "$EFFECTS"; [ "$INIT_OK" = '1' ]; }
+findmnt() { printf '%s\\n' "$DATA_DEVICE"; }
+`;
+  return {
+    script: prelude + source,
+    env: {
+      PATH: process.env.PATH,
+      VOL: volume,
+      PGDATA: join(f.data, "16/main"),
+      PGVER: "16",
+      AUTH_ROOT: f.authorizationRoot,
+      AUTH_ROOT_MODE: "0:700",
+      AUTH_MODE: "0:600",
+      ISSUED_AT: String(Math.floor(Date.now() / 1000) - 1),
+      EFFECTS: f.effects,
+      INIT_OK: "1",
+      expected_device: "8:16",
+      DATA_DEVICE: "8:16",
+      ...overrides,
+    },
+  };
+}
+function runCluster(
+  f: ReturnType<typeof fixture>,
+  overrides: Record<string, string> = {},
+) {
+  const command = cluster(f, overrides);
+  return spawnSync("bash", ["-c", command.script], {
+    env: command.env,
+    encoding: "utf8",
+  });
+}
+function authorize(f: ReturnType<typeof fixture>, value = volume) {
+  writeFileSync(f.receipt, value, { mode: 0o600 });
+}
+
+test("permits startup of an existing matching cluster without an initialization grant", () => {
+  const f = fixture();
+  mkdirSync(join(f.data, "16/main"), { recursive: true });
+  writeFileSync(join(f.data, "16/main/PG_VERSION"), "16\n");
+  expect(runCluster(f).status).toBe(0);
+  expect(effects(f.effects)).toBe("");
+});
+test("does not initialize over a mismatched or unrecognized existing cluster", () => {
+  for (const marker of ["15\n", ""]) {
+    const f = fixture();
+    mkdirSync(join(f.data, "16/main"), { recursive: true });
+    if (marker) writeFileSync(join(f.data, "16/main/PG_VERSION"), marker);
+    authorize(f);
+    expect(runCluster(f).status).not.toBe(0);
+    expect(effects(f.effects)).toBe("");
+  }
+});
+test("does not initialize while filesystem recovery data remains", () => {
+  const f = fixture();
+  mkdirSync(join(f.data, "lost+found"));
+  writeFileSync(join(f.data, "lost+found/recovered"), "data");
+  authorize(f);
+  expect(runCluster(f).status).not.toBe(0);
+  expect(effects(f.effects)).toBe("");
+});
+test("requires a private, current, volume-bound authorization", () => {
+  const invalid: Array<Record<string, string>> = [
+    { AUTH_MODE: "501:600" },
+    { AUTH_MODE: "0:666" },
+    { AUTH_ROOT_MODE: "0:777" },
+    { ISSUED_AT: "1" },
+    { ISSUED_AT: String(Math.floor(Date.now() / 1000) + 600) },
+  ];
+  for (const overrides of invalid) {
+    const f = fixture();
+    authorize(f);
+    expect(runCluster(f, overrides).status).not.toBe(0);
+    expect(effects(f.effects)).toBe("");
+  }
+  for (const value of [null, "/dev/disk/by-id/scsi-0HC_Volume_67890"]) {
+    const f = fixture();
+    if (value) authorize(f, value);
+    expect(runCluster(f).status).not.toBe(0);
+    expect(effects(f.effects)).toBe("");
+  }
+});
+test("rejects a symlinked authorization", () => {
+  const f = fixture();
+  const target = join(f.root, "other");
+  writeFileSync(target, volume);
+  symlinkSync(target, f.receipt);
+  expect(runCluster(f).status).not.toBe(0);
+  expect(effects(f.effects)).toBe("");
+});
+test("consumes initialization authority even if initdb fails", () => {
+  const f = fixture();
+  authorize(f);
+  expect(runCluster(f, { INIT_OK: "0" }).status).not.toBe(0);
+  expect(existsSync(f.receipt)).toBe(false);
+  expect(readFileSync(`${f.receipt}.consumed`, "utf8")).toBe(volume);
+  expect(runCluster(f).status).not.toBe(0);
+  expect(effects(f.effects)).toBe("INITIALIZED\n");
+});
+test("concurrent initializers consume one actual filesystem receipt", async () => {
+  const f = fixture();
+  authorize(f);
+  const command = cluster(f);
+  const run = () =>
+    new Promise<number | null>((resolve, reject) => {
+      const child = spawn("bash", ["-c", command.script], {
+        env: command.env,
+        stdio: "ignore",
+      });
+      child.once("error", reject);
+      child.once("exit", resolve);
+    });
+  const results = await Promise.all([run(), run()]);
+  expect(results.filter((code) => code === 0)).toHaveLength(1);
+  expect(effects(f.effects)).toBe("INITIALIZED\n");
+  expect(existsSync(f.receipt)).toBe(false);
+});
+
+test("rejects redirected data directories and mounts beneath the volume", () => {
+  const f = fixture();
+  mkdirSync(join(f.data, "16/main"), { recursive: true });
+  writeFileSync(join(f.data, "16/main/PG_VERSION"), "16\n");
+  expect(runCluster(f, { DATA_DEVICE: "8:17" }).status).not.toBe(0);
+  expect(effects(f.effects)).toBe("");
+  const other = fixture();
+  mkdirSync(join(other.data, "16"));
+  symlinkSync(join(f.data, "16/main"), join(other.data, "16/main"));
+  expect(runCluster(other).status).not.toBe(0);
+  expect(effects(other.effects)).toBe("");
+});

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -326,12 +326,6 @@ describe("Apps tenant-DB off-host encrypted recovery (#21729)", () => {
     }
   });
 
-  test("refuses the terraform state bucket as the backup destination", () => {
-    expect(variablesTf).toContain(
-      'var.backup_s3_bucket != "eliza-terraform-state"',
-    );
-  });
-
   test("enforces passphrase strength and a retention floor", () => {
     expect(variablesTf).toContain(
       'var.backup_encryption_passphrase == "" || length(var.backup_encryption_passphrase) >= 32',

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -3,7 +3,9 @@
  * host-inventory, and shared-secret drift without inspecting protected values.
  */
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
 
 const repoRoot = new URL("../../../", import.meta.url);
 
@@ -324,16 +326,37 @@ describe("canonical cloud deployment environment contract", () => {
     }
   });
 
-  test("gates protected Terraform operations on the canonical source ref", () => {
+  test("admits only canonical infrastructure sources before credential jobs", () => {
     expect(infra.jobs?.terraform?.needs).toBe("validate-source");
-    const validate = step(
+    const script = step(
       infra,
       "validate-source",
       "Validate canonical source ref",
-    );
-    expect(validate.run).toContain('expected_ref="refs/heads/main"');
-    expect(validate.run).toContain('expected_ref="refs/heads/develop"');
-    expect(validate.run).toContain('if [ "$SOURCE_REF" != "$expected_ref" ]');
+    ).run;
+    if (!script) throw new Error("Missing source admission");
+    for (const environment of [
+      "development",
+      "staging",
+      "production",
+      "unknown",
+    ]) {
+      for (const branch of ["develop", "main", "feature/test"]) {
+        const result = spawnSync("bash", ["-c", script], {
+          env: {
+            PATH: process.env.PATH,
+            TARGET_ENVIRONMENT: environment,
+            TARGET_COMPONENT: "control-plane",
+            SOURCE_REF: `refs/heads/${branch}`,
+          },
+        });
+        const allowed =
+          environment === "production"
+            ? branch === "main"
+            : ["development", "staging"].includes(environment) &&
+              branch === "develop";
+        expect(result.status === 0).toBe(allowed);
+      }
+    }
   });
 
   test("validates quoted Terraform state addresses through the executable parser", () => {
@@ -348,15 +371,71 @@ describe("canonical cloud deployment environment contract", () => {
     expect(validate.run).not.toContain('$STATE_ADDRESS" =~');
   });
 
-  test("selects the dedicated Pages credential without changing other Terraform roots", () => {
-    const token = infra.jobs?.terraform?.env?.CLOUDFLARE_API_TOKEN;
-    expect(token).toContain("inputs.component == 'pages-domains'");
-    expect(token).toContain("secrets.CLOUDFLARE_PAGES_API_TOKEN");
-    expect(token).toContain("|| secrets.CLOUDFLARE_API_TOKEN");
-    expect(token?.match(/secrets\.CLOUDFLARE_PAGES_API_TOKEN/g)).toHaveLength(
-      1,
+  test("missing development credentials cannot fall back to staging or production", () => {
+    const inputs = { environment: "development", component: "control-plane" };
+    const secrets = new Proxy(
+      {
+        HCLOUD_TOKEN: "other-host",
+        HCLOUD_APPS_TOKEN: "other-apps",
+        CLOUDFLARE_API_TOKEN: "other-dns",
+        R2_STATE_ACCESS_KEY_ID: "other-state",
+        R2_STATE_SECRET_ACCESS_KEY: "other-state-secret",
+      },
+      {
+        get(target, key: string) {
+          return Reflect.get(target, key) ?? "";
+        },
+      },
     );
-    expect(token?.match(/secrets\.CLOUDFLARE_API_TOKEN/g)).toHaveLength(1);
+    // These workflow selections use the shared JS/GitHub expression subset
+    // of indexed lookups, equality, && and ||. Missing secret lookups return
+    // an empty string, matching the GitHub Actions secret context.
+    for (const component of [
+      "control-plane",
+      "apps-shared",
+      "apps-data-plane",
+    ]) {
+      for (const name of [
+        "HCLOUD_TOKEN",
+        "CLOUDFLARE_API_TOKEN",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+      ]) {
+        const expression = infra.jobs?.terraform?.env?.[name];
+        if (!expression) throw new Error(`Missing credential binding: ${name}`);
+        const body = expression
+          .replace(/^\$\{\{\s*/, "")
+          .replace(/\s*\}\}$/, "");
+        expect(
+          runInNewContext(
+            body,
+            { inputs: { ...inputs, component }, secrets },
+            { timeout: 1000 },
+          ),
+        ).toBe("");
+        const supplied = {
+          ...secrets,
+          DEVELOPMENT_HCLOUD_TOKEN: "own-host",
+          DEVELOPMENT_HCLOUD_APPS_TOKEN: "own-apps",
+          DEVELOPMENT_CLOUDFLARE_API_TOKEN: "own-dns",
+          DEVELOPMENT_R2_STATE_ACCESS_KEY_ID: "own-state",
+          DEVELOPMENT_R2_STATE_SECRET_ACCESS_KEY: "own-state-secret",
+        };
+        const expected = {
+          HCLOUD_TOKEN: component === "control-plane" ? "own-host" : "own-apps",
+          CLOUDFLARE_API_TOKEN: "own-dns",
+          AWS_ACCESS_KEY_ID: "own-state",
+          AWS_SECRET_ACCESS_KEY: "own-state-secret",
+        };
+        expect(
+          runInNewContext(
+            body,
+            { inputs: { ...inputs, component }, secrets: supplied },
+            { timeout: 1000 },
+          ),
+        ).toBe(expected[name as keyof typeof expected]);
+      }
+    }
   });
 
   test("applies only an encrypted, service-bound artifact from a successful plan attempt", () => {
@@ -521,26 +600,35 @@ describe("canonical cloud deployment environment contract", () => {
     );
   });
 
-  test("derives Terraform deploy branches from the selected environment", () => {
-    const deployBranch = infra.jobs?.terraform?.env?.TF_VAR_deploy_branch;
-    expect(deployBranch).toContain("inputs.environment == 'production'");
-    expect(deployBranch).toContain("'main' || 'develop'");
-    expect(deployBranch).not.toContain("vars.DEPLOY_BRANCH");
-
-    const preflight = step(
+  test("rejects cross-tier runtime origins in the executable infrastructure preflight", () => {
+    const script = step(
       infra,
       "terraform",
       "Validate canonical environment contract",
-    );
-    expect(preflight.run).toContain(
-      'require_exact TF_VAR_deploy_branch "$TF_VAR_deploy_branch" "main"',
-    );
-    expect(preflight.run).toContain(
-      'require_exact TF_VAR_deploy_branch "$TF_VAR_deploy_branch" "develop"',
-    );
-    expect(preflight.run).toContain("https://api.eliza.app");
-    expect(preflight.run).toContain("https://api-staging.eliza.app");
-    expect(preflight.run).not.toContain('echo "$actual"');
+    ).run;
+    if (!script) throw new Error("Missing environment preflight");
+    for (const environment of ["development", "staging", "production"]) {
+      const suffix = environment === "production" ? "" : `-${environment}`;
+      const env = {
+        PATH: process.env.PATH,
+        TARGET_ENVIRONMENT: environment,
+        TF_VAR_deploy_branch: environment === "production" ? "main" : "develop",
+        TF_VAR_apps_base_domain: `apps${suffix}.eliza.app`,
+        TF_VAR_cloud_api_origin: `https://api${suffix}.eliza.app`,
+        TF_VAR_canonical_headscale_hostname: `headscale${suffix}.eliza.app`,
+      };
+      expect(spawnSync("bash", ["-c", script], { env }).status).toBe(0);
+      const wrong =
+        environment === "production"
+          ? "https://api-staging.eliza.app"
+          : "https://api.eliza.app";
+      const rejected = spawnSync("bash", ["-c", script], {
+        env: { ...env, TF_VAR_cloud_api_origin: wrong },
+        encoding: "utf8",
+      });
+      expect(rejected.status).not.toBe(0);
+      expect(rejected.stdout).not.toContain(wrong);
+    }
   });
 
   test("passes and verifies the generalized Pages edge inventory contract", () => {


### PR DESCRIPTION
# Relates to

Part of #29488. This draft implements isolated Terraform tiers and safe tenant-database bootstrap; it does not close the full delivery-tier issue.

# Background

The apps Terraform roots previously shared database/network state across tiers, and the database bootstrap could select an unintended volume or initialize storage without explicit fresh-volume authorization. Each tier now selects its own state bucket, resource names, network, database host, and credentials. The consumer rejects remote state from a different environment. Development is admitted for the control plane and both apps roots.

Database startup requires the exact assigned ext4 volume and PostgreSQL 16. It rejects conflicting mounts, symlinks, mismatched database versions, and unexplained existing data. Initializing an empty volume additionally requires a short-lived, root-owned, one-use authorization receipt; ordinary restarts of existing databases require no receipt. The service retries transient readiness failures without formatting storage.

Change type: infrastructure bug fixes and development-tier support.

# Sync with develop

- [x] Rebased onto `b676280384b15df54204276e34bb8740db26936f`; zero conflicts.
- [x] Pinned Bun 1.3.14 / Node 24.15.0 installation and repository verification passed on the source tree represented by this head.
- [ ] Live infrastructure behavior verified. This remains a draft pending the evidence below.

# Risks

High operational impact when applied. New environment backends are candidate infrastructure, not a migration of the existing shared state. Do not apply the new roots against the legacy backend. Existing data and DNS require reviewed backup/restore, ownership/import, write fencing, and cutover. No apply, DNS change, database migration, or deletion was performed.

# Documentation changes needed?

Updated all three root READMEs with tier selection, state separation, migration order, and the fresh-volume authorization procedure. Nightly database dumps are explicitly insufficient for the proposed five-minute PITR objective.

# Testing

## Where should a reviewer start?

Review the apps-shared bootstrap and its behavioral harness, then the native Terraform remote-state environment tests and workflow credential-selection tests.

## Detailed testing steps

Use Terraform 1.10.5 and the repository-pinned Bun/Node versions. Run `terraform init -backend=false`, `terraform validate`, and `terraform test` in each of the three touched Terraform roots; tests use mocked providers and plan assertions. Run the infra package tests and the cloud deployment environment contract suite, followed by `bun run verify`.

Observed results for this source tree:

- Native Terraform tests: control plane 4 passed; apps data plane 4 passed; apps shared 5 passed. Apps-shared validation and its 5 tests were repeated after the bootstrap edits.
- Infrastructure package: 109 passed, 0 failed, 720 assertions across 9 files, including 17 bootstrap behavior tests.
- Workflow environment contract: 23 passed, 380 assertions.
- Actual template rendered through Terraform console with fixture values, parsed as YAML, and both extracted scripts passed `bash -n`.
- Repository `bun run verify`: exit 0. Guide parity: 160 pairs; touched README local paths and `git diff --check` passed.

The shell harness exercises temporary files and actual hard-link exclusion, while block-device, PostgreSQL, and systemd boundaries use fixtures. These results are not a live boot, restore drill, or provider-isolation proof.

# Evidence Gate

<!-- evidence-head:b7c2ecd0c75f2f233ed07cdca31f013385fff26f -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend user flow changes.
<!-- evidence-row:backend-logs -->
- [ ] Missing: live database-host startup, restart, missing-volume refusal and restore-drill logs. Local test results above do not replace them.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, agent action, or model-provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] Missing: reviewed provider plans/state readback, actual separate project/credential scopes, fresh-volume bootstrap and restored tenant-data readback.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - infrastructure configuration and database bootstrap only.

## Backend + frontend logs

Live backend evidence remains required before merge. Frontend logs are N/A because no rendered application code changes.

## Domain artifacts

Native Terraform plans and rendered shell syntax were verified locally with fixtures. Actual provider state, booted database records, cross-tier access denials, and a recovery drill remain unverified.

# Known gaps / failures

- Current operator Docker-host and control-plane database access is unavailable; provider console visibility alone does not establish it.
- Development Worker/API/Pages/services/auth/payment configuration and coordinated branch-to-tier promotion remain follow-up implementation within #29488.
- Staging and production secret isolation still requires live credential-scope readback. Their existing compatibility names are retained.
- Backup PITR, tenant migration, DNS adoption, and rollback require implementation and live validation before production use.
- Earlier fixture/literal assertion failures and transient timeouts were resolved and retained in the local audit ledger. Final applicable local suites passed; live evidence is still missing.

# Maintainer CI exception

N/A - no exception or branch-protection change requested.

# Deploy Notes

Do not deploy this draft. Follow the migration procedures in the Terraform READMEs only after the missing access, backup, restore, state ownership, and cutover evidence is complete.
