### PR TITLE
fix(plugin-telegram): render a bold heading as one bold span (#30735)

### DIFF
--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -85,6 +85,31 @@ describe("convertMarkdownToTelegram", () => {
     );
   });
 
+  it("renders a bold heading as a single bold span (#30735)", () => {
+    // Bold inside a heading collided with the heading's own bold wrap and
+    // resolved to `**Summary**`, the sequence Telegram rejects (HTTP 400,
+    // "can't find end of bold entity"), or to a mis-nested `**Bold* header*`.
+    expect(convertMarkdownToTelegram("# **Summary**")).toBe("*Summary*");
+    expect(convertMarkdownToTelegram("## **Bold** header")).toBe(
+      "*Bold header*",
+    );
+    expect(convertMarkdownToTelegram("### a **b** and **c** d")).toBe(
+      "*a b and c d*",
+    );
+  });
+
+  it("keeps escaping and other nested tokens inside a bold heading", () => {
+    const out = convertMarkdownToTelegram("# **Step 1.** run `bun test` _now_");
+    expect(out).toBe("*Step 1\\. run `bun test` _now_*");
+    expect(out).not.toContain("\u0000");
+  });
+
+  it("leaves bold outside headings unchanged", () => {
+    expect(convertMarkdownToTelegram("# Title\n**bold** body")).toBe(
+      "*Title*\n*bold* body",
+    );
+  });
+
   it("drops empty headings without consuming the following line", () => {
     expect(convertMarkdownToTelegram("# ")).toBe("");
     expect(convertMarkdownToTelegram("######\t")).toBe("");

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -78,11 +78,20 @@ export function convertMarkdownToTelegram(markdown: string): string {
   // Temporarily replace recognized markdown tokens with sentinel strings.
   // Each sentinel is a string like "\u0000{index}\u0000".
   const replacements: string[] = [];
+  // Escaped inner text of each bold replacement, by sentinel index, so a
+  // heading (itself rendered bold) can absorb bold spans in its content
+  // instead of nesting them: MarkdownV2 has no nested bold, and `**` is the
+  // sequence Telegram rejects as "can't find end of bold entity".
+  const boldInner = new Map<number, string>();
   function storeReplacement(formatted: string): string {
     const sentinel = `\u0000${replacements.length}\u0000`;
     replacements.push(formatted);
     return sentinel;
   }
+  // Sentinel marker as a string constant; a regex literal with the control
+  // character is rejected by lint.
+  const NULL_CHAR = String.fromCharCode(0);
+  const SENTINEL_REPLACE = new RegExp(`${NULL_CHAR}(\\d+)${NULL_CHAR}`, "g");
 
   let converted = markdown;
 
@@ -124,6 +133,7 @@ export function convertMarkdownToTelegram(markdown: string): string {
   converted = converted.replace(/\*\*([^*]+)\*\*/g, (_match, content) => {
     const formattedContent = escapePlainText(content);
     const formatted = `*${formattedContent}*`;
+    boldInner.set(replacements.length, formattedContent);
     return storeReplacement(formatted);
   });
 
@@ -182,16 +192,20 @@ export function convertMarkdownToTelegram(markdown: string): string {
       if (!trimmed) {
         return "";
       }
-      const formatted = `*${escapePlainText(trimmed)}*`;
+      // The whole heading becomes one bold span, so bold already stored for
+      // its content is flattened to that content's escaped text; otherwise
+      // the resolved output would read `**Summary**` or `**Bold* header*`.
+      const flattened = trimmed.replace(SENTINEL_REPLACE, (sentinel, index) => {
+        const inner = boldInner.get(Number.parseInt(index, 10));
+        return inner === undefined ? sentinel : storeReplacement(inner);
+      });
+      const formatted = `*${escapePlainText(flattened)}*`;
       return storeReplacement(formatted);
     },
   );
 
-  // Define the sentinel marker as a string constant.
-  const NULL_CHAR = String.fromCharCode(0);
   const SENTINEL_PATTERN = new RegExp(`(${NULL_CHAR}\\d+${NULL_CHAR})`, "g");
   const SENTINEL_TEST = new RegExp(`^${NULL_CHAR}\\d+${NULL_CHAR}$`);
-  const SENTINEL_REPLACE = new RegExp(`${NULL_CHAR}(\\d+)${NULL_CHAR}`, "g");
 
   const finalEscaped = converted
     .split(SENTINEL_PATTERN)


### PR DESCRIPTION
# Relates to

Closes #30735

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to the heading step of `convertMarkdownToTelegram` and only affects headings whose content already contains a bold span. Headings without bold, bold outside headings, and the other nested tokens inside headings (inline code, italic, links) keep their existing output, which the existing tests pin.

# Background

## What does this PR do?

`convertMarkdownToTelegram` rewrote `**text**` to a `*text*` replacement behind a sentinel, then wrapped every heading line in another bold pair. A heading whose content was already bold therefore resolved to `**Summary**`, the sequence Telegram rejects as "can't find end of bold entity" (HTTP 400), and `## **Bold** header` resolved to the mis-nested `**Bold* header*`. MarkdownV2 has no nested bold, and the heading is itself rendered bold, so bold inside it is redundant.

The bold step now records the escaped inner text of each bold replacement. When a heading's content holds a bold sentinel, the heading substitutes that inner text as its own sentinel (so it is not escaped twice) before wrapping the whole heading once. `# **Summary**` renders as `*Summary*` and `## **Bold** header` as `*Bold header*`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The bold and heading steps in `plugins/plugin-telegram/src/utils.ts`, then the three new cases in `utils.test.ts`.

## Detailed testing steps

Automated tests. The red run under Domain artifacts shows the develop output for the issue's inputs.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:91408ce39739aeee43ef97aea90059d1ec80e5c2 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - outbound message text conversion; no rendered UI surface in this repository.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - outbound message text conversion; no rendered UI surface in this repository.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; deterministic string conversion.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: plugin tests and Biome on this exact head, pasted below.

  <details>
  <summary>vitest and Biome transcript on this head</summary>

  ```
# Backend logs for the #30735 fix (head 91408ce39739aeee43ef97aea90059d1ec80e5c2, rebased on origin/develop 316a47d2895)
# 2026-09-07T05:03:37Z cwd plugins/plugin-telegram
$ npx vitest run src/utils.test.ts --reporter=verbose
 RUN  v4.1.10 /root/eliza-fixes/evidence-run2/plugins/plugin-telegram
 ✓ src/utils.test.ts > convertMarkdownToTelegram > rewrites bold/strikethrough to Telegram syntax 5ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > escapes MarkdownV2 reserved chars in plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > escapes intra-word underscores instead of italicizing identifiers (#19373) 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps flanked underscore italic working 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > treats canonically equivalent flanks identically (#19373 review) 1ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > suppresses the delimiter after non-Latin combining-mark clusters 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps single intra-word underscores escaped and __x__ inner italic unchanged 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves links (url chars other than ) and \ stay raw) 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > renders a bold heading as a single bold span (#30735) 1ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps escaping and other nested tokens inside a bold heading 1ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > leaves bold outside headings unchanged 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > drops empty headings without consuming the following line 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves CRLF fenced code with language tag ```c++
std::vector<int> xs;
``` 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves CRLF fenced code with language tag ```c#
Console.WriteLine();
``` 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves CRLF fenced code with language tag ```shell-session
$ echo ok
``` 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > leaves an unterminated fenced block as escaped plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps balanced URL parentheses inside the Telegram link target 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps malformed or nested link boundary [deep](https://x.test/a_(b_(c))) as plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps malformed or nested link boundary [bad](https://x.test/a_(b) as plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps malformed or nested link boundary [outer [inner]](https://x.test) as plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > resolves nested tokens (inline code inside bold/header) without leaking NUL sentinels 0ms
 ✓ src/utils.test.ts > convertToTelegramButtons > renders url and login buttons, skips malformed ones 2ms
 ✓ src/utils.test.ts > convertToTelegramButtons > returns [] for null/undefined 0ms
 ✓ src/utils.test.ts > cleanText > strips NULL sentinels and handles nullish input 0ms
 Test Files  1 passed (1)
      Tests  24 passed (24)
   Start at  05:03:39
   Duration  1.68s (transform 930ms, setup 124ms, import 1.32s, tests 16ms, environment 0ms)
exit: 0

$ npx biome check src/utils.ts src/utils.test.ts
Checked 2 files in 26ms. No fixes applied.
exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, or action change; the inputs are fixed strings from the issue.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the new tests against the develop converter, showing the `**Summary**` and mis-nested outputs, pasted below.

  <details>
  <summary>Red run: new tests against origin/develop utils.ts</summary>

  ```
# Red run: new utils tests against origin/develop utils.ts (5d9abbb223a)
 ✓ src/utils.test.ts > convertMarkdownToTelegram > rewrites bold/strikethrough to Telegram syntax 4ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > escapes MarkdownV2 reserved chars in plain text 1ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > escapes intra-word underscores instead of italicizing identifiers (#19373) 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps flanked underscore italic working 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > treats canonically equivalent flanks identically (#19373 review) 1ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > suppresses the delimiter after non-Latin combining-mark clusters 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps single intra-word underscores escaped and __x__ inner italic unchanged 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves links (url chars other than ) and \ stay raw) 0ms
 × src/utils.test.ts > convertMarkdownToTelegram > renders a bold heading as a single bold span (#30735) 7ms
 × src/utils.test.ts > convertMarkdownToTelegram > keeps escaping and other nested tokens inside a bold heading 2ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > leaves bold outside headings unchanged 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > drops empty headings without consuming the following line 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves CRLF fenced code with language tag ```c++
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves CRLF fenced code with language tag ```c#
 ✓ src/utils.test.ts > convertMarkdownToTelegram > preserves CRLF fenced code with language tag ```shell-session
 ✓ src/utils.test.ts > convertMarkdownToTelegram > leaves an unterminated fenced block as escaped plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps balanced URL parentheses inside the Telegram link target 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps malformed or nested link boundary [deep](https://x.test/a_(b_(c))) as plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps malformed or nested link boundary [bad](https://x.test/a_(b) as plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > keeps malformed or nested link boundary [outer [inner]](https://x.test) as plain text 0ms
 ✓ src/utils.test.ts > convertMarkdownToTelegram > resolves nested tokens (inline code inside bold/header) without leaking NUL sentinels 1ms
 ✓ src/utils.test.ts > convertToTelegramButtons > renders url and login buttons, skips malformed ones 2ms
 ✓ src/utils.test.ts > convertToTelegramButtons > returns [] for null/undefined 0ms
 ✓ src/utils.test.ts > cleanText > strips NULL sentinels and handles nullish input 0ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
Expected: "*Summary*"
Received: "**Summary**"
Expected: "*Step 1\. run `bun test` _now_*"
Received: "**Step 1\.* run `bun test` _now_*"
 Test Files  1 failed (1)
      Tests  2 failed | 22 passed (24)
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, or action change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, `# **Summary**` converts to `**Summary**` and `# **Step 1.** run ...` to `**Step 1\.* run ...*` (red run above).

### After

`*Summary*` and `*Step 1\. run `bun test` _now_*`; all 24 plugin tests pass (transcript above). I have not called the Telegram API in this change; the rejected `**` sequence is documented in the converter's own heading comment and the issue.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total) after `bun install --frozen-lockfile` on `origin/develop` `316a47d2895`, run once on a temporary branch stacking this commit with the sibling fix on `fix/30736-json-fence-inside-string` / `fix/30735-telegram-bold-heading` so both were validated in one pass. Package tests, typecheck, and Biome were run on this branch head (transcript above). No other gaps; every N/A row above carries its reason.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
