### PR TITLE
fix(cloud): route native Cerebras Qwen and preserve JSON-object mode

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-response-format.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-response-format.test.ts
@@ -1,0 +1,45 @@
+/** Exercises gateway response-format translation through the real OpenAI SDK serializer and response parser, with deterministic provider HTTP responses. */
+
+import { expect, test } from "bun:test";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+import { __nativeToolingTestHooks } from "../v1/chat/completions/route";
+
+test("JSON object mode reaches the provider without an invented strict schema", async () => {
+  const requests: Array<{ response_format: unknown }> = [];
+  const provider = createOpenAI({
+    apiKey: "fixture-provider-key",
+    fetch: Object.assign(
+      async (...[, init]: Parameters<typeof fetch>) => {
+        requests.push(
+          JSON.parse(String(init?.body)) as { response_format: unknown },
+        );
+        return Response.json({
+          id: "format-contract",
+          object: "chat.completion",
+          created: 0,
+          model: "qwen-3.8-27b",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: '{"greeting":"hello"}' },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 },
+        });
+      },
+      { preconnect: fetch.preconnect },
+    ),
+  });
+  const result = await generateText({
+    model: provider.chat("qwen-3.8-27b"),
+    prompt: "Return a JSON object with a greeting.",
+    output: __nativeToolingTestHooks.mapResponseFormat({ type: "json_object" }),
+    maxRetries: 0,
+  });
+  expect(requests).toHaveLength(1);
+  expect(requests[0]?.response_format).toEqual({ type: "json_object" });
+  expect(result.output).toEqual({ greeting: "hello" });
+  expect(result.usage.inputTokens).toBe(12);
+});

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -729,7 +729,7 @@ function mapResponseFormat(responseFormat: ChatRequest["response_format"]) {
   const schema =
     responseFormat.type === "json_schema"
       ? (responseFormat.json_schema.schema ?? { type: "object" })
-      : { type: "object", additionalProperties: true };
+      : undefined;
   const name =
     responseFormat.type === "json_schema"
       ? responseFormat.json_schema.name
@@ -743,7 +743,9 @@ function mapResponseFormat(responseFormat: ChatRequest["response_format"]) {
     name: "object",
     responseFormat: Promise.resolve({
       type: "json" as const,
-      schema,
+      // An absent schema preserves JSON-object mode in the provider SDK.
+      // Supplying a permissive object schema instead requests strict structured output.
+      ...(schema ? { schema } : {}),
       ...(name ? { name } : {}),
       ...(description ? { description } : {}),
     }),
@@ -754,6 +756,7 @@ function mapResponseFormat(responseFormat: ChatRequest["response_format"]) {
       try {
         return { partial: JSON.parse(text) };
       } catch {
+        // error-policy:J3 incomplete streamed JSON has no parsed partial value.
         return undefined;
       }
     },
@@ -762,9 +765,6 @@ function mapResponseFormat(responseFormat: ChatRequest["response_format"]) {
     },
   };
 
-  if (responseFormat.type === "json_object") {
-    return output;
-  }
   return output;
 }
 
