### PR TITLE
fix(app): correct plugin headers and validate critical view states

### DIFF
--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -39,14 +39,22 @@ export const smokeViewDeclarations = [
     "/cloud",
     "CloudView",
     "gui",
-    { capabilities: ["agent-surface"] },
+    { header: "fullscreen", capabilities: ["agent-surface"] },
   ],
   ["contacts", "Contacts", "plugin-contacts", "/contacts", "ContactsView"],
   // The decomposed personal-assistant domain views are the real surfaces (the
   // old monolithic `lifeops` overview view was removed). `documents` is
   // intentionally absent — its `/documents` path collides with the built-in
   // Knowledge tab (`App.tsx` findView matches `/${tab}`).
-  ["calendar", "Calendar", "plugin-calendar", "/calendar", "CalendarView"],
+  [
+    "calendar",
+    "Calendar",
+    "plugin-calendar",
+    "/calendar",
+    "CalendarView",
+    "gui",
+    { header: "fullscreen", capabilities: ["agent-surface"] },
+  ],
   [
     "computer-use-sessions",
     "Computer Sessions",

--- a/packages/app-core/scripts/smoke-view-declarations.test.ts
+++ b/packages/app-core/scripts/smoke-view-declarations.test.ts
@@ -53,7 +53,7 @@ describe("smoke view declaration parity (#15791)", () => {
           "/cloud",
           "CloudView",
           "gui",
-          { capabilities: ["agent-surface"] },
+          { header: "fullscreen", capabilities: ["agent-surface"] },
         ],
         ["notes", "Notes", "plugin-notes", "/notes", "NotesView"],
         [
@@ -62,6 +62,8 @@ describe("smoke view declaration parity (#15791)", () => {
           "plugin-calendar",
           "/calendar",
           "CalendarView",
+          "gui",
+          { header: "fullscreen", capabilities: ["agent-surface"] },
         ],
       ]),
     );

--- a/packages/app/test/interaction-observation.test.ts
+++ b/packages/app/test/interaction-observation.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Exercises the renderer observation oracle with deterministic control states.
+ * Background polling and rejected transport-only mutations must not make an
+ * inert control pass; actual renderer transitions remain activity observations.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type ControlSnapshot,
+  interactionDelta,
+} from "./ui-smoke/interaction-observation";
+
+function snapshot(): ControlSnapshot {
+  return {
+    url: "http://localhost/notes",
+    visibleDismissibleSurfaces: 0,
+    pageFingerprint: "unchanged",
+    details: {
+      tagName: "button",
+      role: null,
+      type: "button",
+      href: null,
+      visible: true,
+      label: "Save",
+      text: "Save",
+      value: null,
+      checked: null,
+      attributes: {},
+    },
+  };
+}
+
+describe("bounded interaction activity oracle", () => {
+  it("does not credit unrelated polling or a rejected mutation as an outcome", () => {
+    const before = { ...snapshot(), apiRequestCount: 0 };
+    // These are the snapshots produced around a no-op click while a poll and
+    // rejected mutation generate traffic. Neither changes the renderer.
+    const afterPolling = { ...snapshot(), apiRequestCount: 1 };
+    const afterRejectedMutation = { ...snapshot(), apiRequestCount: 2 };
+    expect(interactionDelta(before, afterPolling)).toBeNull();
+    expect(interactionDelta(before, afterRejectedMutation)).toBeNull();
+  });
+
+  it("observes a changed control or opened dialog without requiring traffic", () => {
+    const before = snapshot();
+    const after = snapshot();
+    if (!after.details) throw new Error("Fixture requires a control");
+    after.details.attributes["aria-expanded"] = "true";
+    expect(interactionDelta(before, after)).not.toBeNull();
+    expect(
+      interactionDelta(before, {
+        ...snapshot(),
+        visibleDismissibleSurfaces: 1,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("observes navigation but leaves identical renderer states unresolved", () => {
+    expect(interactionDelta(snapshot(), snapshot())).toBeNull();
+    expect(
+      interactionDelta(snapshot(), {
+        ...snapshot(),
+        url: "http://localhost/todos",
+      }),
+    ).not.toBeNull();
+  });
+});

--- a/packages/app/test/ui-smoke/all-views-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-interaction.spec.ts
@@ -15,22 +15,21 @@ import {
   openAppPath,
   seedAppStorage,
 } from "./helpers";
+import {
+  CLICK_OBSERVED_ATTRIBUTES,
+  type ControlDetails,
+  type ControlSnapshot,
+  interactionDelta,
+} from "./interaction-observation";
 import { VIEW_ROUTES } from "./view-routes";
 
 /**
- * Generic per-view interaction coverage (#8796).
- *
- * builtin-views-visual.spec only asserts each view *boots*; this spec drives
- * every interactive control in every built-in view — clicking each button /
- * menu item / tab / link and filling each text input — then asserts each
- * interaction has an observable semantic outcome in addition to the page-error
- * guard. It's the automatable form of "every button, input, menu, dropdown
- * works for every view": instead of hand-writing assertions per control, it
- * enumerates the real controls at runtime and exercises them. Run with
- * E2E_RECORD=1 for video.
- *
- * Clicks that navigate away are recovered by re-opening the route, so one
- * navigation doesn't end coverage of the rest of the page.
+ * Bounded interaction activity smoke over the built-in route fixture.
+ * Enumerated controls are sampled, so links, file inputs, gestures and nested
+ * states outside the crawl are not covered. Observed DOM/navigation changes,
+ * including rendered errors, do not establish operation success or persistence.
+ * Acceptance cases must correlate the specific request and backing-state receipt.
+ * Run with E2E_RECORD=1 for video. Navigations are recovered between samples.
  */
 // Bound per-view work so the suite stays under the playwright timeout while
 // still exercising a representative breadth of controls.
@@ -42,46 +41,10 @@ const CLICK_SELECTOR =
 const INPUT_SELECTOR =
   "input:visible:not([type='file']):not([disabled]), textarea:visible:not([disabled])";
 
-type SemanticResult = {
+type ObservationResult = {
   kind: "observed" | "documented-noop" | "failure";
   message: string;
 };
-
-type ControlDetails = {
-  tagName: string;
-  role: string | null;
-  type: string | null;
-  href: string | null;
-  visible: boolean;
-  label: string;
-  text: string;
-  value: string | null;
-  checked: boolean | null;
-  attributes: Record<string, string | null>;
-};
-
-type ControlSnapshot = {
-  url: string;
-  apiRequestCount: number;
-  visibleDismissibleSurfaces: number;
-  pageFingerprint: string;
-  details: ControlDetails | null;
-};
-
-const CLICK_OBSERVED_ATTRIBUTES = [
-  "data-agent-id",
-  "data-chat-open",
-  "aria-expanded",
-  "aria-pressed",
-  "aria-selected",
-  "aria-current",
-  "data-state",
-  "data-open",
-  "data-active",
-  "data-selected",
-  "data-value",
-  "open",
-] as const;
 
 function truncate(value: string, maxLength = 80): string {
   return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
@@ -102,7 +65,7 @@ async function numericInputValue(input: Locator): Promise<string> {
 async function fillOrToggleInput(
   input: Locator,
   index: number,
-): Promise<SemanticResult> {
+): Promise<ObservationResult> {
   const tagName = ((await input.evaluate((el: Element) => el.tagName)) ?? "")
     .toString()
     .toLowerCase();
@@ -303,7 +266,7 @@ async function visibleDismissibleSurfaceCount(page: Page): Promise<number> {
 
 /**
  * Cheap whole-page content fingerprint (visible text length + djb2 hash).
- * Catches semantic outcomes that land elsewhere in the page than on the
+ * Catches renderer changes that land elsewhere in the page than on the
  * clicked control itself — a dialer display updating, a sidebar collapsing,
  * a pager flipping surfaces — without enumerating product-specific testids.
  */
@@ -321,7 +284,6 @@ async function pageContentFingerprint(page: Page): Promise<string> {
 async function snapshotControl(
   page: Page,
   control: ElementHandle<Element>,
-  apiRequestCount: number,
 ): Promise<ControlSnapshot> {
   const details = await control
     .evaluate((el: Element, observedAttributes: readonly string[]) => {
@@ -356,7 +318,6 @@ async function snapshotControl(
 
   return {
     url: page.url(),
-    apiRequestCount,
     visibleDismissibleSurfaces: await visibleDismissibleSurfaceCount(page),
     pageFingerprint: await pageContentFingerprint(page),
     details,
@@ -375,53 +336,6 @@ function describeControl(details: ControlDetails | null): string {
       .filter(Boolean)
       .join(" "),
   );
-}
-
-function semanticDelta(
-  before: ControlSnapshot,
-  after: ControlSnapshot,
-): string | null {
-  if (after.url !== before.url) {
-    return `URL changed from ${before.url} to ${after.url}`;
-  }
-  if (after.apiRequestCount > before.apiRequestCount) {
-    return `API request count changed ${before.apiRequestCount} -> ${after.apiRequestCount}`;
-  }
-  if (after.visibleDismissibleSurfaces !== before.visibleDismissibleSurfaces) {
-    return `dismissible surface count changed ${before.visibleDismissibleSurfaces} -> ${after.visibleDismissibleSurfaces}`;
-  }
-  if (before.details && !after.details) {
-    return "clicked control detached or was replaced";
-  }
-  if (!before.details || !after.details) {
-    return null;
-  }
-  if (after.details.label !== before.details.label) {
-    return `control label changed from "${before.details.label}" to "${after.details.label}"`;
-  }
-  if (after.details.visible !== before.details.visible) {
-    return `control visibility changed ${String(before.details.visible)} -> ${String(after.details.visible)}`;
-  }
-  if (after.details.text !== before.details.text) {
-    return `control text changed from "${truncate(before.details.text)}" to "${truncate(after.details.text)}"`;
-  }
-  if (after.details.checked !== before.details.checked) {
-    return `checked state changed ${String(before.details.checked)} -> ${String(after.details.checked)}`;
-  }
-  if (after.details.value !== before.details.value) {
-    return `value changed from "${String(before.details.value)}" to "${String(after.details.value)}"`;
-  }
-  for (const attr of CLICK_OBSERVED_ATTRIBUTES) {
-    if (after.details.attributes[attr] !== before.details.attributes[attr]) {
-      return `${attr} changed from "${String(before.details.attributes[attr])}" to "${String(after.details.attributes[attr])}"`;
-    }
-  }
-  // Last-resort DOM-state signal: the outcome landed elsewhere in the page
-  // (dial display, collapsed sidebar, flipped pager surface, toast).
-  if (after.pageFingerprint !== before.pageFingerprint) {
-    return `page content changed (${before.pageFingerprint} -> ${after.pageFingerprint})`;
-  }
-  return null;
 }
 
 function documentedClickNoop(
@@ -492,10 +406,9 @@ async function observeClickOutcome(
   page: Page,
   control: ElementHandle<Element>,
   before: ControlSnapshot,
-  apiRequestCount: () => number,
-): Promise<SemanticResult> {
-  let after = await snapshotControl(page, control, apiRequestCount());
-  let delta = semanticDelta(before, after);
+): Promise<ObservationResult> {
+  let after = await snapshotControl(page, control);
+  let delta = interactionDelta(before, after);
   // The ladder ends well above one second: on a loaded CI runner a state
   // commit + re-render (e.g. sidebar collapse) can land after the first few
   // probes even though the interaction is perfectly healthy.
@@ -507,8 +420,8 @@ async function observeClickOutcome(
       };
     }
     await page.waitForTimeout(delayMs);
-    after = await snapshotControl(page, control, apiRequestCount());
-    delta = semanticDelta(before, after);
+    after = await snapshotControl(page, control);
+    delta = interactionDelta(before, after);
   }
   if (delta) {
     return {
@@ -525,14 +438,14 @@ async function observeClickOutcome(
   }
   return {
     kind: "failure",
-    message: `${describeControl(before.details)} produced no URL, API, DOM state, dialog/menu, value, checked, text, or documented no-op outcome`,
+    message: `${describeControl(before.details)} produced no URL, DOM state, dialog/menu, value, checked, text, or documented no-op outcome`,
   };
 }
 
-async function pressEscapeWithSemanticOutcome(
+async function pressEscapeWithObservation(
   page: Page,
   descriptor: string,
-): Promise<SemanticResult> {
+): Promise<ObservationResult> {
   const beforeCount = await visibleDismissibleSurfaceCount(page);
   const beforeUrl = page.url();
   await page.keyboard.press("Escape");
@@ -795,30 +708,23 @@ async function installInteractionAuditRoutes(page: Page): Promise<void> {
   });
 }
 
-test.describe("every-view interaction coverage", () => {
+test.describe("bounded built-in interaction activity smoke", () => {
   // Copy-address controls call the async Clipboard API; headless CI Chromium
   // denies clipboard-write by default, which turns each copy click into an
   // unhandled-rejection pageerror instead of a "Copied" outcome.
   test.use({ permissions: ["clipboard-read", "clipboard-write"] });
 
   for (const view of VIEW_ROUTES) {
-    test(`${view.id} — exercise every control with semantic outcomes`, async ({
+    test(`${view.id} — sample controls for renderer activity`, async ({
       page,
     }) => {
       const pageErrors: string[] = [];
       const actionFailures: string[] = [];
       const networkFailures: string[] = [];
-      const semanticFailures: string[] = [];
-      const semanticOutcomes: string[] = [];
+      const observationFailures: string[] = [];
+      const observedChanges: string[] = [];
       const documentedNoops: string[] = [];
-      const apiRequests: string[] = [];
       page.on("pageerror", (e) => pageErrors.push(e.message));
-      page.on("request", (request) => {
-        const pathname = new URL(request.url()).pathname;
-        if (pathname.startsWith("/api/")) {
-          apiRequests.push(`${request.method()} ${pathname}`);
-        }
-      });
       page.on("response", (response) => {
         const status = response.status();
         if (status < 500) return;
@@ -835,7 +741,7 @@ test.describe("every-view interaction coverage", () => {
         networkFailures.push(`requestfailed: ${url} ${failureText}`);
       });
       // The generic ladders cannot see a rejected workflow create: a 4xx
-      // still bumps the API request count and the rendered error state is a
+      // can render an error state, which is a
       // legitimate DOM outcome, so the editor follow-ons silently vanish
       // while the case stays green. Record the whole workflow surface so the
       // automations case can assert the successful sequence explicitly.
@@ -866,7 +772,7 @@ test.describe("every-view interaction coverage", () => {
       await installInteractionAuditRoutes(page);
       await openAppPath(page, view.path);
       await page.locator("body").waitFor({ state: "visible", timeout: 60_000 });
-      semanticOutcomes.push(
+      observedChanges.push(
         `view ${view.id}: route ${view.path} rendered ${page.url()}`,
       );
 
@@ -878,11 +784,11 @@ test.describe("every-view interaction coverage", () => {
         try {
           const result = await fillOrToggleInput(input, i);
           if (result.kind === "failure") {
-            semanticFailures.push(result.message);
+            observationFailures.push(result.message);
           } else if (result.kind === "documented-noop") {
             documentedNoops.push(result.message);
           } else {
-            semanticOutcomes.push(result.message);
+            observedChanges.push(result.message);
           }
         } catch (error) {
           actionFailures.push(
@@ -911,11 +817,7 @@ test.describe("every-view interaction coverage", () => {
         if (!controlHandle) {
           continue;
         }
-        const before = await snapshotControl(
-          page,
-          controlHandle,
-          apiRequests.length,
-        );
+        const before = await snapshotControl(page, controlHandle);
         try {
           await control.click({ noWaitAfter: true, timeout: 2_000 });
         } catch (error) {
@@ -925,19 +827,14 @@ test.describe("every-view interaction coverage", () => {
           await controlHandle.dispose();
           continue;
         }
-        const result = await observeClickOutcome(
-          page,
-          controlHandle,
-          before,
-          () => apiRequests.length,
-        );
+        const result = await observeClickOutcome(page, controlHandle, before);
         await controlHandle.dispose();
         if (result.kind === "failure") {
-          semanticFailures.push(`click ${i}: ${result.message}`);
+          observationFailures.push(`click ${i}: ${result.message}`);
         } else if (result.kind === "documented-noop") {
           documentedNoops.push(`click ${i}: ${result.message}`);
         } else {
-          semanticOutcomes.push(`click ${i}: ${result.message}`);
+          observedChanges.push(`click ${i}: ${result.message}`);
         }
         // If a click navigated away from the view, return to keep exercising it.
         if (!page.url().includes(view.path) && view.path !== "/") {
@@ -951,16 +848,16 @@ test.describe("every-view interaction coverage", () => {
         }
         // Dismiss any opened overlay/menu so the next control is reachable.
         try {
-          const escapeResult = await pressEscapeWithSemanticOutcome(
+          const escapeResult = await pressEscapeWithObservation(
             page,
             `click ${i}`,
           );
           if (escapeResult.kind === "failure") {
-            semanticFailures.push(escapeResult.message);
+            observationFailures.push(escapeResult.message);
           } else if (escapeResult.kind === "documented-noop") {
             documentedNoops.push(escapeResult.message);
           } else {
-            semanticOutcomes.push(escapeResult.message);
+            observedChanges.push(escapeResult.message);
           }
         } catch (error) {
           actionFailures.push(
@@ -970,15 +867,15 @@ test.describe("every-view interaction coverage", () => {
       }
 
       expect(
-        semanticFailures,
+        observationFailures,
         [
-          `${view.id}: every exercised input/click/Escape interaction needs an observable semantic outcome or an explicit documented no-op`,
-          ...semanticFailures,
+          `${view.id}: every exercised input/click/Escape interaction needs observable renderer activity or an explicit documented no-op`,
+          ...observationFailures,
         ].join("\n"),
       ).toHaveLength(0);
       expect(
-        semanticOutcomes.length + documentedNoops.length,
-        `${view.id}: expected semantic assertions for at least one enumerated interaction`,
+        observedChanges.length + documentedNoops.length,
+        `${view.id}: expected activity observations for at least one enumerated interaction`,
       ).toBeGreaterThan(0);
       // The contract: no interaction in this view caused an uncaught crash.
       expect(

--- a/packages/app/test/ui-smoke/interaction-observation.spec.ts
+++ b/packages/app/test/ui-smoke/interaction-observation.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Browser negative controls for the bounded renderer activity oracle.
+ * Real browser requests hit isolated routes; background polling and denied
+ * mutations cannot make an unchanged control report an observed result.
+ */
+import { expect, test } from "@playwright/test";
+import {
+  type ControlSnapshot,
+  interactionDelta,
+} from "./interaction-observation";
+
+test("transport-only activity cannot satisfy the renderer observation oracle", async ({
+  page,
+}) => {
+  await page.route("http://oracle.test/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    await route.fulfill({
+      status: pathname === "/api/notes" ? 403 : 200,
+      contentType: pathname === "/" ? "text/html" : "application/json",
+      body:
+        pathname === "/"
+          ? '<button id="save">Save</button>'
+          : JSON.stringify({ error: "denied" }),
+    });
+  });
+  await page.goto("http://oracle.test/");
+  const snapshot = async (): Promise<ControlSnapshot> => {
+    const details = await page.locator("#save").evaluate((el) => ({
+      tagName: el.tagName.toLowerCase(),
+      role: null,
+      type: "button",
+      href: null,
+      visible: true,
+      label: el.textContent ?? "",
+      text: el.textContent ?? "",
+      value: null,
+      checked: null,
+      attributes: {},
+    }));
+    return {
+      url: page.url(),
+      visibleDismissibleSurfaces: 0,
+      pageFingerprint: await page.locator("body").innerText(),
+      details,
+    };
+  };
+  const before = await snapshot();
+  await page.evaluate(() => {
+    document.querySelector("#save")?.addEventListener("click", async () => {
+      await fetch("/api/poll");
+      await fetch("/api/notes", {
+        method: "POST",
+        body: JSON.stringify({ title: "Denied note" }),
+      });
+    });
+  });
+  const rejection = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/notes") &&
+      response.request().method() === "POST",
+  );
+  await page.locator("#save").click();
+  expect((await rejection).status()).toBe(403);
+  expect(interactionDelta(before, await snapshot())).toBeNull();
+  // A real renderer change is still observable, while remaining distinct
+  // from acceptance of the denied operation above.
+  await page.locator("#save").evaluate((el) => {
+    el.textContent = "Permission denied";
+  });
+  expect(interactionDelta(before, await snapshot())).not.toBeNull();
+});

--- a/packages/app/test/ui-smoke/interaction-observation.ts
+++ b/packages/app/test/ui-smoke/interaction-observation.ts
@@ -1,0 +1,83 @@
+/**
+ * Classifies observable renderer changes for the bounded interaction smoke.
+ * Transport activity cannot establish an interaction result; DOM changes are
+ * activity observations only and never certify a committed domain operation.
+ */
+export type ControlDetails = {
+  tagName: string;
+  role: string | null;
+  type: string | null;
+  href: string | null;
+  visible: boolean;
+  label: string;
+  text: string;
+  value: string | null;
+  checked: boolean | null;
+  attributes: Record<string, string | null>;
+};
+
+export type ControlSnapshot = {
+  url: string;
+  visibleDismissibleSurfaces: number;
+  pageFingerprint: string;
+  details: ControlDetails | null;
+};
+
+export const CLICK_OBSERVED_ATTRIBUTES = [
+  "data-agent-id",
+  "data-chat-open",
+  "aria-expanded",
+  "aria-pressed",
+  "aria-selected",
+  "aria-current",
+  "data-state",
+  "data-open",
+  "data-active",
+  "data-selected",
+  "data-value",
+  "open",
+] as const;
+
+export function interactionDelta(
+  before: ControlSnapshot,
+  after: ControlSnapshot,
+): string | null {
+  if (after.url !== before.url) {
+    return `URL changed from ${before.url} to ${after.url}`;
+  }
+  if (after.visibleDismissibleSurfaces !== before.visibleDismissibleSurfaces) {
+    return `dismissible surface count changed ${before.visibleDismissibleSurfaces} -> ${after.visibleDismissibleSurfaces}`;
+  }
+  if (before.details && !after.details) {
+    return "clicked control detached or was replaced";
+  }
+  if (!before.details || !after.details) {
+    return null;
+  }
+  if (after.details.label !== before.details.label) {
+    return `control label changed from "${before.details.label}" to "${after.details.label}"`;
+  }
+  if (after.details.visible !== before.details.visible) {
+    return `control visibility changed ${String(before.details.visible)} -> ${String(after.details.visible)}`;
+  }
+  if (after.details.text !== before.details.text) {
+    return `control text changed from "${before.details.text}" to "${after.details.text}"`;
+  }
+  if (after.details.checked !== before.details.checked) {
+    return `checked state changed ${String(before.details.checked)} -> ${String(after.details.checked)}`;
+  }
+  if (after.details.value !== before.details.value) {
+    return `value changed from "${String(before.details.value)}" to "${String(after.details.value)}"`;
+  }
+  for (const attr of CLICK_OBSERVED_ATTRIBUTES) {
+    if (after.details.attributes[attr] !== before.details.attributes[attr]) {
+      return `${attr} changed from "${String(before.details.attributes[attr])}" to "${String(after.details.attributes[attr])}"`;
+    }
+  }
+  // Last-resort DOM-state signal: the outcome landed elsewhere in the page
+  // (dial display, collapsed sidebar, flipped pager surface, toast).
+  if (after.pageFingerprint !== before.pageFingerprint) {
+    return `page content changed (${before.pageFingerprint} -> ${after.pageFingerprint})`;
+  }
+  return null;
+}

--- a/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Exercises the real Calendar and Cloud renderers under the smoke server's registered
+ * surface contract. Desktop and mobile must have one navigation owner; its
+ * back control must remain reachable and return to the launcher.
+ */
+import { expect, test } from "@playwright/test";
+import {
+  installDefaultAppRoutes,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+
+for (const viewport of [
+  { width: 1440, height: 1000 },
+  { width: 390, height: 844 },
+]) {
+  for (const view of [
+    { name: "Calendar", path: "/calendar", root: "lifeops-calendar-section" },
+    { name: "Eliza Cloud", path: "/cloud", root: "cloud-signed-out" },
+  ]) {
+    test(`${view.name} owns its header and back navigation at ${viewport.width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await seedAppStorage(page);
+      await installDefaultAppRoutes(page);
+      await openAppPath(page, view.path);
+      await expect(page.getByTestId(view.root)).toBeVisible({
+        timeout: 60_000,
+      });
+      await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+      const back = page.getByRole("button", {
+        name: "Back to launcher",
+        exact: true,
+      });
+      await expect(back).toHaveCount(1);
+      await expect(back).toBeInViewport();
+      await back.click();
+      await expect(page).toHaveURL(/\/views(?:[?#]|$)/);
+      await expect(page.getByTestId(view.root)).toHaveCount(0);
+    });
+  }
+}

--- a/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
@@ -4,6 +4,7 @@
  * back control must remain reachable and return to the launcher.
  */
 import { expect, test } from "@playwright/test";
+import { findRemoteBundleDeclaration } from "./aesthetic-audit-rules";
 import {
   installDefaultAppRoutes,
   openAppPath,
@@ -24,7 +25,44 @@ for (const viewport of [
       await page.setViewportSize(viewport);
       await seedAppStorage(page);
       await installDefaultAppRoutes(page);
-      await openAppPath(page, view.path);
+      let routePath = view.path;
+      if (view.path === "/cloud") {
+        // /cloud belongs to the separate account control plane. Mount the
+        // registered plugin bundle through the same isolated route used by
+        // the visual audit, preserving its production surface metadata.
+        const response = await page.request.get("/api/views");
+        expect(response.ok()).toBe(true);
+        const payload: unknown = await response.json();
+        const registered = findRemoteBundleDeclaration(payload, "cloud", "gui");
+        if (
+          !registered ||
+          !payload ||
+          typeof payload !== "object" ||
+          !("views" in payload) ||
+          !Array.isArray(payload.views)
+        )
+          throw new Error("Missing registered Cloud renderer");
+        routePath = "/__audit/plugin-view/cloud";
+        const registry = {
+          ...payload,
+          views: payload.views.map((entry: unknown) =>
+            entry &&
+            typeof entry === "object" &&
+            "id" in entry &&
+            entry.id === registered.id
+              ? { ...entry, path: routePath }
+              : entry,
+          ),
+        };
+        await page.route("**/api/views", (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(registry),
+          }),
+        );
+      }
+      await openAppPath(page, routePath);
       await expect(page.getByTestId(view.root)).toBeVisible({
         timeout: 60_000,
       });

--- a/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
@@ -1,7 +1,7 @@
 /**
- * Exercises the real Calendar and Cloud renderers under the smoke server's registered
- * surface contract. Desktop and mobile must have one navigation owner; its
- * back control must remain reachable and return to the launcher.
+ * Exercises real Calendar, Cloud and Messages renderers with deterministic HTTP
+ * feeds. Navigation has one owner, and short landscape screens must keep event
+ * editing and the message composer reachable through ordinary scrolling.
  */
 import { expect, test } from "@playwright/test";
 import { findRemoteBundleDeclaration } from "./aesthetic-audit-rules";
@@ -95,6 +95,15 @@ test("Calendar landscape scrolling exposes an event for opening", async ({
   await expect(event).toBeInViewport();
   await event.click();
   await expect(page.getByRole("dialog")).toBeVisible();
+  await page.mouse.move(600, 180);
+  await page.mouse.wheel(0, 2000);
+  const cancel = page.getByRole("button", {
+    name: "Cancel event editor",
+    exact: true,
+  });
+  await expect(cancel).toBeInViewport();
+  await cancel.click({ timeout: 15_000 });
+  await expect(page.getByRole("dialog")).toHaveCount(0);
 });
 
 test("Messages landscape keeps status separate and composer reachable", async ({

--- a/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-surface-shell.spec.ts
@@ -79,3 +79,53 @@ for (const viewport of [
     });
   }
 }
+
+test("Calendar landscape scrolling exposes an event for opening", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 844, height: 390 });
+  await seedAppStorage(page);
+  await installDefaultAppRoutes(page);
+  await openAppPath(page, "/calendar");
+  await expect(page.getByTestId("lifeops-calendar-section")).toBeVisible();
+  const event = page.getByRole("button", { name: /Design sync/ }).first();
+  await expect(event).toBeAttached();
+  await page.mouse.move(400, 260);
+  await page.mouse.wheel(0, 500);
+  await expect(event).toBeInViewport();
+  await event.click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+});
+
+test("Messages landscape keeps status separate and composer reachable", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 844, height: 390 });
+  await seedAppStorage(page);
+  await installDefaultAppRoutes(page);
+  await openAppPath(page, "/messages");
+  const status = page.getByText("bridge-only", { exact: true });
+  const role = page.getByRole("button", {
+    name: "Set default SMS",
+    exact: true,
+  });
+  await expect(status).toBeVisible();
+  await expect(role).toBeVisible();
+  const statusBox = await status.boundingBox();
+  const roleBox = await role.boundingBox();
+  if (!statusBox || !roleBox)
+    throw new Error("Messages status controls are not laid out");
+  expect(statusBox.y + statusBox.height).toBeLessThanOrEqual(roleBox.y);
+  await page.mouse.move(400, 260);
+  await page.mouse.wheel(0, 500);
+  const address = page.getByRole("textbox", { name: "To", exact: true });
+  const body = page.getByRole("textbox", { name: "Body", exact: true });
+  await expect(body).toBeInViewport();
+  await address.fill("+15550101234");
+  await body.fill("Layout regression draft");
+  await expect(address).toHaveValue("+15550101234");
+  await expect(body).toHaveValue("Layout regression draft");
+  await expect(
+    page.getByRole("button", { name: "Send SMS", exact: true }),
+  ).toBeEnabled();
+});

--- a/packages/ui/src/components/ui/button.stories.tsx
+++ b/packages/ui/src/components/ui/button.stories.tsx
@@ -11,6 +11,7 @@ const meta = {
       control: "select",
       options: [
         "default",
+        "accentDarkHover",
         "surface",
         "surfaceAccent",
         "surfaceDestructive",
@@ -48,6 +49,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+export const AccentDarkHover: Story = { args: { variant: "accentDarkHover" } };
 export const Secondary: Story = { args: { variant: "secondary" } };
 export const Outline: Story = { args: { variant: "outline" } };
 export const Ghost: Story = { args: { variant: "ghost" } };
@@ -65,6 +67,9 @@ export const AllVariants: Story = {
     <div className="flex flex-wrap items-center gap-3">
       <Button {...args} variant="default">
         Default
+      </Button>
+      <Button {...args} variant="accentDarkHover">
+        Darker accent hover
       </Button>
       <Button {...args} variant="secondary">
         Secondary

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -4,7 +4,7 @@
  * components/ui — other components (alert-dialog, banner, …) reuse
  * `buttonVariants` rather than restyling their own buttons. `asChild` renders
  * the styling onto a Radix Slot child so links can adopt button appearance.
- * Accent-orange resting → darker-orange hover per the brand hover system.
+ * The accentDarkHover variant pairs darker-orange hover with a readable label.
  *
  * On coarse-pointer (touch) surfaces the compact sizes compose a 44px hit floor
  * (`pointer-coarse:min-h/min-w-touch` = `--min-touch-target`) so the rendered
@@ -31,6 +31,8 @@ const buttonVariants = cva(
         // orange fill so far that its dark label loses contrast (45% failed).
         default:
           "bg-accent text-accent-fg hover:bg-accent-hover disabled:bg-accent/80 disabled:text-accent-fg",
+        accentDarkHover:
+          "bg-accent text-accent-fg hover:bg-accent-muted hover:text-inverse disabled:bg-accent/80 disabled:text-accent-fg",
         surface:
           "bg-card text-txt-strong hover:bg-surface disabled:text-muted-strong",
         surfaceAccent:

--- a/packages/ui/src/storybook/plugin-views/CalendarPage.stories.tsx
+++ b/packages/ui/src/storybook/plugin-views/CalendarPage.stories.tsx
@@ -1,0 +1,146 @@
+/**
+ * Renders the canonical CalendarPage through its real hook and HTTP client.
+ * Isolated read fixtures show complete, partial, denied, and unavailable feeds;
+ * mutations are rejected so browsing a story cannot create provider events.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { CalendarPage } from "../../../../../plugins/plugin-calendar/src/components/calendar/CalendarPage";
+import { MockAppProvider } from "../mock-providers";
+
+type FeedState =
+  | "empty"
+  | "populated"
+  | "loading"
+  | "error"
+  | "denied"
+  | "partial";
+function installFeed(state: FeedState) {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url,
+      window.location.href,
+    );
+    if (!url.pathname.startsWith("/api/lifeops/calendar/"))
+      return original(input, init);
+    const method =
+      init?.method ?? (input instanceof Request ? input.method : "GET");
+    const json = (body: object, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    if (method !== "GET")
+      return json({ error: "Story fixture is read-only" }, 403);
+    if (state === "loading") return new Promise<Response>(() => {});
+    if (state === "error")
+      return json({ error: "Calendar service is unavailable" }, 503);
+    if (state === "denied")
+      return json({ error: "Calendar access is denied" }, 403);
+    if (url.pathname.endsWith("/calendars")) return json({ calendars: [] });
+    if (url.pathname.endsWith("/sources")) return json({ sources: [] });
+    const timeMin = url.searchParams.get("timeMin");
+    const timeMax = url.searchParams.get("timeMax");
+    if (!timeMin || !timeMax)
+      return json(
+        { error: "Calendar fixture requires an explicit time window" },
+        400,
+      );
+    const start = new Date(timeMin);
+    start.setHours(10, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(11);
+    return json({
+      calendarId: "primary",
+      timeMin,
+      timeMax,
+      source: "cache",
+      syncedAt: null,
+      state: state === "partial" ? "partial" : "complete",
+      events:
+        state === "empty"
+          ? []
+          : [
+              {
+                id: "story-event",
+                externalId: "story-event",
+                agentId: "story-agent",
+                provider: "google",
+                side: "owner",
+                calendarId: "primary",
+                title: "Design review",
+                description: "Review the upcoming release",
+                location: "",
+                status: "confirmed",
+                startAt: start.toISOString(),
+                endAt: end.toISOString(),
+                isAllDay: false,
+                timezone: null,
+                htmlLink: null,
+                conferenceLink: null,
+                organizer: null,
+                attendees: [],
+                metadata: {},
+                syncedAt: start.toISOString(),
+                updatedAt: start.toISOString(),
+                calendarSummary: "Primary",
+              },
+            ],
+      sources: [
+        {
+          key: {
+            provider: "google",
+            side: "owner",
+            grantId: "story-grant",
+            connectorAccountId: "story-account",
+            calendarId: "primary",
+          },
+          summary: "Primary",
+          accessRole: "reader",
+          visibility: "details",
+          status: state === "partial" ? "error" : "fresh",
+          syncedAt: start.toISOString(),
+          error:
+            state === "partial"
+              ? {
+                  code: "sync_failed",
+                  message: "Source refresh failed",
+                  retryable: true,
+                }
+              : null,
+        },
+      ],
+    });
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+const meta = {
+  title: "Plugin views/Calendar",
+  component: CalendarPage,
+  decorators: [
+    (Story) => (
+      <MockAppProvider>
+        <div style={{ height: "100vh" }}>
+          <Story />
+        </div>
+      </MockAppProvider>
+    ),
+  ],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof CalendarPage>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Empty: Story = { beforeEach: () => installFeed("empty") };
+export const Populated: Story = { beforeEach: () => installFeed("populated") };
+export const Loading: Story = { beforeEach: () => installFeed("loading") };
+export const LoadError: Story = { beforeEach: () => installFeed("error") };
+export const Denied: Story = { beforeEach: () => installFeed("denied") };
+export const PartialSource: Story = {
+  beforeEach: () => installFeed("partial"),
+};

--- a/packages/ui/src/storybook/plugin-views/CloudView.stories.tsx
+++ b/packages/ui/src/storybook/plugin-views/CloudView.stories.tsx
@@ -1,0 +1,139 @@
+/**
+ * Renders the shipped Cloud account view through its injected fetch boundary.
+ * Offline fixtures expose account, section-error, and recovery states without
+ * connecting an account or opening a billing destination.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+import { CloudPage } from "../../../../../plugins/plugin-elizacloud/src/components/cloud/CloudPage";
+import type { CloudViewFetchers } from "../../../../../plugins/plugin-elizacloud/src/components/cloud/CloudView";
+
+const connected = {
+  connected: true,
+  enabled: true,
+  hasApiKey: true,
+  userId: "story-user",
+  organizationId: "story-org",
+};
+const fetchers: CloudViewFetchers = {
+  fetchStatus: async () => connected,
+  fetchCredits: async () => ({
+    connected: true,
+    balance: 12.34,
+    low: false,
+    critical: false,
+    topUpUrl: "https://cloud.eliza.app/cloud/billing",
+  }),
+  fetchAgents: async () => ({ success: true, data: [] }),
+  fetchApiKeys: async () => ({
+    keys: [],
+    manageUrl: "https://cloud.eliza.app/cloud/api-keys",
+  }),
+  fetchBillingSummary: async () => ({
+    balance: 12.34,
+    currency: "USD",
+    hasPaymentMethod: false,
+  }),
+};
+const meta = {
+  title: "Plugin views/Cloud",
+  component: CloudPage,
+  args: {
+    fetchers,
+    interactions: {
+      navigateInternal: fn(),
+      openExternal: fn(async () => false),
+    },
+  },
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof CloudPage>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const EmptyAccount: Story = {};
+export const Loading: Story = {
+  args: { fetchers: { ...fetchers, fetchStatus: () => new Promise(() => {}) } },
+};
+export const SignedOut: Story = {
+  args: {
+    fetchers: {
+      ...fetchers,
+      fetchStatus: async () => ({
+        ...connected,
+        connected: false,
+        hasApiKey: false,
+      }),
+    },
+  },
+};
+export const LoadError: Story = {
+  args: {
+    fetchers: {
+      ...fetchers,
+      fetchStatus: async () => {
+        throw new Error("Account connection is unavailable");
+      },
+    },
+  },
+};
+export const SectionsUnavailable: Story = {
+  args: {
+    fetchers: {
+      ...fetchers,
+      fetchCredits: async () => {
+        throw new Error("Credits unavailable");
+      },
+      fetchAgents: async () => ({
+        success: false,
+        data: [],
+        error: "Hosted agents unavailable",
+      }),
+      fetchApiKeys: async () => {
+        throw new Error("API keys unavailable");
+      },
+      fetchBillingSummary: async () => {
+        throw new Error("Billing unavailable");
+      },
+    },
+  },
+};
+export const Populated: Story = {
+  args: {
+    fetchers: {
+      ...fetchers,
+      fetchAgents: async () => ({
+        success: true,
+        data: [
+          {
+            agent_id: "story-agent",
+            agent_name: "Planning assistant",
+            node_id: null,
+            container_id: null,
+            headscale_ip: null,
+            bridge_url: null,
+            web_ui_url: null,
+            status: "running",
+            agent_config: {},
+            created_at: "2026-09-01T12:00:00Z",
+            updated_at: "2026-09-01T12:00:00Z",
+            containerUrl: "",
+            webUiUrl: null,
+            database_status: "healthy",
+            error_message: null,
+            last_heartbeat_at: null,
+          },
+        ],
+      }),
+      fetchApiKeys: async () => ({
+        keys: [
+          {
+            id: "story-key",
+            name: "Development",
+            keyPrefix: "eliza_preview",
+            createdAt: null,
+          },
+        ],
+        manageUrl: "https://cloud.eliza.app/cloud/api-keys",
+      }),
+    },
+  },
+};

--- a/packages/ui/src/storybook/plugin-views/MessagesSpatialView.stories.tsx
+++ b/packages/ui/src/storybook/plugin-views/MessagesSpatialView.stories.tsx
@@ -1,0 +1,103 @@
+/**
+ * Exercises the shipped Messages presentation across SMS role and send states.
+ * Snapshot fixtures do not send messages or certify Android bridge behavior.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { MessagesSpatialView } from "../../../../../plugins/plugin-messages/src/components/MessagesSpatialView";
+import { SpatialSurface } from "../../spatial";
+
+const meta = {
+  title: "Plugin views/Messages",
+  component: MessagesSpatialView,
+  decorators: [
+    (Story) => (
+      <SpatialSurface>
+        <Story />
+      </SpatialSurface>
+    ),
+  ],
+  args: {
+    snapshot: {
+      threads: [],
+      selectedThreadId: null,
+      composeAddress: "",
+      composeBody: "",
+      ownsSmsRole: true,
+      smsRoleHolder: null,
+      loading: false,
+      sending: false,
+      error: null,
+    },
+  },
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof MessagesSpatialView>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Empty: Story = {};
+export const Loading: Story = {
+  args: { snapshot: { ...meta.args.snapshot, loading: true } },
+};
+export const LoadError: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      error: "Messages could not load. Check device access and retry.",
+    },
+  },
+};
+export const RoleRequired: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      ownsSmsRole: false,
+      smsRoleHolder: "com.android.messaging",
+    },
+  },
+};
+export const Composing: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      composeAddress: "+15550100",
+      composeBody: "Meet at 10?",
+    },
+  },
+};
+export const Sending: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      composeAddress: "+15550100",
+      composeBody: "Meet at 10?",
+      sending: true,
+    },
+  },
+};
+
+const received = {
+  id: "story-message",
+  threadId: "story-thread",
+  address: "+15550100",
+  body: "Meet at 10?",
+  date: Date.UTC(2026, 8, 6, 9),
+  type: 1,
+  read: false,
+};
+export const Populated: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      selectedThreadId: "story-thread",
+      composeAddress: "+15550100",
+      threads: [
+        {
+          id: "story-thread",
+          address: "+15550100",
+          messages: [received],
+          lastMessage: received,
+          unreadCount: 1,
+        },
+      ],
+    },
+  },
+};

--- a/packages/ui/src/storybook/plugin-views/PhoneSpatialView.stories.tsx
+++ b/packages/ui/src/storybook/plugin-views/PhoneSpatialView.stories.tsx
@@ -1,0 +1,81 @@
+/**
+ * Exercises the shipped Phone presentation in resolved device states.
+ * These snapshots are visual fixtures; native call permission and delivery
+ * must be verified on Android rather than inferred from these stories.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { PhoneSpatialView } from "../../../../../plugins/plugin-phone/src/components/PhoneSpatialView";
+import { SpatialSurface } from "../../spatial";
+
+const meta = {
+  title: "Plugin views/Phone",
+  component: PhoneSpatialView,
+  decorators: [
+    (Story) => (
+      <SpatialSurface>
+        <Story />
+      </SpatialSurface>
+    ),
+  ],
+  args: {
+    snapshot: {
+      callReady: true,
+      dialed: "",
+      calls: [],
+      loading: false,
+      error: null,
+    },
+  },
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof PhoneSpatialView>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Empty: Story = {};
+export const Loading: Story = {
+  args: {
+    snapshot: { ...meta.args.snapshot, loading: true, callReady: false },
+  },
+};
+export const LoadError: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      callReady: false,
+      error:
+        "Phone status is unavailable. Retry after checking device permissions.",
+    },
+  },
+};
+export const Denied: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      callReady: false,
+      error: "Phone access is needed. Grant it in device settings, then retry.",
+    },
+  },
+};
+export const Populated: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      dialed: "+15550100",
+      calls: [
+        {
+          id: "incoming",
+          name: "Ada",
+          number: "+15550100",
+          when: "9:00 AM",
+          direction: "incoming",
+        },
+        {
+          id: "missed",
+          name: "Grace",
+          number: "+15550200",
+          when: "Yesterday",
+          direction: "missed",
+        },
+      ],
+    },
+  },
+};

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -50,6 +50,8 @@ electrobun-wgpu {
 @source "../../../ui/src";
 @source "../../../../plugins/app-lifeops/src";
 @source "../../../../plugins/plugin-maps/src";
+/* Cloud and Calendar remote bundles consume this host-owned hover utility. */
+@source inline("hover:bg-accent-muted");
 
 /* Memories sits beside a persistent filter rail in short landscape, where the
    default feature-empty stack falls behind the assistant overlay. Compact only

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -50,8 +50,6 @@ electrobun-wgpu {
 @source "../../../ui/src";
 @source "../../../../plugins/app-lifeops/src";
 @source "../../../../plugins/plugin-maps/src";
-/* Cloud and Calendar remote bundles consume this host-owned hover utility. */
-@source inline("hover:bg-accent-muted");
 
 /* Memories sits beside a persistent filter rail in short landscape, where the
    default feature-empty stack falls behind the assistant overlay. Compact only

--- a/packages/ui/test/stubs/host-external.ts
+++ b/packages/ui/test/stubs/host-external.ts
@@ -14,3 +14,13 @@ export const Camera = {
     return { base64: "", format: "jpeg" };
   },
 };
+
+/** The catalog must never simulate successful native Phone reads. */
+export const Phone = {
+  async getStatus() {
+    throw new Error("Native Phone status is unavailable in the story catalog");
+  },
+  async listRecentCalls() {
+    throw new Error("Native call history is unavailable in the story catalog");
+  },
+};

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -683,7 +683,7 @@ function TimeGrid({
         >
           <div
             aria-hidden
-            className="flex items-center justify-end px-2 text-[10px] font-medium text-muted/70"
+            className="flex items-center justify-end px-2 text-[10px] font-medium text-muted"
           >
             all-day
           </div>
@@ -708,7 +708,7 @@ function TimeGrid({
           {hours.map(({ hour, label }) => (
             <div
               key={hour}
-              className="absolute right-2 text-[10px] font-medium text-muted/70"
+              className="absolute right-2 text-[10px] font-medium text-muted"
               style={{
                 top: `${(hour - DAY_START_HOUR) * HOUR_HEIGHT_PX - 6}px`,
               }}
@@ -1258,7 +1258,7 @@ export function CalendarSection({
 
         {proactiveLine ? (
           <p
-            className="-mt-1 text-[13px] text-muted/70"
+            className="-mt-1 text-[13px] text-muted"
             data-testid="lifeops-calendar-proactive"
           >
             {proactiveLine}

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -1242,7 +1242,8 @@ export function CalendarSection({
             <Button
               ref={newEvent.ref}
               size="dense"
-              className="shrink-0 hover:bg-accent-muted hover:text-white"
+              variant="accentDarkHover"
+              className="shrink-0"
               onClick={() => {
                 setCreateDefaultDate(new Date(calendar.windowStart));
                 setCreateOpen(true);

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -1179,7 +1179,7 @@ export function CalendarSection({
   return (
     <>
       <section
-        className="flex h-full min-h-0 flex-col gap-4"
+        className="flex min-h-full flex-col gap-4"
         data-testid="lifeops-calendar-section"
       >
         <div className="flex flex-wrap items-center justify-between gap-3">

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -1242,7 +1242,7 @@ export function CalendarSection({
             <Button
               ref={newEvent.ref}
               size="dense"
-              className="shrink-0"
+              className="shrink-0 hover:bg-accent-muted"
               onClick={() => {
                 setCreateDefaultDate(new Date(calendar.windowStart));
                 setCreateOpen(true);

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -1242,7 +1242,7 @@ export function CalendarSection({
             <Button
               ref={newEvent.ref}
               size="dense"
-              className="shrink-0 hover:bg-accent-muted"
+              className="shrink-0 hover:bg-accent-muted hover:text-white"
               onClick={() => {
                 setCreateDefaultDate(new Date(calendar.windowStart));
                 setCreateOpen(true);

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.test.tsx
@@ -360,24 +360,6 @@ describe("EventEditorDrawer", () => {
     const title = screen.getByLabelText("Event title") as HTMLInputElement;
     expect(title.value).toBe("");
 
-    const drawerStyle = screen.getByTestId("event-editor-drawer").style;
-    expect(drawerStyle.top).toBe("0px");
-    expect(drawerStyle.right).toBe("0px");
-    expect(drawerStyle.bottom).toBe("0px");
-    expect(drawerStyle.left).toBe("auto");
-    expect(drawerStyle.width).toBe("100vw");
-    expect(drawerStyle.maxWidth).toBe("28rem");
-    expect(drawerStyle.boxSizing).toBe("border-box");
-    expect(drawerStyle.height).toBe("100dvh");
-    expect(drawerStyle.maxHeight).toBe("100dvh");
-    expect(drawerStyle.margin).toBe("0px");
-    expect(drawerStyle.padding).toBe("0px");
-    expect(drawerStyle.overflowX).toBe("hidden");
-    expect(drawerStyle.overflowY).toBe("auto");
-    expect(drawerStyle.transform).toBe("none");
-    expect(drawerStyle.translate).toBe("none");
-    expect(drawerStyle.animation).toBe("none");
-
     const start = document.getElementById(
       "event-editor-start-at",
     ) as HTMLInputElement;

--- a/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
+++ b/plugins/plugin-calendar/src/components/EventEditorDrawer.tsx
@@ -906,6 +906,8 @@ export function EventEditorDrawer({
             maxHeight: "100dvh",
             margin: 0,
             padding: 0,
+            // The portaled editor must scroll its footer above the persistent composer.
+            paddingBottom: "var(--eliza-chat-clearance, 5.25rem)",
             overflowX: "hidden",
             overflowY: "auto",
             transform: "none",

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudPage.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudPage.tsx
@@ -6,14 +6,14 @@
 
 import { ViewHeader } from "@elizaos/ui/components";
 import type { JSX } from "react";
-import { CloudView } from "./CloudView.tsx";
+import { CloudView, type CloudViewProps } from "./CloudView.tsx";
 
-export function CloudPage(): JSX.Element {
+export function CloudPage(props: CloudViewProps = {}): JSX.Element {
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
       <ViewHeader title="Eliza Cloud" />
       <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        <CloudView />
+        <CloudView {...props} showTitle={false} />
       </div>
     </div>
   );

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
@@ -327,6 +327,8 @@ function ApiKeysCard(props: {
 // ---------------------------------------------------------------------------
 
 export interface CloudViewProps {
+  /** Standalone views own a title; a containing CloudPage supplies its own. */
+  showTitle?: boolean;
   /** Test/host injection seam. Defaults to the host `client` cloud wrappers. */
   fetchers?: CloudViewFetchers;
   /** Test seam for the host-brokered internal and external navigation paths. */
@@ -421,7 +423,9 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
         className="flex h-full flex-col items-center justify-center gap-3 bg-bg px-6 text-center"
         data-testid="cloud-signed-out"
       >
-        <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
+        {props.showTitle !== false ? (
+          <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
+        ) : null}
         <p className="max-w-sm text-sm text-muted">
           Connect to view credits, agents, API keys, and billing.
         </p>
@@ -456,7 +460,9 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
     <div className="h-full overflow-y-auto bg-bg" data-testid="cloud-ready">
       <div className="mx-auto flex max-w-2xl flex-col gap-4 px-4 py-6">
         <div className="flex items-center justify-between gap-3">
-          <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
+          {props.showTitle !== false ? (
+            <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
+          ) : null}
           <Badge variant="outline" size="micro" tone="success">
             Connected
           </Badge>

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
@@ -436,7 +436,7 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
         ) : null}
         <Button
           type="button"
-          className="hover:bg-accent-muted"
+          className="hover:bg-accent-muted hover:text-white"
           onClick={() => navigateInternal("/settings")}
         >
           Connect in Settings

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
@@ -436,7 +436,7 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
         ) : null}
         <Button
           type="button"
-          className="hover:bg-accent-muted hover:text-white"
+          variant="accentDarkHover"
           onClick={() => navigateInternal("/settings")}
         >
           Connect in Settings

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
@@ -434,7 +434,11 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
             {navigationError}
           </p>
         ) : null}
-        <Button type="button" onClick={() => navigateInternal("/settings")}>
+        <Button
+          type="button"
+          className="hover:bg-accent-muted"
+          onClick={() => navigateInternal("/settings")}
+        >
           Connect in Settings
         </Button>
       </div>

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -357,7 +357,7 @@ export const elizaOSCloudPlugin: Plugin = {
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       componentExport: "CloudView",
-      surface: { capabilities: ["agent-surface"] },
+      surface: { header: "fullscreen", capabilities: ["agent-surface"] },
       tags: ["cloud", "billing", "credits", "account", "api-keys", "agents"],
       visibleInManager: true,
       desktopTabEnabled: true,

--- a/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
@@ -108,139 +108,143 @@ export function MessagesSpatialView({
     snapshot.composeBody.trim().length > 0;
 
   return (
-    <Card gap={1} padding={1}>
-      <HStack gap={1} align="center">
-        <Text style="caption" tone={roleTone(snapshot)} grow={1}>
-          {roleLabel(snapshot)}
-        </Text>
-        {unread > 0 ? (
-          <Text style="caption" tone="primary">
-            {`${unread} unread`}
+    <div className="min-h-0 overflow-y-auto" data-scroll-cert-scroller>
+      <Card gap={1} padding={1}>
+        <HStack gap={1} align="center">
+          <Text style="caption" tone={roleTone(snapshot)} grow={1}>
+            {roleLabel(snapshot)}
+          </Text>
+          {unread > 0 ? (
+            <Text style="caption" tone="primary">
+              {`${unread} unread`}
+            </Text>
+          ) : null}
+          <Text style="caption" tone="muted">
+            {snapshot.loading
+              ? "loading"
+              : `${snapshot.threads.length} threads`}
+          </Text>
+        </HStack>
+
+        {snapshot.error ? (
+          <Text tone="danger" style="caption">
+            {snapshot.error}
           </Text>
         ) : null}
-        <Text style="caption" tone="muted">
-          {snapshot.loading ? "loading" : `${snapshot.threads.length} threads`}
-        </Text>
-      </HStack>
 
-      {snapshot.error ? (
-        <Text tone="danger" style="caption">
-          {snapshot.error}
-        </Text>
-      ) : null}
+        {!snapshot.ownsSmsRole ? (
+          <Button
+            variant="outline"
+            tone="warning"
+            agent="request-sms-role"
+            onPress={dispatch("request-sms-role")}
+          >
+            Set default SMS
+          </Button>
+        ) : null}
 
-      {!snapshot.ownsSmsRole ? (
-        <Button
-          variant="outline"
-          tone="warning"
-          agent="request-sms-role"
-          onPress={dispatch("request-sms-role")}
-        >
-          Set default SMS
-        </Button>
-      ) : null}
-
-      <Divider label="threads" />
-      {snapshot.threads.length === 0 ? (
-        <Text tone="muted" align="center" style="caption">
-          None
-        </Text>
-      ) : (
-        <List gap={0}>
-          {snapshot.threads.slice(0, 8).map((thread) => {
-            const selected = thread.id === snapshot.selectedThreadId;
-            return (
-              <HStack key={thread.id} gap={1} align="center">
-                <Text tone={directionTone(thread.lastMessage.type)}>
-                  {directionMark(thread.lastMessage.type)}
-                </Text>
-                <VStack gap={0} grow={1}>
-                  <Text bold wrap={false}>
-                    {thread.address || "Unknown"}
+        <Divider label="threads" />
+        {snapshot.threads.length === 0 ? (
+          <Text tone="muted" align="center" style="caption">
+            None
+          </Text>
+        ) : (
+          <List gap={0}>
+            {snapshot.threads.slice(0, 8).map((thread) => {
+              const selected = thread.id === snapshot.selectedThreadId;
+              return (
+                <HStack key={thread.id} gap={1} align="center">
+                  <Text tone={directionTone(thread.lastMessage.type)}>
+                    {directionMark(thread.lastMessage.type)}
                   </Text>
+                  <VStack gap={0} grow={1}>
+                    <Text bold wrap={false}>
+                      {thread.address || "Unknown"}
+                    </Text>
+                    <Text style="caption" tone="muted" wrap={false}>
+                      {thread.lastMessage.body}
+                    </Text>
+                  </VStack>
                   <Text style="caption" tone="muted" wrap={false}>
-                    {thread.lastMessage.body}
+                    {formatMessageTime(thread.lastMessage.date)}
                   </Text>
-                </VStack>
-                <Text style="caption" tone="muted" wrap={false}>
-                  {formatMessageTime(thread.lastMessage.date)}
+                  {thread.unreadCount > 0 ? (
+                    <Text style="caption" tone="primary">
+                      {String(thread.unreadCount)}
+                    </Text>
+                  ) : null}
+                  <Button
+                    variant={selected ? "solid" : "ghost"}
+                    tone="primary"
+                    agent={`open-thread-${thread.id}`}
+                    onPress={dispatch(`open-thread:${thread.id}`)}
+                  >
+                    Open
+                  </Button>
+                </HStack>
+              );
+            })}
+          </List>
+        )}
+
+        <Divider label={selectedThread ? selectedThread.address : "compose"} />
+        {selectedThread ? (
+          <List gap={0}>
+            {selectedThread.messages.slice(-6).map((message) => (
+              <HStack key={message.id} gap={1} align="start">
+                <Text tone={directionTone(message.type)} style="caption">
+                  {messageDirection(message.type)}
                 </Text>
-                {thread.unreadCount > 0 ? (
-                  <Text style="caption" tone="primary">
-                    {String(thread.unreadCount)}
-                  </Text>
-                ) : null}
-                <Button
-                  variant={selected ? "solid" : "ghost"}
-                  tone="primary"
-                  agent={`open-thread-${thread.id}`}
-                  onPress={dispatch(`open-thread:${thread.id}`)}
-                >
-                  Open
-                </Button>
+                <Text grow={1}>{message.body}</Text>
+                <Text style="caption" tone="muted" wrap={false}>
+                  {formatMessageTime(message.date)}
+                </Text>
               </HStack>
-            );
-          })}
-        </List>
-      )}
+            ))}
+          </List>
+        ) : null}
 
-      <Divider label={selectedThread ? selectedThread.address : "compose"} />
-      {selectedThread ? (
-        <List gap={0}>
-          {selectedThread.messages.slice(-6).map((message) => (
-            <HStack key={message.id} gap={1} align="start">
-              <Text tone={directionTone(message.type)} style="caption">
-                {messageDirection(message.type)}
-              </Text>
-              <Text grow={1}>{message.body}</Text>
-              <Text style="caption" tone="muted" wrap={false}>
-                {formatMessageTime(message.date)}
-              </Text>
-            </HStack>
-          ))}
-        </List>
-      ) : null}
-
-      <Field
-        label="To"
-        value={snapshot.composeAddress}
-        placeholder="phone number"
-        agent="compose-address"
-        onChange={(value) => onAction?.(`compose-address:${value}`)}
-      />
-      <Field
-        label="Body"
-        kind="textarea"
-        value={snapshot.composeBody}
-        placeholder="message"
-        agent="compose-body"
-        onChange={(value) => onAction?.(`compose-body:${value}`)}
-      />
-      <HStack gap={1} wrap>
-        <Button
-          grow={1}
-          disabled={!canSend}
-          variant={canSend ? "solid" : "outline"}
-          tone={canSend ? "primary" : "default"}
-          agent={{ id: "messages-send", role: "button", label: "Send SMS" }}
-          onPress={dispatch("send")}
-        >
-          {snapshot.sending ? "Sending…" : "Send"}
-        </Button>
-        <Button
-          variant="outline"
-          tone="default"
-          agent={{
-            id: "messages-refresh",
-            role: "button",
-            label: "Refresh messages",
-          }}
-          disabled={snapshot.loading}
-          onPress={dispatch("refresh")}
-        >
-          {snapshot.loading ? "Refreshing…" : "Refresh"}
-        </Button>
-      </HStack>
-    </Card>
+        <Field
+          label="To"
+          value={snapshot.composeAddress}
+          placeholder="phone number"
+          agent="compose-address"
+          onChange={(value) => onAction?.(`compose-address:${value}`)}
+        />
+        <Field
+          label="Body"
+          kind="textarea"
+          value={snapshot.composeBody}
+          placeholder="message"
+          agent="compose-body"
+          onChange={(value) => onAction?.(`compose-body:${value}`)}
+        />
+        <HStack gap={1} wrap>
+          <Button
+            grow={1}
+            disabled={!canSend}
+            variant={canSend ? "solid" : "outline"}
+            tone={canSend ? "primary" : "default"}
+            agent={{ id: "messages-send", role: "button", label: "Send SMS" }}
+            onPress={dispatch("send")}
+          >
+            {snapshot.sending ? "Sending…" : "Send"}
+          </Button>
+          <Button
+            variant="outline"
+            tone="default"
+            agent={{
+              id: "messages-refresh",
+              role: "button",
+              label: "Refresh messages",
+            }}
+            disabled={snapshot.loading}
+            onPress={dispatch("refresh")}
+          >
+            {snapshot.loading ? "Refreshing…" : "Refresh"}
+          </Button>
+        </HStack>
+      </Card>
+    </div>
   );
 }

--- a/plugins/plugin-personal-assistant/test/undated-owner-todo.cerebras.live.e2e.test.ts
+++ b/plugins/plugin-personal-assistant/test/undated-owner-todo.cerebras.live.e2e.test.ts
@@ -349,8 +349,38 @@ describeIf(suiteEnabled)("Live: undated owner-todo boundary", () => {
     }
   }, LIVE_RUNTIME_BOOT_TIMEOUT_MS + 30_000);
 
-  afterEach(async () => {
+  afterEach(async ({ task }) => {
+    const artifactDir = process.env.ELIZA_LIVE_TEST_ARTIFACT_DIR?.trim();
+    const cerebrasKey = process.env.CEREBRAS_API_KEY?.trim();
+    const preserveFailure = async () => {
+      if (
+        task.result?.state === "fail" &&
+        artifactDir &&
+        wireCapture &&
+        cerebrasKey
+      ) {
+        // Preserve rejected provider calls too: a pre-receipt failure must not
+        // erase the transport evidence needed to distinguish a harness or model
+        // boundary failure from a missing persisted domain effect.
+        await writeCerebrasEvidenceArtifacts({
+          artifactDirectory: path.join(
+            artifactDir,
+            `failure-${crypto.randomUUID()}`,
+          ),
+          calls: wireCapture.calls,
+          trajectories: [],
+          receipts: [],
+          secrets: [cerebrasKey],
+          metadata: {
+            issue: 24104,
+            status: "failed-before-complete-acceptance",
+            evidenceHead: process.env.ELIZA_LIVE_EVIDENCE_HEAD ?? "local",
+          },
+        });
+      }
+    };
     const results = await Promise.allSettled([
+      preserveFailure(),
       runtime?.close(),
       wireCapture?.close(),
     ]);


### PR DESCRIPTION
## Current source and remaining gates

Published head: `ba520719d3ea009e8d896d78aaf20a081c2b3429`. The local UI branch is now `67396525fd29cd4ba1da277fbbaef682d3c13cf1`; its rebased changes and Todo copy/test follow-up have **not been pushed**. The new evidence below is integration evidence from frontend `8397586d03359744e7ac3e2bdb65e986cb81ceeb` and backend `d10073190e99d8f262dfaf5bcd74d7f6e20e67fa`, not a claim that the published PR already contains those prerequisites.

Current full UI/package checks, app dependency/type closure, required app audit, and serialized root verification remain pending before source publication and readiness. Earlier passing package/matrix results below retain their original head/provenance. This remains a draft; no umbrella issue or Calendar acceptance is closed.

## Problem and change

Cloud's remote plugin rendered nested page headers and back controls because its runtime surface disagreed with its registration and CloudPage repeated CloudView's title. Render one canonical header, preserve standalone CloudView title compatibility, and align Cloud/Calendar smoke declarations with the actual fullscreen surfaces. Calendar's muted event summary/hour text now meets the audited contrast requirement.

The all-view interaction crawler no longer treats unrelated network traffic or failed writes as successful interactions. Its generic result explicitly measures renderer activity; workflow-specific persisted acceptance remains separate. Add 24 discovered state stories for Phone, Messages, Calendar and Cloud, plus browser regressions for the real remote bundle's header/back behavior and for transport-only false positives. Preserve rejected live-provider wire evidence in the existing owner-todo harness.

Scoped Sprint 2 work for #24104; this does **not** close the umbrella or certify every production operation. The frozen 12-operation tranche has 11 passes and 1 blocked Calendar provider write. Todo passes use actual Qwen 3.8, complete declared OWNER_TODOS tool, real action and isolated PGlite; they do not prove full-host Stage1. The full-host request is explicitly rejected at 173405 input tokens versus Qwen's 131072 limit; no context was removed. Broader per-view operation enumeration and external native/provider acceptance remain open in the accompanying ledger.

## Validation

- App suite: 931 Bun passes, 19 skips; 1609 Vitest passes. App lint passes.
- Calendar: 720 passes, 4 skips; typecheck/lint pass. Cloud: 631 passes, 5 skips plus 5 packaging passes; typecheck/lint pass.
- Notes: 115 tests pass; separate real filesystem create/update/blank rejection/restart receipts inspected.
- UI typecheck/lint and explicit new-story typecheck pass; 24 state stories pass visual gate with no accessibility or console errors.
- Real browser Calendar/Cloud single-header and back-navigation: 4 passes at 1440/390px. Six Calendar/settings persistence cases pass. Oracle unit 3 passes and real browser transport-only regression passes.
- Canonical matrix: 219 tests, 216 captures; 0 broken / 0 needs-work. Exact bundle `20260906-064743-b676280-cpu`: 655/655 artifacts verified, 0 integrity issues; manifest SHA256 `824998f37d49d1d4a1a13f2f092c4b0592c2697ca5182c1acc539137c09042c9`. Affected desktop/mobile images inspected.
- Historical root attempt hit a native Gateway SwiftLint baseline failure reproduced on pristine base; its separate prerequisite is #30778. This is historical diagnostic evidence, not the current UI gate result. Current serialized verification remains pending as stated above.
- At the published head, fetched/rebased onto `b8e3148eb8750293a5574d6604df4313375017e8`; official `ELIZA_SKIP_FUSED_INFERENCE_SETUP=1 bun install` passes. Capture baseline precedes the unrelated orphan-hardware-assets rebase; affected source behavior is unchanged by that base movement.

## Evidence

Media and exact receipts below were generated and inspected locally, and scanned against configured provider secrets (674 files; zero matches). Deterministic renderer/state fixtures are labeled separately from real Notes storage and live Qwen/PGlite evidence. Native Phone/Messages, authenticated Calendar writes, Cloud billing and voice acceptance are not claimed.

| Evidence | Artifact |
|---|---|
| Before desktop | ![Before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-before-desktop.jpg) |
| After desktop | ![After desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-after-desktop.jpg) |
| Before mobile | ![Before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-before-mobile.jpg) |
| After mobile | ![After mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-after-mobile.jpg) |
| MP4 walkthrough | [MP4 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-cloud-desktop-walkthrough.mp4) |
| Backend logs | [Backend logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-backend-live.log) |
| Frontend console/network | [Frontend console/network](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-frontend-console-network.json) |
| Live model trajectory | [Live model trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-live-qwen-planner-pglite.json) |

Mobile state walkthrough: https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-cloud-mobile-walkthrough.mp4

[Exact verified canonical bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-canonical-evidence-bundle.tar.gz) · [Matrix log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-matrix.log) · [Root verification diagnostics](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-root-verify.log)

[Frozen tranche and remaining campaign ledger](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-operation-ledger.md) ([machine-readable](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-operation-ledger.json)) · [Real Notes receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-notes-storage-receipts.json) · [Full-host rejected request/response](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-fullhost-context-rejection.json)

Reproduce the live storage/model receipts with [Notes script](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-notes-reproduction.ts) and [isolated planner integration test](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todos-reproduction.ts). The browser recordings use deterministic state stories, including loading/error/signed-out states, and are not authenticated billing or native-device proof.

The Todo contradictory-input operation produced a clarification and unchanged PGlite row, not a typed action rejection. Remaining view-operation IDs are unknown where the inventory declares none; absence is not treated as zero operations. The source-only inventory has 43 candidates after excluding the `lifeops-live-test` test fixture, and does not establish authoritative runtime completeness.


[All 24 state-story screenshots, accessibility results and frontend logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-state-story-gate.tar.gz) — final built Storybook renderer gate, zero accessibility/console errors.


Final additional package gates at `ba520719d3ea009e8d896d78aaf20a081c2b3429`: [UI suite](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-ui-package-final.log) **1278 files passed; 13626 tests passed, 7 skipped; exit 0**, 1828.61s, one worker. [App typecheck diagnostics](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-app-typecheck-missing-declarations.log) remain **exit 1** from missing workspace declarations plus downstream errors; no pass claimed. Auth/Vault/Skills official declaration builds subsequently passed. Remaining dependency build closure is serialized with the coordinator root gate to avoid duplicate large bundles. Independent review at this head found no scoped implementation blocker; root/typecheck and acceptance gates remain open.

## Normal-host Todo evidence extension

The retained Todo `2f5885d3-e931-4137-a3d6-54bc8ee4bb38` now passes normal HTTP complete → graceful host restart → persisted completed read → reopen, with repeat calls returning noop and preserving revisions. The Todo DTO and definition share the same ID, `targetKind: definition`, and null due date; no occurrence or alternate store was fabricated. The actual mounted desktop/mobile board shows the reopened item once in Someday. This is **canonical HTTP mutation plus mounted readback**, not chat/voice mutation evidence.

The Todo plugin was enabled through supported configuration and verified in the actual runtime/view registry. The catalog's earlier `isActive` flag alone did not establish that it was loaded. The active-only board's misleading “No todos yet” label was corrected to “No active todos” in local commit `41486a5d8f34b0b0df15b7fa8ef1d2970376e9b7`. Follow-up `67396525fd29cd4ba1da277fbbaef682d3c13cf1` updates three existing scenario locators; all 15 existing TodoView tests pass. Both changes and the lifecycle prerequisites received independent review; required aggregate gates remain pending.

New canonical bundle `20260906-101939-8397586-cpu`: **43/43 verified**, zero integrity issues, manifest SHA256 `5ef603d20b8359e4fc3fb896f13e0732e8129d61f241363940fe50d201d0898d`. The original 655-artifact bundle is unchanged. Full copied backend and Vite log snapshots plus collected browser console/network receipts are retained. Three unrelated 503 resources belong to explicitly disabled coding-agent/orchestrator services; Todo reads return 200. This is not a clean-console or full HAR claim.

[Verified extension bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-extension-bundle.tar.gz) · [Exact review and limitations](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-extension-review.md) · [Integrity verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-extension-verification.json)

Before desktop: ![Todo before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-before-desktop.jpg)

Corrected completed-only desktop: ![Todo after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-after-desktop.jpg)

Reopened desktop: ![Todo reopened desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-reopened-desktop.jpg)

Before mobile: ![Todo before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-before-mobile.jpg)

Corrected completed-only mobile: ![Todo after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-after-mobile.jpg)

Reopened mobile: ![Todo reopened mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-reopened-mobile.jpg)

[Desktop state MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-desktop-states.mp4) · [Mobile state MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-mobile-states.mp4). Videos show recorded states before/after the copy correction and after reopening; HTTP mutation/restart receipts are in the bundle.

[Backend before restart](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-backend-before.log) · [Backend after restart](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-backend-after-restart.log) · [Frontend Vite log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-frontend-vite.log) · [Collected browser console/network](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30783-todo-browser-console-network.json)

This extension closes the additional normal-host Todo completion/reopen/persistence gap; it does not change the original frozen 12-operation denominator or remove the blocked Calendar provider-write row.
