### PR TITLE
chore(ui): refresh inventory after unused QR removal

### DIFF
--- a/packages/ui/scripts/duplicate-molecular-components-report.json
+++ b/packages/ui/scripts/duplicate-molecular-components-report.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
   "sourceAtomicSchemaVersion": 1,
-  "scannedFiles": 886,
+  "scannedFiles": 885,
   "canonicalContracts": [
     {
       "id": "auth-result-shell",

--- a/packages/ui/scripts/duplicate-molecular-components-report.md
+++ b/packages/ui/scripts/duplicate-molecular-components-report.md
@@ -1,6 +1,6 @@
 # Molecular component duplicate inventory
 
-Scanned 886 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
+Scanned 885 maintained React files. 100 exported compositions have a recognized molecular role and at least two atomic dependencies.
 
 Clusters share both a role and an atomic dependency signature. Detection creates a review queue; this committed report contains only final dispositions based on product behavior, state ownership, and responsive layout.
 


### PR DESCRIPTION
Removing the unused QR component in #30804 left the generated molecular component inventory at 886 files, causing the root verification gate to fail in UI lint. Regenerate the JSON and Markdown reports so both record the actual 885 files. The diff changes only those two counts.

Refs #30804 and #30803. This is a standalone correction so other PRs can validate against develop while #30773's separate runner repair completes full CI.

Validation at `7a3f550de09eee8a6f02ceeda977c23f30646d98` on develop `2eb52ff20623c8d1d407c8b03b3ee10be5c6a9b9`:
- Normal `bun install` with the documented `ELIZA_SKIP_FUSED_INFERENCE_SETUP=1` setting passed, with no lockfile changes.
- `RUN_TURBO_CONCURRENCY=1 bun run verify` exited0:374/374 workspace checks (0 cached), followed by all repository audits. Workspace verification took6m58s.
- Independent read-only review found no issues in the exact two-line diff. The canonical `find-duplicate-molecular-components.mjs --check` passed with11 final dispositions.
- Working tree and `git diff --check` are clean.

No rendered UI, runtime, provider, or device behavior changes; screenshots and recordings are not applicable.
