### PR TITLE
fix(cloud): add source-locked staging worker diagnostics

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -429,6 +429,22 @@ per environment; `cloud-cf-deploy.yml` publishes it to the Worker and
 `deploy-tunnel-proxy.yml` publishes the same value to Railway. Neither workflow
 reads a value back from a provider.
 
+## Staging provisioning diagnostics
+
+The provisioning-worker workflow also accepts `mode=diagnose`, dispatched from
+`develop` with `environment=staging` and the exact `expected_worker_sha` currently
+installed on the host. This mode skips deployment and rejects deployment SHA or
+reconciler inputs. It takes a shared read lease on the existing deployment lock,
+checks source and process identity before and after collection, and reports only
+the official running-process image digest plus fixed worker-journal categories.
+It does not restart services, write host files, or change database state.
+
+The journal receipt covers at most the last 10,000 records from 24 hours. Counts
+are worker-wide, may include other provisioning attempts, and do not establish
+an individual agent's failure cause. Raw logs, process environment, hostnames,
+agent identifiers, and private image references are never emitted. A failed or
+unstable read fails the diagnostic instead of certifying a partial observation.
+
 ## Maintenance and assistance
 
 `weekly-maintenance.yml` provides on-demand dependency/security maintenance.

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -1,6 +1,6 @@
 name: Deploy Eliza Provisioning Worker
 
-run-name: Provisioning worker ${{ inputs.environment || 'staging' }} ${{ inputs.deployment_sha || github.sha }} ${{ inputs.effect_digest || 'manual' }}
+run-name: Provisioning worker ${{ inputs.mode == 'diagnose' && 'diagnostic ' || '' }}${{ inputs.environment || 'staging' }} ${{ inputs.deployment_sha || github.sha }} ${{ inputs.effect_digest || 'manual' }}
 
 # SSHes to the Hetzner provisioning host and deploys one immutable commit,
 # installs the systemd unit shipped at packages/cloud/scripts/admin/eliza-provisioning-worker.service,
