### PR TITLE
fix(voice): preserve complete speech and prepare ordered playback

### DIFF
--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
@@ -42,6 +42,7 @@ const TTS_ERROR_ENGINE_LABEL: Record<VoiceTtsError["engine"], string> = {
   "local-inference": "on-device voice",
   elevenlabs: "ElevenLabs voice",
   "native-talkmode": "voice",
+  "speech-sequence": "Speech playback",
 };
 
 export interface ChatVoiceStatusBarProps {

--- a/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
+++ b/packages/ui/src/components/composites/chat/ChatVoiceStatusBar.tsx
@@ -272,10 +272,17 @@ export function ChatVoiceStatusBar({
           data-testid="chat-voice-tts-error"
           data-engine={ttsError.engine}
           title={ttsError.message}
+          className="max-w-full whitespace-normal"
         >
           <AlertTriangle className="size-3 shrink-0" aria-hidden="true" />
-          <span className="truncate">
-            {TTS_ERROR_ENGINE_LABEL[ttsError.engine]} unavailable
+          <span
+            className={
+              ttsError.engine === "speech-sequence" ? "break-words" : "truncate"
+            }
+          >
+            {ttsError.engine === "speech-sequence"
+              ? ttsError.message
+              : `${TTS_ERROR_ENGINE_LABEL[ttsError.engine]} unavailable`}
           </span>
         </Badge>
       ) : null}

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -5314,6 +5314,23 @@ describe("ChatOverlay — per-message action row (#10713)", () => {
     ).toBeNull();
   });
 
