### PR TITLE
fix(cloud): preserve safe revocation failure diagnostics

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
@@ -7,6 +7,7 @@ import {
   InferenceCredentialRevocationUnavailableError,
   InferenceCredentialRevokedError,
   revokeInferenceApiKey,
+  setInferenceSessionBindingActive,
 } from "./inference-credential-revocation";
 
 const ENABLED = { INFERENCE_STRONG_REVOCATION_ENABLED: "true" };
@@ -79,5 +80,107 @@ describe("inference credential revocation client", () => {
         revokeInferenceApiKey("org-1", "key-1"),
       ),
     ).rejects.toBeInstanceOf(InferenceCredentialRevocationUnavailableError);
+  });
+
+  test("login activation preserves the missing-binding diagnosis", async () => {
+    await expect(
+      runWithCloudBindingsAsync(ENABLED, () =>
+        setInferenceSessionBindingActive("org-private", "user-private", "steward-private", true),
+      ),
+    ).rejects.toThrow("Inference revocation Durable Object binding is missing");
+  });
+
+  test("login activation identifies lookup failures without exposing the cause message", async () => {
+    const cause = new TypeError("private lookup metadata user-private");
+    const namespace = {
+      getByName: () => {
+        throw cause;
+      },
+    };
+    const activation = runWithCloudBindingsAsync(
+      { ...ENABLED, INFERENCE_ADMISSION_GATES: namespace },
+      () =>
+        setInferenceSessionBindingActive("org-private", "user-private", "steward-private", true),
+    );
+    await expect(activation).rejects.toMatchObject({
+      code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+      cause,
+      message: "Inference revocation Durable Object lookup failed causeType=TypeError",
+    });
+  });
+
+  test("login activation retains safe downstream failure flags and the original cause", async () => {
+    const cause = Object.assign(new Error("private downstream metadata"), {
+      retryable: true,
+      overloaded: true,
+      remote: true,
+    });
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => {
+          throw cause;
+        },
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        setInferenceSessionBindingActive("org-private", "user-private", "steward-private", true),
+      ),
+    ).rejects.toMatchObject({
+      code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+      cause,
+      message:
+        "Inference revocation boundary is unavailable deadlineExceeded=false causeType=Error retryable=true overloaded=true remote=true",
+    });
+  });
+
+  test("login activation distinguishes its own deadline from an immediate transport error", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: (request: Request) =>
+          new Promise<Response>((_resolve, reject) => {
+            request.signal.addEventListener("abort", () => reject(request.signal.reason), {
+              once: true,
+            });
+          }),
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        setInferenceSessionBindingActive("org-private", "user-private", "steward-private", true),
+      ),
+    ).rejects.toMatchObject({
+      code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+      message:
+        "Inference revocation boundary is unavailable deadlineExceeded=true causeType=AbortError",
+    });
+  });
+
+  test("failure diagnostics reject arbitrary labels and do not invoke custom flag getters", async () => {
+    const cause = new Error("private cause message");
+    cause.name = "private error name";
+    Object.defineProperty(cause, "retryable", {
+      get() {
+        throw new Error("diagnostics must not invoke this getter");
+      },
+    });
+    Object.defineProperty(cause, "overloaded", { value: "private flag value" });
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => {
+          throw cause;
+        },
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        setInferenceSessionBindingActive("org-private", "user-private", "steward-private", true),
+      ),
+    ).rejects.toMatchObject({
+      code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+      cause,
+      message:
+        "Inference revocation boundary is unavailable deadlineExceeded=false causeType=Error",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
@@ -82,6 +82,31 @@ export function isInferenceStrongRevocationEnabled(
   return env.INFERENCE_STRONG_REVOCATION_ENABLED === "true";
 }
 
+/** Only fixed type labels and native boolean flags may enter the indexed log message. */
+function describeBoundaryCause(error: unknown): string {
+  const causeType =
+    error instanceof TypeError
+      ? "TypeError"
+      : error instanceof DOMException && error.name === "AbortError"
+        ? "AbortError"
+        : error instanceof DOMException && error.name === "TimeoutError"
+          ? "TimeoutError"
+          : error instanceof Error
+            ? "Error"
+            : "unclassified";
+  const parts = [`causeType=${causeType}`];
+  if (error instanceof Error) {
+    for (const flag of ["retryable", "overloaded", "remote"]) {
+      // Inspect data properties so an exception's custom getters cannot break diagnostics.
+      const descriptor = Object.getOwnPropertyDescriptor(error, flag);
+      if (descriptor && typeof descriptor.value === "boolean") {
+        parts.push(`${flag}=${descriptor.value}`);
+      }
+    }
+  }
+  return parts.join(" ");
+}
+
 function gateStub(organizationId: string): RuntimeDurableObjectStub {
   const namespace = getCloudBinding<RuntimeDurableObjectNamespace>(GATE_BINDING);
   if (!namespace) {
@@ -89,7 +114,15 @@ function gateStub(organizationId: string): RuntimeDurableObjectStub {
       "Inference revocation Durable Object binding is missing",
     );
   }
-  return namespace.getByName(organizationId);
+  try {
+    return namespace.getByName(organizationId);
+  } catch (error) {
+    // error-policy:J2 preserve lookup failures separately from requests to the object.
+    throw new InferenceCredentialRevocationUnavailableError(
+      `Inference revocation Durable Object lookup failed ${describeBoundaryCause(error)}`,
+      { cause: error },
+    );
+  }
 }
 
 async function gateRequest(
@@ -98,11 +131,12 @@ async function gateRequest(
   body: Record<string, unknown>,
   allowExplicitDenial = false,
 ): Promise<RevocationResponse> {
+  const stub = gateStub(organizationId);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OPERATION_TIMEOUT_MS);
   let response: Response;
   try {
-    response = await gateStub(organizationId).fetch(
+    response = await stub.fetch(
       new Request(`${GATE_ORIGIN}${path}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -113,7 +147,7 @@ async function gateRequest(
   } catch (error) {
     // error-policy:J2 transport failure must stay fail-closed with its cause.
     throw new InferenceCredentialRevocationUnavailableError(
-      "Inference revocation boundary is unavailable",
+      `Inference revocation boundary is unavailable deadlineExceeded=${controller.signal.aborted} ${describeBoundaryCause(error)}`,
       { cause: error },
     );
   } finally {


### PR DESCRIPTION
Staging login failures currently hide whether the revocation boundary failed during binding lookup, timed out, or threw downstream. This PR preserves safe diagnostic information so #18627 can be repaired from an observed cause.

# Relates to

#18627, coordinated within #29918. Diagnostic prerequisite only; this does not close the recurrence or #25025 fixture acceptance.

- [x] Targets `develop`, rebased without conflicts.
- [x] `bun install` and `bun run verify` run after sync; results below.
- [x] Local real-Workers evidence is attached below.

# Sync with develop

- [x] Rebased onto `877ec0a177` without conflicts.
- [x] Post-sync `bun run verify` passes: 373/373 Turbo tasks plus repository audit gates.

# Risks

Low behavioral risk, but this is on the auth path. The typed 503, denial checks, acknowledgement requirement, retry policy, and security gate remain unchanged. New message fields contain only fixed labels and boolean flags; the original exception remains internal. Two independent reviews found no introduced correctness, privacy, or downstream compatibility issue.

# Background

## What does this PR do?

Preserves the missing-binding diagnosis, distinguishes lookup failures from fetch failures, and reports local deadline state plus Cloudflare's `retryable`, `overloaded`, and `remote` boolean flags. Arbitrary exception names/messages and identity/request values are not interpolated.

For fresh signup, read the preceding `StewardSync` activation warning. The later contextual wrapper retains its own generic message. The broader existing formatter is not a general sanitization boundary.

## What kind of change is this?

Non-breaking diagnostic bug fix. It enables the next staging investigation; it does not establish the current outage's cause.

# Documentation changes needed?

No product documentation changes. Operator interpretation and limitations are recorded here.

# Testing

## Where should a reviewer start?

The client regression suite exercises real activation calls with injected boundary failures. Four cases fail before this change and pass afterward; privacy coverage also rejects arbitrary labels and avoids custom flag getters.

## Detailed testing steps

```sh
bun --config=/dev/null test packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
bun --config=/dev/null test packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
bun --config=/dev/null test packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/cloud/shared lint:check
bun run verify
```

Focused results: 10 client, 27 lifecycle, and 8 provisioning tests pass. Package typecheck and lint pass. Bun 1.3.14 and Node 24.15.0 were used for final checks.

# Evidence Gate

<!-- evidence-head:b68ac50d3e4c1b0f826998ad80f7ce876436f674 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - server diagnostic text only; real login acceptance remains pending.
<!-- evidence-row:backend-logs -->
- [x] Real local workerd client-to-Durable-Object responses; not live staging recovery.

```text
normal 200 {"ok":true}
missing 503 {"ok":false,"code":"INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE","message":"Inference revocation Durable Object binding is missing"}
throw 503 {"ok":false,"code":"INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE","message":"Inference revocation boundary is unavailable deadlineExceeded=false causeType=Error remote=true"}
deadline 503 {"ok":false,"code":"INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE","message":"Inference revocation boundary is unavailable deadlineExceeded=true causeType=AbortError retryable=true"}
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change; no new authenticated browser attempt performed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - diagnostic-only change, no schema or persisted business-state change; local response evidence is attached in the backend row.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no inference behavior change.

## Backend + frontend logs

The real revocation client, real async binding context, and production admission class ran in local workerd/Miniflare with the deployed compatibility date. Test-only cases removed the binding, threw from a Durable Object subclass, or delayed it past the existing deadline. DB/recovery paths were not exercised. Assertions checked statuses, typed failure, runtime flags, and absence of synthetic private cause text in the indexed message.

```text
normal   200 ok=true
missing  503 INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE
  Inference revocation Durable Object binding is missing
throw    503 INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE
  Inference revocation boundary is unavailable deadlineExceeded=false causeType=Error remote=true
deadline 503 INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE
  Inference revocation boundary is unavailable deadlineExceeded=true causeType=AbortError retryable=true
```

Frontend: N/A - diagnostic change only.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio change.

## Known gaps / failures

- Staging cause and repair remain unconfirmed. Historical Observability retrieval returned 403 with available CLI credentials. No deployment is included. A coordinated Google login and same-account return are still required after the repair.
- Full cloud-shared tests stop in ordinary batch 45 at two shared-agent runtime tests: trusted system lifecycle action filtering and streamed TODO grounding. Both reproduce on clean `develop` at `877ec0a177` and on this candidate, with the same 27 pass / 2 fail result from `shared-eliza-runtime.test.ts`. Later package batches were not run. These failures are outside this two-file revocation change.
- Initial repository verification failed on stale UI molecular inventory at `99004839d7`; reproduced on a clean checkout. Upstream #30882 repaired those artifacts and this candidate was rebased onto it. Post-sync verification now passes, 373/373 tasks plus repository audits.
- Package lint reports existing oversized migration-snapshot warnings.

## Maintainer CI exception record

N/A - no exception requested. No merge or deployment authorization is implied.
