### PR TITLE
fix(workflow): qualify Smithers 0.35 and reliable workflow/project lifecycle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1293,7 +1293,7 @@
         "drizzle-orm": "0.45.2",
         "effect": "4.0.0-beta.105",
         "smol-toml": "^1.8.0",
-        "smthrs": "0.34.0",
+        "smthrs": "0.35.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
@@ -3443,7 +3443,7 @@
         "@elizaos/shared": "workspace:*",
         "drizzle-orm": "0.45.2",
         "effect": "4.0.0-beta.105",
-        "smthrs": "0.34.0",
+        "smthrs": "0.35.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -3692,8 +3692,6 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
-
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.220", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA=="],
 
     "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.220", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q=="],
@@ -3826,8 +3824,6 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
-    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
-
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
     "@brighter/storage": ["@brighter/storage@1.6.3", "", { "dependencies": { "iconv-lite": "^0.6.3", "mime-types": "^2.1.35" } }, "sha512-7tWxE9lMFsqe3KCK0iPbhGcBocbvJ3Qw9NWj2tMbTcW0uzfMhfa1wyqbwoYhB6v/dgZWu4KYjNgq/00F5DFrsQ=="],
@@ -3889,8 +3885,6 @@
     "@capacitor/synapse": ["@capacitor/synapse@1.0.4", "", {}, "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw=="],
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
-
-    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
 
@@ -4568,10 +4562,6 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
-
-    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
-
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
@@ -4873,8 +4863,6 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
-
-    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@metamask/analytics": ["@metamask/analytics@0.6.0", "", { "dependencies": { "openapi-fetch": "^0.13.5" } }, "sha512-L250lV3PANTcKqhZkmRV1Obkyddm6JDQvDBuUVAi+7TmPdOVdpavWNXyEh7ErscjwG0z2wiF9Ne0ihK/nCdX0w=="],
 
@@ -5253,26 +5241,6 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
-
-    "@opentui/core": ["@opentui/core@0.4.5", "", { "dependencies": { "bun-ffi-structs": "0.2.4", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.5", "@opentui/core-darwin-x64": "0.4.5", "@opentui/core-linux-arm64": "0.4.5", "@opentui/core-linux-arm64-musl": "0.4.5", "@opentui/core-linux-x64": "0.4.5", "@opentui/core-linux-x64-musl": "0.4.5", "@opentui/core-win32-arm64": "0.4.5", "@opentui/core-win32-x64": "0.4.5" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-JsgRTPkA6e+Vxmumxai6SElOSlRQkbzNKHlCfemlArRiLhfC1IZ9RXJo2QH4xSu+uBOWAM90uss73/pPlkdEig=="],
-
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8KUG0oRidnR+oW1RSZJ72/PhZLl+qRRMk5U/mieF4c0SJ5V3tYACpBZAKzQfHNd1f7QzD8FHZct1lPpQgtmkWg=="],
-
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-R2bocsg55gwjOqCp/MWFgFYzRmsduKegB6nzgFAPCvAD/L5Jf30xpWJWFlSg3x8vxe1L9WJ84dfqa4M7mZZ3wA=="],
-
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-R4MZ25a4CzOAGVjW9aj1hUfzQGVfCJwrwBDbNs2SXaIvzcZqkxCVtU4FoQ5LsaD0j/BdNQVg2CIfFkFsm1fDuQ=="],
-
-    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ieqdyKI6EIYPalYAETB2wsdP83hr5Ifi+dFnBFUmdEEFHsoKwBmn2S7bsTOYlX7Bg03F4/YPIg+IvRpeC+cUJw=="],
-
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-SNyuQoxMKI1vuJhgxSSW96adWM6LqFl2SoS3GM4tGeneGOanVVG2Y06PvlytXvF4cKik97t0rqkVMRetmOs93w=="],
-
-    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-mKVKcIcPiSVVZZsdPSBoWwoa2/TCeQAaMDeHF7PFw2kt5bTXZPP7xxWfRQLCNIcA1eaGl59UuwUWHDR2Ve548Q=="],
-
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-GHTTsqeR45q2Iek9Rb7ty+x/hAKn2jZ1ujlCgPR8LBKyF7h0E1dNFryoZ7ehMc3kJndP1sKn836IemKFqxuDdQ=="],
-
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-Y8T/yXCDGagRGiQrtmuB6AhRcPucKFs/Dre3v8kJwNYqDccI4FzUPKclZ7djfmRZNjl7JUqPhZZP/PwDpQocMg=="],
-
-    "@opentui/react": ["@opentui/react@0.4.5", "", { "dependencies": { "@opentui/core": "0.4.5", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-n88Vx0cMmAu++/S14WscjvdcT46IDcxve02jMtcfHQ9j6cySRHfILfGEpOB7xxc8RpCwQceEyOjkKkfzPzm6Jg=="],
 
     "@openzeppelin/contracts": ["@openzeppelin/contracts@3.4.2-solc-0.7", "", {}, "sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA=="],
 
@@ -5790,107 +5758,99 @@
 
     "@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
 
-    "@smthrs/accounts": ["@smthrs/accounts@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0" } }, "sha512-X1miFfRImRs3CoHGjrHANiCZRtrDLAXPwZ30f8dYfToISDUBzwuicqmV1ZXyArUKcfAUVJyj8HvW78VOv/Rpeg=="],
+    "@smthrs/accounts": ["@smthrs/accounts@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0" } }, "sha512-OMEAlmHejodLHzDdREWPrQbA43SetEQp3hURjOBNpRwpWp2NG80UFJkpBfMgc8Gf9pvosYJCpvfokDDB7ZkLhQ=="],
 
-    "@smthrs/agents": ["@smthrs/agents@0.34.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@modelcontextprotocol/sdk": "^1.29.0", "@smthrs/accounts": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/observability": "0.34.0", "ai": "^7.0.10", "effect": "4.0.0-beta.105", "zod": "^4.4.3" } }, "sha512-GZAZ2wZd30x+Qi83aw7Sg7XqK/pC/IvP7/HcCrgjPQdIMlvmHAAIZW0KY9rWxLcSVWAd+aw7uUTq4z7HKjpILw=="],
+    "@smthrs/agents": ["@smthrs/agents@0.35.0", "", { "dependencies": { "@ai-sdk/anthropic": "^4.0.5", "@ai-sdk/openai": "^4.0.5", "@smthrs/accounts": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/usage": "0.35.0", "ai": "^7.0.10", "effect": "4.0.0-beta.105", "zod": "^4.4.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-Oz94PP5RrPApDhyCjYCP4ZbQnjwPHeyJyvhUeEzHrakGWLESGcb8VSq7fH0aTsuEIxgnp4vTl6QJYqjBkMG7TA=="],
 
-    "@smthrs/aws": ["@smthrs/aws@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/sandbox": "0.34.0" }, "peerDependencies": { "@aws-sdk/client-cloudwatch-logs": "^3.700.0", "@aws-sdk/client-codebuild": "^3.700.0", "@aws-sdk/client-ecs": "^3.700.0", "@aws-sdk/client-s3": "^3.700.0" }, "optionalPeers": ["@aws-sdk/client-cloudwatch-logs", "@aws-sdk/client-codebuild", "@aws-sdk/client-ecs", "@aws-sdk/client-s3"] }, "sha512-uP/fOpMaagtB+FDTX5k1eKA0NMlLbPFHutzOJHSlwU9oS/iy1gYtJ5VB/jwqzKT96DQAbWfDikpFXbXCjnzONg=="],
+    "@smthrs/aws": ["@smthrs/aws@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/sandbox": "0.35.0" }, "peerDependencies": { "@aws-sdk/client-cloudwatch-logs": "^3.700.0", "@aws-sdk/client-codebuild": "^3.700.0", "@aws-sdk/client-ecs": "^3.700.0", "@aws-sdk/client-s3": "^3.700.0" }, "optionalPeers": ["@aws-sdk/client-cloudwatch-logs", "@aws-sdk/client-codebuild", "@aws-sdk/client-ecs", "@aws-sdk/client-s3"] }, "sha512-XHs4MSKkngaHn51Uf/WVvZE7hzHwjnWd30bHq0HeSc5HKHfhzBG7Bk8ydHSt0sd1cWHrdiZOwpGfFzuZ5Ufgmw=="],
 
-    "@smthrs/cli": ["@smthrs/cli@0.34.0", "", { "dependencies": { "@clack/core": "^1.4.2", "@clack/prompts": "^1.6.0", "@mdx-js/esbuild": "^3.1.1", "@modelcontextprotocol/sdk": "^1.29.0", "@opentui/core": "^0.4.2", "@opentui/react": "^0.4.2", "@pierre/diffs": "^1.2.11", "@smthrs/accounts": "0.34.0", "@smthrs/agents": "0.34.0", "@smthrs/components": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/devtools": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/engine": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/herdr": "0.34.0", "@smthrs/memory": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/openapi": "0.34.0", "@smthrs/protocol": "0.34.0", "@smthrs/review": "0.34.0", "@smthrs/scheduler": "0.34.0", "@smthrs/scorers": "0.34.0", "@smthrs/server": "0.34.0", "@smthrs/time-travel": "0.34.0", "@smthrs/tui": "0.34.0", "@smthrs/usage": "0.34.0", "@smthrs/vcs": "0.34.0", "@toon-format/toon": "2.3.0", "@xterm/addon-fit": "^0.11.0", "@xterm/xterm": "^6.0.0", "cron-parser": "^5.6.1", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "incur": "^0.4.10", "picocolors": "^1.1.1", "react": "^19.2.7", "smthrs": "0.34.0", "yaml": "^2.9.0", "zod": "^4.4.3" } }, "sha512-RrzYwUmVQmWEWl3YKOR70B7LFAwfXsfDdAlVoVR87EPpOV9v85KzRs/FqglZyfe16iJeUPufAmA6FRdjjUsDBQ=="],
+    "@smthrs/cli": ["@smthrs/cli@0.35.0", "", { "dependencies": { "@clack/core": "^1.4.2", "@clack/prompts": "^1.6.0", "@mdx-js/esbuild": "^3.1.1", "@mdx-js/mdx": "^3.1.1", "@modelcontextprotocol/sdk": "^1.29.0", "@pierre/diffs": "^1.2.11", "@smthrs/accounts": "0.35.0", "@smthrs/agents": "0.35.0", "@smthrs/components": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/devtools": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/engine": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/herdr": "0.35.0", "@smthrs/integrations": "0.35.0", "@smthrs/memory": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/openapi": "0.35.0", "@smthrs/protocol": "0.35.0", "@smthrs/scheduler": "0.35.0", "@smthrs/scorers": "0.35.0", "@smthrs/server": "0.35.0", "@smthrs/time-travel": "0.35.0", "@smthrs/usage": "0.35.0", "@smthrs/vcs": "0.35.0", "@toon-format/toon": "2.3.0", "@xterm/addon-fit": "^0.11.0", "@xterm/xterm": "^6.0.0", "cron-parser": "^5.6.1", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "esbuild": "^0.28.1", "incur": "^0.4.10", "picocolors": "^1.1.1", "react": "^19.2.7", "smthrs": "0.35.0", "yaml": "^2.9.0", "zod": "^4.4.3" }, "peerDependencies": { "@smthrs/review": "0.35.0", "@smthrs/tui": "0.35.0" }, "optionalPeers": ["@smthrs/review", "@smthrs/tui"] }, "sha512-Q18ZvOQjqFqsXzvBmxaF3DD6XAa1STMEWI+ROCEleBFn9NdccFaDCKcjQXxs/Fk/TA1hiTk/HN+uoNoEvFLANg=="],
 
-    "@smthrs/cloudflare": ["@smthrs/cloudflare@0.34.0", "", { "dependencies": { "@smthrs/sandbox": "0.34.0" }, "peerDependencies": { "@cloudflare/sandbox": "^0.12.3" }, "optionalPeers": ["@cloudflare/sandbox"] }, "sha512-KGtehNyKY2yxRVNZK2hOSLyqYLKQ6lr/YycANQ+3PwMDfpUGbc9C92tdfi+Qm6JwTRoArLP8mDi2Ukbf5aPiUQ=="],
+    "@smthrs/cloudflare": ["@smthrs/cloudflare@0.35.0", "", { "dependencies": { "@smthrs/sandbox": "0.35.0" }, "peerDependencies": { "@cloudflare/sandbox": "^0.12.3" }, "optionalPeers": ["@cloudflare/sandbox"] }, "sha512-tM0O6oG9/IuPb/KMZERuDUZR9e7BENvp9uUYlmSFDAk1amO4J8NtQxYGnQSqhOWke0gYJyhUjfKzbJHyprEzug=="],
 
-    "@smthrs/components": ["@smthrs/components@0.34.0", "", { "dependencies": { "@smthrs/agents": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/memory": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/react-reconciler": "0.34.0", "@smthrs/scheduler": "0.34.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-IDQDHKoHMnPFLLluirOyT6hRFeAQRh4Yfwf+XLunhJ59Rw3b3j6S3aXCqGNYrqDzFO4wqWYG3dGuN0qOKQW5AQ=="],
+    "@smthrs/components": ["@smthrs/components@0.35.0", "", { "dependencies": { "@smthrs/agents": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/memory": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/react-reconciler": "0.35.0", "@smthrs/scheduler": "0.35.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" } }, "sha512-HU+OEPiO3HItB5pYkwCvB7JWk8hHK2tG/2MmhSwWgIW8VKzKOLiKrRLiiManfnWhG71Rm56zuYYA9G2G33FqDw=="],
 
-    "@smthrs/control-plane": ["@smthrs/control-plane@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0" } }, "sha512-tfS2SfUD8wX9yoti49eNkz8ahLu0nHO4ytA3qeKks4+1Q0NkrlhWJESHV39CrJYqv8tlk1adCkQevJ1stlj7WA=="],
+    "@smthrs/control-plane": ["@smthrs/control-plane@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0" } }, "sha512-eSzgXEGriBNTFW633dywf1lGx2VMPbTWGb5T3/eW+UCwOv5F6jkv47sJW5exdbJ59A98J6n2Lqb15g57LG0VPQ=="],
 
-    "@smthrs/daytona": ["@smthrs/daytona@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/sandbox": "0.34.0" }, "peerDependencies": { "@daytonaio/sdk": "^0.194.0" }, "optionalPeers": ["@daytonaio/sdk"] }, "sha512-+Ibbz1AQWfhmdEj2m6I0yD3KC583JSweQspaZixKEvgVdA1yBaZp7T0FWgA6cWK1LRZ7MetH+kctUgofw7DXCQ=="],
+    "@smthrs/daytona": ["@smthrs/daytona@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/sandbox": "0.35.0" }, "peerDependencies": { "@daytonaio/sdk": "^0.194.0" }, "optionalPeers": ["@daytonaio/sdk"] }, "sha512-bNICttuqwsSh/22/LRBhq2nslMgJAwvU4xUFKaUncXnnOgP0vfJ+vtXI3Wa4oI/k+CeN1vtiVXacZxmZ0U2wHQ=="],
 
-    "@smthrs/db": ["@smthrs/db@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/scheduler": "0.34.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "4.0.0-beta.105", "zod": "^4.4.3" } }, "sha512-ZV7nqILfk8uj1LWqE82K/Md6uWkZOWrQsTKwxpr8VovNNIw3GtPni0iGJo93/sf72kyVyM4BNvT1kIkPv6PnmQ=="],
+    "@smthrs/db": ["@smthrs/db@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/scheduler": "0.35.0", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "4.0.0-beta.105", "zod": "^4.4.3" } }, "sha512-fbX68spdyqQvc9iHIkPPOYXLoiDZ08JYDxEd1iM3v8zIo8qv3TozAVw5+lbvhcr7X8dOzDi3WWyw4dRjACK9ZA=="],
 
-    "@smthrs/devtools": ["@smthrs/devtools@0.34.0", "", {}, "sha512-Yt64jTeTaCdeqBv8dWMqmrl6IF7y3aKiMjL4reR01oIN2gdaXZJ7BC6ACi3Rg9xuQ6uczrg1o9sT/Ey0WyBcdA=="],
+    "@smthrs/devtools": ["@smthrs/devtools@0.35.0", "", {}, "sha512-2T/RrQ6EHBmPzykRYWoMKwqJtauj/UCmoVYjP0U7JafNR7xJdfC52qr+p3FM1mhRNJm3sI1JSH9lF9n+ADLlaA=="],
 
