### PR TITLE
fix(login): repair clean browser builds and CodeQL coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,7 @@ jobs:
               - 'packages/auth/**'
               - 'packages/core/**'
               - 'packages/logger/**'
+              - 'packages/login/**'
               - 'packages/prompts/**'
               - 'packages/shared/**'
               - 'packages/skills/**'

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -2783,6 +2783,10 @@ export const INVALID_TRACER_PROVIDER = {};
     ],
     alias: [
       {
+        find: /^@elizaos\/login$/,
+        replacement: path.resolve(elizaRoot, "packages/login/src/sdk/index.ts"),
+      },
+      {
         find: /^@homepage\//,
         replacement: `${path.resolve(here, "../homepage/src")}/`,
       },

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -812,7 +812,6 @@ export async function buildNode(
 		buildOptions: {
 			entrypoints: [
 				`${TS_SRC}/index.node.ts`,
-				`${TS_SRC}/errors.ts`,
 				`${TS_SRC}/roles.ts`,
 				`${TS_SRC}/client-public.ts`,
 				`${TS_SRC}/security/kms/index.ts`,
@@ -832,6 +831,22 @@ export async function buildNode(
 	});
 
 	await runNode();
+	// This leaf is shared with browser SDKs; a Node-target build injects a
+	// createRequire shim even though the error contract needs no Node APIs.
+	await runnerFactory({
+		...sharedConfig,
+		buildOptions: {
+			entrypoints: [`${TS_SRC}/errors.ts`],
+			outdir: "dist/node",
+			target: "browser",
+			format: "esm",
+			sourcemap: true,
+			minify: false,
+			generateDts: false,
+			skipClean: true,
+			selfPackageName: "@elizaos/core",
+		},
+	})();
 
 	const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 	console.log(`✅ Node.js build complete in ${duration}s`);
@@ -1640,6 +1655,34 @@ async function verifyPackedEdgeContract(): Promise<void> {
 			"dist/security/kms.js",
 			"dist/security/mcp-server-config.js",
 		];
+		const errorConsumer = join(contractRoot, "browser-errors-entry.js");
+		await fs.writeFile(
+			errorConsumer,
+			[
+				'import { ElizaError, isElizaError, toElizaError } from "@elizaos/core/errors";',
+				'const cause = new Error("request failed");',
+				'const failure = new ElizaError("login unavailable", { code: "LOGIN_UNAVAILABLE", cause, context: { operation: "refresh" } });',
+				'if (!isElizaError(failure) || failure.code !== "LOGIN_UNAVAILABLE" || failure.cause !== cause || failure.context.operation !== "refresh") throw new Error("browser error lost diagnostic context");',
+				'if (toElizaError(failure) !== failure || toElizaError(cause, "LOGIN_FAILED").cause !== cause) throw new Error("browser error normalization lost identity or cause");',
+			].join("\n"),
+		);
+		const browserErrors = await Bun.build({
+			entrypoints: [errorConsumer],
+			target: "browser",
+			format: "iife",
+			write: false,
+		});
+		if (!browserErrors.success) {
+			throw new AggregateError(
+				browserErrors.logs,
+				"Packed browser error contract failed to bundle",
+			);
+		}
+		const { runInNewContext } = await import("node:vm");
+		runInNewContext(await browserErrors.outputs[0].text(), Object.create(null));
+		console.log(
+			"✅ Packed error contract executes without Node globals or shims",
+		);
 		for (const flatFile of expectedFlatFiles) {
 			if (!(await isFile(join(packageRoot, flatFile)))) {
 				throw new Error(`packed @elizaos/core is missing ${flatFile}`);

--- a/packages/core/src/build-flat-entrypoints.test.ts
+++ b/packages/core/src/build-flat-entrypoints.test.ts
@@ -128,7 +128,7 @@ describe("core flat package entrypoints", () => {
 			},
 		});
 
-		expect(outdirs).toEqual(["dist/node"]);
+		expect(outdirs).toEqual(["dist/node", "dist/node"]);
 		expect(declarationOptions).toEqual([{ skipTesting: true }]);
 	});
 });

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -114,6 +114,10 @@ const config: StorybookConfig = {
           replacement: replacement as string,
         }));
     cfg.resolve.alias = [
+      {
+        find: /^@elizaos\/login$/,
+        replacement: resolve(monorepoRoot, "packages/login/src/sdk/index.ts"),
+      },
       // @elizaos/ui — bare barrel, the renderer-only styles entry, then subpaths.
       {
         find: /^@elizaos\/ui\/styles$/,


### PR DESCRIPTION
# Relates to

Fixes #30831. Follow-up to #30743.

- [x] Targets `develop`; post-fetch rebase is current and conflict-free.
- [x] Post-sync `bun install` and `RUN_TURBO_CONCURRENCY=1 bun run verify` passed.
- [x] Reproduced failure and successful clean-build evidence are available below.

# Sync with develop

Current on `c2d55bf5e460055c19fb0c8bdfe217e4f1b2c8d8`.

# Risks

Medium: the shared error artifact changes compiler target. Its public path and API remain the same. Packed Node and browser consumers pass.

# Background

## What does this PR do?

Clean app and Storybook builds resolve `@elizaos/login` from workspace source. The core error leaf is compiled without a Node-only `createRequire` shim, allowing the browser SDK to execute. The CodeQL runtime shard includes the new login package.

## What kind of change is this?

Build and security-scan integration fixes.

# Documentation changes needed?

No public API or setup instructions change.

# Testing

## Where should a reviewer start?

Compare the failures in #30831 with the successful consumer and clean-build receipts attached below.

## Detailed testing steps

- Reproduced the agent-surface browser failure on the old error artifact; the same E2E passed after rebuilding.
- Node-only and full core builds passed, including packed error execution without Node globals or shims.
- Storybook and the app renderer built with `packages/login/dist` temporarily absent.
- App audit: 219 passed; zero broken/needs-work findings and zero OCR regressions. Eight Cloud captures were visually reviewed.
- Focused tests: eight core build, six CodeQL, 21 Vite configuration, eight source-resolution tests passed.
- Post-sync install passed without changes. Root verification: 377 tasks passed, four cached, plus all root audits.

# Evidence Gate

<!-- evidence-head:2239420614109829ed6c8458161f2a5394be355d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - This follow-up changes build resolution, compiler targeting and scan inventory; it changes no rendered component or user interaction. Actual clean builds and the full app audit exercise the affected boundary.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - This follow-up changes build resolution, compiler targeting and scan inventory; it changes no rendered component or user interaction. Actual clean builds and the full app audit exercise the affected boundary.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - This follow-up changes build resolution, compiler targeting and scan inventory; it changes no rendered component or user interaction. Actual clean builds and the full app audit exercise the affected boundary.
<!-- evidence-row:ocr-review -->
- [ ] N/A - This follow-up changes build resolution, compiler targeting and scan inventory; it changes no rendered component or user interaction. Actual clean builds and the full app audit exercise the affected boundary.
<!-- evidence-row:backend-logs -->
- [x] [core-package-build.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30838-core-package-build.log)
<!-- evidence-row:frontend-logs -->
- [x] [clean-storybook.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30838-clean-storybook.log)
<!-- evidence-row:domain-artifacts -->
- [x] [verification.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30838-verification.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, agent behavior or live-model path changes.

# Evidence Details

## Real LLM-call trajectory

N/A - Build and scan configuration only.

## Backend + frontend logs

The failing browser fixture, passing fixture, packed core build, clean Storybook build, app audit and root verification logs are attached below.

## Screenshots (before / after) + video walkthrough

N/A - No rendered source or interaction changes. Full app capture/OCR audit passed; the parent migration PR contains the login flow recordings.

### Before

The browser fixture failed to resolve `node:module` from the core error artifact. Clean Storybook CI failed to resolve `@elizaos/login`.

### After

Both build paths pass; the app audit also passes with the login distribution absent.

### Walkthrough video

N/A - The changed boundary is the build pipeline.

## Audio / voice walkthrough

N/A - No audio behavior changes.

## Known gaps / failures

Hosted PR CI passed at reviewed head `2239420614109829ed6c8458161f2a5394be355d`: source static smoke, billing replay E2E, subscription authority PostgreSQL, and Windows security. Merged as `032bdee3c455cd989a267e4c8a42b6550559c8f9`. Broader post-merge CI also reports unrelated lifeops schema and plugin-workflow dependency failures; these are not claimed fixed here. The reproduced login integration failures are addressed and locally verified.

## Maintainer CI exception record

N/A - no exception requested.


