### PR TITLE
fix(core): keep a ``` inside a JSON string value from being read as a fence (#30736)

### DIFF
--- a/packages/core/src/utils/json-llm.test.ts
+++ b/packages/core/src/utils/json-llm.test.ts
@@ -35,6 +35,69 @@ describe("extractAndParseJSONObjectFromText", () => {
 		).toEqual({ ok: true });
 	});
 
+	it("keeps a ``` inside a JSON string value as data (#30736)", () => {
+		// Valid JSON that JSON.parse accepts. An unanchored fence match captured
+		// the bare `bun test` between the two runs of backticks and failed.
+		const text = '{"text":"Run ```bun test``` first","ok":true}';
+		expect(extractAndParseJSONObjectFromText(text)).toEqual(JSON.parse(text));
+	});
+
+	it("extracts a fenced block from prose when a string value holds a code block (#30736)", () => {
+		// The reply envelope: a JSON.stringify'd {thought, text} whose text
+		// field carries a fenced snippet, wrapped in a ```json fence with prose
+		// on both sides. The inner fence sits after an escaped \n, never at the
+		// start of a line, so only the real closing fence ends the block.
+		const value = {
+			thought: "answer with the command",
+			text: "Run this:\n```bash\nbun test\n```",
+		};
+		const text = `Sure:\n\`\`\`json\n${JSON.stringify(value)}\n\`\`\`\nHope that helps!`;
+		expect(extractAndParseJSONObjectFromText(text)).toEqual(value);
+	});
+
+	it("extracts a whole-value fence when a string value holds a code block (#30736)", () => {
+		const value = { text: "Run this:\n```bash\nbun test\n```" };
+		expect(
+			extractAndParseJSONObjectFromText(
+				`\`\`\`json\n${JSON.stringify(value)}\n\`\`\``,
+			),
+		).toEqual(value);
+	});
+
+	it("extracts JSON from a ```json5 fenced block, with LF or CRLF endings", () => {
+		expect(
+			extractAndParseJSONObjectFromText("```json5\n{ ok: true, }\n```"),
+		).toEqual({ ok: true });
+		expect(
+			extractAndParseJSONObjectFromText("```JSON5\r\n[1, 2, 3]\r\n```"),
+		).toEqual([1, 2, 3]);
+		expect(
+			extractAndParseJSONObjectFromText(
+				"note:\r\n```json5\r\n{ ok: true, }\r\n```\r\nend",
+			),
+		).toEqual({ ok: true });
+	});
+
+	it("extracts a compact whole-value fence", () => {
+		expect(extractAndParseJSONObjectFromText('```{"a":1}```')).toEqual({
+			a: 1,
+		});
+	});
+
+	it("uses the first fenced block when prose carries several", () => {
+		expect(
+			extractAndParseJSONObjectFromText(
+				'first:\n```json\n{"n":1}\n```\nsecond:\n```json\n{"n":2}\n```',
+			),
+		).toEqual({ n: 1 });
+	});
+
+	it("reports the fenced content's error when the fenced block is invalid", () => {
+		expect(() =>
+			extractAndParseJSONObjectFromText("see:\n```json\n{not json\n```"),
+		).toThrow(/Failed to parse/);
+	});
+
 	it("accepts JSON5 leniency (unquoted keys, single quotes, trailing comma)", () => {
 		expect(extractAndParseJSONObjectFromText("{ a: 1, b: 'two', }")).toEqual({
 			a: 1,

--- a/packages/core/src/utils/json-llm.ts
+++ b/packages/core/src/utils/json-llm.ts
@@ -7,8 +7,37 @@
  */
 
 import JSON5 from "json5";
+import { unwrapWholeCodeFence } from "./code-fence.ts";
 
-const jsonBlockPattern = /```(?:json|json5)?\s*\r?\n?([\s\S]*?)\r?\n?```/i;
+const FENCE_LANGUAGES = ["json5", "json"] as const;
+
+// A fenced block embedded in prose. Both delimiters must own their line: a
+// valid JSON string cannot contain a raw newline, so a ``` that starts a line
+// is never string content, whereas an unanchored match would treat the first
+// ``` anywhere in the text (including one inside a string value) as the
+// opening fence and the next one as the closing fence. The alternation lists
+// json5 before json because nothing anchors the end of the info string.
+const jsonBlockPattern =
+	/^[ \t]*```(?:json5|json)?[ \t]*\r?\n([\s\S]*?)\r?\n[ \t]*```[ \t]*\r?$/im;
+
+type ParseAttempt =
+	| { ok: true; value: Record<string, unknown> | unknown[] }
+	| { ok: false; error: unknown };
+
+function parseCandidate(candidate: string): ParseAttempt {
+	// JSON5 already handles unquoted keys, single quotes, and trailing commas.
+	try {
+		const parsed = JSON5.parse(candidate);
+		if (parsed === null || typeof parsed !== "object") {
+			throw new Error("Parsed JSON must be an object or array");
+		}
+		return { ok: true, value: parsed as Record<string, unknown> | unknown[] };
+	} catch (error) {
+		// error-policy:J3 model output is untrusted input; an unparseable
+		// candidate is an explicit failed attempt that the caller reports.
+		return { ok: false, error };
+	}
+}
 
 /**
  * Extract and parse JSON from text using JSON5 for LLM output tolerance.
@@ -25,20 +54,22 @@ export function extractAndParseJSONObjectFromText(
 		throw new Error("Invalid input: text must be a non-empty string");
 	}
 
-	// First try to extract JSON from code blocks if present
-	const match = text.match(jsonBlockPattern);
-	const textToParse = match ? match[1].trim() : text.trim();
+	const trimmed = text.trim();
 
-	// Use JSON5.parse directly - it already handles unquoted keys, single quotes, trailing commas
-	try {
-		const parsed = JSON5.parse(textToParse);
-		if (parsed === null || typeof parsed !== "object") {
-			throw new Error("Parsed JSON must be an object or array");
-		}
-		return parsed as Record<string, unknown> | unknown[];
-	} catch (error) {
-		// error-policy:J2 Give callers a stable parse error while retaining the
-		// native JSON parser's location and syntax detail as the cause.
-		throw new Error("Failed to parse invalid JSON", { cause: error });
-	}
+	// The whole text first: when it is already valid JSON, any ``` inside it
+	// is string data and must not be mistaken for a fence.
+	const direct = parseCandidate(trimmed);
+	if (direct.ok) return direct.value;
+
+	// Then a fence wrapping the entire value (including compact and json5
+	// forms), then a fenced block surrounded by prose.
+	const wholeFence = unwrapWholeCodeFence(trimmed, FENCE_LANGUAGES);
+	const embedded = wholeFence === null ? trimmed.match(jsonBlockPattern) : null;
+	const fenced = wholeFence ?? embedded?.[1] ?? null;
+	const attempt = fenced === null ? direct : parseCandidate(fenced.trim());
+	if (attempt.ok) return attempt.value;
+
+	// error-policy:J2 Give callers a stable parse error while retaining the
+	// native JSON parser's location and syntax detail as the cause.
+	throw new Error("Failed to parse invalid JSON", { cause: attempt.error });
 }


### PR DESCRIPTION
# Relates to

Closes #30736

Overlaps #30536 on the fence pattern's alternation order: this branch adopts the same `json5`-first ordering and covers the ```json5 LF/CRLF cases, so whichever lands second needs a trivial rebase.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Medium by reach, low by behavior. `parseJSONObjectFromText` is called from about a dozen non-test sites (reply, basic capabilities, runtime, message service, image description cache, trust actions, agent extract-params). The change only widens what parses: every input the old path accepted still resolves to the same value because the whole-text parse is attempted first and the fence paths are only consulted when it fails. The one narrowing is that a ``` embedded mid-line in prose no longer opens a fence; a fence must start its line, which is how models emit them.

# Background

## What does this PR do?

`extractAndParseJSONObjectFromText` matched an unanchored, lazy fence pattern before attempting to parse the text. The first ``` anywhere in the input opened the fence and the next one closed it, so valid JSON whose string value contained three backticks (a shell snippet in a reply's `text` field) captured the bare words between them and threw, and `parseJSONObjectFromText` returned `null`. The same happened for a real ```json fence whose payload held an escaped code block. At `reply.ts` that `null` makes the whole `{thought, text}` envelope the reply text.

Now the whole trimmed text is parsed first, so backticks inside a valid value are data. Only then a fence around the entire value is unwrapped through the shared `unwrapWholeCodeFence` helper (compact and json5 forms included), and finally a fenced block embedded in prose is matched with both delimiters anchored to their own line: a valid JSON string cannot contain a raw newline, so a ``` that starts a line is never string content.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/json-llm.ts`, then the seven new cases in `json-llm.test.ts` (the two issue inputs, the whole-value form, json5 with LF and CRLF, compact fence, multiple fences, invalid fenced content).

## Detailed testing steps

Automated tests. The red run under Domain artifacts shows the four new cases that fail on `origin/develop`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:85d639bc651ae91523b5e42b043face01d93f520 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - core parsing helper; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - core parsing helper; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; deterministic string parsing.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: parser tests in core, the agent test that consumes the parser, and Biome on this exact head, pasted below.

  <details>
  <summary>vitest (core + agent) and Biome transcript on this head</summary>

  ```
# Backend logs for the #30736 fix (head 85d639bc651ae91523b5e42b043face01d93f520, rebased on origin/develop 316a47d2895)
# 2026-09-07T05:03:20Z cwd packages/core
$ npx vitest run src/utils/json-llm.test.ts src/utils.parsing.test.ts --reporter=verbose
 RUN  v4.1.10 /root/eliza-fixes/evidence-run2/packages/core
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > parses a plain JSON object 3ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > parses a JSON array 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > parses a model JSON value beyond the former 100,000-character boundary 181ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts JSON from a ```json fenced block surrounded by prose 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > keeps a ``` inside a JSON string value as data (#30736) 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts a fenced block from prose when a string value holds a code block (#30736) 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts a whole-value fence when a string value holds a code block (#30736) 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts JSON from a ```json5 fenced block, with LF or CRLF endings 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts a compact whole-value fence 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > uses the first fenced block when prose carries several 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > reports the fenced content's error when the fenced block is invalid 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > accepts JSON5 leniency (unquoted keys, single quotes, trailing comma) 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > throws on empty / non-string input 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > throws on unparseable text 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > throws when parsed JSON is a primitive scalar 0ms
 ✓ src/utils.parsing.test.ts > stringToUuid > is deterministic and well-formed 6ms
 ✓ src/utils.parsing.test.ts > stringToUuid > returns an already-valid UUID unchanged (idempotent) and accepts numbers 1ms
 ✓ src/utils.parsing.test.ts > validateUuid > accepts valid UUIDs, rejects junk 1ms
 ✓ src/utils.parsing.test.ts > parseJSONObjectFromText > recovers an object from surrounding prose, null on failure or arrays 2ms
 ✓ src/utils.parsing.test.ts > parseJSONObjectFromText > returns null for scalars, which JSON5 parses as valid JSON 1ms
 ✓ src/utils.parsing.test.ts > parseToonKeyValue > parses a compact unlabeled whole-value code fence 0ms
 ✓ src/utils.parsing.test.ts > parseToonKeyValue > parses indexed and scalar keys around adversarial delimiter whitespace 1ms
 ✓ src/utils.parsing.test.ts > parseBooleanFromText > maps affirmative/negative tokens, defaults false 1ms
 ✓ src/utils.parsing.test.ts > truncateToCompleteSentence > returns text unchanged when within the limit 0ms
 ✓ src/utils.parsing.test.ts > truncateToCompleteSentence > truncates at the last sentence period that fits in the limit 0ms
 ✓ src/utils.parsing.test.ts > truncateToCompleteSentence > falls back to a word boundary with ellipsis when no period fits 0ms
 ✓ src/utils.parsing.test.ts > truncateToCompleteSentence > never exceeds tiny limits that cannot fit an ellipsis 0ms
 ✓ src/utils.parsing.test.ts > truncateToCompleteSentence > keeps a tweet-sized truncation within the 280 character cap 0ms
 ✓ src/utils.parsing.test.ts > truncateToCompleteSentence > still ends at a period when one fits, without an ellipsis 0ms
 ✓ src/utils.parsing.test.ts > truncateToCompleteSentence > returns text unchanged when it already fits 0ms
 Test Files  2 passed (2)
      Tests  30 passed (30)
   Start at  05:03:22
   Duration  1.06s (transform 363ms, setup 0ms, import 537ms, tests 208ms, environment 0ms)
exit: 0

$ (cd ../agent && npx vitest run src/actions/extract-params.test.ts)
 RUN  v4.1.10 /root/eliza-fixes/evidence-run2/packages/agent
 Test Files  1 passed (1)
      Tests  24 passed (24)
   Duration  11.94s (transform 9.24s, setup 87ms, import 11.65s, tests 31ms, environment 0ms)

$ npx biome check src/utils/json-llm.ts src/utils/json-llm.test.ts
Checked 2 files in 73ms. No fixes applied.
exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the failing inputs are fixed strings from the issue; no model, prompt, or action change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the new tests against the develop parser, pasted below.

  <details>
  <summary>Red run: new tests against origin/develop json-llm.ts</summary>

  ```
# Red run: new json-llm tests against origin/develop json-llm.ts (5d9abbb223a)
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > parses a plain JSON object 3ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > parses a JSON array 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > parses a model JSON value beyond the former 100,000-character boundary 208ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts JSON from a ```json fenced block surrounded by prose 1ms
 × src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > keeps a ``` inside a JSON string value as data (#30736) 5ms
 × src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts a fenced block from prose when a string value holds a code block (#30736) 1ms
 × src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts a whole-value fence when a string value holds a code block (#30736) 1ms
 × src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts JSON from a ```json5 fenced block, with LF or CRLF endings 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > extracts a compact whole-value fence 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > uses the first fenced block when prose carries several 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > reports the fenced content's error when the fenced block is invalid 1ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > accepts JSON5 leniency (unquoted keys, single quotes, trailing comma) 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > throws on empty / non-string input 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > throws on unparseable text 0ms
 ✓ src/utils/json-llm.test.ts > extractAndParseJSONObjectFromText > throws when parsed JSON is a primitive scalar 1ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 Test Files  1 failed (1)
      Tests  4 failed | 11 passed (15)
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, or action change; the inputs are fixed strings.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, the two issue inputs throw `Failed to parse invalid JSON` and the public wrapper returns `null` (red run above).

### After

Both return the parsed object; all 30 parser tests pass (transcript above).

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total) after `bun install --frozen-lockfile` on `origin/develop` `316a47d2895`, run once on a temporary branch stacking this commit with the sibling fix on `fix/30736-json-fence-inside-string` / `fix/30735-telegram-bold-heading` so both were validated in one pass. Package tests, typecheck, and Biome were run on this branch head (transcript above). No other gaps; every N/A row above carries its reason.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
