### PR TITLE
feat(agent): materialize and seal manifest-v3 restore candidates

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -19,6 +19,24 @@ bun run test
 
 See `package.json` for `build`, `lint`, and other scripts.
 
+## Manifest-v3 quarantine materialization
+
+`createAgentBackupRestoreV3ProcessMaterializer` implements the durable restore
+coordinator's record, component and assembly effects in private one-shot Agent
+processes. It requires an existing isolated `CandidateFs` authority and retains
+the exact root device/inode identities. It does not boot a runtime, register
+plugins, open a listener, authorize a generation commit, or publish routes.
+
+The worker receives bounded metadata and raw record bytes on stdin; fd 3 is a
+parent-liveness channel. Only the digest of the completed canonical receipt is
+returned. Cancellation closes the liveness channel and waits for worker
+settlement, including nested database validation, before the adapter returns.
+Credentials and process preload options are not inherited. This is a trusted
+local-process transport, not an authenticated remote Docker endpoint; its
+caller must exclusively own both the transport and the quarantined roots.
+Production filesystem authority requires Linux. Non-Linux pathname emulation
+is explicitly test-only and makes no cross-process kernel-lock claim.
+
 ## Research tasks
 
 `ResearchTaskExecutor` requires a provider registered for

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -27,15 +27,27 @@ processes. It requires an existing isolated `CandidateFs` authority and retains
 the exact root device/inode identities. It does not boot a runtime, register
 plugins, open a listener, authorize a generation commit, or publish routes.
 
-The worker receives bounded metadata and raw record bytes on stdin; fd 3 is a
-parent-liveness channel. Only the digest of the completed canonical receipt is
-returned. Cancellation closes the liveness channel and waits for worker
-settlement, including nested database validation, before the adapter returns.
+The worker receives bounded metadata and raw record bytes in one length-delimited
+frame on stdin (private transport version 2). Stdin must stay open after that
+frame: EOF or additional bytes cancel the operation. No inherited fd 3 is needed.
+Only the digest of the completed canonical receipt is returned. Cancellation
+closes stdin and waits for worker settlement, including nested database
+validation, before the adapter returns.
 Credentials and process preload options are not inherited. This is a trusted
 local-process transport, not an authenticated remote Docker endpoint; its
 caller must exclusively own both the transport and the quarantined roots.
 Production filesystem authority requires Linux. Non-Linux pathname emulation
 is explicitly test-only and makes no cross-process kernel-lock claim.
