### PR TITLE
fix(ui): keep Home actions reachable in short windows

### DIFF
--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -131,6 +131,38 @@ const HOME_SCREEN_CSS = `
   pointer-events: none;
   visibility: hidden;
 }
+/* Short windows scroll the complete dashboard above the composer. Keeping
+   separate fixed header and card regions here can leave less than one row. */
+@media (max-height: 520px) {
+  [data-home-scroll-frame] {
+    overflow-y: auto;
+    overscroll-behavior-y: contain;
+  }
+  [data-testid="home-content-column"] {
+    height: auto;
+    min-height: 100%;
+  }
+  [data-home-notification-region] {
+    flex-shrink: 0;
+  }
+  [data-testid="home-content-column"]:not([data-home-has-notifications])
+    [data-home-notification-region]:has(
+      [data-testid="home-notification-list"][data-shade-mode="rested"]:not([data-shade-preview]):not([data-shade-occupies-home])
+    ) {
+    max-height: 0;
+    margin-block: 0;
+    overflow: hidden;
+  }
+  [data-home-widget-region] {
+    padding-top: .5rem;
+  }
+  [data-home-below-notifications] {
+    flex: none;
+  }
+  [data-home-below-notifications-inner] {
+    overflow-y: visible;
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   .home-enter { animation: none; }
   [data-home-notification-region],
@@ -355,9 +387,8 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
       ref={homeScreenRef}
       data-testid="home-screen"
       className={cn(
-        // The launcher grid below is the only vertical scroll owner. Keeping
-        // the shell itself clipped avoids nested wheel/touch arbitration with
-        // notification pull gestures.
+        // Keep the composer clearance outside the scrolling content. Short
+        // windows scroll the whole dashboard; taller ones scroll its lower region.
         "eliza-continuous-chat-scroll absolute inset-0 z-[1] touch-pan-y overflow-hidden",
         // The shell root already reserves the status-bar safe area (its
         // paddingTop: var(--safe-area-top)); adding it again here double-padded
@@ -370,12 +401,12 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
         // Clear the floating chat composer at the bottom. Short landscape
         // screens use compact app icons and a smaller breathing gutter so the
         // first row keeps both icon and label in view without touching chat;
-        // overflow still belongs to the launcher region below.
+        // the dashboard scroll frame retains that clearance.
         "pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-chat-clearance,5.25rem)+1.5rem)] [@media(orientation:landscape)_and_(max-height:520px)]:pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-chat-clearance,5.25rem)+0.5rem)]",
       )}
     >
       <style>{HOME_SCREEN_CSS}</style>
-      <div className="flex h-full min-h-0 w-full">
+      <div data-home-scroll-frame="" className="flex h-full min-h-0 w-full">
         {/* A definite-height flex column makes the notification shade and app
             scroller share exactly the space above the floating chat. */}
         <div
@@ -438,6 +469,7 @@ export function HomeScreen({ apps }: HomeScreenProps): React.JSX.Element {
             >
               {apps}
               <div
+                data-home-widget-region=""
                 className={cn(enterClass, "flex min-h-32 flex-col py-6")}
                 style={{ animationDelay: "110ms" }}
               >

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.tsx
@@ -1,13 +1,12 @@
-// Fixture for the home-screen e2e: mounts the REAL HomeScreen — including the
-// REAL unified home-slot WidgetHost (#9143), its per-plugin widget components,
-// and the pinned dashboard notification center (NotificationsHomeCenter) — over
-// the real ShaderBackground (flat orange + edge pulse). The widgets are fed by
-// injected DATA only: the app-store plugins snapshot + notification store are
-// seeded, and `window.fetch` is mocked, all BEFORE first render so the widgets
-// resolve and populate on mount. Paired with run-home-screen-e2e.mjs.
+/**
+ * Mounts the real HomeScreen, notification center, and plugin widgets for
+ * browser interaction tests. Deterministic API data and hydrated stores model
+ * both quiet and attention states before the first render.
+ */
 
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import { __setHydratedForTests } from "../../../state/notifications/notification-store";
 
 import {
   installHomeWidgetFetchMock,
@@ -25,6 +24,7 @@ import { HomeScreen, type HomeTileTarget } from "../HomeScreen";
 seedHomeWidgetAppStore();
 seedHomeWidgetNotifications();
 installHomeWidgetFetchMock();
+__setHydratedForTests(true);
 
 const params =
   typeof location !== "undefined"

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -540,7 +540,7 @@ async function readHomeDarkForegrounds(page) {
   });
 }
 const ATTENTION_HOME_TEST_IDS = [
-  "home-notification-center",
+  "notification-row",
   "chat-widget-todos",
   "todo-goal-attention-row",
   "chat-widget-calendar-upcoming",
@@ -1451,6 +1451,61 @@ try {
   }
   await perfMobile.close();
   await perfContext.close();
+
+  // A short window must scroll the dashboard from its header as well as cards.
+  const shortHome = await browser.newPage({
+    viewport: { width: 844, height: 390 },
+    reducedMotion: "reduce",
+  });
+  shortHome.on("pageerror", recordPageError);
+  await shortHome.goto(`${url}?homeData=attention`);
+  await shortHome.getByTestId("chat-widget-todos").waitFor();
+  const clockBefore = await shortHome.getByTestId("default-home-widgets").boundingBox();
+  await shortHome.mouse.move(140, 60);
+  await shortHome.mouse.wheel(0, 180);
+  await shortHome.waitForFunction(() => {
+    const column = document.querySelector('[data-testid="home-content-column"]');
+    return column?.parentElement?.scrollTop > 0;
+  }, undefined, { timeout: 3000 }).catch(() => {
+    // error-policy:J4 The geometry assertion below reports an unavailable scroll.
+    return false;
+  });
+  const clockAfter = await shortHome.getByTestId("default-home-widgets").boundingBox();
+  assert(
+    clockBefore && clockAfter && clockAfter.y < clockBefore.y - 40,
+    "short home scrolls from the clock instead of trapping Today in a tiny region",
+  );
+  for (const testId of ["todo-goal-attention-row", "today-todo-row"]) {
+    const row = shortHome.getByTestId(testId);
+    await row.scrollIntoViewIfNeeded();
+    const reachable = await row.evaluate((element) => {
+      const frame = document.querySelector("[data-home-scroll-frame]");
+      if (!frame) return false;
+      const bounds = frame.getBoundingClientRect();
+      const rect = element.getBoundingClientRect();
+      const hit = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+      return rect.top >= bounds.top && rect.bottom <= bounds.bottom && element.contains(hit);
+    });
+    assert(reachable, `short home exposes the complete ${testId} hit area above chat clearance`);
+  }
+  await snap(shortHome, "short-home-scrolled");
+  await shortHome.close();
+
+  const shortQuietHome = await browser.newPage({
+    viewport: { width: 844, height: 390 },
+    reducedMotion: "reduce",
+  });
+  shortQuietHome.on("pageerror", recordPageError);
+  await shortQuietHome.goto(`${url}?homeData=quiet`);
+  await shortQuietHome.getByTestId("notifications-empty").waitFor({ state: "attached" });
+  await dragVertical(shortQuietHome.getByTestId("home-screen"), 130);
+  await shortQuietHome.locator('[data-testid="home-notification-list"][data-shade-mode="expanded"]').waitFor({ timeout: 5000 });
+  assert(
+    await shortQuietHome.getByTestId("notifications-empty").isVisible(),
+    "short quiet home still reveals its empty notification shade through a pull gesture",
+  );
+  await snap(shortQuietHome, "short-home-empty-shade-expanded");
+  await shortQuietHome.close();
 
   // Desktop width
   const desktop = await browser.newPage({


### PR DESCRIPTION
# Relates to

Fixes #30802.

# Background

At 844×390, the fixed Home header and empty notification region left Today cards visible only as a thin strip above the composer. Short windows now scroll the complete dashboard, collapse the rested empty notification space, and reduce excess widget padding. Both Today actions fit in the initial empty-inbox layout; populated inboxes can scroll to fully visible action targets.

Bug fix. No documentation or data migration required.

# Risks

Low: CSS layout changes apply only below 521px viewport height. Notification expansion still uses its existing gesture target. The regression exercises both populated scrolling and loaded-empty pull expansion.

# Sync with develop

Rebased without conflicts onto `1ad448520bd`; bun install passed. Post-sync `bun run verify` passed. Current head `9767eea5a408874b5839e5fc492d795e139b10b5`.

# Testing

Real Home component browser suite passes: wheel movement from the header, complete goal/todo hit targets above composer clearance, empty notification pull expansion, and existing desktop/mobile launcher interactions. Corrected the fixture hydration state so the empty-inbox test exercises a loaded inbox, rather than a permanently loading one.

Full UI suite: 13,644 passed / 7 skipped. Full app audit: 219 passed / 216 views; OCR: 204 verified / 12 manual review / 0 broken. Desktop, portrait, tablet and short-landscape rest captures plus short-window hover states inspected. These runs preceded a rebase containing only Cloud billing/mail changes; the affected Home source is unchanged.

# Evidence Gate

<!-- evidence-head:9767eea5a408874b5839e5fc492d795e139b10b5 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-03-home-short-landscape.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-04-home-short-landscape-after.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-home-scroll-hover.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - CSS layout and fixture correction; no backend behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] [30813-home-short-viewport-hydrated-contract.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-home-short-viewport-hydrated-contract.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain changes.
<!-- evidence-row:ocr-review -->
- [x] [30813-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-ocr-triage.json)

# Known gaps / failures

Native account sign-in, wheel behavior, account-row overflow, and voice verification are separate ongoing work. This PR does not claim those flows are fixed. The MP4 uses the real component with deterministic fixture data.

Maintainer CI exception: N/A - no exception requested.



## Additional inspected captures

![Before: desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-01-home-desktop.png)

![Before: portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-02-home-portrait.png)

![After: desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-after-desktop.png)

![After: portrait](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-after-portrait.png)

![Goal hover after scroll](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-02-goal-hover.png)

![Todo hover after scroll](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30813-03-todo-hover.png)

The ordinary-height captures verify unchanged layout; the short-height before/after evidence above shows the repaired initial clipping. Hover and video captures use the real Home component with deterministic data. Browser network requests are fixture-backed; no live backend or native sign-in claim is made by this CSS repair.