+  it("keeps a failed speech attempt visible and clears it when playback recovers", () => {
+    const controller = makeController({
+      ttsError: {
+        engine: "speech-sequence",
+        message:
+          "The reply changed after speech was queued. Play the completed reply again.",
+        atMs: 1,
+      },
+    });
+    const { rerender } = render(<ChatOverlay controller={controller} />);
+    expect(screen.getByTestId("chat-voice-tts-error").textContent).toContain(
+      "reply changed",
+    );
+    rerender(<ChatOverlay controller={{ ...controller, ttsError: null }} />);
+    expect(screen.queryByText(/reply changed after speech/)).toBeNull();
+  });
+
   it("Play speaks the assistant message via the controller", () => {
     const speak = vi.fn();
     openThreadWith({

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -2,6 +2,7 @@
  * Renders the chat overlay that keeps the composer and transcript
  * available across views.
  */
+
 import { logger } from "@elizaos/logger";
 import { MAX_CHAT_MEDIA_RAW_BYTES } from "@elizaos/shared";
 import { transcriptPlainText } from "@elizaos/shared/transcripts";
@@ -33,6 +34,7 @@ import {
 } from "motion/react";
 import * as React from "react";
 import { type OrbState, ThinkingOrb } from "thinking-orbs";
+import { ChatVoiceStatusBar } from "../composites/chat/ChatVoiceStatusBar";
 
 type ChatSheetMotionStyle = MotionStyle & {
   "--chat-composer-background"?: string | MotionValue<string>;
@@ -1374,6 +1376,7 @@ export function ChatOverlay({
     setTranscriptSessionSink,
     setComposerHasDraft,
     needsAudioUnlock,
+    ttsError,
     unlockAudio,
     openSettings,
     navigateHome,
@@ -5857,6 +5860,12 @@ export function ChatOverlay({
           pointerEvents: "none",
         }}
       />
+
+      {ttsError ? (
+        <div className="pointer-events-auto relative mb-2 w-full max-w-3xl">
+          <ChatVoiceStatusBar status="idle" ttsError={ttsError} visible />
+        </div>
+      ) : null}
 
       {/* Audio-unlock prompt. When autoplay policy blocks the first spoken
           reply, the ambient overlay would otherwise go silent with no recourse

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -85,6 +85,7 @@ import {
   VOICE_CONTINUOUS_MODES,
   type VoiceContinuousMode,
   type VoiceContinuousStatus,
+  type VoiceTtsError,
 } from "../../voice/voice-chat-types";
 import { isCloudVoiceRunnable } from "../../voice/voice-provider-defaults";
 import type { ServerControlFrame } from "../../voice/voice-session-protocol";
@@ -213,6 +214,8 @@ export interface ShellController {
   toggleAgentVoiceMute: () => void;
   /** True when autoplay policy blocked playback and a tap is needed to hear it. */
   needsAudioUnlock: boolean;
+  /** The real controller always supplies this; optional for external legacy shell adapters. */
+  ttsError?: VoiceTtsError | null;
   /** Resume audio output in response to a user gesture (enable sound). */
   unlockAudio: () => void;
   /** True while the hands-free voice conversation loop is active — the mic
@@ -2822,6 +2825,7 @@ export function useShellController(): ShellController {
             : ""
         : transcript,
     speaking: voiceOutput.speaking || realtimeVoice.agentSpeaking,
+    ttsError: voiceOutput.ttsError,
     speak: voiceOutput.speak,
     stopSpeaking: voiceOutput.stopSpeaking,
     agentVoiceMuted: voiceOutput.agentVoiceMuted,

--- a/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
@@ -4,6 +4,7 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConversationMessage } from "../../api/client-types-chat";
+import type { VoiceTtsError } from "../../voice/voice-chat-types";
 
 // Hoisted so the vi.mock factories below (which are lifted above imports) can
 // reference them. `cfg` lets individual tests vary speaking / bootstrap state.
@@ -14,6 +15,7 @@ const hoisted = vi.hoisted(() => ({
   voiceChatOptions: null as Record<string, unknown> | null,
   cfg: {
     isSpeaking: false,
+    ttsError: null as VoiceTtsError | null,
     voiceBootstrapTick: 1,
     // Full voice config the useVoiceConfig mock returns; tests vary `asr` to
     // check the hook surfaces the resolved ASR provider for the capture path.
@@ -29,6 +31,7 @@ vi.mock("../../hooks/useVoiceChat", () => ({
       queueAssistantSpeech: hoisted.queueAssistantSpeech,
       stopSpeaking: hoisted.stopSpeaking,
       isSpeaking: hoisted.cfg.isSpeaking,
+      ttsError: hoisted.cfg.ttsError,
       // Unused by the output hook, present to satisfy the shape.
       isListening: false,
       captureMode: "idle",
@@ -105,6 +108,7 @@ beforeEach(() => {
   hoisted.speak.mockClear();
   hoisted.stopSpeaking.mockClear();
   hoisted.cfg.isSpeaking = false;
+  hoisted.cfg.ttsError = null;
   hoisted.cfg.voiceBootstrapTick = 1;
   hoisted.cfg.voiceConfig = { provider: "local-inference" };
   hoisted.voiceChatOptions = null;
@@ -113,6 +117,26 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("useShellVoiceOutput", () => {
+  it("exposes a speech failure and clears it when the engine recovers", () => {
+    const { result, rerender } = render(BASE);
+    expect(result.current.ttsError).toBeNull();
+    hoisted.cfg.ttsError = {
+      engine: "speech-sequence",
+      atMs: 1,
+      message:
+        "The reply changed after speech was queued. Play the completed reply again.",
+    };
+    rerender({ ...BASE });
+    expect(result.current.ttsError?.message).toContain(
+      "Play the completed reply again",
+    );
+    act(() => result.current.speak("The completed reply."));
+    expect(hoisted.speak).toHaveBeenCalledWith("The completed reply.");
+    hoisted.cfg.ttsError = null;
+    rerender({ ...BASE });
+    expect(result.current.ttsError).toBeNull();
+  });
+
   it("routes manual shell playback through the realtime Cartesia gateway", () => {
     const { result } = render({ ...BASE, realtimeVoiceEnabled: true });
 

--- a/packages/ui/src/components/shell/useShellVoiceOutput.ts
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.ts
@@ -7,6 +7,7 @@ import type { ConversationMessage } from "../../api/client-types-chat";
 import type { AsrProvider } from "../../api/client-types-config";
 import { useVoiceChat } from "../../hooks/useVoiceChat";
 import { useVoiceConfig } from "../../voice/useVoiceConfig";
+import type { VoiceTtsError } from "../../voice/voice-chat-types";
 
 /** `useVoiceChat` requires a transcript sink; the overlay owns input elsewhere. */
 const NOOP_TRANSCRIPT = (): void => {};
@@ -34,6 +35,8 @@ function findLatestAssistantText(messages: readonly ConversationMessage[]): {
 export interface ShellVoiceOutput {
   /** True while an assistant reply is being spoken aloud. */
   speaking: boolean;
+  /** The current configured-provider or committed-speech failure, retained until another attempt. */
+  ttsError: VoiceTtsError | null;
   /**
    * Speak an arbitrary message aloud on demand — backs the per-message
    * "Play audio" control (#10713). Distinct from the automatic voice-reply
@@ -118,6 +121,7 @@ export function useShellVoiceOutput(
     speak,
     stopSpeaking,
     isSpeaking,
+    ttsError,
     needsAudioUnlock,
     unlockAudio,
   } = useVoiceChat({
@@ -228,6 +232,7 @@ export function useShellVoiceOutput(
 
   return {
     speaking: isSpeaking,
+    ttsError: ttsError ?? null,
     speak,
     stopSpeaking,
     agentVoiceMuted,

--- a/packages/ui/src/hooks/useVoiceChat.bidirectional.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.bidirectional.test.tsx
@@ -166,10 +166,12 @@ describe("useVoiceChat bidirectional browser voice", () => {
     await waitFor(() => {
       expect(speechSynthesisMock.speak).toHaveBeenCalledTimes(1);
     });
-    expect(speechSynthesisMock.spoken[0]?.text).toBe(thinkingPhrase);
+    expect(speechSynthesisMock.spoken[0]?.text).toBe(
+      "hmm, okay, that's a good idea, let me think for a",
+    );
     expect(onPlaybackStart).toHaveBeenCalledWith(
       expect.objectContaining({
-        text: thinkingPhrase,
+        text: "hmm, okay, that's a good idea, let me think for a",
         provider: "browser",
         segment: "full",
       }),
@@ -190,9 +192,9 @@ describe("useVoiceChat bidirectional browser voice", () => {
     await waitFor(() => {
       expect(speechSynthesisMock.speak).toHaveBeenCalledTimes(2);
     });
-    expect(speechSynthesisMock.spoken[1]?.text).toContain(
-      "I will wait for the next signal.",
-    );
+    expect(
+      speechSynthesisMock.spoken.map((utterance) => utterance.text).join(" "),
+    ).toBe(`${thinkingPhrase}. I will wait for the next signal.`);
   });
 
   it("does not repeat a partial when its temporary id is promoted (#16094)", async () => {
@@ -430,7 +432,9 @@ describe("useVoiceChat bidirectional browser voice", () => {
     await waitFor(() => {
       expect(speechSynthesisMock.speak).toHaveBeenCalledTimes(1);
     });
-    expect(speechSynthesisMock.spoken[0]?.text).toBe(thinkingPhrase);
+    expect(speechSynthesisMock.spoken[0]?.text).toBe(
+      "hmm, okay, that's a good idea, let me think for a",
+    );
     expect(result.current.isListening).toBe(true);
     expect(result.current.captureMode).toBe("hands-free");
 

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -13,6 +13,7 @@
 
 import type { PluginListenerHandle } from "@capacitor/core";
 import { Capacitor } from "@capacitor/core";
+import { ElizaError } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import {
   useCallback,
@@ -74,6 +75,7 @@ import {
 import { playDecodedVoiceAudio } from "../voice/voice-chat-audio-playback";
 import {
   collapseWhitespace,
+  isCommittedSpeechPrefix,
   nextIdleMouthOpen,
   normalizeCacheText,
   normalizeMouthOpen,
@@ -81,6 +83,7 @@ import {
   remainderAfter,
   shouldCacheGeneratedSpeech,
   splitFirstSentence,
+  stableSpeechPrefix,
   toSpeakableText,
 } from "../voice/voice-chat-playback";
 import { mergeTranscriptWindows } from "../voice/voice-chat-recording";
@@ -109,6 +112,7 @@ import {
   type SpeechRecognitionInstance,
   type SpeechRecognitionResultEvent,
   TALKMODE_STOP_SETTLE_MS,
+  toArrayBuffer,
   type VoiceCaptureMode,
   type VoiceChatOptions,
   type VoiceChatState,
@@ -126,6 +130,34 @@ import {
   formatNamedVoiceError,
   formatVoiceErrorPreview,
 } from "./voice-error-preview";
+
+/** Queue identity is fixed before lookahead so preparation and playback use the same voice. */
+interface QueuedSpeechTask extends SpeakTask {
+  voiceConfig: VoiceConfig | null;
+}
+
+interface PreparedSpeech {
+  context: AudioContext;
+  data:
+    | { kind: "decoded"; audioBuffer: AudioBuffer }
+    | { kind: "encoded"; audioBytes: Uint8Array };
+  provider: "elevenlabs" | "local-inference" | "eliza-cloud";
+  cached: boolean;
+}
+
+type SpeechPreparation =
+  | { ok: true; audio: PreparedSpeech }
+  | { ok: false; error: unknown };
+
+interface PrefetchedSpeech {
+  task: QueuedSpeechTask;
+  generation: number;
+  result: Promise<SpeechPreparation>;
+}
+
+/** Lookahead retains one clip. These thresholds select preparation strategy, never discard speech. */
+const MAX_PREFETCH_TEXT_CHARACTERS = 1_000;
+const MAX_PREFETCH_DECODED_BYTES = 32 * 1024 * 1024;
 
 // ── Re-exports (public API) ──────────────────────────────────────────
 
@@ -482,11 +514,13 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   mouthOpenRef.current = mouthOpen;
 
   // ── Progressive speech queue state ────────────────────────────────
-  const queueRef = useRef<SpeakTask[]>([]);
+  const queueRef = useRef<QueuedSpeechTask[]>([]);
   const queueWorkerRunningRef = useRef(false);
   const generationRef = useRef(0);
   const activeTaskFinishRef = useRef<(() => void) | null>(null);
   const activeFetchAbortRef = useRef<AbortController | null>(null);
+  const prefetchedSpeechRef = useRef<PrefetchedSpeech | null>(null);
+  const bufferedPlaybackActiveRef = useRef(false);
   const assistantSpeechRef = useRef<AssistantSpeechState | null>(null);
   const assistantTtsDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -1493,6 +1527,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   const cancelPlayback = useCallback(() => {
     generationRef.current += 1;
     queueRef.current = [];
+    prefetchedSpeechRef.current = null;
+    bufferedPlaybackActiveRef.current = false;
 
     activeFetchAbortRef.current?.abort();
     activeFetchAbortRef.current = null;
@@ -1559,22 +1595,13 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
   // ── ElevenLabs TTS ────────────────────────────────────────────────
 
-  const speakElevenLabs = useCallback(
+  const prepareElevenLabs = useCallback(
     async (
       text: string,
       elConfig: NonNullable<VoiceConfig["elevenlabs"]>,
       task: SpeakTask,
-      generation: number,
+      controller: AbortController,
     ) => {
-      let ctx = sharedAudioCtx;
-      if (!ctx) {
-        ctx = new AudioContext({ latencyHint: "interactive" });
-        warmPlaybackWorklet(ctx);
-        sharedAudioCtx = ctx;
-      }
-      await ensurePlaybackContextRunning(ctx, "elevenlabs", markAudioBlocked);
-      markAudioPlaying();
-
       const voiceId = elConfig.voiceId ?? DEFAULT_ELEVEN_VOICE;
       const modelId = elConfig.modelId ?? DEFAULT_ELEVEN_MODEL;
 
@@ -1593,9 +1620,6 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       }
 
       if (!audioBytes) {
-        const controller = new AbortController();
-        activeFetchAbortRef.current = controller;
-
         const requestBody = {
           text,
           model_id: modelId,
@@ -1692,6 +1716,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               ttsTarget: describeTtsCloudFetchTargetForDebug(),
             });
           } catch (error) {
+            // error-policy:J4 Retry only a live same-provider transport failure.
+            if (controller.signal.aborted) throw error;
             reportRendererDiagnostic({
               scope: "voice.tts-cloud-proxy-unavailable",
               error,
@@ -1732,7 +1758,9 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               body: JSON.stringify(requestBody),
               signal: controller.signal,
             });
-          } catch {
+          } catch (error) {
+            // error-policy:J2 Cancellation must not dispatch another provider request.
+            if (controller.signal.aborted) throw error;
             res = await fetchViaBestAvailableProxy();
           }
 
@@ -1745,10 +1773,6 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           }
         } else {
           res = await fetchViaBestAvailableProxy();
-        }
-
-        if (activeFetchAbortRef.current === controller) {
-          activeFetchAbortRef.current = null;
         }
 
         if (!res.ok) {
@@ -1771,50 +1795,15 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         }
       }
 
-      await playDecodedVoiceAudio({
-        context: ctx,
-        audioBytes,
-        generation,
-        generationRef,
-        provider: "elevenlabs",
-        text,
-        task,
-        cached,
-        analyserRef,
-        timeDomainDataRef,
-        audioSourceRef,
-        playbackFrameTapRef,
-        activeTaskFinishRef,
-        speechTimeoutRef,
-        getPlaybackFramePump,
-        clearSpeechTimers,
-        emitPlaybackStart,
-        tracePlayback: true,
-      });
+      return { audioBytes, cached };
     },
-    [
-      clearSpeechTimers,
-      getPlaybackFramePump,
-      makeElevenCacheKey,
-      markAudioBlocked,
-      markAudioPlaying,
-      rememberCachedSegment,
-    ],
+    [makeElevenCacheKey, rememberCachedSegment],
   );
 
   // ── Eliza Cloud Kokoro TTS ─────────────────────────────────────────────
 
-  const speakElizaCloud = useCallback(
-    async (text: string, task: SpeakTask, generation: number) => {
-      let ctx = sharedAudioCtx;
-      if (!ctx) {
-        ctx = new AudioContext({ latencyHint: "interactive" });
-        warmPlaybackWorklet(ctx);
-        sharedAudioCtx = ctx;
-      }
-      await ensurePlaybackContextRunning(ctx, "eliza-cloud", markAudioBlocked);
-      markAudioPlaying();
-
+  const prepareElizaCloud = useCallback(
+    async (text: string, task: SpeakTask, controller: AbortController) => {
       const cacheKey =
         task.cacheKey ??
         (shouldCacheGeneratedSpeech(text, task.segment)
@@ -1830,8 +1819,6 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       }
 
       if (!audioBytes) {
-        const controller = new AbortController();
-        activeFetchAbortRef.current = controller;
         const timeoutId = setTimeout(() => {
           controller.abort(
             new DOMException("Eliza Cloud TTS timed out", "TimeoutError"),
@@ -1980,9 +1967,6 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           }
         } finally {
           clearTimeout(timeoutId);
-          if (activeFetchAbortRef.current === controller) {
-            activeFetchAbortRef.current = null;
-          }
         }
 
         if (!res.ok) {
@@ -2004,53 +1988,15 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         }
       }
 
-      await playDecodedVoiceAudio({
-        context: ctx,
-        audioBytes,
-        generation,
-        generationRef,
-        provider: "eliza-cloud",
-        text,
-        task,
-        cached,
-        analyserRef,
-        timeDomainDataRef,
-        audioSourceRef,
-        playbackFrameTapRef,
-        activeTaskFinishRef,
-        speechTimeoutRef,
-        getPlaybackFramePump,
-        clearSpeechTimers,
-        emitPlaybackStart,
-      });
+      return { audioBytes, cached };
     },
-    [
-      clearSpeechTimers,
-      getPlaybackFramePump,
-      makeElizaCloudCacheKey,
-      markAudioBlocked,
-      markAudioPlaying,
-      rememberCachedSegment,
-    ],
+    [makeElizaCloudCacheKey, rememberCachedSegment],
   );
 
   // ── Local inference TTS ───────────────────────────────────────────────
 
-  const speakLocalInference = useCallback(
-    async (text: string, task: SpeakTask, generation: number) => {
-      let ctx = sharedAudioCtx;
-      if (!ctx) {
-        ctx = new AudioContext({ latencyHint: "interactive" });
-        warmPlaybackWorklet(ctx);
-        sharedAudioCtx = ctx;
-      }
-      await ensurePlaybackContextRunning(
-        ctx,
-        "local-inference",
-        markAudioBlocked,
-      );
-      markAudioPlaying();
-
+  const prepareLocalInference = useCallback(
+    async (text: string, task: SpeakTask, controller: AbortController) => {
       const cacheKey =
         task.cacheKey ??
         (shouldCacheGeneratedSpeech(text, task.segment)
@@ -2066,8 +2012,6 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       }
 
       if (!audioBytes) {
-        const controller = new AbortController();
-        activeFetchAbortRef.current = controller;
         const timeoutId = setTimeout(() => {
           controller.abort(
             new DOMException("Local inference TTS timed out", "TimeoutError"),
@@ -2086,9 +2030,6 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           });
         } finally {
           clearTimeout(timeoutId);
-          if (activeFetchAbortRef.current === controller) {
-            activeFetchAbortRef.current = null;
-          }
         }
 
         if (!res.ok) {
@@ -2104,34 +2045,9 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         }
       }
 
-      await playDecodedVoiceAudio({
-        context: ctx,
-        audioBytes,
-        generation,
-        generationRef,
-        provider: "local-inference",
-        text,
-        task,
-        cached,
-        analyserRef,
-        timeDomainDataRef,
-        audioSourceRef,
-        playbackFrameTapRef,
-        activeTaskFinishRef,
-        speechTimeoutRef,
-        getPlaybackFramePump,
-        clearSpeechTimers,
-        emitPlaybackStart,
-      });
+      return { audioBytes, cached };
     },
-    [
-      clearSpeechTimers,
-      getPlaybackFramePump,
-      makeLocalInferenceCacheKey,
-      markAudioBlocked,
-      markAudioPlaying,
-      rememberCachedSegment,
-    ],
+    [makeLocalInferenceCacheKey, rememberCachedSegment],
   );
 
   // ── Browser SpeechSynthesis TTS ───────────────────────────────────
@@ -2349,6 +2265,188 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     [clearSpeechTimers, options.lang],
   );
 
+  const prepareBufferedSpeech = useCallback(
+    async (
+      task: QueuedSpeechTask,
+      generation: number,
+      lookahead: boolean,
+    ): Promise<PreparedSpeech> => {
+      const controller = new AbortController();
+      activeFetchAbortRef.current = controller;
+      const provider = task.voiceConfig?.provider;
+      if (
+        provider !== "elevenlabs" &&
+        provider !== "eliza-cloud" &&
+        provider !== "local-inference"
+      ) {
+        throw new ElizaError("Speech provider cannot prepare buffered audio", {
+          code: "VOICE_BUFFERED_PROVIDER_REQUIRED",
+        });
+      }
+      try {
+        if (generation !== generationRef.current)
+          throw new DOMException("Speech cancelled", "AbortError");
+        const preparationStartedAtMs = performance.now();
+        const prepared =
+          provider === "elevenlabs" && task.voiceConfig?.elevenlabs
+            ? await prepareElevenLabs(
+                task.text,
+                task.voiceConfig.elevenlabs,
+                task,
+                controller,
+              )
+            : provider === "eliza-cloud"
+              ? await prepareElizaCloud(task.text, task, controller)
+              : provider === "local-inference"
+                ? await prepareLocalInference(task.text, task, controller)
+                : null;
+        if (!prepared)
+          throw new ElizaError(
+            "Speech provider cannot prepare buffered audio",
+            { code: "VOICE_BUFFERED_PROVIDER_REQUIRED" },
+          );
+        if (generation !== generationRef.current || controller.signal.aborted)
+          throw new DOMException("Speech cancelled", "AbortError");
+        const context =
+          sharedAudioCtx ?? new AudioContext({ latencyHint: "interactive" });
+        if (!sharedAudioCtx) {
+          sharedAudioCtx = context;
+          warmPlaybackWorklet(context);
+        }
+        const audioBuffer = await context.decodeAudioData(
+          toArrayBuffer(prepared.audioBytes),
+        );
+        if (generation !== generationRef.current || controller.signal.aborted)
+          throw new DOMException("Speech cancelled", "AbortError");
+        // Decoding is not a bounded-allocation API. Keep one encoded response
+        // instead of a large decoded lookahead; decode again at its playback
+        // turn without another synthesis request. This is a retention strategy,
+        // not an input-size limit or a peak-memory guarantee.
+        const deferDecode =
+          lookahead &&
+          audioBuffer.length *
+            audioBuffer.numberOfChannels *
+            Float32Array.BYTES_PER_ELEMENT >
+            MAX_PREFETCH_DECODED_BYTES;
+        ttsDebug("prepare:buffered:ready", {
+          provider,
+          lookahead,
+          segment: task.segment,
+          preparationStartedAtMs,
+          preparedAtMs: performance.now(),
+          textChars: task.text.length,
+        });
+        return {
+          context,
+          data: deferDecode
+            ? { kind: "encoded", audioBytes: prepared.audioBytes }
+            : { kind: "decoded", audioBuffer },
+          provider,
+          cached: prepared.cached,
+        };
+      } finally {
+        if (activeFetchAbortRef.current === controller)
+          activeFetchAbortRef.current = null;
+      }
+    },
+    [prepareElevenLabs, prepareElizaCloud, prepareLocalInference],
+  );
+
+  const prepareNextBufferedSpeech = useCallback(() => {
+    if (
+      !bufferedPlaybackActiveRef.current ||
+      prefetchedSpeechRef.current ||
+      Capacitor.isNativePlatform()
+    )
+      return;
+    const task = queueRef.current[0];
+    const provider = task?.voiceConfig?.provider;
+    if (
+      !task ||
+      task.text.length > MAX_PREFETCH_TEXT_CHARACTERS ||
+      !(
+        provider === "eliza-cloud" ||
+        provider === "local-inference" ||
+        (provider === "elevenlabs" && task.voiceConfig?.elevenlabs)
+      )
+    )
+      return;
+    const generation = generationRef.current;
+    // Both outcomes are retained until this task reaches the single playback owner.
+    const result = prepareBufferedSpeech(task, generation, true).then<
+      SpeechPreparation,
+      SpeechPreparation
+    >(
+      (audio) => ({ ok: true, audio }),
+      (error) => ({ ok: false, error }),
+    );
+    prefetchedSpeechRef.current = { task, generation, result };
+  }, [prepareBufferedSpeech]);
+
+  const playBufferedSpeech = useCallback(
+    async (task: QueuedSpeechTask, generation: number) => {
+      const prefetched = prefetchedSpeechRef.current;
+      let audio: PreparedSpeech;
+      if (prefetched?.task === task && prefetched.generation === generation) {
+        prefetchedSpeechRef.current = null;
+        const result = await prefetched.result;
+        if (!result.ok) throw result.error;
+        audio = result.audio;
+      } else {
+        audio = await prepareBufferedSpeech(task, generation, false);
+      }
+      if (generation !== generationRef.current) return;
+      await ensurePlaybackContextRunning(
+        audio.context,
+        audio.provider,
+        markAudioBlocked,
+      );
+      if (generation !== generationRef.current) return;
+      const audioBuffer =
+        audio.data.kind === "decoded"
+          ? audio.data.audioBuffer
+          : await audio.context.decodeAudioData(
+              toArrayBuffer(audio.data.audioBytes),
+            );
+      if (generation !== generationRef.current) return;
+      markAudioPlaying();
+      bufferedPlaybackActiveRef.current = true;
+      prepareNextBufferedSpeech();
+      try {
+        await playDecodedVoiceAudio({
+          context: audio.context,
+          audioBuffer,
+          provider: audio.provider,
+          cached: audio.cached,
+          generation,
+          generationRef,
+          text: task.text,
+          task,
+          analyserRef,
+          timeDomainDataRef,
+          audioSourceRef,
+          playbackFrameTapRef,
+          activeTaskFinishRef,
+          speechTimeoutRef,
+          getPlaybackFramePump,
+          clearSpeechTimers,
+          emitPlaybackStart,
+          tracePlayback: true,
+        });
+      } finally {
+        bufferedPlaybackActiveRef.current = false;
+      }
+    },
+    [
+      prepareBufferedSpeech,
+      prepareNextBufferedSpeech,
+      markAudioBlocked,
+      markAudioPlaying,
+      getPlaybackFramePump,
+      clearSpeechTimers,
+    ],
+  );
+
   const processQueue = useCallback(() => {
     if (queueWorkerRunningRef.current) return;
     queueWorkerRunningRef.current = true;
@@ -2377,6 +2475,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             typeof performance !== "undefined" ? performance.now() : Date.now(),
         };
         queueRef.current = [];
+        prefetchedSpeechRef.current = null;
+        activeFetchAbortRef.current?.abort();
       };
       try {
         while (queueRef.current.length > 0) {
@@ -2384,7 +2484,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           const task = queueRef.current.shift();
           if (!task) break;
 
-          const config = voiceConfigRef.current;
+          const config = task.voiceConfig;
           const elConfig = config?.elevenlabs;
           const useElizaCloud = config?.provider === "eliza-cloud";
           const useElevenLabs = config?.provider === "elevenlabs";
@@ -2466,7 +2566,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             usingAudioAnalysisRef.current = true;
             setUsingAudioAnalysis(true);
             try {
-              await speakElizaCloud(task.text, task, workerGeneration);
+              await playBufferedSpeech(task, workerGeneration);
               continue;
             } catch (error) {
               if (
@@ -2495,7 +2595,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             usingAudioAnalysisRef.current = true;
             setUsingAudioAnalysis(true);
             try {
-              await speakLocalInference(task.text, task, workerGeneration);
+              await playBufferedSpeech(task, workerGeneration);
               continue;
             } catch (error) {
               if (
@@ -2522,12 +2622,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             usingAudioAnalysisRef.current = true;
             setUsingAudioAnalysis(true);
             try {
-              await speakElevenLabs(
-                task.text,
-                elConfig,
-                task,
-                workerGeneration,
-              );
+              await playBufferedSpeech(task, workerGeneration);
               continue;
             } catch (error) {
               if (
@@ -2570,6 +2665,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       } catch (error) {
         workerError = error;
         queueRef.current = [];
+        prefetchedSpeechRef.current = null;
+        activeFetchAbortRef.current?.abort();
         ttsDebug("processQueue:error", {
           err: formatNamedVoiceError(error),
         });
@@ -2601,7 +2698,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       setUsingAudioAnalysis(false);
       setIsSpeaking(false);
     })();
-  }, [speakBrowser, speakElevenLabs, speakElizaCloud, speakLocalInference]);
+  }, [speakBrowser, playBufferedSpeech]);
 
   const enqueueSpeech = useCallback(
     (task: SpeakTask) => {
@@ -2618,6 +2715,9 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       queueRef.current.push({
         ...task,
         text: speakable,
+        voiceConfig: voiceConfigRef.current
+          ? structuredClone(voiceConfigRef.current)
+          : null,
         telemetry: task.telemetry
           ? {
               ...task.telemetry,
@@ -2637,9 +2737,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       });
       speakingStartRef.current = Date.now();
       setIsSpeaking(true);
+      prepareNextBufferedSpeech();
       processQueue();
     },
-    [cancelPlayback, processQueue],
+    [cancelPlayback, prepareNextBufferedSpeech, processQueue],
   );
 
   // ── Public speak APIs ─────────────────────────────────────────────
@@ -2670,12 +2771,14 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   const flushPendingAssistantTts = useCallback(() => {
     assistantTtsDebounceRef.current = null;
     const state = assistantSpeechRef.current;
-    if (!state || state.finalQueued) return;
+    if (!state || state.finalQueued || state.revisionRejected) return;
 
     const latest = state.latestSpeakable;
     if (!latest) return;
 
-    const unsent = remainderAfter(latest, state.queuedSpeakablePrefix);
+    const stable = stableSpeechPrefix(latest);
+    if (stable.length <= state.queuedSpeakablePrefix.length) return;
+    const unsent = remainderAfter(stable, state.queuedSpeakablePrefix);
     if (!unsent) return;
 
     const elConfig = voiceConfigRef.current?.elevenlabs;
@@ -2704,7 +2807,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       telemetry: state.telemetry,
     });
 
-    state.queuedSpeakablePrefix = latest;
+    state.queuedSpeakablePrefix = stable;
   }, [enqueueSpeech, makeElevenCacheKey]);
 
   const queueAssistantSpeech = useCallback(
@@ -2759,8 +2862,29 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       }
 
       const state = assistantSpeechRef.current;
-      if (!state) return;
+      if (!state || state.revisionRejected) return;
 
+      if (
+        state.queuedSpeakablePrefix &&
+        !isCommittedSpeechPrefix(speakable, state.queuedSpeakablePrefix)
+      ) {
+        clearAssistantTtsDebounce();
+        cancelPlayback();
+        state.revisionRejected = true;
+        setIsSpeaking(false);
+        try {
+          remainderAfter(speakable, state.queuedSpeakablePrefix);
+        } catch (error) {
+          // error-policy:J4 Already queued speech cannot be retracted; expose the rejected revision.
+          reportRendererDiagnostic({ scope: "voice.speech-revision", error });
+          setTtsError({
+            engine: "speech-sequence",
+            message: error instanceof Error ? error.message : String(error),
+            atMs: performance.now(),
+          });
+        }
+        return;
+      }
       state.latestSpeakable = speakable;
 
       if (ASSISTANT_TTS_FINAL_ONLY && !isFinal) {
@@ -2814,9 +2938,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       }
 
       const boundaryPrefix = queueableSpeechPrefix(speakable, isFinal);
-      const boundaryUnsent = boundaryPrefix
-        ? remainderAfter(boundaryPrefix, state.queuedSpeakablePrefix)
-        : "";
+      const boundaryUnsent =
+        boundaryPrefix.length > state.queuedSpeakablePrefix.length
+          ? remainderAfter(boundaryPrefix, state.queuedSpeakablePrefix)
+          : "";
       const rawUnsent = remainderAfter(speakable, state.queuedSpeakablePrefix);
       if (!rawUnsent) {
         if (isFinal) {
@@ -2834,11 +2959,12 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       const targetPrefix = boundaryUnsent
         ? boundaryPrefix
         : thresholdFlush
-          ? speakable
+          ? stableSpeechPrefix(speakable)
           : "";
-      const unsent = targetPrefix
-        ? remainderAfter(targetPrefix, state.queuedSpeakablePrefix)
-        : "";
+      const unsent =
+        targetPrefix.length > state.queuedSpeakablePrefix.length
+          ? remainderAfter(targetPrefix, state.queuedSpeakablePrefix)
+          : "";
       const flushNow = Boolean(unsent);
 
       if (flushNow) {
@@ -2876,6 +3002,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       }, ASSISTANT_TTS_DEBOUNCE_MS);
     },
     [
+      cancelPlayback,
       clearAssistantTtsDebounce,
       enqueueSpeech,
       flushPendingAssistantTts,

--- a/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
@@ -597,6 +597,43 @@ describe("useVoiceChat TTS playback across providers", () => {
     }
   });
 
+  it("keeps the next turn when cancelled preparation rejects late", async () => {
+    let rejectCancelled: ((error: Error) => void) | undefined;
+    fetchWithCsrf.mockImplementation(async (url, init) => {
+      if (!String(url).includes("/api/tts/"))
+        return new Response(null, { status: 204 });
+      if (JSON.parse(init.body).text === "Old preparation.") {
+        return new Promise<Response>((_, reject) => {
+          rejectCancelled = reject;
+        });
+      }
+      return new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 });
+    });
+    const onPlaybackStart = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        onPlaybackStart,
+        voiceConfig: { provider: "local-inference" },
+      }),
+    );
+    act(() => result.current.speak("Old preparation."));
+    await waitFor(() => expect(rejectCancelled).toBeDefined());
+    act(() => {
+      result.current.stopSpeaking();
+      result.current.speak("New authorized turn.");
+    });
+    await act(async () => {
+      rejectCancelled?.(new Error("Late cancelled transport error"));
+    });
+    await waitFor(() => expect(onPlaybackStart).toHaveBeenCalledTimes(1));
+    expect(onPlaybackStart.mock.calls[0]?.[0].text).toBe(
+      "New authorized turn.",
+    );
+    await waitFor(() => expect(result.current.isSpeaking).toBe(false));
+    expect(result.current.ttsError).toBeNull();
+  });
+
   it("cancels an in-flight lookahead and never plays its late response in the next turn", async () => {
     finishPlaybackAutomatically = false;
     let release: ((response: Response) => void) | undefined;

--- a/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
@@ -568,7 +568,7 @@ describe("useVoiceChat TTS playback across providers", () => {
     const tapSource = PlaybackFramePump.prototype.tapSource;
     const tapSpy = vi
       .spyOn(PlaybackFramePump.prototype, "tapSource")
-      .mockImplementation(async function (...args) {
+      .mockImplementation(async function (this: PlaybackFramePump, ...args) {
         const tap = await tapSource.apply(this, args);
         if (first) {
           first = false;

--- a/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.tts-playback.test.tsx
@@ -27,6 +27,8 @@ import {
   DEFAULT_BOOT_CONFIG,
   setBootConfig,
 } from "../config/boot-config-store";
+import { PlaybackFramePump } from "../voice/playback-frame-pump";
+import { toSpeakableText } from "../voice/voice-chat-playback";
 import { globalAudioCache } from "../voice/voice-chat-types";
 import {
   __resetDirectCloudTtsFallbackWarnings,
@@ -42,6 +44,8 @@ interface FakeSource {
 }
 
 const createdSources: FakeSource[] = [];
+let finishPlaybackAutomatically = true;
+let decodedSampleCount = 640;
 
 class FakeAudioWorkletNode {
   port: { onmessage: ((event: MessageEvent) => void) | null } = {
@@ -76,7 +80,8 @@ class FakeAudioContext {
       // Auto-finish shortly after start so the playback promise resolves and
       // the full teardown path (disconnect + timer clear) runs.
       start: vi.fn(() => {
-        setTimeout(() => source.onended?.(), 0);
+        if (finishPlaybackAutomatically)
+          setTimeout(() => source.onended?.(), 0);
       }),
       onended: null,
     };
@@ -88,7 +93,7 @@ class FakeAudioContext {
     return {
       duration: 0.04,
       sampleRate: 16_000,
-      length: 640,
+      length: decodedSampleCount,
       numberOfChannels: 1,
       getChannelData: () => new Float32Array(640).fill(0.25),
     };
@@ -144,6 +149,8 @@ function installMocks() {
   fetchedContexts.length = 0;
   decodedAudioInputs.length = 0;
   createdSources.length = 0;
+  finishPlaybackAutomatically = true;
+  decodedSampleCount = 640;
   speechSynthesisMock.spoken = [];
   speechSynthesisMock.speak.mockClear();
   speechSynthesisMock.cancel.mockClear();
@@ -441,6 +448,196 @@ describe("useVoiceChat TTS playback across providers", () => {
       expect(result.current.isSpeaking).toBe(false);
     });
     expect(result.current.ttsError ?? null).toBeNull();
+  });
+
+  it("prepares only the next clip while real queue playback remains ordered", async () => {
+    finishPlaybackAutomatically = false;
+    const { result } = renderVoiceChat({ provider: "local-inference" });
+    const requests: string[] = [];
+    fetchWithCsrf.mockImplementation(async (url, init) => {
+      if (!String(url).includes("/api/tts/"))
+        return new Response(null, { status: 204 });
+      requests.push(JSON.parse(init.body).text);
+      return new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 });
+    });
+    act(() => result.current.speak("First complete sentence."));
+    await waitFor(() => expect(createdSources[0]?.start).toHaveBeenCalled());
+    act(() => {
+      result.current.speak("Second complete sentence.", { append: true });
+      result.current.speak("Third complete sentence.", { append: true });
+    });
+    await waitFor(() => expect(decodedAudioInputs).toHaveLength(2));
+    expect(requests).toEqual([
+      "First complete sentence.",
+      "Second complete sentence.",
+    ]);
+    expect(createdSources).toHaveLength(1);
+    expect(result.current.isSpeaking).toBe(true);
+    act(() => createdSources[0]?.onended?.());
+    await waitFor(() => expect(createdSources[1]?.start).toHaveBeenCalled());
+    await waitFor(() => expect(requests).toHaveLength(3));
+    expect(createdSources).toHaveLength(2);
+    act(() => createdSources[1]?.onended?.());
+    await waitFor(() => expect(createdSources[2]?.start).toHaveBeenCalled());
+    expect(result.current.isSpeaking).toBe(true);
+    act(() => createdSources[2]?.onended?.());
+    await waitFor(() => expect(result.current.isSpeaking).toBe(false));
+  });
+
+  it("defers oversized decoded lookahead without discarding or synthesizing the clip twice", async () => {
+    finishPlaybackAutomatically = false;
+    const { result } = renderVoiceChat({ provider: "local-inference" });
+    act(() => result.current.speak("First audio."));
+    await waitFor(() => expect(createdSources[0]?.start).toHaveBeenCalled());
+    decodedSampleCount = 9_000_000;
+    act(() => result.current.speak("Large tail audio.", { append: true }));
+    await waitFor(() => expect(decodedAudioInputs).toHaveLength(2));
+    expect(createdSources).toHaveLength(1);
+    act(() => createdSources[0]?.onended?.());
+    await waitFor(() => expect(createdSources[1]?.start).toHaveBeenCalled());
+    expect(decodedAudioInputs).toHaveLength(3);
+    expect(fetchedUrls.filter((url) => url.includes("/api/tts/"))).toHaveLength(
+      2,
+    );
+    act(() => createdSources[1]?.onended?.());
+    await waitFor(() => expect(result.current.isSpeaking).toBe(false));
+    expect(result.current.ttsError).toBeNull();
+  });
+
+  it.each([
+    [
+      "I am checking the international",
+      "I am checking the internationalization settings.",
+    ],
+    ["The measured value is 3.", "The measured value is 3.14159 today."],
+    [
+      "Please open https://example.",
+      "Please open https://example.com/path now.",
+    ],
+    ["The next person is Dr.", "The next person is Dr. Rivera."],
+    [
+      "This reply contains a family 👨‍",
+      "This reply contains a family 👨‍👩‍👧‍👦 together.",
+    ],
+  ])("retains the unfinished lexical suffix: %s", async (partial, final) => {
+    const texts: string[] = [];
+    fetchWithCsrf.mockImplementation(async (url, init) => {
+      if (!String(url).includes("/api/tts/"))
+        return new Response(null, { status: 204 });
+      texts.push(JSON.parse(init.body).text);
+      return new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 });
+    });
+    const { result } = renderVoiceChat({ provider: "local-inference" });
+    act(() => result.current.queueAssistantSpeech("lexical", partial, false));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    act(() => result.current.queueAssistantSpeech("lexical", final, true));
+    await waitFor(() => expect(result.current.isSpeaking).toBe(false));
+    expect(texts.join(" ")).toBe(toSpeakableText(final));
+    expect(result.current.ttsError).toBeNull();
+  });
+
+  it("rejects a revised final instead of discarding it as already spoken", async () => {
+    finishPlaybackAutomatically = false;
+    const { result } = renderVoiceChat({ provider: "local-inference" });
+    act(() =>
+      result.current.queueAssistantSpeech(
+        "revision",
+        "The available option is red.",
+        false,
+      ),
+    );
+    await waitFor(() => expect(createdSources[0]?.start).toHaveBeenCalled());
+    act(() =>
+      result.current.queueAssistantSpeech(
+        "revision",
+        "Actually, the available option is blue.",
+        true,
+      ),
+    );
+    await waitFor(() => expect(result.current.isSpeaking).toBe(false));
+    expect(result.current.ttsError?.engine).toBe("speech-sequence");
+    expect(result.current.ttsError?.message).toContain("reply changed");
+    expect(createdSources).toHaveLength(1);
+  });
+
+  it("never starts cancelled audio after a delayed playback-reference attachment", async () => {
+    let release: (() => void) | undefined;
+    let first = true;
+    const tapSource = PlaybackFramePump.prototype.tapSource;
+    const tapSpy = vi
+      .spyOn(PlaybackFramePump.prototype, "tapSource")
+      .mockImplementation(async function (...args) {
+        const tap = await tapSource.apply(this, args);
+        if (first) {
+          first = false;
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+        }
+        return tap;
+      });
+    try {
+      const { result } = renderVoiceChat({ provider: "local-inference" });
+      act(() => result.current.speak("Cancelled during attachment."));
+      await waitFor(() => expect(release).toBeDefined());
+      act(() => {
+        result.current.stopSpeaking();
+        result.current.speak("Current reply.");
+      });
+      await act(async () => {
+        release?.();
+      });
+      await waitFor(() => expect(createdSources[1]?.start).toHaveBeenCalled());
+      expect(createdSources[0]?.start).not.toHaveBeenCalled();
+      await waitFor(() => expect(result.current.isSpeaking).toBe(false));
+    } finally {
+      tapSpy.mockRestore();
+    }
+  });
+
+  it("cancels an in-flight lookahead and never plays its late response in the next turn", async () => {
+    finishPlaybackAutomatically = false;
+    let release: ((response: Response) => void) | undefined;
+    let pendingSignal: AbortSignal | undefined;
+    fetchWithCsrf.mockImplementation(async (_url, init) => {
+      if (JSON.parse(init.body).text === "Cancelled tail.") {
+        pendingSignal = init.signal;
+        return new Promise<Response>((resolve) => {
+          release = resolve;
+        });
+      }
+      return new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 });
+    });
+    const onPlaybackStart = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        onPlaybackStart,
+        voiceConfig: { provider: "local-inference" },
+      }),
+    );
+    act(() => result.current.speak("Initial sentence."));
+    await waitFor(() => expect(createdSources[0]?.start).toHaveBeenCalled());
+    act(() => result.current.speak("Cancelled tail.", { append: true }));
+    await waitFor(() => expect(pendingSignal).toBeDefined());
+    act(() => {
+      result.current.stopSpeaking();
+      result.current.speak("New turn.");
+    });
+    expect(pendingSignal?.aborted).toBe(true);
+    await act(async () => {
+      release?.(new Response(new Uint8Array([9, 9, 9, 9])));
+    });
+    await waitFor(() => expect(createdSources[1]?.start).toHaveBeenCalled());
+    expect(onPlaybackStart.mock.calls.map(([event]) => event.text)).toEqual([
+      "Initial sentence.",
+      "New turn.",
+    ]);
+    expect(decodedAudioInputs).toHaveLength(2);
+    act(() => createdSources[1]?.onended?.());
+    await waitFor(() => expect(result.current.isSpeaking).toBe(false));
   });
 
   it("degrades a failed direct-cloud fetch to the proxy and still plays audio end to end", async () => {

--- a/packages/ui/src/voice/voice-chat-audio-playback.ts
+++ b/packages/ui/src/voice/voice-chat-audio-playback.ts
@@ -1,5 +1,5 @@
 /**
- * Decodes and plays generated voice bytes through the shared Web Audio graph.
+ * Plays prepared voice audio through the shared Web Audio graph.
  * Provider fetchers own authentication and caching; this module owns the one
  * analyser, playback-reference tap, timeout, teardown, and telemetry lifecycle
  * that every decoded-audio provider must follow.
@@ -11,11 +11,7 @@ import {
   type PlaybackFrameTap,
   PlaybackTapLifecycle,
 } from "./playback-frame-pump";
-import {
-  type SpeakTask,
-  toArrayBuffer,
-  type VoicePlaybackStartEvent,
-} from "./voice-chat-types";
+import type { SpeakTask, VoicePlaybackStartEvent } from "./voice-chat-types";
 
 interface MutableCell<T> {
   current: T;
@@ -23,7 +19,7 @@ interface MutableCell<T> {
 
 export interface DecodedVoicePlaybackOptions {
   context: AudioContext;
-  audioBytes: Uint8Array;
+  audioBuffer: AudioBuffer;
   generation: number;
   generationRef: MutableCell<number>;
   provider: VoicePlaybackStartEvent["provider"];
@@ -44,7 +40,7 @@ export interface DecodedVoicePlaybackOptions {
 
 export async function playDecodedVoiceAudio({
   context,
-  audioBytes,
+  audioBuffer,
   generation,
   generationRef,
   provider,
@@ -62,8 +58,6 @@ export async function playDecodedVoiceAudio({
   emitPlaybackStart,
   tracePlayback = false,
 }: DecodedVoicePlaybackOptions): Promise<void> {
-  if (generation !== generationRef.current) return;
-  const audioBuffer = await context.decodeAudioData(toArrayBuffer(audioBytes));
   if (generation !== generationRef.current) return;
 
   const analyser = context.createAnalyser();
@@ -93,6 +87,12 @@ export async function playDecodedVoiceAudio({
     });
   const tapLifecycle = new PlaybackTapLifecycle(playbackFrameTapRef);
   await tapLifecycle.attach(tapPromise);
+  if (generation !== generationRef.current) {
+    tapLifecycle.finish();
+    source.disconnect();
+    analyser.disconnect();
+    return;
+  }
 
   await new Promise<void>((resolve) => {
     let finished = false;

--- a/packages/ui/src/voice/voice-chat-playback.ts
+++ b/packages/ui/src/voice/voice-chat-playback.ts
@@ -3,6 +3,7 @@
  * speech text extraction, and mouth animation helpers.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { sanitizeSpeechText } from "@elizaos/shared";
 import { MOUTH_OPEN_STEP, type SpeechSegmentKind } from "./voice-chat-types";
 
@@ -127,7 +128,7 @@ export function isRealSentenceEnd(value: string, matchIndex: number): boolean {
     matchIndex + 1 < value.length ? value[matchIndex + 1] : undefined;
 
   if (previousChar !== undefined && /\d/.test(previousChar)) {
-    if (nextChar !== undefined && /\d/.test(nextChar)) {
+    if (nextChar === undefined || /\d/.test(nextChar)) {
       return false;
     }
   }
@@ -182,6 +183,21 @@ export function splitFirstSentence(text: string): {
   return { complete: false, firstSentence: value, remainder: "" };
 }
 
+/** Committed words may gain punctuation, but must never turn into a longer word. */
+export function isCommittedSpeechPrefix(
+  fullText: string,
+  prefix: string,
+): boolean {
+  const full = collapseWhitespace(fullText);
+  const committed = collapseWhitespace(prefix);
+  return (
+    !committed ||
+    full === committed ||
+    (full.startsWith(committed) &&
+      /^[\s.,!?;:…]/u.test(full.slice(committed.length)))
+  );
+}
+
 export function remainderAfter(
   fullText: string,
   firstSentence: string,
@@ -189,20 +205,26 @@ export function remainderAfter(
   const full = collapseWhitespace(fullText);
   const first = collapseWhitespace(firstSentence);
   if (!full || !first) return full;
-  if (full.startsWith(first)) return full.slice(first.length).trim();
-
-  const lowerFull = full.toLowerCase();
-  const lowerFirst = first.toLowerCase();
-  if (lowerFull.startsWith(lowerFirst)) {
+  if (isCommittedSpeechPrefix(full, first))
     return full.slice(first.length).trim();
-  }
 
-  const idx = lowerFull.indexOf(lowerFirst);
-  if (idx >= 0) {
-    return full.slice(idx + first.length).trim();
-  }
+  throw new ElizaError(
+    "The reply changed after speech was queued. Play the completed reply again.",
+    {
+      code: "VOICE_SPEECH_REVISION_UNSUPPORTED",
+      context: {
+        queuedCharacters: first.length,
+        receivedCharacters: full.length,
+      },
+    },
+  );
+}
 
-  return "";
+/** Keep the unfinished final lexical unit for a later frame or the final flush. */
+export function stableSpeechPrefix(text: string): string {
+  const value = collapseWhitespace(text);
+  const boundary = value.lastIndexOf(" ");
+  return boundary < 0 ? "" : value.slice(0, boundary);
 }
 
 export function queueableSpeechPrefix(text: string, isFinal: boolean): string {

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -252,7 +252,12 @@ export interface QueueAssistantSpeechOptions {
  */
 export interface VoiceTtsError {
   /** Which configured engine failed. */
-  engine: "eliza-cloud" | "local-inference" | "elevenlabs" | "native-talkmode";
+  engine:
+    | "eliza-cloud"
+    | "local-inference"
+    | "elevenlabs"
+    | "native-talkmode"
+    | "speech-sequence";
   /** Human-readable failure message for a toast/banner. */
   message: string;
   /** UI monotonic timestamp (performance.now) when the failure surfaced. */
@@ -372,6 +377,8 @@ export interface AssistantSpeechState {
   /** Latest speakable from the stream (debounce flush reads this). */
   latestSpeakable: string;
   finalQueued: boolean;
+  /** A non-prefix revision cannot retract speech already submitted for playback. */
+  revisionRejected?: boolean;
   replacePlaybackOnFirstClip: boolean;
   telemetry?: VoiceAssistantSpeechTelemetry;
 }

--- a/plugins/plugin-local-inference/README.md
+++ b/plugins/plugin-local-inference/README.md
@@ -248,3 +248,14 @@ This is an explicit hardware/operator smoke rather than a pull-request check.
 Run it on the Linux host that owns the staged fused library and model assets.
 
 For agent-facing documentation see `CLAUDE.md` / `AGENTS.md` in this directory.
+
+### Complete Kokoro speech
+
+Kokoro speech requires a fused library with the ABI v14 IPA entry or newer.
+The backend preflights the entire utterance, divides oversized phoneme sequences
+at word boundaries, and synthesizes every segment in order. It dispatches the
+checked IPA directly even on espeak-linked hosts. An indivisible oversized word
+raises `KOKORO_PHRASE_TOO_LARGE` before any audio; unsupported older libraries
+raise `KOKORO_IPA_ABI_REQUIRED`. Rebuild the fused library to resolve that error.
+Audio allocation exhaustion is reported as `KOKORO_AUDIO_CAPACITY_EXCEEDED`;
+a clipped waveform is never returned as a complete phrase.

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
@@ -1,5 +1,5 @@
 /** Covers the Kokoro TTS backend including streaming time-to-first-audio. Deterministic, mock runtime. */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { scoreFirstResponseLatency } from "../../e2e-harness";
 import type {
 	AudioSink,
@@ -44,7 +44,11 @@ function makePhrase(text: string): Phrase {
 	};
 }
 
-function makeBackend(opts?: { totalSamples?: number; chunkCount?: number }): {
+function makeBackend(opts?: {
+	totalSamples?: number;
+	chunkCount?: number;
+	phonemizer?: KokoroPhonemizer;
+}): {
 	backend: KokoroTtsBackend;
 	runtime: KokoroMockRuntime;
 } {
@@ -62,13 +66,86 @@ function makeBackend(opts?: { totalSamples?: number; chunkCount?: number }): {
 			sampleRate: 24000,
 		},
 		defaultVoiceId: KOKORO_DEFAULT_VOICE_ID,
-		phonemizer: fixedPhonemizer(),
+		phonemizer: opts?.phonemizer ?? fixedPhonemizer(),
 		streamingChunkSamples: 1200, // 50ms — re-chunks the mock output
 	});
 	return { backend, runtime };
 }
 
 describe("KokoroTtsBackend", () => {
+	it("synthesizes every ordered segment of a long utterance and its final tail", async () => {
+		const phonemizer: KokoroPhonemizer = {
+			id: "length-aware",
+			async phonemize(text) {
+				return {
+					ids: Int32Array.from(Array.from(text, () => 43)),
+					phonemes: text,
+				};
+			},
+		};
+		const { backend, runtime } = makeBackend({ phonemizer });
+		const calls = vi.spyOn(runtime, "synthesize");
+		const text = `${"A complete sentence stays in order. ".repeat(45)}The final words must be spoken.`;
+		const audio = await backend.synthesize({
+			phrase: makePhrase(text),
+			preset: makePreset(KOKORO_DEFAULT_VOICE_ID),
+			cancelSignal: { cancelled: false },
+		});
+		expect(calls.mock.calls.map(([input]) => input.text).join("")).toBe(text);
+		expect(
+			calls.mock.calls.every(
+				([input]) => Array.from(input.phonemes.phonemes).length <= 510,
+			),
+		).toBe(true);
+		expect(calls.mock.calls.length).toBeGreaterThan(1);
+		expect(audio.pcm.length).toBe(9600 * calls.mock.calls.length);
+	});
+
+	it("rejects an oversized final word before emitting an otherwise valid prefix", async () => {
+		const phonemizer: KokoroPhonemizer = {
+			id: "length-aware",
+			async phonemize(text) {
+				return {
+					ids: Int32Array.from(Array.from(text, () => 43)),
+					phonemes: text,
+				};
+			},
+		};
+		const { backend, runtime } = makeBackend({ phonemizer });
+		const onChunk = vi.fn();
+		await expect(
+			backend.synthesizeStream({
+				phrase: makePhrase(`A valid opening. ${"a".repeat(511)}`),
+				preset: makePreset(KOKORO_DEFAULT_VOICE_ID),
+				cancelSignal: { cancelled: false },
+				onChunk,
+			}),
+		).rejects.toMatchObject({ code: "KOKORO_PHRASE_TOO_LARGE" });
+		expect(runtime.calls).toBe(0);
+		expect(onChunk).not.toHaveBeenCalled();
+	});
+
+	it("cancels between long-utterance segments without dispatching the suffix", async () => {
+		const phonemizer: KokoroPhonemizer = {
+			id: "length-aware",
+			async phonemize(text) {
+				return {
+					ids: Int32Array.from(Array.from(text, () => 43)),
+					phonemes: text,
+				};
+			},
+		};
+		const { backend, runtime } = makeBackend({ phonemizer });
+		const result = await backend.synthesizeStream({
+			phrase: makePhrase("A complete sentence. ".repeat(80)),
+			preset: makePreset(KOKORO_DEFAULT_VOICE_ID),
+			cancelSignal: { cancelled: false },
+			onChunk: (chunk) => !chunk.isFinal,
+		});
+		expect(result.cancelled).toBe(true);
+		expect(runtime.calls).toBe(1);
+	});
+
 	it("contracts only grammatically safe I am forms for Kokoro", () => {
 		expect(prepareKokoroSpeakText("I am ready.")).toBe("I'm ready.");
 		expect(prepareKokoroSpeakText("Yes, I am here.")).toBe("Yes, I'm here.");

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-backend.test.ts
@@ -125,6 +125,33 @@ describe("KokoroTtsBackend", () => {
 		expect(onChunk).not.toHaveBeenCalled();
 	});
 
+	it("rejects a nonspoken suffix during full preflight before emitting the prefix", async () => {
+		const phonemizer: KokoroPhonemizer = {
+			id: "separator-aware",
+			async phonemize(text) {
+				return {
+					ids: new Int32Array(),
+					phonemes: /[a-z]/i.test(text) ? text : "",
+				};
+			},
+		};
+		const { backend, runtime } = makeBackend({ phonemizer });
+		const onChunk = vi.fn();
+		const text =
+			"This sentence has many ordinary spoken words. ".repeat(30) +
+			"--- ".repeat(300);
+		await expect(
+			backend.synthesizeStream({
+				phrase: makePhrase(text),
+				preset: makePreset(KOKORO_DEFAULT_VOICE_ID),
+				cancelSignal: { cancelled: false },
+				onChunk,
+			}),
+		).rejects.toMatchObject({ code: "KOKORO_EMPTY_PHONEMES" });
+		expect(runtime.calls).toBe(0);
+		expect(onChunk).not.toHaveBeenCalled();
+	});
+
 	it("cancels between long-utterance segments without dispatching the suffix", async () => {
 		const phonemizer: KokoroPhonemizer = {
 			id: "length-aware",

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-ffi-runtime.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/kokoro-ffi-runtime.test.ts
@@ -34,16 +34,15 @@ function fakeKokoroFfi(opts: {
 	pcm?: Float32Array;
 	calls: FakeFfiCalls;
 	/**
-	 * When set, the fake exports the v14 G2P surface reporting this kind. When
-	 * omitted, the fake OMITS `kokoroG2pKind`/`kokoroSynthesizeIpa` entirely —
-	 * modelling a pre-v14 library (the runtime resolves g2p="unknown").
+	 * Defaults to ABI v14 ASCII. Explicit unknown omits the IPA surface to
+	 * model an unsupported legacy library.
 	 */
-	g2pKind?: "espeak" | "ascii";
+	g2pKind?: "espeak" | "ascii" | "unknown";
 }): ElizaInferenceFfi {
 	const pcm = opts.pcm ?? Float32Array.from([0.1, 0.2, 0.3, 0.4]);
 	const base = {
 		libraryPath: "/fake/libelizainference.so",
-		libraryAbiVersion: opts.g2pKind ? "14" : "13",
+		libraryAbiVersion: opts.g2pKind === "unknown" ? "13" : "14",
 		create: () => 7n as ElizaInferenceContextHandle,
 		destroy: () => {
 			opts.calls.destroyed++;
@@ -73,10 +72,10 @@ function fakeKokoroFfi(opts: {
 			opts.calls.closed++;
 		},
 	};
-	if (opts.g2pKind) {
+	if (opts.g2pKind !== "unknown") {
 		return {
 			...base,
-			kokoroG2pKind: () => opts.g2pKind,
+			kokoroG2pKind: () => opts.g2pKind ?? "ascii",
 			kokoroSynthesizeIpa: (a: {
 				ipa: string;
 				maxSamples: number;
@@ -229,17 +228,14 @@ describe("KokoroFfiRuntime", () => {
 		expect(calls.loads[0]?.voiceBinPath).toBe(
 			path.join(root, "voices", "af_same.bin"),
 		);
-		// Pre-v14 lib (fake omits the G2P surface → g2p="unknown"): the runtime
-		// keeps the raw-text path (correct on espeak-linked builds), never the
-		// JS-side IPA string. IPA-as-text double-phonemizes (#10726/#11238).
-		expect(calls.synths[0]?.text).toBe("hello");
-		expect(calls.ipaSynths).toHaveLength(0);
+		expect(calls.synths).toHaveLength(0);
+		expect(calls.ipaSynths).toHaveLength(1);
 		expect(chunks.filter((c) => !c.isFinal)).toHaveLength(1);
 		expect(chunks.at(-1)?.isFinal).toBe(true);
 		expect(chunks[0]?.len).toBe(4);
 	});
 
-	it("g2p=espeak: sends RAW text (the lib phonemizes with espeak-ng, #11238)", async () => {
+	it("g2p=espeak: sends checked IPA without a second native phonemization", async () => {
 		const ffi = fakeKokoroFfi({ calls, g2pKind: "espeak" });
 		const rt = new KokoroFfiRuntime({
 			layout: makeLayout(root),
@@ -251,10 +247,8 @@ describe("KokoroFfiRuntime", () => {
 				phonemizerId: "phonemizer",
 			}),
 		);
-		expect(calls.synths).toHaveLength(1);
-		expect(calls.synths[0]?.text).toBe("hello");
-		// Never the IPA entry on an espeak-linked lib.
-		expect(calls.ipaSynths).toHaveLength(0);
+		expect(calls.synths).toHaveLength(0);
+		expect(calls.ipaSynths).toHaveLength(1);
 	});
 
 	it("g2p=ascii: feeds espeak-ng IPA through the IPA entry (#11776)", async () => {
@@ -306,23 +300,52 @@ describe("KokoroFfiRuntime", () => {
 		expect(fallbackWarns).toHaveLength(1);
 	});
 
-	it("g2p=unknown (pre-v14 lib): warns once and keeps raw text", async () => {
-		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
-		const ffi = fakeKokoroFfi({ calls }); // no g2pKind → unknown
+	it("rejects a legacy library before delivering audio", async () => {
+		const ffi = fakeKokoroFfi({ calls, g2pKind: "unknown" });
 		const rt = new KokoroFfiRuntime({
 			layout: makeLayout(root),
 			ffi,
 			ctx: 7n as ElizaInferenceContextHandle,
 		});
-		const v = voice("af_same", "af_same.bin");
-		await rt.synthesize(makeInputs(v, () => undefined));
-		await rt.synthesize(makeInputs(v, () => undefined));
-		expect(calls.synths).toHaveLength(2);
+		const onChunk = vi.fn();
+		await expect(
+			rt.synthesize(makeInputs(voice("af_same", "af_same.bin"), onChunk)),
+		).rejects.toMatchObject({ code: "KOKORO_IPA_ABI_REQUIRED" });
+		expect(onChunk).not.toHaveBeenCalled();
+		expect(calls.synths).toHaveLength(0);
 		expect(calls.ipaSynths).toHaveLength(0);
-		const oldLibWarns = warn.mock.calls.filter((c) =>
-			String(c[0]).includes("predates the Kokoro IPA G2P surface"),
-		);
-		expect(oldLibWarns).toHaveLength(1);
+	});
+
+	it("rejects oversized IPA before native dispatch or partial audio", async () => {
+		const rt = new KokoroFfiRuntime({
+			layout: makeLayout(root),
+			ffi: fakeKokoroFfi({ calls }),
+			ctx: 7n as ElizaInferenceContextHandle,
+		});
+		const onChunk = vi.fn();
+		await expect(
+			rt.synthesize(
+				makeInputs(voice("af_same", "af_same.bin"), onChunk, undefined, {
+					ipa: "a".repeat(511),
+				}),
+			),
+		).rejects.toMatchObject({ code: "KOKORO_PHRASE_TOO_LARGE" });
+		expect(onChunk).not.toHaveBeenCalled();
+		expect(calls.ipaSynths).toHaveLength(0);
+	});
+
+	it("rejects exhausted audio capacity before returning a clipped waveform", async () => {
+		const rt = new KokoroFfiRuntime({
+			layout: makeLayout(root),
+			ffi: fakeKokoroFfi({ calls, pcm: new Float32Array(4) }),
+			ctx: 7n as ElizaInferenceContextHandle,
+		});
+		const onChunk = vi.fn();
+		const input = makeInputs(voice("af_same", "af_same.bin"), onChunk);
+		await expect(
+			rt.synthesize({ ...input, maxSamples: 4 }),
+		).rejects.toMatchObject({ code: "KOKORO_AUDIO_CAPACITY_EXCEEDED" });
+		expect(onChunk).not.toHaveBeenCalled();
 	});
 
 	it("materializes packaged voice presets before calling the native loader", async () => {
@@ -413,7 +436,7 @@ describe("KokoroFfiRuntime", () => {
 		await rt.synthesize(makeInputs(v, () => undefined));
 
 		expect(calls.loads).toHaveLength(1);
-		expect(calls.synths).toHaveLength(2);
+		expect(calls.ipaSynths).toHaveLength(2);
 	});
 
 	it("reloads when the requested voice changes", async () => {

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
@@ -28,6 +28,7 @@ import type {
 } from "../types";
 import type { KokoroRuntime } from "./kokoro-runtime";
 import { resolvePhonemizer } from "./phonemizer";
+import { prepareKokoroPhrases } from "./prepare-phrases";
 import type {
 	KokoroBackendOptions,
 	KokoroPhonemizer,
@@ -168,7 +169,11 @@ export class KokoroTtsBackend implements TtsBackend, StreamingTtsBackend {
 		const phonemizer = await this.ensurePhonemizer();
 		args.onKernelTick?.();
 		const speakText = prepareKokoroSpeakText(args.phrase.text);
-		const phonemes = await phonemizer.phonemize(speakText, voice.lang);
+		const phrases = await prepareKokoroPhrases(
+			speakText,
+			voice.lang,
+			phonemizer,
+		);
 		if (args.cancelSignal.cancelled) {
 			args.onChunk({
 				pcm: new Float32Array(0),
@@ -185,51 +190,58 @@ export class KokoroTtsBackend implements TtsBackend, StreamingTtsBackend {
 		// listener before the full phrase finishes decoding.
 		const limit = this.streamingChunkSamples;
 		let cancelled = false;
-		const result = await this.runtime.synthesize({
-			text: speakText,
-			phonemes,
-			phonemizerId: phonemizer.id,
-			voice,
-			cancelSignal: args.cancelSignal,
-			onChunk: ({ pcm, isFinal }) => {
-				args.onKernelTick?.();
-				if (cancelled || args.cancelSignal.cancelled) {
-					cancelled = true;
-					return true;
-				}
-				if (pcm.length === 0) {
-					// Pass through tail markers from the runtime — the final tail is
-					// emitted by us below, so swallow runtime-side finals to avoid
-					// double-tails.
-					if (!isFinal) return false;
+		for (const prepared of phrases) {
+			if (cancelled || args.cancelSignal.cancelled) {
+				cancelled = true;
+				break;
+			}
+			const result = await this.runtime.synthesize({
+				text: prepared.text,
+				phonemes: prepared.phonemes,
+				phonemizerId: phonemizer.id,
+				voice,
+				cancelSignal: args.cancelSignal,
+				onChunk: ({ pcm, isFinal }) => {
+					args.onKernelTick?.();
+					if (cancelled || args.cancelSignal.cancelled) {
+						cancelled = true;
+						return true;
+					}
+					if (pcm.length === 0) {
+						// Pass through tail markers from the runtime — the final tail is
+						// emitted by us below, so swallow runtime-side finals to avoid
+						// double-tails.
+						if (!isFinal) return false;
+						return false;
+					}
+					for (let off = 0; off < pcm.length; off += limit) {
+						if (args.cancelSignal.cancelled) {
+							cancelled = true;
+							return true;
+						}
+						const end = Math.min(pcm.length, off + limit);
+						const slice = pcm.subarray(off, end);
+						const want = args.onChunk({
+							pcm: slice,
+							sampleRate: this.runtime.sampleRate,
+							isFinal: false,
+						});
+						if (want === true || args.cancelSignal.cancelled) {
+							cancelled = true;
+							return true;
+						}
+					}
 					return false;
-				}
-				for (let off = 0; off < pcm.length; off += limit) {
-					if (args.cancelSignal.cancelled) {
-						cancelled = true;
-						return true;
-					}
-					const end = Math.min(pcm.length, off + limit);
-					const slice = pcm.subarray(off, end);
-					const want = args.onChunk({
-						pcm: slice,
-						sampleRate: this.runtime.sampleRate,
-						isFinal: false,
-					});
-					if (want === true || args.cancelSignal.cancelled) {
-						cancelled = true;
-						return true;
-					}
-				}
-				return false;
-			},
-		});
+				},
+			});
+			cancelled = cancelled || result.cancelled;
+		}
 		args.onChunk({
 			pcm: new Float32Array(0),
 			sampleRate: this.runtime.sampleRate,
 			isFinal: true,
 		});
-		return { cancelled: cancelled || result.cancelled };
+		return { cancelled };
 	}
 
 	dispose(): void {

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-ffi-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-ffi-runtime.ts
@@ -1,43 +1,16 @@
 /**
- * In-process Kokoro-82M runtime over the fused `libelizainference` FFI
- * (the `eliza_inference_kokoro_*` exports — introduced at ABI v10; ABI v14 adds
- * the IPA-input entry + G2P-kind query — see `ELIZA_INFERENCE_ABI_VERSION` in
- * ffi-bindings.ts).
- *
- * G2P routing (#11776): the fused build only links libespeak-ng on some hosts
- * and never on Android/iOS. Where it does (`kokoroG2pKind() === "espeak"`) the
- * lib phonemizes raw text itself and synthesis sends the raw phrase (#11238 —
- * sending IPA there would double-phonemize). Where it does NOT
- * (`"ascii"`) the lib's raw-text path is a lossy grapheme fallback that yields
- * unintelligible audio, so synthesis instead feeds the espeak-ng IPA the TS
- * phonemizer already produced through `synthesize_ipa`. A pre-v14 lib
- * (`"unknown"`) keeps raw text with a one-time warning.
- *
- * This is the canonical Kokoro execution path on every platform. It replaces
- * the local-TCP `KokoroGgufRuntime` (POST `/v1/audio/speech` on a running
- * llama-server) for the mobile case — iOS and Google Play forbid the app
- * opening a local TCP socket, so the HTTP→llama-server route cannot ship there.
- * Kokoro synthesizes through the same dlopen()-ed handle as OmniVoice: the
- * fused build links Eliza-1's Kokoro engine (its own GGUF reader + iSTFT
- * decoder) behind `eliza_inference_kokoro_supported/load/synthesize/sample_rate`.
- *
- * Ownership: this runtime owns its own FFI handle + context. The context is
- * created with `create(bundleRoot)` anchored at the bundle root (or the Kokoro
- * model root when there is no Eliza-1 bundle), mirroring how the desktop fused
- * text runtime obtains its ctx. The GGUF + the active voice `.bin` are loaded
- * once via `kokoroLoad` and reloaded only when the requested voice changes.
- *
- * No silent fallback (AGENTS.md §3): when the loaded library does not export
- * the Kokoro symbols (`kokoroSupported() === false`) or the model/voice files
- * are missing, construction / first synthesis throws a structured
- * `VoiceLifecycleError` rather than dropping back to the TCP route.
+ * Runs Kokoro through the fused library using preflighted IPA on ABI v14 or newer.
+ * The exact IPA checked against the 510-codepoint model boundary reaches the
+ * native IPA entry; a second native G2P pass cannot change its size or content.
+ * Legacy libraries and output allocation exhaustion fail before audio delivery.
+ * This runtime owns its FFI context unless a caller supplies one.
  */
 
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { resolveFusedLibraryPath } from "../../desktop-fused-ffi-backend-runtime";
 import {
 	type ElizaInferenceContextHandle,
@@ -422,9 +395,7 @@ export class KokoroFfiRuntime implements KokoroRuntime {
 	 */
 	private readonly g2pKind: "espeak" | "ascii" | "unknown";
 	/** One-time warning latches (avoid log spam on every phrase). */
-	private warnedOldLib = false;
 	private warnedFallbackPhonemizer = false;
-	private warnedEmptyIpa = false;
 
 	constructor(opts: KokoroFfiRuntimeOptions) {
 		this.layout = opts.layout;
@@ -467,10 +438,7 @@ export class KokoroFfiRuntime implements KokoroRuntime {
 			this.ownsCtx = true;
 		}
 
-		// Query the lib's G2P kind once. On an espeak-less build (`ascii`) the
-		// native raw-text path is unintelligible, so synthesis routes through the
-		// IPA entry with the TS phonemizer's espeak-ng IPA (#11776). A pre-v14 lib
-		// lacks the query symbol → `unknown` → keep raw text (warned once).
+		// ABI v14 exposes the IPA entry; unknown libraries cannot honor preflight.
 		this.g2pKind =
 			typeof this.ffi.kokoroG2pKind === "function"
 				? this.ffi.kokoroG2pKind(this.ctx)
@@ -569,76 +537,56 @@ export class KokoroFfiRuntime implements KokoroRuntime {
 		);
 	}
 
-	/**
-	 * Route one phrase to the correct native entry based on the loaded lib's
-	 * G2P kind:
-	 *   - `espeak`: the lib phonemizes raw text with real espeak-ng → send text
-	 *     (the #11238 behavior; sending IPA here would double-phonemize).
-	 *   - `ascii`: the lib's raw-text path is the lossy grapheme fallback
-	 *     (unintelligible) → send the espeak-ng IPA the TS phonemizer produced
-	 *     through the native IPA entry (#11776).
-	 *   - `unknown`: a pre-v14 lib without the IPA entry → keep raw text and warn
-	 *     once (correct on espeak-linked builds, garbled on espeak-less ones).
-	 */
+	/** Dispatch the exact preflighted IPA, never a second phonemization. */
 	private synthesizePcm(
 		args: KokoroRuntimeInputs,
 		maxSamples: number,
 	): Float32Array {
-		if (this.g2pKind === "ascii") {
-			const ipa = args.phonemes.phonemes;
-			if (ipa.length > 0) {
-				if (
-					args.phonemizerId === "fallback-g2p" &&
-					!this.warnedFallbackPhonemizer
-				) {
-					this.warnedFallbackPhonemizer = true;
-					logger.warn(
-						"[KokoroFfiRuntime] the loaded Kokoro lib has no espeak-ng (g2p=ascii) and the " +
-							"TS phonemizer resolved to the lossy 'fallback-g2p' — audio will be degraded. " +
-							"Install the 'phonemizer' npm package (espeak-ng WASM) for intelligible speech (#11776).",
-					);
-				}
-				return this.kokoroSynthesizeIpa(ipa, maxSamples);
-			}
-			if (!this.warnedEmptyIpa) {
-				this.warnedEmptyIpa = true;
-				logger.warn(
-					"[KokoroFfiRuntime] g2p=ascii but the phrase produced no IPA — falling back to raw " +
-						"text (the lib's lossy ASCII grapheme path). Check the TS phonemizer chain (#11776).",
-				);
-			}
-			return this.kokoroSynthesize(args.text, maxSamples);
+		if (
+			this.g2pKind === "unknown" ||
+			typeof this.ffi.kokoroSynthesizeIpa !== "function"
+		) {
+			throw new ElizaError(
+				"[KokoroFfiRuntime] Rebuild the fused library with the ABI v14 IPA entry before using speech.",
+				{ code: "KOKORO_IPA_ABI_REQUIRED" },
+			);
 		}
-
-		if (this.g2pKind === "unknown" && !this.warnedOldLib) {
-			this.warnedOldLib = true;
+		const ipa = args.phonemes.phonemes;
+		const phonemeCount = Array.from(ipa).length;
+		if (phonemeCount === 0 || phonemeCount > 510) {
+			throw new ElizaError(
+				"[KokoroFfiRuntime] Speech input must contain 1 to 510 IPA codepoints; split the complete utterance before synthesis.",
+				{
+					code: "KOKORO_PHRASE_TOO_LARGE",
+					context: { phonemeCount, maximum: 510 },
+				},
+			);
+		}
+		if (
+			args.phonemizerId === "fallback-g2p" &&
+			!this.warnedFallbackPhonemizer
+		) {
+			this.warnedFallbackPhonemizer = true;
 			logger.warn(
-				"[KokoroFfiRuntime] the loaded libelizainference predates the Kokoro IPA G2P surface " +
-					`(ABI v14, #11776; lib reports ABI v${this.ffi.libraryAbiVersion}). Using raw-text ` +
-					"synthesis — correct on an espeak-linked build, but UNINTELLIGIBLE on an espeak-less " +
-					"one. Rebuild the fused lib to pick up the IPA path.",
+				"[KokoroFfiRuntime] fallback-g2p has reduced speech accuracy; install the phonemizer package for espeak-ng IPA.",
 			);
 		}
-		return this.kokoroSynthesize(args.text, maxSamples);
-	}
-
-	private kokoroSynthesize(text: string, maxSamples: number): Float32Array {
-		if (typeof this.ffi.kokoroSynthesize !== "function") {
-			throw new VoiceLifecycleError(
-				"kernel-missing",
-				"[KokoroFfiRuntime] eliza_inference_kokoro_synthesize is not exported by the loaded build",
+		const pcm = this.kokoroSynthesizeIpa(ipa, maxSamples);
+		if (pcm.length >= maxSamples) {
+			throw new ElizaError(
+				"[KokoroFfiRuntime] Speech exhausted the audio allocation; retry with smaller phrases.",
+				{ code: "KOKORO_AUDIO_CAPACITY_EXCEEDED", context: { maxSamples } },
 			);
 		}
-		return this.ffi.kokoroSynthesize({ ctx: this.ctx, text, maxSamples });
+		return pcm;
 	}
 
 	private kokoroSynthesizeIpa(ipa: string, maxSamples: number): Float32Array {
 		if (typeof this.ffi.kokoroSynthesizeIpa !== "function") {
-			// g2pKind === "ascii" is only reachable when the v14 symbols bound, so
-			// this is an invariant breach rather than an old-lib case.
+			// The synthesis preflight already requires this ABI surface.
 			throw new VoiceLifecycleError(
 				"kernel-missing",
-				"[KokoroFfiRuntime] eliza_inference_kokoro_synthesize_ipa is not exported despite g2p=ascii",
+				"[KokoroFfiRuntime] eliza_inference_kokoro_synthesize_ipa is not exported by the loaded library",
 			);
 		}
 		return this.ffi.kokoroSynthesizeIpa({ ctx: this.ctx, ipa, maxSamples });

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts
@@ -31,15 +31,9 @@ export interface KokoroRuntimeChunk {
  * bytes off `layout.voicesDir/<file>`.
  */
 export interface KokoroRuntimeInputs {
-	/**
-	 * Raw (pre-phonemization) phrase text. On an espeak-LINKED fused build the
-	 * in-process engine phonemizes this itself, so it MUST receive the raw text
-	 * — feeding it the JS-side IPA there double-phonemizes into lexically wrong
-	 * audio (#10726/#11238). On an espeak-LESS build (Android/iOS/host without
-	 * libespeak-ng) the engine's raw-text path is the lossy ASCII grapheme map
-	 * (unintelligible), so `KokoroFfiRuntime` instead feeds `phonemes.phonemes`
-	 * (espeak-ng IPA) through `synthesize_ipa` (#11776). The runtime picks per
-	 * loaded lib via `kokoroG2pKind()`.
+	/** Complete synthesis text retained alongside its preflighted phonemes.
+	 * Fused ABI v14+ uses the IPA entry on every platform, avoiding a second
+	 * G2P pass that could diverge from the checked model input.
 	 */
 	text: string;
 	/** espeak-ng IPA + tokenized ids for `text`, produced by the TS phonemizer

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/prepare-phrases.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/prepare-phrases.ts
@@ -17,6 +17,12 @@ export async function prepareKokoroPhrases(
 	phonemizer: KokoroPhonemizer,
 ): Promise<PreparedKokoroPhrase[]> {
 	const phonemes = await phonemizer.phonemize(text, lang);
+	if (phonemes.phonemes.length === 0) {
+		throw new ElizaError(
+			"[Kokoro] A speech segment has no pronounceable phonemes. Remove the unsupported segment before retrying.",
+			{ code: "KOKORO_EMPTY_PHONEMES" },
+		);
+	}
 	// Each native IPA codepoint contributes at most one token. Counting every
 	// codepoint is conservative even when the native vocabulary ignores it.
 	if (Array.from(phonemes.phonemes).length <= 510) {

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/prepare-phrases.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/prepare-phrases.ts
@@ -1,0 +1,45 @@
+/**
+ * Preflights complete Kokoro utterances against the native 510-phoneme boundary.
+ * Word-boundary splitting preserves the ordered text exactly; an indivisible
+ * oversized word fails before any phrase is dispatched to synthesis.
+ */
+import { ElizaError } from "@elizaos/core";
+import type { KokoroPhonemeSequence, KokoroPhonemizer } from "./types";
+
+export interface PreparedKokoroPhrase {
+	text: string;
+	phonemes: KokoroPhonemeSequence;
+}
+
+export async function prepareKokoroPhrases(
+	text: string,
+	lang: string,
+	phonemizer: KokoroPhonemizer,
+): Promise<PreparedKokoroPhrase[]> {
+	const phonemes = await phonemizer.phonemize(text, lang);
+	// Each native IPA codepoint contributes at most one token. Counting every
+	// codepoint is conservative even when the native vocabulary ignores it.
+	if (Array.from(phonemes.phonemes).length <= 510) {
+		return [{ text, phonemes }];
+	}
+	const words = text.match(/\S+\s*|\s+/gu) ?? [];
+	if (words.length < 2) {
+		throw new ElizaError(
+			"[Kokoro] A word exceeds the speech model context. Add a word boundary before retrying.",
+			{
+				code: "KOKORO_PHRASE_TOO_LARGE",
+				context: {
+					phonemeCount: Array.from(phonemes.phonemes).length,
+					maximum: 510,
+				},
+			},
+		);
+	}
+	const midpoint = Math.floor(words.length / 2);
+	const left = words.slice(0, midpoint).join("");
+	const right = words.slice(midpoint).join("");
+	return [
+		...(await prepareKokoroPhrases(left, lang, phonemizer)),
+		...(await prepareKokoroPhrases(right, lang, phonemizer)),
+	];
+}


### PR DESCRIPTION
# Relates to

Relates to #30679. Buffered speech could split unfinished words, silently discard a rewritten final reply, and wait until one clip ended before synthesizing the next. Longer local Kokoro replies also silently stopped after the native 510-phoneme limit.

This change retains incomplete lexical tails, rejects incompatible final rewrites visibly, prepares the next clip while preserving one ordered playback owner, and propagates speech failure/recovery through the app shell. Kokoro now preflights the complete utterance, splits oversized phrases losslessly at word boundaries, and synthesizes the exact checked IPA through ABI v14+. Indivisible oversized input, empty phonemes, unsupported old ABI and exhausted output capacity fail explicitly. Cancellation prevents stale playback and later segment dispatch.

# Sync with develop

Head `9743eb1a4cb94a0f3d14020675e4365f5121c2b0`, cleanly rebased onto `cd821540d73c4e7370a9407c07be19020a3b810b`. Post-sync install passed with the existing fused inference installation retained. Post-sync `bun run verify` passed: all 376 Turbo tasks and all repository audits, exit 0.

# Risks

The buffered web queue serves local inference, Eliza Cloud and ElevenLabs. Live evidence below covers the configured local Kokoro path; other providers and physical native devices remain unverified. Encoded lookahead avoids another synthesis request but is not a peak-memory guarantee. Canonical speakable text is preserved; the existing sanitizer still removes unsupported markup/URLs/emoji. Legacy native libraries without the checked IPA entry now return an actionable error instead of using an unverified truncating path.

# Documentation

Updated local-inference compatibility guidance and contracts for checked IPA synthesis. Shared phrase-cache eligibility/identity remains owned by #30680.

# Testing

- UI full suite: 1,274 files / 13,621 tests passed. Four initial import-time failures were resolved by building the declared cloud-sdk dependency, then those four files / 14 tests passed. Final shell coverage: 233 tests; playback/shell focus: 40 tests. UI typecheck and full lint passed.
- Full local-inference suite: 282 files / 2,916 tests passed, 19 explicit skips; 60 native harness tests passed. Typecheck and full lint passed. Final empty-phoneme follow-up: 29 focused tests passed, independently rerun with a real installed-phonemizer adversarial probe.
- App visual audit: 219 checks passed; OCR 204 verified, zero broken, 12 documented unavailable cases. Captured UI source `dcd4a4ad0b80a1381e998eed6dc6e5ec11427b5c` has identical affected UI bytes after rebase. Native follow-up source is separately identified below.
- Controlled Chromium/WebAudio comparison used identical audio and 450 ms transport latency: baseline inter-clip silence 540 ms; updated clip has no silence interval at least 150 ms. This isolates scheduling and is not live synthesis latency.
- The user listened to the exact two live Kokoro clips and reported **“Sounds complete and natural.”** Their cold/warm inter-clip comparison is observational, not a matched provider benchmark.
- Real long-reply counterexample: 180 words became only 22.6 seconds / 87 ASR words before the repair. The same complete reply now produces 43.875 seconds. Independent native Qwen3-ASR reaches every feature section and the exact final sentence, “Tell me what you want to write down first.” Minor ASR wording/punctuation differences remain. This is recorded-audio proof, not microphone ingress.

# Evidence Gate

<!-- evidence-head:9743eb1a4cb94a0f3d14020675e4365f5121c2b0 -->

<!-- evidence-row:before-screenshots -->
- [x] Fresh baseline-code and current full-app desktop/mobile screenshots are attached below with exact capture revisions.
<!-- evidence-row:after-screenshots -->
- [x] Actual full app failure/recovery desktop/mobile captures are embedded below.
<!-- evidence-row:walkthrough-video -->
- [x] Actual app-shell failure/retry walkthrough MP4 with explanatory narration is attached; application audio is separate.
<!-- evidence-row:backend-logs -->
- [x] Inline backend receipt and complete sanitized logs are attached in the verified archive; earlier configuration failure remains documented.
<!-- evidence-row:frontend-logs -->
- [x] Inline console/network/playback receipts and full sanitized files are included in the verified archive.
<!-- evidence-row:llm-trajectory -->
- [x] N/A for language-model inference changes: this PR changes TTS and playback, not LLM prompts/actions. Real TTS model output is attached below.
<!-- evidence-row:domain-artifacts -->
- [x] Exact human-reviewed short clips, application retry audio and complete repaired long WAV are attached below.
<!-- evidence-row:ocr-review -->
- [x] Inline OCR receipts and exact-hash reports are attached; canonical screenshot review succeeded for all ten screenshots.

# Evidence Details

The screenshots and MP4 exercise the normal `/chat` app: a controlled first TTS 503 becomes a visible speech error, then a real local Kokoro retry clears it. They were captured on UI source `dcd4a4ad0b80a1381e998eed6dc6e5ec11427b5c`. The MP4 includes 1.8-second reading pauses and separately generated explanatory narration; it is not a latency benchmark or the application voice itself.

### Failure: desktop and mobile

![Desktop speech unavailable](https://github.com/user-attachments/assets/24f8d900-4944-45b9-b70c-e41409a3941f)
![Mobile speech unavailable](https://github.com/user-attachments/assets/e7f148f7-7a4f-4500-b137-b2fbdca7bb0a)

### Successful retry: desktop and mobile

![Desktop playback recovered](https://github.com/user-attachments/assets/3d484c71-cf13-48c1-adc4-d1eff986b68e)
![Mobile playback recovered](https://github.com/user-attachments/assets/41c7ba58-9dea-4e18-a960-89326f116df1)

### Narrated walkthrough

https://github.com/user-attachments/assets/3b1b38db-199e-41c5-a93e-8588cc7fc6c9

### Exact human-reviewed live clips

Before: https://github.com/user-attachments/assets/52ae9a4e-1eea-4bc1-a015-62b4ba7bbcf5

After: https://github.com/user-attachments/assets/1f9ee43e-32f1-4b94-86ab-2fa44ac9cbce

User-approved audio SHA256: before `0f1ccd5afd1af99d5fc0c46266405c63d653ed902f116c6fc5efb327e687717c`; after `f2ccd43118f311246ad074ac2ed4d2b15039a3fb5a13d16bcc0c89279ee12f6b`. This listening approval applies only to these clips.

Actual app retry audio: https://github.com/user-attachments/assets/9830ef4d-a203-4cf1-99b5-9a301a8dcdf4

### Complete long reply

[Original 43.875-second WAV](https://github.com/user-attachments/files/31876611/long-reply-complete.wav), SHA256 `4f335c87ec0087d0c33a79f92df4c94ff26d6c2e279a6ba42bb5eb080f2806ab`. Generated at native implementation `6dd0125f952f0f9d6319831e795bb693ed0d18cb`. Follow-up `9564979b979f13fb24b0b6885892076e1c31ffc9` rejects a separator-only tail producing empty IPA before any audio is dispatched. Independent code review found no remaining actionable defect at that revision. The affected UI/native-inference bytes are unchanged by the final rebase; the new full-app failure/retry comparison below is separately captured on the rebased SHA.

# Known gaps / failures

Baseline-code app screenshots, current-head retry captures, inline log/OCR receipts and the 46-artifact canonical bundle are now attached. Published-head independent source review passed, with fresh 48 UI and 29 native tests; all hosted checks passed. These receipts establish the scoped buffered/local repair. Other live TTS providers, Cartesia realtime and physical native devices are not covered by the local evidence. The original real Kokoro smoke exceeded its unchanged 700 ms TTFA budget (824 ms); the scheduling/completeness repair does not claim to fix model cold-start latency. No CI exception is requested, and the parent issue stays in progress.

# Maintainer CI exception record

N/A — no exception requested.


## Final reviewed evidence — 2026-09-06

### Voice evidence log and OCR receipts

Historical full-app recovery capture: dcd4a4ad0b80a1381e998eed6dc6e5ec11427b5c. Collection checkout: 9743eb1a4cb94a0f3d14020675e4365f5121c2b0; collection does not change capture provenance.

<details><summary>Frontend console, network, and playback receipt</summary>

The controlled first local TTS request returned 503. The renderer reported voice.tts-failed-closed and preserved an explicit failure. Retry returned 200. Audio start/end events record one 11.525-second clip. The complete sanitized console/network/event logs are retained.

```text
404 /api/lifeops/todos — 2 response(s)
404 /api/lifeops/goals — 2 response(s)
404 /api/connectors/google/accounts — 1 response(s)
503 /api/tts/local-inference — 1 response(s)
503 /api/coding-agents — 1 response(s)
503 /api/orchestrator/status — 1 response(s)
503 /api/orchestrator/tasks — 1 response(s)
200 /api/tts/local-inference — 1 response(s)
200 /api/voice/playback-frames — 48 response(s)
RendererDiagnostic: voice.tts-failed-closed
Local inference TTS 503: Controlled provider outage for visible recovery proof
Audio start 10254.100 ms; ended 21775.800 ms; decoded duration 11.525 s
```

Other 404/503 responses above are retained observations, not asserted repaired by this PR.
</details>

<details><summary>Backend receipt and limitations</summary>

Current runtime log snapshot records the API listening on 127.0.0.1:30678. It also records no AI provider loaded, a missing Birdeye credential/service, and scheduled dispatch rendering failures. This backend log is not proof of live model generation or a clean full runtime. Historic backend-live.json independently records four successful real Kokoro responses (200; 138044 or 218444 bytes); original short-clip revision is unknown. Browser network receipt supplies the successful full-app retry response.

Complete sanitized current and historical runtime logs are retained with original/sanitized SHA-256 hashes and secret-scan receipts.
</details>

<details><summary>Existing app OCR receipt</summary>

216 entries: 204 verified, 0 broken, 12 needs-eyeball, 0 regressions. These are archived results, not a new current-head audit. Exact capture SHA is not encoded in the OCR JSON.

- builtin-camera: 4 viewports; semantic OCR exemption — The camera is an AOSP-native surface, so the browser audit intentionally renders the unavailable-view boundary.
- plugin-cockpit-gui: 4 viewports; semantic OCR exemption — The Cockpit GUI has no remote bundle in the hermetic browser audit, so the unavailable-view boundary is the only observable surface.
- plugin-lifeops-live-test-gui: 4 viewports; semantic OCR exemption — The LifeOps live-test GUI has no remote bundle in the hermetic browser audit, so the view-registry fallback is the only observable surface.

All 12 exceptions remain unavailable browser surfaces; they are not native-device pass receipts. Full exception texts and source hash are in ocr-receipt.json.
</details>

<details><summary>Fresh OCR over the actual product captures</summary>

Canonical AppleVision OCR at analysis revision 9743eb1a4cb94a0f3d14020675e4365f5121c2b0 recognized all four historical full-app JPGs, each hash-bound to its dcd4a4ad0b80a1381e998eed6dc6e5ec11427b5c capture revision. Both failure views include “on-device voice unavailable”; both recovered views omit that indicator. All four preserve the garden reply ending “water.” Confidence ranges 0.977–1.0. These extracted words support the visible state review; they do not establish audio quality.

Fresh baseline desktop/mobile JPGs captured from cfbb00467b0c7b44425345ee3990d550676be9d7 use the same 9743 backend. Both lack the visible failure indicator after a controlled browser-local TTS503, per root capture receipt and independent image inspection. Canonical OCR is retained in baseline-ocr.json.
</details>

<details><summary>Final current-head failure and retry receipt</summary>

UI and backend revision: 9743eb1a4cb94a0f3d14020675e4365f5121c2b0. The normal local backend uses the documented ELIZA_KOKORO_MODEL_DIR pointing to installed Kokoro artifacts. A controlled browser-local first TTS503 produces the visible “on-device voice unavailable” indicator on desktop and mobile. Actual native Kokoro retry returns200; current-playback.json records started:1 and ended:1, and the final desktop/mobile images show the indicator cleared with the complete garden reply still visible. These are actual full-app captures, independently inspected, with canonical OCR and hashes retained.

The earlier restarted runtime lacked the model-directory configuration and returned502 on retry. That failed attempt remains under runtime-diagnostics/missing-model-*; it was repaired by restoring configuration, not by a code change. The successful configured-runtime log is separate from the earlier startup log. This capture replays a persisted reply and does not establish a new live-model turn, microphone capture, physical device playback, or other TTS providers.
</details>

<details><summary>Canonical bundle integrity and exact current-head transport excerpt</summary>

```text
UI/backend: 9743eb1a4cb94a0f3d14020675e4365f5121c2b0
/api/tts/local-inference: 503 (controlled first attempt)
/api/tts/local-inference: 200 (actual native Kokoro retry)
AudioBufferSource: started=1, ended=1
Canonical bundle: 20260906-083258-9743eb1-cpu
Canonical integrity: 46 artifacts verified / 46, zero issues
Manifest SHA-256: c4692ef3025049d7ac0ef51165998ab7528ed246c840396918eb6fe543bb55e7
Canonical review: exit0; 10 screenshots, 2 videos, 11 logs, 0 trajectories
Canonical review OCR: tesseract.js, 10 succeeded, 0 failures
```

The bundle is an explicitly selected archival collection, not a newly executed test matrix. Its metadata commit identifies the collection code; the hashed per-artifact inventory records each capture revision separately. Unknown original short-clip revisions remain unknown. Integrity and dashboard generation do not certify all-platform acceptance. Configured secrets were scanned before public preparation, with no residual matches.
</details>

Public archive: [30679-evidence-bundle.tar.gz](https://github.com/user-attachments/files/31877228/30679-evidence-bundle.tar.gz), 4,769,922 bytes. SHA-256 `69ad8c7b623237f4628183183b66655f89b929e6569ef8bfe64ff268b156d6a5`. All 46 artifact hashes were rechecked directly from the compressed archive.


### Fresh baseline and current full-app comparison

Baseline UI: `cfbb00467b0c7b44425345ee3990d550676be9d7`. Updated UI/backend: `9743eb1a4cb94a0f3d14020675e4365f5121c2b0`. Baseline and updated failure use the same controlled local TTS503. Updated recovery uses actual native Kokoro.

![Baseline desktop: silent failed speech](https://github.com/user-attachments/assets/e5b23c65-e180-40ab-9fbb-dfe734755fff)

![Baseline mobile: silent failed speech](https://github.com/user-attachments/assets/61552578-0742-460b-bd42-b1b2ebcd3e36)

![Updated desktop: visible speech failure](https://github.com/user-attachments/assets/b9584b90-24cc-4564-9e51-2adbeb0baf3e)

![Updated mobile: visible speech failure](https://github.com/user-attachments/assets/0d753a7f-6ce1-414f-add3-6748b8e12f09)

![Updated desktop: completed playback and cleared error](https://github.com/user-attachments/assets/e64664ab-cdc1-4ef1-bf92-7f1e3d854879)

![Updated mobile: completed playback and cleared error](https://github.com/user-attachments/assets/41b21c90-5a8c-4db5-8319-7840b28d8723)
