### PR TITLE
fix(voice): retire consumed and discarded handoff samples from queue depth

### DIFF
--- a/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
@@ -397,6 +397,7 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
     expect(transition[10]).toBeCloseTo(0, 1);
     expect(transition[20]).toBeCloseTo(-0.8, 2);
     expect(completed).toHaveBeenCalledTimes(1);
+    expect(pb.getStats().queuedSamples).toBe(10);
     await pb.stop();
   });
   it.each(["autoplay", "startup reserve"])(

--- a/packages/ui/src/voice/voice-session-playback.ts
+++ b/packages/ui/src/voice/voice-session-playback.ts
@@ -446,8 +446,11 @@ export async function createVoiceSessionPlayback(
             jsReadOffset += 1;
             jsHandoffReadOffset += 1;
             jsCrossfadePosition += 1;
-            consumedSamples += 1;
+            consumedSamples += 2;
             if (jsCrossfadePosition >= jsCrossfadeSamples) {
+              consumedSamples +=
+                jsHandoffQueue.reduce((sum, pcm) => sum + pcm.length, 0) -
+                jsHandoffReadOffset;
               jsHandoffQueue = [];
               jsHandoffReadOffset = 0;
               handoffCompleted = true;
@@ -459,6 +462,7 @@ export async function createVoiceSessionPlayback(
           } else if (oldSample !== null) {
             ch[i] = oldSample;
             jsHandoffReadOffset += 1;
+            consumedSamples += 1;
           } else {
             ch[i] = 0;
           }
@@ -675,6 +679,9 @@ export async function createVoiceSessionPlayback(
           sequence: ++lastSubmittedSequence,
         });
       } else {
+        sinkQueuedSamples -=
+          jsHandoffQueue.reduce((sum, pcm) => sum + pcm.length, 0) -
+          jsHandoffReadOffset;
         jsHandoffQueue = jsQueue.splice(0);
         jsHandoffReadOffset = jsReadOffset;
         jsReadOffset = 0;

--- a/packages/ui/src/voice/worklets/voice-session-downlink.js
+++ b/packages/ui/src/voice/worklets/voice-session-downlink.js
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/correctness/noUndeclaredVariables: AudioWorklet globals are supplied by the worklet scope.
 
+/** Plays downlink PCM and crossfades queued replies in the browser audio thread. */
 class ElizaVoiceSessionDownlink extends AudioWorkletProcessor {
   constructor() {
     super();
@@ -40,6 +41,9 @@ class ElizaVoiceSessionDownlink extends AudioWorkletProcessor {
         });
       } else if (data.type === "handoff") {
         this.lastSequence = Number(data.sequence) || this.lastSequence;
+        this.queuedSamples -=
+          this.handoffQueue.reduce((sum, pcm) => sum + pcm.length, 0) -
+          this.handoffReadOffset;
         this.handoffQueue = this.queue;
         this.handoffReadOffset = this.readOffset;
         this.queue = [];
@@ -81,8 +85,11 @@ class ElizaVoiceSessionDownlink extends AudioWorkletProcessor {
         this.readOffset += 1;
         this.handoffReadOffset += 1;
         this.crossfadePosition += 1;
-        this.queuedSamples = Math.max(0, this.queuedSamples - 1);
+        this.queuedSamples = Math.max(0, this.queuedSamples - 2);
         if (this.crossfadePosition >= this.crossfadeSamples) {
+          this.queuedSamples -=
+            this.handoffQueue.reduce((sum, pcm) => sum + pcm.length, 0) -
+            this.handoffReadOffset;
           this.handoffQueue = [];
           this.handoffReadOffset = 0;
           this.port.postMessage({
@@ -97,6 +104,7 @@ class ElizaVoiceSessionDownlink extends AudioWorkletProcessor {
       } else if (oldSample !== null) {
         firstChannel[i] = oldSample;
         this.handoffReadOffset += 1;
+        this.queuedSamples = Math.max(0, this.queuedSamples - 1);
       } else {
         firstChannel[i] = 0;
         if (this.handoffQueue.length === 0 && this.hadAudio) {

--- a/packages/ui/test/audio-worklets-runtime.test.mjs
+++ b/packages/ui/test/audio-worklets-runtime.test.mjs
@@ -1,3 +1,4 @@
+/** Exercises the real audio processors with deterministic PCM and a worklet-port harness. */
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 const processors = new Map();
@@ -73,6 +74,24 @@ describe("packaged voice AudioWorklets", () => {
         ([message]) => message.type === "drained",
       ),
     ).toHaveLength(1);
+  });
+
+  it("reports only remaining audio after crossfade discards the old tail", () => {
+    const downlink = processor("eliza-voice-session-downlink");
+    const send = (data) => downlink.port.onmessage({ data });
+    send({ type: "pcm", pcm: new Float32Array(32).fill(0.8), sequence: 1 });
+    downlink.process([], [[new Float32Array(2)]]);
+    send({ type: "handoff", crossfadeSamples: 20, sequence: 2 });
+    send({ type: "pcm", pcm: new Float32Array(32).fill(-0.8), sequence: 3 });
+    const output = new Float32Array(22);
+    downlink.process([], [[output]]);
+    expect(output[20]).toBeCloseTo(-0.8);
+    send({ type: "pcm", pcm: new Float32Array(2), sequence: 4 });
+    expect(downlink.port.postMessage).toHaveBeenLastCalledWith({
+      type: "queue-depth",
+      queuedSamples: 12,
+      sequence: 4,
+    });
   });
 
   it("captures the playback reference as averaged mono PCM", () => {


### PR DESCRIPTION
## Problem and change

Follow-up to #29492. Crossfading consumed samples from both replies, then discarded the old tail, but both playback backends counted only consumption from the new reply. Queue telemetry therefore continued reporting old audio that could no longer play.

Retire both mixed samples, old-only samples, and discarded old tails, including a handoff replaced before completion. Preserve the merged server echo-reference and repeated-handoff fixes.

## Validation

The real playback implementation and packaged AudioWorklet regression failed before repair: the script backend reported 40 samples with only 10 remaining; the worklet reported 42 after enqueue when only 12 remained. Both focused files then passed all 24 tests. AudioContext and worklet ports are deterministic harnesses; this is queue-accounting validation, not physical audio acceptance.

Independent read-only review found no blocking issue in the correction. Normal `bun install` passed. On exact head `9933971a2aa21c7d0bd656276bca8a38c07a8dc2`, based on develop `f2f878f18589ed20e267c9b54e57edd2c672bd83`, `RUN_TURBO_CONCURRENCY=1 bun run verify` passed: 374/374 tasks, zero cached, 6m56.901s, followed by all repository audits (11,432 test files; zero focused or orphaned skips). The two focused playback/worklet files were rerun on this integrated head: all 24 tests passed. `git diff --check` passed; working tree clean.
