### PR TITLE
Preserve renderer-specific stylesheet preloading

### DIFF
--- a/packages/app/src/entry.ts
+++ b/packages/app/src/entry.ts
@@ -47,15 +47,19 @@ const usePublicEntry =
   __ELIZA_PUBLIC_WEB_ENTRY__ === true &&
   shouldUsePublicWebEntry(entryDecisionInput);
 
-const rendererEntry = useMarketingHomeEntry
-  ? import("./marketing-home-entry")
-  : usePublicEntry
-    ? import("./public-web-entry")
-    : import("./main");
-
 // error-policy:J1 renderer-entry boundary — import failures render the same
 // actionable reload card as failures inside the established main boot.
-void rendererEntry.catch(async (error) => {
+async function handleRendererFailure(error: unknown): Promise<void> {
   const { renderBootFailure } = await import("./boot-failure");
   renderBootFailure(error);
-});
+}
+
+// Separate import callbacks let Vite attach each renderer's CSS dependencies.
+// A conditional import callback can collapse those lists to shared CSS only.
+if (useMarketingHomeEntry) {
+  void import("./marketing-home-entry").catch(handleRendererFailure);
+} else if (usePublicEntry) {
+  void import("./public-web-entry").catch(handleRendererFailure);
+} else {
+  void import("./main").catch(handleRendererFailure);
+}

--- a/packages/app/test/ui-smoke/renderer-entry-css.spec.ts
+++ b/packages/app/test/ui-smoke/renderer-entry-css.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Builds the shipped renderer selector with Vite and exercises its lazy CSS in
+ * Chromium. Tiny renderer fixtures isolate bundler behavior while the routing
+ * policy and boot-failure boundary remain the production implementations.
+ */
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { build } from "vite";
+
+const appRoot = fileURLToPath(new URL("../..", import.meta.url));
+const entryPath = path.join(appRoot, "src/entry.ts");
+const renderers = ["marketing-home-entry", "public-web-entry", "main"] as const;
+let fixtureRoot: string;
+
+test.beforeAll(async () => {
+  fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "eliza-renderer-css-"));
+  await writeFile(
+    path.join(fixtureRoot, "index.html"),
+    '<div id="root"></div><script type="module" src="/entry.ts"></script>',
+  );
+  for (const [index, renderer] of renderers.entries()) {
+    await writeFile(
+      path.join(fixtureRoot, `${renderer}.ts`),
+      `
+      import "./${renderer}.css";
+      if (new URLSearchParams(location.search).has("fail")) throw new Error("renderer failed");
+      document.querySelector("#root").textContent = ${JSON.stringify(renderer)};
+      window.executedRenderers = [...(window.executedRenderers || []), ${JSON.stringify(renderer)}];
+    `,
+    );
+    await writeFile(
+      path.join(fixtureRoot, `${renderer}.css`),
+      `:root { --${renderer}-loaded: loaded; } #root { padding-left: ${(index + 1) * 11}px; }`,
+    );
+  }
+  await build({
+    configFile: false,
+    root: fixtureRoot,
+    logLevel: "silent",
+    plugins: [
+      {
+        name: "renderer-fixtures",
+        enforce: "pre",
+        resolveId(source, importer) {
+          if (source === "/entry.ts") return entryPath;
+          if (
+            importer === entryPath &&
+            renderers.some((name) => source === `./${name}`)
+          )
+            return path.join(fixtureRoot, `${source.slice(2)}.ts`);
+        },
+      },
+    ],
+    resolve: {
+      alias: {
+        "@elizaos/shared/elizacloud/domain-contract": path.join(
+          appRoot,
+          "../shared/src/elizacloud/domain-contract.ts",
+        ),
+      },
+    },
+    define: {
+      __ELIZA_WEB_SHELL__: "true",
+      __ELIZA_PUBLIC_WEB_ENTRY__: "true",
+      __ELIZA_CHAT_UI_HARNESS__: "false",
+    },
+    build: { outDir: "dist", emptyOutDir: true, modulePreload: false },
+  });
+});
+
+test.afterAll(async () => {
+  if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true });
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.route("https://eliza.app/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    const isAsset = pathname.startsWith("/assets/");
+    const file = path.join(
+      fixtureRoot,
+      "dist",
+      isAsset ? pathname.slice(1) : "index.html",
+    );
+    await route.fulfill({
+      body: await readFile(file),
+      contentType: file.endsWith(".css")
+        ? "text/css"
+        : file.endsWith(".js")
+          ? "text/javascript"
+          : "text/html",
+    });
+  });
+});
+
+for (const [index, [route, renderer]] of (
+  [
+    ["/", "marketing-home-entry"],
+    ["/login", "public-web-entry"],
+    ["/agent", "main"],
+  ] as const
+).entries()) {
+  test(`${renderer} loads its own CSS without evaluating other renderers`, async ({
+    page,
+  }) => {
+    await page.goto(`https://eliza.app${route}`);
+    await expect(page.locator("#root")).toHaveText(renderer);
+    await expect(page.locator("#root")).toHaveCSS(
+      "padding-left",
+      `${(index + 1) * 11}px`,
+    );
+    expect(
+      await page.evaluate(
+        () =>
+          (window as Window & { executedRenderers?: string[] })
+            .executedRenderers,
+      ),
+    ).toEqual([renderer]);
+    const styles = await page.evaluate(
+      (names) =>
+        names.map((name) =>
+          getComputedStyle(document.documentElement)
+            .getPropertyValue(`--${name}-loaded`)
+            .trim(),
+        ),
+      renderers,
+    );
+    expect(styles).toEqual(
+      renderers.map((name) => (name === renderer ? "loaded" : "")),
+    );
+  });
+}
+
+test("a selected renderer failure reaches the production reload boundary", async ({
+  page,
+}) => {
+  await page.goto("https://eliza.app/?fail");
+  await expect(page.getByTestId("boot-failure")).toContainText(
+    "Couldn't start the app.",
+  );
+  await expect(
+    page.getByRole("button", { name: "Reload", exact: true }),
+  ).toBeVisible();
+  expect(
+    await page.evaluate(
+      () =>
+        (window as Window & { executedRenderers?: string[] }).executedRenderers,
+    ),
+  ).toBeUndefined();
+});

