### PR TITLE
fix(evidence): extract the actual final video frame on FFmpeg 6 and 9

### DIFF
--- a/packages/evidence/src/analyzers/keyframes-terminal.test.ts
+++ b/packages/evidence/src/analyzers/keyframes-terminal.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Verifies terminal video evidence using real FFmpeg files and decoded pixels.
+ * Short final states and sparse frame timing must reach the analyzer's emitted
+ * image; a scene-cut sample cannot substitute for the promised last frame.
+ */
+import { execFile } from "node:child_process";
+import { copyFileSync, existsSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import sharp from "sharp";
+import { afterAll, describe, expect, it } from "vitest";
+import { resolveFfmpegBinary } from "../ffmpeg-binaries.ts";
+import {
+  extractKeyframes,
+  type KeyframesData,
+  videoKeyframesAnalyzer,
+} from "./keyframes.ts";
+import { makeTmpDir } from "./test-fixtures.ts";
+import type { AnalyzerContext } from "./types.ts";
+
+const execFileAsync = promisify(execFile);
+const dir = makeTmpDir();
+const ffmpeg = await resolveFfmpegBinary();
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+async function makeVideo(
+  name: string,
+  colors: string[],
+  sparse = false,
+  audioTail = false,
+): Promise<string> {
+  if (!ffmpeg.available) throw new Error(ffmpeg.reason);
+  const output = join(dir, `${name}.mp4`);
+  const inputs = colors.flatMap((color) => ["-f", "lavfi", "-i", color]);
+  const filter =
+    colors.length === 1
+      ? "[0:v]null[v]"
+      : `${colors.map((_, index) => `[${index}:v]`).join("")}concat=n=${colors.length}:v=1${sparse ? ",setpts=N*5/TB" : ""}[v]`;
+  await execFileAsync(
+    ffmpeg.bin,
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      ...inputs,
+      ...(audioTail
+        ? ["-f", "lavfi", "-i", "anullsrc=r=8000:cl=mono:d=3"]
+        : []),
+      "-filter_complex",
+      filter,
+      "-map",
+      "[v]",
+      ...(audioTail ? ["-map", `${colors.length}:a`, "-c:a", "aac"] : []),
+      "-fps_mode",
+      "vfr",
+      "-pix_fmt",
+      "yuv420p",
+      output,
+    ],
+    { timeout: 30_000 },
+  );
+  return output;
+}
+
+async function expectGreen(file: string): Promise<void> {
+  const { data } = await sharp(file)
+    .removeAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  expect(data[1]).toBeGreaterThan(220);
+  expect(data[0]).toBeLessThan(30);
+  expect(data[2]).toBeLessThan(30);
+}
+
+describe.skipIf(!ffmpeg.available)("actual terminal video frame", () => {
+  it("emits the short terminal state as last even after earlier scene cuts", async () => {
+    const video = await makeVideo("terminal", [
+      "color=c=red:s=64x64:r=10:d=1",
+      "color=c=blue:s=64x64:r=10:d=1",
+      "color=c=lime:s=64x64:r=10:d=0.2",
+    ]);
+    const emitted = new Map<string, string>();
+    const ctx: AnalyzerContext = {
+      tier: "cpu",
+      emitArtifact: async (file, options) => {
+        const copy = join(dir, `emitted-${emitted.size}.png`);
+        copyFileSync(file, copy);
+        emitted.set(options.bundlePath, copy);
+        return {
+          absolutePath: copy,
+          entry: {
+            path: options.bundlePath,
+            kind: options.kind,
+            bytes: statSync(copy).size,
+            sha256: "0".repeat(64),
+            source: "test",
+            producedBy: options.producedBy,
+            createdAt: new Date().toISOString(),
+          },
+        };
+      },
+    };
+    const result = await videoKeyframesAnalyzer.analyze(
+      {
+        absolutePath: video,
+        entry: {
+          path: "video/terminal.mp4",
+          kind: "video",
+          bytes: statSync(video).size,
+          sha256: "0".repeat(64),
+          source: "test",
+          producedBy: "ffmpeg",
+          createdAt: new Date().toISOString(),
+        },
+      },
+      ctx,
+    );
+    expect(result.status).toBe("ran");
+    if (result.status !== "ran") throw new Error("Analyzer did not run");
+    const last = (result.data as KeyframesData).keyframes.find(
+      (frame) => frame.kind === "last",
+    );
+    const image = last && emitted.get(last.bundlePath);
+    if (!image) throw new Error("Analyzer did not emit a last-frame artifact");
+    await expectGreen(image);
+  });
+
+  it("falls back when trailing audio leaves no video frame after the seek", async () => {
+    if (!ffmpeg.available) throw new Error(ffmpeg.reason);
+    const video = await makeVideo(
+      "audio-tail",
+      ["color=c=lime:s=64x64:r=10:d=0.1"],
+      false,
+      true,
+    );
+    const probe = join(dir, "tail-probe.png");
+    await execFileAsync(
+      ffmpeg.bin,
+      [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-sseof",
+        "-1",
+        "-i",
+        video,
+        "-fps_mode",
+        "passthrough",
+        "-update",
+        "1",
+        probe,
+      ],
+      { timeout: 30_000 },
+    );
+    expect(existsSync(probe)).toBe(false);
+    const frames = await extractKeyframes(video, join(dir, "audio-tail"));
+    const last = frames.find((frame) => frame.kind === "last");
+    if (!last) throw new Error("Extractor did not return a last frame");
+    await expectGreen(last.file);
+  });
+
+  it.each([
+    {
+      name: "single-frame",
+      colors: ["color=c=lime:s=64x64:r=10:d=0.1"],
+      sparse: false,
+    },
+    {
+      name: "sparse-tail",
+      colors: [
+        "color=c=red:s=64x64:r=10:d=0.1",
+        "color=c=lime:s=64x64:r=10:d=0.1",
+      ],
+      sparse: true,
+    },
+  ])(
+    "extracts the actual last pixel for $name",
+    async ({ name, colors, sparse }) => {
+      const video = await makeVideo(name, colors, sparse);
+      const frames = await extractKeyframes(video, join(dir, name));
+      const last = frames.find((frame) => frame.kind === "last");
+      if (!last) throw new Error("Extractor did not return a last frame");
+      await expectGreen(last.file);
+    },
+  );
+});

