### PR TITLE
fix(build): protect plugin artifact integrity

### DIFF
--- a/packages/scripts/__tests__/plugin-build.test.ts
+++ b/packages/scripts/__tests__/plugin-build.test.ts
@@ -344,6 +344,37 @@ describe("buildPlugin (shared driver, issue #10200)", () => {
     ).rejects.toThrow();
   });
 
+  test("a missing required rename source aborts instead of publishing an incomplete build", async () => {
+    makeFixture({ src: "export const ok = 1;\n" });
+    await expect(
+      buildPlugin({
+        name: "@elizaos/fixture-plugin",
+        targets: [
+          {
+            label: "Node",
+            entry: "src/index.ts",
+            outSubdir: "node",
+            target: "node",
+            format: "esm",
+            renames: [["missing.js", "required.js"]],
+          },
+        ],
+      }),
+    ).rejects.toThrow();
+    expect(existsSync(distPath("node", "required.js"))).toBe(false);
+  });
+
+  test("a missing required flatten source aborts instead of silently skipping the step", async () => {
+    makeFixture({ tsconfig: false });
+    await expect(
+      buildPlugin({
+        name: "@elizaos/fixture-plugin",
+        targets: [],
+        flatten: [{ from: "required-tree" }],
+      }),
+    ).rejects.toThrow();
+  });
+
   test("dtsTolerant swallows a failed declaration emit and warns, keeping JS outputs", async () => {
     // No tsconfig present → tsc fails (TS5058, missing project) → tolerant mode
     // must warn + continue rather than abort. Spy on console.warn to prove the

--- a/packages/scripts/__tests__/rewrite-dist-relative-imports-node-esm.test.ts
+++ b/packages/scripts/__tests__/rewrite-dist-relative-imports-node-esm.test.ts
@@ -62,8 +62,19 @@ describe("rewrite-dist-relative-imports-node-esm", () => {
       [
         'import { display } from "./actions/display-text.ts";',
         'const modulePromise = import("./ui/widget.tsx");',
+        'const attributedPromise = import("./feature.ts", { with: { type: "json" } });',
+        "const escapedPromise = import('./quo\\'te.ts');",
+        "const templatePromise = import(`./foo\\$" + "{bar}.ts`);",
+        `const guidance = 'Read from "./actions/display-text" for help.';`,
         "export { display, modulePromise };",
       ].join("\n"),
+    );
+    write(root, "packages/example/dist/feature.js", "export default {};\n");
+    write(root, "packages/example/dist/quo'te.js", "export default {};\n");
+    write(
+      root,
+      "packages/example/dist/foo$" + "{bar}.js",
+      "export default {};\n",
     );
 
     const result = spawnSync("node", [scriptPath, "packages/example"], {
@@ -97,5 +108,11 @@ describe("rewrite-dist-relative-imports-node-esm", () => {
       'import { display } from "./actions/display-text.js";',
     );
     expect(runtime).toContain('import("./ui/widget.js")');
+    expect(runtime).toContain(
+      'import("./feature.js", { with: { type: "json" } })',
+    );
+    expect(runtime).toContain("import('./quo\\'te.js')");
+    expect(runtime).toContain("import(`./foo\\$" + "{bar}.js`)");
+    expect(runtime).toContain('Read from "./actions/display-text" for help.');
   });
 });

--- a/packages/scripts/__tests__/tsup-plugin-packages-shared.test.ts
+++ b/packages/scripts/__tests__/tsup-plugin-packages-shared.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Exercises the shared tsup/esbuild source transformer through a real unbundled build and imported output.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const roots: string[] = [];
+const originalCwd = process.cwd();
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("shared plugin tsup source rewriting", () => {
+  test("rewrites module specifiers without changing import-shaped runtime text", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "plugin-tsup-rewrite-"));
+    roots.push(root);
+    mkdirSync(path.join(root, "src"));
+    writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ type: "module" }),
+    );
+    writeFileSync(
+      path.join(root, "src", "sibling.ts"),
+      "export const value = 7;\n",
+    );
+    writeFileSync(
+      path.join(root, "src", "index.ts"),
+      [
+        'import { value } from "./sibling";',
+        "export const guidance = 'Read from \"./sibling\" for help.';",
+        "export const result = value;",
+      ].join("\n"),
+    );
+
+    process.chdir(root);
+    const configModule = await import(
+      `${pathToFileURL(path.join(originalCwd, "plugins", "tsup.plugin-packages.shared.ts")).href}?fixture=${Date.now()}`
+    );
+    const config = configModule.default;
+    const resolveFromPlugin = createRequire(
+      path.join(originalCwd, "plugins", "plugin-blocker", "package.json"),
+    );
+    const { build } = await import(resolveFromPlugin.resolve("esbuild"));
+    await build({
+      absWorkingDir: root,
+      entryPoints: config.entry,
+      outdir: path.join(root, "dist"),
+      format: "esm",
+      bundle: false,
+      sourcemap: false,
+      plugins: config.esbuildPlugins,
+    });
+
+    expect(existsSync(path.join(root, "dist", "index.js"))).toBe(true);
+    const emitted = readFileSync(path.join(root, "dist", "index.js"), "utf8");
+    expect(emitted).toContain('from "./sibling.js"');
+    expect(emitted).toContain('Read from "./sibling" for help.');
+    const runtime = await import(
+      `${pathToFileURL(path.join(root, "dist", "index.js")).href}?run=${Date.now()}`
+    );
+    expect(runtime).toMatchObject({
+      guidance: 'Read from "./sibling" for help.',
+      result: 7,
+    });
+  });
+});