+
+The opt-in `agent-backup-restore-v3-materializer-docker.test.ts` suite exercises
+the built worker through real `docker exec -i` in a networkless Linux container,
+including database-validator cancellation and exact retry. Build this package
+first and preload `node:24.15.0-alpine`, then run the suite with
+`AGENT_RESTORE_V3_DOCKER_TESTS=1`. When using a named Docker context, explicitly
+set `DOCKER_CONFIG` to its configuration directory: Vitest isolates the home
+directory. The harness creates only test-owned containers and tmpfs data and
+removes them after each test; it never pulls an image implicitly. Its idle
+container is a test fixture, not the production quarantine bootstrap.
 
 ## Research tasks
 

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-assembly.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-assembly.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Real filesystem/PGlite integration for five-component candidate assembly.
+ * Stream authority receipts are fixture inputs: this is not provider crypto,
+ * an Agent boot, a routing proof or a live-model restore drill.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
+  AGENT_BACKUP_RESTORE_V3_EXACT_READ_RECEIPT_DERIVATION,
+  AGENT_BACKUP_RESTORE_V3_SOURCE_AUTHORITY_DERIVATION,
+  AGENT_BACKUP_RESTORE_V3_STREAM_RECEIPT_FORMAT,
+  type AgentBackupRestoreV3CandidateReceipt,
+  type AgentBackupRestoreV3ComponentReceipt,
+  type AgentBackupRestoreV3StagingSession,
+} from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { assembleAgentBackupRestoreV3Candidate } from "./agent-backup-restore-v3-candidate-assembly";
+import { materializeAgentBackupRestoreV3CandidateCharacter } from "./agent-backup-restore-v3-candidate-character";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  openAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import { stageAgentBackupRestoreV3CandidateRecord } from "./agent-backup-restore-v3-candidate-records";
+
+const roots = new Set<string>();
+const candidates = new Set<AgentBackupRestoreV3CandidateFs>();
+const databases = new Set<PGlite>();
+const control = () => ({
+  signal: new AbortController().signal,
+  deadlineEpochMs: Date.now() + 120_000,
+});
+const hash = (bytes: Uint8Array) =>
+  createHash("sha256").update(bytes).digest("hex");
+const encode = (text: string) => new TextEncoder().encode(text);
+const FACT = "The restored lighthouse is amber-20732";
+const CHARACTER = encode(
+  '{"name":"Restore QA","bio":["remembers a lighthouse"],"plugins":[]}',
+);
+const MEDIA = encode("private-media-20732");
+const STATE = encode('{"pluginFact":"tide-20732"}');
+const VAULT = encode("opaque-vault-ciphertext-20732");
+const platformOptions = () =>
+  process.platform === "linux"
+    ? {}
+    : { testOnlyAllowNonLinuxFdEmulation: true as const };
+
+async function fixture(realDatabase = false) {
+  const root = await fs.mkdtemp(
+    path.join(await fs.realpath(os.tmpdir()), "restore-v3-assembly-"),
+  );
+  roots.add(root);
+  await fs.chmod(root, 0o700);
+  const attemptRoot = path.join(root, "attempt");
+  await fs.mkdir(attemptRoot, { mode: 0o700 });
+  const candidateFs = await openAgentBackupRestoreV3CandidateFs({
+    trustedRoot: root,
+    attemptRoot,
+    control: control(),
+    ...platformOptions(),
+  });
+  candidates.add(candidateFs);
+  const session: AgentBackupRestoreV3StagingSession = Object.freeze({
+    restoreAttemptId: randomUUID(),
+    operationId: randomUUID(),
+    expectedManifestSha256: "a".repeat(64),
+    stagingHandle: randomUUID(),
+    cleanupHandle: randomUUID(),
+    executionToken: randomUUID(),
+    cleanupRegistered: true,
+    isolatedCandidate: true,
+  });
+  let databaseBytes = new Uint8Array([1]);
+  if (realDatabase) {
+    const sourcePath = path.join(root, "source");
+    const db = new PGlite(sourcePath);
+    databases.add(db);
+    await db.exec(
+      "CREATE TABLE assembly_fact (id integer PRIMARY KEY, fact text NOT NULL)",
+    );
+    await db.query("INSERT INTO assembly_fact VALUES ($1, $2)", [1, FACT]);
+    databaseBytes = new Uint8Array(
+      await (await db.dumpDataDir("gzip")).arrayBuffer(),
+    );
+    await db.close();
+    databases.delete(db);
+    await fs.rm(sourcePath, { recursive: true });
+  }
+  const contents = [CHARACTER, databaseBytes, MEDIA, STATE, VAULT];
+  const paths = [null, null, "photo.bin", "plugin/state.json", "vault.json"];
+  const components: AgentBackupRestoreV3ComponentReceipt[] = [];
+  try {
+    for (const [
+      componentIndex,
+      descriptor,
+    ] of AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS.entries()) {
+      const bytes = contents[componentIndex];
+      if (!bytes) throw new Error("Missing fixture component");
+      const filePath = paths[componentIndex];
+      let dataFrameCount = 0;
+      for (
+        let offsetBytes = 0;
+        offsetBytes < bytes.length;
+        offsetBytes += 256 * 1024
+      ) {
+        const payload = Uint8Array.from(
+          bytes.subarray(offsetBytes, offsetBytes + 256 * 1024),
+        );
+        try {
+          await stageAgentBackupRestoreV3CandidateRecord({
+            candidateFs,
+            session,
+            control: control(),
+            record: {
+              componentIndex,
+              componentName: descriptor.name,
+              dataIndex: dataFrameCount++,
+              offsetBytes,
+              payload,
+              entry: filePath
+                ? {
+                    path: filePath,
+                    fileOffsetBytes: offsetBytes,
+                    fileSizeBytes: bytes.length,
+                    mode: componentIndex === 4 ? 0o400 : 0o600,
+                    mtimeMs: 0,
+                  }
+                : null,
+            },
+          });
+        } finally {
+          payload.fill(0);
+        }
+      }
+      components.push({
+        componentIndex,
+        componentName: descriptor.name,
+        descriptor,
+        dataFrameCount,
+        payloadBytes: bytes.length,
+        payloadSha256: hash(bytes),
+        recordStreamContentHmacSha256: "b".repeat(64),
+      });
+    }
+  } finally {
+    databaseBytes.fill(0);
+  }
+  const receipt: AgentBackupRestoreV3CandidateReceipt = {
+    format: AGENT_BACKUP_RESTORE_V3_STREAM_RECEIPT_FORMAT,
+    restoreAttemptId: session.restoreAttemptId,
+    operationId: session.operationId,
+    expectedManifestSha256: session.expectedManifestSha256,
+    keyBundleGenerationId: randomUUID(),
+    sourceCopyRole: "primary",
+    sourceAuthorityDerivation:
+      AGENT_BACKUP_RESTORE_V3_SOURCE_AUTHORITY_DERIVATION,
+    sourceAuthoritySha256: "c".repeat(64),
+    objectCount: 5,
+    stagedPayloadBytes: components.reduce((n, c) => n + c.payloadBytes, 0),
+    stagedDataRecordCount: components.reduce((n, c) => n + c.dataFrameCount, 0),
+    sourceObjects: components.map((c) => ({
+      componentIndex: c.componentIndex,
+      componentName: c.componentName,
+      chunkIndex: 0,
+      copyRole: "primary",
+      objectId: randomUUID(),
+      exactReadReceiptDerivation:
+        AGENT_BACKUP_RESTORE_V3_EXACT_READ_RECEIPT_DERIVATION,
+      exactReadReceiptSha256: "d".repeat(64),
+      ciphertextSha256: "e".repeat(64),
+      sizeBytes: c.payloadBytes,
+    })),
+    components,
+    authorityRevalidated: true,
+  };
+  return {
+    root,
+    attemptRoot,
+    input: { candidateFs, session, receipt, control: control() },
+  };
+}
+
+afterEach(async () => {
+  for (const db of databases) await db.close();
+  databases.clear();
+  for (const candidate of candidates) await candidate.close();
+  candidates.clear();
+  for (const root of roots) await fs.rm(root, { recursive: true, force: true });
+  roots.clear();
+});
+
+describe("five-component candidate assembly", () => {
+  it("resumes partial materialization, replays on a fresh FS authority, and rejects later tamper", async () => {
+    const { root, attemptRoot, input } = await fixture(true);
+    const character = input.receipt.components[0];
+    if (!character) throw new Error("Missing character");
+    await materializeAgentBackupRestoreV3CandidateCharacter({
+      ...input,
+      receipt: character,
+    });
+    const characterPath = path.join(
+      attemptRoot,
+      "components/character/character.json",
+    );
+    const before = await fs.stat(characterPath, { bigint: true });
+    const held = await input.candidateFs.acquireLock(
+      ".restore-v3-competing-operation.lock",
+      control(),
+    );
+    try {
+      await expect(
+        assembleAgentBackupRestoreV3Candidate(input),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_RESTORE_V3_CANDIDATE_FS_LOCK_BUSY",
+      });
+    } finally {
+      await held.release(control());
+    }
+
+    await expect(
+      assembleAgentBackupRestoreV3Candidate({
+        ...input,
+        receipt: {
+          ...input.receipt,
+          components: input.receipt.components.map((component) =>
+            component.componentName === "vault"
+              ? { ...component, payloadSha256: "f".repeat(64) }
+              : component,
+          ),
+        },
+      }),
+    ).rejects.toThrow();
+    await expect(
+      fs.stat(path.join(attemptRoot, ".restore-v3-candidate-assembled.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    const mutable = structuredClone(input.receipt);
+    const assembly = assembleAgentBackupRestoreV3Candidate({
+      ...input,
+      receipt: mutable,
+    });
+    // Caller mutation after dispatch must not rebind the in-flight assembly.
+    Object.assign(mutable, { expectedManifestSha256: "f".repeat(64) });
+    const assembled = await assembly;
+    expect(await fs.readFile(characterPath)).toEqual(Buffer.from(CHARACTER));
+    expect((await fs.stat(characterPath, { bigint: true })).ino).toBe(
+      before.ino,
+    );
+    expect(
+      await fs.readFile(path.join(attemptRoot, "components/media/photo.bin")),
+    ).toEqual(Buffer.from(MEDIA));
+    expect(
+      await fs.readFile(
+        path.join(attemptRoot, "components/state-files/plugin/state.json"),
+      ),
+    ).toEqual(Buffer.from(STATE));
+    const vaultPath = path.join(attemptRoot, "components/vault/vault.json");
+    expect(await fs.readFile(vaultPath)).toEqual(Buffer.from(VAULT));
+    expect((await fs.stat(vaultPath)).mode & 0o777).toBe(0o400);
+    await expect(
+      fs.stat(path.join(attemptRoot, ".restore-v3-database-validation")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    const markerPath = path.join(
+      attemptRoot,
+      ".restore-v3-candidate-assembled.json",
+    );
+    const marker = await fs.readFile(markerPath, "utf8");
+    expect(JSON.parse(marker)).toEqual(assembled);
+    expect(marker).not.toContain(input.session.executionToken);
+    expect(marker).not.toContain(FACT);
+
+    await input.candidateFs.close();
+    candidates.delete(input.candidateFs);
+    const reopened = await openAgentBackupRestoreV3CandidateFs({
+      trustedRoot: root,
+      attemptRoot,
+      control: control(),
+      ...platformOptions(),
+    });
+    candidates.add(reopened);
+    const retry = { ...input, candidateFs: reopened, control: control() };
+    expect(await assembleAgentBackupRestoreV3Candidate(retry)).toEqual(
+      assembled,
+    );
+    await expect(
+      assembleAgentBackupRestoreV3Candidate({
+        ...retry,
+        receipt: { ...input.receipt, keyBundleGenerationId: randomUUID() },
+      }),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_CANDIDATE_ASSEMBLY_RECEIPT_CONFLICT",
+    });
+
+    await fs.chmod(vaultPath, 0o600);
+    await fs.writeFile(vaultPath, "conflicting-vault");
+    await fs.chmod(vaultPath, 0o400);
+    await expect(
+      assembleAgentBackupRestoreV3Candidate(retry),
+    ).rejects.toThrow();
+    expect(await fs.readFile(vaultPath, "utf8")).toBe("conflicting-vault");
+    expect(await fs.readFile(markerPath, "utf8")).toBe(marker);
+    const db = new PGlite(path.join(attemptRoot, "components/database"));
+    databases.add(db);
+    expect((await db.query("SELECT id, fact FROM assembly_fact")).rows).toEqual(
+      [{ id: 1, fact: FACT }],
+    );
+  }, 150_000);
+
+  it.each([
+    "missing-component",
+    "other-session",
+    "aborted",
+    "nested-accessor",
+  ] as const)("rejects %s before any materialized output", async (kind) => {
+    const { attemptRoot, input } = await fixture();
+    let getterCalls = 0;
+    if (kind === "missing-component")
+      input.receipt = {
+        ...input.receipt,
+        components: input.receipt.components.slice(0, 4),
+      };
+    if (kind === "other-session")
+      input.session = { ...input.session, operationId: randomUUID() };
+    if (kind === "aborted") {
+      const abort = new AbortController();
+      abort.abort();
+      input.control = { ...control(), signal: abort.signal };
+    }
+    if (kind === "nested-accessor") {
+      const components = structuredClone(input.receipt.components);
+      Object.defineProperty(components[0], "payloadBytes", {
+        enumerable: true,
+        get: () => {
+          getterCalls++;
+          return 1;
+        },
+      });
+      input.receipt = { ...input.receipt, components };
+    }
+    await expect(
+      assembleAgentBackupRestoreV3Candidate(input),
+    ).rejects.toThrow();
+    expect(getterCalls).toBe(0);
+    await expect(
+      fs.stat(path.join(attemptRoot, "components")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.stat(path.join(attemptRoot, ".restore-v3-candidate-assembled.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-assembly.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-assembly.test.ts
@@ -26,6 +26,7 @@ import {
   openAgentBackupRestoreV3CandidateFs,
 } from "./agent-backup-restore-v3-candidate-fs";
 import { stageAgentBackupRestoreV3CandidateRecord } from "./agent-backup-restore-v3-candidate-records";
+import { createAgentBackupRestoreV3ProcessMaterializer } from "./agent-backup-restore-v3-materializer-process";
 
 const roots = new Set<string>();
 const candidates = new Set<AgentBackupRestoreV3CandidateFs>();
@@ -49,7 +50,7 @@ const platformOptions = () =>
     ? {}
     : { testOnlyAllowNonLinuxFdEmulation: true as const };
 
-async function fixture(realDatabase = false) {
+async function fixture(realDatabase = false, processTransport = false) {
   const root = await fs.mkdtemp(
     path.join(await fs.realpath(os.tmpdir()), "restore-v3-assembly-"),
   );
@@ -64,6 +65,10 @@ async function fixture(realDatabase = false) {
     ...platformOptions(),
   });
   candidates.add(candidateFs);
+  const materializer = createAgentBackupRestoreV3ProcessMaterializer({
+    candidateFs,
+    ...platformOptions(),
+  });
   const session: AgentBackupRestoreV3StagingSession = Object.freeze({
     restoreAttemptId: randomUUID(),
     operationId: randomUUID(),
@@ -111,27 +116,31 @@ async function fixture(realDatabase = false) {
           bytes.subarray(offsetBytes, offsetBytes + 256 * 1024),
         );
         try {
-          await stageAgentBackupRestoreV3CandidateRecord({
-            candidateFs,
-            session,
-            control: control(),
-            record: {
-              componentIndex,
-              componentName: descriptor.name,
-              dataIndex: dataFrameCount++,
-              offsetBytes,
-              payload,
-              entry: filePath
-                ? {
-                    path: filePath,
-                    fileOffsetBytes: offsetBytes,
-                    fileSizeBytes: bytes.length,
-                    mode: componentIndex === 4 ? 0o400 : 0o600,
-                    mtimeMs: 0,
-                  }
-                : null,
-            },
-          });
+          const record = {
+            componentIndex,
+            componentName: descriptor.name,
+            dataIndex: dataFrameCount++,
+            offsetBytes,
+            payload,
+            entry: filePath
+              ? {
+                  path: filePath,
+                  fileOffsetBytes: offsetBytes,
+                  fileSizeBytes: bytes.length,
+                  mode: componentIndex === 4 ? 0o400 : 0o600,
+                  mtimeMs: 0,
+                }
+              : null,
+          };
+          if (processTransport)
+            await materializer.stageRecord(session, record, control());
+          else
+            await stageAgentBackupRestoreV3CandidateRecord({
+              candidateFs,
+              session,
+              control: control(),
+              record,
+            });
         } finally {
           payload.fill(0);
         }
@@ -180,6 +189,7 @@ async function fixture(realDatabase = false) {
   return {
     root,
     attemptRoot,
+    materializer,
     input: { candidateFs, session, receipt, control: control() },
   };
 }
@@ -194,6 +204,66 @@ afterEach(async () => {
 });
 
 describe("five-component candidate assembly", () => {
+  it("transports every component through private Agent processes without booting a runtime", async () => {
+    const { root, attemptRoot, input, materializer } = await fixture(
+      true,
+      true,
+    );
+    for (const receipt of input.receipt.components) {
+      expect(
+        await materializer.finishComponent(input.session, receipt, control()),
+      ).toEqual(receipt);
+    }
+    expect(
+      await materializer.assembleCandidate(
+        input.session,
+        input.receipt,
+        control(),
+      ),
+    ).toEqual(input.receipt);
+    const markerPath = path.join(
+      attemptRoot,
+      ".restore-v3-candidate-assembled.json",
+    );
+    const marker = await fs.readFile(markerPath, "utf8");
+    const inode = (await fs.stat(markerPath, { bigint: true })).ino;
+    expect(
+      await materializer.assembleCandidate(
+        input.session,
+        input.receipt,
+        control(),
+      ),
+    ).toEqual(input.receipt);
+    expect(await fs.readFile(markerPath, "utf8")).toBe(marker);
+    expect((await fs.stat(markerPath, { bigint: true })).ino).toBe(inode);
+    expect(marker).not.toContain(input.session.executionToken);
+    expect(
+      await fs.readFile(
+        path.join(attemptRoot, "components/character/character.json"),
+      ),
+    ).toEqual(Buffer.from(CHARACTER));
+    expect(
+      await fs.readFile(path.join(attemptRoot, "components/media/photo.bin")),
+    ).toEqual(Buffer.from(MEDIA));
+    expect(
+      await fs.readFile(
+        path.join(attemptRoot, "components/state-files/plugin/state.json"),
+      ),
+    ).toEqual(Buffer.from(STATE));
+    expect(
+      await fs.readFile(path.join(attemptRoot, "components/vault/vault.json")),
+    ).toEqual(Buffer.from(VAULT));
+    const probe = path.join(root, "probe");
+    await fs.cp(path.join(attemptRoot, "components/database"), probe, {
+      recursive: true,
+    });
+    const db = new PGlite(probe);
+    databases.add(db);
+    expect((await db.query("SELECT id, fact FROM assembly_fact")).rows).toEqual(
+      [{ id: 1, fact: FACT }],
+    );
+  }, 150_000);
+
   it("resumes partial materialization, replays on a fresh FS authority, and rejects later tamper", async () => {
     const { root, attemptRoot, input } = await fixture(true);
     const character = input.receipt.components[0];

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-assembly.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-assembly.ts
@@ -1,0 +1,321 @@
+/**
+ * Joins all five authenticated component inboxes into one private candidate.
+ * A single root lock covers materialization, database validation and receipt
+ * publication. The receipt names only the five component directories: it is
+ * not a seal authorization, generation commit, readiness or routing authority.
+ * The authenticated stream and durable coordinator retain those authorities.
+ */
+
+import { createHash } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
+import {
+  type AgentBackupRestoreV3CandidateReceipt,
+  type AgentBackupRestoreV3DeepReadonly,
+  type AgentBackupRestoreV3OperationControl,
+  type AgentBackupRestoreV3StagingSession,
+  type AgentBackupRestoreV3StreamComponentName,
+  parseAgentBackupRestoreV3CandidateReceipt,
+} from "@elizaos/shared";
+import { materializeAgentBackupRestoreV3CandidateCharacter } from "./agent-backup-restore-v3-candidate-character";
+import {
+  type AgentBackupRestoreV3CandidateDatabaseValidationReceipt,
+  validateAgentBackupRestoreV3CandidateDatabase,
+} from "./agent-backup-restore-v3-candidate-database-validation";
+import { materializeAgentBackupRestoreV3CandidateFileSet } from "./agent-backup-restore-v3-candidate-file-set";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  isAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import {
+  internalCleanupControl,
+  snapshotOperationControl,
+  snapshotOwnDataRecord,
+} from "./agent-backup-restore-v3-candidate-fs-control";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+import {
+  bindAgentBackupRestoreV3CandidateRecordSession,
+  snapshotAgentBackupRestoreV3CandidateSession,
+} from "./agent-backup-restore-v3-candidate-records";
+
+const ASSEMBLY_MARKER = ".restore-v3-candidate-assembled.json";
+const RECEIPT_LIMIT = 16 * 1024;
+
+export interface AgentBackupRestoreV3CandidateAssemblyInput {
+  readonly candidateFs: AgentBackupRestoreV3CandidateFs;
+  readonly session: Readonly<AgentBackupRestoreV3StagingSession>;
+  /** Exact receipt produced by the authenticated stream, not client assertions. */
+  readonly receipt: AgentBackupRestoreV3DeepReadonly<AgentBackupRestoreV3CandidateReceipt>;
+  readonly control: Readonly<AgentBackupRestoreV3OperationControl>;
+}
+
+interface AssembledComponent {
+  readonly componentName: AgentBackupRestoreV3StreamComponentName;
+  readonly outputDirectory: string;
+  readonly finishSha256: string;
+  readonly treeSha256: string;
+  readonly device: string;
+  readonly inode: string;
+}
+
+export interface AgentBackupRestoreV3CandidateAssemblyReceipt {
+  readonly version: 1;
+  readonly format: "elizaos.agent-backup.restore-v3-candidate-assembled.v1";
+  readonly sessionSha256: string;
+  readonly candidateReceiptSha256: string;
+  readonly attemptRootDevice: string;
+  readonly attemptRootInode: string;
+  readonly components: readonly Readonly<AssembledComponent>[];
+  readonly databaseValidation: Readonly<AgentBackupRestoreV3CandidateDatabaseValidationReceipt>;
+  readonly assemblySha256: string;
+}
+
+function assemblyError(code: string, message: string, cause?: unknown): never {
+  throw new ElizaError(message, {
+    code: `AGENT_BACKUP_RESTORE_V3_CANDIDATE_ASSEMBLY_${code}`,
+    severity: "fatal",
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256")
+    .update(candidateFsCanonicalJson(value))
+    .digest("hex");
+}
+
+function componentProof(value: {
+  readonly component: {
+    readonly componentName: AgentBackupRestoreV3StreamComponentName;
+  };
+  readonly outputDirectory: string;
+  readonly finishSha256: string;
+  readonly tree: {
+    readonly sha256: string;
+    readonly device: string;
+    readonly inode: string;
+  };
+}): Readonly<AssembledComponent> {
+  return Object.freeze({
+    componentName: value.component.componentName,
+    outputDirectory: value.outputDirectory,
+    finishSha256: value.finishSha256,
+    treeSha256: value.tree.sha256,
+    device: value.tree.device,
+    inode: value.tree.inode,
+  });
+}
+
+export async function assembleAgentBackupRestoreV3Candidate(
+  input: Readonly<AgentBackupRestoreV3CandidateAssemblyInput>,
+): Promise<Readonly<AgentBackupRestoreV3CandidateAssemblyReceipt>> {
+  const exact = snapshotOwnDataRecord(
+    input,
+    ["candidateFs", "session", "receipt", "control"],
+    ["candidateFs", "session", "receipt", "control"],
+    "AGENT_BACKUP_RESTORE_V3_CANDIDATE_ASSEMBLY_INPUT_INVALID",
+    "Candidate assembly requires one exact input object",
+  );
+  if (!isAgentBackupRestoreV3CandidateFs(exact.candidateFs))
+    assemblyError(
+      "INPUT_INVALID",
+      "Candidate assembly requires real filesystem authority",
+    );
+  const candidateFs = exact.candidateFs as AgentBackupRestoreV3CandidateFs;
+  const session = snapshotAgentBackupRestoreV3CandidateSession(
+    exact.session as AgentBackupRestoreV3StagingSession,
+  );
+  const control = snapshotOperationControl(
+    exact.control as AgentBackupRestoreV3OperationControl,
+  );
+  // Canonicalization rejects proxies/accessors before the schema reads nested
+  // fields. This also detaches the entire receipt synchronously before any I/O.
+  const receipt = parseAgentBackupRestoreV3CandidateReceipt(
+    JSON.parse(candidateFsCanonicalJson(exact.receipt)),
+  );
+  if (
+    receipt.restoreAttemptId !== session.restoreAttemptId ||
+    receipt.operationId !== session.operationId ||
+    receipt.expectedManifestSha256 !== session.expectedManifestSha256
+  )
+    assemblyError(
+      "SESSION_CONFLICT",
+      "Candidate receipt differs from the exact staging session",
+    );
+  const candidateReceiptSha256 = digest(receipt);
+  const lock = await candidateFs.acquireLock(
+    ".restore-v3-assemble.lock",
+    control,
+  );
+  let failure: unknown;
+  let result:
+    | Readonly<AgentBackupRestoreV3CandidateAssemblyReceipt>
+    | undefined;
+  try {
+    const sessionSha256 = await bindAgentBackupRestoreV3CandidateRecordSession({
+      candidateFs,
+      session,
+      control,
+      heldLock: lock,
+    });
+    const persisted = await candidateFs.readDurableJson(
+      ASSEMBLY_MARKER,
+      { maximumBytes: RECEIPT_LIMIT },
+      control,
+      lock,
+    );
+    if (persisted !== null) {
+      const identity = snapshotOwnDataRecord(
+        persisted,
+        [
+          "version",
+          "format",
+          "sessionSha256",
+          "candidateReceiptSha256",
+          "attemptRootDevice",
+          "attemptRootInode",
+          "components",
+          "databaseValidation",
+          "assemblySha256",
+        ],
+        [
+          "version",
+          "format",
+          "sessionSha256",
+          "candidateReceiptSha256",
+          "attemptRootDevice",
+          "attemptRootInode",
+          "components",
+          "databaseValidation",
+          "assemblySha256",
+        ],
+        "AGENT_BACKUP_RESTORE_V3_CANDIDATE_ASSEMBLY_RECEIPT_CONFLICT",
+        "Persisted candidate assembly receipt is not exact",
+      );
+      if (
+        identity.sessionSha256 !== sessionSha256 ||
+        identity.candidateReceiptSha256 !== candidateReceiptSha256
+      )
+        assemblyError(
+          "RECEIPT_CONFLICT",
+          "Candidate assembly belongs to another exact stream",
+        );
+    }
+
+    const components: Readonly<AssembledComponent>[] = [];
+    let databaseValidation:
+      | Readonly<AgentBackupRestoreV3CandidateDatabaseValidationReceipt>
+      | undefined;
+    for (const component of receipt.components) {
+      const materialization = {
+        candidateFs,
+        session,
+        receipt: component,
+        control,
+      };
+      if (component.componentName === "character") {
+        components.push(
+          componentProof(
+            await materializeAgentBackupRestoreV3CandidateCharacter(
+              materialization,
+              lock,
+            ),
+          ),
+        );
+      } else if (component.componentName === "database") {
+        databaseValidation =
+          await validateAgentBackupRestoreV3CandidateDatabase(
+            materialization,
+            lock,
+          );
+        components.push(
+          Object.freeze({
+            componentName: "database",
+            outputDirectory: "components/database",
+            finishSha256: databaseValidation.extractionFinishSha256,
+            treeSha256: databaseValidation.sourceTreeSha256,
+            device: databaseValidation.sourceTreeDevice,
+            inode: databaseValidation.sourceTreeInode,
+          }),
+        );
+      } else {
+        components.push(
+          componentProof(
+            await materializeAgentBackupRestoreV3CandidateFileSet(
+              materialization,
+              lock,
+            ),
+          ),
+        );
+      }
+    }
+    if (!databaseValidation)
+      assemblyError(
+        "DATABASE_MISSING",
+        "Candidate assembly has no physical database validation",
+      );
+    const body = Object.freeze({
+      version: 1 as const,
+      format: "elizaos.agent-backup.restore-v3-candidate-assembled.v1" as const,
+      sessionSha256,
+      candidateReceiptSha256,
+      attemptRootDevice: candidateFs.attemptRootIdentity.device,
+      attemptRootInode: candidateFs.attemptRootIdentity.inode,
+      components: Object.freeze(components),
+      databaseValidation,
+    });
+    const expected = Object.freeze({ ...body, assemblySha256: digest(body) });
+    if (
+      persisted !== null &&
+      candidateFsCanonicalJson(persisted) !== candidateFsCanonicalJson(expected)
+    )
+      assemblyError(
+        "RECEIPT_CONFLICT",
+        "Candidate assembly differs from its durable receipt",
+      );
+    if (persisted === null) {
+      await candidateFs.publishDurableJson(
+        ASSEMBLY_MARKER,
+        expected,
+        { maximumBytes: RECEIPT_LIMIT },
+        control,
+        lock,
+      );
+    }
+    const durable = await candidateFs.readDurableJson(
+      ASSEMBLY_MARKER,
+      { maximumBytes: RECEIPT_LIMIT },
+      control,
+      lock,
+    );
+    if (
+      candidateFsCanonicalJson(durable) !== candidateFsCanonicalJson(expected)
+    )
+      assemblyError(
+        "RECEIPT_CONFLICT",
+        "Candidate assembly changed during publication",
+      );
+    result = expected;
+  } catch (cause) {
+    // error-policy:J2 Preserve the operation failure across lock teardown.
+    failure = cause;
+  }
+  try {
+    await lock.release(internalCleanupControl());
+  } catch (cause) {
+    // error-policy:J2 Failed release is never hidden behind an assembly receipt.
+    if (failure !== undefined)
+      assemblyError(
+        "CLEANUP_FAILED",
+        "Candidate assembly and lock release failed",
+        new AggregateError([failure, cause]),
+      );
+    throw cause;
+  }
+  if (failure !== undefined) throw failure;
+  if (!result)
+    assemblyError(
+      "RECEIPT_MISSING",
+      "Candidate assembly produced no durable receipt",
+    );
+  return result;
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-character.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-character.ts
@@ -476,6 +476,7 @@ async function materializeCopiedCharacter(
   input: Readonly<MaterializeAgentBackupRestoreV3CandidateCharacterInput>,
   component: Readonly<AgentBackupRestoreV3ComponentReceipt>,
   maximumBytes: number,
+  heldLock?: AgentBackupRestoreV3CandidateFsLock,
 ): Promise<Readonly<AgentBackupRestoreV3CandidateCharacterReceipt>> {
   if (
     component.payloadBytes <= 0 ||
@@ -496,10 +497,12 @@ async function materializeCopiedCharacter(
   let result: Readonly<AgentBackupRestoreV3CandidateCharacterReceipt> | null =
     null;
   try {
-    lock = await input.candidateFs.acquireLock(
-      ".restore-v3-materialize-c0.lock",
-      input.control,
-    );
+    lock =
+      heldLock ??
+      (await input.candidateFs.acquireLock(
+        ".restore-v3-materialize-c0.lock",
+        input.control,
+      ));
     await bindAgentBackupRestoreV3CandidateRecordSession({
       candidateFs: input.candidateFs,
       session: input.session,
@@ -654,7 +657,7 @@ async function materializeCopiedCharacter(
     primaryFailure = cause;
   }
   let cleanupFailure: unknown;
-  if (lock) {
+  if (lock && !heldLock) {
     try {
       await lock.release(input.control);
     } catch (cause) {
@@ -683,6 +686,7 @@ async function materializeCopiedCharacter(
 /** Validates and preserves the exact original JSON bytes below the candidate. */
 export function materializeAgentBackupRestoreV3CandidateCharacter(
   input: Readonly<MaterializeAgentBackupRestoreV3CandidateCharacterInput>,
+  heldLock?: AgentBackupRestoreV3CandidateFsLock,
 ): Promise<Readonly<AgentBackupRestoreV3CandidateCharacterReceipt>> {
   const exactInput = snapshotPlainDataRecord(
     input,
@@ -722,5 +726,6 @@ export function materializeAgentBackupRestoreV3CandidateCharacter(
     }),
     receipt,
     maximumBytes,
+    heldLock,
   );
 }

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-database-validation.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-database-validation.ts
@@ -16,6 +16,7 @@ import {
 } from "./agent-backup-restore-v3-candidate-database";
 import {
   type AgentBackupRestoreV3CandidateFs,
+  type AgentBackupRestoreV3CandidateFsLock,
   isAgentBackupRestoreV3CandidateFs,
 } from "./agent-backup-restore-v3-candidate-fs";
 import {
@@ -71,6 +72,7 @@ function receiptFor(
 
 export async function validateAgentBackupRestoreV3CandidateDatabase(
   input: Readonly<AgentBackupRestoreV3CandidateDatabaseInput>,
+  heldLock?: AgentBackupRestoreV3CandidateFsLock,
 ): Promise<Readonly<AgentBackupRestoreV3CandidateDatabaseValidationReceipt>> {
   const exact = snapshotOwnDataRecord(
     input,
@@ -91,23 +93,28 @@ export async function validateAgentBackupRestoreV3CandidateDatabase(
   const control = snapshotOperationControl(
     exact.control as AgentBackupRestoreV3OperationControl,
   );
-  const source = await extractAgentBackupRestoreV3CandidateDatabase({
-    candidateFs,
-    session,
-    control,
-    receipt:
-      exact.receipt as AgentBackupRestoreV3CandidateDatabaseInput["receipt"],
-  });
+  const source = await extractAgentBackupRestoreV3CandidateDatabase(
+    {
+      candidateFs,
+      session,
+      control,
+      receipt:
+        exact.receipt as AgentBackupRestoreV3CandidateDatabaseInput["receipt"],
+    },
+    heldLock,
+  );
   const copiedInput = Object.freeze({
     candidateFs,
     session,
     control,
     receipt: source.component,
   });
-  const lock = await candidateFs.acquireLock(
-    ".restore-v3-validate-database.lock",
-    control,
-  );
+  const lock =
+    heldLock ??
+    (await candidateFs.acquireLock(
+      ".restore-v3-validate-database.lock",
+      control,
+    ));
   let result:
     | Readonly<AgentBackupRestoreV3CandidateDatabaseValidationReceipt>
     | undefined;
@@ -243,7 +250,7 @@ export async function validateAgentBackupRestoreV3CandidateDatabase(
     failure = cause;
   }
   try {
-    await lock.release(internalCleanupControl());
+    if (!heldLock) await lock.release(internalCleanupControl());
   } catch (cause) {
     // error-policy:J2 Both failures remain visible to the operation reconciler.
     if (failure !== undefined)

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-database-validation.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-database-validation.ts
@@ -1,0 +1,264 @@
+/**
+ * Validates a physical database on a disposable private copy, keeping the
+ * authenticated extraction immutable for crash and response-loss replay.
+ * This is SQL lifecycle proof, never an Agent readiness or activation proof.
+ */
+
+import { createHash } from "node:crypto";
+import type { AgentBackupRestoreV3OperationControl } from "@elizaos/shared";
+import {
+  AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_COPY_MARKER,
+  AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY,
+  type AgentBackupRestoreV3CandidateDatabaseExtractionReceipt,
+  type AgentBackupRestoreV3CandidateDatabaseInput,
+  extractAgentBackupRestoreV3CandidateDatabase,
+  extractAgentBackupRestoreV3CandidateDatabaseValidationCopy,
+} from "./agent-backup-restore-v3-candidate-database";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  isAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import {
+  internalCleanupControl,
+  snapshotOperationControl,
+  snapshotOwnDataRecord,
+} from "./agent-backup-restore-v3-candidate-fs-control";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+import { snapshotAgentBackupRestoreV3CandidateSession } from "./agent-backup-restore-v3-candidate-records";
+import { AgentBackupRestoreV3PgliteArchiveError } from "./agent-backup-restore-v3-pglite-archive";
+import { runAgentBackupRestoreV3PgliteValidationProcess } from "./agent-backup-restore-v3-pglite-validation-process";
+
+const VALIDATION_MARKER = ".restore-v3-component-c1.database-validated.json";
+const MAXIMUM_RECEIPT_BYTES = 8192;
+const DISPOSABLE_PATHS = Object.freeze([
+  AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY,
+  AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_COPY_MARKER,
+]);
+
+export interface AgentBackupRestoreV3CandidateDatabaseValidationReceipt {
+  readonly version: 1;
+  readonly format: "elizaos.agent-backup.restore-v3-database-validated.v1";
+  readonly sessionSha256: string;
+  readonly extractionFinishSha256: string;
+  readonly sourceTreeSha256: string;
+  readonly sourceTreeDevice: string;
+  readonly sourceTreeInode: string;
+  readonly serverVersion: string;
+  readonly receiptSha256: string;
+}
+
+function receiptFor(
+  source: Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt>,
+  serverVersion: string,
+): Readonly<AgentBackupRestoreV3CandidateDatabaseValidationReceipt> {
+  const body = {
+    version: 1 as const,
+    format: "elizaos.agent-backup.restore-v3-database-validated.v1" as const,
+    sessionSha256: source.sessionSha256,
+    extractionFinishSha256: source.finishSha256,
+    sourceTreeSha256: source.tree.sha256,
+    sourceTreeDevice: source.tree.device,
+    sourceTreeInode: source.tree.inode,
+    serverVersion,
+  };
+  return Object.freeze({
+    ...body,
+    receiptSha256: createHash("sha256")
+      .update(candidateFsCanonicalJson(body))
+      .digest("hex"),
+  });
+}
+
+export async function validateAgentBackupRestoreV3CandidateDatabase(
+  input: Readonly<AgentBackupRestoreV3CandidateDatabaseInput>,
+): Promise<Readonly<AgentBackupRestoreV3CandidateDatabaseValidationReceipt>> {
+  const exact = snapshotOwnDataRecord(
+    input,
+    ["candidateFs", "session", "receipt", "control"],
+    ["candidateFs", "session", "receipt", "control"],
+    "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_INPUT_INVALID",
+    "Database validation requires one exact input object",
+  );
+  if (!isAgentBackupRestoreV3CandidateFs(exact.candidateFs))
+    throw new AgentBackupRestoreV3PgliteArchiveError(
+      "INPUT_INVALID",
+      "Database validation requires real filesystem authority",
+    );
+  const candidateFs = exact.candidateFs as AgentBackupRestoreV3CandidateFs;
+  const session = snapshotAgentBackupRestoreV3CandidateSession(
+    exact.session as AgentBackupRestoreV3CandidateDatabaseInput["session"],
+  );
+  const control = snapshotOperationControl(
+    exact.control as AgentBackupRestoreV3OperationControl,
+  );
+  const source = await extractAgentBackupRestoreV3CandidateDatabase({
+    candidateFs,
+    session,
+    control,
+    receipt:
+      exact.receipt as AgentBackupRestoreV3CandidateDatabaseInput["receipt"],
+  });
+  const copiedInput = Object.freeze({
+    candidateFs,
+    session,
+    control,
+    receipt: source.component,
+  });
+  const lock = await candidateFs.acquireLock(
+    ".restore-v3-validate-database.lock",
+    control,
+  );
+  let result:
+    | Readonly<AgentBackupRestoreV3CandidateDatabaseValidationReceipt>
+    | undefined;
+  let failure: unknown;
+  const proveSource = async () => {
+    const current = await candidateFs.proveTree(
+      source.outputDirectory,
+      undefined,
+      control,
+      lock,
+    );
+    if (
+      candidateFsCanonicalJson(current) !==
+      candidateFsCanonicalJson(source.tree)
+    )
+      throw new AgentBackupRestoreV3PgliteArchiveError(
+        "SOURCE_TREE_CHANGED",
+        "Database extraction changed during isolated validation",
+      );
+  };
+  try {
+    await proveSource();
+    const persisted = await candidateFs.readDurableJson(
+      VALIDATION_MARKER,
+      { maximumBytes: MAXIMUM_RECEIPT_BYTES },
+      control,
+      lock,
+    );
+    if (persisted !== null) {
+      const keys = Object.keys(receiptFor(source, "170000"));
+      const data = snapshotOwnDataRecord(
+        persisted,
+        keys,
+        keys,
+        "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_VALIDATION_CONFLICT",
+        "Database validation receipt is not exact",
+      );
+      if (
+        typeof data.serverVersion !== "string" ||
+        !/^[1-9][0-9]{4,5}$/.test(data.serverVersion)
+      )
+        throw new AgentBackupRestoreV3PgliteArchiveError(
+          "VALIDATION_CONFLICT",
+          "Database validation receipt has no server identity",
+        );
+      const expected = receiptFor(source, data.serverVersion);
+      if (
+        candidateFsCanonicalJson(persisted) !==
+        candidateFsCanonicalJson(expected)
+      )
+        throw new AgentBackupRestoreV3PgliteArchiveError(
+          "VALIDATION_CONFLICT",
+          "Database validation receipt differs from this extraction",
+        );
+      result = expected;
+    } else {
+      // A previous process may have died after opening its copy. Its inherited
+      // kernel lock prevents admission here until that writer has exited.
+      await candidateFs.cleanupVolatile(
+        DISPOSABLE_PATHS,
+        undefined,
+        control,
+        lock,
+      );
+      let serverVersion: string | undefined;
+      let validationFailure: unknown;
+      try {
+        const copy =
+          await extractAgentBackupRestoreV3CandidateDatabaseValidationCopy(
+            copiedInput,
+            lock,
+          );
+        const validated = await runAgentBackupRestoreV3PgliteValidationProcess({
+          candidateFs,
+          heldLock: lock,
+          copyTree: copy.tree,
+          control,
+        });
+        serverVersion = validated.serverVersion;
+      } catch (cause) {
+        // error-policy:J2 Keep lifecycle failure through bounded scratch cleanup.
+        validationFailure = cause;
+      }
+      try {
+        await candidateFs.cleanupVolatile(
+          DISPOSABLE_PATHS,
+          undefined,
+          internalCleanupControl(),
+          lock,
+        );
+      } catch (cause) {
+        // error-policy:J2 Failed cleanup never permits a validation receipt.
+        if (validationFailure !== undefined)
+          throw new AgentBackupRestoreV3PgliteArchiveError(
+            "VALIDATION_CLEANUP_FAILED",
+            "Database validation and scratch cleanup failed",
+            new AggregateError([validationFailure, cause]),
+          );
+        throw cause;
+      }
+      if (validationFailure !== undefined) throw validationFailure;
+      if (!serverVersion)
+        throw new AgentBackupRestoreV3PgliteArchiveError(
+          "VALIDATION_FAILED",
+          "Database validation produced no server identity",
+        );
+      await proveSource();
+      const expected = receiptFor(source, serverVersion);
+      await candidateFs.publishDurableJson(
+        VALIDATION_MARKER,
+        expected,
+        { maximumBytes: MAXIMUM_RECEIPT_BYTES },
+        control,
+        lock,
+      );
+      const durable = await candidateFs.readDurableJson(
+        VALIDATION_MARKER,
+        { maximumBytes: MAXIMUM_RECEIPT_BYTES },
+        control,
+        lock,
+      );
+      if (
+        candidateFsCanonicalJson(durable) !== candidateFsCanonicalJson(expected)
+      )
+        throw new AgentBackupRestoreV3PgliteArchiveError(
+          "VALIDATION_CONFLICT",
+          "Database validation proof changed after publication",
+        );
+      result = expected;
+    }
+  } catch (cause) {
+    // error-policy:J2 Preserve the primary failure across lock teardown.
+    failure = cause;
+  }
+  try {
+    await lock.release(internalCleanupControl());
+  } catch (cause) {
+    // error-policy:J2 Both failures remain visible to the operation reconciler.
+    if (failure !== undefined)
+      throw new AgentBackupRestoreV3PgliteArchiveError(
+        "VALIDATION_CLEANUP_FAILED",
+        "Database validation and lock release failed",
+        new AggregateError([failure, cause]),
+      );
+    throw cause;
+  }
+  if (failure !== undefined) throw failure;
+  if (!result)
+    throw new AgentBackupRestoreV3PgliteArchiveError(
+      "VALIDATION_FAILED",
+      "Database validation did not produce an exact receipt",
+    );
+  return result;
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-database.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-database.ts
@@ -144,8 +144,9 @@ export interface AgentBackupRestoreV3CandidateDatabaseInput {
 
 export function extractAgentBackupRestoreV3CandidateDatabase(
   input: Readonly<AgentBackupRestoreV3CandidateDatabaseInput>,
+  heldLock?: AgentBackupRestoreV3CandidateFsLock,
 ): Promise<Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt>> {
-  return extractDatabaseAt(input, OUTPUT_DIRECTORY, FINISH_MARKER);
+  return extractDatabaseAt(input, OUTPUT_DIRECTORY, FINISH_MARKER, heldLock);
 }
 
 /** Only the validator consumes this disposable copy, while holding the root lock. */

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-database.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-database.ts
@@ -1,0 +1,458 @@
+/**
+ * Extracts the exact authenticated database record inbox into quarantine.
+ * Its durable receipt proves archive extraction only, not a validated/opened
+ * PGlite lifecycle, generation commit, restart, or permission to publish routes.
+ * All mutation uses the merged candidate-FS capability under its existing lock.
+ */
+
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { createGunzip } from "node:zlib";
+import {
+  AGENT_BACKUP_CAPTURE_V2_LIMITS,
+  AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
+  type AgentBackupRestoreV3ComponentReceipt,
+  AgentBackupRestoreV3ComponentReceiptSchema,
+  type AgentBackupRestoreV3OperationControl,
+  type AgentBackupRestoreV3StagingSession,
+} from "@elizaos/shared";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  type AgentBackupRestoreV3CandidateTreeProof,
+  isAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import {
+  assertActive,
+  internalCleanupControl,
+  snapshotOperationControl,
+  snapshotOwnDataRecord,
+} from "./agent-backup-restore-v3-candidate-fs-control";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+import {
+  AgentBackupRestoreV3CandidateRecordError,
+  bindAgentBackupRestoreV3CandidateRecordSession,
+  readAgentBackupRestoreV3CandidateRecord,
+  snapshotAgentBackupRestoreV3CandidateSession,
+} from "./agent-backup-restore-v3-candidate-records";
+import {
+  AgentBackupRestoreV3PgliteArchiveError,
+  readAgentBackupRestoreV3PgliteArchive,
+} from "./agent-backup-restore-v3-pglite-archive";
+
+const OUTPUT_DIRECTORY = "components/database";
+const FINISH_MARKER = ".restore-v3-component-c1.database-extracted.json";
+const MAXIMUM_COMPRESSED_BYTES = 1024 * 1024 * 1024;
+const FINISH_MAXIMUM_BYTES = 32 * 1024;
+
+export interface AgentBackupRestoreV3CandidateDatabaseExtractionReceipt {
+  readonly version: 1;
+  readonly format: "elizaos.agent-backup.restore-v3-database-extracted.v1";
+  readonly sessionSha256: string;
+  readonly component: Readonly<AgentBackupRestoreV3ComponentReceipt>;
+  readonly outputDirectory: typeof OUTPUT_DIRECTORY;
+  readonly lastRecordReceiptSha256: string;
+  readonly tree: Readonly<AgentBackupRestoreV3CandidateTreeProof>;
+  readonly finishSha256: string;
+}
+
+function invalid(code: string, message: string, cause?: unknown): never {
+  throw new AgentBackupRestoreV3PgliteArchiveError(code, message, cause);
+}
+
+function receiptSnapshot(
+  value: Readonly<AgentBackupRestoreV3ComponentReceipt>,
+): Readonly<AgentBackupRestoreV3ComponentReceipt> {
+  const record = snapshotOwnDataRecord(
+    value,
+    [
+      "componentIndex",
+      "componentName",
+      "descriptor",
+      "dataFrameCount",
+      "payloadBytes",
+      "payloadSha256",
+      "recordStreamContentHmacSha256",
+    ],
+    [
+      "componentIndex",
+      "componentName",
+      "descriptor",
+      "dataFrameCount",
+      "payloadBytes",
+      "payloadSha256",
+      "recordStreamContentHmacSha256",
+    ],
+    "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_COMPONENT_INVALID",
+    "Database receipt requires one exact plain data object",
+  );
+  const expected = AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS[1];
+  if (!expected)
+    invalid("COMPONENT_INVALID", "Database component policy is unavailable");
+  const descriptor = snapshotOwnDataRecord(
+    record.descriptor,
+    Object.keys(expected),
+    Object.keys(expected),
+    "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_COMPONENT_INVALID",
+    "Database descriptor requires one exact plain data object",
+  );
+  const parsed = AgentBackupRestoreV3ComponentReceiptSchema.parse({
+    ...record,
+    descriptor,
+  });
+  if (
+    parsed.componentIndex !== 1 ||
+    parsed.componentName !== "database" ||
+    candidateFsCanonicalJson(parsed.descriptor) !==
+      candidateFsCanonicalJson(expected)
+  )
+    invalid(
+      "COMPONENT_INVALID",
+      "Extraction requires the exact database component",
+    );
+  if (
+    parsed.dataFrameCount === 0 ||
+    parsed.dataFrameCount > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDataFrames ||
+    parsed.payloadBytes === 0 ||
+    parsed.payloadBytes > MAXIMUM_COMPRESSED_BYTES
+  )
+    invalid(
+      "COMPONENT_LIMIT",
+      "Database component is empty or exceeds its bounded capture policy",
+    );
+  return Object.freeze({
+    ...parsed,
+    descriptor: Object.freeze({ ...parsed.descriptor }),
+  });
+}
+
+export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
+  readonly candidateFs: AgentBackupRestoreV3CandidateFs;
+  readonly session: Readonly<AgentBackupRestoreV3StagingSession>;
+  readonly receipt: Readonly<AgentBackupRestoreV3ComponentReceipt>;
+  readonly control: Readonly<AgentBackupRestoreV3OperationControl>;
+}): Promise<Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt>> {
+  const exact = snapshotOwnDataRecord(
+    input,
+    ["candidateFs", "session", "receipt", "control"],
+    ["candidateFs", "session", "receipt", "control"],
+    "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_INPUT_INVALID",
+    "Database extraction requires one plain input object",
+  );
+  if (!isAgentBackupRestoreV3CandidateFs(exact.candidateFs))
+    invalid(
+      "INPUT_INVALID",
+      "Database extraction requires the real candidate filesystem capability",
+    );
+  const candidateFs = exact.candidateFs as AgentBackupRestoreV3CandidateFs;
+  const session = snapshotAgentBackupRestoreV3CandidateSession(
+    exact.session as AgentBackupRestoreV3StagingSession,
+  );
+  const component = receiptSnapshot(
+    exact.receipt as AgentBackupRestoreV3ComponentReceipt,
+  );
+  const control = snapshotOperationControl(
+    exact.control as AgentBackupRestoreV3OperationControl,
+  );
+  const lock = await candidateFs.acquireLock(
+    ".restore-v3-materialize-c1.lock",
+    control,
+  );
+  let primaryFailure: unknown;
+  let result:
+    | Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt>
+    | undefined;
+  try {
+    const sessionSha256 = await bindAgentBackupRestoreV3CandidateRecordSession({
+      candidateFs,
+      session,
+      control,
+      heldLock: lock,
+    });
+    const gunzip = createGunzip({ chunkSize: 64 * 1024 });
+    let decoderFailure: Error | undefined;
+    // The reader may not be attached yet when a source/abort failure arrives.
+    // Record it now; parsing or the explicit check below reports the failure.
+    gunzip.on("error", (error) => {
+      decoderFailure = error;
+    });
+    const interrupt = () => {
+      gunzip.destroy(
+        new AgentBackupRestoreV3PgliteArchiveError(
+          "INTERRUPTED",
+          "Database archive extraction was cancelled or exceeded its deadline",
+        ),
+      );
+    };
+    control.signal.addEventListener("abort", interrupt, { once: true });
+    const deadline = setTimeout(
+      interrupt,
+      Math.min(
+        2_147_483_647,
+        Math.max(1, control.deadlineEpochMs - Date.now()),
+      ),
+    );
+    let lastRecordReceiptSha256: string | null = null;
+    const feed = async () => {
+      const hash = createHash("sha256");
+      let bytes = 0;
+      for (
+        let dataIndex = 0;
+        dataIndex < component.dataFrameCount;
+        dataIndex++
+      ) {
+        const inbox = await readAgentBackupRestoreV3CandidateRecord({
+          candidateFs,
+          session,
+          componentIndex: 1,
+          dataIndex,
+          control,
+          heldLock: lock,
+        });
+        try {
+          const record = inbox.receipt.record;
+          if (
+            record.componentIndex !== 1 ||
+            record.componentName !== "database" ||
+            record.dataIndex !== dataIndex ||
+            record.offsetBytes !== bytes ||
+            record.entry !== null ||
+            record.payloadBytes !== inbox.payload.byteLength ||
+            (lastRecordReceiptSha256 !== null &&
+              inbox.receipt.previousReceiptSha256 !== lastRecordReceiptSha256)
+          )
+            invalid(
+              "RECORD_INVALID",
+              "Database records must be an exact contiguous opaque chain",
+            );
+          if (bytes > component.payloadBytes - inbox.payload.byteLength)
+            invalid(
+              "COMPONENT_LIMIT",
+              "Database record exceeds the authenticated payload size",
+            );
+          bytes += inbox.payload.byteLength;
+          hash.update(inbox.payload);
+          // The zlib callback, not Readable.from() read-ahead, owns this buffer's
+          // lifetime. Do not clear plaintext while the decoder still uses it.
+          await new Promise<void>((resolve, reject) => {
+            gunzip.write(inbox.payload, (error) =>
+              error ? reject(error) : resolve(),
+            );
+          });
+          assertActive(control);
+          lastRecordReceiptSha256 = inbox.receipt.receiptSha256;
+        } finally {
+          inbox.payload.fill(0);
+        }
+      }
+      if (
+        bytes !== component.payloadBytes ||
+        hash.digest("hex") !== component.payloadSha256
+      )
+        invalid(
+          "PAYLOAD_MISMATCH",
+          "Database payload differs from its authenticated finish",
+        );
+      try {
+        const unexpected = await readAgentBackupRestoreV3CandidateRecord({
+          candidateFs,
+          session,
+          componentIndex: 1,
+          dataIndex: component.dataFrameCount,
+          control,
+          heldLock: lock,
+        });
+        unexpected.payload.fill(0);
+        invalid(
+          "RECORD_COUNT_MISMATCH",
+          "Database inbox has records beyond its authenticated finish",
+        );
+      } catch (cause) {
+        // error-policy:J3 Only absence at the exact terminal slot is acceptable.
+        if (
+          !(
+            cause instanceof AgentBackupRestoreV3CandidateRecordError &&
+            cause.code === "AGENT_BACKUP_RESTORE_V3_CANDIDATE_RECORD_ABSENT"
+          )
+        )
+          throw cause;
+      }
+      gunzip.end();
+    };
+    const supply = feed().catch((cause) => {
+      // error-policy:J2 Wake the reader; the same source failure is joined below.
+      const error =
+        cause instanceof Error
+          ? cause
+          : new AgentBackupRestoreV3PgliteArchiveError(
+              "SOURCE_FAILED",
+              "Database record source failed",
+              cause,
+            );
+      gunzip.destroy(error);
+      throw error;
+    });
+    // error-policy:J5 The supply rejection is observed by the join in finally.
+    void supply.catch(() => undefined);
+    async function* decodedTar() {
+      for await (const chunk of gunzip) {
+        if (!Buffer.isBuffer(chunk))
+          invalid("CHUNK_INVALID", "Database decoder emitted a non-byte chunk");
+        try {
+          yield chunk;
+        } finally {
+          chunk.fill(0);
+        }
+      }
+    }
+    let extractionFailure: unknown;
+    try {
+      await candidateFs.ensureFileTreeDirectory(
+        OUTPUT_DIRECTORY,
+        control,
+        lock,
+      );
+      const extracted = await readAgentBackupRestoreV3PgliteArchive({
+        tar: decodedTar(),
+        control,
+        // Absolute and ratio ceilings both apply; small real physical dumps
+        // need the fixed allowance for PostgreSQL's compressible empty pages.
+        limits: {
+          maximumTarBytes: Math.min(
+            8 * 1024 ** 3,
+            Math.max(64 * 1024 ** 2, component.payloadBytes * 128),
+          ),
+        },
+        visit: async (entry, consume) => {
+          if (entry.type === "directory") {
+            await candidateFs.ensureFileTreeDirectory(
+              `${OUTPUT_DIRECTORY}/${entry.path}`,
+              control,
+              lock,
+            );
+            await consume(async () => {});
+            return;
+          }
+          const writer = await candidateFs.createFileTreeFile(
+            OUTPUT_DIRECTORY,
+            {
+              path: entry.path,
+              sizeBytes: entry.sizeBytes,
+              mode: 0o600,
+              mtimeMs: 0,
+            },
+            undefined,
+            control,
+            lock,
+          );
+          const hash = createHash("sha256");
+          try {
+            await consume(async (chunk) => {
+              hash.update(chunk);
+              if (!writer.replayed) await writer.write(chunk, control);
+            });
+            const proof = await writer.finalize(control);
+            if (proof.sha256 !== hash.digest("hex"))
+              invalid(
+                "FILE_CONFLICT",
+                "Extracted database file differs from the authenticated archive",
+              );
+          } finally {
+            await writer.close();
+          }
+        },
+      });
+      await supply;
+      if (decoderFailure) throw decoderFailure;
+      if (lastRecordReceiptSha256 === null)
+        invalid(
+          "RECORD_INVALID",
+          "Database extraction has no terminal record receipt",
+        );
+      const tree = await candidateFs.proveTree(
+        OUTPUT_DIRECTORY,
+        undefined,
+        control,
+        lock,
+      );
+      if (
+        tree.bytes !== extracted.extractedBytes ||
+        tree.files !== extracted.files ||
+        tree.directories !== extracted.directories
+      )
+        invalid(
+          "TREE_CONFLICT",
+          "Database extraction contains entries outside its exact archive",
+        );
+      const body = {
+        version: 1 as const,
+        format:
+          "elizaos.agent-backup.restore-v3-database-extracted.v1" as const,
+        sessionSha256,
+        component,
+        outputDirectory: OUTPUT_DIRECTORY as typeof OUTPUT_DIRECTORY,
+        lastRecordReceiptSha256,
+        tree,
+      };
+      const finish = Object.freeze({
+        ...body,
+        finishSha256: createHash("sha256")
+          .update(candidateFsCanonicalJson(body))
+          .digest("hex"),
+      });
+      await candidateFs.publishDurableJson(
+        FINISH_MARKER,
+        finish,
+        { maximumBytes: FINISH_MAXIMUM_BYTES },
+        control,
+        lock,
+      );
+      const persisted = await candidateFs.readDurableJson(
+        FINISH_MARKER,
+        { maximumBytes: FINISH_MAXIMUM_BYTES },
+        control,
+        lock,
+      );
+      if (
+        candidateFsCanonicalJson(persisted) !== candidateFsCanonicalJson(finish)
+      )
+        invalid(
+          "FINISH_CONFLICT",
+          "Database extraction receipt changed after publication",
+        );
+      result = finish;
+    } catch (cause) {
+      // error-policy:J2 Retain the primary parser/filesystem error through join.
+      extractionFailure = cause;
+    } finally {
+      clearTimeout(deadline);
+      control.signal.removeEventListener("abort", interrupt);
+      gunzip.destroy();
+    }
+    // Do not release the candidate lock while a record read can still settle.
+    const settled = await Promise.allSettled([supply]);
+    if (extractionFailure !== undefined) throw extractionFailure;
+    if (settled[0]?.status === "rejected") throw settled[0].reason;
+  } catch (cause) {
+    // error-policy:J2 Preserve extraction failure if lock teardown also fails.
+    primaryFailure = cause;
+  }
+  try {
+    await lock.release(internalCleanupControl());
+  } catch (cause) {
+    // error-policy:J2 Both failures remain inspectable; neither becomes success.
+    if (primaryFailure !== undefined)
+      invalid(
+        "CLEANUP_FAILED",
+        "Database extraction and lock cleanup failed",
+        new AggregateError([primaryFailure, cause]),
+      );
+    throw cause;
+  }
+  if (primaryFailure !== undefined) throw primaryFailure;
+  if (!result)
+    invalid(
+      "FINISH_MISSING",
+      "Database extraction did not publish an exact finish",
+    );
+  return result;
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-database.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-database.ts
@@ -18,6 +18,7 @@ import {
 } from "@elizaos/shared";
 import {
   type AgentBackupRestoreV3CandidateFs,
+  type AgentBackupRestoreV3CandidateFsLock,
   type AgentBackupRestoreV3CandidateTreeProof,
   isAgentBackupRestoreV3CandidateFs,
 } from "./agent-backup-restore-v3-candidate-fs";
@@ -43,13 +44,22 @@ const OUTPUT_DIRECTORY = "components/database";
 const FINISH_MARKER = ".restore-v3-component-c1.database-extracted.json";
 const MAXIMUM_COMPRESSED_BYTES = 1024 * 1024 * 1024;
 const FINISH_MAXIMUM_BYTES = 32 * 1024;
+export const AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY =
+  ".restore-v3-database-validation";
+export const AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_COPY_MARKER =
+  ".restore-v3-component-c1.validation-copy-extracted.json";
+type DatabaseDirectory =
+  | typeof OUTPUT_DIRECTORY
+  | typeof AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY;
 
-export interface AgentBackupRestoreV3CandidateDatabaseExtractionReceipt {
+export interface AgentBackupRestoreV3CandidateDatabaseExtractionReceipt<
+  Directory extends DatabaseDirectory = typeof OUTPUT_DIRECTORY,
+> {
   readonly version: 1;
   readonly format: "elizaos.agent-backup.restore-v3-database-extracted.v1";
   readonly sessionSha256: string;
   readonly component: Readonly<AgentBackupRestoreV3ComponentReceipt>;
-  readonly outputDirectory: typeof OUTPUT_DIRECTORY;
+  readonly outputDirectory: Directory;
   readonly lastRecordReceiptSha256: string;
   readonly tree: Readonly<AgentBackupRestoreV3CandidateTreeProof>;
   readonly finishSha256: string;
@@ -125,12 +135,46 @@ function receiptSnapshot(
   });
 }
 
-export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
+export interface AgentBackupRestoreV3CandidateDatabaseInput {
   readonly candidateFs: AgentBackupRestoreV3CandidateFs;
   readonly session: Readonly<AgentBackupRestoreV3StagingSession>;
   readonly receipt: Readonly<AgentBackupRestoreV3ComponentReceipt>;
   readonly control: Readonly<AgentBackupRestoreV3OperationControl>;
-}): Promise<Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt>> {
+}
+
+export function extractAgentBackupRestoreV3CandidateDatabase(
+  input: Readonly<AgentBackupRestoreV3CandidateDatabaseInput>,
+): Promise<Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt>> {
+  return extractDatabaseAt(input, OUTPUT_DIRECTORY, FINISH_MARKER);
+}
+
+/** Only the validator consumes this disposable copy, while holding the root lock. */
+export function extractAgentBackupRestoreV3CandidateDatabaseValidationCopy(
+  input: Readonly<AgentBackupRestoreV3CandidateDatabaseInput>,
+  heldLock: AgentBackupRestoreV3CandidateFsLock,
+): Promise<
+  Readonly<
+    AgentBackupRestoreV3CandidateDatabaseExtractionReceipt<
+      typeof AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY
+    >
+  >
+> {
+  return extractDatabaseAt(
+    input,
+    AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY,
+    AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_COPY_MARKER,
+    heldLock,
+  );
+}
+
+async function extractDatabaseAt<Directory extends DatabaseDirectory>(
+  input: Readonly<AgentBackupRestoreV3CandidateDatabaseInput>,
+  outputDirectory: Directory,
+  finishMarker: string,
+  heldLock?: AgentBackupRestoreV3CandidateFsLock,
+): Promise<
+  Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt<Directory>>
+> {
   const exact = snapshotOwnDataRecord(
     input,
     ["candidateFs", "session", "receipt", "control"],
@@ -153,13 +197,14 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
   const control = snapshotOperationControl(
     exact.control as AgentBackupRestoreV3OperationControl,
   );
-  const lock = await candidateFs.acquireLock(
-    ".restore-v3-materialize-c1.lock",
-    control,
-  );
+  const lock =
+    heldLock ??
+    (await candidateFs.acquireLock(".restore-v3-materialize-c1.lock", control));
   let primaryFailure: unknown;
   let result:
-    | Readonly<AgentBackupRestoreV3CandidateDatabaseExtractionReceipt>
+    | Readonly<
+        AgentBackupRestoreV3CandidateDatabaseExtractionReceipt<Directory>
+      >
     | undefined;
   try {
     const sessionSha256 = await bindAgentBackupRestoreV3CandidateRecordSession({
@@ -306,11 +351,7 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
     }
     let extractionFailure: unknown;
     try {
-      await candidateFs.ensureFileTreeDirectory(
-        OUTPUT_DIRECTORY,
-        control,
-        lock,
-      );
+      await candidateFs.ensureFileTreeDirectory(outputDirectory, control, lock);
       const extracted = await readAgentBackupRestoreV3PgliteArchive({
         tar: decodedTar(),
         control,
@@ -325,7 +366,7 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
         visit: async (entry, consume) => {
           if (entry.type === "directory") {
             await candidateFs.ensureFileTreeDirectory(
-              `${OUTPUT_DIRECTORY}/${entry.path}`,
+              `${outputDirectory}/${entry.path}`,
               control,
               lock,
             );
@@ -333,7 +374,7 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
             return;
           }
           const writer = await candidateFs.createFileTreeFile(
-            OUTPUT_DIRECTORY,
+            outputDirectory,
             {
               path: entry.path,
               sizeBytes: entry.sizeBytes,
@@ -369,7 +410,7 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
           "Database extraction has no terminal record receipt",
         );
       const tree = await candidateFs.proveTree(
-        OUTPUT_DIRECTORY,
+        outputDirectory,
         undefined,
         control,
         lock,
@@ -389,7 +430,7 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
           "elizaos.agent-backup.restore-v3-database-extracted.v1" as const,
         sessionSha256,
         component,
-        outputDirectory: OUTPUT_DIRECTORY as typeof OUTPUT_DIRECTORY,
+        outputDirectory,
         lastRecordReceiptSha256,
         tree,
       };
@@ -400,14 +441,14 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
           .digest("hex"),
       });
       await candidateFs.publishDurableJson(
-        FINISH_MARKER,
+        finishMarker,
         finish,
         { maximumBytes: FINISH_MAXIMUM_BYTES },
         control,
         lock,
       );
       const persisted = await candidateFs.readDurableJson(
-        FINISH_MARKER,
+        finishMarker,
         { maximumBytes: FINISH_MAXIMUM_BYTES },
         control,
         lock,
@@ -437,7 +478,7 @@ export async function extractAgentBackupRestoreV3CandidateDatabase(input: {
     primaryFailure = cause;
   }
   try {
-    await lock.release(internalCleanupControl());
+    if (!heldLock) await lock.release(internalCleanupControl());
   } catch (cause) {
     // error-policy:J2 Both failures remain inspectable; neither becomes success.
     if (primaryFailure !== undefined)

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-file-set.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-file-set.ts
@@ -543,6 +543,7 @@ async function validatePersistedFinish(
 async function materializeCopiedFileSet(
   input: MaterializeAgentBackupRestoreV3CandidateFileSetInput,
   component: Readonly<AgentBackupRestoreV3ComponentReceipt>,
+  heldLock?: AgentBackupRestoreV3CandidateFsLock,
 ): Promise<Readonly<AgentBackupRestoreV3CandidateFileSetReceipt>> {
   const limits = snapshotLimits(input.limits);
   const policy =
@@ -628,10 +629,12 @@ async function materializeCopiedFileSet(
   };
 
   try {
-    lock = await input.candidateFs.acquireLock(
-      `.restore-v3-materialize-c${component.componentIndex}.lock`,
-      input.control,
-    );
+    lock =
+      heldLock ??
+      (await input.candidateFs.acquireLock(
+        `.restore-v3-materialize-c${component.componentIndex}.lock`,
+        input.control,
+      ));
     const boundSessionSha256 =
       await bindAgentBackupRestoreV3CandidateRecordSession({
         candidateFs: input.candidateFs,
@@ -845,7 +848,7 @@ async function materializeCopiedFileSet(
       cleanupFailures.push(cause);
     }
   }
-  if (lock) {
+  if (lock && !heldLock) {
     try {
       await lock.release(input.control);
     } catch (cause) {
@@ -874,6 +877,7 @@ async function materializeCopiedFileSet(
 /** Snapshots the authenticated receipt synchronously, then replays its inbox. */
 export function materializeAgentBackupRestoreV3CandidateFileSet(
   input: Readonly<MaterializeAgentBackupRestoreV3CandidateFileSetInput>,
+  heldLock?: AgentBackupRestoreV3CandidateFsLock,
 ): Promise<Readonly<AgentBackupRestoreV3CandidateFileSetReceipt>> {
   const exactInput = snapshotPlainDataRecord(
     input,
@@ -914,5 +918,6 @@ export function materializeAgentBackupRestoreV3CandidateFileSet(
       testOnlyLifecycle,
     }),
     receipt,
+    heldLock,
   );
 }

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-fs-control.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-fs-control.ts
@@ -964,6 +964,7 @@ export async function writeAll(
 }
 
 interface KernelLockLease {
+  readonly descriptor: number;
   readonly release: () => Promise<void>;
 }
 
@@ -1089,6 +1090,16 @@ export class AgentBackupRestoreV3CandidateFsLock {
     return this.#state === "active";
   }
 
+  inheritedDescriptor(authority: symbol): number {
+    if (authority !== LOCK_USE_AUTHORITY || this.#state !== "active") {
+      candidateFsError(
+        "AGENT_BACKUP_RESTORE_V3_CANDIDATE_FS_LOCK_INVALID",
+        "Candidate lock descriptor is unavailable",
+      );
+    }
+    return this.#lease.descriptor;
+  }
+
   acquireUse(authority: symbol): () => void {
     if (authority !== LOCK_USE_AUTHORITY || this.#state !== "active") {
       candidateFsError(
@@ -1146,6 +1157,20 @@ export class AgentBackupRestoreV3CandidateFsControl {
   #closePromise: Promise<void> | null = null;
   #pendingLockAcquisitions = 0;
   #lockAcquisitionDrainWaiters: Array<() => void> = [];
+
+  async withInheritedLockDescriptor<T>(
+    lock: AgentBackupRestoreV3CandidateFsLock,
+    operation: (descriptor: number) => Promise<T>,
+    control: Readonly<AgentBackupRestoreV3OperationControl>,
+  ): Promise<T> {
+    const releaseUse = this.beginLockUse(lock);
+    try {
+      await this.assertLockHeld(lock, control);
+      return await operation(lock.inheritedDescriptor(LOCK_USE_AUTHORITY));
+    } finally {
+      releaseUse();
+    }
+  }
 
   private constructor(input: {
     trustedAuthority: CandidateFsDirectoryAuthority;
@@ -1447,6 +1472,7 @@ export class AgentBackupRestoreV3CandidateFsControl {
       }
       setAdd(TEST_PLATFORM_LOCKS, key);
       lease = OBJECT_FREEZE({
+        descriptor: this.#attemptAuthority.handle.fd,
         release: async () => {
           setDelete(TEST_PLATFORM_LOCKS, key);
         },
@@ -1465,10 +1491,12 @@ export class AgentBackupRestoreV3CandidateFsControl {
         "/bin/sh",
         [
           "-c",
-          "command -v flock >/dev/null 2>&1 || exit 74; flock --exclusive --nonblock 3 || exit 73; printf 1; exec sleep 2147483647",
+          "command -v flock >/dev/null 2>&1 || exit 74; flock --exclusive --nonblock 3 || exit 73; printf 1; exec cat >/dev/null",
         ],
         {
-          stdio: ["ignore", "pipe", "ignore", lockHandle.fd],
+          // EOF releases an orphan helper after parent death. Descendants that
+          // can mutate quarantine inherit this same open-file-description lock.
+          stdio: ["pipe", "pipe", "ignore", lockHandle.fd],
         },
       );
       try {
@@ -1490,6 +1518,7 @@ export class AgentBackupRestoreV3CandidateFsControl {
         throw cause;
       }
       lease = OBJECT_FREEZE({
+        descriptor: lockHandle.fd,
         release: async () => {
           let processFailure: unknown;
           try {

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-fs.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-fs.test.ts
@@ -6,6 +6,7 @@
 
 import { spawnSync } from "node:child_process";
 import { createHash, Hash } from "node:crypto";
+import { fstatSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -139,6 +140,62 @@ afterEach(async () => {
 });
 
 describe("restore-v3 candidate filesystem", () => {
+  it("retains the inode lock until its inherited-descriptor consumer settles", async () => {
+    const { candidate } = await fixture();
+    const control = operationControl();
+    const lock = await candidate.acquireLock(
+      ".restore-v3-child-test.lock",
+      control,
+    );
+    let enter: () => void = () => {
+      throw new Error("entry promise was not initialized");
+    };
+    let finish: () => void = () => {
+      throw new Error("finish promise was not initialized");
+    };
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve;
+    });
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const running = candidate.withInheritedLockDescriptor(
+      lock,
+      async (descriptor) => {
+        const root = fstatSync(descriptor, { bigint: true });
+        expect(root.isDirectory()).toBe(true);
+        expect(root.ino.toString()).toBe(candidate.attemptRootIdentity.inode);
+        enter();
+        await finished;
+      },
+      control,
+    );
+    await entered;
+    let released = false;
+    const release = lock.release(control).then(() => {
+      released = true;
+    });
+    await Promise.resolve();
+    expect(released).toBe(false);
+    finish();
+    await running;
+    await release;
+    expect(released).toBe(true);
+    await expect(
+      candidate.withInheritedLockDescriptor(
+        lock,
+        async () => {
+          throw new Error("released descriptor escaped");
+        },
+        control,
+      ),
+    ).rejects.toThrow();
+    const next = await candidate.acquireLock(
+      ".restore-v3-next-child-test.lock",
+      control,
+    );
+    await next.release(control);
+  });
   it("fails closed off Linux unless the explicit test emulation is enabled", async () => {
     if (process.platform === "linux") return;
     const trustedRoot = await privateTemporaryRoot(

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-fs.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-fs.ts
@@ -168,6 +168,23 @@ export class AgentBackupRestoreV3CandidateFs {
     );
   }
 
+  /**
+   * Trusted subprocess consumers may inherit, never close, this descriptor.
+   * The callback must reap every child before settling; lock release waits for
+   * it, and the kernel lock survives parent death until inherited FDs close.
+   */
+  withInheritedLockDescriptor<T>(
+    lock: AgentBackupRestoreV3CandidateFsLock,
+    operation: (descriptor: number) => Promise<T>,
+    control: Readonly<AgentBackupRestoreV3OperationControl>,
+  ): Promise<T> {
+    return this.#control.withInheritedLockDescriptor(
+      lock,
+      operation,
+      snapshotOperationControl(control),
+    );
+  }
+
   async acquireLock(
     name: string,
     control: Readonly<AgentBackupRestoreV3OperationControl>,

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-materializer.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-materializer.ts
@@ -1,0 +1,73 @@
+/**
+ * Agent implementation of the coordinator's record/materialization effects.
+ * Only the trusted, authority-locked coordinator transport may invoke it; this
+ * capability does not authenticate an HTTP caller or issue a seal/boot grant.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import {
+  AgentBackupRestoreV3ComponentReceiptSchema,
+  type AgentBackupRestoreV3IsolatedCandidateStaging,
+} from "@elizaos/shared";
+import { materializeAgentBackupRestoreV3CandidateCharacter } from "./agent-backup-restore-v3-candidate-character";
+import { validateAgentBackupRestoreV3CandidateDatabase } from "./agent-backup-restore-v3-candidate-database-validation";
+import { materializeAgentBackupRestoreV3CandidateFileSet } from "./agent-backup-restore-v3-candidate-file-set";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  isAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import { snapshotOperationControl } from "./agent-backup-restore-v3-candidate-fs-control";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+import {
+  snapshotAgentBackupRestoreV3CandidateSession,
+  stageAgentBackupRestoreV3CandidateRecord,
+} from "./agent-backup-restore-v3-candidate-records";
+
+export function createAgentBackupRestoreV3CandidateMaterializer(
+  candidateFs: AgentBackupRestoreV3CandidateFs,
+): Pick<
+  AgentBackupRestoreV3IsolatedCandidateStaging,
+  "stageRecord" | "finishComponent"
+> {
+  if (!isAgentBackupRestoreV3CandidateFs(candidateFs))
+    throw new ElizaError(
+      "Agent materialization requires real quarantine filesystem authority",
+      {
+        code: "AGENT_BACKUP_RESTORE_V3_MATERIALIZER_INPUT_INVALID",
+        severity: "fatal",
+      },
+    );
+  return Object.freeze({
+    async stageRecord(session, record, control) {
+      const result = await stageAgentBackupRestoreV3CandidateRecord({
+        candidateFs,
+        session,
+        record,
+        control,
+      });
+      return result.record;
+    },
+    async finishComponent(session, receipt, control) {
+      const component = AgentBackupRestoreV3ComponentReceiptSchema.parse(
+        JSON.parse(candidateFsCanonicalJson(receipt)),
+      );
+      Object.freeze(component.descriptor);
+      Object.freeze(component);
+      const input = {
+        candidateFs,
+        session: snapshotAgentBackupRestoreV3CandidateSession(session),
+        receipt: component,
+        control: snapshotOperationControl(control),
+      };
+      if (component.componentName === "character")
+        return (await materializeAgentBackupRestoreV3CandidateCharacter(input))
+          .component;
+      if (component.componentName === "database") {
+        await validateAgentBackupRestoreV3CandidateDatabase(input);
+        return component;
+      }
+      return (await materializeAgentBackupRestoreV3CandidateFileSet(input))
+        .component;
+    },
+  });
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-materializer.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-materializer.ts
@@ -6,9 +6,14 @@
 
 import { ElizaError } from "@elizaos/core";
 import {
+  type AgentBackupRestoreV3CandidateReceipt,
   AgentBackupRestoreV3ComponentReceiptSchema,
   type AgentBackupRestoreV3IsolatedCandidateStaging,
+  type AgentBackupRestoreV3OperationControl,
+  type AgentBackupRestoreV3StagingSession,
+  parseAgentBackupRestoreV3CandidateReceipt,
 } from "@elizaos/shared";
+import { assembleAgentBackupRestoreV3Candidate } from "./agent-backup-restore-v3-candidate-assembly";
 import { materializeAgentBackupRestoreV3CandidateCharacter } from "./agent-backup-restore-v3-candidate-character";
 import { validateAgentBackupRestoreV3CandidateDatabase } from "./agent-backup-restore-v3-candidate-database-validation";
 import { materializeAgentBackupRestoreV3CandidateFileSet } from "./agent-backup-restore-v3-candidate-file-set";
@@ -23,12 +28,21 @@ import {
   stageAgentBackupRestoreV3CandidateRecord,
 } from "./agent-backup-restore-v3-candidate-records";
 
+export interface AgentBackupRestoreV3CandidateMaterializer
+  extends Pick<
+    AgentBackupRestoreV3IsolatedCandidateStaging,
+    "stageRecord" | "finishComponent"
+  > {
+  assembleCandidate(
+    session: Readonly<AgentBackupRestoreV3StagingSession>,
+    receipt: Readonly<AgentBackupRestoreV3CandidateReceipt>,
+    control: Readonly<AgentBackupRestoreV3OperationControl>,
+  ): Promise<AgentBackupRestoreV3CandidateReceipt>;
+}
+
 export function createAgentBackupRestoreV3CandidateMaterializer(
   candidateFs: AgentBackupRestoreV3CandidateFs,
-): Pick<
-  AgentBackupRestoreV3IsolatedCandidateStaging,
-  "stageRecord" | "finishComponent"
-> {
+): AgentBackupRestoreV3CandidateMaterializer {
   if (!isAgentBackupRestoreV3CandidateFs(candidateFs))
     throw new ElizaError(
       "Agent materialization requires real quarantine filesystem authority",
@@ -37,7 +51,19 @@ export function createAgentBackupRestoreV3CandidateMaterializer(
         severity: "fatal",
       },
     );
-  return Object.freeze({
+  const materializer: AgentBackupRestoreV3CandidateMaterializer = {
+    async assembleCandidate(session, receipt, control) {
+      const candidate = parseAgentBackupRestoreV3CandidateReceipt(
+        JSON.parse(candidateFsCanonicalJson(receipt)),
+      );
+      await assembleAgentBackupRestoreV3Candidate({
+        candidateFs,
+        session,
+        receipt: candidate,
+        control,
+      });
+      return candidate;
+    },
     async stageRecord(session, record, control) {
       const result = await stageAgentBackupRestoreV3CandidateRecord({
         candidateFs,
@@ -69,5 +95,6 @@ export function createAgentBackupRestoreV3CandidateMaterializer(
       return (await materializeAgentBackupRestoreV3CandidateFileSet(input))
         .component;
     },
-  });
+  };
+  return Object.freeze(materializer);
 }

--- a/packages/agent/src/services/agent-backup-restore-v3-candidate-records.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-candidate-records.ts
@@ -832,7 +832,8 @@ function snapshotRecordControl(
   return snapshot;
 }
 
-function snapshotRecord(
+/** Caller owns the intrinsic payload copy and must zero it after its effect settles. */
+export function snapshotAgentBackupRestoreV3CandidateRecord(
   input: Readonly<AgentBackupRestoreV3StagedRecord>,
   control: Readonly<AgentBackupRestoreV3OperationControl>,
 ): CopiedRecord {
@@ -1844,7 +1845,7 @@ export function stageAgentBackupRestoreV3CandidateRecord(
   const session = snapshotSession(
     exactInput.session as Readonly<AgentBackupRestoreV3StagingSession>,
   );
-  const copied = snapshotRecord(
+  const copied = snapshotAgentBackupRestoreV3CandidateRecord(
     exactInput.record as Readonly<AgentBackupRestoreV3StagedRecord>,
     control,
   );

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-docker.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-docker.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Opt-in native Linux proof for the actual Docker exec stdin boundary.
+ * Uses the built Agent worker in an exact-ID, networkless throwaway container;
+ * only test-owned tmpfs state is writable. Requires a completed package build
+ * and AGENT_RESTORE_V3_DOCKER_TESTS=1; never substitutes pathname emulation.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
+  type AgentBackupRestoreV3ComponentReceipt,
+  type AgentBackupRestoreV3StagedRecord,
+} from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+import { snapshotAgentBackupRestoreV3CandidateRecord } from "./agent-backup-restore-v3-candidate-records";
+import { materializerReceiptDigest } from "./agent-backup-restore-v3-materializer-wire";
+
+const enabled = process.env.AGENT_RESTORE_V3_DOCKER_TESTS === "1";
+const repo = fileURLToPath(new URL("../../../..", import.meta.url));
+const worker =
+  "/repo/packages/agent/dist/services/agent-backup-restore-v3-materializer-worker.js";
+const validator =
+  "/repo/packages/agent/dist/services/agent-backup-restore-v3-pglite-validation-worker.js";
+const containers = new Set<string>();
+const roots = new Set<string>();
+const exchanges = new Set<{
+  disconnect: () => void;
+  result: Promise<{ code: number | null; stdout: string; stderr: string }>;
+}>();
+const control = () => ({
+  signal: new AbortController().signal,
+  deadlineEpochMs: Date.now() + 90_000,
+});
+const hash = (bytes: Uint8Array) =>
+  createHash("sha256").update(bytes).digest("hex");
+
+function docker(...args: string[]): string {
+  return execFileSync("docker", args, { encoding: "utf8", timeout: 15_000 });
+}
+function remote(id: string, source: string): string {
+  return docker(
+    "exec",
+    id,
+    "env",
+    "-i",
+    "/usr/local/bin/node",
+    "--input-type=module",
+    "-e",
+    source,
+  );
+}
+
+async function fixture() {
+  await fs.access(
+    path.join(
+      repo,
+      "packages/agent/dist/services/agent-backup-restore-v3-materializer-worker.js",
+    ),
+  );
+  const image = docker(
+    "image",
+    "inspect",
+    "node:24.15.0-alpine",
+    "--format",
+    "{{.Id}}",
+  ).trim();
+  if (!/^sha256:[0-9a-f]{64}$/.test(image))
+    throw new Error("Expected one local image ID");
+  const id = docker(
+    "create",
+    "--name",
+    `restore-stdio-${randomUUID()}`,
+    "--network",
+    "none",
+    "--restart",
+    "no",
+    "--read-only",
+    "--tmpfs",
+    "/restore:rw,nosuid,nodev,mode=0700,size=256m",
+    "--mount",
+    `type=bind,source=${repo},target=/repo,readonly`,
+    "--entrypoint",
+    "/bin/sleep",
+    image,
+    "infinity",
+  ).trim();
+  if (!/^[0-9a-f]{64}$/.test(id))
+    throw new Error("Expected one full Docker container ID");
+  containers.add(id);
+  docker("start", id);
+  const identity = JSON.parse(
+    remote(
+      id,
+      `import fs from "node:fs/promises";
+    await fs.mkdir("/restore/attempt", {mode:0o700});
+    const identity = async p => {const s=await fs.stat(p,{bigint:true});return {device:String(s.dev),inode:String(s.ino)}};
+    process.stdout.write(JSON.stringify({trustedRootIdentity:await identity("/restore"),attemptRootIdentity:await identity("/restore/attempt")}));`,
+    ),
+  );
+  const session = {
+    restoreAttemptId: randomUUID(),
+    operationId: randomUUID(),
+    expectedManifestSha256: "a".repeat(64),
+    stagingHandle: randomUUID(),
+    cleanupHandle: randomUUID(),
+    executionToken: randomUUID(),
+    cleanupRegistered: true,
+    isolatedCandidate: true,
+  };
+  const authority = {
+    version: 2,
+    trustedRoot: "/restore",
+    attemptRoot: "/restore/attempt",
+    ...identity,
+    session,
+  };
+  const exchange = (
+    method: string,
+    receipt: unknown,
+    payload: Uint8Array = new Uint8Array(),
+    endInput = false,
+  ) => {
+    const metadata = Buffer.from(
+      candidateFsCanonicalJson({
+        ...authority,
+        deadlineEpochMs: control().deadlineEpochMs,
+        method,
+        receipt,
+      }),
+    );
+    const prefix = Buffer.alloc(4);
+    prefix.writeUInt32BE(metadata.length);
+    const child = spawn(
+      "docker",
+      ["exec", "-i", id, "env", "-i", "/usr/local/bin/node", worker],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const done = new Promise<{
+      code: number | null;
+      stdout: string;
+      stderr: string;
+    }>((resolve, reject) => {
+      child.on("error", reject);
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+        chunk.fill(0);
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+        chunk.fill(0);
+      });
+      child.stdin.on("error", () => {
+        /* error-policy:J5 The failed exec exit is observed through done. */
+      });
+      child.once("close", (code) => {
+        settled = true;
+        resolve({ code, stdout, stderr });
+      });
+    });
+    child.stdin.write(prefix);
+    child.stdin.write(metadata);
+    child.stdin.write(payload);
+    if (endInput) child.stdin.end();
+    const timer = setTimeout(() => child.stdin.destroy(), 90_000);
+    const result = done.finally(() => {
+      clearTimeout(timer);
+      child.stdin.destroy();
+      metadata.fill(0);
+      prefix.fill(0);
+    });
+    const active = {
+      result,
+      disconnect: () => child.stdin.destroy(),
+      loseClient: () => child.kill("SIGKILL"),
+      settled: () => settled,
+    };
+    exchanges.add(active);
+    return active;
+  };
+  const stage = async (record: AgentBackupRestoreV3StagedRecord) => {
+    const copy = snapshotAgentBackupRestoreV3CandidateRecord(record, control());
+    try {
+      const result = await exchange("stageRecord", copy.receipt, copy.payload)
+        .result;
+      expect(result).toEqual({
+        code: 0,
+        stdout: materializerReceiptDigest(copy.receipt),
+        stderr: "",
+      });
+      return copy.receipt;
+    } finally {
+      copy.payload.fill(0);
+    }
+  };
+  return { id, stage, exchange, session };
+}
+
+afterEach(async () => {
+  for (const exchange of exchanges) exchange.disconnect();
+  await Promise.allSettled([...exchanges].map((exchange) => exchange.result));
+  exchanges.clear();
+  for (const id of containers) docker("rm", "--force", id);
+  containers.clear();
+  for (const root of roots) await fs.rm(root, { recursive: true, force: true });
+  roots.clear();
+});
+
+// Explicit Docker lane: ordinary unit runs must not create containers or pull images.
+describe.skipIf(!enabled)("native Docker restore worker stdio", () => {
+  it("materializes exact bytes through exec without inherited descriptors, network or runtime boot", async () => {
+    const f = await fixture();
+    const payload = new TextEncoder().encode(
+      '{"name":"Docker restore QA","bio":["amber"],"plugins":[]}',
+    );
+    const record = {
+      componentIndex: 0,
+      componentName: "character" as const,
+      dataIndex: 0,
+      offsetBytes: 0,
+      entry: null,
+      payload,
+    };
+    const staged = await f.stage(record);
+    const receipt: AgentBackupRestoreV3ComponentReceipt = {
+      componentIndex: 0,
+      componentName: "character",
+      descriptor: AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS[0],
+      dataFrameCount: 1,
+      payloadBytes: payload.length,
+      payloadSha256: staged.payloadSha256,
+      recordStreamContentHmacSha256: "b".repeat(64),
+    };
+    expect(await f.exchange("finishComponent", receipt).result).toEqual({
+      code: 0,
+      stdout: materializerReceiptDigest(receipt),
+      stderr: "",
+    });
+    expect(
+      remote(
+        f.id,
+        'import fs from "node:fs/promises";process.stdout.write(await fs.readFile("/restore/attempt/components/character/character.json","utf8"));',
+      ),
+    ).toBe(new TextDecoder().decode(payload));
+    expect(
+      docker(
+        "inspect",
+        f.id,
+        "--format",
+        "{{.HostConfig.NetworkMode}}|{{json .HostConfig.PortBindings}}|{{.Path}}|{{.State.Running}}",
+      ).trim(),
+    ).toMatch(/^none\|(?:null|\{\})\|\/bin\/sleep\|true$/);
+    expect(await f.stage(record)).toEqual(staged);
+  }, 90_000);
+
+  it("treats EOF after a complete frame as cancellation, not a request terminator", async () => {
+    const f = await fixture();
+    const record = snapshotAgentBackupRestoreV3CandidateRecord(
+      {
+        componentIndex: 0,
+        componentName: "character",
+        dataIndex: 0,
+        offsetBytes: 0,
+        entry: null,
+        payload: new TextEncoder().encode('{"name":"Cancelled"}'),
+      },
+      control(),
+    );
+    try {
+      const result = await f.exchange(
+        "stageRecord",
+        record.receipt,
+        record.payload,
+        true,
+      ).result;
+      expect(result.code).not.toBe(0);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+      expect(
+        remote(
+          f.id,
+          'import fs from "node:fs/promises";process.stdout.write(JSON.stringify(await fs.readdir("/restore/attempt")));',
+        ),
+      ).toBe("[]");
+    } finally {
+      record.payload.fill(0);
+    }
+  }, 90_000);
+
+  it.each(["stdin EOF", "client process loss"] as const)(
+    "reaps a live native database-validation descendant on %s, then restores on exact retry",
+    async (failure) => {
+      const f = await fixture();
+      const root = await fs.mkdtemp(
+        path.join(await fs.realpath(os.tmpdir()), "restore-docker-source-"),
+      );
+      roots.add(root);
+      const db = new PGlite(path.join(root, "source"));
+      let payload: Uint8Array;
+      try {
+        await db.exec("CREATE TABLE docker_fact (value text NOT NULL)");
+        await db.query("INSERT INTO docker_fact VALUES ($1)", [
+          "amber docker lighthouse",
+        ]);
+        payload = new Uint8Array(
+          await (await db.dumpDataDir("gzip")).arrayBuffer(),
+        );
+      } finally {
+        await db.close();
+      }
+      await fs.rm(path.join(root, "source"), { recursive: true });
+      let records = 0;
+      try {
+        for (let offset = 0; offset < payload.length; offset += 256 * 1024) {
+          await f.stage({
+            componentIndex: 1,
+            componentName: "database",
+            dataIndex: records++,
+            offsetBytes: offset,
+            entry: null,
+            payload: payload.subarray(offset, offset + 256 * 1024),
+          });
+        }
+        const receipt: AgentBackupRestoreV3ComponentReceipt = {
+          componentIndex: 1,
+          componentName: "database",
+          descriptor: AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS[1],
+          dataFrameCount: records,
+          payloadBytes: payload.length,
+          payloadSha256: hash(payload),
+          recordStreamContentHmacSha256: "b".repeat(64),
+        };
+        const running = f.exchange("finishComponent", receipt);
+        const scan = `import fs from "node:fs/promises"; const matches=[];
+        for (const pid of await fs.readdir("/proc")) {if (!/^[0-9]+$/.test(pid)) continue;
+          try {const args=(await fs.readFile("/proc/"+pid+"/cmdline","utf8")).split("\\0");
+            if(args[1]===${JSON.stringify(validator)}) matches.push(pid);
+          } catch(error) { // error-policy:J4 A process exiting during enumeration is visibly absent.
+            if(error.code!=="ENOENT"&&error.code!=="ESRCH") throw error;}}
+        process.stdout.write(JSON.stringify(matches));`;
+        let descendants: string[] = [];
+        const deadline = Date.now() + 30_000;
+        while (Date.now() < deadline && !running.settled()) {
+          descendants = JSON.parse(remote(f.id, scan));
+          if (descendants.length) break;
+          await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        }
+        // Observe a real live validation PID before disconnect, not just a timer.
+        expect(descendants.length).toBe(1);
+        if (failure === "stdin EOF") running.disconnect();
+        else running.loseClient();
+        const cancelled = await running.result;
+        expect(cancelled.code).not.toBe(0);
+        expect(cancelled.stdout).toBe("");
+        expect(cancelled.stderr).toBe("");
+        // A killed Docker CLI cannot attest remote settlement through its exit.
+        // Observe the remote worker and validator, not just the local client PID.
+        const scanWorkers = scan.replace(
+          JSON.stringify(validator),
+          JSON.stringify(worker),
+        );
+        const cleanupDeadline = Date.now() + 10_000;
+        let remainingWorkers: string[];
+        do {
+          remainingWorkers = JSON.parse(remote(f.id, scanWorkers));
+          if (!remainingWorkers.length) break;
+          await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        } while (Date.now() < cleanupDeadline);
+        expect(remainingWorkers).toEqual([]);
+        expect(JSON.parse(remote(f.id, scan))).toEqual([]);
+        expect(
+          remote(
+            f.id,
+            'import fs from "node:fs";process.stdout.write(String(fs.existsSync("/restore/attempt/.restore-v3-database-validation")));',
+          ),
+        ).toBe("false");
+        expect(await f.exchange("finishComponent", receipt).result).toEqual({
+          code: 0,
+          stdout: materializerReceiptDigest(receipt),
+          stderr: "",
+        });
+        expect(
+          remote(
+            f.id,
+            'import fs from "node:fs/promises";import {PGlite} from "/repo/node_modules/@electric-sql/pglite/dist/index.js";await fs.cp("/restore/attempt/components/database","/restore/probe",{recursive:true});const db=new PGlite("/restore/probe");try{process.stdout.write(JSON.stringify((await db.query("SELECT value FROM docker_fact")).rows));}finally{await db.close();}',
+          ),
+        ).toBe('[{"value":"amber docker lighthouse"}]');
+      } finally {
+        payload.fill(0);
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-process.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-process.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Real process/filesystem tests of the private Agent materializer transport.
+ * macOS uses explicitly test-only pathname emulation, not a Linux flock proof.
+ * Parser tests exercise fragmented binary ingress and fail before dispatch.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import {
+  AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
+  type AgentBackupRestoreV3ComponentReceipt,
+  type AgentBackupRestoreV3StagingSession,
+} from "@elizaos/shared";
+import { afterEach, expect, it } from "vitest";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  openAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+import { snapshotAgentBackupRestoreV3CandidateRecord } from "./agent-backup-restore-v3-candidate-records";
+import { createAgentBackupRestoreV3ProcessMaterializer } from "./agent-backup-restore-v3-materializer-process";
+import {
+  MATERIALIZER_METADATA_MAX_BYTES,
+  readMaterializerRequest,
+} from "./agent-backup-restore-v3-materializer-wire";
+
+const roots = new Set<string>();
+const candidates = new Set<AgentBackupRestoreV3CandidateFs>();
+const control = () => ({
+  signal: new AbortController().signal,
+  deadlineEpochMs: Date.now() + 60_000,
+});
+const options = () =>
+  process.platform === "linux"
+    ? {}
+    : { testOnlyAllowNonLinuxFdEmulation: true as const };
+const hash = (bytes: Uint8Array) =>
+  createHash("sha256").update(bytes).digest("hex");
+
+async function fixture() {
+  const root = await fs.mkdtemp(
+    path.join(await fs.realpath(os.tmpdir()), "restore-process-"),
+  );
+  roots.add(root);
+  await fs.chmod(root, 0o700);
+  const attemptRoot = path.join(root, "attempt");
+  await fs.mkdir(attemptRoot, { mode: 0o700 });
+  const candidateFs = await openAgentBackupRestoreV3CandidateFs({
+    trustedRoot: root,
+    attemptRoot,
+    control: control(),
+    ...options(),
+  });
+  candidates.add(candidateFs);
+  const session: AgentBackupRestoreV3StagingSession = {
+    restoreAttemptId: randomUUID(),
+    operationId: randomUUID(),
+    expectedManifestSha256: "a".repeat(64),
+    stagingHandle: randomUUID(),
+    cleanupHandle: randomUUID(),
+    executionToken: randomUUID(),
+    cleanupRegistered: true,
+    isolatedCandidate: true,
+  };
+  const payload = new TextEncoder().encode(
+    '{"name":"Transport QA","bio":["private fact"],"plugins":[]}',
+  );
+  const record = {
+    componentIndex: 0,
+    componentName: "character" as const,
+    dataIndex: 0,
+    offsetBytes: 0,
+    entry: null,
+    payload,
+  };
+  const descriptor = AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS[0];
+  if (!descriptor) throw new Error("Missing character descriptor");
+  const receipt: AgentBackupRestoreV3ComponentReceipt = {
+    componentIndex: 0,
+    componentName: "character",
+    descriptor,
+    dataFrameCount: 1,
+    payloadBytes: payload.length,
+    payloadSha256: hash(payload),
+    recordStreamContentHmacSha256: "b".repeat(64),
+  };
+  const snapshot = snapshotAgentBackupRestoreV3CandidateRecord(
+    record,
+    control(),
+  );
+  snapshot.payload.fill(0);
+  const request = {
+    version: 1,
+    trustedRoot: root,
+    attemptRoot,
+    trustedRootIdentity: candidateFs.trustedRootIdentity,
+    attemptRootIdentity: candidateFs.attemptRootIdentity,
+    session,
+    deadlineEpochMs: control().deadlineEpochMs,
+    method: "stageRecord",
+    receipt: snapshot.receipt,
+  };
+  const metadata = Buffer.from(candidateFsCanonicalJson(request));
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32BE(metadata.length);
+  return {
+    root,
+    attemptRoot,
+    candidateFs,
+    session,
+    record,
+    receipt,
+    request,
+    wire: Buffer.concat([prefix, metadata, payload]),
+    materializer: createAgentBackupRestoreV3ProcessMaterializer({
+      candidateFs,
+      ...options(),
+    }),
+  };
+}
+
+afterEach(async () => {
+  for (const candidate of candidates) await candidate.close();
+  candidates.clear();
+  for (const root of roots) await fs.rm(root, { recursive: true, force: true });
+  roots.clear();
+});
+
+it("snapshots caller bytes and authority, replays in another process, and rejects a conflicting session", async () => {
+  const f = await fixture();
+  const expected = Uint8Array.from(f.record.payload);
+  const session = { ...f.session };
+  const sent = f.materializer.stageRecord(session, f.record, control());
+  f.record.payload.fill(0);
+  session.executionToken = randomUUID();
+  const ack = await sent;
+  expect(ack.payloadSha256).toBe(hash(expected));
+  expect(
+    await f.materializer.stageRecord(
+      f.session,
+      { ...f.record, payload: expected },
+      control(),
+    ),
+  ).toEqual(ack);
+  await expect(
+    f.materializer.stageRecord(
+      session,
+      { ...f.record, payload: expected },
+      control(),
+    ),
+  ).rejects.toMatchObject({
+    code: "AGENT_BACKUP_RESTORE_V3_MATERIALIZER_RECEIPT_UNPROVEN",
+  });
+  await f.materializer.finishComponent(f.session, f.receipt, control());
+  const filename = path.join(
+    f.attemptRoot,
+    "components/character/character.json",
+  );
+  const before = await fs.stat(filename, { bigint: true });
+  expect(await fs.readFile(filename)).toEqual(Buffer.from(expected));
+  await f.materializer.finishComponent(f.session, f.receipt, control());
+  expect((await fs.stat(filename, { bigint: true })).ino).toBe(before.ino);
+}, 60_000);
+
+it("joins a cancelled worker and permits exact retry without a late writer", async () => {
+  const f = await fixture();
+  const abort = new AbortController();
+  const pending = f.materializer.stageRecord(f.session, f.record, {
+    ...control(),
+    signal: abort.signal,
+  });
+  // Let the adapter's authority checks and actual child spawn run first.
+  await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  abort.abort();
+  await expect(pending).rejects.toThrow();
+  await f.materializer.stageRecord(f.session, f.record, control());
+  await f.materializer.finishComponent(f.session, f.receipt, control());
+  expect(
+    await fs.readFile(
+      path.join(f.attemptRoot, "components/character/character.json"),
+    ),
+  ).toEqual(Buffer.from(f.record.payload));
+}, 60_000);
+
+it("refuses a replaced root before it can mutate either occurrence", async () => {
+  const f = await fixture();
+  const old = path.join(f.root, "old-attempt");
+  await fs.rename(f.attemptRoot, old);
+  await fs.mkdir(f.attemptRoot, { mode: 0o700 });
+  await expect(
+    f.materializer.stageRecord(f.session, f.record, control()),
+  ).rejects.toThrow();
+  expect(await fs.readdir(f.attemptRoot)).toEqual([]);
+  expect(await fs.readdir(old)).toEqual([]);
+});
+
+it("losslessly reads byte-fragmented binary ingress and zeroes transport buffers", async () => {
+  const f = await fixture();
+  const chunks = Array.from(f.wire, (byte) => Buffer.from([byte]));
+  const parsed = await readMaterializerRequest(Readable.from(chunks));
+  expect(parsed.request).toEqual(f.request);
+  expect(parsed.payload).toEqual(f.record.payload);
+  expect(chunks.every((chunk) => chunk[0] === 0)).toBe(true);
+  parsed.payload.fill(0);
+});
+
+it.each(["oversize", "truncated", "trailing", "tampered"] as const)(
+  "rejects %s ingress without filesystem effects or exposed input",
+  async (kind) => {
+    const f = await fixture();
+    let bytes = Buffer.from(f.wire);
+    if (kind === "oversize")
+      bytes.writeUInt32BE(MATERIALIZER_METADATA_MAX_BYTES + 1);
+    if (kind === "truncated") bytes = bytes.subarray(0, bytes.length - 1);
+    if (kind === "trailing") bytes = Buffer.concat([bytes, Buffer.from([1])]);
+    if (kind === "tampered") bytes[bytes.length - 1] ^= 1;
+    await expect(
+      readMaterializerRequest(Readable.from([bytes])),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_MATERIALIZER_INPUT_INVALID",
+      message: "Quarantined Agent materialization did not complete",
+    });
+    expect(bytes.every((byte) => byte === 0)).toBe(true);
+    expect(await fs.readdir(f.attemptRoot)).toEqual([]);
+  },
+);

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-process.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-process.test.ts
@@ -8,7 +8,7 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import {
   AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
   type AgentBackupRestoreV3ComponentReceipt,
@@ -93,7 +93,7 @@ async function fixture() {
   );
   snapshot.payload.fill(0);
   const request = {
-    version: 1,
+    version: 2,
     trustedRoot: root,
     attemptRoot,
     trustedRootIdentity: candidateFs.trustedRootIdentity,
@@ -205,6 +205,27 @@ it("losslessly reads byte-fragmented binary ingress and zeroes transport buffers
   expect(parsed.payload).toEqual(f.record.payload);
   expect(chunks.every((chunk) => chunk[0] === 0)).toBe(true);
   parsed.payload.fill(0);
+});
+
+it("returns a complete frame while preserving the open liveness stream", async () => {
+  const f = await fixture();
+  const input = new PassThrough();
+  const pending = readMaterializerRequest(input);
+  input.write(f.wire);
+  try {
+    const parsed = await pending;
+    expect(parsed.request).toEqual(f.request);
+    expect(parsed.payload).toEqual(f.record.payload);
+    expect(input.destroyed).toBe(false);
+    expect(input.readableEnded).toBe(false);
+    parsed.payload.fill(0);
+    const trailing = Buffer.from([7]);
+    input.write(trailing);
+    expect(input.read()).toEqual(trailing);
+    trailing.fill(0);
+  } finally {
+    input.destroy();
+  }
 });
 
 it.each(["oversize", "truncated", "trailing", "tampered"] as const)(

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-process.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-process.ts
@@ -45,7 +45,7 @@ export function createAgentBackupRestoreV3ProcessMaterializer(input: {
   )
     throw materializerWireError("INPUT_INVALID");
   const roots = Object.freeze({
-    version: 1 as const,
+    version: 2 as const,
     trustedRoot: candidateFs.trustedRoot,
     attemptRoot: candidateFs.attemptRoot,
     trustedRootIdentity: candidateFs.trustedRootIdentity,
@@ -177,19 +177,12 @@ async function runWorker(
       ...(emulate ? ["--test-only-non-linux-fs"] : []),
     ],
     {
-      stdio: ["pipe", "pipe", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
       // Never inherit NODE_OPTIONS, model credentials, preload hooks or vault keys.
       env: emulate ? { NODE_ENV: "test" } : {},
     },
   );
-  const liveness = child.stdio[3];
-  if (
-    !child.stdin ||
-    !child.stdout ||
-    !child.stderr ||
-    !liveness ||
-    !("end" in liveness)
-  ) {
+  if (!child.stdin || !child.stdout || !child.stderr) {
     child.kill("SIGKILL");
     await new Promise<void>((resolve) => child.once("close", () => resolve()));
     throw materializerWireError("PROCESS_FAILED");
@@ -204,7 +197,6 @@ async function runWorker(
     failure = materializerWireError(code);
     // EOF cooperatively aborts the worker, which joins its validation children.
     // Killing only the worker PID could leave a child writing after DB rollback.
-    liveness.end();
     child.stdin?.destroy();
   };
   const abort = () => interrupt("INTERRUPTED");
@@ -217,7 +209,6 @@ async function runWorker(
   );
   control.signal.addEventListener("abort", abort, { once: true });
   child.on("error", () => interrupt("PROCESS_FAILED"));
-  liveness.on("error", () => interrupt("PROCESS_FAILED"));
   child.stdin.on("error", () => interrupt("INPUT_FAILED"));
   child.stdout.on("error", () => interrupt("OUTPUT_INVALID"));
   child.stderr.on("error", () => interrupt("PROCESS_FAILED"));
@@ -239,7 +230,7 @@ async function runWorker(
     if (!failure) {
       child.stdin.write(prefix);
       child.stdin.write(metadata);
-      child.stdin.end(payload);
+      child.stdin.write(payload);
     }
     const code = await reaped;
     if (failure) throw failure;
@@ -252,7 +243,7 @@ async function runWorker(
   } finally {
     clearTimeout(timeout);
     control.signal.removeEventListener("abort", abort);
-    liveness.destroy();
+    child.stdin.destroy();
     await reaped;
     prefix.fill(0);
     output.fill(0);

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-process.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-process.ts
@@ -1,0 +1,260 @@
+/**
+ * Local process adapter for the durable coordinator's Agent materializer seam.
+ * Each call owns one private worker and one bounded raw record, snapshots its
+ * authority before yielding, and joins the worker before settling. This does
+ * not authorize remote Docker execution or start a live Agent generation.
+ */
+
+import { Buffer } from "node:buffer";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  AgentBackupRestoreV3ComponentReceiptSchema,
+  type AgentBackupRestoreV3OperationControl,
+  parseAgentBackupRestoreV3CandidateReceipt,
+} from "@elizaos/shared";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  isAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import { snapshotOperationControl } from "./agent-backup-restore-v3-candidate-fs-control";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+import type { AgentBackupRestoreV3CandidateMaterializer } from "./agent-backup-restore-v3-candidate-materializer";
+import {
+  snapshotAgentBackupRestoreV3CandidateRecord,
+  snapshotAgentBackupRestoreV3CandidateSession,
+} from "./agent-backup-restore-v3-candidate-records";
+import {
+  MATERIALIZER_METADATA_MAX_BYTES,
+  MaterializerRequestSchema,
+  materializerReceiptDigest,
+  materializerWireError,
+} from "./agent-backup-restore-v3-materializer-wire";
+
+export function createAgentBackupRestoreV3ProcessMaterializer(input: {
+  readonly candidateFs: AgentBackupRestoreV3CandidateFs;
+  readonly testOnlyAllowNonLinuxFdEmulation?: true;
+}): AgentBackupRestoreV3CandidateMaterializer {
+  const candidateFs = input.candidateFs;
+  if (!isAgentBackupRestoreV3CandidateFs(candidateFs))
+    throw materializerWireError("INPUT_INVALID");
+  const emulate = input.testOnlyAllowNonLinuxFdEmulation === true;
+  if (
+    emulate &&
+    (process.platform === "linux" || process.env.NODE_ENV !== "test")
+  )
+    throw materializerWireError("INPUT_INVALID");
+  const roots = Object.freeze({
+    version: 1 as const,
+    trustedRoot: candidateFs.trustedRoot,
+    attemptRoot: candidateFs.attemptRoot,
+    trustedRootIdentity: candidateFs.trustedRootIdentity,
+    attemptRootIdentity: candidateFs.attemptRootIdentity,
+  });
+  const execute = async (
+    metadata: Buffer,
+    payload: Uint8Array,
+    expectedDigest: string,
+    control: Readonly<AgentBackupRestoreV3OperationControl>,
+  ) => {
+    try {
+      await candidateFs.assertAuthority(control);
+      await runWorker(metadata, payload, expectedDigest, control, emulate);
+      await candidateFs.assertAuthority(control);
+    } finally {
+      metadata.fill(0);
+      payload.fill(0);
+    }
+  };
+  const encode = (value: unknown): Buffer => {
+    const validated = MaterializerRequestSchema.parse(value);
+    const metadata = Buffer.from(candidateFsCanonicalJson(validated));
+    if (metadata.length > MATERIALIZER_METADATA_MAX_BYTES) {
+      metadata.fill(0);
+      throw materializerWireError("INPUT_INVALID");
+    }
+    return metadata;
+  };
+  const materializer: AgentBackupRestoreV3CandidateMaterializer = {
+    stageRecord(sessionValue, recordValue, controlValue) {
+      const control = snapshotOperationControl(controlValue);
+      const session =
+        snapshotAgentBackupRestoreV3CandidateSession(sessionValue);
+      const { receipt, payload } = snapshotAgentBackupRestoreV3CandidateRecord(
+        recordValue,
+        control,
+      );
+      let metadata: Buffer;
+      try {
+        metadata = encode({
+          ...roots,
+          session,
+          deadlineEpochMs: control.deadlineEpochMs,
+          method: "stageRecord",
+          receipt,
+        });
+      } catch (cause) {
+        // error-policy:J2 Release the owned plaintext copy before propagating validation failure.
+        payload.fill(0);
+        throw cause;
+      }
+      return execute(
+        metadata,
+        payload,
+        materializerReceiptDigest(receipt),
+        control,
+      ).then(() => receipt);
+    },
+    finishComponent(sessionValue, receiptValue, controlValue) {
+      const control = snapshotOperationControl(controlValue);
+      const session =
+        snapshotAgentBackupRestoreV3CandidateSession(sessionValue);
+      const receipt = AgentBackupRestoreV3ComponentReceiptSchema.parse(
+        JSON.parse(candidateFsCanonicalJson(receiptValue)),
+      );
+      const metadata = encode({
+        ...roots,
+        session,
+        deadlineEpochMs: control.deadlineEpochMs,
+        method: "finishComponent",
+        receipt,
+      });
+      return execute(
+        metadata,
+        new Uint8Array(),
+        materializerReceiptDigest(receipt),
+        control,
+      ).then(() => receipt);
+    },
+    assembleCandidate(sessionValue, receiptValue, controlValue) {
+      const control = snapshotOperationControl(controlValue);
+      const session =
+        snapshotAgentBackupRestoreV3CandidateSession(sessionValue);
+      const receipt = parseAgentBackupRestoreV3CandidateReceipt(
+        JSON.parse(candidateFsCanonicalJson(receiptValue)),
+      );
+      const metadata = encode({
+        ...roots,
+        session,
+        deadlineEpochMs: control.deadlineEpochMs,
+        method: "assembleCandidate",
+        receipt,
+      });
+      return execute(
+        metadata,
+        new Uint8Array(),
+        materializerReceiptDigest(receipt),
+        control,
+      ).then(() => receipt);
+    },
+  };
+  return Object.freeze(materializer);
+}
+
+async function runWorker(
+  metadata: Buffer,
+  payload: Uint8Array,
+  expectedDigest: string,
+  control: Readonly<AgentBackupRestoreV3OperationControl>,
+  emulate: boolean,
+): Promise<void> {
+  const worker = fileURLToPath(
+    new URL(
+      import.meta.url.endsWith(".ts")
+        ? "./agent-backup-restore-v3-materializer-worker.ts"
+        : "./agent-backup-restore-v3-materializer-worker.js",
+      import.meta.url,
+    ),
+  );
+  const child = spawn(
+    process.execPath,
+    [
+      // Source checkout only; published JS uses rewritten ESM imports directly.
+      ...(worker.endsWith(".ts") && !process.versions.bun
+        ? ["--import", import.meta.resolve("tsx/esm")]
+        : []),
+      worker,
+      ...(emulate ? ["--test-only-non-linux-fs"] : []),
+    ],
+    {
+      stdio: ["pipe", "pipe", "pipe", "pipe"],
+      // Never inherit NODE_OPTIONS, model credentials, preload hooks or vault keys.
+      env: emulate ? { NODE_ENV: "test" } : {},
+    },
+  );
+  const liveness = child.stdio[3];
+  if (
+    !child.stdin ||
+    !child.stdout ||
+    !child.stderr ||
+    !liveness ||
+    !("end" in liveness)
+  ) {
+    child.kill("SIGKILL");
+    await new Promise<void>((resolve) => child.once("close", () => resolve()));
+    throw materializerWireError("PROCESS_FAILED");
+  }
+  const output = Buffer.alloc(64);
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32BE(metadata.length);
+  let outputBytes = 0;
+  let failure: Error | undefined;
+  const interrupt = (code: string) => {
+    if (failure) return;
+    failure = materializerWireError(code);
+    // EOF cooperatively aborts the worker, which joins its validation children.
+    // Killing only the worker PID could leave a child writing after DB rollback.
+    liveness.end();
+    child.stdin?.destroy();
+  };
+  const abort = () => interrupt("INTERRUPTED");
+  const timeout = setTimeout(
+    abort,
+    Math.min(2_147_483_647, Math.max(1, control.deadlineEpochMs - Date.now())),
+  );
+  const reaped = new Promise<number | null>((resolve) =>
+    child.once("close", resolve),
+  );
+  control.signal.addEventListener("abort", abort, { once: true });
+  child.on("error", () => interrupt("PROCESS_FAILED"));
+  liveness.on("error", () => interrupt("PROCESS_FAILED"));
+  child.stdin.on("error", () => interrupt("INPUT_FAILED"));
+  child.stdout.on("error", () => interrupt("OUTPUT_INVALID"));
+  child.stderr.on("error", () => interrupt("PROCESS_FAILED"));
+  child.stderr.on("data", (chunk: Buffer) => chunk.fill(0));
+  child.stdout.on("data", (chunk: Buffer) => {
+    try {
+      if (chunk.length > output.length - outputBytes) {
+        interrupt("OUTPUT_INVALID");
+        return;
+      }
+      chunk.copy(output, outputBytes);
+      outputBytes += chunk.length;
+    } finally {
+      chunk.fill(0);
+    }
+  });
+  try {
+    if (control.signal.aborted) abort();
+    if (!failure) {
+      child.stdin.write(prefix);
+      child.stdin.write(metadata);
+      child.stdin.end(payload);
+    }
+    const code = await reaped;
+    if (failure) throw failure;
+    if (
+      code !== 0 ||
+      outputBytes !== 64 ||
+      output.toString("utf8") !== expectedDigest
+    )
+      throw materializerWireError("RECEIPT_UNPROVEN");
+  } finally {
+    clearTimeout(timeout);
+    control.signal.removeEventListener("abort", abort);
+    liveness.destroy();
+    await reaped;
+    prefix.fill(0);
+    output.fill(0);
+  }
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-wire.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-wire.ts
@@ -1,6 +1,7 @@
 /**
  * Private one-operation wire contract for a quarantined Agent materializer.
  * Stdin carries a length-prefixed JSON authority followed by raw record bytes;
+ * stdin remains open as the operation's liveness channel after the frame;
  * stdout carries only the digest of the exact completed receipt. This is not
  * public authentication: the coordinator must exclusively own the transport.
  */
@@ -30,7 +31,7 @@ const IdentitySchema = z.strictObject({
   inode: z.string().regex(/^[1-9][0-9]*$/),
 });
 const authority = {
-  version: z.literal(1),
+  version: z.literal(2),
   trustedRoot: z.string().min(1).max(4096),
   attemptRoot: z.string().min(1).max(4096),
   trustedRootIdentity: IdentitySchema,
@@ -70,7 +71,11 @@ export function materializerReceiptDigest(receipt: unknown): string {
     .digest("hex");
 }
 
-/** Owns and zeroes ingress buffers, including malformed/trailing input. */
+/**
+ * Owns and zeroes ingress buffers. Stops at one complete frame without closing
+ * stdin: EOF means cancellation, not successful request delivery. The caller
+ * must monitor the remaining stream for disconnect or forbidden trailing data.
+ */
 export async function readMaterializerRequest(
   input: Readable,
 ): Promise<{ request: MaterializerRequest; payload: Uint8Array }> {
@@ -82,7 +87,7 @@ export async function readMaterializerRequest(
   let request: MaterializerRequest | undefined;
   let payload: Uint8Array | undefined;
   try {
-    for await (const value of input) {
+    for await (const value of input.iterator({ destroyOnReturn: false })) {
       if (!Buffer.isBuffer(value)) throw materializerWireError("INPUT_INVALID");
       try {
         let offset = 0;
@@ -135,16 +140,17 @@ export async function readMaterializerRequest(
       } finally {
         value.fill(0);
       }
+      if (request && payload && payloadBytes === payload.length) {
+        if (
+          request.method === "stageRecord" &&
+          createHash("sha256").update(payload).digest("hex") !==
+            request.receipt.payloadSha256
+        )
+          throw materializerWireError("INPUT_INVALID");
+        return { request, payload };
+      }
     }
-    if (!request || !payload || payloadBytes !== payload.length)
-      throw materializerWireError("INPUT_INVALID");
-    if (
-      request.method === "stageRecord" &&
-      createHash("sha256").update(payload).digest("hex") !==
-        request.receipt.payloadSha256
-    )
-      throw materializerWireError("INPUT_INVALID");
-    return { request, payload };
+    throw materializerWireError("INPUT_INVALID");
   } catch {
     // error-policy:J1 Never expose private metadata, session tokens or parser input.
     payload?.fill(0);

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-wire.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-wire.ts
@@ -1,0 +1,156 @@
+/**
+ * Private one-operation wire contract for a quarantined Agent materializer.
+ * Stdin carries a length-prefixed JSON authority followed by raw record bytes;
+ * stdout carries only the digest of the exact completed receipt. This is not
+ * public authentication: the coordinator must exclusively own the transport.
+ */
+
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import type { Readable } from "node:stream";
+import { ElizaError } from "@elizaos/core";
+import {
+  AGENT_BACKUP_CAPTURE_V2_LIMITS,
+  AgentBackupRestoreV3CandidateReceiptSchema,
+  AgentBackupRestoreV3ComponentReceiptSchema,
+  AgentBackupRestoreV3StageRecordReceiptSchema,
+  AgentBackupRestoreV3StagingSessionSchema,
+} from "@elizaos/shared";
+import { z } from "zod";
+import { candidateFsCanonicalJson } from "./agent-backup-restore-v3-candidate-fs-json";
+
+// Covers the canonical receipt's 8192 bounded source-object descriptors, not
+// arbitrary model context. Oversize input is rejected, never truncated.
+export const MATERIALIZER_METADATA_MAX_BYTES = 8 * 1024 * 1024;
+export const MATERIALIZER_PAYLOAD_MAX_BYTES =
+  AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes;
+
+const IdentitySchema = z.strictObject({
+  device: z.string().regex(/^(0|[1-9][0-9]*)$/),
+  inode: z.string().regex(/^[1-9][0-9]*$/),
+});
+const authority = {
+  version: z.literal(1),
+  trustedRoot: z.string().min(1).max(4096),
+  attemptRoot: z.string().min(1).max(4096),
+  trustedRootIdentity: IdentitySchema,
+  attemptRootIdentity: IdentitySchema,
+  session: AgentBackupRestoreV3StagingSessionSchema,
+  deadlineEpochMs: z.number().int().safe().positive(),
+};
+export const MaterializerRequestSchema = z.discriminatedUnion("method", [
+  z.strictObject({
+    ...authority,
+    method: z.literal("stageRecord"),
+    receipt: AgentBackupRestoreV3StageRecordReceiptSchema,
+  }),
+  z.strictObject({
+    ...authority,
+    method: z.literal("finishComponent"),
+    receipt: AgentBackupRestoreV3ComponentReceiptSchema,
+  }),
+  z.strictObject({
+    ...authority,
+    method: z.literal("assembleCandidate"),
+    receipt: AgentBackupRestoreV3CandidateReceiptSchema,
+  }),
+]);
+export type MaterializerRequest = z.infer<typeof MaterializerRequestSchema>;
+
+export function materializerWireError(code: string): ElizaError {
+  return new ElizaError("Quarantined Agent materialization did not complete", {
+    code: `AGENT_BACKUP_RESTORE_V3_MATERIALIZER_${code}`,
+    severity: "fatal",
+  });
+}
+
+export function materializerReceiptDigest(receipt: unknown): string {
+  return createHash("sha256")
+    .update(candidateFsCanonicalJson(receipt))
+    .digest("hex");
+}
+
+/** Owns and zeroes ingress buffers, including malformed/trailing input. */
+export async function readMaterializerRequest(
+  input: Readable,
+): Promise<{ request: MaterializerRequest; payload: Uint8Array }> {
+  const prefix = Buffer.alloc(4);
+  let prefixBytes = 0;
+  let metadata: Buffer | undefined;
+  let metadataBytes = 0;
+  let payloadBytes = 0;
+  let request: MaterializerRequest | undefined;
+  let payload: Uint8Array | undefined;
+  try {
+    for await (const value of input) {
+      if (!Buffer.isBuffer(value)) throw materializerWireError("INPUT_INVALID");
+      try {
+        let offset = 0;
+        while (offset < value.length) {
+          if (prefixBytes < 4) {
+            const count = Math.min(4 - prefixBytes, value.length - offset);
+            value.copy(prefix, prefixBytes, offset, offset + count);
+            prefixBytes += count;
+            offset += count;
+            if (prefixBytes === 4) {
+              const length = prefix.readUInt32BE();
+              if (length === 0 || length > MATERIALIZER_METADATA_MAX_BYTES)
+                throw materializerWireError("INPUT_INVALID");
+              metadata = Buffer.alloc(length);
+            }
+          } else if (metadata && metadataBytes < metadata.length) {
+            const count = Math.min(
+              metadata.length - metadataBytes,
+              value.length - offset,
+            );
+            value.copy(metadata, metadataBytes, offset, offset + count);
+            metadataBytes += count;
+            offset += count;
+            if (metadataBytes === metadata.length) {
+              request = MaterializerRequestSchema.parse(
+                JSON.parse(
+                  new TextDecoder("utf-8", { fatal: true }).decode(metadata),
+                ),
+              );
+              const length =
+                request.method === "stageRecord"
+                  ? request.receipt.payloadBytes
+                  : 0;
+              if (length > MATERIALIZER_PAYLOAD_MAX_BYTES)
+                throw materializerWireError("INPUT_INVALID");
+              payload = new Uint8Array(length);
+              metadata.fill(0);
+            }
+          } else {
+            if (
+              !payload ||
+              value.length - offset > payload.length - payloadBytes
+            )
+              throw materializerWireError("INPUT_INVALID");
+            payload.set(value.subarray(offset), payloadBytes);
+            payloadBytes += value.length - offset;
+            offset = value.length;
+          }
+        }
+      } finally {
+        value.fill(0);
+      }
+    }
+    if (!request || !payload || payloadBytes !== payload.length)
+      throw materializerWireError("INPUT_INVALID");
+    if (
+      request.method === "stageRecord" &&
+      createHash("sha256").update(payload).digest("hex") !==
+        request.receipt.payloadSha256
+    )
+      throw materializerWireError("INPUT_INVALID");
+    return { request, payload };
+  } catch {
+    // error-policy:J1 Never expose private metadata, session tokens or parser input.
+    payload?.fill(0);
+    throw materializerWireError("INPUT_INVALID");
+  } finally {
+    prefix.fill(0);
+    metadata?.fill(0);
+  }
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-worker.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-worker.ts
@@ -5,7 +5,7 @@
  * PGlite validation children) before releasing authority or exiting.
  */
 
-import { Socket } from "node:net";
+import type { Buffer } from "node:buffer";
 import { openAgentBackupRestoreV3CandidateFs } from "./agent-backup-restore-v3-candidate-fs";
 import { createAgentBackupRestoreV3CandidateMaterializer } from "./agent-backup-restore-v3-candidate-materializer";
 import {
@@ -16,16 +16,18 @@ import {
 
 process.umask(0o077);
 const abort = new AbortController();
-const parent = new Socket({ fd: 3, readable: true, writable: false });
 const disconnect = () => {
   abort.abort();
   process.stdin.destroy();
 };
-parent.on("end", disconnect);
-parent.on("error", disconnect);
-parent.on("data", disconnect);
+process.stdin.on("end", disconnect);
+process.stdin.on("error", disconnect);
 process.stdout.on("error", disconnect);
-parent.resume();
+
+const trailingInput = (bytes: Buffer) => {
+  bytes.fill(0);
+  disconnect();
+};
 
 async function main(): Promise<void> {
   const emulation = process.argv.slice(2);
@@ -40,6 +42,10 @@ async function main(): Promise<void> {
   )
     throw materializerWireError("INPUT_INVALID");
   const { request, payload } = await readMaterializerRequest(process.stdin);
+  // SSH/Docker expose stdin, not arbitrary inherited descriptors. Keeping this
+  // same pipe open lets transport disconnect cancel an already-dispatched effect.
+  process.stdin.on("data", trailingInput);
+  process.stdin.resume();
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     const remaining = request.deadlineEpochMs - Date.now();
@@ -123,5 +129,6 @@ await main()
   })
   .finally(() => {
     process.stdout.removeListener("error", disconnect);
-    parent.destroy();
+    process.stdin.removeListener("data", trailingInput);
+    process.stdin.destroy();
   });

--- a/packages/agent/src/services/agent-backup-restore-v3-materializer-worker.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-materializer-worker.ts
@@ -1,0 +1,127 @@
+/**
+ * One-shot private Agent restore entrypoint: no runtime, plugins or listeners.
+ * The owning coordinator supplies the exact private root identities on stdin.
+ * Parent disconnect aborts the operation and joins all materializers (including
+ * PGlite validation children) before releasing authority or exiting.
+ */
+
+import { Socket } from "node:net";
+import { openAgentBackupRestoreV3CandidateFs } from "./agent-backup-restore-v3-candidate-fs";
+import { createAgentBackupRestoreV3CandidateMaterializer } from "./agent-backup-restore-v3-candidate-materializer";
+import {
+  materializerReceiptDigest,
+  materializerWireError,
+  readMaterializerRequest,
+} from "./agent-backup-restore-v3-materializer-wire";
+
+process.umask(0o077);
+const abort = new AbortController();
+const parent = new Socket({ fd: 3, readable: true, writable: false });
+const disconnect = () => {
+  abort.abort();
+  process.stdin.destroy();
+};
+parent.on("end", disconnect);
+parent.on("error", disconnect);
+parent.on("data", disconnect);
+process.stdout.on("error", disconnect);
+parent.resume();
+
+async function main(): Promise<void> {
+  const emulation = process.argv.slice(2);
+  if (
+    emulation.length !== 0 &&
+    !(
+      emulation.length === 1 &&
+      emulation[0] === "--test-only-non-linux-fs" &&
+      process.platform !== "linux" &&
+      process.env.NODE_ENV === "test"
+    )
+  )
+    throw materializerWireError("INPUT_INVALID");
+  const { request, payload } = await readMaterializerRequest(process.stdin);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const remaining = request.deadlineEpochMs - Date.now();
+    if (abort.signal.aborted || remaining <= 0 || remaining > 2_147_483_647)
+      throw materializerWireError("INTERRUPTED");
+    timeout = setTimeout(() => abort.abort(), remaining);
+    const control = {
+      signal: abort.signal,
+      deadlineEpochMs: request.deadlineEpochMs,
+    };
+    const candidateFs = await openAgentBackupRestoreV3CandidateFs({
+      trustedRoot: request.trustedRoot,
+      attemptRoot: request.attemptRoot,
+      control,
+      ...(emulation.length === 1
+        ? { testOnlyAllowNonLinuxFdEmulation: true as const }
+        : {}),
+    });
+    let digest: string;
+    try {
+      if (
+        materializerReceiptDigest(candidateFs.trustedRootIdentity) !==
+          materializerReceiptDigest(request.trustedRootIdentity) ||
+        materializerReceiptDigest(candidateFs.attemptRootIdentity) !==
+          materializerReceiptDigest(request.attemptRootIdentity)
+      )
+        throw materializerWireError("ROOT_CHANGED");
+      const materializer =
+        createAgentBackupRestoreV3CandidateMaterializer(candidateFs);
+      if (request.method === "stageRecord") {
+        const {
+          payloadBytes: _bytes,
+          payloadSha256: _hash,
+          ...record
+        } = request.receipt;
+        digest = materializerReceiptDigest(
+          await materializer.stageRecord(
+            request.session,
+            { ...record, payload },
+            control,
+          ),
+        );
+      } else if (request.method === "finishComponent") {
+        digest = materializerReceiptDigest(
+          await materializer.finishComponent(
+            request.session,
+            request.receipt,
+            control,
+          ),
+        );
+      } else {
+        digest = materializerReceiptDigest(
+          await materializer.assembleCandidate(
+            request.session,
+            request.receipt,
+            control,
+          ),
+        );
+      }
+    } finally {
+      await candidateFs.close();
+    }
+    if (abort.signal.aborted || Date.now() >= request.deadlineEpochMs)
+      throw materializerWireError("INTERRUPTED");
+    await new Promise<void>((resolve, reject) =>
+      process.stdout.write(digest, (error) =>
+        error ? reject(materializerWireError("OUTPUT_FAILED")) : resolve(),
+      ),
+    );
+  } finally {
+    clearTimeout(timeout);
+    payload.fill(0);
+  }
+}
+
+await main()
+  .catch(() => {
+    // error-policy:J1 Only a failed exit crosses the private process boundary;
+    // filesystem, SQL and parser diagnostics must never expose restored content.
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    process.stdout.removeListener("error", disconnect);
+    parent.destroy();
+  });

--- a/packages/agent/src/services/agent-backup-restore-v3-pglite-archive.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-pglite-archive.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@elizaos/shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { extractAgentBackupRestoreV3CandidateDatabase } from "./agent-backup-restore-v3-candidate-database";
+import { validateAgentBackupRestoreV3CandidateDatabase } from "./agent-backup-restore-v3-candidate-database-validation";
 import {
   type AgentBackupRestoreV3CandidateFs,
   openAgentBackupRestoreV3CandidateFs,
@@ -181,6 +182,32 @@ function parse(
 }
 
 describe("physical PGlite archive", () => {
+  it("never validates an archive containing corrupt physical database control files", async () => {
+    const { input, attemptRoot } = await extractionFixture();
+    await expect(
+      validateAgentBackupRestoreV3CandidateDatabase({
+        ...input,
+        control: { ...control(), deadlineEpochMs: Date.now() + 15_000 },
+      }),
+    ).rejects.toThrow();
+    await expect(
+      fs.stat(
+        path.join(
+          attemptRoot,
+          ".restore-v3-component-c1.database-validated.json",
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.stat(path.join(attemptRoot, ".restore-v3-database-validation")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(
+      await fs.readFile(
+        path.join(attemptRoot, "components/database/PG_VERSION"),
+        "utf8",
+      ),
+    ).toBe("17\n");
+  }, 20_000);
   it("never publishes extraction on payload mismatch, then safely replays the correct finish", async () => {
     const { input, finish } = await extractionFixture();
     await expect(
@@ -310,6 +337,35 @@ describe("physical PGlite archive", () => {
         control: control(),
       }),
     ).toEqual(result);
+    const beforeValidation = await fs.stat(
+      path.join(attemptRoot, result.outputDirectory, "PG_VERSION"),
+    );
+    const validation = await validateAgentBackupRestoreV3CandidateDatabase({
+      candidateFs: candidate,
+      session: SESSION,
+      receipt,
+      control: control(),
+    });
+    expect(validation.extractionFinishSha256).toBe(result.finishSha256);
+    expect(validation.serverVersion).toMatch(/^[1-9][0-9]{4,5}$/);
+    expect(
+      await validateAgentBackupRestoreV3CandidateDatabase({
+        candidateFs: candidate,
+        session: SESSION,
+        receipt,
+        control: control(),
+      }),
+    ).toEqual(validation);
+    expect(
+      (
+        await fs.stat(
+          path.join(attemptRoot, result.outputDirectory, "PG_VERSION"),
+        )
+      ).mtimeMs,
+    ).toBe(beforeValidation.mtimeMs);
+    await expect(
+      fs.stat(path.join(attemptRoot, ".restore-v3-database-validation")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
     const restored = new PGlite(path.join(attemptRoot, result.outputDirectory));
     databases.add(restored);
     expect(
@@ -328,7 +384,7 @@ describe("physical PGlite archive", () => {
         )
       ).rows,
     ).toEqual([{ count: 1 }]);
-  }, 60_000);
+  }, 90_000);
 
   it.each([
     "../escape",

--- a/packages/agent/src/services/agent-backup-restore-v3-pglite-archive.test.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-pglite-archive.test.ts
@@ -1,0 +1,503 @@
+/** Real PGlite round-trip and adversarial physical archive parsing proofs. */
+
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
+  type AgentBackupRestoreV3ComponentReceipt,
+  type AgentBackupRestoreV3StagingSession,
+} from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractAgentBackupRestoreV3CandidateDatabase } from "./agent-backup-restore-v3-candidate-database";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  openAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import { stageAgentBackupRestoreV3CandidateRecord } from "./agent-backup-restore-v3-candidate-records";
+import {
+  type AgentBackupRestoreV3PgliteArchiveLimits,
+  readAgentBackupRestoreV3PgliteArchive,
+} from "./agent-backup-restore-v3-pglite-archive";
+
+const roots = new Set<string>();
+const candidates = new Set<AgentBackupRestoreV3CandidateFs>();
+const databases = new Set<PGlite>();
+const SESSION = Object.freeze({
+  restoreAttemptId: "10000000-0000-4000-8000-000000000001",
+  operationId: "20000000-0000-4000-8000-000000000002",
+  expectedManifestSha256: "a".repeat(64),
+  stagingHandle: "30000000-0000-4000-8000-000000000003",
+  cleanupHandle: "40000000-0000-4000-8000-000000000004",
+  executionToken: "exact-database-execution-token",
+  cleanupRegistered: true,
+  isolatedCandidate: true,
+}) satisfies AgentBackupRestoreV3StagingSession;
+
+async function stageDatabase(
+  candidateFs: AgentBackupRestoreV3CandidateFs,
+  bytes: Uint8Array,
+): Promise<AgentBackupRestoreV3ComponentReceipt> {
+  let dataFrameCount = 0;
+  for (let offset = 0; offset < bytes.length; offset += 256 * 1024) {
+    const payload = Uint8Array.from(
+      bytes.subarray(offset, offset + 256 * 1024),
+    );
+    try {
+      await stageAgentBackupRestoreV3CandidateRecord({
+        candidateFs,
+        session: SESSION,
+        record: {
+          componentIndex: 1,
+          componentName: "database",
+          dataIndex: dataFrameCount++,
+          offsetBytes: offset,
+          entry: null,
+          payload,
+        },
+        control: control(),
+      });
+    } finally {
+      payload.fill(0);
+    }
+  }
+  const descriptor = AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS[1];
+  if (!descriptor) throw new Error("Missing database descriptor");
+  return {
+    componentIndex: 1,
+    componentName: "database",
+    descriptor,
+    dataFrameCount,
+    payloadBytes: bytes.length,
+    payloadSha256: createHash("sha256").update(bytes).digest("hex"),
+    recordStreamContentHmacSha256: "b".repeat(64),
+  };
+}
+
+function control() {
+  return {
+    signal: new AbortController().signal,
+    deadlineEpochMs: Date.now() + 60_000,
+  };
+}
+
+async function extractionFixture(payload = gzipSync(archive(minimumEntries))) {
+  const root = await fs.mkdtemp(
+    path.join(await fs.realpath(os.tmpdir()), "restore-v3-database-inbox-"),
+  );
+  roots.add(root);
+  await fs.chmod(root, 0o700);
+  const attemptRoot = path.join(root, "attempt");
+  await fs.mkdir(attemptRoot, { mode: 0o700 });
+  const candidateFs = await openAgentBackupRestoreV3CandidateFs({
+    trustedRoot: root,
+    attemptRoot,
+    control: control(),
+    ...(process.platform === "linux"
+      ? {}
+      : { testOnlyAllowNonLinuxFdEmulation: true }),
+  });
+  candidates.add(candidateFs);
+  const receipt = await stageDatabase(candidateFs, payload);
+  const input = { candidateFs, session: SESSION, receipt, control: control() };
+  return {
+    input,
+    attemptRoot,
+    finish: path.join(
+      attemptRoot,
+      ".restore-v3-component-c1.database-extracted.json",
+    ),
+  };
+}
+
+afterEach(async () => {
+  for (const db of databases) await db.close();
+  databases.clear();
+  for (const candidate of candidates) await candidate.close();
+  candidates.clear();
+  for (const root of roots) await fs.rm(root, { recursive: true, force: true });
+  roots.clear();
+});
+
+function checksum(header: Buffer) {
+  header.fill(32, 148, 156);
+  const sum = header.reduce((total, byte) => total + byte, 0);
+  header.write(`${sum.toString(8).padStart(6, "0")}\0 `, 148, "ascii");
+}
+
+function header(name: string, size: number, type = "0"): Buffer {
+  const bytes = Buffer.alloc(512);
+  bytes.write(name, 0, "utf8");
+  bytes.write("0000600\0", 100, "ascii");
+  bytes.write(`${size.toString(8).padStart(11, "0")}\0`, 124, "ascii");
+  bytes.write(type, 156, "ascii");
+  bytes.write("ustar\0" + "00", 257, "ascii");
+  checksum(bytes);
+  return bytes;
+}
+
+function archive(
+  entries: { name: string; payload?: string; type?: string }[],
+): Buffer {
+  return Buffer.concat([
+    ...entries.flatMap((entry) => {
+      const bytes = Buffer.from(entry.payload ?? "");
+      return [
+        header(entry.name, bytes.length, entry.type),
+        bytes,
+        Buffer.alloc((512 - (bytes.length % 512)) % 512),
+      ];
+    }),
+    Buffer.alloc(1024),
+  ]);
+}
+
+async function* fragments(bytes: Uint8Array, width = 117) {
+  for (let offset = 0; offset < bytes.length; offset += width)
+    yield bytes.subarray(offset, offset + width);
+}
+
+const minimumEntries = [
+  { name: "/PG_VERSION", payload: "17\n" },
+  { name: "/global/pg_control", payload: "fixture-control" },
+];
+
+function parse(
+  bytes: Uint8Array,
+  limits?: Partial<AgentBackupRestoreV3PgliteArchiveLimits>,
+) {
+  return readAgentBackupRestoreV3PgliteArchive({
+    tar: fragments(bytes),
+    control: control(),
+    limits,
+    visit: async (_entry, consume) => {
+      await consume(async () => {});
+    },
+  });
+}
+
+describe("physical PGlite archive", () => {
+  it("never publishes extraction on payload mismatch, then safely replays the correct finish", async () => {
+    const { input, finish } = await extractionFixture();
+    await expect(
+      extractAgentBackupRestoreV3CandidateDatabase({
+        ...input,
+        receipt: { ...input.receipt, payloadSha256: "c".repeat(64) },
+      }),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_PAYLOAD_MISMATCH",
+    });
+    await expect(fs.stat(finish)).rejects.toMatchObject({ code: "ENOENT" });
+    const first = await extractAgentBackupRestoreV3CandidateDatabase(input);
+    expect(await extractAgentBackupRestoreV3CandidateDatabase(input)).toEqual(
+      first,
+    );
+  });
+
+  it("rejects truncated gzip without a durable extraction receipt", async () => {
+    const bytes = gzipSync(archive(minimumEntries));
+    const { input, finish } = await extractionFixture(
+      bytes.subarray(0, bytes.length - 7),
+    );
+    await expect(
+      extractAgentBackupRestoreV3CandidateDatabase(input),
+    ).rejects.toThrow();
+    await expect(fs.stat(finish)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects an extra authenticated record rather than ignoring its suffix", async () => {
+    const { input, finish } = await extractionFixture();
+    await stageAgentBackupRestoreV3CandidateRecord({
+      candidateFs: input.candidateFs,
+      session: SESSION,
+      record: {
+        componentIndex: 1,
+        componentName: "database",
+        dataIndex: input.receipt.dataFrameCount,
+        offsetBytes: input.receipt.payloadBytes,
+        entry: null,
+        payload: new Uint8Array([1]),
+      },
+      control: control(),
+    });
+    await expect(
+      extractAgentBackupRestoreV3CandidateDatabase(input),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_RECORD_COUNT_MISMATCH",
+    });
+    await expect(fs.stat(finish)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("refuses replay when a quarantined file has changed, without overwriting it", async () => {
+    const { input, attemptRoot } = await extractionFixture();
+    const first = await extractAgentBackupRestoreV3CandidateDatabase(input);
+    const target = path.join(attemptRoot, first.outputDirectory, "PG_VERSION");
+    await fs.writeFile(target, "18\n");
+    await fs.utimes(target, 0, 0);
+    await expect(
+      extractAgentBackupRestoreV3CandidateDatabase(input),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_FILE_CONFLICT",
+    });
+    expect(await fs.readFile(target, "utf8")).toBe("18\n");
+  });
+
+  it("rejects a different attempt authority before creating database output", async () => {
+    const { input, attemptRoot } = await extractionFixture();
+    await expect(
+      extractAgentBackupRestoreV3CandidateDatabase({
+        ...input,
+        session: { ...SESSION, expectedManifestSha256: "d".repeat(64) },
+      }),
+    ).rejects.toThrow();
+    await expect(
+      fs.stat(path.join(attemptRoot, "components/database")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reopens a real gzip dump in an isolated candidate and recovers the saved fact", async () => {
+    const root = await fs.mkdtemp(
+      path.join(await fs.realpath(os.tmpdir()), "restore-v3-pglite-"),
+    );
+    roots.add(root);
+    await fs.chmod(root, 0o700);
+    const source = new PGlite(path.join(root, "source"));
+    databases.add(source);
+    await source.exec(
+      "CREATE TABLE restore_fact (id integer PRIMARY KEY, fact text NOT NULL)",
+    );
+    await source.query("INSERT INTO restore_fact VALUES ($1, $2)", [
+      1,
+      "The remembered comet is indigo-20732",
+    ]);
+    const dump = await source.dumpDataDir("gzip");
+    await source.close();
+    databases.delete(source);
+    await fs.rm(path.join(root, "source"), { recursive: true });
+
+    const attemptRoot = path.join(root, "attempt");
+    await fs.mkdir(attemptRoot, { mode: 0o700 });
+    const candidate = await openAgentBackupRestoreV3CandidateFs({
+      trustedRoot: root,
+      attemptRoot,
+      control: control(),
+      ...(process.platform === "linux"
+        ? {}
+        : { testOnlyAllowNonLinuxFdEmulation: true }),
+    });
+    candidates.add(candidate);
+    const bytes = new Uint8Array(await dump.arrayBuffer());
+    const receipt = await stageDatabase(candidate, bytes);
+    bytes.fill(0);
+    const result = await extractAgentBackupRestoreV3CandidateDatabase({
+      candidateFs: candidate,
+      session: SESSION,
+      receipt,
+      control: control(),
+    });
+    expect(result.tree.files).toBeGreaterThan(10);
+    expect(result.tree.bytes).toBeGreaterThan(1024 * 1024);
+    // The first response may have been lost; retry before opening the database.
+    expect(
+      await extractAgentBackupRestoreV3CandidateDatabase({
+        candidateFs: candidate,
+        session: SESSION,
+        receipt,
+        control: control(),
+      }),
+    ).toEqual(result);
+    const restored = new PGlite(path.join(attemptRoot, result.outputDirectory));
+    databases.add(restored);
+    expect(
+      (await restored.query("SELECT id, fact FROM restore_fact")).rows,
+    ).toEqual([{ id: 1, fact: "The remembered comet is indigo-20732" }]);
+    await restored.close();
+    databases.delete(restored);
+    const restarted = new PGlite(
+      path.join(attemptRoot, result.outputDirectory),
+    );
+    databases.add(restarted);
+    expect(
+      (
+        await restarted.query(
+          "SELECT count(*)::integer AS count FROM restore_fact",
+        )
+      ).rows,
+    ).toEqual([{ count: 1 }]);
+  }, 60_000);
+
+  it.each([
+    "../escape",
+    "/../escape",
+    "//absolute",
+    "a/../../escape",
+    "a\\b",
+    "a//b",
+    "./relative",
+    "a/\u0001",
+    ".restore-v3-control",
+  ])("rejects unsafe archive path %j", async (name) => {
+    await expect(
+      parse(archive([...minimumEntries, { name, payload: "bad" }])),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_PATH_INVALID",
+    });
+  });
+
+  it.each(["1", "2", "3", "4", "6", "x", "g", "L", "S"])(
+    "refuses link/special/extended type %s before consuming its contents",
+    async (type) => {
+      await expect(
+        parse(archive([...minimumEntries, { name: "bad", type }])),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_TYPE_FORBIDDEN",
+      });
+    },
+  );
+
+  it("rejects normalized duplicates and file/directory collisions", async () => {
+    await expect(
+      parse(archive([...minimumEntries, { name: "PG_VERSION" }])),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_DUPLICATE",
+    });
+    await expect(
+      parse(archive([...minimumEntries, { name: "global" }])),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_PATH_COLLISION",
+    });
+    await expect(
+      parse(archive([...minimumEntries, { name: "PG_VERSION/child" }])),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_PATH_COLLISION",
+    });
+  });
+
+  it("rejects header tamper, hidden octal values and nonzero padding", async () => {
+    const tampered = archive(minimumEntries);
+    tampered[0] = 88;
+    await expect(parse(tampered)).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_CHECKSUM_MISMATCH",
+    });
+    const hidden = archive(minimumEntries);
+    hidden[101] = 0;
+    checksum(hidden.subarray(0, 512));
+    await expect(parse(hidden)).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_HEADER_INVALID",
+    });
+    const padding = archive(minimumEntries);
+    padding[520] = 1;
+    await expect(parse(padding)).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_PADDING_INVALID",
+    });
+  });
+
+  it("rejects high-bit aliases of USTAR magic and canonically equivalent paths", async () => {
+    const magic = archive(minimumEntries);
+    magic[257] = magic.readUInt8(257) | 128;
+    checksum(magic.subarray(0, 512));
+    await expect(parse(magic)).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_HEADER_INVALID",
+    });
+    await expect(
+      parse(
+        archive([...minimumEntries, { name: "café" }, { name: "cafe\u0301" }]),
+      ),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_DUPLICATE",
+    });
+  });
+
+  it("requires both end blocks and rejects appended archives or partial padding", async () => {
+    const valid = archive(minimumEntries);
+    await expect(
+      parse(valid.subarray(0, valid.length - 512)),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_TRUNCATED",
+    });
+    await expect(parse(Buffer.concat([valid, valid]))).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_TRAILING_DATA",
+    });
+    await expect(
+      parse(Buffer.concat([valid, Buffer.alloc(1)])),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_TRUNCATED",
+    });
+  });
+
+  it("rejects archives missing the physical database rather than booting empty", async () => {
+    await expect(
+      parse(archive([{ name: "PG_VERSION", payload: "17\n" }])),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_DATABASE_MISSING",
+    });
+    await expect(parse(archive([]))).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_DATABASE_MISSING",
+    });
+  });
+
+  it.each([
+    [{ maximumFileBytes: 2 }, "FILE_LIMIT"],
+    [{ maximumTarBytes: 512 }, "TAR_LIMIT"],
+    [{ maximumExtractedBytes: 3 }, "EXTRACTED_LIMIT"],
+    [{ maximumFiles: 1 }, "FILE_COUNT_LIMIT"],
+    [{ maximumDepth: 1 }, "PATH_INVALID"],
+  ] as const)("enforces extraction budget %j", async (limits, code) => {
+    await expect(parse(archive(minimumEntries), limits)).rejects.toMatchObject({
+      code: `AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_${code}`,
+    });
+  });
+
+  it("closes its source on cancellation and stops calling the consumer", async () => {
+    const abort = new AbortController();
+    let closed = false;
+    let visits = 0;
+    async function* source() {
+      try {
+        yield* fragments(archive(minimumEntries));
+      } finally {
+        closed = true;
+      }
+    }
+    await expect(
+      readAgentBackupRestoreV3PgliteArchive({
+        tar: source(),
+        control: { ...control(), signal: abort.signal },
+        visit: async (_entry, consume) => {
+          visits++;
+          await consume(async () => {
+            abort.abort();
+          });
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_RESTORE_V3_CANDIDATE_FS_ABORTED",
+    });
+    expect(closed).toBe(true);
+    expect(visits).toBe(1);
+  });
+
+  it("does not mutate borrowed source buffers and zeroizes consumed copies", async () => {
+    const bytes = archive(minimumEntries);
+    const before = Buffer.from(bytes);
+    const borrowed: Uint8Array[] = [];
+    await readAgentBackupRestoreV3PgliteArchive({
+      tar: fragments(bytes),
+      control: control(),
+      visit: async (_entry, consume) => {
+        await consume(async (chunk) => {
+          borrowed.push(chunk);
+        });
+      },
+    });
+    expect(bytes).toEqual(before);
+    expect(borrowed.length).toBeGreaterThan(0);
+    expect(borrowed.every((chunk) => chunk.every((byte) => byte === 0))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/agent/src/services/agent-backup-restore-v3-pglite-archive.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-pglite-archive.ts
@@ -1,0 +1,426 @@
+/**
+ * Bounded, strict reader for the physical PGlite archive captured by manifest-v3.
+ * Consumers receive only normalized regular files and directories, never archive
+ * links or extraction paths. Input is decompressed tar from an authenticated
+ * component; this parser does not confer source authority or permit activation.
+ */
+
+import { Buffer } from "node:buffer";
+import { ElizaError } from "@elizaos/core";
+import type { AgentBackupRestoreV3OperationControl } from "@elizaos/shared";
+import {
+  assertActive,
+  snapshotOperationControl,
+  snapshotOwnDataRecord,
+} from "./agent-backup-restore-v3-candidate-fs-control";
+
+const BLOCK = 512;
+const CHUNK = 256 * 1024;
+
+export const AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_LIMITS = Object.freeze({
+  maximumTarBytes: 8 * 1024 * 1024 * 1024,
+  maximumFileBytes: 2 * 1024 * 1024 * 1024,
+  maximumExtractedBytes: 8 * 1024 * 1024 * 1024,
+  maximumFiles: 100_000,
+  maximumDirectories: 16_384,
+  maximumDepth: 32,
+  maximumPathBytes: 1024,
+});
+
+export type AgentBackupRestoreV3PgliteArchiveLimits = {
+  readonly [Key in keyof typeof AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_LIMITS]: number;
+};
+
+export interface AgentBackupRestoreV3PgliteArchiveEntry {
+  readonly path: string;
+  readonly type: "file" | "directory";
+  readonly sizeBytes: number;
+}
+
+export class AgentBackupRestoreV3PgliteArchiveError extends ElizaError {
+  override readonly name = "AgentBackupRestoreV3PgliteArchiveError";
+
+  constructor(code: string, message: string, cause?: unknown) {
+    super(message, {
+      code: `AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_${code}`,
+      severity: "fatal",
+      ...(cause === undefined ? {} : { cause }),
+    });
+  }
+}
+
+function invalid(code: string, message: string, cause?: unknown): never {
+  throw new AgentBackupRestoreV3PgliteArchiveError(code, message, cause);
+}
+
+function limitsSnapshot(
+  input: Partial<AgentBackupRestoreV3PgliteArchiveLimits> | undefined,
+): AgentBackupRestoreV3PgliteArchiveLimits {
+  const defaults = AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_LIMITS;
+  const data = snapshotOwnDataRecord(
+    input ?? {},
+    Object.keys(defaults),
+    [],
+    "AGENT_BACKUP_RESTORE_V3_PGLITE_ARCHIVE_LIMIT_INVALID",
+    "Archive limits require one plain data object",
+  );
+  const result: {
+    -readonly [Key in keyof AgentBackupRestoreV3PgliteArchiveLimits]: number;
+  } = { ...defaults };
+  for (const key of Object.keys(defaults) as (keyof typeof defaults)[]) {
+    const value = data[key] === undefined ? defaults[key] : data[key];
+    if (
+      typeof value !== "number" ||
+      !Number.isSafeInteger(value) ||
+      value <= 0 ||
+      value > defaults[key]
+    ) {
+      invalid(
+        "LIMIT_INVALID",
+        "Archive limits must be positive and cannot widen policy",
+      );
+    }
+    result[key] = value;
+  }
+  return Object.freeze(result);
+}
+
+class ArchiveReader {
+  readonly iterator: AsyncIterator<Uint8Array>;
+  readonly control: Readonly<AgentBackupRestoreV3OperationControl>;
+  readonly maximumBytes: number;
+  totalBytes = 0;
+  private current: Buffer | null = null;
+  private offset = 0;
+  private ended = false;
+
+  constructor(
+    source: AsyncIterable<Uint8Array>,
+    control: Readonly<AgentBackupRestoreV3OperationControl>,
+    maximumBytes: number,
+  ) {
+    this.iterator = source[Symbol.asyncIterator]();
+    this.control = control;
+    this.maximumBytes = maximumBytes;
+  }
+
+  async pull(): Promise<boolean> {
+    assertActive(this.control);
+    if (this.current && this.offset === this.current.length) {
+      this.current.fill(0);
+      this.current = null;
+      this.offset = 0;
+    }
+    while (!this.current && !this.ended) {
+      const next = await this.iterator.next();
+      assertActive(this.control);
+      if (next.done) {
+        this.ended = true;
+        return false;
+      }
+      if (
+        !(next.value instanceof Uint8Array) ||
+        next.value.byteLength > CHUNK
+      ) {
+        invalid(
+          "CHUNK_INVALID",
+          "Archive decoder must produce bounded byte chunks",
+        );
+      }
+      if (this.totalBytes > this.maximumBytes - next.value.byteLength) {
+        invalid("TAR_LIMIT", "Archive exceeds its decompressed byte budget");
+      }
+      this.totalBytes += next.value.byteLength;
+      if (next.value.byteLength !== 0) this.current = Buffer.from(next.value);
+    }
+    return this.current !== null;
+  }
+
+  async consume(
+    length: number,
+    visitor: (chunk: Uint8Array) => Promise<void>,
+  ): Promise<void> {
+    let remaining = length;
+    while (remaining > 0) {
+      if (!(await this.pull()) || !this.current)
+        invalid("TRUNCATED", "Archive ended inside a record");
+      const size = Math.min(remaining, this.current.length - this.offset);
+      await visitor(
+        new Uint8Array(
+          this.current.buffer,
+          this.current.byteOffset + this.offset,
+          size,
+        ),
+      );
+      assertActive(this.control);
+      this.offset += size;
+      remaining -= size;
+    }
+  }
+
+  async header(): Promise<Buffer> {
+    const bytes = Buffer.alloc(BLOCK);
+    let offset = 0;
+    try {
+      await this.consume(BLOCK, async (chunk) => {
+        bytes.set(chunk, offset);
+        offset += chunk.length;
+      });
+      return bytes;
+    } catch (cause) {
+      // error-policy:J3 A partial untrusted header is cleared before propagation.
+      bytes.fill(0);
+      throw cause;
+    }
+  }
+
+  async zeroes(length: number): Promise<void> {
+    await this.consume(length, async (chunk) => {
+      if (chunk.some((byte) => byte !== 0))
+        invalid("PADDING_INVALID", "Archive padding is non-zero");
+    });
+  }
+
+  async end(): Promise<void> {
+    while (await this.pull()) {
+      if (!this.current)
+        invalid("TRUNCATED", "Archive decoder lost its current chunk");
+      if (this.current.subarray(this.offset).some((byte) => byte !== 0))
+        invalid("TRAILING_DATA", "Archive contains data after the end marker");
+      this.offset = this.current.length;
+    }
+    if (this.totalBytes % BLOCK !== 0)
+      invalid("TRUNCATED", "Archive ends with a partial padding block");
+  }
+
+  async close(): Promise<void> {
+    this.current?.fill(0);
+    this.current = null;
+    if (!this.ended) await this.iterator.return?.();
+  }
+}
+
+function octal(header: Buffer, start: number, length: number): number {
+  const bytes = header.subarray(start, start + length);
+  // Reject hidden values after a NUL, base-256 and embedded padding.
+  let digits = "";
+  let padding = false;
+  for (const byte of bytes) {
+    if (byte === 0 || byte === 32) {
+      if (byte === 0 || digits.length > 0) padding = true;
+    } else if (byte >= 48 && byte <= 55 && !padding) {
+      digits += String.fromCharCode(byte);
+    } else {
+      invalid("HEADER_INVALID", "Archive numeric field is not canonical octal");
+    }
+  }
+  const value = digits === "" ? 0 : Number.parseInt(digits, 8);
+  if (!Number.isSafeInteger(value))
+    invalid("HEADER_INVALID", "Archive integer is out of range");
+  return value;
+}
+
+function field(header: Buffer, start: number, length: number): string {
+  const bytes = header.subarray(start, start + length);
+  const nul = bytes.indexOf(0);
+  if (nul !== -1 && bytes.subarray(nul).some((byte) => byte !== 0))
+    invalid("HEADER_INVALID", "Archive string has bytes after its terminator");
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      nul === -1 ? bytes : bytes.subarray(0, nul),
+    );
+  } catch (cause) {
+    // error-policy:J3 Reject invalid archive names instead of replacing bytes.
+    invalid("PATH_INVALID", "Archive string is not UTF-8", cause);
+  }
+}
+
+function parseHeader(
+  header: Buffer,
+  limits: AgentBackupRestoreV3PgliteArchiveLimits,
+): Readonly<AgentBackupRestoreV3PgliteArchiveEntry> {
+  let checksum = 0;
+  for (let index = 0; index < BLOCK; index++)
+    checksum += index >= 148 && index < 156 ? 32 : header.readUInt8(index);
+  if (octal(header, 148, 8) !== checksum)
+    invalid("CHECKSUM_MISMATCH", "Archive header checksum is invalid");
+  if (
+    !header.subarray(257, 262).equals(Buffer.from("ustar", "ascii")) ||
+    ![0, 32].includes(header.readUInt8(262)) ||
+    !header.subarray(263, 265).equals(Buffer.from("00", "ascii"))
+  )
+    invalid("HEADER_INVALID", "Archive must use PGlite USTAR 00 headers");
+  const type =
+    header[156] === 53
+      ? "directory"
+      : header[156] === 0 || header[156] === 48
+        ? "file"
+        : null;
+  if (!type)
+    invalid(
+      "TYPE_FORBIDDEN",
+      "Archive links, devices and extended headers are forbidden",
+    );
+  if (field(header, 157, 100) !== "")
+    invalid(
+      "TYPE_FORBIDDEN",
+      "Archive regular entries cannot name a link target",
+    );
+  for (const [offset, length] of [
+    [100, 8],
+    [108, 8],
+    [116, 8],
+    [136, 12],
+    [329, 8],
+    [337, 8],
+    [476, 12],
+    [488, 12],
+  ] as const)
+    octal(header, offset, length);
+  field(header, 265, 32);
+  field(header, 297, 32);
+  if (header.subarray(500).some((byte) => byte !== 0))
+    invalid("HEADER_INVALID", "Archive reserved header bytes are non-zero");
+  const sizeBytes = octal(header, 124, 12);
+  if (type === "directory" && sizeBytes !== 0)
+    invalid("HEADER_INVALID", "Archive directory cannot contain bytes");
+  if (sizeBytes > limits.maximumFileBytes)
+    invalid("FILE_LIMIT", "Archive file exceeds its byte budget");
+  // PGlite's tinytar uses 131 prefix bytes, then atime and ctime, and emits
+  // PGDATA-relative names with a single leading slash. Never resolve it as root.
+  const prefix = field(header, 345, 131);
+  let name = `${prefix ? `${prefix}/` : ""}${field(header, 0, 100)}`;
+  if (name.startsWith("/")) name = name.slice(1);
+  if (type === "directory" && name.endsWith("/")) name = name.slice(0, -1);
+  const segments = name.split("/");
+  if (
+    !name ||
+    name.includes("\\") ||
+    Array.from(name).some(
+      (character) =>
+        character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127,
+    ) ||
+    Buffer.byteLength(name) > limits.maximumPathBytes ||
+    segments.length > limits.maximumDepth ||
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === "." ||
+        segment === ".." ||
+        segment.startsWith(".restore-v3-") ||
+        Buffer.byteLength(segment) > 255,
+    )
+  )
+    invalid("PATH_INVALID", "Archive entry path is unsafe or oversized");
+  return Object.freeze({ path: name, type, sizeBytes });
+}
+
+/**
+ * The trusted consumer must await consume() exactly once per entry. Chunks are
+ * borrowed until that callback settles and must not escape without a copy.
+ * Partial output stays quarantined on failure; only the caller owns cleanup.
+ */
+export async function readAgentBackupRestoreV3PgliteArchive(input: {
+  readonly tar: AsyncIterable<Uint8Array>;
+  readonly control: Readonly<AgentBackupRestoreV3OperationControl>;
+  readonly limits?: Partial<AgentBackupRestoreV3PgliteArchiveLimits>;
+  readonly visit: (
+    entry: Readonly<AgentBackupRestoreV3PgliteArchiveEntry>,
+    consume: (visitor: (chunk: Uint8Array) => Promise<void>) => Promise<void>,
+  ) => Promise<void>;
+}): Promise<
+  Readonly<{
+    tarBytes: number;
+    extractedBytes: number;
+    files: number;
+    directories: number;
+  }>
+> {
+  const control = snapshotOperationControl(input.control);
+  const limits = limitsSnapshot(input.limits);
+  const reader = new ArchiveReader(input.tar, control, limits.maximumTarBytes);
+  const entries = new Set<string>();
+  const files = new Set<string>();
+  const directories = new Set<string>();
+  let extractedBytes = 0;
+  try {
+    for (;;) {
+      const header = await reader.header();
+      let entry: Readonly<AgentBackupRestoreV3PgliteArchiveEntry>;
+      try {
+        if (header.every((byte) => byte === 0)) {
+          await reader.zeroes(BLOCK);
+          await reader.end();
+          break;
+        }
+        entry = parseHeader(header, limits);
+      } finally {
+        header.fill(0);
+      }
+      const normalizedPath = entry.path.normalize("NFC");
+      if (entries.has(normalizedPath))
+        invalid("DUPLICATE", "Archive repeats a normalized path");
+      entries.add(normalizedPath);
+      const segments = entry.path.split("/");
+      const directoryCount =
+        entry.type === "directory" ? segments.length : segments.length - 1;
+      for (let count = 1; count <= directoryCount; count++) {
+        const name = segments.slice(0, count).join("/");
+        if (files.has(name))
+          invalid("PATH_COLLISION", "Archive directory collides with a file");
+        directories.add(name);
+        if (directories.size > limits.maximumDirectories)
+          invalid("DIRECTORY_LIMIT", "Archive exceeds its directory budget");
+      }
+      if (entry.type === "file") {
+        if (directories.has(entry.path))
+          invalid("PATH_COLLISION", "Archive file collides with a directory");
+        files.add(entry.path);
+        if (files.size > limits.maximumFiles)
+          invalid("FILE_COUNT_LIMIT", "Archive exceeds its file count budget");
+        if (extractedBytes > limits.maximumExtractedBytes - entry.sizeBytes)
+          invalid(
+            "EXTRACTED_LIMIT",
+            "Archive exceeds its extracted byte budget",
+          );
+        extractedBytes += entry.sizeBytes;
+      }
+      let consumed = false;
+      let settled = false;
+      let visiting = true;
+      try {
+        await input.visit(entry, async (visitor) => {
+          if (consumed || !visiting)
+            invalid(
+              "CONSUMER_INVALID",
+              "Archive entry must be consumed exactly once during its visit",
+            );
+          consumed = true;
+          await reader.consume(entry.sizeBytes, visitor);
+          settled = true;
+        });
+      } finally {
+        visiting = false;
+      }
+      if (!settled)
+        invalid(
+          "CONSUMER_INVALID",
+          "Archive consumer did not await the complete entry",
+        );
+      await reader.zeroes((BLOCK - (entry.sizeBytes % BLOCK)) % BLOCK);
+    }
+    if (!files.has("PG_VERSION") || !files.has("global/pg_control"))
+      invalid(
+        "DATABASE_MISSING",
+        "Archive does not contain an existing physical database",
+      );
+    return Object.freeze({
+      tarBytes: reader.totalBytes,
+      extractedBytes,
+      files: files.size,
+      directories: directories.size,
+    });
+  } finally {
+    await reader.close();
+  }
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-pglite-validation-process.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-pglite-validation-process.ts
@@ -1,0 +1,172 @@
+/**
+ * Runs and reaps an isolated PGlite validation lifecycle before releasing its
+ * caller's quarantine lock. Only a private scratch copy may be passed here.
+ * Credentials and process options are not inherited; diagnostics are discarded.
+ */
+
+import { Buffer } from "node:buffer";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AgentBackupRestoreV3OperationControl } from "@elizaos/shared";
+import { AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY } from "./agent-backup-restore-v3-candidate-database";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  type AgentBackupRestoreV3CandidateFsLock,
+  type AgentBackupRestoreV3CandidateTreeProof,
+  isAgentBackupRestoreV3CandidateFs,
+} from "./agent-backup-restore-v3-candidate-fs";
+import { snapshotOperationControl } from "./agent-backup-restore-v3-candidate-fs-control";
+import { AgentBackupRestoreV3PgliteArchiveError } from "./agent-backup-restore-v3-pglite-archive";
+
+export function runAgentBackupRestoreV3PgliteValidationProcess(input: {
+  readonly candidateFs: AgentBackupRestoreV3CandidateFs;
+  readonly heldLock: AgentBackupRestoreV3CandidateFsLock;
+  readonly copyTree: Readonly<AgentBackupRestoreV3CandidateTreeProof>;
+  readonly control: Readonly<AgentBackupRestoreV3OperationControl>;
+}): Promise<Readonly<{ serverVersion: string }>> {
+  const control = snapshotOperationControl(input.control);
+  const candidateFs = input.candidateFs;
+  if (!isAgentBackupRestoreV3CandidateFs(candidateFs))
+    throw new AgentBackupRestoreV3PgliteArchiveError(
+      "INPUT_INVALID",
+      "Validation requires a real candidate filesystem authority",
+    );
+  const expected = {
+    dataDirectory: path.join(
+      candidateFs.attemptRoot,
+      AGENT_BACKUP_RESTORE_V3_DATABASE_VALIDATION_DIRECTORY,
+    ),
+    device: input.copyTree.device,
+    inode: input.copyTree.inode,
+    lockDevice: candidateFs.attemptRootIdentity.device,
+    lockInode: candidateFs.attemptRootIdentity.inode,
+  };
+  return candidateFs.withInheritedLockDescriptor(
+    input.heldLock,
+    (descriptor) => runWorker(expected, descriptor, control),
+    control,
+  );
+}
+
+async function runWorker(
+  expected: Readonly<{
+    dataDirectory: string;
+    device: string;
+    inode: string;
+    lockDevice: string;
+    lockInode: string;
+  }>,
+  inheritedLockDescriptor: number,
+  control: Readonly<AgentBackupRestoreV3OperationControl>,
+): Promise<Readonly<{ serverVersion: string }>> {
+  const worker = fileURLToPath(
+    new URL(
+      import.meta.url.endsWith(".ts")
+        ? "./agent-backup-restore-v3-pglite-validation-worker.ts"
+        : "./agent-backup-restore-v3-pglite-validation-worker.js",
+      import.meta.url,
+    ),
+  );
+  // fd 3 is the parent-liveness pipe; fd 4 retains the exact kernel flock.
+  const child = spawn(process.execPath, [worker], {
+    stdio: ["pipe", "pipe", "pipe", "pipe", inheritedLockDescriptor],
+    env: {},
+  });
+  if (!child.stdin || !child.stdout || !child.stderr) {
+    child.kill("SIGKILL");
+    await new Promise<void>((resolve) => child.once("close", () => resolve()));
+    throw new AgentBackupRestoreV3PgliteArchiveError(
+      "VALIDATION_PROCESS_FAILED",
+      "Validation process pipes are unavailable",
+    );
+  }
+  let failure: Error | undefined;
+  const output = Buffer.alloc(4096);
+  let outputBytes = 0;
+  const fail = (code: string) => {
+    failure ??= new AgentBackupRestoreV3PgliteArchiveError(
+      code,
+      "Isolated PGlite validation failed; no database diagnostics were exposed",
+    );
+    child.kill("SIGKILL");
+  };
+  const abort = () => fail("VALIDATION_INTERRUPTED");
+  const timeout = setTimeout(
+    abort,
+    Math.min(2_147_483_647, Math.max(1, control.deadlineEpochMs - Date.now())),
+  );
+  control.signal.addEventListener("abort", abort, { once: true });
+  child.on("error", () => fail("VALIDATION_PROCESS_FAILED"));
+  child.stdin.on("error", () => fail("VALIDATION_INPUT_FAILED"));
+  child.stdout.on("error", () => fail("VALIDATION_OUTPUT_INVALID"));
+  child.stderr.on("error", () => fail("VALIDATION_PROCESS_FAILED"));
+  child.stdout.on("data", (chunk: Buffer) => {
+    if (chunk.length > output.length - outputBytes) {
+      chunk.fill(0);
+      fail("VALIDATION_OUTPUT_INVALID");
+      return;
+    }
+    chunk.copy(output, outputBytes);
+    outputBytes += chunk.length;
+    chunk.fill(0);
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    chunk.fill(0);
+  });
+  const reaped = new Promise<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }>((resolve) => {
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+  try {
+    if (control.signal.aborted) abort();
+    child.stdin.end(JSON.stringify(expected));
+    // A timeout is not a completed cleanup: always join the child's close event.
+    const exit = await reaped;
+    if (failure) throw failure;
+    if (exit.code !== 0 || exit.signal !== null)
+      throw new AgentBackupRestoreV3PgliteArchiveError(
+        "VALIDATION_FAILED",
+        "PGlite could not open, query and close the isolated physical database",
+      );
+    let value: unknown;
+    try {
+      value = JSON.parse(output.toString("utf8", 0, outputBytes));
+    } catch (cause) {
+      // error-policy:J3 Do not propagate stdout content through parse diagnostics.
+      throw new AgentBackupRestoreV3PgliteArchiveError(
+        "VALIDATION_OUTPUT_INVALID",
+        "PGlite validation returned no canonical proof",
+        cause instanceof SyntaxError ? undefined : cause,
+      );
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value))
+      throw new AgentBackupRestoreV3PgliteArchiveError(
+        "VALIDATION_OUTPUT_INVALID",
+        "PGlite validation returned no canonical proof",
+      );
+    const result = value as Record<string, unknown>;
+    if (
+      Object.keys(result).sort().join(",") !==
+        "device,inode,serverVersion,version" ||
+      result.version !== 1 ||
+      result.device !== expected.device ||
+      result.inode !== expected.inode ||
+      typeof result.serverVersion !== "string" ||
+      !/^[1-9][0-9]{4,5}$/.test(result.serverVersion)
+    )
+      throw new AgentBackupRestoreV3PgliteArchiveError(
+        "VALIDATION_OUTPUT_INVALID",
+        "PGlite validation proof differs from the exact worker request",
+      );
+    return Object.freeze({ serverVersion: result.serverVersion });
+  } finally {
+    clearTimeout(timeout);
+    control.signal.removeEventListener("abort", abort);
+    child.kill("SIGKILL");
+    await reaped;
+    output.fill(0);
+  }
+}

--- a/packages/agent/src/services/agent-backup-restore-v3-pglite-validation-worker.ts
+++ b/packages/agent/src/services/agent-backup-restore-v3-pglite-validation-worker.ts
@@ -1,0 +1,144 @@
+/**
+ * Disposable PGlite validation process; never a live Agent boot entry point.
+ * It receives only a private copy path/inode via stdin and emits no database
+ * rows or diagnostic text. The parent owns cancellation, reaping and cleanup.
+ */
+
+import { constants, fstatSync } from "node:fs";
+import fs from "node:fs/promises";
+import { Socket } from "node:net";
+import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { fuzzystrmatch } from "@electric-sql/pglite/contrib/fuzzystrmatch";
+import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
+import { vector } from "@electric-sql/pglite/vector";
+
+async function main(): Promise<void> {
+  process.umask(0o077);
+  let input = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    if (typeof chunk !== "string" || input.length + chunk.length > 4096)
+      throw new Error("Invalid validation input");
+    input += chunk;
+  }
+  const parsed: unknown = JSON.parse(input);
+  input = "";
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    throw new Error("Invalid validation input");
+  const value = parsed as Record<string, unknown>;
+  if (
+    Object.keys(value).sort().join(",") !==
+      "dataDirectory,device,inode,lockDevice,lockInode" ||
+    typeof value.dataDirectory !== "string" ||
+    !path.isAbsolute(value.dataDirectory) ||
+    path.normalize(value.dataDirectory) !== value.dataDirectory ||
+    typeof value.device !== "string" ||
+    !/^(0|[1-9][0-9]*)$/.test(value.device) ||
+    typeof value.inode !== "string" ||
+    !/^[1-9][0-9]*$/.test(value.inode)
+  )
+    throw new Error("Invalid validation identity");
+  const lockRoot = fstatSync(4, { bigint: true });
+  if (
+    !lockRoot.isDirectory() ||
+    lockRoot.dev.toString() !== value.lockDevice ||
+    lockRoot.ino.toString() !== value.lockInode
+  )
+    throw new Error("Validation lock identity mismatch");
+  const dataDirectory = value.dataDirectory;
+  const root = await fs.lstat(dataDirectory, { bigint: true });
+  if (
+    !root.isDirectory() ||
+    (root.mode & 0o7777n) !== 0o700n ||
+    root.dev.toString() !== value.device ||
+    root.ino.toString() !== value.inode
+  )
+    throw new Error("Validation root changed");
+  const version = await fs.open(
+    path.join(dataDirectory, "PG_VERSION"),
+    constants.O_RDONLY | constants.O_NOFOLLOW,
+  );
+  let major: string;
+  try {
+    const stat = await version.stat();
+    if (
+      !stat.isFile() ||
+      stat.nlink !== 1 ||
+      stat.size < 2 ||
+      stat.size > 16 ||
+      (stat.mode & 0o077) !== 0
+    )
+      throw new Error("Missing physical database");
+    const bytes = Buffer.alloc(stat.size);
+    try {
+      const read = await version.read(bytes, 0, bytes.length, 0);
+      const text = bytes.toString("utf8");
+      if (read.bytesRead !== bytes.length || !/^[1-9][0-9]*\n$/.test(text))
+        throw new Error("Invalid physical database version");
+      major = text.trim();
+    } finally {
+      bytes.fill(0);
+    }
+  } finally {
+    await version.close();
+  }
+
+  // No manager/bootstrap/migration hooks, credentials, Electric sync or network.
+  // Match the runtime's bundled SQL extensions without enabling their writers.
+  // The physical PG_VERSION was verified under the inherited quarantine lock.
+  // noInitDb is not an open-existing flag in 0.4.6: it also skips engine startup.
+  const database = new PGlite({
+    dataDir: dataDirectory,
+    extensions: { vector, fuzzystrmatch, pg_trgm },
+  });
+  let serverVersion: string;
+  try {
+    await database.waitReady;
+    const query = await database.query<{ server_version: string }>(
+      "SELECT current_setting('server_version_num') AS server_version",
+    );
+    const row = query.rows[0];
+    if (
+      query.rows.length !== 1 ||
+      !row ||
+      !/^[1-9][0-9]{4,5}$/.test(row.server_version) ||
+      String(Math.floor(Number(row.server_version) / 10000)) !== major
+    )
+      throw new Error("Database server identity mismatch");
+    serverVersion = row.server_version;
+  } finally {
+    await database.close();
+  }
+  const after = await fs.lstat(dataDirectory, { bigint: true });
+  if (!after.isDirectory() || after.dev !== root.dev || after.ino !== root.ino)
+    throw new Error("Validation root changed");
+  process.stdout.write(
+    JSON.stringify({
+      version: 1,
+      serverVersion,
+      device: value.device,
+      inode: value.inode,
+    }),
+  );
+}
+
+// Node supplies a pollable socketpair for this pipe. Do not use fs.ReadStream:
+// a blocking thread-pool read cannot be cancelled when validation completes.
+const parentLiveness = new Socket({ fd: 3, readable: true, writable: false });
+parentLiveness.on("end", () => {
+  process.kill(process.pid, "SIGKILL");
+});
+parentLiveness.on("error", () => {
+  process.kill(process.pid, "SIGKILL");
+});
+parentLiveness.resume();
+await main()
+  .catch(() => {
+    // error-policy:J1 Database diagnostics may contain private rows or settings.
+    // The parent receives a failed process, never raw stderr or fabricated proof.
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    parentLiveness.destroy();
+  });

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution-postgres.integration.test.ts
@@ -14,6 +14,7 @@ import { Client } from "pg";
 import { openAgentBackupRestoreV3CandidateFs } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-fs";
 import { createAgentBackupRestoreV3CandidateMaterializer } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-materializer";
 import { readAgentBackupRestoreV3CandidateRecord } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-records";
+import { createAgentBackupRestoreV3ProcessMaterializer } from "../../../../../../agent/src/services/agent-backup-restore-v3-materializer-process";
 import {
   acquireEphemeralPostgres,
   type EphemeralPostgres,
@@ -1120,7 +1121,7 @@ describe("restore-v3 candidate repository on real PostgreSQL", () => {
   );
 
   realPostgresTest(
-    "seals five real Agent components under PRIMARY locks and recovers partial assembly without empty restore",
+    "seals five real Agent components across private processes under PRIMARY locks and recovers partial assembly",
     async () => {
       if (!control || !executionRepository) throw new Error("PostgreSQL harness unavailable");
       const database = control;
@@ -1174,7 +1175,10 @@ describe("restore-v3 candidate repository on real PostgreSQL", () => {
           await source.close();
         }
         await fs.rm(sourcePath, { recursive: true });
-        const agent = createAgentBackupRestoreV3CandidateMaterializer(candidateFs);
+        const agent = createAgentBackupRestoreV3ProcessMaterializer({
+          candidateFs,
+          ...(process.platform === "linux" ? {} : { testOnlyAllowNonLinuxFdEmulation: true }),
+        });
         let assemblyCalls = 0;
         let fault: "mismatch" | "lost" | null = "mismatch";
         let cancelAssembly: AbortController | undefined;

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution-postgres.integration.test.ts
@@ -2,8 +2,14 @@
 
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS } from "@elizaos/shared";
 import { Client } from "pg";
+import { openAgentBackupRestoreV3CandidateFs } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-fs";
+import { createAgentBackupRestoreV3CandidateMaterializer } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-materializer";
+import { readAgentBackupRestoreV3CandidateRecord } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-records";
 import {
   acquireEphemeralPostgres,
   type EphemeralPostgres,
@@ -15,7 +21,9 @@ import {
   type CandidateFixture,
   createCandidatePrerequisiteSchema,
   fixtureSha256,
+  seedAdditionalCandidateAttempt,
   seedCandidateAuthority,
+  withAdditionalAttempt,
 } from "./agent-backup-restore-v3-candidate-test-fixture";
 
 const dbHelpersActual = await import("../../helpers");
@@ -872,6 +880,234 @@ describe("restore-v3 candidate repository on real PostgreSQL", () => {
         },
         cleanupReceiptSha256: fixtureSha256("reassigned-survivor-receipt"),
       });
+    },
+    TEST_TIMEOUT,
+  );
+
+  realPostgresTest(
+    "holds source and candidate locks through real Agent effects and reconciles lost commit acknowledgements",
+    async () => {
+      if (!control || !executionRepository) throw new Error("PostgreSQL harness unavailable");
+      const database = control;
+      const ids = {
+        restoreAttemptId: randomUUID(),
+        restoreOperationId: randomUUID(),
+        leaseId: randomUUID(),
+        leaseGeneration: randomUUID(),
+      };
+      await seedAdditionalCandidateAttempt(
+        { query: (text, values) => database.query(text, values ? [...values] : undefined) },
+        fixture,
+        ids,
+      );
+      const attempt = withAdditionalAttempt(fixture, ids);
+      const operationControl = {
+        signal: new AbortController().signal,
+        deadlineEpochMs: Date.now() + 60_000,
+      };
+      const root = await fs.mkdtemp(
+        path.join(await fs.realpath(os.tmpdir()), "restore-v3-pg-agent-"),
+      );
+      await fs.chmod(root, 0o700);
+      const attemptRoot = path.join(root, "attempt");
+      await fs.mkdir(attemptRoot, { mode: 0o700 });
+      const candidateFs = await openAgentBackupRestoreV3CandidateFs({
+        trustedRoot: root,
+        attemptRoot,
+        control: operationControl,
+        ...(process.platform === "linux" ? {} : { testOnlyAllowNonLinuxFdEmulation: true }),
+      });
+      const acknowledged = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const agent = createAgentBackupRestoreV3CandidateMaterializer(candidateFs);
+      let recordCalls = 0;
+      let finishCalls = 0;
+      let cancelNextRecord: AbortController | undefined;
+      const execution =
+        executionRepository.createAgentBackupRestoreV3MaterializingCandidateExecution(
+          attempt.sourceAuthority,
+          {
+            async stageRecord(session, record, effectControl) {
+              recordCalls++;
+              expect(effectControl.deadlineEpochMs).toBeLessThanOrEqual(
+                attempt.leaseExpiresAt.getTime(),
+              );
+              const receipt = await agent.stageRecord(session, record, effectControl);
+              cancelNextRecord?.abort();
+              cancelNextRecord = undefined;
+              acknowledged.resolve();
+              await release.promise;
+              return receipt;
+            },
+            async finishComponent(session, receipt, effectControl) {
+              finishCalls++;
+              return agent.finishComponent(session, receipt, effectControl);
+            },
+          },
+        );
+      try {
+        const session = await execution.begin(
+          { authority: attempt.authority, manifest: attempt.manifest },
+          operationControl,
+        );
+        const text = '{"name":"PostgreSQL restore QA","bio":["durable private fact"],"plugins":[]}';
+        const payload = new TextEncoder().encode(text);
+        const record = {
+          componentIndex: 0,
+          componentName: "character" as const,
+          dataIndex: 0,
+          offsetBytes: 0,
+          entry: null,
+          payload,
+        };
+        const running = Promise.resolve(execution.stageRecord(session, record, operationControl));
+        try {
+          await Promise.race([
+            acknowledged.promise,
+            running.then(() => {
+              throw new Error("Stage settled before test released the Agent acknowledgement");
+            }),
+          ]);
+          const beforeCommit = await database.query<{ count: number }>(
+            "SELECT count(*)::integer AS count FROM agent_backup_restore_v3_candidate_stage_ledger WHERE candidate_id = $1",
+            [session.stagingHandle],
+          );
+          expect(beforeCommit.rows).toEqual([{ count: 0 }]);
+          const staged = await readAgentBackupRestoreV3CandidateRecord({
+            candidateFs,
+            session,
+            componentIndex: 0,
+            dataIndex: 0,
+            control: operationControl,
+          });
+          expect(staged.payload).toEqual(payload);
+          staged.payload.fill(0);
+
+          // Independent transactions must not acquire any destructive authority
+          // while the Agent effect is durable but its acknowledgement is pending.
+          const lockedRows = [
+            [
+              "SELECT id FROM agent_sandbox_backups WHERE id = $1 FOR UPDATE NOWAIT",
+              attempt.authority.backupId,
+            ],
+            [
+              "SELECT id FROM agent_backup_restore_operations WHERE id = $1 FOR UPDATE NOWAIT",
+              ids.restoreOperationId,
+            ],
+            [
+              "SELECT id FROM agent_backup_restore_leases WHERE id = $1 FOR UPDATE NOWAIT",
+              ids.leaseId,
+            ],
+            [
+              "SELECT agent_id FROM agent_backup_catalog_authorities WHERE agent_id = $1 FOR UPDATE NOWAIT",
+              attempt.authority.agentId,
+            ],
+            [
+              "SELECT id FROM agent_backup_objects WHERE backup_id = $1 FOR UPDATE NOWAIT",
+              attempt.authority.backupId,
+            ],
+            [
+              "SELECT id FROM agent_backup_restore_v3_candidates WHERE id = $1 FOR UPDATE NOWAIT",
+              session.stagingHandle,
+            ],
+          ] as const;
+          for (const [query, id] of lockedRows) {
+            await database.query("BEGIN");
+            try {
+              await expect(database.query(query, [id])).rejects.toMatchObject({ code: "55P03" });
+            } finally {
+              await database.query("ROLLBACK");
+            }
+          }
+        } finally {
+          release.resolve();
+          await running;
+        }
+        const accepted = await running;
+        expect(accepted.payloadSha256).toBe(fixtureSha256(payload));
+        expect(recordCalls).toBe(1);
+        expect(await execution.stageRecord(session, record, operationControl)).toEqual(accepted);
+        expect(recordCalls).toBe(1);
+
+        const component = {
+          componentIndex: 0,
+          componentName: "character" as const,
+          descriptor: AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS[0]!,
+          dataFrameCount: 1,
+          payloadBytes: payload.length,
+          payloadSha256: fixtureSha256(payload),
+          recordStreamContentHmacSha256: "b".repeat(64),
+        };
+        const finished = await withLostNextCommitAcknowledgment({
+          sqlState: "08006",
+          run: async () => execution.finishComponent(session, component, operationControl),
+        });
+        expect(finished).toEqual(component);
+        expect(finishCalls).toBe(1);
+        expect(
+          await fs.readFile(path.join(attemptRoot, "components/character/character.json"), "utf8"),
+        ).toBe(text);
+        const afterCommit = await database.query<{ command_kind: string; count: number }>(
+          "SELECT command_kind, count(*)::integer AS count FROM agent_backup_restore_v3_candidate_stage_ledger WHERE candidate_id = $1 GROUP BY command_kind ORDER BY command_kind",
+          [session.stagingHandle],
+        );
+        expect(afterCommit.rows).toEqual([
+          { command_kind: "finish", count: 1 },
+          { command_kind: "record", count: 1 },
+        ]);
+        const databaseRecord = {
+          ...record,
+          componentIndex: 1,
+          componentName: "database" as const,
+        };
+        const cancelled = new AbortController();
+        cancelNextRecord = cancelled;
+        await expect(
+          execution.stageRecord(session, databaseRecord, {
+            ...operationControl,
+            signal: cancelled.signal,
+          }),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        const afterCancellation = await database.query<{ count: number }>(
+          "SELECT count(*)::integer AS count FROM agent_backup_restore_v3_candidate_stage_ledger WHERE candidate_id = $1 AND component_index = 1",
+          [session.stagingHandle],
+        );
+        expect(afterCancellation.rows).toEqual([{ count: 0 }]);
+        const partial = await readAgentBackupRestoreV3CandidateRecord({
+          candidateFs,
+          session,
+          componentIndex: 1,
+          dataIndex: 0,
+          control: operationControl,
+        });
+        expect(partial.payload).toEqual(payload);
+        partial.payload.fill(0);
+        expect(await execution.stageRecord(session, databaseRecord, operationControl)).toEqual(
+          partial.receipt.record,
+        );
+        expect(recordCalls).toBe(3);
+        await database.query(
+          "UPDATE agent_backup_restore_leases SET expires_at = clock_timestamp() - interval '1 second' WHERE id = $1",
+          [ids.leaseId],
+        );
+        await expect(
+          execution.stageRecord(
+            session,
+            {
+              ...databaseRecord,
+              dataIndex: 1,
+              offsetBytes: payload.length,
+            },
+            operationControl,
+          ),
+        ).rejects.toThrow();
+        expect(recordCalls).toBe(3);
+        expect(await execution.abort(session, "staging-failed", operationControl)).toBe(true);
+      } finally {
+        release.resolve();
+        await candidateFs.close();
+        await fs.rm(root, { recursive: true, force: true });
+      }
     },
     TEST_TIMEOUT,
   );

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution-postgres.integration.test.ts
@@ -5,7 +5,11 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS } from "@elizaos/shared";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
+  type AgentBackupRestoreV3ComponentReceipt,
+} from "@elizaos/shared";
 import { Client } from "pg";
 import { openAgentBackupRestoreV3CandidateFs } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-fs";
 import { createAgentBackupRestoreV3CandidateMaterializer } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-materializer";
@@ -18,6 +22,8 @@ import { computeAgentBackupRestoreV3CleanupSettlementEvidenceSha256 } from "../a
 import {
   applyCandidateMigrations,
   buildCandidateFixture,
+  buildCandidateSealAuthorizationRequest,
+  buildCandidateSealReceipt,
   type CandidateFixture,
   createCandidatePrerequisiteSchema,
   fixtureSha256,
@@ -927,6 +933,7 @@ describe("restore-v3 candidate repository on real PostgreSQL", () => {
         executionRepository.createAgentBackupRestoreV3MaterializingCandidateExecution(
           attempt.sourceAuthority,
           {
+            assembleCandidate: agent.assembleCandidate,
             async stageRecord(session, record, effectControl) {
               recordCalls++;
               expect(effectControl.deadlineEpochMs).toBeLessThanOrEqual(
@@ -1105,6 +1112,287 @@ describe("restore-v3 candidate repository on real PostgreSQL", () => {
         expect(await execution.abort(session, "staging-failed", operationControl)).toBe(true);
       } finally {
         release.resolve();
+        await candidateFs.close();
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+    TEST_TIMEOUT,
+  );
+
+  realPostgresTest(
+    "seals five real Agent components under PRIMARY locks and recovers partial assembly without empty restore",
+    async () => {
+      if (!control || !executionRepository) throw new Error("PostgreSQL harness unavailable");
+      const database = control;
+      const { createAgentBackupRestoreV3CandidateSealAuthority } = await import(
+        "../agent-backup-restore-v3-candidate-seal-authority"
+      );
+      const ids = {
+        restoreAttemptId: randomUUID(),
+        restoreOperationId: randomUUID(),
+        leaseId: randomUUID(),
+        leaseGeneration: randomUUID(),
+      };
+      await seedAdditionalCandidateAttempt(
+        { query: (text, values) => database.query(text, values ? [...values] : undefined) },
+        fixture,
+        ids,
+      );
+      const attempt = withAdditionalAttempt(fixture, ids);
+      const operationControl = {
+        signal: new AbortController().signal,
+        deadlineEpochMs: Date.now() + 110_000,
+      };
+      const root = await fs.mkdtemp(
+        path.join(await fs.realpath(os.tmpdir()), "restore-v3-pg-seal-"),
+      );
+      await fs.chmod(root, 0o700);
+      const attemptRoot = path.join(root, "attempt");
+      await fs.mkdir(attemptRoot, { mode: 0o700 });
+      const candidateFs = await openAgentBackupRestoreV3CandidateFs({
+        trustedRoot: root,
+        attemptRoot,
+        control: operationControl,
+        ...(process.platform === "linux" ? {} : { testOnlyAllowNonLinuxFdEmulation: true }),
+      });
+      const release = Promise.withResolvers<void>();
+      const assembled = Promise.withResolvers<void>();
+      let databaseBytes: Uint8Array | undefined;
+      try {
+        const sourcePath = path.join(root, "source-database");
+        const source = new PGlite(sourcePath);
+        try {
+          await source.exec(
+            "CREATE TABLE restored_fact (id integer PRIMARY KEY, fact text NOT NULL)",
+          );
+          await source.query("INSERT INTO restored_fact VALUES ($1, $2)", [
+            1,
+            "amber lighthouse 20732",
+          ]);
+          databaseBytes = new Uint8Array(await (await source.dumpDataDir("gzip")).arrayBuffer());
+        } finally {
+          await source.close();
+        }
+        await fs.rm(sourcePath, { recursive: true });
+        const agent = createAgentBackupRestoreV3CandidateMaterializer(candidateFs);
+        let assemblyCalls = 0;
+        let fault: "mismatch" | "lost" | null = "mismatch";
+        let cancelAssembly: AbortController | undefined;
+        const execution =
+          executionRepository.createAgentBackupRestoreV3MaterializingCandidateExecution(
+            attempt.sourceAuthority,
+            {
+              ...agent,
+              async assembleCandidate(session, receipt, effectControl) {
+                assemblyCalls++;
+                const result = await agent.assembleCandidate(session, receipt, effectControl);
+                cancelAssembly?.abort();
+                cancelAssembly = undefined;
+                assembled.resolve();
+                await release.promise;
+                if (fault === "lost")
+                  throw new Error("injected lost Agent assembly acknowledgement");
+                return fault === "mismatch"
+                  ? { ...result, sourceAuthoritySha256: "f".repeat(64) }
+                  : result;
+              },
+            },
+          );
+        const session = await execution.begin(
+          { authority: attempt.authority, manifest: attempt.manifest },
+          operationControl,
+        );
+        const encode = (text: string) => new TextEncoder().encode(text);
+        const contents = [
+          encode('{"name":"Sealed QA","bio":["remembers a lighthouse"],"plugins":[]}'),
+          databaseBytes,
+          encode("private media"),
+          encode('{"state":"tide"}'),
+          encode("opaque vault ciphertext"),
+        ];
+        const paths = [null, null, "photo.bin", "plugin/state.json", "vault.json"];
+        const components: AgentBackupRestoreV3ComponentReceipt[] = [];
+        for (const [
+          componentIndex,
+          descriptor,
+        ] of AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS.entries()) {
+          const bytes = contents[componentIndex];
+          if (!bytes) throw new Error("Missing component bytes");
+          const filePath = paths[componentIndex];
+          let dataFrameCount = 0;
+          for (let offsetBytes = 0; offsetBytes < bytes.length; offsetBytes += 256 * 1024) {
+            const payload = Uint8Array.from(bytes.subarray(offsetBytes, offsetBytes + 256 * 1024));
+            try {
+              await execution.stageRecord(
+                session,
+                {
+                  componentIndex,
+                  componentName: descriptor.name,
+                  dataIndex: dataFrameCount++,
+                  offsetBytes,
+                  payload,
+                  entry: filePath
+                    ? {
+                        path: filePath,
+                        fileOffsetBytes: offsetBytes,
+                        fileSizeBytes: bytes.length,
+                        mode: componentIndex === 4 ? 0o400 : 0o600,
+                        mtimeMs: 0,
+                      }
+                    : null,
+                },
+                operationControl,
+              );
+            } finally {
+              payload.fill(0);
+            }
+          }
+          components.push(
+            await execution.finishComponent(
+              session,
+              {
+                componentIndex,
+                componentName: descriptor.name,
+                descriptor,
+                dataFrameCount,
+                payloadBytes: bytes.length,
+                payloadSha256: fixtureSha256(bytes),
+                recordStreamContentHmacSha256: "b".repeat(64),
+              },
+              operationControl,
+            ),
+          );
+        }
+        databaseBytes.fill(0);
+        const receipt = buildCandidateSealReceipt(attempt, components);
+        const authorization = await createAgentBackupRestoreV3CandidateSealAuthority().authorize(
+          buildCandidateSealAuthorizationRequest(attempt, session, receipt),
+          operationControl,
+        );
+        const first = Promise.resolve(
+          execution.seal(session, receipt, authorization, operationControl),
+        );
+        const failure = first.then(
+          () => null,
+          (cause: unknown) => cause,
+        );
+        try {
+          await Promise.race([assembled.promise, first]);
+          const active = await database.query<{ state: string }>(
+            "SELECT state FROM agent_backup_restore_v3_candidates WHERE id = $1",
+            [session.stagingHandle],
+          );
+          expect(active.rows).toEqual([{ state: "active" }]);
+          for (const [query, id] of [
+            [
+              "SELECT id FROM agent_backup_restore_v3_candidates WHERE id = $1 FOR UPDATE NOWAIT",
+              session.stagingHandle,
+            ],
+            [
+              "SELECT id FROM agent_backup_restore_v3_candidate_seal_authorizations WHERE id = $1 FOR UPDATE NOWAIT",
+              authorization.authorizationId,
+            ],
+            [
+              "SELECT id FROM agent_backup_restore_leases WHERE id = $1 FOR UPDATE NOWAIT",
+              ids.leaseId,
+            ],
+          ] as const) {
+            await database.query("BEGIN");
+            try {
+              await expect(database.query(query, [id])).rejects.toMatchObject({ code: "55P03" });
+            } finally {
+              await database.query("ROLLBACK");
+            }
+          }
+        } finally {
+          release.resolve();
+        }
+        expect(await failure).toMatchObject({
+          code: "AGENT_BACKUP_RESTORE_V3_CANDIDATE_SEAL_CONFLICT",
+        });
+        const marker = path.join(attemptRoot, ".restore-v3-candidate-assembled.json");
+        const markerBytes = await fs.readFile(marker, "utf8");
+        const markerInode = (await fs.stat(marker, { bigint: true })).ino;
+        const rollback = await database.query<{
+          state: string;
+          proof_state: string;
+          terminal_count: number;
+        }>(
+          "SELECT c.state, a.state AS proof_state, (SELECT count(*)::integer FROM agent_backup_restore_v3_candidate_terminal_commands t WHERE t.candidate_id = c.id) AS terminal_count FROM agent_backup_restore_v3_candidates c JOIN agent_backup_restore_v3_candidate_seal_authorizations a ON a.candidate_id = c.id WHERE c.id = $1",
+          [session.stagingHandle],
+        );
+        expect(rollback.rows).toEqual([
+          { state: "active", proof_state: "active", terminal_count: 0 },
+        ]);
+        fault = "lost";
+        await expect(
+          execution.seal(session, receipt, authorization, operationControl),
+        ).rejects.toThrow("injected lost Agent assembly");
+        fault = null;
+        const cancelled = new AbortController();
+        cancelAssembly = cancelled;
+        await expect(
+          execution.seal(session, receipt, authorization, {
+            ...operationControl,
+            signal: cancelled.signal,
+          }),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expect(
+          (
+            await database.query<{ state: string }>(
+              "SELECT state FROM agent_backup_restore_v3_candidates WHERE id = $1",
+              [session.stagingHandle],
+            )
+          ).rows,
+        ).toEqual([{ state: "active" }]);
+        expect(
+          await withLostNextCommitAcknowledgment({
+            sqlState: "08006",
+            run: async () => execution.seal(session, receipt, authorization, operationControl),
+          }),
+        ).toEqual(receipt);
+        expect(assemblyCalls).toBe(4);
+        const sealed = await database.query<{ state: string; proof_state: string }>(
+          "SELECT c.state, a.state AS proof_state FROM agent_backup_restore_v3_candidates c JOIN agent_backup_restore_v3_candidate_seal_authorizations a ON a.candidate_id = c.id WHERE c.id = $1",
+          [session.stagingHandle],
+        );
+        expect(sealed.rows).toEqual([{ state: "sealed", proof_state: "consumed" }]);
+        await database.query(
+          "UPDATE agent_backup_restore_leases SET expires_at = clock_timestamp() - interval '1 second' WHERE id = $1",
+          [ids.leaseId],
+        );
+        expect(
+          await execution.seal(session, receipt, authorization, {
+            ...operationControl,
+            deadlineEpochMs: Date.now() - 1,
+          }),
+        ).toEqual(receipt);
+        expect(assemblyCalls).toBe(4);
+        expect(await fs.readFile(marker, "utf8")).toBe(markerBytes);
+        expect((await fs.stat(marker, { bigint: true })).ino).toBe(markerInode);
+        for (const [componentIndex, filePath] of paths.entries()) {
+          if (!filePath) continue;
+          const component = components[componentIndex];
+          if (!component) throw new Error("Missing component receipt");
+          expect(
+            await fs.readFile(
+              path.join(attemptRoot, "components", component.componentName, filePath),
+            ),
+          ).toEqual(Buffer.from(contents[componentIndex]!));
+        }
+        const probePath = path.join(root, "database-probe");
+        await fs.cp(path.join(attemptRoot, "components/database"), probePath, { recursive: true });
+        const restored = new PGlite(probePath);
+        try {
+          expect(
+            (await restored.query("SELECT id, fact FROM restored_fact ORDER BY id")).rows,
+          ).toEqual([{ id: 1, fact: "amber lighthouse 20732" }]);
+        } finally {
+          await restored.close();
+        }
+      } finally {
+        release.resolve();
+        databaseBytes?.fill(0);
         await candidateFs.close();
         await fs.rm(root, { recursive: true, force: true });
       }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-materialization.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-materialization.pglite.test.ts
@@ -90,6 +90,7 @@ test("requires real Agent acknowledgements, replays partial effects and prevents
   const execution = createAgentBackupRestoreV3MaterializingCandidateExecution(
     fixture.sourceAuthority,
     {
+      assembleCandidate: agent.assembleCandidate,
       async stageRecord(session, record, effectControl) {
         recordCalls++;
         borrowedCopies.push(record.payload);

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-materialization.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-v3-materialization.pglite.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Real coordinator PGlite transactions joined to the Agent filesystem adapter.
+ * Faults are injected after actual Agent effects to prove rollback and replay;
+ * this does not substitute for HTTP transport or multi-connection PostgreSQL.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS,
+  type AgentBackupRestoreV3ComponentReceipt,
+  type AgentBackupRestoreV3OperationControl,
+} from "@elizaos/shared";
+import {
+  type AgentBackupRestoreV3CandidateFs,
+  openAgentBackupRestoreV3CandidateFs,
+} from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-fs";
+import { createAgentBackupRestoreV3CandidateMaterializer } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-materializer";
+import { readAgentBackupRestoreV3CandidateRecord } from "../../../../../../agent/src/services/agent-backup-restore-v3-candidate-records";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV = "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { closeDatabaseConnectionsForTests, getPgliteClientForTests } from "../../client";
+import { createAgentBackupRestoreV3MaterializingCandidateExecution } from "../agent-backup-restore-v3-candidate-execution";
+import {
+  applyCandidateMigrations,
+  buildCandidateFixture,
+  type CandidateFixture,
+  createCandidatePrerequisiteSchema,
+  fixtureSha256,
+  seedCandidateAuthority,
+} from "./agent-backup-restore-v3-candidate-test-fixture";
+
+const control = (): Readonly<AgentBackupRestoreV3OperationControl> => ({
+  signal: new AbortController().signal,
+  deadlineEpochMs: Date.now() + 900_000,
+});
+let fixture: CandidateFixture;
+let root: string;
+let candidateFs: AgentBackupRestoreV3CandidateFs;
+
+beforeAll(async () => {
+  const database = getPgliteClientForTests();
+  fixture = await buildCandidateFixture();
+  await createCandidatePrerequisiteSchema(database);
+  await applyCandidateMigrations(database);
+  await seedCandidateAuthority(database, fixture);
+  root = await fs.mkdtemp(
+    path.join(await fs.realpath(os.tmpdir()), "restore-v3-coordinator-agent-"),
+  );
+  await fs.chmod(root, 0o700);
+  const attemptRoot = path.join(root, "attempt");
+  await fs.mkdir(attemptRoot, { mode: 0o700 });
+  candidateFs = await openAgentBackupRestoreV3CandidateFs({
+    trustedRoot: root,
+    attemptRoot,
+    control: control(),
+    ...(process.platform === "linux" ? {} : { testOnlyAllowNonLinuxFdEmulation: true }),
+  });
+});
+
+afterAll(async () => {
+  if (candidateFs) await candidateFs.close();
+  if (root) await fs.rm(root, { recursive: true, force: true });
+  await closeDatabaseConnectionsForTests();
+});
+
+async function ledgerCount(kind: "record" | "finish"): Promise<number> {
+  const result = await getPgliteClientForTests().query<{ count: number }>(
+    "SELECT count(*)::integer AS count FROM agent_backup_restore_v3_candidate_stage_ledger WHERE command_kind = $1",
+    [kind],
+  );
+  const count = result.rows[0]?.count;
+  if (count === undefined) throw new Error("Missing ledger count");
+  return count;
+}
+
+test("requires real Agent acknowledgements, replays partial effects and prevents stale writes", async () => {
+  const agent = createAgentBackupRestoreV3CandidateMaterializer(candidateFs);
+  let recordCalls = 0;
+  let finishCalls = 0;
+  let recordFault: "mismatch" | "lost" | null = "mismatch";
+  let finishFault = true;
+  const borrowedCopies: Uint8Array[] = [];
+  const execution = createAgentBackupRestoreV3MaterializingCandidateExecution(
+    fixture.sourceAuthority,
+    {
+      async stageRecord(session, record, effectControl) {
+        recordCalls++;
+        borrowedCopies.push(record.payload);
+        expect(effectControl.deadlineEpochMs).toBeLessThanOrEqual(fixture.leaseExpiresAt.getTime());
+        const receipt = await agent.stageRecord(session, record, effectControl);
+        if (recordFault === "lost") throw new Error("injected lost Agent acknowledgement");
+        return recordFault === "mismatch" ? { ...receipt, payloadSha256: "f".repeat(64) } : receipt;
+      },
+      async finishComponent(session, component, effectControl) {
+        finishCalls++;
+        const receipt = await agent.finishComponent(session, component, effectControl);
+        return finishFault ? { ...receipt, payloadSha256: "f".repeat(64) } : receipt;
+      },
+    },
+  );
+  const session = await execution.begin(
+    { authority: fixture.authority, manifest: fixture.manifest },
+    control(),
+  );
+  expect(await fs.readdir(candidateFs.attemptRoot)).toEqual([]);
+  const cleanup = await getPgliteClientForTests().query<{ state: string }>(
+    "SELECT state FROM agent_backup_restore_v3_candidate_cleanup_outbox WHERE id = $1",
+    [session.cleanupHandle],
+  );
+  expect(cleanup.rows).toEqual([{ state: "held" }]);
+  const text = '{"name":"Coordinator restore QA","bio":["private coordinator fact"],"plugins":[]}';
+  const record = () => ({
+    componentIndex: 0,
+    componentName: "character" as const,
+    dataIndex: 0,
+    offsetBytes: 0,
+    entry: null,
+    payload: new TextEncoder().encode(text),
+  });
+  await expect(execution.stageRecord(session, record(), control())).rejects.toMatchObject({
+    code: "AGENT_BACKUP_RESTORE_V3_MATERIALIZATION_CONFLICT",
+  });
+  expect(await ledgerCount("record")).toBe(0);
+  expect(borrowedCopies.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);
+  const staged = await readAgentBackupRestoreV3CandidateRecord({
+    candidateFs,
+    session,
+    componentIndex: 0,
+    dataIndex: 0,
+    control: control(),
+  });
+  expect(new TextDecoder().decode(staged.payload)).toBe(text);
+  staged.payload.fill(0);
+
+  recordFault = "lost";
+  await expect(execution.stageRecord(session, record(), control())).rejects.toThrow(
+    "injected lost",
+  );
+  expect(await ledgerCount("record")).toBe(0);
+  recordFault = null;
+  const mutableSession = { ...session };
+  const callerRecord = record();
+  const running = execution.stageRecord(mutableSession, callerRecord, control());
+  mutableSession.executionToken = "not-the-authorized-execution";
+  callerRecord.payload.fill(0);
+  const accepted = await running;
+  expect(accepted.payloadSha256).toBe(fixtureSha256(text));
+  expect(await ledgerCount("record")).toBe(1);
+  expect(borrowedCopies.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);
+  const beforeReplay = recordCalls;
+  expect(await execution.stageRecord(session, record(), control())).toEqual(accepted);
+  expect(recordCalls).toBe(beforeReplay);
+
+  const descriptor = AGENT_BACKUP_RESTORE_V3_COMPONENT_DESCRIPTORS[0];
+  if (!descriptor) throw new Error("Missing character descriptor");
+  const component: AgentBackupRestoreV3ComponentReceipt = {
+    componentIndex: 0,
+    componentName: "character",
+    descriptor,
+    dataFrameCount: 1,
+    payloadBytes: new TextEncoder().encode(text).length,
+    payloadSha256: fixtureSha256(text),
+    recordStreamContentHmacSha256: "b".repeat(64),
+  };
+  await expect(execution.finishComponent(session, component, control())).rejects.toMatchObject({
+    code: "AGENT_BACKUP_RESTORE_V3_MATERIALIZATION_CONFLICT",
+  });
+  expect(await ledgerCount("finish")).toBe(0);
+  const outputPath = path.join(candidateFs.attemptRoot, "components/character/character.json");
+  expect(await fs.readFile(outputPath, "utf8")).toBe(text);
+  const inode = (await fs.stat(outputPath, { bigint: true })).ino;
+  finishFault = false;
+  expect(await execution.finishComponent(session, component, control())).toEqual(component);
+  expect(await ledgerCount("finish")).toBe(1);
+  expect((await fs.stat(outputPath, { bigint: true })).ino).toBe(inode);
+  const beforeClosedFinish = finishCalls;
+  await expect(execution.finishComponent(session, component, control())).rejects.toThrow();
+  expect(finishCalls).toBe(beforeClosedFinish);
+  await expect(execution.stageRecord(session, record(), control())).rejects.toThrow();
+  expect(recordCalls).toBe(beforeReplay);
+
+  await getPgliteClientForTests().query(
+    "UPDATE agent_backup_restore_leases SET expires_at = clock_timestamp() - interval '1 second' WHERE id = $1",
+    [fixture.authority.leaseId],
+  );
+  await expect(
+    execution.stageRecord(
+      session,
+      {
+        componentIndex: 1,
+        componentName: "database",
+        dataIndex: 0,
+        offsetBytes: 0,
+        entry: null,
+        payload: new Uint8Array([7]),
+      },
+      control(),
+    ),
+  ).rejects.toThrow();
+  expect(recordCalls).toBe(beforeReplay);
+  expect(await execution.abort(session, "staging-failed", control())).toBe(true);
+  await expect(execution.stageRecord(session, record(), control())).rejects.toThrow();
+  expect(recordCalls).toBe(beforeReplay);
+  const terminal = await getPgliteClientForTests().query<{ state: string }>(
+    "SELECT state FROM agent_backup_restore_v3_candidate_cleanup_outbox WHERE id = $1",
+    [session.cleanupHandle],
+  );
+  expect(terminal.rows).toEqual([{ state: "pending" }]);
+  expect(await fs.readFile(outputPath, "utf8")).toBe(text);
+}, 120_000);

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-v3-candidate-execution.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-v3-candidate-execution.ts
@@ -1,6 +1,7 @@
 /** Durable begin/stage/finish/abort repository for one restore-v3 candidate. */
 
 import { randomBytes, randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import {
   AgentBackupRestoreV3ComponentReceiptSchema,
   type AgentBackupRestoreV3IsolatedCandidateStaging,
@@ -15,7 +16,8 @@ import {
   parseAgentBackupRestoreV3SourceAuthority,
   parseAgentBackupRestoreV3StagingSession,
 } from "@elizaos/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
+import type { DbTransaction } from "../client";
 import { dbWrite } from "../helpers";
 import { agentBackupRestoreOperations } from "../schemas/agent-backup-catalog";
 import {
@@ -60,6 +62,24 @@ export type AgentBackupRestoreV3CandidateExecution = Pick<
   AgentBackupRestoreV3IsolatedCandidateStaging,
   "begin" | "stageRecord" | "finishComponent" | "abort"
 >;
+
+/**
+ * Trusted Agent transport. Calls run while PRIMARY source/lease and stage
+ * authority locks remain held. Implementations must honor control, reap pending
+ * writes before settling, and make exact partial-effect retries idempotent.
+ * They must not issue coordinator DB queries through a separate transaction.
+ */
+export type AgentBackupRestoreV3CandidateMaterializer = Pick<
+  AgentBackupRestoreV3IsolatedCandidateStaging,
+  "stageRecord" | "finishComponent"
+>;
+
+function materializationError(message: string): never {
+  throw new ElizaError(message, {
+    code: "AGENT_BACKUP_RESTORE_V3_MATERIALIZATION_CONFLICT",
+    severity: "fatal",
+  });
+}
 
 export class AgentBackupRestoreV3CandidateExecutionConflictError extends Error {
   readonly code = "AGENT_BACKUP_RESTORE_V3_CANDIDATE_CONFLICT";
@@ -258,9 +278,54 @@ function exactFinishMatches(
 
 class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecution {
   readonly #bound: BoundCandidateExecution;
+  readonly #materializer: AgentBackupRestoreV3CandidateMaterializer | undefined;
 
-  constructor(bound: BoundCandidateExecution) {
+  constructor(
+    bound: BoundCandidateExecution,
+    materializer?: AgentBackupRestoreV3CandidateMaterializer,
+  ) {
     this.#bound = bound;
+    this.#materializer = materializer;
+  }
+
+  async #materializationControl(
+    tx: DbTransaction,
+    control: Readonly<AgentBackupRestoreV3OperationControl>,
+  ): Promise<Readonly<AgentBackupRestoreV3OperationControl>> {
+    // Reuse the canonical backup -> operation -> lease -> catalogue -> objects
+    // lock order BEFORE the stage trigger takes the candidate lock. The metadata
+    // ledger alone checks active execution, not current source/lease authority.
+    const c = agentBackupRestoreV3Candidates;
+    const [candidate] = await tx
+      .select({
+        leaseExpiresAt: sql<Date | string>`lock_agent_backup_restore_v3_current_authority(
+          ${c.organization_id}, ${c.agent_id}, ${c.backup_id}, ${c.restore_attempt_id},
+          ${c.operation_id}, ${c.restore_operation_id}, ${c.lease_id}, ${c.lease_owner_id},
+          ${c.lease_generation}, ${c.catalog_epoch}, ${c.source_copy_role},
+          ${c.source_activation_generation}, ${c.source_lifecycle_revision},
+          ${c.expected_manifest_sha256}, ${c.key_bundle_generation_id},
+          ${c.source_authority_canonical}, ${c.source_authority_sha256},
+          ${c.object_count}, NULL)`,
+      })
+      .from(c)
+      .where(
+        and(
+          eq(c.id, this.#bound.candidateId),
+          eq(c.execution_token_sha256, this.#bound.executionTokenSha256),
+          eq(c.state, "active"),
+        ),
+      )
+      .limit(1);
+    if (!candidate) materializationError("Materialization lost its locked candidate authority");
+    const bounded = Object.freeze({
+      signal: control.signal,
+      deadlineEpochMs: Math.min(
+        control.deadlineEpochMs,
+        asDate(candidate.leaseExpiresAt).getTime(),
+      ),
+    });
+    assertAgentBackupRestoreV3OperationControl(bounded, "Restore-v3 Agent materialization");
+    return bounded;
   }
 
   async begin(
@@ -511,13 +576,11 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
       entry,
       payload,
     };
-    try {
-      return this.#stageRecord(sessionInput, copied, control);
-    } finally {
-      // #stageRecord hashes and validates the copy before its first await. No
-      // plaintext is needed while PostgreSQL settles the durable receipt.
+    return this.#stageRecord(sessionInput, copied, control).finally(() => {
+      // The Agent consumes this owned copy inside the authority transaction.
+      // Keep it through acknowledgement/rollback, then zeroize on every exit.
       payload.fill(0);
-    }
+    });
   }
 
   async #stageRecord(
@@ -526,7 +589,8 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
     control: Readonly<AgentBackupRestoreV3OperationControl>,
   ): Promise<CandidateRecordReceipt> {
     assertAgentBackupRestoreV3OperationControl(control, "Restore-v3 record stage");
-    this.#requireExactSession(sessionInput);
+    const session = parseAgentBackupRestoreV3StagingSession(sessionInput);
+    this.#requireExactSession(session);
     const receipt = freezeRecordReceipt(
       AgentBackupRestoreV3StageRecordReceiptSchema.parse({
         componentIndex: record.componentIndex,
@@ -546,6 +610,9 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
     try {
       await dbWrite.transaction(async (tx) => {
         await applyAgentBackupRestoreV3TransactionDeadline(tx, control, "Restore-v3 record stage");
+        const effectControl = this.#materializer
+          ? await this.#materializationControl(tx, control)
+          : undefined;
         await tx.insert(agentBackupRestoreV3CandidateStageLedger).values({
           candidate_id: this.#bound.candidateId,
           organization_id: this.#bound.organizationId,
@@ -570,6 +637,25 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
           command_sha256: commandSha256,
           receipt_sha256: receiptSha256,
         });
+        if (this.#materializer && effectControl) {
+          const acknowledged = freezeRecordReceipt(
+            AgentBackupRestoreV3StageRecordReceiptSchema.parse(
+              await this.#materializer.stageRecord(session, record, effectControl),
+            ),
+          );
+          if (
+            canonicalAgentBackupRestoreV3StageRecordReceipt(acknowledged) !==
+            canonicalAgentBackupRestoreV3StageRecordReceipt(receipt)
+          )
+            materializationError(
+              "Agent record acknowledgement differs from the exact staged command",
+            );
+          await applyAgentBackupRestoreV3TransactionDeadline(
+            tx,
+            effectControl,
+            "Restore-v3 Agent record acknowledgement",
+          );
+        }
         assertAgentBackupRestoreV3OperationControl(control, "Restore-v3 record stage");
       });
       return receipt;
@@ -672,7 +758,8 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
     control: Readonly<AgentBackupRestoreV3OperationControl>,
   ): Promise<CandidateComponentReceipt> {
     assertAgentBackupRestoreV3OperationControl(control, "Restore-v3 component finish");
-    this.#requireExactSession(sessionInput);
+    const session = parseAgentBackupRestoreV3StagingSession(sessionInput);
+    this.#requireExactSession(session);
     const receipt = freezeComponentReceipt(
       AgentBackupRestoreV3ComponentReceiptSchema.parse(receiptInput),
     );
@@ -688,6 +775,9 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
           control,
           "Restore-v3 component finish",
         );
+        const effectControl = this.#materializer
+          ? await this.#materializationControl(tx, control)
+          : undefined;
         await tx.insert(agentBackupRestoreV3CandidateStageLedger).values({
           candidate_id: this.#bound.candidateId,
           organization_id: this.#bound.organizationId,
@@ -711,6 +801,25 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
           command_sha256: commandSha256,
           receipt_sha256: receiptSha256,
         });
+        if (this.#materializer && effectControl) {
+          const acknowledged = freezeComponentReceipt(
+            AgentBackupRestoreV3ComponentReceiptSchema.parse(
+              await this.#materializer.finishComponent(session, receipt, effectControl),
+            ),
+          );
+          if (
+            canonicalAgentBackupRestoreV3ComponentReceipt(acknowledged) !==
+            canonicalAgentBackupRestoreV3ComponentReceipt(receipt)
+          )
+            materializationError(
+              "Agent component acknowledgement differs from the exact finish command",
+            );
+          await applyAgentBackupRestoreV3TransactionDeadline(
+            tx,
+            effectControl,
+            "Restore-v3 Agent component acknowledgement",
+          );
+        }
         assertAgentBackupRestoreV3OperationControl(control, "Restore-v3 component finish");
       });
       return receipt;
@@ -904,6 +1013,33 @@ class CandidateExecutionRepository implements AgentBackupRestoreV3CandidateExecu
 export function createAgentBackupRestoreV3CandidateExecution(
   sourceAuthorityInput: Readonly<AgentBackupRestoreV3SourceAuthority>,
 ): AgentBackupRestoreV3CandidateExecution {
+  return createCandidateExecution(sourceAuthorityInput);
+}
+
+/** Explicit materializing variant; omitting Agent effects is never a fallback. */
+export function createAgentBackupRestoreV3MaterializingCandidateExecution(
+  sourceAuthority: Readonly<AgentBackupRestoreV3SourceAuthority>,
+  materializer: AgentBackupRestoreV3CandidateMaterializer,
+): AgentBackupRestoreV3CandidateExecution {
+  if (
+    !materializer ||
+    typeof materializer.stageRecord !== "function" ||
+    typeof materializer.finishComponent !== "function"
+  )
+    materializationError("Restore candidate requires an explicit Agent materializer");
+  return createCandidateExecution(
+    sourceAuthority,
+    Object.freeze({
+      stageRecord: materializer.stageRecord.bind(materializer),
+      finishComponent: materializer.finishComponent.bind(materializer),
+    }),
+  );
+}
+
+function createCandidateExecution(
+  sourceAuthorityInput: Readonly<AgentBackupRestoreV3SourceAuthority>,
+  materializer?: AgentBackupRestoreV3CandidateMaterializer,
+): AgentBackupRestoreV3CandidateExecution {
   const sourceAuthority = parseAgentBackupRestoreV3SourceAuthority(sourceAuthorityInput);
   const sourceAuthorityCanonical = canonicalizeAgentBackupRestoreV3SourceAuthority(sourceAuthority);
   const executionToken = randomBytes(32).toString("base64url");
@@ -931,6 +1067,7 @@ export function createAgentBackupRestoreV3CandidateExecution(
         repository ??
         new CandidateExecutionRepository(
           Object.freeze({ ...bound, restoreAttemptId: authority.restoreAttemptId }),
+          materializer,
         );
       return Promise.resolve(selected.begin(request, control)).then((session) => {
         // Bind only after a successful durable begin/replay. Malformed first

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-v3-candidate-execution.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-v3-candidate-execution.ts
@@ -49,6 +49,10 @@ import {
   snapshotAgentBackupRestoreV3OperationControl,
   throwIfAgentBackupRestoreV3DatabaseDeadline,
 } from "./agent-backup-restore-v3-candidate-database-control";
+import {
+  type AgentBackupRestoreV3CandidateAssembler,
+  assembleAndSealAgentBackupRestoreV3Candidate,
+} from "./agent-backup-restore-v3-candidate-seal-authority";
 
 type CandidateBeginRequest = Parameters<AgentBackupRestoreV3IsolatedCandidateStaging["begin"]>[0];
 type CandidateRecordReceipt = Awaited<
@@ -72,7 +76,7 @@ export type AgentBackupRestoreV3CandidateExecution = Pick<
 export type AgentBackupRestoreV3CandidateMaterializer = Pick<
   AgentBackupRestoreV3IsolatedCandidateStaging,
   "stageRecord" | "finishComponent"
->;
+> & { readonly assembleCandidate: AgentBackupRestoreV3CandidateAssembler };
 
 function materializationError(message: string): never {
   throw new ElizaError(message, {
@@ -1020,20 +1024,31 @@ export function createAgentBackupRestoreV3CandidateExecution(
 export function createAgentBackupRestoreV3MaterializingCandidateExecution(
   sourceAuthority: Readonly<AgentBackupRestoreV3SourceAuthority>,
   materializer: AgentBackupRestoreV3CandidateMaterializer,
-): AgentBackupRestoreV3CandidateExecution {
+): AgentBackupRestoreV3IsolatedCandidateStaging {
   if (
     !materializer ||
     typeof materializer.stageRecord !== "function" ||
-    typeof materializer.finishComponent !== "function"
+    typeof materializer.finishComponent !== "function" ||
+    typeof materializer.assembleCandidate !== "function"
   )
     materializationError("Restore candidate requires an explicit Agent materializer");
-  return createCandidateExecution(
-    sourceAuthority,
-    Object.freeze({
-      stageRecord: materializer.stageRecord.bind(materializer),
-      finishComponent: materializer.finishComponent.bind(materializer),
-    }),
-  );
+  const effects = Object.freeze({
+    stageRecord: materializer.stageRecord.bind(materializer),
+    finishComponent: materializer.finishComponent.bind(materializer),
+    assembleCandidate: materializer.assembleCandidate.bind(materializer),
+  });
+  const staging: AgentBackupRestoreV3IsolatedCandidateStaging = {
+    ...createCandidateExecution(sourceAuthority, effects),
+    seal: (session, receipt, authorization, control) =>
+      assembleAndSealAgentBackupRestoreV3Candidate(
+        session,
+        receipt,
+        authorization,
+        control,
+        effects.assembleCandidate,
+      ),
+  };
+  return Object.freeze(staging);
 }
 
 function createCandidateExecution(

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-v3-candidate-seal-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-v3-candidate-seal-authority.ts
@@ -45,6 +45,17 @@ const AMBIGUOUS_COMMIT_RECOVERY_POLL_MS = 25;
 const ADDITIONAL_AMBIGUOUS_COMMIT_SQL_STATES = new Set(["40003", "57P02"]);
 const SEAL_COMMAND_CONTEXT = "elizaos.agent-backup.restore-v3-candidate-seal-command.v1";
 
+/**
+ * Trusted Agent effect invoked under PRIMARY authority locks. It must honor
+ * control, reap all writes before settling, and avoid separate coordinator DB
+ * transactions. The acknowledgement attests assembly, not generation activation.
+ */
+export type AgentBackupRestoreV3CandidateAssembler = (
+  session: Readonly<AgentBackupRestoreV3StagingSession>,
+  receipt: Readonly<AgentBackupRestoreV3CandidateReceipt>,
+  control: Readonly<AgentBackupRestoreV3OperationControl>,
+) => AgentBackupRestoreV3CandidateReceipt | Promise<AgentBackupRestoreV3CandidateReceipt>;
+
 export class AgentBackupRestoreV3CandidateSealConflictError extends Error {
   readonly code = "AGENT_BACKUP_RESTORE_V3_CANDIDATE_SEAL_CONFLICT";
 
@@ -877,22 +888,54 @@ export function sealAgentBackupRestoreV3Candidate(
   authorizationInput: Readonly<AgentBackupRestoreV3CandidateSealAuthorization>,
   control: Readonly<AgentBackupRestoreV3OperationControl>,
 ): Promise<AgentBackupRestoreV3CandidateReceipt> {
+  return sealCandidate(sessionInput, receiptInput, authorizationInput, control);
+}
+
+/** Assemble the exact private files while the terminal command retains its locks. */
+export function assembleAndSealAgentBackupRestoreV3Candidate(
+  sessionInput: Readonly<AgentBackupRestoreV3StagingSession>,
+  receiptInput: Readonly<AgentBackupRestoreV3CandidateReceipt>,
+  authorizationInput: Readonly<AgentBackupRestoreV3CandidateSealAuthorization>,
+  control: Readonly<AgentBackupRestoreV3OperationControl>,
+  assembler: AgentBackupRestoreV3CandidateAssembler,
+): Promise<AgentBackupRestoreV3CandidateReceipt> {
+  if (typeof assembler !== "function")
+    throw conflict("Candidate seal requires an explicit Agent assembler");
+  return sealCandidate(sessionInput, receiptInput, authorizationInput, control, assembler);
+}
+
+function sealCandidate(
+  sessionInput: Readonly<AgentBackupRestoreV3StagingSession>,
+  receiptInput: Readonly<AgentBackupRestoreV3CandidateReceipt>,
+  authorizationInput: Readonly<AgentBackupRestoreV3CandidateSealAuthorization>,
+  control: Readonly<AgentBackupRestoreV3OperationControl>,
+  assembler?: AgentBackupRestoreV3CandidateAssembler,
+): Promise<AgentBackupRestoreV3CandidateReceipt> {
   const operationControl = snapshotAgentBackupRestoreV3OperationControl(control);
-  const prepared = prepareSeal(sessionInput, receiptInput, authorizationInput);
+  const session = parseAgentBackupRestoreV3StagingSession(sessionInput);
+  const prepared = prepareSeal(session, receiptInput, authorizationInput);
   try {
     assertAgentBackupRestoreV3OperationControl(operationControl, "Restore-v3 candidate seal");
   } catch (cause) {
-    // An inactive but otherwise valid control may only reconcile an already-
-    // committed exact seal. It never enters the mutating transaction below.
+    // error-policy:J1 Inactive callers only reconcile an already-committed seal;
+    // they never enter the mutating transaction below.
     if (!isValidInactiveControl(operationControl)) throw cause;
     return replayExactSealedReceiptOrThrow(prepared, operationControl, cause);
   }
-  return sealPreparedCandidate(prepared, operationControl);
+  return sealPreparedCandidate(
+    prepared,
+    operationControl,
+    assembler ? (receipt, effectControl) => assembler(session, receipt, effectControl) : undefined,
+  );
 }
 
 async function sealPreparedCandidate(
   prepared: PreparedSeal,
   control: Readonly<AgentBackupRestoreV3OperationControl>,
+  assemble?: (
+    receipt: AgentBackupRestoreV3CandidateReceipt,
+    control: Readonly<AgentBackupRestoreV3OperationControl>,
+  ) => AgentBackupRestoreV3CandidateReceipt | Promise<AgentBackupRestoreV3CandidateReceipt>,
 ): Promise<AgentBackupRestoreV3CandidateReceipt> {
   try {
     await dbWrite.transaction(async (tx) => {
@@ -957,10 +1000,47 @@ async function sealPreparedCandidate(
         sealed_receipt_sha256: prepared.receiptSha256,
         command_sha256: prepared.terminalCommandSha256,
       });
+      if (assemble) {
+        // The trigger has validated/locked all external authorities and consumed
+        // the one-shot proof inside this still-uncommitted transaction. Failure
+        // below rolls it back; a partial private assembly remains retryable.
+        const effectControl = Object.freeze({
+          signal: control.signal,
+          deadlineEpochMs: Math.min(
+            control.deadlineEpochMs,
+            prepared.authorization.expiresAtEpochMs,
+          ),
+        });
+        await applyAgentBackupRestoreV3TransactionDeadline(
+          tx,
+          effectControl,
+          "Restore-v3 Agent assembly",
+        );
+        const acknowledgement = await assemble(prepared.receipt, effectControl);
+        if (
+          canonicalizeAgentBackupRestoreV3CandidateReceipt(acknowledgement) !==
+          prepared.receiptCanonical
+        )
+          throw conflict("Agent assembly acknowledgement differs from the exact candidate");
+        await applyAgentBackupRestoreV3TransactionDeadline(
+          tx,
+          effectControl,
+          "Restore-v3 Agent assembly acknowledgement",
+        );
+        if (
+          (await readPostLockDatabaseNow(tx)).getTime() >= prepared.authorization.expiresAtEpochMs
+        )
+          throw conflict("Restore-v3 assembly outlived its seal authorization");
+        assertAgentBackupRestoreV3OperationControl(
+          effectControl,
+          "Restore-v3 Agent assembly acknowledgement",
+        );
+      }
       await applyAgentBackupRestoreV3TransactionDeadline(tx, control, "Restore-v3 candidate seal");
     });
     return prepared.receipt;
   } catch (cause) {
+    // error-policy:J1 Reconcile only an exact committed seal; otherwise preserve failure.
     // A timeout/cancellation can race the COMMIT acknowledgement. Reconcile
     // once from PRIMARY under a fresh read-only budget before classifying the
     // original failure; absence still preserves the original fail-closed error.


### PR DESCRIPTION
# Relates to

Part of #20732, under #20726. **Does not close #20732 or enable restore.**
This PR delivers the candidate-data materialization boundary: authenticated record inbox → physical database/files → five-component assembly → assembly-backed PRIMARY seal.

- [x] Targets `develop`, rebased without conflicts onto `dac71fc5a613529a42f8cd686ed333e0fc693b1c`.
- [x] Installation attempted after sync; the unrelated local Metal-toolchain failure and supported scoped install are recorded below.
- [x] Reproducible behavior and limitations are documented below.

# Sync with develop

Seven implementation commits; no historical worktree diff was imported. The rebase added only the existing migration-reader change from develop; restore source and tests are byte-identical across that rebase.

# Risks

High-impact data integrity / concurrency boundary, kept behind explicit use of the materializing factory. No applied migration, default feature gate, routing, provider-create, billing activation or deployment configuration changes. Review lock ordering, replay semantics, private filesystem identities, physical archive handling and child-process settlement particularly carefully.

# Background

## What does this PR do?

- Extract the authenticated physical PGlite archive using bounded strict USTAR handling into the isolated candidate. Reject unsupported entries and malformed/truncated archives.
- Validate a disposable private copy with the actual PGlite engine; preserve the authenticated extraction for exact replay. The validation child retains the quarantine kernel lock and is reaped before cleanup.
- Assemble character, database, media, plugin state and vault under one quarantine lock; persist exact tree/receipt proofs.
- Add the explicit materializing repository adapter. Hold PRIMARY source/operation/lease/catalogue/object/candidate authority through actual Agent effects; persist ledger/seal state only after the exact acknowledgement. Reuse the existing migration/terminal-command authorities.
- Execute these effects in private one-shot Agent processes. Raw bounded frames travel on stdin; stdin stays open as liveness. Only a canonical receipt digest crosses stdout. No credentials or preload options are inherited.
- Prove the compiled worker over native Linux Docker exec, including stdin cancellation and abrupt Docker-client loss while a real database-validation child is alive.

The existing metadata-only foundation API remains compatible; it is not silently selected as fallback by the new materializing factory. This worker is a trusted private process boundary, **not an authenticated public or production Docker endpoint**.

## What kind of change is this?

Additive feature; completes the data-materialization/assembly unit of explicit restore.

# Documentation changes needed?

Updated `packages/agent/README.md` with transport version 2, liveness/cancellation ownership, native Docker test prerequisites and the distinction from production quarantine bootstrap.

# Testing

## Where should a reviewer start?

1. The real PostgreSQL candidate-execution integration test: see actual five-component materialization, transaction locks, failed acknowledgements, lost COMMIT recovery and retained output.
2. The Docker materializer test: observe a live validator PID before failure injection, then remote settlement and exact retry.
3. Archive extraction/validation and candidate assembly, then the materializing repository and private transport.

## Detailed testing steps

Pinned Bun 1.3.14 / Node 24.15.0. Run focused Agent suites from `packages/agent`:

```sh
bunx --no-install vitest run --config vitest.config.ts \
  src/services/agent-backup-restore-v3-candidate-assembly.test.ts \
  src/services/agent-backup-restore-v3-candidate-materializers.test.ts \
  src/services/agent-backup-restore-v3-candidate-fs.test.ts \
  src/services/agent-backup-restore-v3-pglite-archive.test.ts \
  src/services/agent-backup-restore-v3-candidate-records.test.ts \
  src/services/agent-backup-restore-v3-materializer-process.test.ts \
  --coverage.enabled=false
```

Native Docker proof requires the built Agent package, a local `node:24.15.0-alpine` image and a running Docker daemon. The harness resolves the image to its immutable ID; it does not pull implicitly. Set `DOCKER_CONFIG` explicitly when using a named context because Vitest isolates HOME:

```sh
AGENT_RESTORE_V3_DOCKER_TESTS=1 bunx --no-install vitest run \
  --config vitest.config.ts \
  src/services/agent-backup-restore-v3-materializer-docker.test.ts \
  --coverage.enabled=false
```

For the real PostgreSQL test, from `packages/cloud/shared`, use an owned temporary directory shared with the local Docker VM for `TMPDIR`, and select the local Docker context:

```sh
env -u APPS_TENANT_DB_TEST_DSN -u DATABASE_URL -u TEST_DATABASE_URL \
  APPS_TENANT_DB_EPHEMERAL=1 APPS_TENANT_DB_TEST_IMAGE=postgres:16-alpine \
  REQUIRE_REAL_POSTGRES_RESTORE_V3_CANDIDATE_TESTS=1 \
  bun test src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution-postgres.integration.test.ts

bun test src/db/repositories/__tests__/agent-backup-restore-v3-materialization.pglite.test.ts \
  src/db/repositories/__tests__/agent-backup-restore-v3-candidate-execution.pglite.test.ts \
  src/db/repositories/__tests__/agent-backup-restore-v3-candidate-seal-authority.pglite.test.ts
```

# Evidence Gate

<!-- evidence-head:0f4f03185e2052fdcc750b27154d3b3963481407 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend filesystem/process/transaction work; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend filesystem/process/transaction work; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI or device workflow in this materialization unit.
<!-- evidence-row:backend-logs -->
- [x] Actual process and PostgreSQL test output is pasted in Evidence Details below; plaintext-sensitive worker diagnostics are deliberately not emitted.
<details>
<summary>Observed focused results (all exit 0)</summary>

```text
Agent:
 Test Files  6 passed (6)
      Tests  128 passed (128)
 Duration 179.61s

Native Docker (compiled worker, Linux, no FD emulation):
 Test Files  1 passed (1)
      Tests  4 passed (4)
 Duration 72.42s
 Cases: exact character materialization/replay; complete-frame EOF cancellation;
 real validator cancellation on stdin EOF; real validator cancellation on client SIGKILL.
 The validator PID is observed before failure injection.
 Remote worker/validator exit and scratch-copy removal are checked before exact retry.

Real PostgreSQL:
(pass) serializes exact and divergent slot races across independent sessions
(pass) admits one cleanup claimant, recovers an expired lease atomically, and fences settlement
(pass) serializes one owner generation across multiple rows and rejects stale lost-ACK recovery
(pass) holds source and candidate locks through real Agent effects and reconciles lost commit acknowledgements
(pass) seals five real Agent components across private processes under PRIMARY locks and recovers partial assembly
 5 pass
 0 fail
 86 expect() calls
 31.71s

PGlite repository regressions:
 4 pass
 0 fail
 136 expect() calls
 6.29s
```

The focused runs preceded the rebase; a tree comparison confirms no restore source/test changes from that rebase. Final post-sync verification and compiled Docker rerun: `bun run verify` exited 0 after all package tasks and final repository audits; 11,469 tests scanned, zero focused tests or orphaned skips. The post-build Docker suite was rerun at the final head: 4/4 pass in 72.07s, exit 0. Real PostgreSQL was also rerun after sync/install/build at this exact head: 5/5 pass, 86 assertions, 30.25s, exit 0. Agent and cloud/shared typecheck/lint pass; `git diff --check` passes. Existing repository warnings remain visible; this is not a warning-free claim.

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/provider/action/prompt execution is changed or booted by this unit; the live remembered-fact Agent drill remains required by #20732.
<!-- evidence-row:domain-artifacts -->
- [x] Restored SQL rows, exact file bytes, retained assembly identity and transaction visibility are inspected by the real integration tests, detailed below.
<details>
<summary>Inspected restoration outputs and authority behavior</summary>

The real PostgreSQL fixture dumps a physical source database and deletes its test-owned source directory, then restores all five components through actual private Agent processes. It inspects independent-connection lock/visibility behavior during effects, mismatched/lost/cancelled assembly acknowledgements, lost PostgreSQL COMMIT acknowledgement and exact sealed replay after expiry. The assembly marker's bytes and inode remain unchanged on terminal replay; exact media/state/vault bytes are read back. Querying a disposable copy of the restored database returns:

```json
[{"id":1,"fact":"amber lighthouse 20732"}]
```

The native Docker test independently dumps/deletes a physical source, interrupts its real validation descendant, retries, and queries the restored output:

```json
[{"value":"amber docker lighthouse"}]
```


The following is a consolidated report of the exact query read-backs asserted by the passing real tests (not worker stdout or an LLM transcript):

```json
{
  "postgres_repository_integration": {
    "query": "SELECT id, fact FROM restored_fact ORDER BY id",
    "rows": [{"id": 1, "fact": "amber lighthouse 20732"}]
  },
  "native_docker_materialization": {
    "query": "SELECT value FROM docker_fact",
    "rows": [{"value": "amber docker lighthouse"}]
  }
}
```

These are synthetic test facts, not user data. Database queries use disposable copies so inspection cannot mutate the retained authenticated candidate.


</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this PR does not execute a live Agent or model. SQL data recovery is not represented as remembered-fact conversational proof.

## Backend + frontend logs

See the complete observed output in the backend-logs evidence row above.

Frontend: N/A - backend-only unit.

## Domain artifacts inspected

See the inspected artifacts in the domain-artifacts evidence row above.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changes.

## Audio / voice walkthrough

N/A - no audio/voice path changed.

## Known gaps / failures

- The first native test invocation could not resolve the named Colima context inside Vitest's isolated HOME. Explicit `DOCKER_CONFIG` fixed the test environment; no filesystem authority check was weakened.
- Two initial test-only Uint8Array generic inference errors were corrected before final typecheck/tests.
- Plain `bun install` fails in the unchanged fused native-inference postinstall because this macOS host lacks the Metal Toolchain. The installer and native source are unchanged from develop. The existing `ELIZA_SKIP_FUSED_INFERENCE_SETUP=1 bun install` path completed successfully, with no lockfile change. This does not claim native inference build coverage.
- Local non-Linux tests explicitly use test-only pathname emulation; the Docker lane exercises actual Linux descriptor anchors and locks.
- Provider-stream/source authority is synthetic in these materialization integration fixtures. This is not a new full provider-crypto end-to-end proof.
- The Docker container uses a networkless idle PID1 fixture with a read-only repository mount. It is not the production image/bootstrap integration.
- The new explicit coordinator variant is integrated with actual Agent materialization, but the production caller after `container_created` is still required. Production SSH transport must retain exact container/image/node-incarnation fences and cannot infer remote settlement solely from a lost local client.
- Exact generation commit/boot, signed identity/readiness/functional receipts, funding/activation/route CAS, old-target cleanup and remaining crash/node/publication scenarios stay in #20732.
- The separately authorized staging backup → wipe → restore → boot → remembered fact → exactly one response and measured RTO drill is not done. Test durations are not production RTO.
- No activation gate enabled, no deployment, no paid resource, no merge or acceptance checkbox closure. #20726 remains NO-GO; #24594/#24601 and unrelated #29921/#30815 were not absorbed.

## Maintainer CI exception record

N/A - no exception requested. Independent review and applicable exact-head hosted checks remain required before merge.

AI-assisted implementation with Codex, lane `/root`.
