### PR TITLE
fix(ui): restore accent badge contrast and stabilize view regression checks

### DIFF
--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -666,10 +666,15 @@ describe("App screen-background fuzz — color invariant across view switching",
     window.addEventListener("unhandledrejection", swallow);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     window.removeEventListener("error", swallow);
     window.removeEventListener("unhandledrejection", swallow);
     cleanup();
+    // Radix restores focus in a zero-delay unmount timer. Finish that real
+    // callback before Vitest replaces the jsdom realm and its Event classes.
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
     vi.unstubAllGlobals();
   });
 
@@ -913,10 +918,15 @@ describe("App view-surface mutation isolation — rogue view cannot leak global 
     window.addEventListener("unhandledrejection", swallow);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     window.removeEventListener("error", swallow);
     window.removeEventListener("unhandledrejection", swallow);
     cleanup();
+    // Radix restores focus in a zero-delay unmount timer. Finish that real
+    // callback before Vitest replaces the jsdom realm and its Event classes.
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    });
     vi.unstubAllGlobals();
   });
 

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -274,13 +274,16 @@ describe("CloudRouterShell app-mode catch-all (app.elizacloud.ai)", () => {
     setHostname("app.elizacloud.ai");
     installFetchRecorder();
     renderCatchAllWithAppModeMarkers();
-    // The gate chunk is lazy; the login redirect lands after it loads.
-    expect(await screen.findByTestId("login-page")).toBeTruthy();
+    // The first lazy chunk includes test-time transformation under suite load;
+    // wait for its real redirect without imposing a one-second build budget.
+    expect(
+      await screen.findByTestId("login-page", {}, { timeout: 5_000 }),
+    ).toBeTruthy();
     expect(screen.queryByTestId("agent-app")).toBeNull();
     expect(fetchLog).toEqual([]);
     await flushMicrotasks();
     expect(privateLoads).toBe(0);
-  });
+  }, 10_000);
 
   it("gates every non-registered (marketing/app) path on the app host, not just the root", async () => {
     setHostname("app.elizacloud.ai");

--- a/packages/ui/src/components/ui/badge.stories.tsx
+++ b/packages/ui/src/components/ui/badge.stories.tsx
@@ -24,6 +24,29 @@ export const Secondary: Story = { args: { variant: "secondary" } };
 export const Destructive: Story = { args: { variant: "destructive" } };
 export const Outline: Story = { args: { variant: "outline" } };
 
+export const DarkAccent: Story = {
+  globals: { theme: "dark" },
+  args: { tone: "accent" },
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Badge {...args} variant="default">
+        Connected
+      </Badge>
+      <Badge {...args} variant="secondary">
+        Needs attention
+      </Badge>
+      <Badge {...args} variant="outline">
+        Configured
+      </Badge>
+    </div>
+  ),
+};
+
+export const LightAccent: Story = {
+  ...DarkAccent,
+  globals: { theme: "light" },
+};
+
 /** Every variant in one view. */
 export const AllVariants: Story = {
   render: (args) => (

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -102,7 +102,7 @@ const badgeVariants = cva(
       },
       tone: {
         default: "",
-        accent: "bg-accent/12 text-accent-fg",
+        accent: "bg-accent/12 text-txt",
         success: "bg-ok/10 text-ok",
         warning: "bg-warn/10 text-warn",
         danger: "bg-danger/10 text-danger",
@@ -128,6 +128,14 @@ const badgeVariants = cva(
           "pointer-events-none absolute -top-4 left-0 whitespace-nowrap rounded-sm border-0 bg-accent px-1 py-0 font-mono text-[10px] leading-[14px] text-accent-foreground",
       },
     },
+    compoundVariants: [
+      {
+        variant: "default",
+        tone: "accent",
+        // The stronger hover fill needs its paired accent foreground.
+        class: "hover:text-accent-foreground",
+      },
+    ],
     defaultVariants: {
       variant: "default",
       size: "default",

--- a/packages/ui/src/services/local-inference/catalog.test.ts
+++ b/packages/ui/src/services/local-inference/catalog.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_ELIGIBLE_MODEL_IDS,
+  ELIZA_1_PUBLISHED_TIER_IDS,
   ELIZA_1_TIER_IDS,
   FIRST_RUN_DEFAULT_MODEL_ID,
   findCatalogModel,
@@ -70,11 +71,19 @@ describe("local inference catalog", () => {
     );
   });
 
-  it("keeps the visible model hub focused on Eliza-1 only", () => {
+  it("offers only published Eliza-1 tiers in the visible model hub", () => {
     const visible = localInferenceService.getCatalog();
     expect(visible.map((model) => model.id).sort()).toEqual(
-      [...ELIZA_1_TIER_IDS].sort(),
+      [...ELIZA_1_PUBLISHED_TIER_IDS].sort(),
     );
+    const visibleIds = new Set(visible.map((model) => model.id));
+    for (const model of MODEL_CATALOG) {
+      if (model.publishStatus === "pending") {
+        expect(visibleIds.has(model.id), `${model.id} is not published`).toBe(
+          false,
+        );
+      }
+    }
     expect(
       visible.filter((model) => DEFAULT_ELIGIBLE_MODEL_IDS.has(model.id))
         .length,

--- a/packages/ui/src/storybook/plugin-views/MessagesSpatialView.stories.tsx
+++ b/packages/ui/src/storybook/plugin-views/MessagesSpatialView.stories.tsx
@@ -3,6 +3,7 @@
  * Snapshot fixtures do not send messages or certify Android bridge behavior.
  */
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { MessagesSpatialView } from "../../../../../plugins/plugin-messages/src/components/MessagesSpatialView";
 import { SpatialSurface } from "../../spatial";
 
@@ -99,5 +100,75 @@ export const Populated: Story = {
         },
       ],
     },
+  },
+};
+
+const shortViewportAction = fn();
+
+/** A landscape app body must scroll without compressing status or actions. */
+export const ShortViewport: Story = {
+  args: {
+    snapshot: {
+      ...meta.args.snapshot,
+      ownsSmsRole: false,
+      smsRoleHolder: "com.android.messaging",
+    },
+    onAction: shortViewportAction,
+  },
+  render: (args) => (
+    <div
+      data-testid="messages-viewport"
+      style={{ width: "100%", maxWidth: 844, height: 258, overflow: "hidden" }}
+    >
+      <SpatialSurface>
+        <MessagesSpatialView {...args} />
+      </SpatialSurface>
+    </div>
+  ),
+  play: async ({ canvasElement, args }) => {
+    shortViewportAction.mockClear();
+    const canvas = within(canvasElement);
+    const frame = canvas.getByTestId("messages-viewport");
+    const status = canvas.getByText("bridge:com.android.messaging");
+    const role = canvas.getByRole("button", { name: "Set default SMS" });
+    const statusRect = status.getBoundingClientRect();
+    await expect(statusRect.height).toBeGreaterThan(0);
+    await expect(statusRect.bottom).toBeLessThanOrEqual(
+      role.getBoundingClientRect().top,
+    );
+    await userEvent.click(role);
+    await expect(args.onAction).toHaveBeenCalledWith("request-sms-role");
+    const refresh = canvas.getByRole("button", { name: "Refresh messages" });
+    let scroller = refresh.parentElement;
+    while (
+      scroller &&
+      scroller !== frame &&
+      !(
+        ["auto", "scroll"].includes(getComputedStyle(scroller).overflowY) &&
+        scroller.scrollHeight > scroller.clientHeight
+      )
+    ) {
+      scroller = scroller.parentElement;
+    }
+    if (!scroller || scroller === frame)
+      throw new Error("Short Messages view has no reachable scroll container");
+    scroller.scrollTop = scroller.scrollHeight;
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+    const control = refresh.getBoundingClientRect();
+    const viewport = frame.getBoundingClientRect();
+    await expect(control.top).toBeGreaterThanOrEqual(viewport.top);
+    await expect(control.bottom).toBeLessThanOrEqual(viewport.bottom);
+    const hit = document.elementFromPoint(
+      control.x + control.width / 2,
+      control.y + control.height / 2,
+    );
+    await expect(hit && refresh.contains(hit)).toBeTruthy();
+    await userEvent.click(refresh);
+    await expect(args.onAction).toHaveBeenCalledWith("refresh");
+    await expect(
+      canvas.getByRole("button", { name: "Send SMS" }),
+    ).toBeDisabled();
   },
 };

--- a/packages/ui/test/story-gate/run-story-gate.mjs
+++ b/packages/ui/test/story-gate/run-story-gate.mjs
@@ -757,6 +757,8 @@ async function main() {
       deviceScaleFactor: 1,
       reducedMotion: "reduce",
       colorScheme: "dark",
+      // Keep local Date arithmetic aligned with the shim's UTC formatting.
+      timezoneId: "UTC",
     });
     while (cursor < stories.length) {
       const story = stories[cursor++];

--- a/packages/ui/test/story-gate/story-gate-timezone.test.mjs
+++ b/packages/ui/test/story-gate/story-gate-timezone.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * Exercises the real Story Gate browser under a DST-observing host timezone.
+ * Local calendar arithmetic and formatted hour labels must share the same zone.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+it("keeps summer event positions aligned with winter-derived hour labels", () => {
+  const directory = mkdtempSync(join(tmpdir(), "story-timezone-"));
+  try {
+    writeFileSync(
+      join(directory, "index.json"),
+      JSON.stringify({
+        entries: {
+          "calendar--timezone": {
+            id: "calendar--timezone",
+            type: "story",
+            title: "Calendar",
+            name: "Timezone",
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(directory, "iframe.html"),
+      `<!doctype html>
+      <html><body class="sb-show-main"><main>Calendar timezone alignment</main><script>
+      window.__STORYBOOK_PREVIEW__ = { currentRender: { phase: 'finished' } };
+      const format = value => new Intl.DateTimeFormat(undefined, {hour: 'numeric'}).format(value);
+      const hourLabel = format(new Date(2024, 0, 1, 10));
+      const eventLabel = format(new Date(2025, 5, 1, 10));
+      if (hourLabel !== eventLabel) console.error('Calendar hour misalignment: ' + hourLabel + ' vs ' + eventLabel);
+      if (new Date(2025, 5, 1, 10).getHours() !== 10) console.error('Local calendar arithmetic changed');
+      </script></body></html>`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(dirname(fileURLToPath(import.meta.url)), "run-story-gate.mjs"),
+        "--static-dir",
+        directory,
+        "--out",
+        join(directory, "output"),
+        "--concurrency",
+        "1",
+        "--no-a11y",
+        "--no-screenshots",
+      ],
+      {
+        env: { ...process.env, TZ: "America/New_York" },
+        encoding: "utf8",
+        timeout: 30000,
+      },
+    );
+    const report = JSON.parse(
+      readFileSync(join(directory, "output", "report.json"), "utf8"),
+    );
+    expect(report.results[0].consoleErrors, result.stderr).toEqual([]);
+    expect(report.results[0].verdict).toBe("good");
+    expect(result.status).toBe(0);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}, 40000);

--- a/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
@@ -108,7 +108,10 @@ export function MessagesSpatialView({
     snapshot.composeBody.trim().length > 0;
 
   return (
-    <div className="min-h-0 overflow-y-auto" data-scroll-cert-scroller>
+    <div
+      className="h-full min-h-0 w-full overflow-y-auto"
+      data-scroll-cert-scroller
+    >
       <Card gap={1} padding={1}>
         <HStack gap={1} align="center">
           <Text style="caption" tone={roleTone(snapshot)} grow={1}>

--- a/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesSpatialView.tsx
@@ -108,10 +108,7 @@ export function MessagesSpatialView({
     snapshot.composeBody.trim().length > 0;
 
   return (
-    <div
-      className="h-full min-h-0 w-full overflow-y-auto"
-      data-scroll-cert-scroller
-    >
+    <div className="min-h-0 overflow-y-auto" data-scroll-cert-scroller>
       <Card gap={1} padding={1}>
         <HStack gap={1} align="center">
           <Text style="caption" tone={roleTone(snapshot)} grow={1}>


### PR DESCRIPTION
Home’s “Needs attention” badge used black text on a dark translucent accent fill. This restores the theme foreground and pairs the default badge’s stronger hover fill with its matching foreground. Measured desktop and mobile contrast improves from **1.29:1 → 15.63:1 at rest** and **1.35:1 → 14.93:1 on hover**.

Regression checks cover Messages scroll reachability and hit targets, summer/winter browser dates, Radix focus-restoration teardown, lazy login loading, and published local-model selection. Messages production layout is unchanged: exact-base comparison showed its existing scroll container already worked.

Related to #24104; follows #30783. This scoped fix does not close the all-view campaign. Risk is low: a shared badge foreground/hover pairing and test-harness changes. No documentation or API migration is needed.

Validation:

- Final head `6bc9d46ab189f6de510203fecc0814f75a59e5a9`, base `5d9abbb223ad5daef4e82370db610a7972d2a204`: normal install and root verification passed, **373/373 uncached tasks in 6m50.231s**, plus all final audits. Independent exact-head source review found no blocking defect.
- Intermediate `a9a79d36`: install/root passed; rebuilt ShortViewport story passed with real scrolling, hit testing, action callback checks and no console/a11y error. This confirms it passes without the removed Messages sizing classes.
- Earlier `5efc11f3`: focused package tests/types/lint passed; full UI suite **13,853 passed / 7 skipped**, app audit **219 passed**, plugin-surface suite **6 passed**, and **38 story captures good**. These remain explicitly prior-head results.
- All eight final scoped blobs match the reviewed intermediate source. Incoming base changes affect retired tooling, agent typings and Cerebras schemas, not these fixture rendering paths. The provider change is not claimed equivalent for live acceptance.

Evidence uses the normal built renderer with deterministic backend fixtures. App captures are dark theme; light AccentBadge evidence is an isolated primitive check. Actual source IDs remain on every artifact. The transient mobile “Swipe for apps” tooltip appears in both before and after recordings. Native SMS, live account effects and combined runtime acceptance are outside this PR’s proof.

Review Home at desktop/mobile widths in rest and hover states; compare the labelled before/after captures. The Messages story checks already-shipped behavior, not a newly repaired clipping defect. Complete raw logs and original video are retained.

[Exact-head validation receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-6bc-final-validation-receipt.json) · [Source equivalence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-guardian-24104-6bc9-source-equivalence.json) · [Full artifact inventory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-publication-inventory-final.json)

[Complete verified canonical archive](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-canonical-5efc11-654-artifacts.tar.gz) · [Fixture startup log (diagnostic only)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-5efc11-fixture.log)

<!-- evidence-head:6bc9d46ab189f6de510203fecc0814f75a59e5a9 -->

<!-- evidence-row:before-screenshots -->
Baseline `1b89a8bc`, full-page desktop/mobile rest and hover:
![Before 1440 rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-before-1b89-1440-rest.jpg)
![Before 1440 hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-before-1b89-1440-hover.jpg)
![Before 390 rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-before-1b89-390-rest.jpg)
![Before 390 hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-before-1b89-390-hover.jpg)
<!-- evidence-row:after-screenshots -->
Reviewed `5efc11f3` Home/Badge source is identical in the final diff; `a9a79d36` Messages story uses unchanged upstream production:
![After 1440 rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-after-5efc11-1440-rest.jpg)
![After 1440 hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-after-5efc11-1440-hover.jpg)
![After 390 rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-after-5efc11-390-rest.jpg)
![After 390 hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-after-5efc11-390-hover.jpg)
![Isolated dark accent badge](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-badge-5efc11-dark-accent.png)
![Isolated light accent badge](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-badge-5efc11-light-accent.png)
![Messages post-scroll ShortViewport](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-a9-short-viewport-plugin-views-messages--short-viewport.png)
<!-- evidence-row:walkthrough-video -->
[Complete baseline walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-before-1b89-home-walkthrough.mp4) · [Complete after walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-after-5efc11-home-walkthrough.mp4)

<!-- evidence-row:backend-logs -->
N/A - This badge and regression-harness diff changes no backend operation. Rendering uses deterministic HTTP fixtures; their startup diagnostic is linked above and is not business-operation evidence.

<!-- evidence-row:frontend-logs -->
[Before console](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-before-1b89-frontend-console.json) · [Before network](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-before-1b89-frontend-network.json) · [After console](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-after-5efc11-frontend-console.json) · [After network](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-home-after-5efc11-frontend-network.json)

<!-- evidence-row:llm-trajectory -->
N/A - This diff changes presentation and regression harnesses, not agent prompts or live model behavior. Separate combined runtime acceptance remains pending.

<!-- evidence-row:domain-artifacts -->
[Original manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-canonical-5efc11-manifest.json) · [Archive verification receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-publication-receipt.json) · [Independent before/after review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-guardian-24104-1b89-5efc-comparison-review.md)

Manifest SHA-256 `65bea40371ea8f446e05ad91ba4afc1a64277c8260c777831fe6e0582d40d82e`; archive SHA-256 `c13f6c5abb86fd21f24eaeaaeafb29585d2f264854d470cdf6da0947dfbf80c6`. All 656 archive members (654 artifacts plus manifest/meta) were rehashed. Metadata node v24.3.0 is the pinned Bun 1.3.14 compatibility value; it is preserved unchanged.

<!-- evidence-row:ocr-review -->
[Actual Tesseract.js 7 OCR readouts of original before/after and badge captures](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30868-24104-ocr-original-captures.json) — full text and image hashes retained; OCR is supplementary to measured contrast and manual image/video review.