@@ -12,6 +12,18 @@ run-name: Provisioning worker ${{ inputs.environment || 'staging' }} ${{ inputs.
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: Deploy, or read a staging worker diagnostic without changing the host
+        required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - diagnose
+      expected_worker_sha:
+        description: Exact currently deployed worker commit; required only for diagnose
+        required: false
+        type: string
       environment:
         description: 'Target environment (host + secrets resolved from this)'
         required: true
@@ -50,7 +62,18 @@ jobs:
       deployment_sha: ${{ steps.snapshot.outputs.deployment_sha }}
     steps:
       - id: env
+        env:
+          MODE: ${{ inputs.mode }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
+          TRUSTED_REF: ${{ github.ref }}
         run: |
+          set -euo pipefail
+          if [ "$MODE" = diagnose ]; then
+            [ "$TRUSTED_REF" = refs/heads/develop ] && [ "$TARGET_ENVIRONMENT" = staging ] || {
+              echo "::error::Worker diagnostics require staging from refs/heads/develop"
+              exit 1
+            }
+          fi
           # Production is a protected release target. A manual dispatch from
           # any non-main ref must never be able to select production secrets or
           # deploy the current main snapshot while running unreviewed code.
@@ -73,6 +96,8 @@ jobs:
           echo "Resolved: environment=$env branch=$branch"
       - id: snapshot
         env:
+          MODE: ${{ inputs.mode }}
+          EXPECTED_WORKER_SHA: ${{ inputs.expected_worker_sha }}
           BRANCH: ${{ steps.env.outputs.branch }}
           EFFECT_DIGEST: ${{ inputs.effect_digest }}
           GH_TOKEN: ${{ github.token }}
@@ -81,6 +106,17 @@ jobs:
           TARGET_ENVIRONMENT: ${{ steps.env.outputs.environment }}
         run: |
           set -euo pipefail
+          if [ "$MODE" = diagnose ]; then
+            [[ "$EXPECTED_WORKER_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "::error::Diagnostics require an exact lowercase 40-hex expected_worker_sha"
+              exit 1
+            }
+            [ -z "$EFFECT_DIGEST" ] && [ -z "$REQUESTED_SHA" ] || {
+              echo "::error::Diagnostics do not accept deployment or reconciler inputs"
+              exit 1
+            }
+            exit 0
+          fi
           if [ "${{ github.event_name }}" = "push" ]; then
             deployment_sha="$PUSH_SHA"
           elif [ -n "$REQUESTED_SHA" ]; then
@@ -119,7 +155,49 @@ jobs:
           echo "deployment_sha=$deployment_sha" >> "$GITHUB_OUTPUT"
           echo "Resolved immutable deployment snapshot: $deployment_sha"
 
+  diagnose:
+    name: Read staging worker diagnostic
+    needs: determine-env
+    if: inputs.mode == 'diagnose'
+    runs-on: ubuntu-24.04
+    environment: staging
+    timeout-minutes: 5
+    steps:
+      - name: Checkout reviewed diagnostic source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          submodules: false
+      - name: Prepare reviewed diagnostic
+        id: diagnostic
+        run: |
+          set -euo pipefail
+          source_base64=$(base64 -w0 packages/cloud/scripts/admin/staging-worker-diagnostic.mjs)
+          echo "source_base64=$source_base64" >> "$GITHUB_OUTPUT"
+      - name: Read source-locked worker state
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        env:
+          EXPECTED_WORKER_SHA: ${{ inputs.expected_worker_sha }}
+          DIAGNOSTIC_SOURCE_BASE64: ${{ steps.diagnostic.outputs.source_base64 }}
+        with:
+          host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+          username: deploy
+          key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+          command_timeout: 2m
+          envs: EXPECTED_WORKER_SHA,DIAGNOSTIC_SOURCE_BASE64
+          script: |
+            set -euo pipefail
+            [[ "$EXPECTED_WORKER_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1
+            # Read the existing lock without creating or changing any host file.
+            exec 9</tmp/eliza-provisioning-worker-deploy.lock
+            flock -s -w 30 9 || exit 1
+            printf '%s' "$DIAGNOSTIC_SOURCE_BASE64" | base64 --decode | \
+              /usr/bin/env -i PATH=/usr/bin:/bin \
+              /usr/bin/node --input-type=module - "$EXPECTED_WORKER_SHA"
+
   deploy:
+    if: inputs.mode != 'diagnose'
     name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }} @ ${{ needs.determine-env.outputs.deployment_sha }})
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     needs: determine-env

--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
@@ -1,0 +1,149 @@
+/**
+ * Produces a closed, identifier-free summary of the deployed staging worker.
+ * Only fixed service reads and a bounded journal tail are permitted; source and
+ * process identity must remain stable throughout the read. Journal matches are
+ * worker-wide observations and do not establish an individual agent's cause.
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const UNIT = "eliza-provisioning-worker.service";
+const CATEGORIES = {
+  docker_health_timeout: /\[docker-sandbox\] Docker health check timed out/,
+  tailnet_health_timeout: /\[docker-sandbox\] Tailnet health check timed out/,
+  transport_unresolved: /remained transport-unresolved/,
+  mesh_auth_rejected:
+    /Container failed mesh join: headscale auth key expired\/rejected/,
+  image_pull_failed: /\[docker-sandbox\] Image pull failed/,
+  capacity_unavailable: /No Docker capacity and autoscale is not configured/,
+  job_timeout: /\[provisioning-jobs\] Execution timed out/,
+  health_diagnostics_unavailable:
+    /Failed to collect health timeout diagnostics/,
+};
+
+export function summarizeJournal(text) {
+  const counts = Object.fromEntries(
+    Object.keys(CATEGORIES).map((key) => [key, 0]),
+  );
+  let records = 0;
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    const entry = JSON.parse(line);
+    if (!entry || typeof entry.MESSAGE !== "string") {
+      throw new Error("journal_format_invalid");
+    }
+    records += 1;
+    for (const [category, pattern] of Object.entries(CATEGORIES)) {
+      if (pattern.test(entry.MESSAGE)) counts[category] += 1;
+    }
+  }
+  return {
+    scope: "worker-wide-not-agent-specific",
+    windowHours: 24,
+    tailLimit: 10000,
+    records,
+    counts,
+  };
+}
+
+export function summarizeImage(environment) {
+  const pins = environment
+    .split("\0")
+    .filter((entry) => entry.startsWith("ELIZA_AGENT_IMAGE="));
+  if (pins.length !== 1) throw new Error("image_pin_missing_or_ambiguous");
+  const match =
+    /^ELIZA_AGENT_IMAGE=ghcr\.io\/elizaos\/(eliza|eliza-demo)@(sha256:[0-9a-f]{64})$/.exec(
+      pins[0],
+    );
+  if (!match) return { family: "other", digest: null };
+  return {
+    family: match[1] === "eliza-demo" ? "demo" : "canonical",
+    digest: match[2],
+  };
+}
+
+function command(file, args) {
+  const result = spawnSync(file, args, {
+    encoding: "utf8",
+    timeout: 30000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { PATH: "/usr/bin:/bin", LANG: "C" },
+  });
+  if (result.error || result.status !== 0) throw new Error("host_read_failed");
+  return result.stdout;
+}
+
+export function collectDiagnostic(
+  expectedSha,
+  run = command,
+  readEnvironment = (pid) => readFileSync(`/proc/${pid}/environ`, "utf8"),
+) {
+  if (!/^[0-9a-f]{40}$/.test(expectedSha))
+    throw new Error("expected_source_invalid");
+  const source = () =>
+    run("/usr/bin/git", [
+      "-c",
+      "safe.directory=/opt/eliza",
+      "-C",
+      "/opt/eliza",
+      "rev-parse",
+      "HEAD",
+    ]).trim();
+  const property = (name) =>
+    run("/usr/bin/systemctl", [
+      "show",
+      UNIT,
+      `--property=${name}`,
+      "--value",
+    ]).trim();
+  if (source() !== expectedSha) throw new Error("deployed_source_mismatch");
+  const pid = property("MainPID");
+  if (!/^[1-9][0-9]{0,9}$/.test(pid))
+    throw new Error("worker_process_unavailable");
+  const active = property("ActiveState");
+  if (active !== "active") throw new Error("worker_not_active");
+  const image = summarizeImage(readEnvironment(pid));
+  const journal = summarizeJournal(
+    run("/usr/bin/sudo", [
+      "-n",
+      "/usr/bin/journalctl",
+      "--unit",
+      UNIT,
+      "--since",
+      "24 hours ago",
+      "--lines=10000",
+      "--output=json",
+      "--output-fields=MESSAGE",
+      "--no-pager",
+      "--quiet",
+    ]),
+  );
+  if (
+    source() !== expectedSha ||
+    property("MainPID") !== pid ||
+    property("ActiveState") !== "active"
+  )
+    throw new Error("worker_changed_during_read");
+  return {
+    schemaVersion: 1,
+    kind: "staging-worker-readonly",
+    sourceCommit: expectedSha,
+    service: "active",
+    image,
+    journal,
+  };
+}
+
+if (process.argv[1] === "-") {
+  try {
+    process.stdout.write(
+      `${JSON.stringify(collectDiagnostic(process.argv[2]))}\n`,
+    );
+  } catch {
+    // error-policy:J1 Host failures may include private output; emit no raw error.
+    process.stderr.write(
+      "staging-worker-diagnostic: read failed; no private data emitted\n",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * Exercises journal privacy and stable source/process admission for the staging
+ * diagnostic using hostile input and deterministic read-boundary responses.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import {
+  collectDiagnostic,
+  summarizeImage,
+  summarizeJournal,
+} from "./staging-worker-diagnostic.mjs";
+
+const SHA = "a".repeat(40);
+const DIGEST = "b".repeat(64);
+const PRIVATE = "private-token@example.invalid/agent-123";
+const environment = `PASSWORD=${PRIVATE}\0ELIZA_AGENT_IMAGE=ghcr.io/elizaos/eliza-demo@sha256:${DIGEST}\0`;
+const journal = [
+  {
+    MESSAGE: `[docker-sandbox] Docker health check timed out for ${PRIVATE}`,
+    HOSTNAME: PRIVATE,
+  },
+  {
+    MESSAGE: `[docker-sandbox] Container failed mesh join: headscale auth key expired/rejected ${PRIVATE}`,
+  },
+  { MESSAGE: PRIVATE },
+]
+  .map(JSON.stringify)
+  .join("\n");
+
+function hostReads({ changedSource = false, changedPid = false } = {}) {
+  let sourceReads = 0;
+  let pidReads = 0;
+  return (file, args) => {
+    if (file === "/usr/bin/git")
+      return changedSource && sourceReads++ > 0 ? "c".repeat(40) : SHA;
+    if (file === "/usr/bin/sudo") return journal;
+    if (file === "/usr/bin/systemctl" && args.includes("--property=MainPID"))
+      return changedPid && pidReads++ > 0 ? "456" : "123";
+    if (
+      file === "/usr/bin/systemctl" &&
+      args.includes("--property=ActiveState")
+    )
+      return "active";
+    throw new Error("unexpected command");
+  };
+}
+
+test("host reads produce only public image facts and worker-level category counts", () => {
+  const result = collectDiagnostic(SHA, hostReads(), (pid) => {
+    assert.equal(pid, "123");
+    return environment;
+  });
+  assert.equal(result.journal.counts.docker_health_timeout, 1);
+  assert.equal(result.journal.counts.mesh_auth_rejected, 1);
+  assert.equal(result.journal.records, 3);
+  assert.equal(result.image.digest, `sha256:${DIGEST}`);
+  assert.equal(JSON.stringify(result).includes(PRIVATE), false);
+  assert.equal(JSON.stringify(result).includes("HOSTNAME"), false);
+});
+
+test("invalid expected source rejects before any host read", () => {
+  let called = false;
+  assert.throws(
+    () =>
+      collectDiagnostic("$(arbitrary-command)", () => {
+        called = true;
+      }),
+    /expected_source_invalid/,
+  );
+  assert.equal(called, false);
+});
+
+test("source or process replacement during collection prevents certification", () => {
+  for (const mutation of [{ changedSource: true }, { changedPid: true }]) {
+    assert.throws(
+      () => collectDiagnostic(SHA, hostReads(mutation), () => environment),
+      /worker_changed_during_read/,
+    );
+  }
+});
+
+test("private or malformed image references never escape the boundary", () => {
+  for (const value of [
+    PRIVATE,
+    `ghcr.io/elizaos/eliza-demo@sha256:${DIGEST}\n${PRIVATE}`,
+  ]) {
+    assert.deepEqual(summarizeImage(`ELIZA_AGENT_IMAGE=${value}\0`), {
+      family: "other",
+      digest: null,
+    });
+  }
+  assert.throws(
+    () => summarizeImage("PASSWORD=hidden\0"),
+    /image_pin_missing_or_ambiguous/,
+  );
+  assert.throws(
+    () => summarizeImage(environment + environment),
+    /image_pin_missing_or_ambiguous/,
+  );
+});
+
+test("malformed journal records cannot become healthy-looking empty observations", () => {
+  assert.throws(() => summarizeJournal('{"MESSAGE":'), SyntaxError);
+  assert.throws(
+    () => summarizeJournal('{"MESSAGE":[1,2]}'),
+    /journal_format_invalid/,
+  );
+  assert.equal(summarizeJournal("").records, 0);
+});
+
+test("stdin CLI rejects hostile source input without emitting it or invoking host reads", () => {
+  const source = readFileSync(
+    new URL("./staging-worker-diagnostic.mjs", import.meta.url),
+    "utf8",
+  );
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "-", PRIVATE],
+    { input: source, encoding: "utf8" },
+  );
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /read failed; no private data emitted/);
+  assert.equal(result.stderr.includes(PRIVATE), false);
+});


### PR DESCRIPTION
# Relates to

Relates to #30552. Staging Personal provisioning times out without a container identity; its database row cannot distinguish worker transport, image-pull, or runtime health failures.

- [x] Targets develop from synchronization base 9b314da5e65327702d3d02ad36684e7632ebe288, without conflicts.
- [x] Post-sync bun install passed with pinned Bun 1.3.14 and Node 24.15.0.
- [x] Full repository verification passed on the candidate after sync.

# Sync with develop

Base 9b314da5e65327702d3d02ad36684e7632ebe288. Independently owned CLI and form fixes landed on develop during verification; they do not touch the diagnostic files. Candidate f6ac33d8db1c8ab020911d48e75dee39e610090c.

# Risks

Medium: the diagnostic uses existing protected staging SSH authority to read the worker process environment and journal. It emits only a closed output schema: validated public image digest, source commit, service state, and fixed category counts. Raw logs, credentials, hostnames and agent identifiers remain inside the process. Invalid or changing source/process identity fails the read. The journal is worker-wide and does not identify an individual agent's cause.

# Background

## What does this PR do?

Adds a `diagnose` dispatch choice to the existing provisioning-worker workflow. It requires `develop`, staging, and the exact currently installed worker SHA; rejects deployment/reconciler inputs; and skips the deploy job. The SSH step takes a shared lease on the existing deployment lock, reads the active worker's image pin and at most 10,000 journal records from 24 hours, and checks source/PID again before publishing. It neither writes host files nor restarts services nor changes database state. Normal deploy remains the default, preserving its run-name format and existing guards.

## What kind of change is this?

Operator diagnostics needed to investigate the unresolved staging provisioning failure.

# Documentation changes needed?

Updated the workflow README with invocation constraints, output scope and limits.

# Testing

## Where should a reviewer start?

Review admission before credential use, the fixed remote commands and lock, then the privacy boundary tests. The protected run is a post-merge observation, not a prerequisite that could be obtained by executing an unreviewed branch with credentials.

## Detailed testing steps

- Six Node tests pass: sensitive journal/environment data cannot escape, invalid source rejects before host access, source/PID replacement prevents publication, malformed journal input fails, and the real stdin CLI suppresses hostile input on failure.
- 78 existing provisioning workflow, environment/concurrency and effect-ledger contracts pass.
- Biome, actionlint and diff checks pass.
- Post-sync install passed in 113.76 seconds on the shared host. Final root `bun run verify` passed with exit 0, including the 11,447-file focused/skip audit. Six diagnostic tests and 78 deployment contracts passed again after rebase.

# Evidence Gate

<!-- evidence-head:f6ac33d8db1c8ab020911d48e75dee39e610090c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - No rendered interface changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - No rendered interface changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - This is a manual operator diagnostic with no frontend flow.

<!-- evidence-row:backend-logs -->
- [x] N/A - Protected host execution must use the reviewed develop workflow after merge; no live worker receipt is claimed before that run. Local CLI and parser boundary tests are recorded below.

<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code or browser behavior changes.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - No model, prompt, action, or agent behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] The exact-candidate local privacy/admission and workflow contract results are attached below.

<details><summary>Diagnostic boundary tests</summary>

```text
✔ host reads produce only public image facts and worker-level category counts (0.666083ms)
✔ invalid expected source rejects before any host read (0.203625ms)
✔ source or process replacement during collection prevents certification (0.32125ms)
✔ private or malformed image references never escape the boundary (0.43025ms)
✔ malformed journal records cannot become healthy-looking empty observations (0.09675ms)
✔ stdin CLI rejects hostile source input without emitting it or invoking host reads (500.527667ms)
ℹ tests 6
ℹ suites 0
ℹ pass 6
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1280.781958
```

</details>

<details><summary>Existing deployment contract tests</summary>

```text
78 pass
0 fail
916 expect() calls
Ran 78 tests across 4 files. [4.15s]
```

Files: cloud-deploy-environment-contract, develop-effect-ledger, provisioning-worker-deploy-workflow, deploy-approval-concurrency-workflow.

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - No model-facing behavior changes.

## Backend + frontend logs

Candidate `f6ac33d8db1c8ab020911d48e75dee39e610090c`, base `9b314da5e65327702d3d02ad36684e7632ebe288`. The four changed files are byte-identical to independently reviewed candidate `7de902e5eefb795088817b2d358120c8ac54e0b1`. Checks used Node 24.15.0 and Bun 1.3.14.


Live staging execution remains pending normal review and merge. No raw worker logs will be published.

## Screenshots (before / after) + video walkthrough

### Before

N/A - No UI.

### After

N/A - No UI.

### Walkthrough video

N/A - No browser flow.

## Audio / voice walkthrough

N/A - No audio changes.

## Known gaps / failures

This diagnostic has not run on the protected host yet. Counts may include other provisioning attempts; a zero count is not proof that an agent is healthy. The deployment goal remains open until actual Personal provisioning, final staging certification and production acceptance pass.

## Maintainer CI exception record

N/A - No exception requested. Normal required checks and review apply.