--- a/packages/evidence/src/analyzers/keyframes.ts
+++ b/packages/evidence/src/analyzers/keyframes.ts
@@ -84,7 +84,7 @@ export async function extractKeyframes(
       videoPath,
       "-vf",
       "select='gt(scene,0.3)'",
-      "-vsync",
+      "-fps_mode",
       "vfr",
       "-frames:v",
       String(maxSceneFrames),

--- a/packages/evidence/src/analyzers/keyframes.ts
+++ b/packages/evidence/src/analyzers/keyframes.ts
@@ -108,25 +108,52 @@ export async function extractKeyframes(
     ],
     { timeout: 60_000 },
   );
-  // Seek to the final frame: read the whole stream and keep only the last.
-  await execFileAsync(
-    ffmpeg.bin,
-    [
-      "-hide_banner",
-      "-loglevel",
-      "error",
-      "-sseof",
-      "-1",
-      "-i",
-      videoPath,
-      "-update",
-      "1",
-      "-frames:v",
-      "1",
-      last,
-    ],
-    { timeout: 60_000 },
-  );
+  // Seek near EOF for normal recordings, then decode through the actual end.
+  // Audio or sparse VFR tails can leave no video frame after the seek; only a
+  // fresh candidate can prove success, otherwise retry without seeking.
+  const lastScratch = fs.mkdtempSync(path.join(outDir, ".last-frame-"));
+  const candidate = path.join(lastScratch, "last.png");
+  const deadline = performance.now() + 60_000;
+  const extractLast = async (seek: boolean): Promise<void> => {
+    const remaining = Math.ceil(deadline - performance.now());
+    if (remaining <= 0) {
+      throw new EvidenceError(
+        "Final video frame extraction exceeded its deadline",
+        {
+          code: "VIDEO_FINAL_FRAME_TIMEOUT",
+        },
+      );
+    }
+    await execFileAsync(
+      ffmpeg.bin,
+      [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        ...(seek ? ["-sseof", "-1"] : []),
+        "-i",
+        videoPath,
+        "-fps_mode",
+        "passthrough",
+        "-update",
+        "1",
+        candidate,
+      ],
+      { timeout: remaining },
+    );
+  };
+  try {
+    await extractLast(true);
+    if (!fs.existsSync(candidate)) await extractLast(false);
+    if (!fs.existsSync(candidate)) {
+      throw new EvidenceError("Video did not yield a final decoded frame", {
+        code: "VIDEO_FINAL_FRAME_MISSING",
+      });
+    }
+    fs.renameSync(candidate, last);
+  } finally {
+    fs.rmSync(lastScratch, { recursive: true, force: true });
+  }
   const out: { file: string; kind: "scene" | "first" | "last" }[] = [
     { file: first, kind: "first" },
   ];


