### PR TITLE
fix(shared): keep a crash-torn JSONL line from swallowing the next record (#30878)

### DIFF
--- a/packages/agent/src/services/capability-broker.test.ts
+++ b/packages/agent/src/services/capability-broker.test.ts
@@ -7,6 +7,7 @@
  * cases, and the audit file is read back from disk.
  */
 import {
+  appendFileSync,
   existsSync,
   mkdtempSync,
   readFileSync,
@@ -180,6 +181,28 @@ describe("CapabilityBroker", () => {
       expect(typeof line.policyKey).toBe("string");
       expect(typeof line.ts).toBe("string");
     }
+  });
+
+  it("keeps a decision readable after a crash-torn audit line", () => {
+    const auditFilePath = path.join(stateDir, "audit", "capability.jsonl");
+    const broker = new CapabilityBroker({
+      stateDir,
+      auditFilePath,
+      mode: () => "local-safe",
+      distributionProfile: () => "unrestricted",
+    });
+    broker.check({ kind: "fs", op: "read", target: "/tmp/one" });
+    // An append interrupted before its trailing newline. A plain append would
+    // put the next decision on this same line, and the audit reader would
+    // discard both.
+    appendFileSync(auditFilePath, '{"ts":"2026-01-01T00:00:00.000Z","kind":');
+    broker.check({ kind: "fs", op: "read", target: "/tmp/two" });
+
+    const rawLines = readFileSync(auditFilePath, "utf8").trim().split("\n");
+    expect(rawLines).toHaveLength(3);
+    expect(rawLines[1]).toBe('{"ts":"2026-01-01T00:00:00.000Z","kind":');
+    const last = JSON.parse(rawLines[2]) as AuditedDecision;
+    expect(last.target).toBe("/tmp/two");
   });
 
   it("recentDecisions(n) returns last n entries", () => {

--- a/packages/agent/src/services/capability-broker.ts
+++ b/packages/agent/src/services/capability-broker.ts
@@ -23,11 +23,12 @@
  * record. The file is truncated at broker boot if it exceeds 50MB.
  */
 
-import { appendFileSync, mkdirSync, statSync, truncateSync } from "node:fs";
+import { mkdirSync, statSync, truncateSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { logger } from "@elizaos/core";
 import {
+  appendJsonlRecord,
   type DistributionProfile,
   type RuntimeExecutionMode,
   resolveDistributionProfile,
@@ -461,7 +462,9 @@ export class CapabilityBroker {
       this.recent.splice(0, this.recent.length - RECENT_DECISION_BUFFER);
     }
     try {
-      appendFileSync(this.auditFilePath, `${JSON.stringify(record)}\n`, "utf8");
+      // Isolates a line torn by an interrupted earlier append so this decision
+      // stays readable on its own line of the audit trail.
+      appendJsonlRecord(this.auditFilePath, record);
     } catch (err) {
       // The audit boundary is the only place we tolerate a catch — but we
       // surface the failure structurally rather than swallowing it. A broken

--- a/packages/app-core/src/services/account-pool-consumer-metering.torn-append.test.ts
+++ b/packages/app-core/src/services/account-pool-consumer-metering.torn-append.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pins that the consumer usage log writer isolates a crash-torn line: the
+ * record written after an interrupted append lands on its own line and stays
+ * parseable. The reader's tolerance of the torn line itself is a separate
+ * contract (#30530); this file asserts on the bytes the writer produces. Real
+ * temp state directory, no transport.
+ */
+import {
+  appendFileSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetAccountPoolConsumerMeteringForTests,
+  createAccountPoolConsumerKey,
+  recordAccountPoolConsumerUsage,
+} from "./account-pool-consumer-metering.js";
+
+let stateDir: string;
+let prevStateDir: string | undefined;
+let prevBrokerSecret: string | undefined;
+
+beforeEach(() => {
+  prevStateDir = process.env.ELIZA_STATE_DIR;
+  prevBrokerSecret = process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+  stateDir = mkdtempSync(path.join(tmpdir(), "consumer-metering-torn-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET =
+    "admin-broker-secret-admin-broker-secret";
+  __resetAccountPoolConsumerMeteringForTests();
+});
+
+afterEach(() => {
+  __resetAccountPoolConsumerMeteringForTests();
+  if (prevStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+  else process.env.ELIZA_STATE_DIR = prevStateDir;
+  if (prevBrokerSecret === undefined)
+    delete process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET;
+  else process.env.ELIZA_ACCOUNT_POOL_BROKER_SECRET = prevBrokerSecret;
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+async function seedRecord(consumerId: string, tokens: number): Promise<void> {
+  await recordAccountPoolConsumerUsage({
+    ts: 1_800_000_000_000,
+    consumerId,
+    consumerLabel: "torn-append",
+    model: "claude-test",
+    streaming: false,
+    status: 200,
+    latencyMs: 5,
+    usage: {
+      input_tokens: tokens,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+  });
+}
+
+describe("consumer usage log after a crash-torn line", () => {
+  it("writes the next record on its own line, intact", async () => {
+    const created = createAccountPoolConsumerKey({ label: "torn" });
+    if (!created) throw new Error("failed to create key");
+    await seedRecord(created.consumer.id, 10);
+
+    // An append interrupted before its trailing newline. The bytes stay in
+    // place; the next append must not land on the same line.
+    const dir = path.join(stateDir, "account-pool", "consumer-usage");
+    const files = readdirSync(dir);
+    expect(files).toHaveLength(1);
+    const file = path.join(dir, files[0]);
+    const torn = `{"consumerId":"${created.consumer.id}","ts":1`;
+    appendFileSync(file, torn);
+
+    await seedRecord(created.consumer.id, 7);
+
+    const lines = readFileSync(file, "utf8").split("\n");
+    expect(lines).toHaveLength(4);
+    expect(lines[1]).toBe(torn);
+    const intact = JSON.parse(lines[2]) as { totalTokens: number };
+    expect(intact.totalTokens).toBe(7);
+    expect(JSON.parse(lines[0])).toMatchObject({ totalTokens: 10 });
+  });
+});

--- a/packages/app-core/src/services/account-pool-consumer-metering.ts
+++ b/packages/app-core/src/services/account-pool-consumer-metering.ts
@@ -8,7 +8,6 @@
  */
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import {
-  appendFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -21,6 +20,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "@elizaos/core";
+import { appendJsonlRecord } from "@elizaos/shared";
 
 const STORE_DIR = "account-pool";
 const KEY_FILE = "consumer-keys.json";
@@ -835,10 +835,9 @@ export async function recordAccountPoolConsumerUsage(
       // record plus small aggregate files. The async queue and cross-process lock
       // serialize this low-volume local broker path and prevent ledger races.
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-      appendFileSync(file, `${JSON.stringify(record)}\n`, {
-        flag: "a",
-        mode: 0o600,
-      });
+      // Isolates a line torn by an interrupted earlier append; otherwise this
+      // record would land on that line and the admission reader would lose it.
+      appendJsonlRecord(file, record, { mode: 0o600 });
 
       const totals = readTotalsFile();
       const day = dayStamp(record.ts);

--- a/packages/app-core/src/services/account-usage.test.ts
+++ b/packages/app-core/src/services/account-usage.test.ts
@@ -660,6 +660,26 @@ describe("local JSONL usage counters", () => {
     expect(readTodayCounters("anthropic", "acct-1").tokens).toBe(5);
   });
 
+  it("counts the record written after a crash-torn line", () => {
+    recordCall("anthropic", "acct-1", { ok: true, tokens: 10 });
+    const dir = path.join(stateDir, "usage", "anthropic", "acct-1");
+    const [file] = readdirSync(dir);
+    // An append interrupted before its trailing newline. A plain append would
+    // put the next record on this same line and the reader would skip both.
+    appendFileSync(path.join(dir, file), '{"ts":1,"tokens":');
+
+    recordCall("anthropic", "acct-1", { ok: true, tokens: 7 });
+
+    const lines = readFileSync(path.join(dir, file), "utf-8").split("\n");
+    expect(lines).toHaveLength(4);
+    expect(lines[1]).toBe('{"ts":1,"tokens":');
+    expect(readTodayCounters("anthropic", "acct-1")).toEqual({
+      calls: 2,
+      tokens: 17,
+      errors: 0,
+    });
+  });
+
   it("creates the day directory on demand and writes a real file", () => {
     expect(existsSync(path.join(stateDir, "usage"))).toBe(false);
     recordCall("anthropic", "acct-1", { ok: true });

--- a/packages/app-core/src/services/account-usage.ts
+++ b/packages/app-core/src/services/account-usage.ts
@@ -10,13 +10,14 @@
  *
  * The probes throw on HTTP error so the caller can decide whether to mark
  * the account as `rate-limited` / `needs-reauth` / `invalid`. The counters
- * are best-effort and synchronous — at our scale appendFileSync is fine.
+ * are best-effort and synchronous — at our scale a synchronous append is fine.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fetchCodexUsage } from "@elizaos/auth/codex-usage";
 import { ElizaError, resolveStateDir } from "@elizaos/core";
+import { appendJsonlRecord } from "@elizaos/shared";
 import type { LinkedAccountUsage } from "@elizaos/shared/contracts/service-routing";
 
 /**
@@ -348,10 +349,9 @@ export function recordCall(
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  appendFileSync(file, `${JSON.stringify(line)}\n`, {
-    flag: "a",
-    mode: 0o600,
-  });
+  // Isolates a line torn by an interrupted earlier append; otherwise this
+  // record would land on that line and readTodayCounters would drop both.
+  appendJsonlRecord(file, line, { mode: 0o600 });
 }
 
 export interface DailyCounters {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -321,6 +321,7 @@ export * from "./utils/errors.js";
 export * from "./utils/exec-safety.js";
 export * from "./utils/format.js";
 export * from "./utils/host-capabilities.js";
+export * from "./utils/jsonl-append.js";
 export * from "./utils/labels.js";
 export * from "./utils/log-prefix.js";
 export * from "./utils/name-tokens.js";

--- a/packages/shared/src/utils/jsonl-append.test.ts
+++ b/packages/shared/src/utils/jsonl-append.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Exercises appendJsonlRecord against real temporary files: a torn tail is
+ * isolated on its own line, a new or empty file gets no leading blank line,
+ * and an ordinary append is byte-identical to the plain form.
+ */
+
+import {
+  appendFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendJsonlRecord } from "./jsonl-append";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "jsonl-append-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function lines(file: string): string[] {
+  return readFileSync(file, "utf8").split("\n");
+}
+
+describe("appendJsonlRecord", () => {
+  it("creates the file and writes exactly one line", () => {
+    const file = path.join(dir, "new.jsonl");
+    appendJsonlRecord(file, { n: 1 }, { mode: 0o600 });
+    expect(readFileSync(file, "utf8")).toBe('{"n":1}\n');
+    if (process.platform !== "win32") {
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("appends to a well-formed file byte for byte like a plain append", () => {
+    const file = path.join(dir, "plain.jsonl");
+    writeFileSync(file, '{"n":1}\n');
+    appendJsonlRecord(file, { n: 2 });
+    expect(readFileSync(file, "utf8")).toBe('{"n":1}\n{"n":2}\n');
+  });
+
+  it("does not add a blank line to an empty file", () => {
+    const file = path.join(dir, "empty.jsonl");
+    writeFileSync(file, "");
+    appendJsonlRecord(file, { n: 1 });
+    expect(readFileSync(file, "utf8")).toBe('{"n":1}\n');
+  });
+
+  it("isolates a crash-torn tail so the next record is intact", () => {
+    const file = path.join(dir, "torn.jsonl");
+    writeFileSync(file, '{"n":1}\n');
+    // An append interrupted before its trailing newline.
+    appendFileSync(file, '{"n":2,"tokens":');
+    appendJsonlRecord(file, { n: 3 });
+    expect(lines(file)).toEqual(['{"n":1}', '{"n":2,"tokens":', '{"n":3}', ""]);
+    expect(JSON.parse(lines(file)[2])).toEqual({ n: 3 });
+  });
+
+  it("recovers a complete record that only lost its newline", () => {
+    const file = path.join(dir, "no-newline.jsonl");
+    writeFileSync(file, '{"n":1}');
+    appendJsonlRecord(file, { n: 2 });
+    expect(
+      lines(file)
+        .slice(0, 2)
+        .map((line) => JSON.parse(line)),
+    ).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+});

--- a/packages/shared/src/utils/jsonl-append.ts
+++ b/packages/shared/src/utils/jsonl-append.ts
@@ -1,0 +1,69 @@
+/**
+ * Appends one record to an append-only JSONL file without letting a torn
+ * predecessor swallow it. Writers such as the usage counters, the consumer
+ * metering log, and the capability audit log append `JSON.stringify(record)`
+ * plus a newline, and their readers split on newlines and skip lines that do
+ * not parse. A crash, signal, or full disk between a record and its newline
+ * leaves a torn final line with no newline, and a plain append would then
+ * land the next record on that same line, so the reader would discard the
+ * intact record together with the torn bytes. This helper writes a newline
+ * first whenever the file does not already end with one, so torn bytes stay
+ * on their own line and every record written afterwards is readable.
+ *
+ * The tail check and the append are two operations, so concurrent writers to
+ * one file still need their own serialization; the callers here are either
+ * single-process or lock-serialized.
+ */
+
+import {
+  appendFileSync,
+  closeSync,
+  fstatSync,
+  openSync,
+  readSync,
+} from "node:fs";
+
+export interface AppendJsonlRecordOptions {
+  /** File mode applied when the append creates the file. */
+  readonly mode?: number;
+}
+
+/**
+ * Append `record` as one JSON line, isolating any torn line the file already
+ * ends with. Creates the file when it does not exist.
+ */
+export function appendJsonlRecord(
+  file: string,
+  record: unknown,
+  options: AppendJsonlRecordOptions = {},
+): void {
+  const line = `${JSON.stringify(record)}\n`;
+  const payload = fileEndsWithNewline(file) ? line : `\n${line}`;
+  appendFileSync(file, payload, {
+    encoding: "utf8",
+    flag: "a",
+    ...(options.mode === undefined ? {} : { mode: options.mode }),
+  });
+}
+
+/** True for a missing or empty file, or one whose last byte is `\n`. */
+function fileEndsWithNewline(file: string): boolean {
+  let fd: number;
+  try {
+    fd = openSync(file, "r");
+  } catch (error) {
+    // error-policy:J3 a missing file has no torn tail; every other open
+    // failure is reported by the append that follows.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+  try {
+    const size = fstatSync(fd).size;
+    if (size === 0) return true;
+    const last = Buffer.alloc(1);
+    readSync(fd, last, 0, 1, size - 1);
+    return last[0] === 0x0a;
+  } finally {
+    closeSync(fd);
+  }
+}


### PR DESCRIPTION
# Relates to

Closes #30878

Complements #30530, which makes the consumer metering reader stop throwing on a torn line; this PR keeps the record written after such a line from being lost, for that log and two others. The two PRs touch different hunks of `account-pool-consumer-metering.ts` (writer here, reader there) and this one adds its metering test in a separate file, so they do not conflict.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. On a well-formed file the helper's output is byte-identical to the plain append it replaces (pinned by test), file modes are unchanged, and the only new behavior is one leading newline when the file's last byte is not a newline. The tail check and the append are two operations, so the helper does not add cross-process serialization; the three callers are single-process or already lock-serialized, and the helper's header says so. One new export on the `@elizaos/shared` root barrel, which already carries Node-only helpers such as `eliza-root`.

# Background

## What does this PR do?

Three append-only JSONL writers (`recordCall` in account-usage, `recordAccountPoolConsumerUsage` in consumer metering, the capability-broker audit log) append `JSON.stringify(record)` plus a newline, and their readers split on newlines and skip lines that fail to parse. An append interrupted before its newline leaves a torn final line, and the next successful append landed on that same line, so the reader discarded the intact record together with the torn bytes. Reproduced on `develop` through the real account-usage module: two records written, the counters report one (transcript under Domain artifacts).

`appendJsonlRecord` in `@elizaos/shared` writes a newline first whenever the file does not already end with one, then appends the record. The three writers use it. A torn line now stays on its own line, every later record is readable, and a complete record that only lost its newline becomes readable too.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/shared/src/utils/jsonl-append.ts` and its test, then the three call sites and the regression added beside each: `account-usage.test.ts` (counters count the record after a torn line), `account-pool-consumer-metering.torn-append.test.ts` (the record lands on its own line), `capability-broker.test.ts` (the decision after a torn audit line parses).

## Detailed testing steps

Automated tests. The red run under Domain artifacts shows the three consumer regressions failing against the develop writers.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:38ce978465b3ed0e4e3cb988b8adb12b4d48f273 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - file-system append helper; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - file-system append helper; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: tests, typecheck, and Biome across the three packages on this exact head, pasted below.

  <details>
  <summary>vitest, typecheck, and Biome transcript on this head</summary>

  ```
# Backend logs for the #30878 fix (head 38ce978465b3ed0e4e3cb988b8adb12b4d48f273, rebased on origin/develop 867f0909eab)
# 2026-09-07T06:12:27Z
$ (packages/shared) npx vitest run src/utils/jsonl-append.test.ts --reporter=verbose
 ✓ src/utils/jsonl-append.test.ts > appendJsonlRecord > creates the file and writes exactly one line 3ms
 ✓ src/utils/jsonl-append.test.ts > appendJsonlRecord > appends to a well-formed file byte for byte like a plain append 1ms
 ✓ src/utils/jsonl-append.test.ts > appendJsonlRecord > does not add a blank line to an empty file 1ms
 ✓ src/utils/jsonl-append.test.ts > appendJsonlRecord > isolates a crash-torn tail so the next record is intact 1ms
 ✓ src/utils/jsonl-append.test.ts > appendJsonlRecord > recovers a complete record that only lost its newline 1ms
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ (packages/app-core) npx vitest run src/services/account-usage.test.ts src/services/account-pool-consumer-metering.torn-append.test.ts src/services/account-pool-consumer-metering.test.ts --reporter=verbose
 ✓ src/services/account-usage.test.ts > local JSONL usage counters > counts the record written after a crash-torn line 2ms
 ✓ src/services/account-pool-consumer-metering.torn-append.test.ts > consumer usage log after a crash-torn line > writes the next record on its own line, intact 8ms
 Test Files  3 passed (3)
      Tests  52 passed (52)

$ (packages/agent) npx vitest run src/services/capability-broker.test.ts --reporter=verbose
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > keeps a decision readable after a crash-torn audit line 1ms
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ bun run --cwd packages/shared typecheck; bun run --cwd packages/app-core typecheck; bun run --cwd packages/agent typecheck   (run via bun run verify on this head: 372/373 tasks, see Known gaps)

$ npx biome check <the nine changed files>
Checked 9 files in 43ms. No fixes applied.
exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the develop reproduction through the real module, and the red run of the new tests against the develop writers, pasted below.

  <details>
  <summary>Reproduction on origin/develop through account-usage.ts</summary>

  ```
# Reproduction on origin/develop 316a47d2895 through packages/app-core/src/services/account-usage.ts (writers at develop state)
# 2026-09-07T05:48:14Z ELIZA_STATE_DIR=<temp>
import { appendFileSync, mkdirSync, readFileSync, readdirSync } from "node:fs";
import path from "node:path";
import { recordCall, readTodayCounters } from "packages/app-core/src/services/account-usage.ts";
const provider = "probe-provider", account = "probe-account";
// 1) one real record
recordCall(provider, account, { tokens: 10, ok: true } as never);
// 2) simulate a crash mid-append: partial line, no trailing newline
const dir = path.join(process.env.ELIZA_STATE_DIR!, "usage", provider, account);
const file = path.join(dir, readdirSync(dir)[0]);
appendFileSync(file, '{"ts":1,"tokens":');
// 3) the next real record
recordCall(provider, account, { tokens: 7, ok: true } as never);
console.log("file lines:", JSON.stringify(readFileSync(file, "utf8").split("\n")));
console.log("readTodayCounters:", JSON.stringify(readTodayCounters(provider, account)));
console.log("expected calls=2 tokens=17 (two intact records) if the torn line were isolated");
--- output
file lines: ["{\"ts\":1788760094673,\"tokens\":10,\"ok\":true}","{\"ts\":1,\"tokens\":{\"ts\":1788760094674,\"tokens\":7,\"ok\":true}",""]
readTodayCounters: {"calls":1,"tokens":10,"errors":0}
expected calls=2 tokens=17 (two intact records) if the torn line were isolated
  ```

  </details>

  <details>
  <summary>Red run: new tests against the develop writers</summary>

  ```
# Red run: new tests against the develop writers (helper and tests from this branch, writers reverted)
$ (packages/app-core) npx vitest run src/services/account-usage.test.ts src/services/account-pool-consumer-metering.torn-append.test.ts
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > parses the legacy FLAT response shape (utilization is 0..1, multiplied to percent) 3ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > treats nested 1.0 utilization as 1% and uses the weekly reset 1ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > parses the current weekly_scoped limits shape into per-model buckets 1ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > parses the live 2026-07 payload: percentage-point units, weekly reset, fable bucket 1ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > prefers the limits[].percent source over nested windows when both exist 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > null weekly_scoped resets_at (fresh window) omits the bucket reset 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > prefers the nested utilization over the flat field when both are present 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > preserves utilization already expressed as a 0..100 percentage 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > clamps percentage utilization above 100 1ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > maps 0 utilization to 0 percent (not dropped) 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > omits pct fields when utilization is missing / non-numeric / NaN 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage null root 1ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage array root 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage numeric five_hour window 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage array seven_day window 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage object limits collection 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage non-object limits entry 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage non-object limit scope 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects a malformed Anthropic usage non-object scoped model 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > retains available usage when the 'session window' is null 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > retains available usage when the 'weekly window' is null 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > retains available usage when the 'limits collection' is null 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > keeps aggregate and named model usage when another model scope is null 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > rejects malformed Anthropic usage JSON with a typed decoding error 3ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > passes through an epoch-MILLISECONDS reset timestamp unchanged 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > returns undefined resetsAt for an unparseable reset string 0ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > stamps refreshedAt from the system clock 2ms
 ✓ src/services/account-usage.test.ts > pollAnthropicUsage > throws with the HTTP status when the response is not ok 1ms
 ✓ src/services/account-usage.test.ts > pollCodexUsage > parses the rate_limit.primary_window shape (used_percent already 0..100) 1ms
 ✓ src/services/account-usage.test.ts > pollCodexUsage > maps the secondary (7-day) window to weeklyPct 0ms
 ✓ src/services/account-usage.test.ts > pollCodexUsage > clamps used_percent above 100 down to 100 and 0 stays 0 0ms
 ✓ src/services/account-usage.test.ts > pollCodexUsage > omits sessionPct/resetsAt when the primary_window is absent 0ms
 ✓ src/services/account-usage.test.ts > pollCodexUsage > propagates malformed Codex usage as a failed refresh 0ms
 ✓ src/services/account-usage.test.ts > pollCodexUsage > throws with the HTTP status when the response is not ok 0ms
 ✓ src/services/account-usage.test.ts > local JSONL usage counters > returns zeroed counters when no file has been written yet 1ms
 ✓ src/services/account-usage.test.ts > local JSONL usage counters > appends one JSONL line per call and aggregates calls/tokens/errors 2ms
 ✓ src/services/account-usage.test.ts > local JSONL usage counters > keeps counters isolated per (provider, account) pair 2ms
 ✓ src/services/account-usage.test.ts > local JSONL usage counters > skips unparseable JSONL lines instead of throwing 1ms
 ✓ src/services/account-usage.test.ts > local JSONL usage counters > ignores non-finite token values when aggregating 1ms
 × src/services/account-usage.test.ts > local JSONL usage counters > counts the record written after a crash-torn line 8ms
 ✓ src/services/account-usage.test.ts > local JSONL usage counters > creates the day directory on demand and writes a real file 1ms
 × src/services/account-pool-consumer-metering.torn-append.test.ts > consumer usage log after a crash-torn line > writes the next record on its own line, intact 14ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
- Expected
+ Received
- Expected
+ Received
 Test Files  2 failed (2)
      Tests  2 failed | 40 passed (42)

$ (packages/agent) npx vitest run src/services/capability-broker.test.ts
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > denies fs.write on host paths in cloud mode and allows allowlisted net.connect 5ms
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > local-yolo + unrestricted allows shell.exec without a sandbox prefix 1ms
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > local-safe denies shell.exec at host but allows it through sandbox.* tools 1ms
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > store profile + local-yolo still denies fs.write outside VFS 1ms
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > audit log has one JSONL line per check and parses cleanly 2ms
 × src/services/capability-broker.test.ts > CapabilityBroker > keeps a decision readable after a crash-torn audit line 7ms
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > recentDecisions(n) returns last n entries 1ms
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > truncates the audit log when it exceeds 50 MB at boot 107ms
 ✓ src/services/capability-broker.test.ts > CapabilityBroker > getCapabilityBroker returns a cached singleton 5ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
- Expected
+ Received
 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, after one record, a torn append, and a second record, the usage file holds two lines and the counters report one call (reproduction above).

### After

The file holds three lines, the torn bytes alone on the second, and the counters report two calls (tests above).

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` on this head (rebased onto `origin/develop` `867f0909eab`, `bun install --frozen-lockfile` reporting no changes): Turbo 372 successful, 373 total. The one failure is `@elizaos/ui#lint:check`, which stops in `find-duplicate-molecular-components.mjs --check` with `Molecular inventory artifacts are stale: json, markdown` (scanned files 907 in the committed report vs 908 on disk). That is a property of the develop tip, not of this change: the same check fails identically on a pristine checkout of `origin/develop` `867f0909eab` with no commits from this branch, and this branch touches no file under `packages/ui`. A regeneration of the two report files is proposed separately as a chore PR. An earlier `bun run verify` on the pre-rebase head of this same change (base `316a47d2895`) passed 373/373. Package tests, typecheck, and Biome pass on this head (transcript above).

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
