### PR TITLE
fix(ui): use canonical alert for shortcut rejection

### DIFF
--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
@@ -15,6 +15,7 @@ import {
   setChatOverlayHotkey,
   useChatOverlayHotkey,
 } from "../../state/useChatOverlayHotkey";
+import { Alert, AlertDescription } from "../ui/alert";
 import { Button } from "../ui/button";
 import { SettingsSwitchRow } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow } from "./settings-layout";
@@ -162,12 +163,9 @@ export function ChatHotkeySettingsGroup() {
         }
       />
       {error && (
-        <div
-          className="rounded-sm border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger"
-          role="alert"
-        >
-          {error}
-        </div>
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
       )}
     </SettingsGroup>
   );


### PR DESCRIPTION
The shortcut-rejection message introduced three design-contract violations on develop (raw surface, radius, and border), causing repository verification to fail for downstream work including #29689. Render the existing error through the canonical destructive Alert and AlertDescription so the shared primitive owns its presentation. Shortcut registration and error handling are unchanged.

Validation:
- All five existing ChatHotkeySettingsGroup behavioral tests pass, including OS rejection without persisting the rejected shortcut.
- `bun run verify`: all 377 workspace tasks and repository audits pass.
- Molecular inventory remains unchanged.
- Full app visual audit: 219 checks passed; 216 views, zero broken or needs-work findings. Packaged OCR: 204 verified, zero broken, 12 requiring human review.
- Inspected Settings captures at four viewports and before/after shortcut error renders at desktop and mobile, including rest and hover. The focused capture uses the real component and a deterministic rejected native bridge; it is renderer evidence, not an OS-registration integration claim.
- Focused browser captures reported no page errors. No backend behavior changed.

Base: `aaaa91577c567d96c673b370e796c7666fe6c85b`.

<details>
<summary>Reviewed desktop and mobile rendering evidence</summary>

Real shortcut component, deterministic native rejection boundary.

| View | Before | After |
| --- | --- | --- |
| Desktop | ![Before desktop](https://github.com/user-attachments/assets/eda7de63-3723-472d-9eb2-b4f918383c19) | ![After desktop](https://github.com/user-attachments/assets/9e56b575-0c3e-498e-b39e-da4e5ba9d8d9) |
| Mobile | ![Before mobile](https://github.com/user-attachments/assets/29a7787f-e58d-4821-9fd7-887574773c27) | ![After mobile](https://github.com/user-attachments/assets/96bc8b56-208c-4b1a-9463-484084d19949) |

Hover: [desktop](https://github.com/user-attachments/assets/737bf150-4308-448b-a956-15a7c2c66c3f), [mobile](https://github.com/user-attachments/assets/de7113d9-3ec8-475d-b502-ef42b8da53da).

Desktop walkthrough:

https://github.com/user-attachments/assets/34d543c5-8e05-4a7c-89fd-cf8bdeaac8eb

Mobile walkthrough:

https://github.com/user-attachments/assets/ba62d2b4-0cb4-48fe-803a-edfb3c40b39b

All four focused browser runs reported zero page errors. Backend/network and live-model evidence: N/A for this presentation-only change; the native response was deliberately rejected by the fixture.

</details>
