### PR TITLE
fix(cloud): retain sanitized telemetry denial evidence

### DIFF
--- a/.github/workflows/cloud-latency-certification.yml
+++ b/.github/workflows/cloud-latency-certification.yml
@@ -155,6 +155,7 @@ jobs:
             artifacts/cloud-latency-certification/inference-auth.jsonl
             artifacts/cloud-latency-certification/inference-auth-worker.jsonl
             artifacts/cloud-latency-certification/inference-traces.json
+            artifacts/cloud-latency-certification/trace-denial.json
             artifacts/cloud-latency-certification/summary.json
           if-no-files-found: warn
           retention-days: 7

--- a/packages/cloud/scripts/cloud-latency-certification.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.mjs
@@ -20,7 +20,10 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
-import { collectInferenceTraceEvidence } from "./cloudflare-inference-trace-evidence.mjs";
+import {
+  CloudflareTraceApiError,
+  collectInferenceTraceEvidence,
+} from "./cloudflare-inference-trace-evidence.mjs";
 import {
   inferenceAuthTailFailureCode,
   isCloudflarePlacement,
@@ -527,17 +530,47 @@ async function runPaired({ deploySha, sourceSha, outputDir, env }) {
   }
 }
 
-async function runTraces({ deploySha, outputDir, env, pairedRecords }) {
+/** Retain sanitized API denials even when raw capture cleanup precedes CLI failure. */
+export async function runTraces(
+  { deploySha, outputDir, env, pairedRecords },
+  { fetchImpl = fetch } = {},
+) {
   const secrets = requireTraceSecrets(env);
   const privateRoot = env.RUNNER_TEMP?.trim() || tmpdir();
   return await withPrivateTraceDirectory(async (directory) => {
-    const evidence = await collectInferenceTraceEvidence({
-      pairedRecords,
-      deploySha,
-      accountId: secrets.cloudflareAccountId,
-      apiToken: secrets.cloudflareApiToken,
-      privateDirectory: directory,
-    });
+    let evidence;
+    try {
+      evidence = await collectInferenceTraceEvidence({
+        pairedRecords,
+        deploySha,
+        accountId: secrets.cloudflareAccountId,
+        apiToken: secrets.cloudflareApiToken,
+        privateDirectory: directory,
+        fetchImpl,
+      });
+    } catch (error) {
+      // error-policy:J2 retain only the collector's validated denial before
+      // rethrowing; withPrivateTraceDirectory still removes every raw response.
+      if (error instanceof CloudflareTraceApiError) {
+        try {
+          await writeFile(
+            join(outputDir, "trace-denial.json"),
+            `${JSON.stringify({ kind: "cloudflare_trace_api_denial", ...error.diagnostic })}\n`,
+            { mode: 0o600, flag: "wx" },
+          );
+        } catch (cause) {
+          // error-policy:J2 evidence retention failure must not mask the API
+          // denial or expose a filesystem path through the CLI message.
+          throw new Error(
+            "Cloudflare trace denial evidence could not be retained",
+            {
+              cause: new AggregateError([error, cause]),
+            },
+          );
+        }
+      }
+      throw error;
+    }
     await writeFile(
       join(outputDir, "inference-traces.json"),
       `${JSON.stringify(evidence)}\n`,

--- a/packages/cloud/scripts/cloud-latency-certification.test.mjs
+++ b/packages/cloud/scripts/cloud-latency-certification.test.mjs
@@ -5,7 +5,15 @@
 
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -16,6 +24,7 @@ import {
   requireAuthSecrets,
   requirePairedSecrets,
   requireTraceSecrets,
+  runTraces,
   validateAuthEvidence,
   validatePairedEvidence,
   verifyExactDeployment,
@@ -461,5 +470,88 @@ test("trace credentials fail closed without exposing configured values", () => {
         return true;
       },
     );
+  }
+});
+
+test("trace API denial survives private cleanup without retaining upstream secrets", async () => {
+  const root = await mkdtemp(join(tmpdir(), "eliza-trace-denial-test-"));
+  const outputDir = join(root, "output");
+  const privateRoot = join(root, "capture");
+  await mkdir(outputDir);
+  await mkdir(privateRoot);
+  const secret = "upstream-private-value";
+  const options = {
+    deploySha: SHA,
+    outputDir,
+    env: {
+      RUNNER_TEMP: privateRoot,
+      CLOUDFLARE_API_TOKEN: secret,
+      CLOUDFLARE_ACCOUNT_ID: secret,
+    },
+    pairedRecords: Array.from({ length: 22 }, (_, index) => ({
+      target: "gateway",
+      sequence: index + 1,
+      observedAt: new Date(1_780_000_000_000 + index * 500).toISOString(),
+      headers: {
+        "cf-ray": `${(index + 1).toString(16).padStart(16, "0")}-ORD`,
+      },
+    })),
+  };
+  const fetchImpl = async () =>
+    new Response(
+      JSON.stringify({
+        success: false,
+        errors: [
+          {
+            code: 10000,
+            message: secret,
+            documentation_url: `https://example.invalid/${secret}`,
+          },
+        ],
+        token: secret,
+      }),
+      { status: 403 },
+    );
+  try {
+    await assert.rejects(runTraces(options, { fetchImpl }), (error) => {
+      assert.equal(error.diagnostic.endpoint, "keys");
+      assert.equal(error.diagnostic.httpStatus, 403);
+      assert.ok(!error.message.includes(secret));
+      return true;
+    });
+    const artifact = await readFile(
+      join(outputDir, "trace-denial.json"),
+      "utf8",
+    );
+    assert.deepEqual(JSON.parse(artifact), {
+      kind: "cloudflare_trace_api_denial",
+      endpoint: "keys",
+      httpStatus: 403,
+      errorCodes: [10000],
+      documentationUrls: [],
+    });
+    assert.ok(!artifact.includes(secret));
+    assert.deepEqual(await readdir(privateRoot), []);
+    assert.equal(existsSync(join(outputDir, "inference-traces.json")), false);
+    assert.equal(
+      (await stat(join(outputDir, "trace-denial.json"))).mode & 0o777,
+      0o600,
+    );
+
+    await assert.rejects(runTraces(options, { fetchImpl }), (error) => {
+      assert.equal(
+        error.message,
+        "Cloudflare trace denial evidence could not be retained",
+      );
+      assert.equal(error.cause.errors[0].diagnostic.httpStatus, 403);
+      return true;
+    });
+    assert.equal(
+      await readFile(join(outputDir, "trace-denial.json"), "utf8"),
+      artifact,
+    );
+    assert.deepEqual(await readdir(privateRoot), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.mjs
@@ -47,6 +47,82 @@ export class CloudflareTraceSchemaError extends Error {
   }
 }
 
+const DENIAL_DOCUMENTATION_URLS = new Set([
+  "https://developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/keys/",
+  "https://developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/query/",
+  "https://developers.cloudflare.com/fundamentals/api/troubleshooting/",
+  "https://developers.cloudflare.com/fundamentals/api/how-to/restrict-tokens/",
+  "https://developers.cloudflare.com/fundamentals/api/how-to/create-via-api/",
+  "https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/",
+]);
+
+function denialDetails(responseText) {
+  const empty = { errorCodes: [], documentationUrls: [] };
+  // This public diagnostic is only a preview of an error envelope. Oversized
+  // responses remain private; never copy a partial or arbitrary response here.
+  if (typeof responseText !== "string" || responseText.length > 65_536)
+    return empty;
+  let envelope;
+  try {
+    envelope = JSON.parse(responseText);
+  } catch {
+    // error-policy:J3 malformed denial bodies yield no optional details; the
+    // original HTTP failure remains authoritative.
+    return empty;
+  }
+  if (!Array.isArray(envelope?.errors) || envelope.errors.length > 32)
+    return empty;
+  const errorCodes = new Set();
+  const documentationUrls = new Set();
+  for (const error of envelope.errors) {
+    if (
+      Number.isInteger(error?.code) &&
+      error.code >= 0 &&
+      error.code <= 999_999
+    )
+      errorCodes.add(error.code);
+    // Exact string membership rejects userinfo, alternate paths, query strings,
+    // fragments and encoded payloads, even on the official documentation host.
+    if (DENIAL_DOCUMENTATION_URLS.has(error?.documentation_url))
+      documentationUrls.add(error.documentation_url);
+  }
+  return {
+    errorCodes: [...errorCodes],
+    documentationUrls: [...documentationUrls],
+  };
+}
+
+/** Exposes only validated public diagnostics while retaining the HTTP failure. */
+export class CloudflareTraceApiError extends CloudflareTraceSchemaError {
+  constructor({ endpoint, httpStatus, responseText }) {
+    if (
+      (endpoint !== "keys" && endpoint !== "query") ||
+      !Number.isInteger(httpStatus) ||
+      httpStatus < 0 ||
+      httpStatus > 599
+    ) {
+      throw new CloudflareTraceSchemaError(
+        "Invalid telemetry failure boundary",
+      );
+    }
+    const details = denialDetails(responseText);
+    const diagnostic = Object.freeze({
+      endpoint,
+      httpStatus,
+      errorCodes: Object.freeze(details.errorCodes),
+      documentationUrls: Object.freeze(details.documentationUrls),
+    });
+    super(
+      `Cloudflare trace telemetry returned HTTP ${httpStatus} ${JSON.stringify(diagnostic)}`,
+    );
+    this.name = "CloudflareTraceApiError";
+    Object.defineProperty(this, "diagnostic", {
+      value: diagnostic,
+      enumerable: true,
+    });
+  }
+}
+
 function object(value) {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value
@@ -557,9 +633,11 @@ async function apiRequest({
   const text = await response.text();
   await writeRaw(privateDirectory, rawSequence, rawLabel, text);
   if (!response.ok) {
-    throw new CloudflareTraceSchemaError(
-      `Cloudflare trace telemetry returned HTTP ${response.status}`,
-    );
+    throw new CloudflareTraceApiError({
+      endpoint,
+      httpStatus: response.status,
+      responseText: text,
+    });
   }
   return text;
 }

--- a/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
+++ b/packages/cloud/scripts/cloudflare-inference-trace-evidence.test.mjs
@@ -14,6 +14,7 @@ import {
   buildRootTraceQuery,
   buildTraceEventsQuery,
   buildTraceKeysRequest,
+  CloudflareTraceApiError,
   CloudflareTraceSchemaError,
   collectInferenceTraceEvidence,
   pairedGatewayTraceWindow,
@@ -685,6 +686,170 @@ test("API failures never copy private response content into errors", async () =>
     assert.equal(existsSync(join(directory, "001-keys.json")), true);
   } finally {
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("collector preserves sanitized keys and query denials without accepting private error data", async () => {
+  const docs =
+    "https://developers.cloudflare.com/api/resources/workers/subresources/observability/subresources/telemetry/methods/query/";
+  const troubleshooting =
+    "https://developers.cloudflare.com/fundamentals/api/troubleshooting/";
+  const publicError = { code: 10000, documentation_url: docs };
+  const cases = [
+    {
+      name: "valid duplicate errors",
+      body: JSON.stringify({
+        errors: [
+          publicError,
+          publicError,
+          { code: 10001, documentation_url: troubleshooting },
+        ],
+        message: "private-response-marker",
+      }),
+      codes: [10000, 10001],
+      urls: [docs, troubleshooting],
+    },
+    {
+      name: "adversarial fields",
+      body: JSON.stringify({
+        errors: [
+          null,
+          [],
+          "private-response-marker",
+          {
+            code: "10000",
+            documentation_url: `${docs}?token=private-response-marker`,
+          },
+          { code: -1, documentation_url: `${docs}#private-response-marker` },
+          { code: 1.5, documentation_url: `${docs}private-response-marker` },
+          {
+            code: 1_000_000,
+            documentation_url:
+              "https://developers.cloudflare.com/private-response-marker/",
+          },
+          {
+            code: 1e100,
+            documentation_url: docs.replace(
+              "https://",
+              "https://private-response-marker@",
+            ),
+          },
+          {
+            documentation_url: docs.replace(
+              "developers.cloudflare.com",
+              "developers.cloudflare.com.attacker.invalid",
+            ),
+          },
+          { documentation_url: docs.replace("https://", "http://") },
+          { documentation_url: docs.replace("query/", "%71uery/") },
+          {
+            code: 10000,
+            message: "private-response-marker",
+            documentation_url: docs,
+          },
+        ],
+      }),
+      codes: [10000],
+      urls: [docs],
+    },
+    {
+      name: "malformed",
+      body: '{"errors":[private-response-marker',
+      status: 502,
+      codes: [],
+      urls: [],
+    },
+    { name: "null envelope", body: "null", codes: [], urls: [] },
+    {
+      name: "wrong errors shape",
+      body: '{"errors":{"code":10000}}',
+      codes: [],
+      urls: [],
+    },
+    {
+      name: "oversized errors",
+      body: JSON.stringify({
+        errors: Array.from({ length: 33 }, () => publicError),
+      }),
+      codes: [],
+      urls: [],
+    },
+    {
+      name: "oversized response",
+      body: JSON.stringify({
+        errors: [publicError],
+        message: "private-response-marker".repeat(4000),
+      }),
+      codes: [],
+      urls: [],
+    },
+  ];
+  for (const endpoint of ["keys", "query"]) {
+    for (const scenario of cases) {
+      const directory = await mkdtemp(join(tmpdir(), "eliza-trace-denial-"));
+      const httpStatus = scenario.status ?? 403;
+      let calls = 0;
+      try {
+        await assert.rejects(
+          collectInferenceTraceEvidence({
+            pairedRecords: pairedRecords(),
+            deploySha: SHA,
+            accountId: "private-account-id",
+            apiToken: "private-api-token",
+            privateDirectory: directory,
+            sleepImpl: async () => assert.fail("HTTP denials must not retry"),
+            fetchImpl: async (url) => {
+              calls++;
+              if (endpoint === "query" && url.endsWith("/keys"))
+                return new Response(keysEnvelope());
+              assert.equal(url.endsWith(`/${endpoint}`), true);
+              return new Response(scenario.body, { status: httpStatus });
+            },
+          }),
+          (error) => {
+            assert.ok(error instanceof CloudflareTraceApiError);
+            assert.ok(error instanceof CloudflareTraceSchemaError);
+            assert.deepEqual(error.diagnostic, {
+              endpoint,
+              httpStatus,
+              errorCodes: scenario.codes,
+              documentationUrls: scenario.urls,
+            });
+            assert.ok(error.message.includes(`HTTP ${httpStatus}`));
+            assert.ok(Object.isFrozen(error.diagnostic));
+            assert.ok(Object.isFrozen(error.diagnostic.errorCodes));
+            assert.ok(Object.isFrozen(error.diagnostic.documentationUrls));
+            assert.throws(() => {
+              error.diagnostic = {};
+            }, TypeError);
+            assert.throws(() => {
+              error.diagnostic.errorCodes.push(42);
+            }, TypeError);
+            const exported = `${error.message}\n${JSON.stringify(error)}`;
+            for (const privateValue of [
+              "private-response-marker",
+              "private-account-id",
+              "private-api-token",
+            ])
+              assert.equal(
+                exported.includes(privateValue),
+                false,
+                scenario.name,
+              );
+            return true;
+          },
+        );
+        assert.equal(calls, endpoint === "keys" ? 1 : 2);
+        const privateFile =
+          endpoint === "keys" ? "001-keys.json" : "002-roots-s1-r1-1.json";
+        assert.equal(
+          await readFile(join(directory, privateFile), "utf8"),
+          scenario.body,
+        );
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Closes #30819. Retain bounded, safe diagnostics when Cloudflare's Workers telemetry API rejects trace collection. The operator can see the failing endpoint, HTTP status, numeric error codes, and recognized official documentation links without retaining upstream text or credentials.

The fresh staging latency run [34063277968](https://github.com/elizaOS/eliza/actions/runs/34063277968) completed44 model calls but failed with only `Cloudflare trace telemetry returned HTTP403`. This patch improves that failure's evidence; it does not repair token permissions or claim complete distributed tracing.

## Implementation

- Typed denial retains only validated endpoint/status, bounded integer codes, and exact allowlisted documentation URLs.
- The certification caller writes sanitized `trace-denial.json` with exclusive creation and mode0600, then rethrows the original failure.
- Raw telemetry still remains private and is removed on every exit. Workflow uploads only the explicitly named sanitized artifact.
- No provider payload, dispatch, billing, credential, or infrastructure configuration changes.

## Validation

Candidate `e1c3ea1c4762154e8ae1cd5ac550b4c65e3609f7`, base `d9592ab4ec5b7f45658ae45f6cb90255f8fc70d2`.

- Normal pinned Bun1.3.14 install: exit0, tracked source unchanged.
- Node24.15.0 collector/certification/provenance/auth/chat suites:67 passed,0 failed,0 skipped.
- Bun workflow boundary suite:15 passed,71 assertions,0 failed. It executes protected preflight and cleanup scripts, including rejection of symlink cleanup targets.
- Pinned Biome checks passed for the four changed JavaScript files; diff whitespace check passed.
- Full repository `bun run verify`: exit 0, tracked source unchanged; completed 2026-09-06T22:57:34Z after normal pinned install on the head/base above.

The collector/caller tests execute denied HTTP responses, malformed and adversarial error envelopes, safe artifact creation, and private-directory cleanup. The inspected denial artifact contains only `kind`, `endpoint`, `httpStatus`, `errorCodes`, and `documentationUrls`; arbitrary upstream messages and links are excluded. Tests also verify exclusive writes and private file permissions.

## Evidence scope

UI screenshots/video: N/A — no rendered UI changes.
Live-model trajectory for changed behavior: N/A — diagnostic-only error propagation; no model request changes. The linked staging run is the observed affected boundary, not successful new tracing.
Database/native evidence: N/A — no database or native behavior changes.
Production acceptance: not claimed. A later protected staging run is needed to observe the new diagnostic and determine the actual API denial condition.