--- a/packages/app/test/ui-smoke/renderer-entry-css.spec.ts
+++ b/packages/app/test/ui-smoke/renderer-entry-css.spec.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "@playwright/test";
-import { build } from "vite";
+import { build, normalizePath } from "vite";
 
 const appRoot = fileURLToPath(new URL("../..", import.meta.url));
 const entryPath = path.join(appRoot, "src/entry.ts");
@@ -47,7 +47,8 @@ test.beforeAll(async () => {
         resolveId(source, importer) {
           if (source === "/entry.ts") return entryPath;
           if (
-            importer === entryPath &&
+            importer !== undefined &&
+            normalizePath(importer) === normalizePath(entryPath) &&
             renderers.some((name) => source === `./${name}`)
           )
             return path.join(fixtureRoot, `${source.slice(2)}.ts`);


### PR DESCRIPTION
Fixes #30856.

The compiled apex homepage loaded its component without the homepage stylesheet, leaving the shader over the page. Vite combined the conditional renderer imports into one preload callback and retained only shared CSS. Keeping import failure handling on each branch preserves the stylesheet list for the selected renderer without changing routing or boot recovery.

Validation: actual Vite + Chromium regression fails marketing/public CSS before the fix and passes all four cases after it (styles, isolated renderer execution, boot failure boundary). The compiled unified app now recovers from an intentionally failed Spanish chunk on desktop/mobile with correct styles, reachable hover, and no horizontal overflow. Four tests also pass after portable fixture-path normalization. Root `RUN_TURBO_CONCURRENCY=2 bun run verify` passed all tasks and root audits. The run began on `d58e49d14c`; the only edit during it was test-path normalization, which separately passed all four browser tests and Biome.

Evidence build used base `83b9d8f565` plus the exact entry fix committed as `d58e49d14c`; the only later change normalizes test paths. No deployed-service claim.

| State | Desktop | Mobile |
| --- | --- | --- |
| Intentional locale error before explicit retry | ![Desktop error](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30851-desktop-before.png) | ![Mobile error](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30851-mobile-before.png) |
| Recovered with styles | ![Desktop recovered](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30851-desktop-after.png) | ![Mobile recovered](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30851-mobile-after.png) |

[Desktop recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30851-desktop-retry.mp4) · [Mobile recording](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30851-mobile-retry.mp4) · [Raw evidence, pre-fix shader-only screenshot, CSS diagnosis and red/green logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30851-completed-visual-evidence.zip).

The full preceding app capture passed 219 cases. OCR reported five recognition failures; all labels were visibly present on manual inspection. The bundle preserves raw results and adjudication without claiming a computed OCR pass. Live-model evidence is N/A for this renderer-only fix. No meaningful redesign or live account operation is involved.

The task owner authorized merging without waiting for hosted CI.