-    "@smthrs/driver": ["@smthrs/driver@0.34.0", "", { "dependencies": { "@smthrs/db": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/scheduler": "0.34.0", "effect": "4.0.0-beta.105", "zod": "^4.4.3" } }, "sha512-f3Bi59BtagVadnj+jJA5wQQkHJ/qyA4hwAoqtTNpNRxadXWshX9KDirUZSKqPwIWMjS/2iZUel/WZPk/sokExw=="],
+    "@smthrs/driver": ["@smthrs/driver@0.35.0", "", { "dependencies": { "@smthrs/db": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/scheduler": "0.35.0", "effect": "4.0.0-beta.105", "zod": "^4.4.3" } }, "sha512-vFA0ZflhRWYVu3GC4h3wPSUY7+clYRn+wwxzvTA45DszVWzyzVSOQod/gnCHKiFfG1u3gqylUwPbDVbjffkArw=="],
 
-    "@smthrs/electric-proxy": ["@smthrs/electric-proxy@0.34.0", "", { "dependencies": { "@smthrs/gateway": "0.34.0" }, "bin": { "smithers-electric-proxy": "bin/smithers-electric-proxy.js" } }, "sha512-byR2lby/gTZKFwszBa+bgS5VQ060AichJX27cnExzwbq48js6lFC4Nb1Oay8/yXdREMQLS0WETbeOEx1VHtkIw=="],
+    "@smthrs/electric-proxy": ["@smthrs/electric-proxy@0.35.0", "", { "dependencies": { "@smthrs/gateway": "0.35.0" }, "bin": { "smithers-electric-proxy": "bin/smithers-electric-proxy.js" } }, "sha512-JNg2ChmF1KngD2KYSSdTwauqWWc2lFDI6OF04ri5o5AxhvYtTGX6b7rpW7Zfa7/iMYxlJ65WT9BqM1AXujxKFg=="],
 
-    "@smthrs/engine": ["@smthrs/engine@0.34.0", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.105", "@effect/platform-node-shared": "4.0.0-beta.105", "@effect/sql-sqlite-bun": "4.0.0-beta.105", "@smthrs/agents": "0.34.0", "@smthrs/components": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/react-reconciler": "0.34.0", "@smthrs/sandbox": "0.34.0", "@smthrs/scheduler": "0.34.0", "@smthrs/scorers": "0.34.0", "@smthrs/time-travel": "0.34.0", "@smthrs/tool-context": "0.34.0", "@smthrs/vcs": "0.34.0", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "^0.5.4", "@electric-sql/pglite-socket": "^0.2.6", "pg": "^8.22.0" } }, "sha512-UdsqIuWtMImrd5FOQRze4Hoi3UMB05zG7lOYV69VEWwkaidhDHjXvivJD3sUQbHZ+h6nd01rHsbn2OMzS2U1HA=="],
+    "@smthrs/engine": ["@smthrs/engine@0.35.0", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.105", "@effect/platform-node-shared": "4.0.0-beta.105", "@effect/sql-sqlite-bun": "4.0.0-beta.105", "@smthrs/agents": "0.35.0", "@smthrs/components": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/react-reconciler": "0.35.0", "@smthrs/sandbox": "0.35.0", "@smthrs/scheduler": "0.35.0", "@smthrs/scorers": "0.35.0", "@smthrs/time-travel": "0.35.0", "@smthrs/tool-context": "0.35.0", "@smthrs/vcs": "0.35.0", "ai": "^7.0.10", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "react": "^19.2.7", "react-dom": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "^0.5.4", "@electric-sql/pglite-socket": "^0.2.6", "pg": "^8.22.0" } }, "sha512-EC/1OMVeP+7WJrom5Lj6aqrVnRYWEe+PBscQrx/GWPaV85ifk8te46YX6E0jHIEeuLq/SRh389I8zkbHUptvuw=="],
 
-    "@smthrs/errors": ["@smthrs/errors@0.34.0", "", { "dependencies": { "effect": "4.0.0-beta.105" } }, "sha512-Eesq9jUfEmL89xxoatln9tGiKQcBcUPHE55WB4osnJSTTs0obaNxNm9U4v/4rU9xnvJjqLmtDMDW/6HDV5+hjQ=="],
+    "@smthrs/errors": ["@smthrs/errors@0.35.0", "", { "dependencies": { "effect": "4.0.0-beta.105" } }, "sha512-zz4vKYSe+owdhki1ZOvsE1GRglm+sPV5jVmr+YtWs2SAZGhSHCyXw1uPCwacQyZDQIcDG8C3sd9zwByY3qFJAQ=="],
 
-    "@smthrs/gateway": ["@smthrs/gateway@0.34.0", "", { "dependencies": { "@smthrs/protocol": "0.34.0" } }, "sha512-XsL+oJzzuk0FlxqGJu2FVgWUfgAhnbupgxi8NBeTsx3+nVgpjWQbewbYdt6/8T+g8zuPBcgqiYOabK7aFDPRDA=="],
+    "@smthrs/gateway": ["@smthrs/gateway@0.35.0", "", { "dependencies": { "@smthrs/protocol": "0.35.0" } }, "sha512-lQ/YOVMHYN4qG0oR5DhTRYE8/aK+XPos4++0037ZuQi5m9KGLp5Qclxcmt2hUyEQBZfXGXEsophQTtPDKzzFAg=="],
 
-    "@smthrs/gateway-client": ["@smthrs/gateway-client@0.34.0", "", { "dependencies": { "@smthrs/electric-proxy": "^0.34.0", "@smthrs/gateway": "0.34.0", "@smthrs/protocol": "0.34.0", "@smthrs/usage": "0.34.0", "@tanstack/db": "0.6.13", "@tanstack/electric-db-collection": "0.3.11", "@tanstack/query-db-collection": "1.0.45", "@tanstack/react-query": "5.101.2" } }, "sha512-pmcEer2WwAo2ebZdj54bYEnQpaeIkGh7EvAYDfm4LzpulTuRVbhAShIH+CRldKVUpBbjUg4jme+RoIhRlgq28g=="],
+    "@smthrs/gateway-client": ["@smthrs/gateway-client@0.35.0", "", { "dependencies": { "@smthrs/electric-proxy": "^0.35.0", "@smthrs/gateway": "0.35.0", "@smthrs/protocol": "0.35.0", "@smthrs/usage": "0.35.0", "@tanstack/db": "0.6.13", "@tanstack/electric-db-collection": "0.3.11", "@tanstack/query-db-collection": "1.0.45", "@tanstack/react-query": "5.101.2" } }, "sha512-1GW6lMwjRVsXFOxtb9CEw18l6SzwFtaJOfhjk9IdOubVpZw2R3PoVCmYuhUh9NOjLJUeQc5mhi0iuyrqs5QQOg=="],
 
-    "@smthrs/gateway-react": ["@smthrs/gateway-react@0.34.0", "", { "dependencies": { "@smthrs/gateway-client": "0.34.0", "@tanstack/react-db": "0.1.91", "@tanstack/react-query": "5.101.2", "effect": "4.0.0-beta.105" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-ZyEzjVwWQK8xFFVInjloBW1ZOfFvepr1G332WvEMchdK1KKW5MHa1jl6buwKmxkbrkF8WEFMGM07YSVdKOlnzw=="],
+    "@smthrs/gateway-react": ["@smthrs/gateway-react@0.35.0", "", { "dependencies": { "@smthrs/gateway-client": "0.35.0", "@tanstack/react-db": "0.1.91", "@tanstack/react-query": "5.101.2", "effect": "4.0.0-beta.105" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-BCz7l3SUFfPz6JEeATnOrypQ0G8+sO5IHCEkwk77s/3OCa0bN+MvWWOXLNkR7UXKZEOom93sq8DrKDzu3GqZiA=="],
 
-    "@smthrs/gateway-ui": ["@smthrs/gateway-ui@0.34.0", "", { "dependencies": { "@smthrs/gateway-client": "0.34.0", "@smthrs/gateway-react": "0.34.0", "@smthrs/ui": "0.34.0", "@smthrs/ui-styleguide": "0.34.0", "@xyflow/react": "^12.10.2", "dagre": "^0.8.5" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-RHUifX7sOdzxM5V/2zmeq1UK9fO2fax5i2ebjlkYt3jDuRmzeiq2WazeW0d1CfdwJ1ovMWxicJYzuNRVyseYXw=="],
+    "@smthrs/gateway-ui": ["@smthrs/gateway-ui@0.35.0", "", { "dependencies": { "@smthrs/gateway-client": "0.35.0", "@smthrs/gateway-react": "0.35.0", "@smthrs/ui": "0.35.0", "@smthrs/ui-styleguide": "0.35.0", "@xyflow/react": "^12.10.2", "dagre": "^0.8.5" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-/LNcivh0q+CZUMeT8ABEzixdl6FdoHCxIR0QWsavobYH0EAAnckvveEilo952mm6ee1XpyDUTutVydkvnMA75Q=="],
 
-    "@smthrs/gcp": ["@smthrs/gcp@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/sandbox": "0.34.0" }, "peerDependencies": { "@google-cloud/run": "^2.0.0", "@google-cloud/storage": "^7.0.0" }, "optionalPeers": ["@google-cloud/run", "@google-cloud/storage"] }, "sha512-Av6zB5/opsgggnC94NB6RagHuq9dQYykWjWrzRfvwfmZsAShPPQwoROppkRzl3UAgi6NUxKvD7Gc8lKxayjPjg=="],
+    "@smthrs/gcp": ["@smthrs/gcp@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/sandbox": "0.35.0" }, "peerDependencies": { "@google-cloud/run": "^2.0.0", "@google-cloud/storage": "^7.0.0" }, "optionalPeers": ["@google-cloud/run", "@google-cloud/storage"] }, "sha512-mYZPH6pK/pauL7NE97N+7K5gkFLsW/hNHRvd9PMxG6MpMgw9n3tTY/z4dPT31uQ0CwV58/JELnWrpp/3KR3RBw=="],
 
-    "@smthrs/graph": ["@smthrs/graph@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-yPByKTXEn2PnzoUBYxK0gHrDl3dQLO52QIFAmUJHel45MkJTACUT9htT0hthPaPv1OVUjYx2ykPgo1wE6ZuaWQ=="],
+    "@smthrs/graph": ["@smthrs/graph@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "drizzle-orm": "^0.45.2", "zod": "^4.4.3" } }, "sha512-y2xBi9HXzZLpD0hyhEiumTCHoEA1KeRunpaLw9FALotMzqNGxKDtIbm00h5MzkC1BT0a1cx1t4+aS6iTmEbpnA=="],
 
-    "@smthrs/herdr": ["@smthrs/herdr@0.34.0", "", {}, "sha512-zhjf/taAo5Bga4YgyMnV1qFK5gwg+EpOpGjTUkupCfFhhcQ6xFz+aWNhpPf7jvjmMzVtuwdumOZvRZg94jdwgw=="],
+    "@smthrs/herdr": ["@smthrs/herdr@0.35.0", "", {}, "sha512-1yxYBB/5yhUdUz58EktfhvOgiVZtSq8tc54RBj8ynJMcCQIhOl6RMDcm/1kF0hxWy7oyr9Z4S9gaBT9KbJixcg=="],
 
-    "@smthrs/integrations": ["@smthrs/integrations@0.34.0", "", { "dependencies": { "@smthrs/components": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/engine": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/react-reconciler": "0.34.0", "@smthrs/scheduler": "0.34.0", "effect": "4.0.0-beta.105", "react": "^19.2.7", "zod": "4.4.3" } }, "sha512-Xxm+q2M6pQD9xs5yMl1mNiPv6kBK6/0a+3/vcl5nQ3C/DZDYmCbVjUMKKdMwh2hPIBORqciaTJKWn8yZW5eH2Q=="],
+    "@smthrs/integrations": ["@smthrs/integrations@0.35.0", "", { "dependencies": { "@smthrs/components": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/engine": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/react-reconciler": "0.35.0", "@smthrs/scheduler": "0.35.0", "effect": "4.0.0-beta.105", "react": "^19.2.7", "zod": "4.4.3" } }, "sha512-Rla3RlIw/quW8H35G3d7B58y78pXYAKCo98EfSKZTAskwA3kLS48XQ69DqZzdB6TK99PI5HBCTIqFzngVr3NGA=="],
 
-    "@smthrs/jj-darwin-arm64": ["@smthrs/jj-darwin-arm64@0.34.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-pE8B8yiQ1C9CJs7O1NdjwN6+z3sz1GAW4gmuOf0/NP1uMuhsxLhoXfdKeqQllcAnUJtZ8BkE5Jqk1LoL4iTQxg=="],
+    "@smthrs/jj-darwin-arm64": ["@smthrs/jj-darwin-arm64@0.35.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-f9PLOekMu34+1Ek35eczlH7WbNQrznl0YH2aOt9Xtjqxb9Jr4JVYZuX6VDZ8Rn0EiIyyNNc5LJtMc9ZrpCsxSA=="],
 
-    "@smthrs/jj-darwin-x64": ["@smthrs/jj-darwin-x64@0.34.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-RX6X+xSj6FxSLAz8S/h61Xs7cgdlnlmLglbTGRWNK8SPtMtZsvgQyHY/1gkjEyfoyj9uQvtuDhGEBQG124fzjg=="],
+    "@smthrs/jj-darwin-x64": ["@smthrs/jj-darwin-x64@0.35.0", "", { "os": "darwin", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-UjL8+4W3hI8TOxBrcw7tBRLYpXsfBFwZ53wzgl5C1W13V3S08aBj+yCHZB8S1jAGMBvHbqIfuJ+Gyc7ge97nUQ=="],
 
-    "@smthrs/jj-linux-arm64": ["@smthrs/jj-linux-arm64@0.34.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-fCP3o0ov2tcGnYiPejkYgCwKN/xQ1+47iDgTAqTL7BtegjRvNJThx09K+5LFWOwElukXjdTYsqQY0ihnoXPPRw=="],
+    "@smthrs/jj-linux-arm64": ["@smthrs/jj-linux-arm64@0.35.0", "", { "os": "linux", "cpu": "arm64", "bin": { "jj": "bin/jj" } }, "sha512-AMfXNLTV4eqXz1E7VGLr5ihJZK1zW+aU1XWnWGZ2cErjrTpRJSKL4ewUH5Lox5yv72MoA+wjzJhyXFjC701Wig=="],
 
-    "@smthrs/jj-linux-x64": ["@smthrs/jj-linux-x64@0.34.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-YNU7taTmzSDqwlqSqu0RVzkgXQbeSxxNkImUbfHzVUBnuE9Jz+BoX9rNvPuXzmDYJBVB2eSAhg9IDHAceAYsdg=="],
+    "@smthrs/jj-linux-x64": ["@smthrs/jj-linux-x64@0.35.0", "", { "os": "linux", "cpu": "x64", "bin": { "jj": "bin/jj" } }, "sha512-o2uDqBuyKBB4pFm18nlkuBozoHOr0Smdo3J21qx8GmsVuakBjYsjZWBuJwn4N+Pw5uGxlkhSf9GzdiyPLpJS3g=="],
 
-    "@smthrs/jj-win32-x64": ["@smthrs/jj-win32-x64@0.34.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-9EIPQoZ1BV8JledMetGFmA4iagX4dtFM8hEkV993qIn22Vuu2G8h6yTMpV+S9UUiIYSz4/yg+oDkyL27P6w1TA=="],
+    "@smthrs/jj-win32-x64": ["@smthrs/jj-win32-x64@0.35.0", "", { "os": "win32", "cpu": "x64", "bin": { "jj": "bin/jj.exe" } }, "sha512-nr4oN01/ZiNaFzEKJfotvNCefDQETD3N3LL/QNJItiutHux7JqXO/1hIroUJk3DsX/sg4LoS1hLKBvWKX9jeqQ=="],
 
-    "@smthrs/memory": ["@smthrs/memory@0.34.0", "", { "dependencies": { "@smthrs/db": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/scheduler": "0.34.0", "@vectorize-io/hindsight-client": "0.8.4", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "zod": "^4.4.3" } }, "sha512-3rirGbJmaJOg2wtzVW4m12iUe1DT0hndJ8pVhZJgdgFyC/bCqLIQgEWrTV6Sr+gO3DkrxFPrN2DjtcXVzs7RkA=="],
+    "@smthrs/memory": ["@smthrs/memory@0.35.0", "", { "dependencies": { "@smthrs/db": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/scheduler": "0.35.0", "@vectorize-io/hindsight-client": "0.8.4", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "zod": "^4.4.3" } }, "sha512-B3B1NWmuK3Q5cegSPBk/1Uj7T7IrLhZgZ7qFvQAqy+ZDDHSgKI4pDeJMG6rsBTubQr60/dr/XXgjQzFBHo1aMw=="],
 
-    "@smthrs/microsandbox": ["@smthrs/microsandbox@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/sandbox": "0.34.0" }, "peerDependencies": { "microsandbox": "0.6.6" }, "optionalPeers": ["microsandbox"] }, "sha512-j1+KPR6zEQ0TiVwX/mMpRSwox+LR8Srz2Fxscqfw7uL9dwJubuazwe1DpOP82xqXzqZwS38oyo2NCH/RP9GrkQ=="],
+    "@smthrs/microsandbox": ["@smthrs/microsandbox@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/sandbox": "0.35.0" }, "peerDependencies": { "microsandbox": "0.6.6" }, "optionalPeers": ["microsandbox"] }, "sha512-dkax/HBVPo+cBH2mSUWGrBBV0nJJNjPkQO64wdjf2dynTFpoWHHCiSBRCmCRSXrB5SewehqqcOqX6LhBPfq2WQ=="],
 
-    "@smthrs/observability": ["@smthrs/observability@0.34.0", "", { "dependencies": { "@effect/opentelemetry": "4.0.0-beta.105", "@effect/platform-bun": "4.0.0-beta.105", "@effect/platform-node-shared": "4.0.0-beta.105", "effect": "4.0.0-beta.105" } }, "sha512-t5udSPtCyQy7HBC9ua6tFulQaocvvCOjzARWB9THuc8XU8Bsb1C68AZGSUMBjwZhWVgOvOJUKTGg3qC2z5E9ng=="],
+    "@smthrs/observability": ["@smthrs/observability@0.35.0", "", { "dependencies": { "@effect/opentelemetry": "4.0.0-beta.105", "@effect/platform-bun": "4.0.0-beta.105", "@effect/platform-node-shared": "4.0.0-beta.105", "effect": "4.0.0-beta.105" } }, "sha512-P1aBJXkkx8VAGQzcwaXVUle8c8zRiM7oLnGCOMa7zc11w1JcMJLxWBRSOmx5B7aaZic2No0wnYQpqfIOJvgXKQ=="],
 
-    "@smthrs/openapi": ["@smthrs/openapi@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/scheduler": "0.34.0", "ai": "^7.0.10", "effect": "4.0.0-beta.105", "yaml": "^2.9.0", "zod": "^4.4.3" } }, "sha512-Mco3q9qAKRboudupzd9eXg63yLQl5V0TRIEj0K9DYjppoYuu+9Xxg/VGppYjvy9TH/DKaz0MDrdSlpZ+amzBaw=="],
+    "@smthrs/openapi": ["@smthrs/openapi@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/scheduler": "0.35.0", "ai": "^7.0.10", "effect": "4.0.0-beta.105", "yaml": "^2.9.0", "zod": "^4.4.3" } }, "sha512-y67bkR0byVoZRBsGgBs1TzaLGnD6T25Oa3RtFmBLl/2q4VPTnAmUZEJD2jWWBYIU3ojIlLpx8RsVeFG0hI6DHQ=="],
 
-    "@smthrs/protocol": ["@smthrs/protocol@0.34.0", "", {}, "sha512-UeYL9fEgnGg9UElkluo2Fp07ewRfDQlCnIlBwT08pwNL0GDhJqhPNPqyTH0OcG3uei99U2JDmgXF+/l8+poNug=="],
+    "@smthrs/protocol": ["@smthrs/protocol@0.35.0", "", {}, "sha512-ZnPCjhsHS1Vq/XQ9xnEjOkwnhcvHrqKXuiym0giW8nmmyKuJ5HrHaTR2RNnh3EMkeZjmsiy58hVYc/e8Ny7IzQ=="],
 
-    "@smthrs/react-reconciler": ["@smthrs/react-reconciler@0.34.0", "", { "dependencies": { "@smthrs/devtools": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-UiLP59M3WyR/jRq/5Q1ZSaBqgW49YqHSXElP7hXbumOnxarPnAYRRFRqB5CZkwPxxik1euRP9omcivW4GYkBtw=="],
+    "@smthrs/react-reconciler": ["@smthrs/react-reconciler@0.35.0", "", { "dependencies": { "@smthrs/devtools": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "bippy": "^0.5.42", "react": "^19.2.7", "react-reconciler": "^0.33.0" } }, "sha512-h4Ypn3AU10N+nhnJkWuCkuK+M5nQOJ5ELEZX6xqR1JsdkA4xCmr/nhO4dE2vUDQZBjy0NjmIUeelOHjEA7c1Zw=="],
 
-    "@smthrs/review": ["@smthrs/review@0.34.0", "", { "dependencies": { "@pierre/diffs": "^1.2.12", "@smthrs/agents": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/engine": "0.34.0", "@smthrs/ui-styleguide": "0.34.0", "effect": "4.0.0-beta.105", "mermaid": "^11.16.0", "smthrs": "0.34.0", "zod": "^4.4.3" }, "bin": { "smithers-review": "src/cli/main.ts" } }, "sha512-cO+d+JLPJTinRbDJ1R8p77xrdStmuHf6JRVXnd5J/AT/ooHSstPfKywqJcnRxCzliN+2P+RmCu3Rv1FZ3RqYWg=="],
+    "@smthrs/sandbox": ["@smthrs/sandbox@0.35.0", "", { "dependencies": { "@smthrs/db": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/scheduler": "0.35.0", "effect": "4.0.0-beta.105" } }, "sha512-argumlrS6tPkTL4DksCWnoXG/jyBJBKKMiFM/9fP2SQc8DfgzAveGCSwEZv++Nd+qfGQK0BDkw1+cwBb2o26ng=="],
 
-    "@smthrs/sandbox": ["@smthrs/sandbox@0.34.0", "", { "dependencies": { "@smthrs/db": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/scheduler": "0.34.0", "effect": "4.0.0-beta.105" } }, "sha512-Actg0eNEpbEukrChtgSqpHOBRJtCzCW8b8Tt+DM/3wQQCI8jLw6o/aRj5fT54yT7NPejz2RMiNqSqcrh6SJ01w=="],
+    "@smthrs/scheduler": ["@smthrs/scheduler@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "effect": "4.0.0-beta.105" } }, "sha512-z/knMgIYlYO5HRvw+ao1tIsTRLMUrio9I0aK9i2WTgcuKUwdUY1VCZuQ1I+mMANGuOn07+eh4FnEAIIentJjEQ=="],
 
-    "@smthrs/scheduler": ["@smthrs/scheduler@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "effect": "4.0.0-beta.105" } }, "sha512-L9tlNfiVvER7sEFw14Bt7ykrP5UPPK+ZeYxa/i5HwtteuwlwC6Q1sJMbnHExezZS+DXJW7LhAq2Oxkt5a5spfA=="],
+    "@smthrs/scorers": ["@smthrs/scorers@0.35.0", "", { "dependencies": { "@smthrs/agents": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/scheduler": "0.35.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "typescript": "~6.0.3", "zod": "^4.4.3" } }, "sha512-ntKOkE4RjXlr6lJ7c2SFrNu9bClpmvo4sFWl2bdJLj5aZGVif+oG+lMM5LStypNwsvCW0LU+u8nG/f3ZzQaxfg=="],
 
-    "@smthrs/scorers": ["@smthrs/scorers@0.34.0", "", { "dependencies": { "@smthrs/agents": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/scheduler": "0.34.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "typescript": "~6.0.3", "zod": "^4.4.3" } }, "sha512-cnpgSmZqW83kHtEc+ZZ7n7g01ON9LATud6KOCHMSQvO2oW50FIUXZG7p2J50MWGvlPydUT0rSa3gf4c2L8zauw=="],
+    "@smthrs/server": ["@smthrs/server@0.35.0", "", { "dependencies": { "@smthrs/accounts": "0.35.0", "@smthrs/components": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/devtools": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/engine": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/gateway": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/integrations": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/protocol": "0.35.0", "@smthrs/scheduler": "0.35.0", "@smthrs/time-travel": "0.35.0", "@smthrs/ui-styleguide": "0.35.0", "@smthrs/usage": "0.35.0", "cron-parser": "^5.6.1", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "hono": "^4.12.27", "react": "^19.2.7", "react-dom": "^19.2.7", "ws": "^8.21.0" }, "peerDependencies": { "playwright": "^1.61.1" }, "optionalPeers": ["playwright"] }, "sha512-vroyr5ip12/PbnFLwvQiVpGxR5Vcg/TwJkNC2UMYlGT+a/I+bC3XpFJVOK9WZGZrfoTM2RUTZ2eunf0eIn05xw=="],
 
-    "@smthrs/server": ["@smthrs/server@0.34.0", "", { "dependencies": { "@smthrs/accounts": "0.34.0", "@smthrs/components": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/devtools": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/engine": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/gateway": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/integrations": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/protocol": "0.34.0", "@smthrs/scheduler": "0.34.0", "@smthrs/time-travel": "0.34.0", "@smthrs/ui-styleguide": "0.34.0", "@smthrs/usage": "0.34.0", "cron-parser": "^5.6.1", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "hono": "^4.12.27", "react": "^19.2.7", "react-dom": "^19.2.7", "ws": "^8.21.0" }, "peerDependencies": { "playwright": "^1.61.1" }, "optionalPeers": ["playwright"] }, "sha512-zN36QNxaTS60c6vLFNOokxKOD0Gh7QhrdwQNAniCFKBckV1uf//VDCBzkAJtt24AimMyRXJJ5vogSFOw6F0m4w=="],
+    "@smthrs/telegram": ["@smthrs/telegram@0.35.0", "", {}, "sha512-50Pc5nkkBAYWOAweSPOQExK2Jf9FnNpsA5K9SARzO0vAlcmThjPphpwh8sLGSK/6zBkwEr7gDvHtOC5V4LO43A=="],
 
-    "@smthrs/telegram": ["@smthrs/telegram@0.34.0", "", {}, "sha512-8h7uhgc9I7KVUaQxVInL9+tqfcjaI1wXDEuyQEuF2sDJrH1yikjiWl5TkA5hbXAeKKj5wYiQloEp8xM3w2E02A=="],
+    "@smthrs/testing": ["@smthrs/testing@0.35.0", "", { "dependencies": { "@smthrs/components": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/engine": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/herdr": "0.35.0", "@smthrs/react-reconciler": "0.35.0", "@smthrs/scheduler": "0.35.0", "effect": "4.0.0-beta.105", "zod": "^4.4.3" }, "peerDependencies": { "koffi": "^2.16.2", "smthrs": "^0.35.0" }, "optionalPeers": ["koffi", "smthrs"] }, "sha512-FRdpD1asSRU6XpAyqI1R+FO9GBiqCov/xJYPnIW+MbqOrhOGHKYbiUiwz5RNhT+H+rHH44BV0GSD7m35DNq2tw=="],
 
-    "@smthrs/testing": ["@smthrs/testing@0.34.0", "", { "dependencies": { "@smthrs/components": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/engine": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/herdr": "0.34.0", "@smthrs/react-reconciler": "0.34.0", "@smthrs/scheduler": "0.34.0", "effect": "4.0.0-beta.105", "zod": "^4.4.3" }, "peerDependencies": { "koffi": "^2.16.2", "smthrs": "^0.34.0" }, "optionalPeers": ["koffi", "smthrs"] }, "sha512-uHziGJ+YdPsngUgQqpZKQ8haeiLpX5UqETL0Ro7ul0reYorfrWC/xwQTWtjiSTX5KRaYMPWtSjtE3l61BGq4JA=="],
+    "@smthrs/time-travel": ["@smthrs/time-travel@0.35.0", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.105", "@effect/platform-node-shared": "4.0.0-beta.105", "@smthrs/db": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/react-reconciler": "0.35.0", "@smthrs/scheduler": "0.35.0", "@smthrs/vcs": "0.35.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "picocolors": "^1.1.1" } }, "sha512-SW72b2xIKs4TfW1X+JbQRoaa0HEsyZaK0gR7cvzsBh41u+zVphcQn2JruAuPopr8/wsCGsmI3uITyTCemlGsKQ=="],
 
-    "@smthrs/time-travel": ["@smthrs/time-travel@0.34.0", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.105", "@effect/platform-node-shared": "4.0.0-beta.105", "@smthrs/db": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/react-reconciler": "0.34.0", "@smthrs/scheduler": "0.34.0", "@smthrs/vcs": "0.34.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "picocolors": "^1.1.1" } }, "sha512-X70eifNjZXlAEs/+xvnocPgYaTUqkLkIMp1tzmGimKgD0B08Xq0O104Z4x6xUj4cpsGPB8/ErcpiFdxIYhBJJQ=="],
+    "@smthrs/tool-context": ["@smthrs/tool-context@0.35.0", "", { "dependencies": { "ai": "^7.0.10", "zod": "^4.4.3" } }, "sha512-uABOQIDMedNPtBilE75iwd/1Sk889Tp3RmKR1a/J/k0lYraqm7vv2y6PyWb15XGodmB1l3R+AeZuuKILcwMRJg=="],
 
-    "@smthrs/tool-context": ["@smthrs/tool-context@0.34.0", "", { "dependencies": { "ai": "^7.0.10", "zod": "^4.4.3" } }, "sha512-6yxgRN+PqI1Egae1gKHJ4QfragPLtJf6xTqNUCxDTLTjr2gOwqyt6vnv6A342u+/bzRWjRfbGqw6UTErKo98Mg=="],
+    "@smthrs/ui": ["@smthrs/ui@0.35.0", "", { "dependencies": { "@milkdown/crepe": "7.21.2", "@milkdown/kit": "7.21.2", "@milkdown/plugin-listener": "7.21.2", "@pierre/diffs": "^1.2.12", "@smthrs/ui-styleguide": "0.35.0", "@xterm/addon-fit": "^0.11.0", "@xterm/xterm": "^6.0.0", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "d3-force": "3.0.0", "radix-ui": "^1.6.1", "recharts": "^3.2.1" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-/Wtr2KyQGD7+7z3dT0K7/f8X9F+cl9BsjcEkINz4j0uX+IpXLhRqGsekDU4Hj5olrbtSG2CibFiE6IQUnxqt0w=="],
 
-    "@smthrs/tui": ["@smthrs/tui@0.34.0", "", { "dependencies": { "@opentui/core": "^0.4.2", "@opentui/react": "^0.4.2", "@smthrs/gateway-client": "0.34.0", "@smthrs/gateway-react": "0.34.0", "@smthrs/tui-ui": "0.34.0", "@smthrs/ui-core": "0.34.0", "react": "^19.2.7", "react-dom": "^19.2.7" }, "bin": { "smithers-mon": "src/index.tsx" } }, "sha512-G6793MCwduXBzkmAQ17jJwF2xHaRyiy1NojtSPnT1SsWpkEgn3j5BmTPYsWW+Cd7+x9djpAdoxxPsfTsNXwZIg=="],
+    "@smthrs/ui-styleguide": ["@smthrs/ui-styleguide@0.35.0", "", {}, "sha512-SAgI8zBddWSy1goPBSvlXhXf11mkrVe8VDLLjwVXlUQ4kjDB6zrVP2IoF6Z2Sc7w9yVcuiAV5O37LKFyyZpsig=="],
 
-    "@smthrs/tui-ui": ["@smthrs/tui-ui@0.34.0", "", { "dependencies": { "@opentui/core": "^0.4.2", "@opentui/react": "^0.4.2", "react": "^19.2.7" } }, "sha512-nIzyiPCOtC4Z3VCptXvaT1XZF1ExMxzAk8PbsHkgkimPnLUr2fs3FRwpP6X8WzeZ6CfBDvXmoBWmCN6s8GnKWA=="],
+    "@smthrs/usage": ["@smthrs/usage@0.35.0", "", { "dependencies": { "@smthrs/accounts": "0.35.0" } }, "sha512-CJjbjFzhz5w43/ZhJG1pIUSGC+AUwQVm5qyQWcx0dNd1JiQA9hQTbi6ZHRbUkRvwTAgOm2xpQHWmHgq/60wL5A=="],
 
-    "@smthrs/ui": ["@smthrs/ui@0.34.0", "", { "dependencies": { "@milkdown/crepe": "7.21.2", "@milkdown/kit": "7.21.2", "@milkdown/plugin-listener": "7.21.2", "@pierre/diffs": "^1.2.12", "@smthrs/ui-styleguide": "0.34.0", "@xterm/addon-fit": "^0.11.0", "@xterm/xterm": "^6.0.0", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "d3-force": "3.0.0", "radix-ui": "^1.6.1", "recharts": "^3.2.1" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-HfBtKSpg+AbL3Yjl4Ht+diA4yAEYyyCSKUXu2tI4WmPl2U68ieQTH1g/I7606K4W5ipxa9J45xOBYYH2IO3Pxw=="],
+    "@smthrs/vcs": ["@smthrs/vcs@0.35.0", "", { "dependencies": { "@effect/platform-node-shared": "4.0.0-beta.105", "@smthrs/observability": "0.35.0", "effect": "4.0.0-beta.105" }, "optionalDependencies": { "@smthrs/jj-darwin-arm64": "0.35.0", "@smthrs/jj-darwin-x64": "0.35.0", "@smthrs/jj-linux-arm64": "0.35.0", "@smthrs/jj-linux-x64": "0.35.0", "@smthrs/jj-win32-x64": "0.35.0" } }, "sha512-HG9oRP4H75qDuCzhLE+bWki3rDh2hiG3xHrmlht70dxabe9jb/n8s5HSLLm7Dq3ipyHkWBaBECfE6kfo/33S0A=="],
 
-    "@smthrs/ui-core": ["@smthrs/ui-core@0.34.0", "", { "dependencies": { "@smthrs/gateway-client": "0.34.0", "@smthrs/gateway-react": "0.34.0", "zustand": "^5.0.13" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-LugZhMZ87A4PuZHo8hMvHY/S/JzTpudvppjqZ5EOQdlEoJnN1A89SEG9l3qHUK37gFOE2fi6HTh1ZJ1DBLM4mQ=="],
+    "@smthrs/vercel": ["@smthrs/vercel@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/sandbox": "0.35.0" }, "peerDependencies": { "@vercel/sandbox": "^2.0.0" }, "optionalPeers": ["@vercel/sandbox"] }, "sha512-lEXEFwGtyYN7Ct8Owc9FX1qTcb3kpGp5bRqgQNZE81hqDKVYeAvo+obxf7ZQH2WA/YrIiWBgNjSAsrWK0c/UMA=="],
 
-    "@smthrs/ui-styleguide": ["@smthrs/ui-styleguide@0.34.0", "", {}, "sha512-syuZ7ojCB4DvWRP/JkOZ1sqFEbXNpPdjNmJFqLLiz39DWa7sS8km7piFpMmwjiv2S4FShkT9Gj9CXhBj00DIgQ=="],
-
-    "@smthrs/usage": ["@smthrs/usage@0.34.0", "", { "dependencies": { "@smthrs/accounts": "0.34.0" } }, "sha512-C0wGkFBypKyvhv9MquyGPq5UDWE+PLD0TkUp9e0HaljIJvCyv73fWu64LM2cUOSZoZs9u9c7lwUER3tQeN6Bdw=="],
-
-    "@smthrs/vcs": ["@smthrs/vcs@0.34.0", "", { "dependencies": { "@effect/platform-node-shared": "4.0.0-beta.105", "@smthrs/observability": "0.34.0", "effect": "4.0.0-beta.105" }, "optionalDependencies": { "@smthrs/jj-darwin-arm64": "0.34.0", "@smthrs/jj-darwin-x64": "0.34.0", "@smthrs/jj-linux-arm64": "0.34.0", "@smthrs/jj-linux-x64": "0.34.0", "@smthrs/jj-win32-x64": "0.34.0" } }, "sha512-AY0hHYf/dlYD/TNqOBeRCi9GyJhgIM3PFJZNBG+s5RAsKtgLlifrzl9Tctvr3Ud6diZxKz0k1FL5TlmGzoAfkg=="],
-
-    "@smthrs/vercel": ["@smthrs/vercel@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/sandbox": "0.34.0" }, "peerDependencies": { "@vercel/sandbox": "^2.0.0" }, "optionalPeers": ["@vercel/sandbox"] }, "sha512-RqM62AZR0Tmo6qNZG4kzTTdB08N2nSzWbz3Sea0kIPnIuTOfzxM+2aD0lzvMpRIClCXpKCfSifqeMBvIsbgOSA=="],
-
-    "@smthrs/xstate": ["@smthrs/xstate@0.34.0", "", { "dependencies": { "@smthrs/errors": "0.34.0", "@smthrs/react-reconciler": "0.34.0", "react": "^19.2.7" }, "peerDependencies": { "xstate": "^5.19.0" }, "optionalPeers": ["xstate"] }, "sha512-ZCPl9GqdnnW+BiYF+jb8cAd2OW/p0jnu2IKNhaRp4511UdtRWLue1gmF4QjrCDgqRl91v+kd/3gIw6upuS08Gg=="],
+    "@smthrs/xstate": ["@smthrs/xstate@0.35.0", "", { "dependencies": { "@smthrs/errors": "0.35.0", "@smthrs/react-reconciler": "0.35.0", "react": "^19.2.7" }, "peerDependencies": { "xstate": "^5.19.0" }, "optionalPeers": ["xstate"] }, "sha512-Rm3hX17W88UU0Jod1zgyiTkXE716qtlCM10naa6DC2VvWY5l5CdsL9Yqx99FyRqhjtcdUoC4liP6p3a/wn2BMw=="],
 
     "@snazzah/davey": ["@snazzah/davey@0.1.12", "", { "optionalDependencies": { "@snazzah/davey-android-arm-eabi": "0.1.12", "@snazzah/davey-android-arm64": "0.1.12", "@snazzah/davey-darwin-arm64": "0.1.12", "@snazzah/davey-darwin-x64": "0.1.12", "@snazzah/davey-freebsd-x64": "0.1.12", "@snazzah/davey-linux-arm-gnueabihf": "0.1.12", "@snazzah/davey-linux-arm64-gnu": "0.1.12", "@snazzah/davey-linux-arm64-musl": "0.1.12", "@snazzah/davey-linux-x64-gnu": "0.1.12", "@snazzah/davey-linux-x64-musl": "0.1.12", "@snazzah/davey-wasm32-wasi": "0.1.12", "@snazzah/davey-win32-arm64-msvc": "0.1.12", "@snazzah/davey-win32-ia32-msvc": "0.1.12", "@snazzah/davey-win32-x64-msvc": "0.1.12" } }, "sha512-V+NlX5931RwVamZhhEfZekMdcvXDKdMAmHW1AuGaykVQsNyBOq3bpmGpoKRBDCYgFWKIufJ0Dcg3m4cYhvUy6g=="],
 
@@ -6238,61 +6198,25 @@
 
     "@types/cross-spawn": ["@types/cross-spawn@6.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA=="],
 
-    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
-
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
-
-    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
-
-    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
-
-    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
 
     "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
 
-    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
-
-    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
-
-    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
-
     "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
 
-    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
-
     "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
-
-    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
-
-    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
-
-    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
-
-    "@types/d3-geo": ["@types/d3-geo@3.1.1", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w=="],
-
-    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
 
     "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
 
     "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
 
-    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
-
-    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
-
-    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
-
     "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
-
-    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
 
     "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
 
     "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
 
     "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
-
-    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
 
     "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
@@ -6321,8 +6245,6 @@
     "@types/fluent-ffmpeg": ["@types/fluent-ffmpeg@2.1.28", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ovxsDwBcPfJ+eYs1I/ZpcYCnkce7pvH9AHSvrZllAp1ZPpTRDZAFjF3TRFbukxSgIYTTNYePbS0rKUmaxVbXw=="],
 
     "@types/fs-extra": ["@types/fs-extra@8.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ=="],
-
-    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hashring": ["@types/hashring@3.2.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-Y80Bt3Y9Z6erq9bGvwbxLD8z0XGLxK41XXeAJtaX4BbVUvStqhfGjKtXNVNISfBVxE/hndVw6aQ3EdOIVcwIFg=="],
 
@@ -6533,8 +6455,6 @@
     "@uniswap/v3-sdk": ["@uniswap/v3-sdk@3.30.0", "", { "dependencies": { "@ethersproject/abi": "^5.5.0", "@ethersproject/abstract-signer": "^5.7.0", "@ethersproject/address": "^5.0.2", "@ethersproject/solidity": "^5.0.9", "@uniswap/sdk-core": "^7.13.0", "@uniswap/swap-router-contracts": "^1.3.0", "@uniswap/v3-periphery": "^1.1.1", "@uniswap/v3-staker": "1.0.0", "jsbi": "^3.1.4", "tiny-invariant": "^1.1.0", "tiny-warning": "^1.0.3", "tslib": "^2.3.0" } }, "sha512-3AMxJigAiUVguYupzaVLTN9Myx8sbWOqOtod8JBtrbYQ9PImqpMmscpMSbeICoEfeUa0QiY9Me0r9CYcNjBwIA=="],
 
     "@uniswap/v3-staker": ["@uniswap/v3-staker@1.0.0", "", { "dependencies": { "@openzeppelin/contracts": "3.4.1-solc-0.7-2", "@uniswap/v3-core": "1.0.0", "@uniswap/v3-periphery": "^1.0.1" } }, "sha512-JV0Qc46Px5alvg6YWd+UIaGH9lDuYG/Js7ngxPit1SPaIP30AlVer1UYB7BRYeUVVxE+byUyIeN5jeQ7LLDjIw=="],
-
-    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@upstash/redis": ["@upstash/redis@1.38.2", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-RZ+JaRCVIS+ZTGnjOnDMr+/0aqDxsBb5rV6aW+Pys4SGELwr5lwE3UbLHRCHqMQ5Ulxj0b/CFBHfbmE175Otog=="],
 
@@ -7030,8 +6950,6 @@
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.2.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg=="],
-
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
@@ -7236,8 +7154,6 @@
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
-    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
-
     "cosmiconfig": ["cosmiconfig@9.0.0", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg=="],
 
     "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
@@ -7280,63 +7196,29 @@
 
     "curve25519-js": ["curve25519-js@0.0.4", "", {}, "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w=="],
 
-    "cytoscape": ["cytoscape@3.34.1", "", {}, "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g=="],
-
-    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
-
-    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
-
     "d": ["d@1.0.2", "", { "dependencies": { "es5-ext": "^0.10.64", "type": "^2.7.2" } }, "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw=="],
-
-    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
 
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 
-    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
-
-    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
-
-    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
-
     "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
-
-    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
-
-    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
 
     "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
 
     "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
 
-    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
-
     "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
-
-    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
 
     "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
 
     "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
 
-    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
-
-    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
-
     "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
 
     "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
 
-    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
-
     "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
 
-    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
-
-    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
-
     "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
-
-    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
 
     "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
 
@@ -7353,8 +7235,6 @@
     "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
     "dagre": ["dagre@0.8.5", "", { "dependencies": { "graphlib": "^2.1.8", "lodash": "^4.17.15" } }, "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw=="],
-
-    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
 
     "dargs": ["dargs@7.0.0", "", {}, "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg=="],
 
@@ -7413,8 +7293,6 @@
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
-
-    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "delay": ["delay@5.0.0", "", {}, "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="],
 
@@ -7950,8 +7828,6 @@
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
 
-    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
-
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "hardhat": ["hardhat@2.29.0", "", { "dependencies": { "@ethereumjs/util": "^9.1.0", "@ethersproject/abi": "^5.1.2", "@nomicfoundation/edr": "0.12.0-next.23", "@nomicfoundation/solidity-analyzer": "^0.1.0", "@sentry/node": "^5.18.1", "adm-zip": "^0.4.16", "aggregate-error": "^3.0.0", "ansi-escapes": "^4.3.0", "boxen": "^5.1.2", "chokidar": "^4.0.0", "ci-info": "^2.0.0", "debug": "^4.1.1", "enquirer": "^2.3.0", "env-paths": "^2.2.0", "ethereum-cryptography": "^1.0.3", "find-up": "^5.0.0", "fp-ts": "1.19.3", "fs-extra": "^7.0.1", "immutable": "^4.0.0-rc.12", "io-ts": "1.10.4", "json-stream-stringify": "^3.1.4", "keccak": "^3.0.2", "lodash": "^4.17.11", "micro-eth-signer": "^0.14.0", "mnemonist": "^0.38.0", "mocha": "^11.1.0", "p-map": "^4.0.0", "picocolors": "^1.1.0", "raw-body": "^2.4.1", "resolve": "1.17.0", "semver": "^6.3.0", "solc": "0.8.26", "source-map-support": "^0.5.13", "stacktrace-parser": "^0.1.10", "tinyglobby": "^0.2.6", "tsort": "0.0.1", "undici": "^5.14.0", "uuid": "^8.3.2", "ws": "^7.4.6" }, "peerDependencies": { "ts-node": "*", "typescript": "*" }, "optionalPeers": ["ts-node", "typescript"], "bin": { "hardhat": "internal/cli/bootstrap.js" } }, "sha512-tsj5mCSjDCFOhGfBl4vwqDEcwdlES9VUzRWfdrwvEVhus6D8W6u+WfUKRLLwFhKGS/8lKPoXGsjYWPXl3CCpOg=="],
@@ -8069,8 +7945,6 @@
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "import-local": ["import-local@3.1.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg=="],
-
-    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -8334,8 +8208,6 @@
 
     "keyvaluestorage-interface": ["keyvaluestorage-interface@1.0.0", "", {}, "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="],
 
-    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
-
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
@@ -8349,8 +8221,6 @@
     "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
 
     "latest-version": ["latest-version@9.0.0", "", { "dependencies": { "package-json": "^10.0.0" } }, "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA=="],
-
-    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
 
@@ -8603,8 +8473,6 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
 
@@ -8974,8 +8842,6 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
-    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
-
     "pacote": ["pacote@21.0.1", "", { "dependencies": { "@npmcli/git": "^6.0.0", "@npmcli/installed-package-contents": "^3.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^8.0.0", "@npmcli/run-script": "^10.0.0", "cacache": "^20.0.0", "fs-minipass": "^3.0.0", "minipass": "^7.0.2", "npm-package-arg": "^13.0.0", "npm-packlist": "^10.0.1", "npm-pick-manifest": "^10.0.0", "npm-registry-fetch": "^19.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "sigstore": "^4.0.0", "ssri": "^12.0.0", "tar": "^7.4.3" }, "bin": { "pacote": "bin/index.js" } }, "sha512-LHGIUQUrcDIJUej53KJz1BPvUuHrItrR2yrnN0Kl9657cJ0ZT6QJHk9wWPBnQZhYT5KLyZWrk9jaYc2aKDu4yw=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
@@ -9015,8 +8881,6 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
-    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -9103,10 +8967,6 @@
     "png-to-ico": ["png-to-ico@2.1.8", "", { "dependencies": { "@types/node": "^17.0.36", "minimist": "^1.2.6", "pngjs": "^6.0.0" }, "bin": { "png-to-ico": "bin/cli.js" } }, "sha512-Nf+IIn/cZ/DIZVdGveJp86NG5uNib1ZXMiDd/8x32HCTeKSvgpyg6D/6tUBn1QO/zybzoMK0/mc3QRgAyXdv9w=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
-
-    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
-
-    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "pony-cause": ["pony-cause@2.1.11", "", {}, "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg=="],
 
@@ -9432,8 +9292,6 @@
 
     "robot3": ["robot3@0.4.1", "", {}, "sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ=="],
 
-    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
-
     "rolldown": ["rolldown@1.2.4", "", { "dependencies": { "@oxc-project/types": "=0.144.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.4", "@rolldown/binding-darwin-arm64": "1.2.4", "@rolldown/binding-darwin-x64": "1.2.4", "@rolldown/binding-freebsd-x64": "1.2.4", "@rolldown/binding-linux-arm-gnueabihf": "1.2.4", "@rolldown/binding-linux-arm64-gnu": "1.2.4", "@rolldown/binding-linux-arm64-musl": "1.2.4", "@rolldown/binding-linux-ppc64-gnu": "1.2.4", "@rolldown/binding-linux-s390x-gnu": "1.2.4", "@rolldown/binding-linux-x64-gnu": "1.2.4", "@rolldown/binding-linux-x64-musl": "1.2.4", "@rolldown/binding-openharmony-arm64": "1.2.4", "@rolldown/binding-win32-arm64-msvc": "1.2.4", "@rolldown/binding-win32-x64-msvc": "1.2.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w=="],
 
     "rollup": ["@rollup/wasm-node@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-GJFM5d4k5dSoY/oyILsKArplGvkss1DOURyXsl6IEM/X9RV3bQwqu9GY6tYfA97ZwIejfAguHa9fo1pGOQcyDg=="],
@@ -9441,8 +9299,6 @@
     "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.1.1", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.5", "source-map": "^0.8.0", "yargs": "^18.1.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-ThaGiHTU8XW02OkK80TrTHATraJmM9OAduU4otal+7gyXLpYEtmGBLfx5kW+EHvvLwn03YGW2NnwKUIqsYlJAA=="],
 
     "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
-
-    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -9453,8 +9309,6 @@
     "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
-    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
@@ -9560,7 +9414,7 @@
 
     "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
-    "smthrs": ["smthrs@0.34.0", "", { "dependencies": { "@mdx-js/esbuild": "^3.1.1", "@smthrs/agents": "0.34.0", "@smthrs/aws": "0.34.0", "@smthrs/cli": "0.34.0", "@smthrs/cloudflare": "0.34.0", "@smthrs/components": "0.34.0", "@smthrs/control-plane": "0.34.0", "@smthrs/daytona": "0.34.0", "@smthrs/db": "0.34.0", "@smthrs/driver": "0.34.0", "@smthrs/engine": "0.34.0", "@smthrs/errors": "0.34.0", "@smthrs/gateway-client": "0.34.0", "@smthrs/gateway-react": "0.34.0", "@smthrs/gateway-ui": "0.34.0", "@smthrs/gcp": "0.34.0", "@smthrs/graph": "0.34.0", "@smthrs/memory": "0.34.0", "@smthrs/microsandbox": "0.34.0", "@smthrs/observability": "0.34.0", "@smthrs/openapi": "0.34.0", "@smthrs/react-reconciler": "0.34.0", "@smthrs/sandbox": "0.34.0", "@smthrs/scheduler": "0.34.0", "@smthrs/scorers": "0.34.0", "@smthrs/server": "0.34.0", "@smthrs/telegram": "0.34.0", "@smthrs/testing": "0.34.0", "@smthrs/time-travel": "0.34.0", "@smthrs/tool-context": "0.34.0", "@smthrs/ui": "0.34.0", "@smthrs/vcs": "0.34.0", "@smthrs/vercel": "0.34.0", "@smthrs/xstate": "0.34.0", "ai": "^7.0.10", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "incur": "^0.4.10", "react": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "^0.5.4", "@electric-sql/pglite-socket": "^0.2.6", "pg": "^8.22.0" }, "bin": { "smithers": "src/bin/smithers.js" } }, "sha512-TkkTazvfbMy5sWuQG5PhfdlJhSSSLHje7rBXYmW3DoaITCmAP6VQLTJYTvBxuMPo4620M7wwa7UKuifODEbtoA=="],
+    "smthrs": ["smthrs@0.35.0", "", { "dependencies": { "@effect/platform-node-shared": "4.0.0-beta.105", "@mdx-js/esbuild": "^3.1.1", "@smthrs/agents": "0.35.0", "@smthrs/aws": "0.35.0", "@smthrs/cli": "0.35.0", "@smthrs/cloudflare": "0.35.0", "@smthrs/components": "0.35.0", "@smthrs/control-plane": "0.35.0", "@smthrs/daytona": "0.35.0", "@smthrs/db": "0.35.0", "@smthrs/driver": "0.35.0", "@smthrs/engine": "0.35.0", "@smthrs/errors": "0.35.0", "@smthrs/gateway-client": "0.35.0", "@smthrs/gateway-react": "0.35.0", "@smthrs/gateway-ui": "0.35.0", "@smthrs/gcp": "0.35.0", "@smthrs/graph": "0.35.0", "@smthrs/memory": "0.35.0", "@smthrs/microsandbox": "0.35.0", "@smthrs/observability": "0.35.0", "@smthrs/openapi": "0.35.0", "@smthrs/react-reconciler": "0.35.0", "@smthrs/sandbox": "0.35.0", "@smthrs/scheduler": "0.35.0", "@smthrs/scorers": "0.35.0", "@smthrs/server": "0.35.0", "@smthrs/telegram": "0.35.0", "@smthrs/testing": "0.35.0", "@smthrs/time-travel": "0.35.0", "@smthrs/tool-context": "0.35.0", "@smthrs/ui": "0.35.0", "@smthrs/vcs": "0.35.0", "@smthrs/vercel": "0.35.0", "@smthrs/xstate": "0.35.0", "ai": "^7.0.10", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "4.0.0-beta.105", "incur": "^0.4.10", "react": "^19.2.7", "zod": "^4.4.3" }, "optionalDependencies": { "@electric-sql/pglite": "^0.5.4", "@electric-sql/pglite-socket": "^0.2.6", "pg": "^8.22.0" }, "bin": { "smithers": "src/bin/smithers.js" } }, "sha512-fAXbIHHUfGxDhIRU/K5dzPGOTgJkq3UFhe1mw31nWP5codvlxGyZQ2fguElxJtQ7a7xRZR6h/G8IWbZjcrlRTA=="],
 
     "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
 
@@ -9685,8 +9539,6 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
-
-    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
@@ -10047,8 +9899,6 @@
     "web-ext": ["web-ext@10.6.0", "", { "dependencies": { "@babel/runtime": "8.0.0", "@devicefarmer/adbkit": "3.3.9", "addons-linter": "10.10.0", "camelcase": "8.0.0", "chrome-launcher": "1.2.0", "debounce": "1.2.1", "decamelize": "6.0.1", "es6-error": "4.1.1", "firefox-profile": "4.7.1", "fx-runner": "1.6.0", "https-proxy-agent": "^7.0.0", "jose": "5.9.6", "jszip": "3.10.1", "multimatch": "6.0.0", "open": "11.0.0", "parse-json": "8.3.0", "pino": "10.3.1", "promise-toolbox": "0.21.0", "source-map-support": "0.5.21", "strip-bom": "5.0.0", "strip-json-comments": "5.0.3", "tmp": "0.2.7", "update-notifier": "7.3.1", "watchpack": "2.5.2", "yargs": "17.7.2", "zip-dir": "2.0.0" }, "bin": { "web-ext": "bin/web-ext.js" } }, "sha512-r1MfSwVy5wRQw3UgTUCw9CDViFIoDPri1Wq8qh/mRjC8T+K0TfuxKz68bzYTEP3rbAW6Wn8y7v/jXzBYd3LLGA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
-
-    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
 
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
@@ -10662,14 +10512,6 @@
 
     "@openai/codex-sdk/@openai/codex": ["@openai/codex@0.144.4", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.4-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.4-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.4-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.144.4-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.4-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.144.4-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-DTHzYatlKq9dw55E0/HsbK4tRCEKabuJ10ybbqpsG8gVv/kvwEdg3Z4OI3cvLXKa21xkIa4lkGlZoO/HmqmFFw=="],
 
-    "@opentui/core/marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
-
-    "@opentui/core/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
-
-    "@opentui/core/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "@opentui/react/react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
-
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
     "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
@@ -10773,6 +10615,8 @@
     "@smthrs/engine/@electric-sql/pglite": ["@electric-sql/pglite@0.5.5", "", {}, "sha512-QeZ+oB7QaU4EJj2awrB8hwFZ5TXxLRBQ9Gfq0dQauYDdWsRtuWRCERgtri35vRfL07KQHlVlc/4Qxvn7a5AXeA=="],
 
     "@smthrs/engine/@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.8", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.5", "@electric-sql/pglite-age": "0.0.6", "@electric-sql/pglite-pg_hashids": "0.0.6", "@electric-sql/pglite-pg_ivm": "0.0.6", "@electric-sql/pglite-pg_textsearch": "0.0.7", "@electric-sql/pglite-pg_uuidv7": "0.0.6", "@electric-sql/pglite-pgtap": "0.0.6", "@electric-sql/pglite-pgvector": "0.0.6" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-s/hDC799oT1YLrQoyfiBKqwFcIn0m6OUEuU2ENdzr3uxW5rJBM73hpQeiBmSs+pqDD2A3PH4a8839ExqoROVmQ=="],
+
+    "@smthrs/engine/ai": ["ai@7.0.66", "", { "dependencies": { "@ai-sdk/gateway": "4.0.52", "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-wBUyoCYF3GVr+62nelBgR8YbpTSsMZrzFyOOjiwijylNSM2TFCW35C+Pml2vc59/WLMpyhS/LWZ55M+B9DAcSg=="],
 
     "@smthrs/gateway-client/@tanstack/react-query": ["@tanstack/react-query@5.101.2", "", { "dependencies": { "@tanstack/query-core": "5.101.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg=="],
 
@@ -11108,16 +10952,6 @@
 
     "css-select/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
-    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
-
-    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
-
-    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
-    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
-
-    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
-
     "default-browser/default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
     "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
@@ -11391,10 +11225,6 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "merge-options/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
-
-    "mermaid/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
-
-    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
@@ -12188,12 +12018,6 @@
 
     "@openai/codex-sdk/@openai/codex/@openai/codex-win32-x64": ["@openai/codex@0.144.4-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-iL1ky0ERgdQJOKzom/Ms1fhpwkSmpsA9eVrzAqURFlYGS8z7JqwEgm33+nLGCsY7y25d8Xs/LJ91Oiqz3yXcUg=="],
 
-    "@opentui/core/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "@opentui/core/strip-ansi/ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
-
-    "@opentui/react/react-devtools-core/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
-
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
@@ -12261,6 +12085,12 @@
     "@smthrs/agents/ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
     "@smthrs/agents/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.27", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw=="],
+
+    "@smthrs/engine/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.52", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SXUM8jzzuTUJRq+EOgPd5to6DSx0EKslVn+IVZHbUEX6k/3vCPNrvjckbK26HnNxHU/STxm+zTSJteqrO+7Z0w=="],
+
+    "@smthrs/engine/ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
+
+    "@smthrs/engine/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.27", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw=="],
 
     "@smthrs/gateway-client/@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
 
@@ -12526,12 +12356,6 @@
 
     "cross-spawn-windows-exe/is-wsl/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
-    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
-
-    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
-
-    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
-
     "domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
@@ -12695,8 +12519,6 @@
     "mcp-handler/redis/@redis/search": ["@redis/search@1.2.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw=="],
 
     "mcp-handler/redis/@redis/time-series": ["@redis/time-series@1.1.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g=="],
-
-    "mermaid/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "micromark-extension-math/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -13207,6 +13029,10 @@
     "@smthrs/agents/ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
 
     "@smthrs/agents/ai/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "@smthrs/engine/ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
+    "@smthrs/engine/ai/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@smthrs/openapi/ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
 

--- a/packages/app/test/ui-smoke/workflow-editor.spec.ts
+++ b/packages/app/test/ui-smoke/workflow-editor.spec.ts
@@ -384,3 +384,58 @@ export default smithers(() => <Workflow name="digest"><Task id="digest" output={
   expect(api.getCreateCount()).toBe(1);
   expect(api.getRunCount()).toBe(1);
 });
+
+for (const viewport of [
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "mobile", width: 390, height: 844 },
+]) {
+  test(`workflow history recovers from an HTTP failure on ${viewport.name}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize(viewport);
+    const api = await installWorkflowApi(page);
+    let unavailable = true;
+    await page.route(
+      "**/api/workflow/workflows/*/revisions**",
+      async (route) => {
+        if (!unavailable) return route.fallback();
+        await route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "History unavailable for this workflow",
+          }),
+        });
+      },
+    );
+    await openAppPath(page, "/automations");
+    await page.getByRole("button", { name: "New automation" }).click();
+    await page.getByRole("menuitem", { name: "New workflow" }).click();
+    await page.getByLabel("Workflow name").fill("Review and publish");
+    await page.getByLabel("Save workflow").click();
+    await expect.poll(() => api.getSaved()?.name).toBe("Review and publish");
+    await page.getByRole("button", { name: "History", exact: true }).click();
+    const studio = page.getByTestId("workflow-studio");
+    await expect(studio.getByRole("alert")).toContainText(
+      "History unavailable for this workflow",
+    );
+    await expect(studio.getByText("No saved revisions")).toHaveCount(0);
+    await page.screenshot({
+      path: testInfo.outputPath("history-unavailable.png"),
+      fullPage: true,
+    });
+    unavailable = false;
+    await studio.getByRole("button", { name: "Retry history" }).hover();
+    await page.screenshot({
+      path: testInfo.outputPath("history-retry-hover.png"),
+      fullPage: true,
+    });
+    await studio.getByRole("button", { name: "Retry history" }).click();
+    await expect(studio.getByRole("alert")).toHaveCount(0);
+    await expect(studio.getByText("No saved revisions")).toHaveCount(1);
+    await page.screenshot({
+      path: testInfo.outputPath("history-recovered.png"),
+      fullPage: true,
+    });
+  });
+}

--- a/packages/scripts/__tests__/smithers-dependency-closure.test.ts
+++ b/packages/scripts/__tests__/smithers-dependency-closure.test.ts
@@ -93,7 +93,7 @@ test("Smithers PGlite closure remains peer-compatible and enabled", () => {
       pluginManifest.dependencies,
       `${pluginManifestPath} dependencies`,
     );
-    expect(dependencies.smthrs, pluginManifestPath).toBe("0.34.0");
+    expect(dependencies.smthrs, pluginManifestPath).toBe("0.35.0");
   }
 
   const lock = object(
@@ -102,7 +102,7 @@ test("Smithers PGlite closure remains peer-compatible and enabled", () => {
   );
   const packages = object(lock.packages, "bun.lock.packages");
   const engine = packageTuple(packages, "@smthrs/engine");
-  expect(versionOf(engine[0])).toBe("0.34.0");
+  expect(versionOf(engine[0])).toBe("0.35.0");
   const optionalDependencies = object(
     engine[2]?.optionalDependencies,
     "Smithers optional deps",

--- a/packages/ui/scripts/check-design-system.mjs
+++ b/packages/ui/scripts/check-design-system.mjs
@@ -9,7 +9,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
-import { ATOMS, buildInventory } from "./find-duplicate-components.mjs";
+import {
+  ATOMS,
+  buildInventory,
+  isHiddenSourceArtifactDirectory,
+} from "./find-duplicate-components.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../../..");
@@ -428,6 +432,7 @@ export function isGovernedSource(file) {
   const rel = relative(file);
   return (
     /^(packages|plugins)\//.test(rel) &&
+    !path.posix.dirname(rel).split("/").some(isHiddenSourceArtifactDirectory) &&
     /\.[jt]sx?$/.test(rel) &&
     !/(^|\/)(node_modules|dist|build|coverage|generated|dist-mobile(?:-[^/]+)?)(\/|$)/.test(
       rel,
@@ -444,6 +449,7 @@ function* walk(directory) {
   if (!fs.existsSync(directory)) return;
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
     if (
+      (entry.isDirectory() && isHiddenSourceArtifactDirectory(entry.name)) ||
       [
         "node_modules",
         "dist",
@@ -495,6 +501,7 @@ function* walkStylesheets(directory) {
   if (!fs.existsSync(directory)) return;
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
     if (
+      (entry.isDirectory() && isHiddenSourceArtifactDirectory(entry.name)) ||
       [
         "node_modules",
         "dist",

--- a/packages/ui/scripts/check-design-system.test.mjs
+++ b/packages/ui/scripts/check-design-system.test.mjs
@@ -1,6 +1,8 @@
 /** Verifies deterministic, fail-closed design-system compliance accounting. */
 
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
@@ -30,6 +32,51 @@ import {
   validateExceptions,
   validatePublicCardVariantCompatibility,
 } from "./check-design-system.mjs";
+import {
+  buildInventory,
+  listMaintainedSourceFiles,
+} from "./find-duplicate-components.mjs";
+
+test("hidden cached React and CSS cannot change maintained inventory or compliance", () => {
+  const fixture = fs.mkdtempSync(
+    fileURLToPath(new URL("./.molecule-binding-inventory-", import.meta.url)),
+  );
+  const cacheRoot = fileURLToPath(new URL("./.vite/", import.meta.url));
+  const createdCacheRoot = !fs.existsSync(cacheRoot);
+  fs.mkdirSync(cacheRoot, { recursive: true });
+  const cache = fs.mkdtempSync(path.join(cacheRoot, "inventory-"));
+  const now = new Date("2026-08-24T00:00:00Z");
+  try {
+    const inventory = buildInventory();
+    const compliance = buildComplianceReport({ now });
+    for (const directory of [fixture, cache]) {
+      fs.writeFileSync(
+        path.join(directory, "cached.tsx"),
+        'export function CachedButton() { return <button className="cached-control">Cached</button>; }',
+      );
+      fs.writeFileSync(
+        path.join(directory, "cached.js"),
+        'import { createElement } from "react"; export function CachedInput() { return createElement("input"); }',
+      );
+      fs.writeFileSync(
+        path.join(directory, "cached.css"),
+        ".cached-control { color: blue; background: black; }",
+      );
+    }
+    assert.deepEqual(buildInventory(), inventory);
+    assert.deepEqual(buildComplianceReport({ now }), compliance);
+    assert.ok(
+      listMaintainedSourceFiles().includes(
+        fileURLToPath(new URL("../.storybook/preview.tsx", import.meta.url)),
+      ),
+      "maintained Storybook previews must remain governed",
+    );
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true });
+    fs.rmSync(cache, { recursive: true, force: true });
+    if (createdCacheRoot) fs.rmdirSync(cacheRoot);
+  }
+});
 
 test("generated mobile platform bundles and staging roots are outside governed source", () => {
   assert.equal(

--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "sourceAtomicSchemaVersion": 1,
-  "scannedFiles": 887,
+  "scannedFiles": 886,
   "canonicalContracts": [
     {
       "id": "auth-result-shell",

--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "sourceAtomicSchemaVersion": 1,
-  "scannedFiles": 886,
+  "scannedFiles": 887,
   "canonicalContracts": [
     {
       "id": "auth-result-shell",

--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -108,7 +108,7 @@
       "maintainedReferences": 2
     }
   ],
-  "eligibleComponents": 101,
+  "eligibleComponents": 100,
   "clusters": [
     {
       "archetype": "row",

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 886 maintained React files. 101 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 886 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 886 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 887 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 887 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 886 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 

--- a/packages/ui/scripts/find-duplicate-components.mjs
+++ b/packages/ui/scripts/find-duplicate-components.mjs
@@ -112,12 +112,23 @@ const ATOM_BY_NAME = new Map(
 const relative = (file) =>
   path.relative(repoRoot, file).replaceAll(path.sep, "/");
 
+/** Recognizes generated caches and the inventory harness's temporary workspaces. */
+export function isHiddenSourceArtifactDirectory(name) {
+  return (
+    [".vite", ".vite-temp", ".eliza", ".next", ".turbo", ".cache"].includes(
+      name,
+    ) ||
+    name.startsWith(".molecule-binding-") ||
+    name.startsWith(".playwright-artifacts-")
+  );
+}
+
 export function isMaintainedSource(file) {
   const rel = relative(file);
   const maintained =
     /^(packages|plugins)\//.test(rel) &&
     /\.[jt]sx?$/.test(rel) &&
-    !/(^|\/)\.eliza(\/|$)/.test(rel) &&
+    !path.posix.dirname(rel).split("/").some(isHiddenSourceArtifactDirectory) &&
     !/(^|\/)(node_modules|dist|build|coverage|generated|dist-mobile(?:-[^/]+)?)(\/|$)/.test(
       rel,
     ) &&
@@ -143,6 +154,7 @@ function* walk(directory) {
   if (!fs.existsSync(directory)) return;
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
     if (
+      (entry.isDirectory() && isHiddenSourceArtifactDirectory(entry.name)) ||
       [
         "node_modules",
         "dist",

--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -151,6 +151,8 @@ describe("WorkflowEditor", () => {
         {
           id: "old-run",
           workflowId: "workflow-1",
+          workflowVersionId: "v1",
+          workflowName: "Digest",
           mode: "manual",
           status: "finished",
           finished: true,
@@ -197,6 +199,8 @@ describe("WorkflowEditor", () => {
     const running: WorkflowExecution = {
       id: "live-poll",
       workflowId: "workflow-1",
+      workflowVersionId: "v1",
+      workflowName: "Digest",
       mode: "manual",
       status: "running",
       finished: false,

--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -1,6 +1,7 @@
 /** Exercises the native Smithers studio over mocked elizaOS Cloud workflow APIs. */
 // @vitest-environment jsdom
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -18,7 +19,10 @@ import {
   vi,
 } from "vitest";
 import { client } from "../../api";
-import type { WorkflowDefinition } from "../../api/client-types-chat";
+import type {
+  WorkflowDefinition,
+  WorkflowExecution,
+} from "../../api/client-types-chat";
 import { CHAT_PREFILL_EVENT, type ChatPrefillEventDetail } from "../../events";
 import { WorkflowEditor } from "./WorkflowEditor";
 
@@ -113,6 +117,115 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("WorkflowEditor", () => {
+  it("shows failed history reads and lets the user retry", async () => {
+    api.getWorkflowRevisions.mockRejectedValueOnce(
+      new Error("History service unavailable"),
+    );
+    render(<WorkflowEditor initial={workflow()} />);
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    expect(await screen.findByText(/History service unavailable/)).toBeTruthy();
+    expect(screen.queryByText("No saved revisions")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Retry history" }));
+    expect(await screen.findByText("No saved revisions")).toBeTruthy();
+    expect(screen.queryByText(/History service unavailable/)).toBeNull();
+  });
+
+  it("does not show a previous workflow's runs after its delayed response arrives", async () => {
+    const oldRuns = Promise.withResolvers<WorkflowExecution[]>();
+    api.getWorkflowExecutions.mockReturnValueOnce(oldRuns.promise);
+    const { rerender } = render(<WorkflowEditor initial={workflow()} />);
+    await waitFor(() =>
+      expect(api.getWorkflowExecutions).toHaveBeenCalledWith("workflow-1", 30),
+    );
+    rerender(
+      <WorkflowEditor
+        initial={{ ...workflow(), id: "workflow-2", name: "Review" }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Runs" }));
+    await waitFor(() =>
+      expect(api.getWorkflowExecutions).toHaveBeenCalledWith("workflow-2", 30),
+    );
+    await act(async () =>
+      oldRuns.resolve([
+        {
+          id: "old-run",
+          workflowId: "workflow-1",
+          mode: "manual",
+          status: "finished",
+          finished: true,
+          startedAt: now,
+          stoppedAt: now,
+          input: {},
+          events: [],
+          output: "old workflow result",
+        },
+      ]),
+    );
+    expect(screen.queryByText("old workflow result")).toBeNull();
+    expect(screen.queryByText("old-run")).toBeNull();
+  });
+
+  it("keeps a newly started run when an earlier runs request finishes late", async () => {
+    const oldRuns = Promise.withResolvers<WorkflowExecution[]>();
+    api.getWorkflowExecutions.mockReturnValueOnce(oldRuns.promise);
+    render(<WorkflowEditor initial={workflow()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    await waitFor(() => expect(api.runWorkflowDefinition).toHaveBeenCalled());
+    await screen.findByLabelText("Output");
+    await act(async () => oldRuns.resolve([]));
+    expect(screen.getByLabelText("Output")).toBeTruthy();
+    expect(screen.queryByText("No runs yet")).toBeNull();
+  });
+
+  it("still starts a saved workflow when revision refresh fails", async () => {
+    api.getWorkflowRevisions.mockRejectedValue(
+      new Error("Revision backend unavailable"),
+    );
+    render(<WorkflowEditor />);
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    await waitFor(() =>
+      expect(api.runWorkflowDefinition).toHaveBeenCalledWith("workflow-1", {}),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    expect(
+      await screen.findByText(/Revision backend unavailable/),
+    ).toBeTruthy();
+  });
+
+  it("marks live status stale on a failed poll and recovers on the next poll", async () => {
+    const running: WorkflowExecution = {
+      id: "live-poll",
+      workflowId: "workflow-1",
+      mode: "manual",
+      status: "running",
+      finished: false,
+      startedAt: now,
+      stoppedAt: null,
+      input: {},
+      events: [],
+    };
+    api.getWorkflowExecutions.mockResolvedValue([running]);
+    api.getWorkflowExecution
+      .mockRejectedValueOnce(new Error("Status temporarily unavailable"))
+      .mockResolvedValue({
+        ...running,
+        status: "finished",
+        finished: true,
+        stoppedAt: now,
+        output: "Recovered result",
+      });
+    render(<WorkflowEditor initial={workflow()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Runs" }));
+    expect(
+      await screen.findByText(/Live status unavailable/, {}, { timeout: 3000 }),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText(/Recovered result/, {}, { timeout: 3000 }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Live status unavailable/)).toBeNull();
+  });
+
   it("renders native source, visual triggers, and typed widgets", async () => {
     render(<WorkflowEditor initial={workflow()} />);
     expect(screen.getByText("Build digest")).toBeTruthy();
@@ -341,6 +454,12 @@ describe("WorkflowEditor", () => {
         },
       ],
     });
+    api.cancelWorkflowExecution.mockRejectedValueOnce(
+      new Error("Cancellation unavailable"),
+    );
+    api.restoreWorkflowRevision.mockRejectedValueOnce(
+      new Error("Restore unavailable"),
+    );
     render(<WorkflowEditor initial={workflow()} />);
     fireEvent.click(screen.getByRole("button", { name: "Runs" }));
     expect(
@@ -351,6 +470,14 @@ describe("WorkflowEditor", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm cancel run" }));
     await waitFor(() =>
       expect(api.cancelWorkflowExecution).toHaveBeenCalledWith("run-live"),
+    );
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Cancellation unavailable",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel run" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm cancel run" }));
+    await waitFor(() =>
+      expect(screen.queryByText("Cancellation unavailable")).toBeNull(),
     );
 
     fireEvent.click(screen.getByRole("button", { name: "History" }));
@@ -367,6 +494,9 @@ describe("WorkflowEditor", () => {
         "workflow-1",
         "v0",
       ),
+    );
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Restore unavailable",
     );
   });
 

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -21,7 +21,7 @@ import {
   Workflow as WorkflowIcon,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { client } from "../../api";
 import type {
   WorkflowDefinition,
@@ -321,6 +321,21 @@ export function WorkflowEditor({
   onSaved,
   onCancel,
 }: WorkflowEditorProps) {
+  return (
+    <WorkflowEditorSession
+      key={initial?.id ?? "new"}
+      initial={initial}
+      onSaved={onSaved}
+      onCancel={onCancel}
+    />
+  );
+}
+
+function WorkflowEditorSession({
+  initial = null,
+  onSaved,
+  onCancel,
+}: WorkflowEditorProps) {
   const [workflow, setWorkflow] = useState<WorkflowDefinition>(
     () => initial ?? newWorkflow(),
   );
@@ -339,6 +354,14 @@ export function WorkflowEditor({
   const [cancelArmedId, setCancelArmedId] = useState<string | null>(null);
   const [restoreArmedId, setRestoreArmedId] = useState<string | null>(null);
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const [runsLoading, setRunsLoading] = useState(Boolean(initial?.id));
+  const [runsError, setRunsError] = useState<string | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(Boolean(initial?.id));
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [pollError, setPollError] = useState<string | null>(null);
+  const runsRequest = useRef(0);
+  const executionReadVersion = useRef(0);
+  const historyRequest = useRef(0);
 
   useEffect(() => {
     const next = initial ?? newWorkflow();
@@ -358,15 +381,55 @@ export function WorkflowEditor({
 
   const refreshRuns = useCallback(async () => {
     if (!workflow.id) return;
-    const next = await client.getWorkflowExecutions(workflow.id, 30);
-    setExecutions(next);
-    setSelectedRunId((current) => current ?? next[0]?.id ?? null);
+    const request = ++runsRequest.current;
+    const version = ++executionReadVersion.current;
+    setRunsLoading(true);
+    setRunsError(null);
+    try {
+      const next = await client.getWorkflowExecutions(workflow.id, 30);
+      if (
+        request !== runsRequest.current ||
+        version !== executionReadVersion.current
+      )
+        return;
+      setExecutions(next);
+      setPollError(null);
+      setSelectedRunId((current) =>
+        next.some((run) => run.id === current)
+          ? current
+          : (next[0]?.id ?? null),
+      );
+    } catch (cause) {
+      // error-policy:J4 a failed history read remains visibly unavailable and retryable.
+      if (
+        request === runsRequest.current &&
+        version === executionReadVersion.current
+      )
+        setRunsError(
+          cause instanceof Error ? cause.message : "Unable to load runs.",
+        );
+    } finally {
+      if (request === runsRequest.current) setRunsLoading(false);
+    }
   }, [workflow.id]);
 
   const refreshRevisions = useCallback(async () => {
     if (!workflow.id) return;
-    const next = await client.getWorkflowRevisions(workflow.id, 30);
-    setRevisions(next.revisions);
+    const request = ++historyRequest.current;
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      const next = await client.getWorkflowRevisions(workflow.id, 30);
+      if (request === historyRequest.current) setRevisions(next.revisions);
+    } catch (cause) {
+      // error-policy:J4 revision failures are distinct from an empty revision history.
+      if (request === historyRequest.current)
+        setHistoryError(
+          cause instanceof Error ? cause.message : "Unable to load history.",
+        );
+    } finally {
+      if (request === historyRequest.current) setHistoryLoading(false);
+    }
   }, [workflow.id]);
 
   useEffect(() => {
@@ -374,21 +437,57 @@ export function WorkflowEditor({
     void refreshRevisions();
   }, [refreshRuns, refreshRevisions]);
 
+  const pollingRunId = selectedRun?.id;
+  const pollingRunStatus = selectedRun?.status;
   useEffect(() => {
-    if (!selectedRun || terminal(selectedRun.status)) return;
+    setPollError(null);
+    if (!pollingRunId || !pollingRunStatus || terminal(pollingRunStatus))
+      return;
+    let active = true;
+    let pending = false;
     const timer = window.setInterval(async () => {
+      if (pending) return;
+      pending = true;
+      const version = ++executionReadVersion.current;
       try {
-        const updated = await client.getWorkflowExecution(selectedRun.id);
+        const updated = await client.getWorkflowExecution(pollingRunId);
+        if (!active || version !== executionReadVersion.current) return;
+        setPollError(null);
         setExecutions((current) => [
           updated,
           ...current.filter((run) => run.id !== updated.id),
         ]);
-      } catch {
-        // error-policy:J4 polling failures leave the last known live state visible.
+      } catch (cause) {
+        // error-policy:J4 retain the last result while explicitly marking live status as stale.
+        if (active && version === executionReadVersion.current)
+          setPollError(
+            cause instanceof Error
+              ? cause.message
+              : "Unable to refresh run status.",
+          );
+      } finally {
+        pending = false;
       }
     }, 1_000);
-    return () => window.clearInterval(timer);
-  }, [selectedRun]);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [pollingRunId, pollingRunStatus]);
+
+  const performMutation = async (operation: () => Promise<void>) => {
+    setError(null);
+    try {
+      await operation();
+    } catch (cause) {
+      // error-policy:J4 rejected user operations retain current state and display the failure.
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Unable to complete the operation.",
+      );
+    }
+  };
 
   const save = useCallback(async (): Promise<WorkflowDefinition | null> => {
     setSaving(true);
@@ -412,10 +511,10 @@ export function WorkflowEditor({
       setWorkflow(saved);
       setSavedVersion(JSON.stringify(saved));
       onSaved?.(saved);
-      const next = await client.getWorkflowRevisions(saved.id, 30);
-      setRevisions(next.revisions);
+      void refreshRevisions();
       return saved;
     } catch (cause) {
+      // error-policy:J4 save failures preserve the editable draft and show the operation error.
       setError(
         cause instanceof Error ? cause.message : "Unable to save workflow.",
       );
@@ -423,7 +522,7 @@ export function WorkflowEditor({
     } finally {
       setSaving(false);
     }
-  }, [onSaved, workflow]);
+  }, [onSaved, refreshRevisions, workflow]);
 
   const run = useCallback(
     async (input: Record<string, unknown> = {}) => {
@@ -434,6 +533,8 @@ export function WorkflowEditor({
           !workflow.id || dirty ? (await save())?.id : workflow.id;
         if (!workflowId) return;
         const execution = await client.runWorkflowDefinition(workflowId, input);
+        executionReadVersion.current += 1;
+        setRunsError(null);
         setExecutions((current) => [
           execution,
           ...current.filter((run) => run.id !== execution.id),
@@ -441,6 +542,7 @@ export function WorkflowEditor({
         setSelectedRunId(execution.id);
         setTab("runs");
       } catch (cause) {
+        // error-policy:J4 a failed run request is visible and leaves the saved definition available.
         setError(
           cause instanceof Error ? cause.message : "Unable to start workflow.",
         );
@@ -622,7 +724,10 @@ export function WorkflowEditor({
       />
 
       {error ? (
-        <div className="mx-4 mt-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+        <div
+          role="alert"
+          className="mx-4 mt-3 rounded-lg border border-destructive/25 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
           {error}
         </div>
       ) : null}
@@ -683,6 +788,26 @@ export function WorkflowEditor({
                 <RefreshCw className="size-3.5" />
               </Button>
             </div>
+            {runsLoading ? (
+              <p role="status" className="p-2 text-xs text-muted-foreground">
+                Loading runs…
+              </p>
+            ) : null}
+            {runsError ? (
+              <div
+                role="alert"
+                className="space-y-2 p-2 text-xs text-destructive"
+              >
+                <p>Unable to refresh runs: {runsError}</p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void refreshRuns()}
+                >
+                  Retry runs
+                </Button>
+              </div>
+            ) : null}
             <div className="space-y-1">
               {executions.map((execution) => (
                 <Button
@@ -711,18 +836,24 @@ export function WorkflowEditor({
                   </span>
                 </Button>
               ))}
-              {executions.length === 0 ? (
+              {!runsLoading && !runsError && executions.length === 0 ? (
                 <div
-                  className="grid min-h-32 place-items-center"
+                  className="flex min-h-32 flex-col items-center justify-center gap-3"
                   title="No runs"
                 >
                   <Activity className="size-6 text-muted-foreground/40" />
-                  <span className="sr-only">No runs</span>
+                  <p className="text-xs text-muted-foreground">No runs yet</p>
                 </div>
               ) : null}
             </div>
           </aside>
           <section className="min-h-0 overflow-auto p-3">
+            {pollError ? (
+              <p role="alert" className="mb-3 text-xs text-destructive">
+                Live status unavailable: {pollError}. Showing the last received
+                status; retrying automatically.
+              </p>
+            ) : null}
             {selectedRun ? (
               <div className="mx-auto max-w-4xl space-y-3">
                 <div className="flex flex-wrap items-center gap-2">
@@ -758,9 +889,10 @@ export function WorkflowEditor({
                           return;
                         }
                         setCancelArmedId(null);
-                        void client
-                          .cancelWorkflowExecution(selectedRun.id)
-                          .then(refreshRuns);
+                        void performMutation(async () => {
+                          await client.cancelWorkflowExecution(selectedRun.id);
+                          await refreshRuns();
+                        });
                       }}
                     >
                       <CircleStop className="size-4" />
@@ -906,14 +1038,15 @@ export function WorkflowEditor({
                               aria-label="Approve"
                               title="Approve"
                               onClick={() =>
-                                void client
-                                  .decideWorkflowApproval(
+                                void performMutation(async () => {
+                                  await client.decideWorkflowApproval(
                                     selectedRun.id,
                                     nodeId,
                                     iteration,
                                     true,
-                                  )
-                                  .then(refreshRuns)
+                                  );
+                                  await refreshRuns();
+                                })
                               }
                             >
                               <Check className="size-4" />
@@ -924,14 +1057,15 @@ export function WorkflowEditor({
                               aria-label="Deny"
                               title="Deny"
                               onClick={() =>
-                                void client
-                                  .decideWorkflowApproval(
+                                void performMutation(async () => {
+                                  await client.decideWorkflowApproval(
                                     selectedRun.id,
                                     nodeId,
                                     iteration,
                                     false,
-                                  )
-                                  .then(refreshRuns)
+                                  );
+                                  await refreshRuns();
+                                })
                               }
                             >
                               <X className="size-4" />
@@ -983,6 +1117,26 @@ export function WorkflowEditor({
       {tab === "history" ? (
         <div className="min-h-0 flex-1 overflow-auto p-4">
           <div className="mx-auto max-w-3xl space-y-1">
+            {historyLoading ? (
+              <p role="status" className="p-3 text-sm text-muted-foreground">
+                Loading history…
+              </p>
+            ) : null}
+            {historyError ? (
+              <div
+                role="alert"
+                className="space-y-2 p-3 text-sm text-destructive"
+              >
+                <p>Unable to load history: {historyError}</p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void refreshRevisions()}
+                >
+                  Retry history
+                </Button>
+              </div>
+            ) : null}
             {revisions.map((revision) => (
               <div
                 key={revision.id}
@@ -1012,26 +1166,30 @@ export function WorkflowEditor({
                       return;
                     }
                     setRestoreArmedId(null);
-                    void client
-                      .restoreWorkflowRevision(workflow.id, revision.versionId)
-                      .then((restored) => {
-                        setWorkflow(restored);
-                        setSavedVersion(JSON.stringify(restored));
-                        void refreshRevisions();
-                      });
+                    void performMutation(async () => {
+                      const restored = await client.restoreWorkflowRevision(
+                        workflow.id,
+                        revision.versionId,
+                      );
+                      setWorkflow(restored);
+                      setSavedVersion(JSON.stringify(restored));
+                      void refreshRevisions();
+                    });
                   }}
                 >
                   <ArchiveRestore className="size-4" />
                 </Button>
               </div>
             ))}
-            {revisions.length === 0 ? (
+            {!historyLoading && !historyError && revisions.length === 0 ? (
               <div
-                className="grid min-h-72 place-items-center"
+                className="flex min-h-72 flex-col items-center justify-center gap-3"
                 title="No saved revisions"
               >
                 <History className="size-8 text-muted-foreground/40" />
-                <span className="sr-only">No saved revisions</span>
+                <p className="text-sm text-muted-foreground">
+                  No saved revisions
+                </p>
               </div>
             ) : null}
           </div>

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -282,7 +282,7 @@ README → "GitHub credentials".
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
-| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.1.2` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
+| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.10.0` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
 | `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional managed Codex ACP sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`. The successor receives these as `INITIAL_AGENT_MODE`; custom commands are not rewritten. |
 | `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | unset (required when Landlock unavailable) | Codex ACP sandbox mode used when Linux Landlock is unavailable. No default — unset/invalid throws `CODEX_NO_LANDLOCK_NO_FALLBACK` rather than widening to host access. |
 | `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -282,7 +282,7 @@ README → "GitHub credentials".
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
-| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.1.2` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
+| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.10.0` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
 | `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional managed Codex ACP sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`. The successor receives these as `INITIAL_AGENT_MODE`; custom commands are not rewritten. |
 | `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | unset (required when Landlock unavailable) | Codex ACP sandbox mode used when Linux Landlock is unavailable. No default — unset/invalid throws `CODEX_NO_LANDLOCK_NO_FALLBACK` rather than widening to host access. |
 | `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -31,7 +31,7 @@ export ELIZA_ACP_TRANSPORT=native
 export ELIZA_ACP_DEFAULT_AGENT=elizaos
 export ELIZA_ELIZAOS_ACP_COMMAND="eliza-code-acp"
 export ELIZA_PI_AGENT_ACP_COMMAND="pi-agent"
-export ELIZA_CODEX_ACP_COMMAND="npx -y @agentclientprotocol/codex-acp@1.1.2"
+export ELIZA_CODEX_ACP_COMMAND="npx -y @agentclientprotocol/codex-acp@1.10.0"
 export ELIZA_CLAUDE_ACP_COMMAND="npx -y @agentclientprotocol/claude-agent-acp@0.34.0"
 ```
 
@@ -157,7 +157,7 @@ second credential broker, and child trajectories retain their session join key.
 | `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to keep one pre-initialized native `elizaos` child ready. It starts without session credentials, accepts one authenticated environment claim, and is disposed after that session; unclaimed children are recycled after two minutes. |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command. |
-| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.1.2` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
+| `ELIZA_CODEX_ACP_COMMAND` | `npx -y @agentclientprotocol/codex-acp@1.10.0` | Native Codex ACP command. The manifest default and the legacy `@zed-industries` default select the isolated managed successor; any other custom command is executed verbatim. |
 | `ELIZA_CODEX_ACP_SANDBOX_MODE` / `ELIZA_CODEX_SANDBOX_MODE` | unset | Optional managed Codex ACP sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`. The successor receives these as `INITIAL_AGENT_MODE`; custom commands are not rewritten. |
 | `ELIZA_CODEX_ACP_NO_LANDLOCK_SANDBOX_MODE` | unset (required when Landlock unavailable) | Codex ACP sandbox mode used when Linux Landlock is unavailable. No default — unset/invalid throws `CODEX_NO_LANDLOCK_NO_FALLBACK` rather than widening to host access. |
 | `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |
@@ -232,7 +232,7 @@ These live smokes ship with the repo:
 
 ```bash
 # Native AcpService against Codex ACP. No global acpx is required; the default
-# native Codex command is `npx -y @agentclientprotocol/codex-acp@1.1.2`.
+# native Codex command is `npx -y @agentclientprotocol/codex-acp@1.10.0`.
 # Authenticate Codex first.
 bun run build
 RUN_LIVE_NATIVE_ACP=1 bun run test:e2e:native
@@ -249,7 +249,7 @@ RUN_LIVE_ACPX=1 ELIZA_ACP_TRANSPORT=cli bun run test -- __tests__/live/sub-agent
 ```
 
 `live-native-acp-smoke.mjs` exercises the default native path by spawning a
-real Codex ACP session through `npx -y @agentclientprotocol/codex-acp@1.1.2`,
+real Codex ACP session through `npx -y @agentclientprotocol/codex-acp@1.10.0`,
 sending "what is 7 + 8?", and verifying `task_complete` fires with response
 `"15"`. The Vitest wrapper is skipped unless `RUN_LIVE_NATIVE_ACP=1` is set;
 when enabled, it requires `NATIVE ACP SMOKE PASSED`.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -221,7 +221,7 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     const events: unknown[] = [];
     const p = queueProc();
     const client = new NativeAcpClient({
-      command: "npx -y @agentclientprotocol/codex-acp@1.1.2",
+      command: "npx -y @agentclientprotocol/codex-acp@1.10.0",
       cwd: "/tmp/native-acp",
       approvalPreset: "autonomous",
       terminal: false,
@@ -232,14 +232,23 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     await waitForWrites(p, 1);
     expect(spawnMock).toHaveBeenCalledWith(
       "npx",
-      ["-y", "@agentclientprotocol/codex-acp@1.1.2"],
+      ["-y", "@agentclientprotocol/codex-acp@1.10.0"],
       expect.objectContaining({ cwd: "/tmp/native-acp" }),
     );
     expect(writeAt(p, 0)).toMatchObject({
       jsonrpc: "2.0",
       id: 1,
       method: "initialize",
-      params: { clientCapabilities: { terminal: false } },
+      params: {
+        clientCapabilities: {
+          terminal: false,
+          _meta: {
+            jetbrains: {
+              air: { version: 1, capabilities: ["sessionFailure"] },
+            },
+          },
+        },
+      },
     });
     emitJson(p, { jsonrpc: "2.0", id: 1, result: {} });
     await started;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -2990,6 +2990,40 @@ describe("AcpService", () => {
     expect(client.prompt).toHaveBeenCalledTimes(1);
   });
 
+  it("claims a promptable session before an idle reclaim can race a follow-up", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-reclaim-race",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    const client = firstNativeClient();
+    let enterBeforeStop: () => void = () => undefined;
+    const beforeStopEntered = new Promise<void>((resolve) => {
+      enterBeforeStop = resolve;
+    });
+    let releaseBeforeStop: () => void = () => undefined;
+    const beforeStopGate = new Promise<void>((resolve) => {
+      releaseBeforeStop = resolve;
+    });
+
+    const reclaim = service.stopPromptableSession(sessionId, async () => {
+      enterBeforeStop();
+      await beforeStopGate;
+    });
+    await beforeStopEntered;
+
+    await expect(service.sendPrompt(sessionId, "follow up")).rejects.toThrow(
+      /already busy/,
+    );
+    expect(client.prompt).not.toHaveBeenCalled();
+    releaseBeforeStop();
+    await expect(reclaim).resolves.toBe(true);
+    expect(client.closeSession).toHaveBeenCalledWith("protocol-session");
+    expect((await service.getSession(sessionId))?.status).toBe("stopped");
+  });
+
   it("native cancel settles from the original prompt's cancelled terminal result", async () => {
     const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
     await service.start();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1428,7 +1428,7 @@ describe("AcpService", () => {
 
     expect(nativeClientMock.instances).toHaveLength(1);
     expect(nativeClientMock.instances[0]?.opts.command).toContain(
-      "--package=@agentclientprotocol/codex-acp@1.1.2",
+      "--package=@agentclientprotocol/codex-acp@1.10.0",
     );
     expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
       "agent",
@@ -1473,7 +1473,7 @@ describe("AcpService", () => {
 
     expect(nativeClientMock.instances).toHaveLength(1);
     expect(nativeClientMock.instances[0]?.opts.command).toContain(
-      "--package=@agentclientprotocol/codex-acp@1.1.2",
+      "--package=@agentclientprotocol/codex-acp@1.10.0",
     );
     expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
       "agent-full-access",
@@ -1516,7 +1516,7 @@ describe("AcpService", () => {
       expect(result.status).toBe("ready");
       expect(nativeClientMock.instances).toHaveLength(2);
       expect(nativeClientMock.instances[0]?.opts.command).toContain(
-        "--package=@agentclientprotocol/codex-acp@1.1.2",
+        "--package=@agentclientprotocol/codex-acp@1.10.0",
       );
       expect(nativeClientMock.instances[0]?.opts.env?.INITIAL_AGENT_MODE).toBe(
         undefined,
@@ -2781,6 +2781,65 @@ describe("AcpService", () => {
     expect(result.finalText).toBe(
       "the change is proven and received at runtime",
     );
+  });
+
+  it("retains typed adapter warnings without adding them to the model answer", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    const events: Array<{ event: string; data: unknown }> = [];
+    service.onSessionEvent((_sid, event, data) => events.push({ event, data }));
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-diagnostics",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    const diagnostic = {
+      id: "notice-1",
+      revision: 1,
+      severity: "warning",
+      category: "unknown",
+      title: "Provider configuration notice",
+      details: "Complete diagnostic details 🟠",
+      actions: [],
+    };
+    const client = firstNativeClient();
+    client.prompt.mockImplementationOnce(async () => {
+      client.emit({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "protocol-session",
+          update: {
+            sessionUpdate: "session_info_update",
+            _meta: {
+              jetbrains: { air: { version: 1, sessionFailure: diagnostic } },
+            },
+          },
+        },
+      } as AcpJsonRpcMessage);
+      client.emit({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "protocol-session",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Verified result" },
+          },
+        },
+      } as AcpJsonRpcMessage);
+      return { stopReason: "end_turn" };
+    });
+    const result = await service.sendPrompt(sessionId, "finish");
+    expect(result.finalText).toBe("Verified result");
+    expect(events).toContainEqual({
+      event: "diagnostic",
+      data: { diagnostic },
+    });
+    expect(
+      events.filter(({ event }) => event === "message").map(({ data }) => data),
+    ).toEqual([{ text: "Verified result" }]);
+    await service.stop();
   });
 
   it("native sendPrompt forwards thought chunks as reasoning without polluting the final answer", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-session-forward.test.ts
@@ -8,7 +8,10 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpService } from "../../src/services/acp-service.js";
-import { createActiveSessionForwardHandler } from "../../src/services/active-session-forward.js";
+import {
+  createActiveSessionForwardHandler,
+  isSessionBusy,
+} from "../../src/services/active-session-forward.js";
 import { SubAgentInbox } from "../../src/services/sub-agent-inbox.js";
 
 // Room ids are UUID-validated by the binding helper, so fixtures use real
@@ -26,6 +29,16 @@ type Session = {
   status: string;
   metadata: Record<string, unknown>;
 };
+
+describe("active-session busy lifecycle", () => {
+  it("queues blocked, authenticating, and unknown nonterminal states", () => {
+    expect(isSessionBusy("blocked")).toBe(true);
+    expect(isSessionBusy("authenticating")).toBe(true);
+    expect(isSessionBusy("future_status")).toBe(true);
+    expect(isSessionBusy("ready")).toBe(false);
+    expect(isSessionBusy("completed")).toBe(false);
+  });
+});
 
 function makeAcp(sessions: Session[]) {
   return {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
@@ -33,6 +33,12 @@ const acpStub = {
     }),
   sendToSession: () => Promise.resolve(),
   stopSession: () => Promise.resolve(),
+  getSession: (sessionId: string) =>
+    Promise.resolve(
+      sessionId === "session-1"
+        ? { id: sessionId, status: "ready", metadata: {} }
+        : null,
+    ),
 };
 
 function makeService(): OrchestratorTaskService {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -528,6 +528,28 @@ describe("OrchestratorTaskService — lifecycle", () => {
     expect(reopened.archivedAt).toBeNull();
   });
 
+  it("stops a retained live ACP session on cleanup without erasing completion evidence", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    const live = (await acp.getSession(sessionId)) as SessionInfo;
+    acp.emit(
+      sessionId,
+      "task_complete",
+      { response: "verified result" },
+      live,
+      "completed-turn",
+    );
+    await settleStatus(service, taskId, "done");
+    expect((await service.getTask(taskId))?.sessions[0]?.status).toBe(
+      "completed",
+    );
+
+    const archived = must(await service.archiveTask(taskId), "archived");
+
+    expect(acp.stopped).toContain(sessionId);
+    expect(archived.status).toBe("archived");
+    expect(archived.sessions[0]?.status).toBe("completed");
+  });
+
   it("reopens a session-less task to open", async () => {
     const service = makeService();
     const { id } = await service.createTask(createInput());
@@ -1103,6 +1125,33 @@ describe("OrchestratorTaskService — lifecycle", () => {
     expect(relayed.sessionId).toBe(sessionId);
     expect(relayed.message).toContain("tweak the header");
     expect(await service.postUserMessage("missing", "x")).toBeNull();
+  });
+
+  it("forwards to retained live ACP state without rewriting durable completion", async () => {
+    const { service, acp, taskId, sessionId } = await withSpawnedSession();
+    const live = (await acp.getSession(sessionId)) as SessionInfo;
+    acp.emit(
+      sessionId,
+      "task_complete",
+      { response: "verified result" },
+      live,
+      "completed-turn",
+    );
+    await settleStatus(service, taskId, "done");
+    expect((await service.getTask(taskId))?.sessions[0]?.status).toBe(
+      "completed",
+    );
+
+    const result = must(
+      await service.postUserMessage(taskId, "one more adjustment"),
+      "post",
+    );
+
+    expect(result.forwardedTo).toEqual([sessionId]);
+    expect(acp.sent.at(-1)?.message).toContain("one more adjustment");
+    expect((await service.getTask(taskId))?.sessions[0]?.status).toBe(
+      "completed",
+    );
   });
 
   it("auto-spawns a coding agent when a message is posted with no session live", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-watchdog.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-watchdog.test.ts
@@ -22,6 +22,32 @@ const NOW = 1_000_000;
 const STALL = 180_000;
 
 describe("detectStalledSessions (#8901)", () => {
+  it("ignores promptable ready sessions at the default threshold", () => {
+    const sessions: WatchdogSessionView[] = [
+      {
+        id: "retained-ready",
+        status: "ready",
+        lastActivityMs: NOW - STALL,
+      },
+    ];
+
+    expect(detectStalledSessions(sessions, NOW, STALL)).toEqual([]);
+  });
+
+  it("flags in-flight work exactly at the default threshold", () => {
+    const sessions: WatchdogSessionView[] = [
+      {
+        id: "stalled-running",
+        status: "running",
+        lastActivityMs: NOW - STALL,
+      },
+    ];
+
+    expect(detectStalledSessions(sessions, NOW, STALL)).toEqual([
+      { id: "stalled-running", idleMs: STALL },
+    ]);
+  });
+
   it("flags active sessions idle beyond the threshold", () => {
     const sessions: WatchdogSessionView[] = [
       { id: "busy", status: "running", lastActivityMs: NOW - 10_000 },
@@ -38,6 +64,22 @@ describe("detectStalledSessions (#8901)", () => {
       { id: "err", status: "error", lastActivityMs: NOW - 9_999_999 },
     ];
     expect(detectStalledSessions(sessions, NOW, STALL)).toEqual([]);
+  });
+
+  it("exempts user-gated sessions while retaining watchdog coverage for unknown states", () => {
+    const sessions: WatchdogSessionView[] = [
+      { id: "blocked", status: "blocked", lastActivityMs: NOW - STALL },
+      {
+        id: "auth",
+        status: "authenticating",
+        lastActivityMs: NOW - STALL,
+      },
+      { id: "future", status: "future_status", lastActivityMs: NOW - STALL },
+    ];
+
+    expect(detectStalledSessions(sessions, NOW, STALL)).toEqual([
+      { id: "future", idleMs: STALL },
+    ]);
   });
 });
 
@@ -57,7 +99,7 @@ describe("TaskWatchdogService.runOnce (#8901)", () => {
         {
           id: "stuck",
           status: "running",
-          lastActivityAt: new Date(NOW - 200_000),
+          lastActivityAt: new Date(NOW - STALL),
         },
         { id: "ok", status: "running", lastActivityAt: new Date(NOW - 1_000) },
       ],
@@ -74,6 +116,26 @@ describe("TaskWatchdogService.runOnce (#8901)", () => {
     // Second tick, still stalled → does NOT re-prod (grill once).
     await svc.runOnce(NOW + 1_000);
     expect(sendToSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("never prods retained ready sessions across repeated ticks", async () => {
+    const sendToSession = vi.fn(async () => ({}));
+    const acp = {
+      listSessions: async () => [
+        {
+          id: "retained-ready",
+          status: "ready",
+          lastActivityAt: new Date(NOW - STALL),
+        },
+      ],
+      sendToSession,
+    };
+    const svc = new TaskWatchdogService(makeRuntime(acp));
+
+    expect(await svc.runOnce(NOW)).toEqual([]);
+    expect(await svc.runOnce(NOW + STALL)).toEqual([]);
+    expect(sendToSession).not.toHaveBeenCalled();
+    expect(svc.getStalledSessionIds()).toEqual([]);
   });
 
   it("clears the prod flag when a session recovers, so a later stall re-grills", async () => {

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^22.0.0",
-    "smthrs": "0.34.0",
+    "smthrs": "0.35.0",
     "coding-agent-adapters": "0.16.3",
     "drizzle-orm": "0.45.2",
     "effect": "4.0.0-beta.105",
@@ -183,7 +183,7 @@
         "type": "string",
         "description": "Native ACP command used for Codex sessions when ELIZA_ACP_TRANSPORT=native. The manifest default and legacy @zed-industries default select the isolated managed successor; any other custom command is executed verbatim.",
         "required": false,
-        "default": "npx -y @agentclientprotocol/codex-acp@1.1.2",
+        "default": "npx -y @agentclientprotocol/codex-acp@1.10.0",
         "sensitive": false
       },
       "ELIZA_CODEX_ACP_SANDBOX_MODE": {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/admission-integration.test.ts
@@ -127,10 +127,36 @@ class FakeAcp {
     return this.sessions.get(id) ?? null;
   }
 
+  async updateSessionMetadata(
+    id: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    const session = this.sessions.get(id);
+    if (session) session.metadata = { ...session.metadata, ...patch };
+  }
+
+  setSessionStatus(id: string, status: SessionInfo["status"]): void {
+    const session = this.sessions.get(id);
+    if (session) session.status = status;
+  }
+
   async stopSession(id: string): Promise<void> {
     const s = this.sessions.get(id);
     if (s) s.status = "stopped";
     this.handler?.(id, "stopped", {});
+  }
+
+  async stopPromptableSession(
+    id: string,
+    beforeStop?: () => Promise<void>,
+  ): Promise<boolean> {
+    const selected = await this.getSession(id);
+    if (selected?.status !== "ready") return false;
+    await beforeStop?.();
+    const fresh = await this.getSession(id);
+    if (fresh?.status !== "ready") return false;
+    await this.stopSession(id);
+    return true;
   }
 
   onSessionEvent(cb: EventHandler): () => void {
@@ -277,8 +303,8 @@ describe("admission queue integration (#13772)", () => {
     });
     await service.start();
 
-    // Task A takes the only worker slot; its ACP session is keepAlive (stays
-    // `running` at the transport even after the task finishes).
+    // Task A takes the only worker slot; its retained ACP session returns to
+    // promptable idle after the task finishes.
     const a = await newTask(store, "a");
     await service.spawnAgentForTask(a);
     const liveSession = acp.listSessions()[0];
@@ -288,6 +314,7 @@ describe("admission queue integration (#13772)", () => {
     // keepAlive session now pins a slot with no live work. Mark it done directly
     // in the store to model that.
     await store.updateTask(a, { status: "done" });
+    if (liveSession) acp.setSessionStatus(liveSession.id, "ready");
 
     // Task B queues behind the pinned slot, then a drain reclaims A's idle
     // session and dispatches B.
@@ -306,6 +333,63 @@ describe("admission queue integration (#13772)", () => {
     expect(
       acp.listSessions().find((s) => s.id === liveSession?.id)?.status,
     ).toBe("stopped");
+  });
+
+  it("does not reclaim a busy retained follow-up under cap-1 pressure", async () => {
+    const acp = new FakeAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    const a = await newTask(store, "busy-follow-up");
+    await service.spawnAgentForTask(a);
+    const retained = acp.listSessions()[0];
+    expect(retained).toBeDefined();
+    await store.updateTask(a, { status: "done" });
+    if (retained) acp.setSessionStatus(retained.id, "busy");
+
+    const b = await newTask(store, "queued-behind-follow-up");
+    const queued = await service.spawnAgentForTask(b);
+    expect(queued?.admission?.state).toBe("queued");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect((await acp.getSession(retained?.id ?? ""))?.status).toBe("busy");
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(1);
+  });
+
+  it("does not stamp or stop a candidate claimed by a follow-up", async () => {
+    class PromptRaceAcp extends FakeAcp {
+      override async stopPromptableSession(id: string): Promise<boolean> {
+        this.setSessionStatus(id, "busy");
+        return false;
+      }
+    }
+
+    const acp = new PromptRaceAcp(1);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const service = new OrchestratorTaskService(makeRuntime(acp) as never, {
+      store,
+    });
+    await service.start();
+
+    const a = await newTask(store, "ready-race");
+    await service.spawnAgentForTask(a);
+    const retained = acp.listSessions()[0];
+    expect(retained).toBeDefined();
+    await store.updateTask(a, { status: "done" });
+    if (retained) acp.setSessionStatus(retained.id, "ready");
+    const b = await newTask(store, "queued-during-race");
+    const queued = await service.spawnAgentForTask(b);
+    expect(queued?.admission?.state).toBe("queued");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect((await acp.getSession(retained?.id ?? ""))?.status).toBe("busy");
+    expect((await service.getAdmissionSnapshot()).queueDepth).toBe(1);
+    const survivor = await acp.getSession(retained?.id ?? "");
+    expect(survivor?.metadata?.adminStopReason).toBeUndefined();
+    expect(survivor?.metadata?.adminStopStampedAt).toBeUndefined();
   });
 
   it("spawns the read-only verifier at full worker cap via system headroom", async () => {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/codex-acp-command.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/codex-acp-command.test.ts
@@ -22,7 +22,7 @@ describe("defaultCodexAcpCommand", () => {
         "-y",
         "--prefix",
         "/tmp/eliza coding agent",
-        "--package=@agentclientprotocol/codex-acp@1.1.2",
+        "--package=@agentclientprotocol/codex-acp@1.10.0",
         "--",
         "codex-acp",
       ],
@@ -57,6 +57,12 @@ describe("defaultCodexAcpCommand", () => {
     expect(
       resolveCodexAcpCommand(
         "npx -y @zed-industries/codex-acp@0.14.0",
+        isolated,
+      ),
+    ).toBe(isolated);
+    expect(
+      resolveCodexAcpCommand(
+        "npx -y @agentclientprotocol/codex-acp@1.10.0",
         isolated,
       ),
     ).toBe(isolated);

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -235,6 +235,13 @@ export class NativeAcpClient {
         clientCapabilities: {
           fs: { readTextFile: true, writeTextFile: true },
           terminal: this.opts.terminal !== false,
+          // Codex ACP's negotiated extension keeps provider diagnostics separate
+          // from model response chunks; AcpService retains the typed records.
+          _meta: {
+            jetbrains: {
+              air: { version: 1, capabilities: ["sessionFailure"] },
+            },
+          },
         },
         clientInfo: {
           name: "@elizaos/plugin-agent-orchestrator",

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -976,6 +976,7 @@ export class AcpService extends Service {
       resolveCancellationRequested: () => void;
     }
   >();
+  private readonly reclaimingSessionIds = new Set<string>();
   private readonly acpCallbacks: AcpEventCallback[] = [];
   private readonly activeProcesses = new Map<string, ProcessRecord>();
   private readonly nativeClients = new Map<string, NativeAcpClient>();
@@ -2412,8 +2413,14 @@ export class AcpService extends Service {
   ): Promise<PromptResult> {
     this.ensureStarted();
     const session = await this.requireSession(sessionId);
-    if (this.promptTurns.has(sessionId)) {
-      throw new Error(`ACP session is already busy: ${sessionId}`);
+    if (
+      this.promptTurns.has(sessionId) ||
+      this.reclaimingSessionIds.has(sessionId)
+    ) {
+      throw new ElizaError(`ACP session is already busy: ${sessionId}`, {
+        code: "ACP_SESSION_BUSY",
+        context: { sessionId },
+      });
     }
     let resolveSettled: () => void = () => undefined;
     const settled = new Promise<void>((resolve) => {
@@ -3140,6 +3147,35 @@ export class AcpService extends Service {
 
   async stopSession(sessionId: string): Promise<void> {
     await this.closeSession(sessionId);
+  }
+
+  /** Stop a promptable session without racing a follow-up prompt. */
+  async stopPromptableSession(
+    sessionId: string,
+    beforeStop?: () => Promise<void>,
+  ): Promise<boolean> {
+    const selected = await this.requireSession(sessionId);
+    if (
+      selected.status !== "ready" ||
+      this.promptTurns.has(sessionId) ||
+      this.reclaimingSessionIds.has(sessionId)
+    ) {
+      return false;
+    }
+    // No await between eligibility and claim: sendPrompt checks the same set
+    // before installing its turn, so exactly one side wins the session.
+    this.reclaimingSessionIds.add(sessionId);
+    try {
+      const fresh = await this.requireSession(sessionId);
+      if (fresh.status !== "ready" || this.promptTurns.has(sessionId)) {
+        return false;
+      }
+      await beforeStop?.();
+      await this.closeSession(sessionId);
+      return true;
+    } finally {
+      this.reclaimingSessionIds.delete(sessionId);
+    }
   }
 
   private async closeInitialTaskSession(sessionId: string): Promise<void> {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -270,7 +270,9 @@ function isIncompletePromptStopReason(stopReason: string | undefined): boolean {
 }
 
 const DEFAULT_WORKDIR_ROOT = join(tmpdir(), "eliza-acp");
-const SUCCESSOR_CODEX_ACP_PACKAGE = "@agentclientprotocol/codex-acp@1.1.2";
+const SUCCESSOR_CODEX_ACP_PACKAGE = "@agentclientprotocol/codex-acp@1.10.0";
+const PREVIOUS_SUCCESSOR_CODEX_ACP_COMMAND =
+  "npx -y @agentclientprotocol/codex-acp@1.1.2";
 const LEGACY_CODEX_ACP_COMMAND = "npx -y @zed-industries/codex-acp@0.14.0";
 const DECLARED_SUCCESSOR_CODEX_ACP_COMMAND = `npx -y ${SUCCESSOR_CODEX_ACP_PACKAGE}`;
 
@@ -298,6 +300,7 @@ export function resolveCodexAcpCommand(
   if (
     !trimmed ||
     trimmed === LEGACY_CODEX_ACP_COMMAND ||
+    trimmed === PREVIOUS_SUCCESSOR_CODEX_ACP_COMMAND ||
     trimmed === DECLARED_SUCCESSOR_CODEX_ACP_COMMAND
   ) {
     return fallback;
@@ -4517,6 +4520,32 @@ export class AcpService extends Service {
     }
 
     if (sessionId && method === "session/update") {
+      if (sessionUpdate === "session_info_update") {
+        const meta = asRecord(updateBlock?._meta);
+        const air = asRecord(asRecord(meta?.jetbrains)?.air);
+        const diagnostic = asRecord(air?.sessionFailure);
+        if (
+          diagnostic &&
+          typeof diagnostic.title === "string" &&
+          (diagnostic.severity === "warning" || diagnostic.severity === "error")
+        ) {
+          this.emitSessionEvent(sessionId, "diagnostic", { diagnostic });
+          this.log(
+            diagnostic.severity === "warning" ? "warn" : "error",
+            diagnostic.title,
+            { sessionId, diagnostic },
+          );
+          if (diagnostic.severity === "error") {
+            this.runtime.reportError(
+              "AcpService.nativeDiagnostic",
+              new ElizaError(diagnostic.title, {
+                code: "ACP_SESSION_DIAGNOSTIC",
+                context: { sessionId, diagnostic },
+              }),
+            );
+          }
+        }
+      }
       // agent_message_chunk: content.text streams
       const content = asRecord(updateBlock?.content);
       const role = stringifyMaybe(

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -19,7 +19,11 @@ import { decideInterruptionWithModel } from "./interruption-decider.js";
 import { sessionBoundRoomIds } from "./session-room-binding.js";
 import type { SubAgentInbox } from "./sub-agent-inbox.js";
 import { requireTaskAgentAccess } from "./task-policy.js";
-import { type SessionInfo, TERMINAL_SESSION_STATUSES } from "./types.js";
+import {
+  isSessionPromptInFlight,
+  type SessionInfo,
+  TERMINAL_SESSION_STATUSES,
+} from "./types.js";
 
 // Skip forwarding our own posts back into `acp.sendPrompt` — would echo-loop.
 // `entityId === runtime.agentId` is not enough: the router uses a synthetic
@@ -39,7 +43,7 @@ export const INTERNAL_FORWARD_SKIP_SOURCES = new Set([
  * to `ready`. Only `ready` is promptable.
  */
 export function isSessionBusy(status: string): boolean {
-  return status !== "ready" && !TERMINAL_SESSION_STATUSES.has(status);
+  return isSessionPromptInFlight(status);
 }
 
 const SRC = "@elizaos/plugin-agent-orchestrator";

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -230,6 +230,7 @@ import {
 import {
   AdmissionQueueFullError,
   type ApprovalPreset,
+  isSessionPromptable,
   SessionCapError,
   type SessionInfo,
   type SpawnResult,
@@ -5172,12 +5173,13 @@ export class OrchestratorTaskService extends Service {
       senderKind: "user",
       direction: "stdin",
     });
-    const active = doc.sessions.filter(
+    let active = doc.sessions.filter(
       (s) => !TERMINAL_TASK_SESSION_STATUSES.has(s.status),
     );
     const forwardedTo: string[] = [];
     const failedTo: Array<{ sessionId: string; error: string }> = [];
     const acp = this.acp();
+    if (acp) active = await this.liveTaskSessions(doc, acp);
     if (!acp) {
       const error = "ACP service unavailable";
       if (active.length > 0) {
@@ -5348,9 +5350,12 @@ export class OrchestratorTaskService extends Service {
       return this.getTask(taskId);
     }
 
+    const acp = this.acp();
+    const liveSessions = acp ? await this.liveTaskSessions(doc, acp) : [];
     const sessionId =
       input.sessionId ??
       source?.sessionId ??
+      liveSessions.at(-1)?.sessionId ??
       latestActiveSession(doc)?.sessionId;
     if (!sessionId) {
       throw new RecoveryConflictError(
@@ -5359,7 +5364,10 @@ export class OrchestratorTaskService extends Service {
     }
     const session = doc.sessions.find((item) => item.sessionId === sessionId);
     if (!session) throw new RecoveryConflictError("Session not found");
-    if (TERMINAL_TASK_SESSION_STATUSES.has(session.status)) {
+    if (
+      TERMINAL_TASK_SESSION_STATUSES.has(session.status) &&
+      !liveSessions.some((item) => item.sessionId === sessionId)
+    ) {
       throw new RecoveryConflictError(
         "Cannot retry in a terminal session; use new-session mode",
       );
@@ -6717,14 +6725,14 @@ export class OrchestratorTaskService extends Service {
   private async stopActiveSessions(
     doc: OrchestratorTaskDocument,
   ): Promise<void> {
-    const active = doc.sessions.filter(
+    const durableActive = doc.sessions.filter(
       (s) => !TERMINAL_TASK_SESSION_STATUSES.has(s.status),
     );
-    if (active.length === 0) return;
     const acp = this.acp();
     if (!acp) {
+      if (durableActive.length === 0) return;
       await Promise.all(
-        active.map((session) =>
+        durableActive.map((session) =>
           this.store.updateSession(session.sessionId, {
             status: "stop_failed",
           }),
@@ -6735,6 +6743,8 @@ export class OrchestratorTaskService extends Service {
         "ACP service unavailable; cannot stop active sessions",
       );
     }
+    const active = await this.liveTaskSessions(doc, acp);
+    if (active.length === 0) return;
     const failures: Array<{ sessionId: string; error: string }> = [];
     await Promise.all(
       active.map(async (session) => {
@@ -6757,10 +6767,12 @@ export class OrchestratorTaskService extends Service {
           });
           return;
         }
-        await this.store.updateSession(session.sessionId, {
-          status: "stopped",
-          stoppedAt: Date.now(),
-        });
+        if (!TERMINAL_TASK_SESSION_STATUSES.has(session.status)) {
+          await this.store.updateSession(session.sessionId, {
+            status: "stopped",
+            stoppedAt: Date.now(),
+          });
+        }
       }),
     );
     if (failures.length > 0) {
@@ -6774,6 +6786,26 @@ export class OrchestratorTaskService extends Service {
         }`,
       );
     }
+  }
+
+  /** Resolve task-session consumers against current ACP state when available. */
+  private async liveTaskSessions(
+    doc: OrchestratorTaskDocument,
+    acp: AcpService,
+  ): Promise<OrchestratorTaskSession[]> {
+    const live: OrchestratorTaskSession[] = [];
+    for (const session of doc.sessions) {
+      const current = await acp.getSession(session.sessionId);
+      if (current && !TERMINAL_SESSION_STATUSES.has(current.status)) {
+        live.push(session);
+      } else if (
+        !current &&
+        !TERMINAL_TASK_SESSION_STATUSES.has(session.status)
+      ) {
+        live.push(session);
+      }
+    }
+    return live;
   }
 
   // ---- stuck-task reaper -------------------------------------------------
@@ -7293,7 +7325,7 @@ export class OrchestratorTaskService extends Service {
     const sessions = await acp.listSessions();
     const candidates: Array<{ id: string; createdAt: number }> = [];
     for (const session of sessions) {
-      if (TERMINAL_SESSION_STATUSES.has(session.status)) continue;
+      if (!isSessionPromptable(session.status)) continue;
       // Resolve via `resolveTaskId`, not the in-memory `sessionTaskIndex`
       // directly: after a parent restart the index is empty but pre-restart
       // keepAlive sessions are still live, so the session→task mapping only
@@ -7324,10 +7356,15 @@ export class OrchestratorTaskService extends Service {
     const victim = candidates[0];
     if (!victim) return false;
     try {
-      // Mark the stop administrative BEFORE stopping so the swarm
-      // coordinator's `stopped` synthesis reads it as lifecycle plumbing.
-      await markSessionAdministrativelyStopped(acp, victim.id, "idle_reclaim");
-      await acp.stopSession(victim.id);
+      const taskId = await this.resolveTaskId(victim.id);
+      if (!taskId) return false;
+      const owner = await this.store.getTask(taskId);
+      if (!owner || !TERMINAL_TASK_STATUSES.has(owner.task.status))
+        return false;
+      const stopped = await acp.stopPromptableSession(victim.id, () =>
+        markSessionAdministrativelyStopped(acp, victim.id, "idle_reclaim"),
+      );
+      if (!stopped) return false;
       this.log("info", "reclaimed idle keepAlive session for queued task", {
         sessionId: victim.id,
       });

--- a/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-watchdog-service.ts
@@ -32,7 +32,7 @@ import {
   Service,
 } from "@elizaos/core";
 import { getSessionSpendUsd, readSpendCapUsd } from "./spend-allowance.js";
-import { TERMINAL_SESSION_STATUSES } from "./types.js";
+import { isSessionExecuting, TERMINAL_SESSION_STATUSES } from "./types.js";
 
 export const TASK_WATCHDOG_SERVICE_TYPE = "ORCHESTRATOR_TASK_WATCHDOG";
 
@@ -60,8 +60,8 @@ export interface StalledSession {
 }
 
 /**
- * Pure: which active (non-terminal) sessions have been idle longer than
- * `stallMs` as of `nowMs`. Terminal sessions are never "stalled" — they're done.
+ * Pure: which prompt-in-flight sessions have been idle longer than `stallMs`
+ * as of `nowMs`. Promptable idle and terminal sessions are never stalled.
  */
 export function detectStalledSessions(
   sessions: WatchdogSessionView[],
@@ -70,7 +70,7 @@ export function detectStalledSessions(
 ): StalledSession[] {
   const stalled: StalledSession[] = [];
   for (const s of sessions) {
-    if (TERMINAL_SESSION_STATUSES.has(s.status)) continue;
+    if (!isSessionExecuting(s.status)) continue;
     const idleMs = nowMs - s.lastActivityMs;
     if (idleMs >= stallMs) stalled.push({ id: s.id, idleMs });
   }

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -140,6 +140,28 @@ export const TERMINAL_SESSION_STATUSES: ReadonlySet<string> = new Set([
   "cancelled",
 ]);
 
+/** Whether a retained session is idle and can accept a new prompt. */
+export function isSessionPromptable(status: string): boolean {
+  return status === "ready";
+}
+
+/** Whether a live session has a prompt in flight and must not be reclaimed. */
+export function isSessionPromptInFlight(status: string): boolean {
+  return !isSessionPromptable(status) && !TERMINAL_SESSION_STATUSES.has(status);
+}
+
+const USER_GATED_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  "blocked",
+  "authenticating",
+]);
+
+/** Whether a session is executing work that can meaningfully stall. */
+export function isSessionExecuting(status: string): boolean {
+  return (
+    isSessionPromptInFlight(status) && !USER_GATED_SESSION_STATUSES.has(status)
+  );
+}
+
 export type SessionEventCallback = (
   sessionId: string,
   event: SessionEventName,

--- a/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
+++ b/plugins/plugin-agent-orchestrator/tests/e2e/live-native-acp-smoke.mjs
@@ -25,7 +25,7 @@ const DEFAULT_CODEX_MODEL =
   process.env.LIVE_NATIVE_ACP_CODEX_MODEL ?? "gpt-5.5";
 const DEFAULT_CODEX_REASONING_EFFORT =
   process.env.LIVE_NATIVE_ACP_CODEX_REASONING_EFFORT ?? "low";
-const DEFAULT_CODEX_COMMAND = "npx -y @agentclientprotocol/codex-acp@1.1.2";
+const DEFAULT_CODEX_COMMAND = "npx -y @agentclientprotocol/codex-acp@1.10.0";
 const GIT_IDENTITY_EVIDENCE =
   process.env.LIVE_NATIVE_ACP_GIT_IDENTITY_EVIDENCE === "1";
 const GIT_IDENTITY_PROMPT =

--- a/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/__tests__/unit/CodingAgentTasksPanel.test.tsx
@@ -1,17 +1,5 @@
+/** Exercises task listing, detail controls, and polling recovery with mocked client boundaries. */
 // @vitest-environment jsdom
-//
-// Behavioral + data-display tests for CodingAgentTasksPanel (the task-coordinator
-// gui/xr view, src/CodingAgentTasksPanel.tsx). Renders it with realistic
-// CodingAgentTaskThread / CodingAgentTaskThreadDetail fixtures and
-// assert: (a) the populated list shows specific titles/subtitles + total/active/
-// done count chips + session/decision chips; (b) typing in search re-fetches
-// with that search; (c) the show-archived toggle re-fetches with includeArchived
-// and flips aria-pressed; (d) an empty result renders TaskEmptyState; (e)
-// clicking a card opens ThreadDetailPane with the fixture's acceptance/session/
-// artifact/decision/transcript values + the counts row; (f) Delete archives the
-// thread and Reopen reopens an archived one; (g) the back chip returns to the
-// list. We mock @elizaos/ui's client + useApp + Button and @elizaos/ui/agent-
-// surface's useAgentElement so the component's own behavior is under test.
 import {
   cleanup,
   fireEvent,
@@ -423,6 +411,27 @@ function panel(): HTMLElement {
 }
 
 describe("CodingAgentTasksPanel — list", () => {
+  it("retains tasks while a background refresh fails and clears the error after recovery", async () => {
+    listCodingAgentTaskThreads.mockResolvedValue([ACTIVE_THREAD]);
+    render(<CodingAgentTasksPanel />);
+    await screen.findByText("Fix the broken CI build");
+    listCodingAgentTaskThreads.mockRejectedValueOnce(
+      new Error("Task backend unavailable"),
+    );
+    expect(
+      await screen.findByText(
+        /Task backend unavailable/,
+        {},
+        { timeout: 7000 },
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Fix the broken CI build")).toBeTruthy();
+    await waitFor(
+      () => expect(screen.queryByText(/Task backend unavailable/)).toBeNull(),
+      { timeout: 7000 },
+    );
+  }, 15000);
+
   it("renders each thread's title + subtitle and the total/active/done count chips", async () => {
     listCodingAgentTaskThreads.mockResolvedValue([
       ACTIVE_THREAD,

--- a/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -1,3 +1,7 @@
+/**
+ * Displays project-scoped coding tasks and their live session details. Polling
+ * retains the last received list and exposes failures until the backend recovers.
+ */
 import { Button } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { ApiError, client } from "@elizaos/ui/api";
@@ -661,7 +665,10 @@ export function CodingAgentTasksPanel({
     if (activeProjectId === undefined) return;
     let cancelled = false;
 
+    let refreshing = false;
     const refreshThreads = async (silent = false) => {
+      if (refreshing) return;
+      refreshing = true;
       if (!silent) {
         setLoading(true);
       }
@@ -674,7 +681,6 @@ export function CodingAgentTasksPanel({
         });
         if (cancelled) return;
         setLoadError(null);
-        setMutationError(null);
         setBackendAbsent(false);
         setThreads(nextThreads);
         setSelectedThreadId((current) => {
@@ -685,6 +691,7 @@ export function CodingAgentTasksPanel({
           return null;
         });
       } catch (error) {
+        // error-policy:J4 keep the last task list while visibly reporting refresh failures.
         if (cancelled) return;
         // The task-thread endpoint is owned by the Node-only
         // @elizaos/plugin-agent-orchestrator and is absent on mobile/web
@@ -698,22 +705,21 @@ export function CodingAgentTasksPanel({
           setSelectedThread(null);
           return;
         }
-        if (!silent) {
-          setLoadError(
-            getClientErrorMessage(
-              error,
-              t("codingagenttaskspanel.unknown", {
-                defaultValue: "Unknown",
-              }),
-            ),
-          );
-        }
+        setLoadError(
+          getClientErrorMessage(
+            error,
+            t("codingagenttaskspanel.unknown", {
+              defaultValue: "Unknown",
+            }),
+          ),
+        );
         if (!silent) {
           setThreads([]);
           setSelectedThreadId(null);
           setSelectedThread(null);
         }
       } finally {
+        refreshing = false;
         if (!cancelled && !silent) {
           setLoading(false);
         }

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.test.tsx
@@ -1,14 +1,5 @@
+/** Exercises project selection and failed registry recovery with mocked client calls and inline dropdown primitives. */
 // @vitest-environment jsdom
-//
-// ProjectSwitcher (#13776 item 5) — drives the switcher through the REAL
-// client boundary (mocked) and the dropdown primitives (rendered inline so
-// items are always in the DOM for assertions). Proves: it renders one row per
-// registered project with the active one marked, initial load reports the
-// active project to the host, selecting a row calls client.activateProject and
-// fires onActiveProjectChange with the new id, the degenerate zero/one-project
-// case self-hides and reports null (unfiltered, exactly like pre-switcher
-// builds — #14112), and registry/switch failures render visible error states.
-
 import {
   cleanup,
   fireEvent,
@@ -235,7 +226,12 @@ describe("ProjectSwitcher", () => {
   });
 
   it("renders a visible unavailable state when the registry load fails", async () => {
-    calls.listProjects.mockRejectedValue(new Error("registry down"));
+    calls.listProjects
+      .mockRejectedValueOnce(new Error("registry down"))
+      .mockResolvedValue({
+        projects: [PROJECT_A, PROJECT_B],
+        activeProjectId: "proj-b",
+      });
     const onChange = vi.fn();
     render(<ProjectSwitcher onActiveProjectChange={onChange} />);
 
@@ -246,6 +242,14 @@ describe("ProjectSwitcher", () => {
       screen.getByTestId("project-switcher-error").getAttribute("title"),
     ).toBe("registry down");
     expect(onChange).toHaveBeenCalledWith(null);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry loading projects" }),
+    );
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith("proj-b"));
+    expect(screen.queryByText("Projects unavailable")).toBeNull();
+    expect(
+      screen.getByTestId("project-switcher-trigger").textContent,
+    ).toContain(PROJECT_B.name);
   });
 
   it("renders a visible error when activation fails", async () => {

--- a/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
+++ b/plugins/plugin-task-coordinator/src/ProjectSwitcher.tsx
@@ -69,9 +69,11 @@ export function ProjectSwitcher({
   const { t: appT } = useAppSelectorShallow((s) => ({ t: s.t }));
   const t = appT ?? fallbackTranslate;
   const [state, setState] = useState<ProjectSwitcherState>(INITIAL_STATE);
+  const [reloadVersion, setReloadVersion] = useState(0);
 
   const loadProjects = useCallback(
     async (signal: { cancelled: boolean }) => {
+      setState((current) => ({ ...current, loading: true, error: null }));
       try {
         const { projects, activeProjectId } = await client.listProjects();
         if (signal.cancelled) return;
@@ -88,6 +90,7 @@ export function ProjectSwitcher({
         // are ≥2 projects to switch between (#14112).
         onActiveProjectChange?.(projects.length > 1 ? activeProjectId : null);
       } catch (error) {
+        // error-policy:J4 registry failures remain visible and can be retried.
         if (signal.cancelled) return;
         setState((prev) => ({
           ...prev,
@@ -102,13 +105,14 @@ export function ProjectSwitcher({
     [onActiveProjectChange],
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: A retry explicitly starts a new cancellable registry request.
   useEffect(() => {
     const signal = { cancelled: false };
     void loadProjects(signal);
     return () => {
       signal.cancelled = true;
     };
-  }, [loadProjects]);
+  }, [loadProjects, reloadVersion]);
 
   const handleSelect = useCallback(
     async (projectId: string) => {
@@ -127,6 +131,7 @@ export function ProjectSwitcher({
         }));
         onActiveProjectChange?.(activated.id);
       } catch (error) {
+        // error-policy:J4 failed activation preserves the selected project and shows the error.
         setState((prev) => ({
           ...prev,
           switching: false,
@@ -159,7 +164,8 @@ export function ProjectSwitcher({
         type="button"
         variant="dangerOutline"
         size="dense"
-        disabled
+        onClick={() => setReloadVersion((current) => current + 1)}
+        aria-label="Retry loading projects"
         data-testid="project-switcher-error"
         title={state.error}
         className="max-w-[12rem]"

--- a/plugins/plugin-task-coordinator/src/TaskCardList.tsx
+++ b/plugins/plugin-task-coordinator/src/TaskCardList.tsx
@@ -368,7 +368,11 @@ export function TaskEmptyState({
     <>
       <Separator tone="subtle40" />
       <div
-        className="flex min-h-64 flex-col items-center justify-center gap-3 py-10 text-center [@media(max-height:500px)]:min-h-0 [@media(max-height:500px)]:py-4"
+        className="flex flex-col items-center justify-center gap-3 text-center"
+        style={{
+          minHeight: "min(16rem, 35dvh)",
+          paddingBlock: "min(2.5rem, 4dvh)",
+        }}
         data-testid="task-empty-state"
       >
         <CircleDashed

--- a/plugins/plugin-task-coordinator/src/TaskCardList.tsx
+++ b/plugins/plugin-task-coordinator/src/TaskCardList.tsx
@@ -1,6 +1,7 @@
-// Shared visual task-card language for the /orchestrator and /task-coordinator
-// single-pane landings. Both views render the same card medallion + chips so the
-// two surfaces read as one product. Pure presentation — no data fetching.
+/**
+ * Shares task cards, status indicators, and empty states across the task and
+ * orchestrator surfaces. Data loading remains with each owning view.
+ */
 
 import { Button, Card, Input, Separator, StatusPulseDot } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
@@ -367,7 +368,7 @@ export function TaskEmptyState({
     <>
       <Separator tone="subtle40" />
       <div
-        className="flex min-h-64 flex-col items-center justify-center gap-3 py-10 text-center"
+        className="flex min-h-64 flex-col items-center justify-center gap-3 py-10 text-center [@media(max-height:500px)]:min-h-0 [@media(max-height:500px)]:py-4"
         data-testid="task-empty-state"
       >
         <CircleDashed

--- a/plugins/plugin-task-coordinator/src/TaskCardList.tsx
+++ b/plugins/plugin-task-coordinator/src/TaskCardList.tsx
@@ -370,13 +370,15 @@ export function TaskEmptyState({
       <div
         className="flex flex-col items-center justify-center gap-3 text-center"
         style={{
-          minHeight: "min(16rem, 35dvh)",
+          minHeight: "min(16rem, max(0px, calc(100dvh - 300px)))",
           paddingBlock: "min(2.5rem, 4dvh)",
+          rowGap: "min(0.75rem, 1.5dvh)",
         }}
         data-testid="task-empty-state"
       >
         <CircleDashed
           className="size-10 text-accent/40"
+          style={{ maxHeight: "clamp(0px, calc(100dvh - 500px), 2.5rem)" }}
           strokeWidth={1.5}
           aria-hidden
         />

--- a/plugins/plugin-workflow/README.md
+++ b/plugins/plugin-workflow/README.md
@@ -7,3 +7,32 @@ Workflows are executable TS/TSX modules, authored from chat or the Workflows stu
 See [CLAUDE.md](./CLAUDE.md) for the source contract, architecture, routes, and validation commands.
 
 `ELIZA_SMTHRS_TIMEOUT_MS` optionally sets the worker deadline in milliseconds. It accepts canonical decimal integers from `1` through `2147483647`; invalid configuration fails before worker startup.
+
+## Validation scenarios
+
+The integration is pinned to Smithers 0.35.0. Run the isolated package suite with
+`bun run --cwd plugins/plugin-workflow test`. Its real-runner scenarios cover:
+
+- complete output passed between dependent tasks, persisted rows, and reuse of a completed run without replaying model calls;
+- invalid render errors and finite retry budgets for malformed model output;
+- approval-gated execution that resumes only after a persisted decision;
+- external signals that resume a waiting workflow with the complete payload;
+- timeout, cancellation, inherited child pipes, and delayed event delivery.
+
+`bun run --cwd packages/app test:e2e:workflow-real` exercises authoring, event
+triggers, execution output, widgets, and reload persistence through the browser
+and a real local runtime. That lane uses a deterministic model bridge; it is
+separate from credentialed model validation. Use `E2E_RECORD=1` with the app's
+`test:e2e` runner when collecting video and trace evidence.
+
+The coding-task integration has a live subscription lane:
+
+```bash
+RUN_LIVE_SMITHERS_SUBSCRIPTION=1 bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/live/smithers-codex-subscription.live.test.ts
+```
+
+It requires an authenticated Codex subscription and checks an exact model
+response through the durable Smithers worker and native ACP transport. The
+managed Codex adapter is pinned to 1.10.0; startup diagnostics are negotiated as
+typed records and retained separately from the model answer. Run the owning
+package checks and root `bun run verify` after changing either dependency.

--- a/plugins/plugin-workflow/__tests__/fixtures/smithers-worker-lifecycle-fixture.mjs
+++ b/plugins/plugin-workflow/__tests__/fixtures/smithers-worker-lifecycle-fixture.mjs
@@ -37,6 +37,9 @@ if (mode === 'ignore-termination') {
     emit({ kind: 'result', result: { runId: payload.runId, status: 'finished' } });
     process.exit(0);
   }, 100);
+} else if (mode === 'event-before-result') {
+  emit({ kind: 'event', event: { type: 'TaskStarted' } });
+  emit({ kind: 'result', result: { runId: payload.runId, status: 'finished' } });
 } else if (mode === 'oversized-stdout-line') {
   process.stdout.write('x'.repeat(Number(payload.input.outputBytes)));
 } else {

--- a/plugins/plugin-workflow/__tests__/integration/smithers-runner.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/smithers-runner.test.ts
@@ -8,6 +8,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 import { readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
+  controlSmithersRun,
   resolveSmithersWorkflowDir,
   runSmithersWorkflow,
 } from '../../src/services/smithers-runtime';
@@ -16,6 +17,10 @@ import type { WorkflowDefinitionResponse } from '../../src/types/index';
 const tenantId = `smithers-runner-test-${process.pid}`;
 const workflowId = 'real-smthrs-workflow';
 const finiteWorkflowId = 'finite-retry-workflow';
+const dependentWorkflowId = 'dependent-task-workflow';
+const invalidWorkflowId = 'invalid-render-workflow';
+const approvalWorkflowId = 'approval-resume-workflow';
+const signalWorkflowId = 'signal-resume-workflow';
 
 const workflow: WorkflowDefinitionResponse = {
   id: workflowId,
@@ -43,7 +48,14 @@ export default smithers(() => (
 
 afterAll(async () => {
   await Promise.all(
-    [workflowId, finiteWorkflowId].map((id) =>
+    [
+      workflowId,
+      finiteWorkflowId,
+      dependentWorkflowId,
+      invalidWorkflowId,
+      approvalWorkflowId,
+      signalWorkflowId,
+    ].map((id) =>
       rm(resolveSmithersWorkflowDir(tenantId, id), {
         recursive: true,
         force: true,
@@ -53,6 +65,195 @@ afterAll(async () => {
 });
 
 describe('real Smithers runner', () => {
+  test('resumes a persisted approval without running the guarded task early', async () => {
+    const definition: WorkflowDefinitionResponse = {
+      ...workflow,
+      id: approvalWorkflowId,
+      source: `/** @jsxImportSource smthrs */
+import { createSmithers } from "smthrs/create";
+import { approvalDecisionSchema } from "smthrs";
+import { z } from "zod";
+const { Workflow, Sequence, Approval, Task, smithers, outputs } = createSmithers({decision: approvalDecisionSchema, output: z.object({message: z.string()})}, {dbPath: process.env.ELIZA_SMTHRS_DB_PATH});
+export default smithers(() => <Workflow name="approval"><Sequence><Approval id="publish-gate" output={outputs.decision} request={{title:"Publish the reviewed result?"}} /><Task id="publish" output={outputs.output} agent={globalThis.__elizaSmithers.agent}>Publish the reviewed result.</Task></Sequence></Workflow>);`,
+    };
+    let calls = 0;
+    const request = {
+      tenantId,
+      workflow: definition,
+      runId: `approval-${Date.now()}`,
+      mode: 'manual' as const,
+      input: {},
+      timeoutMs: 60000,
+      generate: async () => {
+        calls += 1;
+        return '{"message":"Published after approval"}';
+      },
+    };
+    const paused = await runSmithersWorkflow(request);
+    expect(paused.status).toBe('waiting-approval');
+    expect(calls).toBe(0);
+    const iteration = paused.events.find(
+      (event) => event.nodeId === 'publish-gate' && typeof event.iteration === 'number'
+    )?.iteration;
+    if (iteration === undefined)
+      throw new Error('Approval event must identify its durable iteration');
+    await controlSmithersRun(tenantId, approvalWorkflowId, {
+      kind: 'approve',
+      runId: request.runId,
+      nodeId: 'publish-gate',
+      iteration,
+    });
+    const finished = await runSmithersWorkflow(request);
+    expect(finished.status, JSON.stringify(finished.error)).toBe('finished');
+    expect(finished.output).toEqual([
+      expect.objectContaining({
+        message: 'Published after approval',
+        nodeId: 'publish',
+        runId: request.runId,
+      }),
+    ]);
+    expect(calls).toBe(1);
+  }, 150000);
+
+  test('resumes a persisted signal wait with the complete external payload', async () => {
+    const definition: WorkflowDefinitionResponse = {
+      ...workflow,
+      id: signalWorkflowId,
+      source: `/** @jsxImportSource smthrs */
+import { createSmithers } from "smthrs/create";
+import { z } from "zod";
+const { Workflow, Signal, Task, smithers, outputs } = createSmithers({signal: z.object({message:z.string()}), output: z.object({message:z.string()})}, {dbPath:process.env.ELIZA_SMTHRS_DB_PATH});
+export default smithers(() => <Workflow name="signal"><Signal id="review-ready" schema={outputs.signal}>{data => <Task id="publish" output={outputs.output} agent={globalThis.__elizaSmithers.agent}>{data.message}</Task>}</Signal></Workflow>);`,
+    };
+    const prompts: unknown[] = [];
+    const message = `Signal payload 🟠 ${'preserved '.repeat(2000)}complete`;
+    const request = {
+      tenantId,
+      workflow: definition,
+      runId: `signal-${Date.now()}`,
+      mode: 'manual' as const,
+      input: {},
+      timeoutMs: 60000,
+      generate: async (prompt: unknown) => {
+        prompts.push(prompt);
+        return '{"message":"Signal consumed"}';
+      },
+    };
+    const waiting = await runSmithersWorkflow(request);
+    expect(waiting.status, JSON.stringify(waiting.error)).toBe('waiting-event');
+    expect(prompts).toHaveLength(0);
+    await controlSmithersRun(tenantId, signalWorkflowId, {
+      kind: 'signal',
+      runId: request.runId,
+      signal: 'review-ready',
+      payload: { message },
+    });
+    const finished = await runSmithersWorkflow(request);
+    expect(finished.status, JSON.stringify(finished.error)).toBe('finished');
+    expect(finished.output).toEqual([
+      expect.objectContaining({
+        message: 'Signal consumed',
+        nodeId: 'publish',
+        runId: request.runId,
+      }),
+    ]);
+    expect(JSON.stringify(prompts)).toContain(message);
+  }, 150000);
+
+  test('passes complete persisted output into a dependent task and resumes without replay', async () => {
+    const completeMessage = `start-${'workflow context 🟠 '.repeat(4_000)}-end`;
+    const dependentWorkflow: WorkflowDefinitionResponse = {
+      ...workflow,
+      id: dependentWorkflowId,
+      source: `/** @jsxImportSource smthrs */
+import { createSmithers } from "smthrs/create";
+import { z } from "zod";
+const { Workflow, Task, smithers, outputs } = createSmithers({
+  draft: z.object({ message: z.string() }),
+  output: z.object({ message: z.string() }),
+}, { dbPath: process.env.ELIZA_SMTHRS_DB_PATH });
+const agent = globalThis.__elizaSmithers.agent;
+export default smithers(() => (
+  <Workflow name="dependent-output">
+    <Task id="draft" output={outputs.draft} agent={agent}>Draft the result.</Task>
+    <Task id="review" output={outputs.output} agent={agent} deps={{ draft: outputs.draft }}>
+      {({ draft }) => draft.message}
+    </Task>
+  </Workflow>
+));`,
+      steps: [
+        { id: 'draft', label: 'Draft', kind: 'task', agent: 'elizaOS' },
+        { id: 'review', label: 'Review', kind: 'task', agent: 'elizaOS' },
+      ],
+    };
+    const prompts: unknown[] = [];
+    const request = {
+      tenantId,
+      workflow: dependentWorkflow,
+      runId: `dependent-${Date.now()}`,
+      mode: 'manual' as const,
+      input: {},
+      timeoutMs: 20_000,
+      generate: async ({ prompt }: { prompt: unknown }) => {
+        prompts.push(prompt);
+        return { message: prompts.length === 1 ? completeMessage : 'reviewed' };
+      },
+    };
+    const result = await runSmithersWorkflow(request);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe('finished');
+    expect(prompts).toHaveLength(2);
+    expect(JSON.stringify(prompts[1])).toContain(completeMessage);
+    expect(result.output).toEqual(
+      expect.arrayContaining([expect.objectContaining({ message: 'reviewed' })])
+    );
+
+    const resumed = await runSmithersWorkflow(request);
+    expect(resumed.status).toBe('finished');
+    expect(prompts).toHaveLength(2);
+    const database = new Database(
+      join(resolveSmithersWorkflowDir(tenantId, dependentWorkflowId), 'runs.sqlite')
+    );
+    try {
+      expect(
+        database
+          .query<{ message: string }, [string]>('SELECT message FROM draft WHERE run_id = ?')
+          .all(request.runId)
+      ).toEqual([{ message: completeMessage }]);
+      expect(
+        database
+          .query<{ message: string }, [string]>('SELECT message FROM output WHERE run_id = ?')
+          .all(request.runId)
+      ).toEqual([{ message: 'reviewed' }]);
+    } finally {
+      database.close();
+    }
+  }, 60_000);
+
+  test('preserves actionable native render errors across the worker protocol', async () => {
+    const result = await runSmithersWorkflow({
+      tenantId,
+      workflow: {
+        ...workflow,
+        id: invalidWorkflowId,
+        source: `import { createSmithers } from "smthrs/create";
+import { z } from "zod";
+const { smithers } = createSmithers({ output: z.object({ message: z.string() }) },
+  { dbPath: process.env.ELIZA_SMTHRS_DB_PATH });
+export default smithers(() => { throw new Error("Select a project before running review"); });`,
+      },
+      runId: `invalid-render-${Date.now()}`,
+      mode: 'manual',
+      input: {},
+      timeoutMs: 20_000,
+      generate: async () => {
+        throw new Error('A failed render must not invoke the model');
+      },
+    });
+    expect(result.status).toBe('failed');
+    expect(result.error?.message).toContain('Select a project before running review');
+  }, 45_000);
+
   test('executes TSX, bridges model generation, and streams native events', async () => {
     const modelRequests: unknown[] = [];
     const events: string[] = [];

--- a/plugins/plugin-workflow/__tests__/unit/smithers-worker-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-worker-lifecycle.test.ts
@@ -18,6 +18,7 @@ const fixturePath = fileURLToPath(
   new URL('../fixtures/smithers-worker-lifecycle-fixture.mjs', import.meta.url)
 );
 const originalBunBin = process.env.BUN_BIN;
+type UnrefTimer = ReturnType<typeof setTimeout> & { unref(): void };
 
 function workflow(): WorkflowDefinitionResponse {
   const now = new Date().toISOString();
@@ -43,6 +44,7 @@ async function run(
     timeoutMs?: number;
     input?: Record<string, unknown>;
     generate?: SmithersRunRequest['generate'];
+    onEvent?: SmithersRunRequest['onEvent'];
   } = {}
 ) {
   return runSmithersWorkflow({
@@ -53,6 +55,7 @@ async function run(
     input: { fixtureMode: mode, ...options.input },
     timeoutMs: options.timeoutMs ?? 20_000,
     ...(options.signal ? { signal: options.signal } : {}),
+    ...(options.onEvent ? { onEvent: options.onEvent } : {}),
     generate: options.generate ?? (async () => 'done'),
   });
 }
@@ -148,6 +151,97 @@ describe('Smithers worker lifecycle', () => {
   test('observes a closed stdin while preserving a valid terminal result', async () => {
     const result = await run('closed-input-result');
     expect(result.status).toBe('finished');
+  });
+
+  test('preserves a terminal result when durable event delivery exceeds pipe drain grace', async () => {
+    const delivered: string[] = [];
+    const result = await run('event-before-result', {
+      onEvent: async (event) => {
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+        delivered.push(event.type);
+      },
+    });
+
+    expect(result.status).toBe('finished');
+    expect(delivered).toEqual(['TaskStarted']);
+    expect(result.events.map((event) => event.type)).toEqual(['TaskStarted']);
+  });
+
+  test('observes an immediate event delivery rejection before child outcome settles', async () => {
+    const deliveryError = new Error('immediate event delivery rejection');
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      if (reason === deliveryError) unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      await expect(
+        run('event-before-result', {
+          onEvent: () => Promise.reject(deliveryError),
+        })
+      ).rejects.toBe(deliveryError);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  test('times out when event delivery does not settle after the worker exits', async () => {
+    const startedAt = Date.now();
+    const workflowOutcome = run('event-before-result', {
+      timeoutMs: 3_000,
+      onEvent: () => new Promise(() => {}),
+    }).then(
+      (value) => ({ kind: 'result' as const, value }),
+      (error) => ({ kind: 'error' as const, error })
+    );
+    let watchdogTimer: UnrefTimer | undefined;
+    const watchdogOutcome = new Promise<{ kind: 'watchdog' }>((resolve) => {
+      const timer = setTimeout(() => resolve({ kind: 'watchdog' }), 5_000) as unknown as UnrefTimer;
+      timer.unref();
+      watchdogTimer = timer;
+    });
+    try {
+      const outcome = await Promise.race([workflowOutcome, watchdogOutcome]);
+
+      expect(outcome).toMatchObject({
+        kind: 'error',
+        error: { code: 'SMTHRS_WORKFLOW_TIMEOUT' },
+      });
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+    } finally {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
+    }
+  });
+
+  test('cancels when event delivery does not settle after the worker exits', async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 500);
+    const startedAt = Date.now();
+    const workflowOutcome = run('event-before-result', {
+      signal: controller.signal,
+      timeoutMs: 3_000,
+      onEvent: () => new Promise(() => {}),
+    });
+    let watchdogTimer: UnrefTimer | undefined;
+    const watchdogOutcome = new Promise<{ status: 'watchdog' }>((resolve) => {
+      const timer = setTimeout(
+        () => resolve({ status: 'watchdog' }),
+        2_000
+      ) as unknown as UnrefTimer;
+      timer.unref();
+      watchdogTimer = timer;
+    });
+    try {
+      const outcome = await Promise.race([workflowOutcome, watchdogOutcome]);
+
+      expect(outcome.status).toBe('cancelled');
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    } finally {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
+    }
   });
 
   test('terminates a worker whose stdout line exceeds the protocol budget', async () => {

--- a/plugins/plugin-workflow/package.json
+++ b/plugins/plugin-workflow/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@elizaos/shared": "workspace:*",
-    "smthrs": "0.34.0",
+    "smthrs": "0.35.0",
     "zod": "^4.4.3",
     "drizzle-orm": "0.45.2",
     "effect": "4.0.0-beta.105"

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -406,9 +406,18 @@ function statusFromSmithers(status: string): WorkflowExecutionStatus {
 }
 
 function errorPayload(error: unknown): { message: string; stack?: string } {
-  return error instanceof Error
-    ? { message: error.message, ...(error.stack ? { stack: error.stack } : {}) }
-    : { message: String(error) };
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return {
+      message: error.message,
+      ...('stack' in error && typeof error.stack === 'string' ? { stack: error.stack } : {}),
+    };
+  }
+  return { message: typeof error === 'object' ? JSON.stringify(error) : String(error) };
 }
 
 export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<SmithersRunResult> {
@@ -460,8 +469,15 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
   let stdoutBuffer = '';
   let stdoutNoise = '';
   let stdinError: Error | undefined;
-  let lineProcessing = Promise.resolve();
+  const observeLineProcessing = (processing: Promise<void>): Promise<void> => {
+    // error-policy:J5 the same rejection is re-observed and propagated after
+    // child-process settlement through observedLineProcessing below.
+    void processing.catch(() => undefined);
+    return processing;
+  };
+  let lineProcessing = observeLineProcessing(Promise.resolve());
   const protocolController = new AbortController();
+  const deliveryController = new AbortController();
 
   const protocolAbortOutcome = new Promise<{ kind: 'aborted' }>((resolve) => {
     if (protocolController.signal.aborted) {
@@ -469,6 +485,15 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
       return;
     }
     protocolController.signal.addEventListener('abort', () => resolve({ kind: 'aborted' }), {
+      once: true,
+    });
+  });
+  const deliveryAbortOutcome = new Promise<{ kind: 'aborted' }>((resolve) => {
+    if (deliveryController.signal.aborted) {
+      resolve({ kind: 'aborted' });
+      return;
+    }
+    deliveryController.signal.addEventListener('abort', () => resolve({ kind: 'aborted' }), {
       once: true,
     });
   });
@@ -547,7 +572,18 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
         payload: raw,
       };
       events.push(event);
-      await request.onEvent?.(event);
+      const deliveryOutcome = Promise.resolve(request.onEvent?.(event)).then(
+        () => ({ kind: 'delivered' as const }),
+        (error) => ({ kind: 'error' as const, error })
+      );
+      const delivery = await Promise.race([deliveryOutcome, deliveryAbortOutcome]);
+      if (delivery.kind === 'error') throw delivery.error;
+      if (delivery.kind === 'aborted' && !terminationCause) {
+        const reason = deliveryController.signal.reason;
+        if (reason === 'abort' || reason === 'timeout' || reason === 'overflow') {
+          terminationCause = reason;
+        }
+      }
     }
   };
 
@@ -560,13 +596,15 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     }
     stdoutBuffer = appended.buffer;
     worker.stdout?.pause();
-    lineProcessing = lineProcessing
-      .then(async () => {
-        for (const line of appended.lines) await consumeLine(line);
-      })
-      .finally(() => {
-        if (!terminationCause && !processExited) worker.stdout?.resume();
-      });
+    lineProcessing = observeLineProcessing(
+      lineProcessing
+        .then(async () => {
+          for (const line of appended.lines) await consumeLine(line);
+        })
+        .finally(() => {
+          if (!terminationCause && !processExited) worker.stdout?.resume();
+        })
+    );
   });
   worker.stderr?.setEncoding('utf8');
   worker.stderr?.on('data', (chunk: string) => {
@@ -580,14 +618,21 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     if (terminationCause || processExited) return;
     terminationCause = cause;
     protocolController.abort(cause);
+    deliveryController.abort(cause);
     worker.kill('SIGTERM');
     forceKillTimer = setTimeout(() => worker.kill('SIGKILL'), WORKER_TERMINATION_GRACE_MS);
     forceKillTimer.unref();
   };
-  const abort = (): void => terminate('abort');
+  const abort = (): void => {
+    if (processExited) deliveryController.abort('abort');
+    else terminate('abort');
+  };
   if (request.signal?.aborted) abort();
   else request.signal?.addEventListener('abort', abort, { once: true });
-  const timeoutTimer = setTimeout(() => terminate('timeout'), timeoutMs);
+  const timeoutTimer = setTimeout(() => {
+    if (processExited) deliveryController.abort('timeout');
+    else terminate('timeout');
+  }, timeoutMs);
 
   const outcome = await new Promise<{
     exitCode: number | null;
@@ -627,9 +672,7 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
       settle(code);
     });
   }).finally(async () => {
-    clearTimeout(timeoutTimer);
     if (forceKillTimer) clearTimeout(forceKillTimer);
-    request.signal?.removeEventListener('abort', abort);
     await unlink(payloadPath).catch((error: NodeJS.ErrnoException) => {
       // error-policy:J6 run state is already persisted; teardown reports only
       // unexpected payload cleanup failures through the worker diagnostic path.
@@ -645,7 +688,7 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     }
   }
   if (stdoutBuffer && terminationCause !== 'overflow') {
-    lineProcessing = lineProcessing.then(() => consumeLine(stdoutBuffer));
+    lineProcessing = observeLineProcessing(lineProcessing.then(() => consumeLine(stdoutBuffer)));
   }
   let lineProcessingFailed = false;
   let lineProcessingError: unknown;
@@ -655,15 +698,13 @@ export async function runSmithersWorkflow(request: SmithersRunRequest): Promise<
     lineProcessingFailed = true;
     lineProcessingError = error;
   });
-  let lineProcessingTimer: NodeJS.Timeout | undefined;
-  let releaseLineProcessingTimer: (() => void) | undefined;
-  const lineProcessingDeadline = new Promise<void>((resolve) => {
-    releaseLineProcessingTimer = resolve;
-    lineProcessingTimer = setTimeout(resolve, WORKER_STDIO_DRAIN_GRACE_MS);
-  });
-  await Promise.race([observedLineProcessing, lineProcessingDeadline]);
-  if (lineProcessingTimer) clearTimeout(lineProcessingTimer);
-  releaseLineProcessingTimer?.();
+  // Protocol-owned generation is aborted as soon as the worker exits, so the
+  // remaining work here is ordered event delivery. It is part of the run
+  // contract: do not let the pipe-drain fallback skip a terminal result queued
+  // behind a slow persistence or runtime event callback.
+  await observedLineProcessing;
+  clearTimeout(timeoutTimer);
+  request.signal?.removeEventListener('abort', abort);
   if (lineProcessingFailed) throw lineProcessingError;
 
   if (outcome.processError) {


### PR DESCRIPTION
# Relates to

Closes #30749. Closes #30750. Closes #30758. Closes #28428. Closes #30787.

Includes the qualified lifecycle fixes from #30519 and #28459 with original author attribution. #29418 was reviewed and closed because its regression did not exercise the claimed Unicode failure.

# Sync with develop

Rebased without conflicts onto `9b314da5e65`; installed using Bun 1.3.14 and Node 24.15.0. `bun run verify` passes: 376/376 Turbo tasks and all concluding repository audits.

- [x] Targets develop; rebased without conflicts.
- [x] Bun install and repository verification completed after sync.
- [x] Final visual bundle and inline evidence review complete.

# Risks

Medium: updates the durable workflow runtime and native Codex adapter, and changes retained-session lifecycle decisions. Custom adapter commands remain honored. Smithers database migrations execute through its existing runtime. Approval, signal, cancellation, delayed event delivery, persistence, ownership and retained-session races are covered explicitly.

# Background

## What does this PR do?

Updates both Smithers consumers to `smthrs@0.35.0` and the managed native Codex adapter to `@agentclientprotocol/codex-acp@1.10.0`. The old adapter could not run the configured Codex model. Native adapter diagnostics now use negotiated typed events rather than contaminating model answer text.

A completed Smithers task now retains a usable follow-up session without the watchdog prompting it while idle or admission reclaiming it during a prompt. Durable task consumers consult live ACP state. Idle reclamation claims the session atomically, and adapter-defined executing states remain monitored.

Workflow Runs and History distinguish loading, empty and failed states, support retries, retain visible polling errors, and reject superseded reads. Switching workflows resets editor state. A delayed list response cannot erase a newly started run. Projects retains mutation errors through polling, retries project loading and fits empty states into short viewports.

The UI inventory now ignores known generated caches and temporary inventory workspaces. This prevents local Vite output from changing the checked-in report or racing fixture teardown in CI; maintained hidden sources such as Storybook stay governed.

## What kind of change is this?

Bug fixes, dependency updates and UI reliability improvements.

# Documentation changes needed?

Updated plugin workflow validation scenarios and the orchestrator adapter configuration documentation, including paired CLAUDE/AGENTS guides.

# Testing

## Where should a reviewer start?

Use the attached walkthrough and screenshots, then read the live trajectory: the model returns a unique nonce through Smithers, recalls it on a second prompt in the same native ACP session, an attempted reclaim during the follow-up is rejected, and that idle session is reclaimed successfully.

## Detailed testing steps

- Run `bun run --cwd plugins/plugin-workflow test`: 124 passing tests across all 16 isolated files. Real Smithers children persist and resume approval and signal waits; dependent tasks receive complete large Unicode output; a completed run does not replay model calls.
- Exercise slow event delivery, cancellation and callback deadlines. The #30519 tests reproduce four failures before the fix and pass afterward.
- Exercise retained-session follow-ups, retry/stop, watchdog and queue admission. The #28459 watchdog/admission tests reproduce five failures before the fix; all 293 tests in its six affected files pass with the qualified implementation.
- Inject History HTTP 503 in desktop and mobile browser fixtures, retry, and observe an explicit empty state. Exercise create/save/run/cancel/restore and Projects lifecycle controls.
- Run the real local workflow browser journey: create, persist, trigger, execute, render the widget, reload and recover the saved workflow.
- Owning-package suites: UI 13,631 passed / 7 skipped across 1,278 files; orchestrator 3,155 passed / 11 skipped across 285 files; Projects 254 passed across 33 files; workflows 124 passed across 16 files. That is 17,164 passing tests, excluding duplicate focused runs. The separate live proof covers the credentialed Codex path. Root verification and app visual/OCR results are attached below.

# Evidence Gate

<!-- evidence-head:ae8121aa9d9255f8c9900137fc8371eec72b5bd5 -->

<!-- evidence-row:before-screenshots -->
- [x] [Workflow desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-workflow-history-before-desktop.png); [workflow mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-workflow-history-before-mobile.png); [Projects desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-projects-before-desktop-landscape.png); [Projects mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-projects-before-mobile-landscape.png)
<!-- evidence-row:after-screenshots -->
- [x] [Workflow desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-desktop-history-recovered.png); [workflow mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-mobile-history-recovered.png); [Projects desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-builtin-tasks-desktop-landscape.png); [Projects mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-builtin-tasks-mobile-landscape.png)
<!-- evidence-row:walkthrough-video -->
- [x] [Real workflow MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-real-workflow.mp4); [Projects MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-projects-desktop.mp4); [Mobile retry MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-workflow-mobile-retry.mp4)
<!-- evidence-row:backend-logs -->
- [x] [Canonical backend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-backend-events.json)
<!-- evidence-row:frontend-logs -->
- [x] [Complete normalized network and console transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-frontend-network.json)
<!-- evidence-row:llm-trajectory -->
- [x] [Live Smithers and retained Codex session trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-qualified-model-trajectory.json)
<!-- evidence-row:domain-artifacts -->
- [x] [Persisted executions and trigger responses](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-workflow-persistence.json)
<!-- evidence-row:ocr-review -->
- [x] [OCR review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-ocr-review.json); [Verified bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-verified-visual-bundle.zip)

# Evidence Details

## Real LLM-call trajectory

The live model proof uses the normal managed adapter and existing subscription authentication. Browser fixtures use deterministic responses; they are UI evidence, not a substitute for the separate live-model proof.

## Backend + frontend logs

The canonical backend capture intentionally emits safe startup/output-observed records rather than arbitrary subprocess text. The accompanying Playwright network transcript contains all 466 requests, and the domain artifact retains 31 unmodified workflow/trigger JSON responses, including completed persisted runs. Request headers and query parameters are omitted from the shareable network transcript.

## Screenshots (before / after) + video walkthrough

Before captures identify the earlier qualification iteration, before the final empty-state and short-viewport refinements. After captures show the delivered revision. Failure/retry captures deliberately inject an HTTP error.

## Audio / voice walkthrough

N/A - this change does not alter voice, audio capture, transcription or speech synthesis.

## Known gaps / failures

The old managed Codex adapter failed against the configured model; the replacement passes the live proof. The first hosted run found a local-cache-dependent inventory. The scanner fix reproduces the 886→887 discrepancy and proves cached React/CSS leave inventory and compliance unchanged; the corrected report is committed. The minimal real-local browser harness does not mount the personal-assistant scheduled-task endpoint or build-info endpoint; their eight 404 responses are retained in the network log. All workflow and trigger requests succeed. The real-local screenshot also retains the expected Cloud sign-in chat sheet; authenticated UI fixtures provide the unobstructed layout captures. No universal claim about untested devices or third-party outages is made.

## Maintainer CI exception record

N/A - no exception requested.

## Final revision validation

[Validation summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-validation-summary.txt); [376-task repository verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-repository-verify.log); [13,631 passing UI tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-ui-suite.log); [219 passing visual tests and bundle integrity](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-visual-audit.log).

The final browser runs passed all seven fixture journeys and the real local journey. The domain responses contain three completed executions (two manual, one trigger). All workflow and trigger requests succeeded. The 438-artifact canonical visual bundle has zero integrity issues. OCR reports 204 verified, 12 requiring visual inspection, zero broken. All affected desktop/mobile/tablet captures were inspected; none has a computed needs-work or broken verdict.

## Workflow History before and after

Earlier qualification desktop/mobile before the final empty-state refinement:

![Earlier workflow desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-workflow-history-before-desktop.png)

![Earlier workflow mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-workflow-history-before-mobile.png)

Final desktop/mobile after successful retry:

![Final workflow desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-desktop-history-recovered.png)

![Final workflow mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-mobile-history-recovered.png)

Failure remains visible and retry is reachable:

![Mobile explicit history failure](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-mobile-history-unavailable.png)

[Desktop hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-desktop-history-retry-hover.png); [Mobile hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-mobile-history-retry-hover.png).

## Projects before and after

Earlier qualification desktop and short mobile landscape:

![Earlier Projects desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-projects-before-desktop-landscape.png)

![Earlier Projects landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-projects-before-mobile-landscape.png)

Final desktop and landscape, with both empty-state lines visible:

![Final Projects desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-builtin-tasks-desktop-landscape.png)

![Final Projects landscape](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-builtin-tasks-mobile-landscape.png)

[Final portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-builtin-tasks-mobile-portrait.png); [Final tablet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-builtin-tasks-ipad-portrait.png); [Shared Orchestrator short viewport](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-plugin-orchestrator-gui-mobile-landscape.png).

[Workflow Studio walkthrough MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-workflow-studio.mp4); [Real persisted and triggered workflow MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30784-ae8121-real-workflow.mp4).
