### PR TITLE
fix(cli): reject non-regular migration source files

### DIFF
--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -174,6 +174,16 @@ function readOptional<T>(
 }
 
 function readIfPresent(p: string): string | undefined {
+  const stat = statIfPresent(p);
+  if (stat === undefined) return undefined;
+  if (!stat.isFile()) {
+    throw new MigrationSourceReadError(
+      { path: p, operation: "read" },
+      new Error(
+        "Expected a regular file; refusing to read a special filesystem entry.",
+      ),
+    );
+  }
   return readOptional(p, "read", () =>
     normalizeEol(fs.readFileSync(p, "utf8")),
   );

--- a/packages/elizaos/src/migrate/source-read-failures.test.ts
+++ b/packages/elizaos/src/migrate/source-read-failures.test.ts
@@ -103,3 +103,41 @@ it("still builds a partial home when optional files are absent", () => {
     readOcAgentHome(path.join(root, "absent"), "demo").soul,
   ).toBeUndefined();
 });
+
+it.skipIf(process.platform === "win32")(
+  "rejects a FIFO persona without blocking or writing migration artifacts",
+  () => {
+    const root = home();
+    const soul = path.join(root, "SOUL.md");
+    const fifo = spawnSync("mkfifo", [soul], { encoding: "utf8" });
+    expect(fifo.error).toBeUndefined();
+    expect(fifo.status).toBe(0);
+    const character = path.join(root, "character.json");
+    const archive = path.join(root, "export.eliza-agent");
+    const result = spawnSync(
+      "bun",
+      [
+        fileURLToPath(new URL("../cli.ts", import.meta.url)),
+        "migrate-agent",
+        "--from",
+        root,
+        "--agent-id",
+        "demo",
+        "--emit-character",
+        character,
+        "--out",
+        archive,
+        "--password",
+        "synthetic-test-password",
+      ],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("MIGRATION_SOURCE_READ_FAILED");
+    expect(result.stderr).toContain(soul);
+    expect(fs.existsSync(character)).toBe(false);
+    expect(fs.existsSync(archive)).toBe(false);
+  },
+  10000,
+);


### PR DESCRIPTION
A FIFO at an optional OpenClaw source path such as `SOUL.md` blocks `migrate-agent` indefinitely. Require a regular file before reading it and use the existing `MigrationSourceReadError`; absent optional files and regular-file symlinks keep their existing behavior. This completes the remaining wrong-type case from #30754 after #30777.

Closes #30754. Related: #30766.

Validation at `f4493023eb9fa9dde56809f221af12c35751652c`, based on `65a4f5216421ba74a75b1bc9bc98de0ae2d1ceb1`:

- The baseline FIFO probe timed out. The fixed packaged CLI exits 1 with `MIGRATION_SOURCE_READ_FAILED` and writes neither character nor archive; the regular-file control exits 0 and writes both.
- 260 package tests across 23 files passed with two workers; package typecheck, lint and build passed.
- `bun install` completed with pinned Bun 1.3.14 and Node 24.15.0. `bun run verify` completed all 376 tasks and final repository audits; the final audit reported no focused tests or orphaned skips.
- Independent review confirmed the change preserves normal source reads and missing optional paths. UI, native-device and live-model evidence are not applicable to this local filesystem boundary.
