### PR TITLE
Remove retired CLI plugin build override

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -157,10 +157,6 @@
       "cache": false,
       "outputs": []
     },
-    "@elizaos/plugin-cli#build": {
-      "dependsOn": ["@elizaos/core#build", "^build"],
-      "outputs": ["dist/**"]
-    },
     "@elizaos/plugin-app-control#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
The retired `@elizaos/plugin-cli` workspace still had a Turbo build override, causing the final repository audit to fail after all 373 build/type/lint tasks passed. Remove the orphaned override; no active workspace task changes.

Follow-up to #30851 and #30761. `bun run audit:turbo-build-deps` now passes all three checks (dependency edges, task ownership and workspace cycles). Final repository verification is being rerun locally. The task owner authorized merging without waiting for hosted CI.