@@ -4058,6 +4058,7 @@ function toOpenAiFinishReason(
 }
 
 export const __nativeToolingTestHooks = {
+  mapResponseFormat,
   mapToolChoice,
   convertTools,
   computeEffectiveMaxTokens,

--- a/packages/cloud/shared/src/lib/models/catalog.ts
+++ b/packages/cloud/shared/src/lib/models/catalog.ts
@@ -1,4 +1,4 @@
-// Defines cloud shared catalog behavior for backend service consumers.
+/** Defines model identities and capability metadata consumed by cloud routing and selectors. */
 import { normalizeProviderKey } from "../providers/model-id-translation";
 
 export interface CatalogModel {
@@ -50,6 +50,7 @@ export const CEREBRAS_DEFAULT_TEXT_SMALL_MODEL = CEREBRAS_DEFAULT_TEXT_MODEL;
 export const CEREBRAS_DEFAULT_TEXT_LARGE_MODEL = CEREBRAS_DEFAULT_TEXT_MODEL;
 export const CEREBRAS_NATIVE_TEXT_MODELS = [
   CEREBRAS_DEFAULT_TEXT_MODEL,
+  "qwen-3.8-27b",
   "gpt-oss-120b",
   "zai-glm-4.7",
 ] as const;
@@ -72,6 +73,19 @@ const BITROUTER_RECOMMENDED_MODEL_IDS = new Set<string>([CEREBRAS_DEFAULT_TEXT_M
 // - Groq docs: https://console.groq.com/docs/models
 // - Cerebras: https://api.cerebras.ai/public/v1/models?format=openrouter
 const BITROUTER_FEATURED_TEXT_MODELS: CatalogModel[] = [
+  {
+    id: "qwen-3.8-27b",
+    object: "model",
+    created: 0,
+    owned_by: "cerebras",
+    name: "Qwen3.8 27B",
+    description: "Cerebras language model for reasoning and tool use",
+    type: "language",
+    // Public Cerebras catalog capability; account-specific billing is resolved separately.
+    context_window: 65536,
+    max_tokens: 32768,
+    tags: ["reasoning", "tool-use", "cerebras"],
+  },
   {
     id: CEREBRAS_DEFAULT_TEXT_MODEL,
     object: "model",

--- a/packages/cloud/shared/src/lib/pricing.ts
+++ b/packages/cloud/shared/src/lib/pricing.ts
@@ -1,4 +1,5 @@
-// Defines cloud shared pricing behavior for backend service consumers.
+/** Resolves model billing identities and delegates costs to the authoritative pricing catalog. */
+import { CEREBRAS_NATIVE_TEXT_MODELS } from "./models/catalog";
 import { normalizeProviderKey } from "./providers/model-id-translation";
 import {
   calculateImageGenerationCostFromCatalog,
@@ -96,8 +97,7 @@ export function getProviderFromModel(model: string): string {
   }
 
   // Handle non-prefixed format: "gpt-5-mini"
-  if (model === "gemma-4-31b") return "cerebras";
-  if (model === "gpt-oss-120b") return "cerebras";
+  if (CEREBRAS_NATIVE_TEXT_MODELS.some((nativeModel) => nativeModel === model)) return "cerebras";
   // bge-* embeds on the platform-operated TEI sidecar
   // (packages/cloud/services/embeddings), matching its "selfhosted"
   // pricing/billing rows — not on an external provider.

--- a/packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-cerebras-fallback.test.ts
@@ -1,4 +1,4 @@
-// Exercises language model cerebras fallback behavior with deterministic cloud-shared lib fixtures.
+/** Exercises actual SDK routing and error handling against deterministic provider HTTP responses. */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -27,7 +27,9 @@ mock.module("@/lib/utils/logger", () => ({
 }));
 
 const { generateText } = await import("ai");
-const { getLanguageModel, resolveAiProviderSource } = await import("./language-model");
+const { getProviderFromModel } = await import("../pricing");
+const { getLanguageModel, hasLanguageModelProviderConfigured, resolveAiProviderSource } =
+  await import("./language-model");
 
 function hostOf(url: RequestInfo | URL): "openrouter" | "cerebras" | "other" {
   const u = String(url);
@@ -77,6 +79,38 @@ describe("getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallbac
     hosts = [];
   });
 
+  test.each(["qwen-3.8-27b", "cerebras/qwen-3.8-27b", "cerebras:qwen-3.8-27b"])(
+    "%s uses the configured Cerebras credential and sends its native model id",
+    async (model) => {
+      const backupKey = process.env.OPENROUTER_API_KEY;
+      delete process.env.OPENROUTER_API_KEY;
+      const requests: Array<{ model: string; authorization: string | null }> = [];
+      globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+        hosts.push(hostOf(url));
+        const body = JSON.parse(String(init?.body)) as { model: string };
+        requests.push({ model: body.model, authorization: authorizationHeader(init) });
+        return completion(body.model, "A complete Qwen reply");
+      }) as typeof fetch;
+      try {
+        expect(hasLanguageModelProviderConfigured(model)).toBe(true);
+        const result = await generateText({
+          model: getLanguageModel(model),
+          prompt: "hi",
+          maxRetries: 0,
+        });
+        expect(result.text).toBe("A complete Qwen reply");
+        expect(getProviderFromModel(model)).toBe(resolveAiProviderSource(model));
+        expect(hosts).toEqual(["cerebras"]);
+        expect(requests).toEqual([
+          { model: "qwen-3.8-27b", authorization: "Bearer test-cerebras-key" },
+        ]);
+      } finally {
+        if (backupKey === undefined) delete process.env.OPENROUTER_API_KEY;
+        else process.env.OPENROUTER_API_KEY = backupKey;
+      }
+    },
+  );
+
   test("a bare Cerebras id serves directly via cerebras.ai on the happy path", async () => {
     globalThis.fetch = (async (url: RequestInfo | URL) => {
       hosts.push(hostOf(url));
@@ -115,24 +149,27 @@ describe("getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallbac
     expect(authHeaders).toEqual(["Bearer pooled-cerebras-key"]);
   });
 
-  test("a 429 surfaces (cerebras-only) and is never routed to OpenRouter", async () => {
-    globalThis.fetch = (async (url: RequestInfo | URL) => {
-      hosts.push(hostOf(url));
-      return tooManyRequests();
-    }) as typeof fetch;
+  test.each(["openai/gpt-oss-120b:nitro", "qwen-3.8-27b"])(
+    "a 429 from %s surfaces without routing to OpenRouter",
+    async (model) => {
+      globalThis.fetch = (async (url: RequestInfo | URL) => {
+        hosts.push(hostOf(url));
+        return tooManyRequests();
+      }) as typeof fetch;
 
-    await expect(
-      generateText({
-        // The decorated id dedicated agents emit; still a Cerebras-native model.
-        model: getLanguageModel("openai/gpt-oss-120b:nitro"),
-        prompt: "hi",
-        maxRetries: 0,
-      }),
-    ).rejects.toBeDefined();
-    // No OpenRouter fallback: the 429 surfaces so the chat path can return the
-    // graceful "model provider rate-limited" reply.
-    expect(hosts).toEqual(["cerebras"]);
-  });
+      await expect(
+        generateText({
+          // The decorated id dedicated agents emit; still a Cerebras-native model.
+          model: getLanguageModel(model),
+          prompt: "hi",
+          maxRetries: 0,
+        }),
+      ).rejects.toBeDefined();
+      // No OpenRouter fallback: the 429 surfaces so the chat path can return the
+      // graceful "model provider rate-limited" reply.
+      expect(hosts).toEqual(["cerebras"]);
+    },
+  );
 
   test("a 429 FAILS FAST under default retries (one cerebras call, no ~50s backoff loop)", async () => {
     // The bug: the gateway calls generateText/streamText WITHOUT maxRetries, so


### PR DESCRIPTION
# Relates to

Relates to #17072. This repairs two blockers found while running the real Cerebras latency benchmark: the gateway rejected `qwen-3.8-27b` as unconfigured, and JSON-object requests were incorrectly translated into strict JSON-schema requests that Cerebras rejected inside the SSE stream.

The gateway now recognizes the native Qwen model and its provider, while preserving unknown-price handling. JSON-object mode uses the SDK's JSON-object path; explicit JSON-schema mode retains the supplied schema. No model default or pricing value is changed.

# Sync with develop

- Source: `cfbb00467b0c7b44425345ee3990d550676be9d7`.
- Base: `cd821540d7` (`origin/develop` fetched before rebase).
- Clean rebase; post-sync `bun install` passed (existing staged fused-inference setup explicitly skipped). Post-sync `bun run verify` passed, including all 376 Turbo tasks and repository audits.

# Risks

Provider classification affects routing and billing lookup. The model remains subject to the existing explicit unknown-price contract; this PR does not invent a price, make requests free, or change account tier. JSON schema requests retain their stricter semantics. Tests exercise the real AI SDK's generated wire request.

# Documentation

N/A — internal model catalog and gateway protocol correction; no new user configuration or API parameter.

# Testing

- Cloud API full suite: 596 files passed; full cloud shared suite passed. Owning typechecks and lint passed, including the API workerd dry-run/router checks.
- The five changed source/test files are byte-identical to the independently reviewed, package-tested revision after rebase. The full repository gate was rerun on the current head.
- Independent code review found no actionable issue in the native model classification or actual-SDK JSON format correction. Formal PR review remains required.
- Live authenticated local Workerd gateway: models list includes Qwen; ordinary and streamed requests succeed; JSON-object response contains valid JSON and terminates with usage and `[DONE]`. Before the correction, the Qwen request returned `503 ai_not_configured`; JSON mode then reproduced an embedded provider `400` despite HTTP 200 before the second fix.
- Full real AgentRuntime + PGLite + native 384-dimensional embeddings, routed through the repaired gateway to Cerebras: 30 fresh-room samples passed, with zero HTTP 429 responses across 83 wire attempts and one expected cancellation. First visible reply p50/p95: 1160.128/1732.278 ms. Command completion p50/p95: 3452.579/8339.955 ms.

# Evidence Gate

<!-- evidence-head:cfbb00467b0c7b44425345ee3990d550676be9d7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — API/provider protocol correction; no rendered UI changed. Before behavior is the live 503 and provider-format error above.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI changed; successful response bytes and complete runtime trajectories are attached below.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — request/response and provider routing changes; the real runtime report records the exercised path.
<!-- evidence-row:backend-logs -->
- [x] Complete live runtime/wire evidence: [30-sample gateway report](https://github.com/user-attachments/files/31876630/qwen-live-gateway-30-samples.json).
<!-- evidence-row:frontend-logs -->
- [x] N/A — no browser frontend changed or used for this protocol benchmark.
<!-- evidence-row:llm-trajectory -->
- [x] The attached report retains complete synthetic requests, model executions, responses and wire outcomes from actual Cerebras calls.
<!-- evidence-row:domain-artifacts -->
- [x] The report includes real conversation persistence/recall, cancellation and embedding boundary outcomes.
<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered visual surface changed.

# Evidence Details

[Download the complete 30-sample report](https://github.com/user-attachments/files/31876630/qwen-live-gateway-30-samples.json). Configured secret values were scanned before upload; zero matches. The report's source field correctly identifies the benchmark executable at `cc19976a3c90e46ad0aaf5b81d24ce82a0de426d`; the gateway ran the reviewed implementation at `ca35dbd61bb08cdd3c22e4fcaf940e2efc4f4888`. Those gateway changes are preserved in the current rebased head. This is local Workerd/PGlite with local KMS and mock Redis, not hosted-cloud latency. No new live run is attributed to the rebased SHA.

# Known gaps / failures

This is one delivery for #17072, not completion of its cache-policy/latency investigation. The separate benchmark-harness branch owns replay/post-idle experiments and explicit post-delivery failure detection. Account tier, token price and hosted deployment timing remain unverified; no cost or cache-affinity improvement claim is made. Formal exact-head PR review and hosted checks remain pending.

# Maintainer CI exception record

N/A — no exception requested.
