### PR TITLE
fix(cloud): tolerate delivery latency in auth revocation writes

### DIFF
--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
@@ -7,12 +7,47 @@ import {
   InferenceCredentialRevocationUnavailableError,
   InferenceCredentialRevokedError,
   revokeInferenceApiKey,
+  revokeInferenceSessionsThrough,
   setInferenceSessionBindingActive,
 } from "./inference-credential-revocation";
 
 const ENABLED = { INFERENCE_STRONG_REVOCATION_ENABLED: "true" };
 
 describe("inference credential revocation client", () => {
+  test("login and logout wait for a delayed durable acknowledgement", async () => {
+    const committedPaths = new Set<string>();
+    const namespace = {
+      getByName: () => ({
+        fetch: (request: Request) =>
+          new Promise<Response>((resolve, reject) => {
+            const timer = setTimeout(() => {
+              committedPaths.add(new URL(request.url).pathname);
+              resolve(Response.json({ committed: true }));
+            }, 2_000);
+            request.signal.addEventListener(
+              "abort",
+              () => {
+                clearTimeout(timer);
+                reject(request.signal.reason);
+              },
+              { once: true },
+            );
+          }),
+      }),
+    };
+    await runWithCloudBindingsAsync(
+      { ...ENABLED, INFERENCE_ADMISSION_GATES: namespace },
+      async () => {
+        await Promise.all([
+          setInferenceSessionBindingActive("org-1", "user-1", "steward-1", true),
+          revokeInferenceSessionsThrough("org-1", "user-1", 100),
+        ]);
+      },
+    );
+    expect(committedPaths.has("/session/set-binding-active")).toBe(true);
+    expect(committedPaths.has("/session/revoke-through")).toBe(true);
+  });
+
   test("fails closed when the Durable Object binding is absent", async () => {
     await expect(
       runWithCloudBindingsAsync(ENABLED, () =>
@@ -154,7 +189,29 @@ describe("inference credential revocation client", () => {
       message:
         "Inference revocation boundary is unavailable deadlineExceeded=true causeType=AbortError",
     });
-  });
+  }, 15_000);
+
+  test("request-time checks keep a short failure deadline", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: (request: Request) =>
+          new Promise<Response>((_resolve, reject) => {
+            request.signal.addEventListener("abort", () => reject(request.signal.reason), {
+              once: true,
+            });
+          }),
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        assertInferenceCredentialActive("org-1", {
+          kind: "api_key",
+          credentialId: "key-1",
+          userId: "user-1",
+        }),
+      ),
+    ).rejects.toBeInstanceOf(InferenceCredentialRevocationUnavailableError);
+  }, 4_000);
 
   test("failure diagnostics reject arbitrary labels and do not invoke custom flag getters", async () => {
     const cause = new Error("private cause message");

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
@@ -17,7 +17,10 @@ import type { InferenceAuthRejectionReason } from "./inference-auth-cache";
 
 const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
-const OPERATION_TIMEOUT_MS = 1_500;
+const CREDENTIAL_CHECK_TIMEOUT_MS = 1_500;
+// Lifecycle writes need time to reach the object and confirm durable
+// state; request-time credential checks retain their shorter failure budget.
+const LIFECYCLE_MUTATION_TIMEOUT_MS = 10_000;
 
 export type InferenceCredentialCheck =
   | { kind: "api_key"; credentialId: string; userId: string }
@@ -129,11 +132,15 @@ async function gateRequest(
   organizationId: string,
   path: string,
   body: Record<string, unknown>,
-  allowExplicitDenial = false,
+  operation: "check" | "mutation",
 ): Promise<RevocationResponse> {
   const stub = gateStub(organizationId);
+  const allowExplicitDenial = operation === "check";
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), OPERATION_TIMEOUT_MS);
+  const timeout = setTimeout(
+    () => controller.abort(),
+    operation === "check" ? CREDENTIAL_CHECK_TIMEOUT_MS : LIFECYCLE_MUTATION_TIMEOUT_MS,
+  );
   let response: Response;
   try {
     response = await stub.fetch(
@@ -189,7 +196,7 @@ export async function assertInferenceCredentialActive(
   credential: InferenceCredentialCheck,
 ): Promise<void> {
   if (!isInferenceStrongRevocationEnabled()) return;
-  const result = await gateRequest(organizationId, "/credential/check", credential, true);
+  const result = await gateRequest(organizationId, "/credential/check", credential, "check");
   if (result.allowed !== true) {
     throw new InferenceCredentialRevokedError(result.reason ?? "revoked");
   }
@@ -201,7 +208,7 @@ async function commitMutation(
   body: Record<string, unknown>,
 ): Promise<void> {
   if (!isInferenceStrongRevocationEnabled()) return;
-  const result = await gateRequest(organizationId, path, body);
+  const result = await gateRequest(organizationId, path, body, "mutation");
   if (result.committed !== true) {
     throw new InferenceCredentialRevocationUnavailableError(
       "Inference revocation boundary did not confirm the mutation",


### PR DESCRIPTION
Merged and deployed to staging as `c039b4a455f769b53ee9fa1b793428ad6aaa7e79`. Two browser Google login/logout cycles passed, including same-agent return and logout after more than three idle minutes. [Release and browser evidence](https://github.com/elizaOS/eliza/pull/30884#issuecomment-5569632073).

Staging logout returned 503 because the revocation client aborted after 1.5 seconds, before the Durable Object handled the request. Give lifecycle writes 10 seconds to reach the object and receive acknowledgement. Request-time credential checks keep their 1.5-second deadline.

# Relates to

#18627, coordinated within #29918. Follow-up to #30883. Scoped staging auth acceptance passed; the parent issue remains open for any broader acceptance work.

- [x] Targets `develop`, rebased without conflicts onto `d27659348e7c0d751b258f3c45fc8271e96f9d28`.
- [x] `bun install` and `bun run verify` run after sync; results below.
- [x] Real local Workers evidence is attached below.

# Sync with develop

- [x] Rebased onto current `origin/develop` without conflicts.
- [x] Repository verification passes, 373 tasks plus audit gates.

# Risks

Medium: this changes waiting time on authentication lifecycle writes. A persistent outage can now take 10 seconds per mutation fetch to fail. Existing signup activation retries can total about 20 seconds; sequential bulk operations can accumulate waits and extend transaction occupancy. The timer covers fetch, not subsequent response-body parsing. No retries are added. Durable acknowledgement, credential denial, fail-closed errors, and logout credential preservation remain intact. Two independent adversarial reviews found no blocking issue.

# Background

## What does this PR do?

Separates the lifecycle mutation deadline from the request-time credential-check deadline in the shared revocation client.

Live staging traces showed three logout failures with `deadlineExceeded=true causeType=AbortError retryable=true`. The corresponding Durable Object invocations began after the callers had finished and were canceled almost immediately. A rapid retry succeeded with a 19 ms object invocation. These observations support delivery delay exceeding the client budget. They do not prove the platform's precise scheduling or wakeup cause.

## What kind of change is this?

Non-breaking bug fix. The 1.5-second shared deadline was introduced in `207770ab85dfa03ea684e4d97332413dde803b3a`, authored August 16, 2026. That date does not establish when staging latency began.

# Documentation changes needed?

No product documentation change. Operational limits and verification gaps are recorded here.

# Testing

## Where should a reviewer start?

The delayed-acknowledgement regression exercises activation and logout through the public revocation client. It fails on the previous deadline and passes with this change. Separate unresponsive-boundary cases verify that mutations still fail closed and credential checks retain the shorter deadline.

## Detailed testing steps

Focused checks passed: 12 revocation-client tests, 27 identity-lifecycle tests, 8 provisioning tests, and 13 logout-route tests. Package typecheck and lint pass. Repository `bun run verify` passes all 373 tasks and audit gates. Final checks use Bun 1.3.14 and Node 24.15.0.

```sh
bun --config=/dev/null test packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
bun --config=/dev/null test packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
bun --config=/dev/null test packages/cloud/shared/src/lib/steward-sync-default-provisioning.test.ts
bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/cloud/shared lint:check
bun run --cwd packages/cloud/shared test
bun run verify
```

# Evidence Gate

<!-- evidence-head:cfd56df39dab1613a773a63269ed82e320401744 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change. Baseline browser behavior is recorded in the linked issue; candidate browser acceptance remains pending.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change; no rendered UI code changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Missing - no MP4 walkthrough was captured. Live browser network and Worker evidence are attached in the linked release comment.
<!-- evidence-row:backend-logs -->
- [x] Real local workerd, production revocation client and admission Durable Object, with injected delay before delivery and SQLite-backed state:

```text
Previous deadline, 2.2-second injected delivery delay:
activate 503 INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE deadlineExceeded=true
revoke   503 INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE deadlineExceeded=true
Candidate, 2.2-second delay:
activate 200 {"ok":true,"denied":false}
revoke   200 {"ok":true,"denied":true}
Candidate, 6.4-second delay:
activate 200 {"ok":true,"denied":false}
revoke   200 {"ok":true,"denied":true}
```
<!-- evidence-row:frontend-logs -->
- [x] Browser network evidence: https://github.com/elizaOS/eliza/pull/30884#issuecomment-5569632073
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Local real SQLite Durable Object state was read after each acknowledged mutation. Activation allowed the credential; logout denied it, including after 6.4-second injected delivery delay. Exact outputs:

```text
2.2-second injected delivery delay
activate 200 {"ok":true,"denied":false}
revoke 200 {"ok":true,"denied":true}
6.4-second injected delivery delay
activate 200 {"ok":true,"denied":false}
revoke 200 {"ok":true,"denied":true}
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual change.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior change.

## Backend + frontend logs

The inline backend transcript above comes from real local workerd and the production Durable Object class. The namespace wrapper injects delivery latency and honors abort; unrelated database/recovery paths are not exercised. This proves the client budget and persisted revocation behavior under controlled delay, not Cloudflare staging recovery.

Baseline browser evidence: https://github.com/elizaOS/eliza/issues/18627#issuecomment-5568521438

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI change.

### After

N/A - no rendered UI change; no rendered UI code changed.

### Walkthrough video

Not captured. The release comment records the real browser flow, network responses, same-agent equality check, and correlated Worker acknowledgements.

## Audio / voice walkthrough

N/A - no audio change.

## Known gaps / failures

- Full cloud-shared tests stop at ordinary batch 45 of 388 with two failures in shared-runtime tests: trusted system lifecycle action filtering and streamed TODO owner scope. Both were reproduced on the earlier clean develop baseline and remain outside this two-file change. Later package batches were not run.
- Package lint reports pre-existing oversized migration-snapshot warnings.
- The walkthrough-video artifact remains missing. Browser network evidence is recorded in the release comment.
- Staging login, same-account return, and idle logout passed on the deployed merge. Fail-closed unavailable-boundary coverage is local; no artificial staging outage was introduced.
- Live traces establish the client deadline symptom, not the exact Cloudflare scheduling cause.

## Maintainer CI exception record

N/A - no exception requested. No merge or deployment bypass is requested.