--- a/packages/scripts/lib/rewrite-module-specifiers.mjs
+++ b/packages/scripts/lib/rewrite-module-specifiers.mjs
@@ -1,0 +1,105 @@
+/**
+ * Finds and rewrites only syntax-owned ECMAScript module specifiers while preserving all other source bytes.
+ * Build callers provide the path-resolution policy because source and emitted trees resolve extensions differently.
+ */
+import ts from "typescript";
+
+/** @param {import("typescript").Node} node */
+function moduleSpecifier(node) {
+  if (
+    (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+    node.moduleSpecifier &&
+    ts.isStringLiteralLike(node.moduleSpecifier)
+  ) {
+    return node.moduleSpecifier;
+  }
+  if (
+    ts.isExternalModuleReference(node) &&
+    node.expression &&
+    ts.isStringLiteralLike(node.expression)
+  ) {
+    return node.expression;
+  }
+  if (
+    ts.isCallExpression(node) &&
+    node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+    node.arguments.length >= 1 &&
+    ts.isStringLiteralLike(node.arguments[0])
+  ) {
+    return node.arguments[0];
+  }
+  if (
+    ts.isImportTypeNode(node) &&
+    ts.isLiteralTypeNode(node.argument) &&
+    ts.isStringLiteralLike(node.argument.literal)
+  ) {
+    return node.argument.literal;
+  }
+  return null;
+}
+
+/** @param {string} value @param {string} quote */
+function encodeStringContent(value, quote) {
+  const escaped = value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\b", "\\b")
+    .replaceAll("\f", "\\f")
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "\\r")
+    .replaceAll("\t", "\\t")
+    .replaceAll("\v", "\\v")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029")
+    .replaceAll(quote, `\\${quote}`);
+  return quote === "`" ? escaped.replaceAll("${", "\\${") : escaped;
+}
+
+/**
+ * @param {string} source
+ * @param {string} filePath
+ * @param {(specifier: string) => string | Promise<string>} resolveSpecifier
+ */
+export async function rewriteModuleSpecifiers(
+  source,
+  filePath,
+  resolveSpecifier,
+) {
+  const scriptKind = /\.tsx?$/.test(filePath)
+    ? filePath.endsWith(".tsx")
+      ? ts.ScriptKind.TSX
+      : ts.ScriptKind.TS
+    : ts.ScriptKind.JS;
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+  const ranges = [];
+  const visit = (node) => {
+    const literal = moduleSpecifier(node);
+    if (literal) {
+      ranges.push({
+        start: literal.getStart(sourceFile) + 1,
+        end: literal.getEnd() - 1,
+        quote: source[literal.getStart(sourceFile)],
+        value: literal.text,
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  let output = source;
+  let changed = false;
+  for (const range of ranges.reverse()) {
+    const replacement = await resolveSpecifier(range.value);
+    if (replacement !== range.value) {
+      const encoded = encodeStringContent(replacement, range.quote);
+      output = `${output.slice(0, range.start)}${encoded}${output.slice(range.end)}`;
+      changed = true;
+    }
+  }
+  return { changed, source: output };
+}

--- a/packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+++ b/packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
@@ -3,6 +3,7 @@
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { findWorkspaceRoot } from "./lib/repo-root.mjs";
+import { rewriteModuleSpecifiers } from "./lib/rewrite-module-specifiers.mjs";
 
 const workspaceRoot = findWorkspaceRoot(process.cwd());
 const packageDir = process.argv[2]
@@ -111,27 +112,15 @@ async function rewriteFile(filePath) {
     }
     throw error;
   }
-  const importPattern =
-    /(\b(?:from|import)\s*\(?\s*["'])(\.{1,2}\/[^"']+)(["']\)?)/g;
+  const rewritten = await rewriteModuleSpecifiers(
+    source,
+    filePath,
+    (specifier) => resolveRelativeSpecifier(filePath, specifier),
+  );
 
-  let changed = false;
-  let output = "";
-  let lastIndex = 0;
-  for (const match of source.matchAll(importPattern)) {
-    const [full, prefix, specifier, suffix] = match;
-    const replacement = await resolveRelativeSpecifier(filePath, specifier);
-    output += source.slice(lastIndex, match.index);
-    output += `${prefix}${replacement}${suffix}`;
-    lastIndex = match.index + full.length;
-    if (replacement !== specifier) {
-      changed = true;
-    }
-  }
-  output += source.slice(lastIndex);
-
-  if (changed) {
+  if (rewritten.changed) {
     try {
-      await writeFile(filePath, output, "utf8");
+      await writeFile(filePath, rewritten.source, "utf8");
     } catch (error) {
       if (error?.code === "ENOENT") {
         return false;
@@ -139,7 +128,7 @@ async function rewriteFile(filePath) {
       throw error;
     }
   }
-  return changed;
+  return rewritten.changed;
 }
 
 if (!(await exists(distDir))) {

--- a/plugins/plugin-build.ts
+++ b/plugins/plugin-build.ts
@@ -1,12 +1,8 @@
 #!/usr/bin/env bun
 /**
- * Shared plugin build driver (issue #9626, TL;DR #2). The model-provider and
- * connector plugins each hand-rolled the same Bun.build + tsc-d.ts + d.ts-alias
- * algorithm with minor per-package variation (which targets, minify, whether a
- * dist clean runs, and the exact declaration-alias shims). This collapses that
- * orchestration to one place; each plugin's `build.ts` becomes a small,
- * declarative `buildPlugin({...})` call that lists only what it actually differs
- * on. The emitted `dist/` is byte-identical to the previous hand-rolled build.
+ * Orchestrates plugin bundles and required publication artifacts from declarative package build files.
+ * Every configured move, declaration, shim, and copy is part of the published package contract, so a
+ * failed or missing step aborts instead of reporting success with an incomplete `dist/` tree.
  */
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir, rename, writeFile } from "node:fs/promises";
@@ -203,14 +199,10 @@ export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
       throw new Error(`${t.label} build failed`);
     }
     for (const [from, to] of t.renames ?? []) {
-      try {
-        await rename(
-          join(distDir, t.outSubdir, from),
-          join(distDir, t.outSubdir, to),
-        );
-      } catch (e) {
-        console.warn(`${t.label} rename step warning:`, e);
-      }
+      await rename(
+        join(distDir, t.outSubdir, from),
+        join(distDir, t.outSubdir, to),
+      );
     }
     console.log(
       `✅ ${t.label} complete in ${((Date.now() - start) / 1000).toFixed(2)}s`,
@@ -219,7 +211,6 @@ export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
 
   for (const f of config.flatten ?? []) {
     const fromDir = join(distDir, f.from);
-    if (!existsSync(fromDir)) continue;
     const toDir = join(distDir, f.to ?? ".");
     console.log(`📂 Flattening dist/${f.from} → dist/${f.to ?? "."}…`);
     await moveTreeContents(fromDir, toDir);

--- a/plugins/tsup.plugin-packages.shared.ts
+++ b/plugins/tsup.plugin-packages.shared.ts
@@ -8,6 +8,7 @@
 
 import { existsSync, promises as fsp, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
+import { rewriteModuleSpecifiers } from "../packages/scripts/lib/rewrite-module-specifiers.mjs";
 
 type EsbuildOnLoadArgs = {
   path: string;
@@ -115,13 +116,14 @@ const rewriteRelativeTsExtensions = {
   setup(build: EsbuildPluginBuild) {
     build.onLoad({ filter: /\.(ts|tsx)$/ }, async (args) => {
       const source = await fsp.readFile(args.path, "utf8");
-      const transformed = source.replace(
-        /((?:\bfrom\s+|\bimport\s*\(\s*|\bimport\s+|\bexport\s+(?:\*|\{[^}]*\})\s+from\s+)["'])(\.\.?\/[^"']+?)(["'])/g,
-        (_match, prefix: string, specifier: string, suffix: string) =>
-          `${prefix}${resolveRelativeRuntimeSpecifier(args.path, specifier)}${suffix}`,
+      const transformed = await rewriteModuleSpecifiers(
+        source,
+        args.path,
+        (specifier: string) =>
+          resolveRelativeRuntimeSpecifier(args.path, specifier),
       );
       return {
-        contents: transformed,
+        contents: transformed.source,
         loader: args.path.endsWith(".tsx") ? "tsx" : "ts",
       };
     });


### PR DESCRIPTION
## Problem

Plugin publication could report success after a configured rename or flatten source was missing, leaving an incomplete `dist/` tree. Both shared relative-import rewrite paths also used regexes that could rewrite import-shaped text inside runtime strings.

Closes #30705.

## Approach

- make configured rename and flatten steps fail closed
- share one TypeScript-AST-based module-specifier discovery helper between the tsup source transform and emitted-dist rewrite script
- preserve source quoting/escapes while rewriting static imports, re-exports, dynamic imports (including options), import types, and import-equals specifiers
- add regression coverage that imports a real esbuild output and verifies runtime text remains unchanged

## Verification

- `bun test packages/scripts/__tests__/plugin-build.test.ts packages/scripts/__tests__/rewrite-dist-relative-imports-node-esm.test.ts packages/scripts/__tests__/tsup-plugin-packages-shared.test.ts` — 18 passed, 51 assertions
- sabotage run with the former behavior — 4 expected failures (missing rename, missing flatten, dist runtime-string mutation, tsup runtime-string mutation)
- additional red-first probes reproduced two-argument `import()` omission plus quote/template escape corruption before their fixes
- `bun run --cwd plugins/plugin-linear build` — passed (real tsup path)
- `bun run --cwd plugins/plugin-zai build` — passed (real rename path)
- `bun run --cwd plugins/plugin-whatsapp build` — passed (real dist rewrite path)
- `bun run verify` — passed on the rebased final tree (373/373 Turbo tasks)
- `bun run test:scripts` — not green: unrelated existing/environment failures in `deploy-freshness-guard` (timeout), `capacitor-bridge-typecheck-boundary` (stale generated shim export), and `gateway-webhook-deploy-workflow` (fixture drift)

## Risk and exclusions

- No dependency, package export, or public runtime API change.
- Build configuration remains repository-authored trusted input; this change does not alter its path model.
- No UI or live integration evidence applies because the change is build orchestration only.

<!-- evidence-head:f81574dd6b3123cb6202bb3442bec1d3e2bf0766 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - build orchestration has no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - build orchestration has no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI path changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - emitted artifacts were verified by real plugin builds and automated runtime imports

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual content changed

AI provider/model: openai-codex / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@055cbad66cc7be43b558242522386ba540fef666:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [impact-pr-fleet]
<!-- eliza-computer-attribution:v1 {"provider":"openai-codex","model":"gpt-5.6-sol","client":"Hermes Agent","skill_revision":"elizaOS/eliza@055cbad66cc7be43b558242522386ba540fef666:packages/skills/skills/contribute-to-eliza"} -->

