### PR TITLE
fix(login): resolve SDK source in clean Vitest lanes

### DIFF
--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -263,6 +263,10 @@ export default defineConfig({
         find: /^@elizaos\/auth\/(.+)$/,
         replacement: path.join(authSrc, "$1"),
       },
+      {
+        find: /^@elizaos\/login$/,
+        replacement: path.join(monorepoRoot, "packages/login/src/sdk/index.ts"),
+      },
       { find: /^@elizaos\/ui$/, replacement: path.join(uiDir, "src/index.ts") },
       {
         find: /^@elizaos\/ui\/api$/,

--- a/packages/scripts/vitest/default.config.ts
+++ b/packages/scripts/vitest/default.config.ts
@@ -229,6 +229,13 @@ const vitestInlineDeps = [
 
 const vitestResolveAlias: ModuleAlias[] = [
   {
+    find: /^@elizaos\/login$/,
+    replacement: path.join(
+      elizaWorkspaceRoot,
+      "packages/login/src/sdk/index.ts",
+    ),
+  },
+  {
     // Resolve @elizaos/logger to source (it is re-exported by source-aliased
     // @elizaos/core); avoids depending on logger's dist being built per test job.
     find: /^@elizaos\/logger$/,

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
     dedupe: ["react", "react-dom"],
     alias: [
       {
+        find: /^@elizaos\/login$/,
+        replacement: resolve(monorepoRoot, "packages/login/src/sdk/index.ts"),
+      },
+      {
         find: /^@elizaos\/ui$/,
         replacement: resolve(uiSrc, "index.ts"),
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: /^@elizaos\/login$/,
+        replacement: path.join(root, "packages/login/src/sdk/index.ts"),
+      },
+      {
         // plugin-app-control's build (tsup, index + worker entries only)
         // never emits dist/actions/*.js; the agent's settings-actions.ts
         // subpath import resolves only under the `eliza-source` exports


### PR DESCRIPTION
# Relates to

Fixes #30850. Follow-up to #30743 and #30838; builds on #30851.

# Sync with develop

Rebased on `5d9abbb223ad5daef4e82370db610a7972d2a204`; post-sync install passed without changes.

# Risks

Low: only test resolution changes. Public exports and runtime code are unchanged.

# Background

## What does this PR do?

Root, shared, UI and app-core Vitest configurations resolve `@elizaos/login` from its SDK source. Clean test runs no longer require an independently built login distribution when the shared UI imports its login provider.

The shared source-alias builder and its Vite regression tests were fixed separately in #30851; this PR retains only the four independent configurations that need the source mapping.

## What kind of change is this?

Test configuration bug fix.

# Documentation changes needed?

No public API or setup changes.

# Testing

## Where should a reviewer start?

Compare the failing clean UI import with the successful login UI suite below. The distribution was absent during both runs.

## Detailed testing steps

- Reproduced the UI provider import failure with `packages/login/dist` absent.
- All 142 login UI tests passed with the distribution absent after the mapping fix.
- All 40 scenario runtime tests passed with the distribution absent and the shared resolver fix.
- After rebasing onto the independently merged resolver fix, all 24 configuration tests passed.
- The final rebased clean run passed all 142 login UI tests and the web entrypoint test.
- Post-sync install passed without dependency changes.
- Root verification passed all 373 workspace tasks with no cache hits and every final repository audit, using one Turbo worker.

# Evidence Gate

<!-- evidence-head:3efc62d2b31d5c91e97868bf857b1f2f6c23b665 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Only Vitest configuration changes; no rendered source or product interaction changes. Real clean test runs exercise the affected build-resolution boundary.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Only Vitest configuration changes; no rendered source or product interaction changes. Real clean test runs exercise the affected build-resolution boundary.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Only Vitest configuration changes; no rendered source or product interaction changes. Real clean test runs exercise the affected build-resolution boundary.
<!-- evidence-row:ocr-review -->
- [ ] N/A - Only Vitest configuration changes; no rendered source or product interaction changes. Real clean test runs exercise the affected build-resolution boundary.
<!-- evidence-row:backend-logs -->
- [x] [30850-clean-scenario.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-clean-scenario.log)
<!-- evidence-row:frontend-logs -->
- [x] [30850-clean-ui-after.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-clean-ui-after.log)
<!-- evidence-row:domain-artifacts -->
- [x] [30850-config-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-config-tests.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt or agent behavior changes.

# Evidence Details

## Real LLM-call trajectory

N/A - Test configuration only.

## Backend + frontend logs

[Before failure](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-clean-ui-before.log) · [Clean UI suite](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-clean-ui-after.log) · [Clean scenario suite](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-clean-scenario.log) · [Configuration checks](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-config-tests.log)

## Screenshots (before / after) + video walkthrough

N/A - No rendered source or interaction changes.

### Before

UI provider import fails to resolve the unbuilt login package.

### After

The clean UI suite executes successfully from source.

### Walkthrough video

N/A - Test resolution is the changed boundary.

## Audio / voice walkthrough

N/A - No audio changes.

## Known gaps / failures

Root verification passed. All hosted PR checks passed at `3efc62d2b31d5c91e97868bf857b1f2f6c23b665`. Merged as `99004839d71d50cfd5ab2529b14dd4488e45d909`; verified its ancestry on `origin/develop`. External provider acceptance limits remain documented on #30743; this follow-up makes no additional provider claims.

## Maintainer CI exception record

N/A - No exception requested.


Final rebased evidence: [root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-3efc-root-verify.log) · [142 clean UI tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-3efc-clean-ui.log) · [clean web entrypoint](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30850-3efc-clean-app.log).