### PR DESCRIPTION
Fixes #30800; prerequisite for #23110 evidence review.

The video analyzer could label a frame from one second before the end as the final frame. A real red → blue → brief green video produced a blue `last` image. The repair decodes through EOF, so the emitted image is green, and replaces FFmpeg 9's removed `-vsync` option with supported per-stream frame timing.

Normal recordings retain a near-EOF seek. A fresh temporary image proves successful output; when trailing audio or sparse video leaves no image after the seek, the extractor retries from the beginning. Both attempts share the existing 60-second deadline. Failed extraction cannot promote a stale or partially generated candidate.

Validation on current source: real pixel regression failed before the repair; focused 10 tests pass on bundled FFmpeg 6 and installed FFmpeg 9, including actual trailing-audio fallback, short terminal state, single-frame and sparse video. Package typecheck and lint pass. Independent reviewers confirmed the defect and reviewed the final candidate/deadline/cleanup behavior.

Performance review rejected an initial always-full-decode implementation: its terminal pass alone took 32.86 seconds on a deterministic two-minute 4K/30fps clip. The revised complete three-pass extractor took 12.18 seconds on that fixture. These are different timing scopes; neither is a production-wide latency claim.

Current candidate `8e11f29028d7909cbe29f6362ad6cf52b461510e` is based on `1ad448520bd652124f83caecbfa560dbc8e33a2f`. Normal installation, the full evidence suite (536 passed, two opt-in live vision tests skipped), typecheck, and lint passed. Root `bun run verify` passed all 376 workspace tasks and repository audits on this exact head. The checkout remained clean after every gate.

## Evidence Gate

<!-- evidence-head:8e11f29028d7909cbe29f6362ad6cf52b461510e -->
<!-- evidence-row:before-screenshots -->
- [x] Original incorrect blue keyframe attached below (domain output, no rendered app change).
<!-- evidence-row:after-screenshots -->
- [x] Fresh repaired green keyframe attached below.
<!-- evidence-row:walkthrough-video -->
- [x] Actual source MP4 attached below; app walkthrough N/A because no product UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] FFmpeg and completed package-gate receipts included in verified bundle; final root verification passed separately as recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A — CLI evidence analyzer; no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — deterministic media extraction, no model invocation.
<!-- evidence-row:domain-artifacts -->
- [x] Original and repaired PNGs, actual video, timings and source hashes included; all four uploaded artifact hashes verified.
<!-- evidence-row:ocr-review -->
- [x] N/A — synthetic solid-color frame proof uses decoded pixels; no text UI is modified.

## Verified media evidence — 2026-09-06

The original extractor emitted a blue `last` frame from a real 2.2-second red → blue → green video. Fresh extraction at `8e11f29028d7909cbe29f6362ad6cf52b461510e` emits the final green state. The video is synthetic test content; extraction and decoded pixels are real FFmpeg output.

### Source video

https://github.com/user-attachments/assets/a840fafa-ac7d-44a1-b7ae-aa66190ff67d

### Incorrect original output

![Original last frame is blue](https://github.com/user-attachments/assets/4a88a11f-2f71-4dca-b7f6-752f9eba701e)

### Corrected output

![Corrected last frame is green](https://github.com/user-attachments/assets/ed362a0c-2e47-412d-86d5-ff94bb5ad3df)

### Bundle and checks

[Download the verified evidence bundle](https://github.com/user-attachments/files/31878037/30800-8e11f29-evidence.tar.gz). All 16 copied artifacts pass canonical integrity verification. Archive SHA-256: `4532d328cb6e7912c6ef81885b7d86d159837bc2fb28638e6d29dea95ee9fcfa`. All four published attachment hashes match their local originals through authenticated readback.

The bundle contains the original failing pixel regression, actual source video and emitted frames, FFmpeg 6/9 focused runs (10 tests each), and current installation, full package suite, typecheck, and lint receipts. The full suite passed 536 tests; two separately opted-in live vision tests were skipped and are not evidence for this deterministic extraction change. The historical focused and scaling receipts concern the same unchanged implementation: both the implementation and terminal test files are byte-identical between `0076a37361c757b06e91c0b52510f9ac415182de` and `8e11f29028d7909cbe29f6362ad6cf52b461510e`.

Root verification was still running when this immutable bundle was finalized and is excluded. Its separate final receipt is root `bun run verify` exit 0, all 376 tasks successful and every repository audit passing at the exact candidate head. No frontend or model path changes; the relevant consumer-visible artifacts are the extracted images. This evidence does not complete parent issue #23110.
