### PR TITLE
fix(ui): stop the molecular inventory check from failing on the scan count (#30885)

### DIFF
--- a/packages/ui/scripts/find-duplicate-molecular-components.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.mjs
@@ -820,16 +820,44 @@ export function serializeMolecularReport(report) {
   };
 }
 
+// The scan count is a statistic of the tree, not a disposition: it moves
+// whenever any PR adds or removes a React file, and comparing it made
+// `--check` fail for every such PR until someone regenerated the artifact,
+// which two people then raced to land. Regeneration still records the real
+// count; the check compares only the reviewable content around it.
+const SCAN_COUNT_SENTENCE = /^Scanned \d+ maintained React files\./m;
+
+function withoutScanCount(report) {
+  if (typeof report !== "object" || report === null) return report;
+  const { scannedFiles: _scannedFiles, ...content } = report;
+  return content;
+}
+
+function withoutMarkdownScanCount(markdown) {
+  return markdown.replace(
+    SCAN_COUNT_SENTENCE,
+    "Scanned N maintained React files.",
+  );
+}
+
 export function assertMolecularArtifactsCurrent(report, artifacts) {
   const stale = [];
   try {
-    if (!isDeepStrictEqual(JSON.parse(artifacts.json), report)) {
+    if (
+      !isDeepStrictEqual(
+        withoutScanCount(JSON.parse(artifacts.json)),
+        withoutScanCount(report),
+      )
+    ) {
       stale.push("json");
     }
   } catch {
     stale.push("json");
   }
-  if (artifacts.markdown !== renderMolecularMarkdown(report)) {
+  if (
+    withoutMarkdownScanCount(artifacts.markdown) !==
+    withoutMarkdownScanCount(renderMolecularMarkdown(report))
+  ) {
     stale.push("markdown");
   }
   if (stale.length > 0) {

--- a/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
+++ b/packages/ui/scripts/find-duplicate-molecular-components.test.mjs
@@ -380,9 +380,57 @@ test("molecular artifact checks compare formatted JSON by schema and data", () =
     () =>
       assertMolecularArtifactsCurrent(report, {
         ...artifacts,
-        json: JSON.stringify({ ...report, scannedFiles: 1 }, null, 4),
+        json: JSON.stringify({ ...report, eligibleComponents: 1 }, null, 4),
       }),
     /artifacts are stale: json/,
+  );
+});
+
+// The scan count is a statistic of the tree, not a disposition. Comparing it
+// made the check fail for every PR that added or removed a React file until
+// someone regenerated the artifact, and the regeneration was then raced
+// (#30885). Only the reviewable content decides staleness.
+test("molecular artifact checks tolerate a drifted scan count but not drifted content", () => {
+  const report = {
+    canonicalContracts: [],
+    clusters: [],
+    eligibleComponents: 0,
+    scannedFiles: 907,
+  };
+  const artifacts = serializeMolecularReport(report);
+  const driftedCount = serializeMolecularReport({
+    ...report,
+    scannedFiles: 908,
+  });
+  assert.match(driftedCount.markdown, /Scanned 908 maintained React files\./);
+  assert.match(artifacts.markdown, /Scanned 907 maintained React files\./);
+
+  assert.doesNotThrow(() =>
+    assertMolecularArtifactsCurrent(report, driftedCount),
+  );
+  assert.doesNotThrow(() =>
+    assertMolecularArtifactsCurrent(report, {
+      json: driftedCount.json,
+      markdown: artifacts.markdown,
+    }),
+  );
+
+  const driftedContent = serializeMolecularReport({
+    ...report,
+    eligibleComponents: 1,
+    scannedFiles: 908,
+  });
+  assert.throws(
+    () => assertMolecularArtifactsCurrent(report, driftedContent),
+    /artifacts are stale: json, markdown/,
+  );
+  assert.throws(
+    () =>
+      assertMolecularArtifactsCurrent(report, {
+        json: artifacts.json,
+        markdown: driftedContent.markdown,
+      }),
+    /artifacts are stale: markdown/,
   );
 });
 


### PR DESCRIPTION
# Relates to

Closes #30885. Follows the finding attentionhead raised on #30880.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Only the comparison inside `assertMolecularArtifactsCurrent` changes: `scannedFiles` is dropped from both sides of the JSON comparison and the scan-count sentence is normalized on both sides of the Markdown comparison. Every other field, the cluster dispositions, the canonical contracts, and the eligible-composition count still decide staleness, pinned in both directions by the new test. Regeneration is untouched and keeps writing the real count.

# Background

## What does this PR do?

`--check` compared the committed molecular report byte for byte against a fresh scan, including the raw `scannedFiles` count and the Markdown sentence that repeats it. That number moves whenever any change adds or removes a React file under `packages/ui/src`, so every such PR turned `@elizaos/ui#lint:check`, and with it `bun run verify`, red for the whole repository until someone regenerated the artifact. The regeneration was then raced: #29271, `b4ed96b571b`, and today #30882 against #30880 all landed or attempted the same one-number refresh. On `867f0909eab` the gate was red for exactly that reason (committed 907, tree 908).

The check now compares only the reviewable content. A count-only drift is current; a changed disposition, contract, or eligible composition is still stale.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`assertMolecularArtifactsCurrent` and the two helpers above it in `packages/ui/scripts/find-duplicate-molecular-components.mjs`, then the new test "molecular artifact checks tolerate a drifted scan count but not drifted content". The existing "compare formatted JSON by schema and data" test changes its stale case from a count change to a content change, because a count change is no longer stale by design.

## Detailed testing steps

Automated tests plus the live `--check` on this head. The red run below shows the new test failing against the develop script.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:51a19a0670ed9266f7188daa931f6d6c1b800f99 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - repository audit script; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - repository audit script; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the molecular suite, the live check, and the packages/ui lint chain on this head, pasted below.

  <details>
  <summary>node --test, live --check, and lint:check result lines on this head</summary>

  ```
$ node --test scripts/find-duplicate-molecular-components.test.mjs
ok 1 - molecular inventory is deterministic and requires meaningful signatures
ok 2 - canonical molecule contracts fail closed on owner drift
ok 3 - canonical molecule contracts require named consumers to keep composing the owner
ok 4 - molecule contract registry rejects under-proven owners
ok 5 - consumer composition resolves the owner binding through aliases and barrels
ok 6 - molecular decisions bind exact members and semantic structure
ok 7 - molecular decision workflow states cannot pass the completion gate
ok 8 - molecular decision registry rejects fingerprints that cannot bind
ok 9 - molecular artifact checks compare formatted JSON by schema and data
ok 10 - molecular artifact checks tolerate a drifted scan count but not drifted content
ok 11 - molecular report includes roles, dependencies, and source evidence
# pass 11
# fail 0

$ node scripts/find-duplicate-molecular-components.mjs --check
Molecular inventory is current with 11 final dispositions.

$ bun run --cwd packages/ui lint:check   (this head, packages/ui)
$ bunx @biomejs/biome check src scripts/*.ts && node --test scripts/check-design-system.test.mjs scripts/find-duplicate-molecular-components.test.mjs scripts/stories-coverage-gate.test.mjs && node --import tsx --test scripts/design-component-graph.test.ts scripts/design-contract-graph.test.ts && node scripts/check-design-system.mjs --require-tight-baseline && node scripts/find-duplicate-molecular-components.mjs --check && node --import tsx scripts/check-design-contract-graph.ts --require-tight-debt && node scripts/stories-coverage.mjs --check
Checked 3460 files in 6s. No fixes applied.
# tests 47
# pass 47
# fail 0
# tests 41
# pass 41
# fail 0
Scanned 1301 governed React source files.
Molecular inventory is current with 11 final dispositions.
Scanned 908 maintained React source files.
ui lint:check exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the updated test against the develop script, pasted below.

  <details>
  <summary>Red run: updated tests against origin/develop find-duplicate-molecular-components.mjs</summary>

  ```
# Red run: updated tests against origin/develop find-duplicate-molecular-components.mjs (d27659348e7)
$ node --test scripts/find-duplicate-molecular-components.test.mjs
ok 1 - molecular inventory is deterministic and requires meaningful signatures
ok 2 - canonical molecule contracts fail closed on owner drift
ok 3 - canonical molecule contracts require named consumers to keep composing the owner
ok 4 - molecule contract registry rejects under-proven owners
ok 5 - consumer composition resolves the owner binding through aliases and barrels
ok 6 - molecular decisions bind exact members and semantic structure
ok 7 - molecular decision workflow states cannot pass the completion gate
ok 8 - molecular decision registry rejects fingerprints that cannot bind
ok 9 - molecular artifact checks compare formatted JSON by schema and data
not ok 10 - molecular artifact checks tolerate a drifted scan count but not drifted content
ok 11 - molecular report includes roles, dependencies, and source evidence
# tests 11
# pass 10
# fail 1
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, a report whose only difference is `scannedFiles` fails `--check` with `artifacts are stale: json, markdown` (red run above), which is what turned the gate red on `867f0909eab`.

### After

A count-only difference is current; a content difference is still reported stale, and the live check on this head passes.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total) on this head, base `origin/develop` `d27659348e7`, `bun install --frozen-lockfile` reporting no changes. The packages/ui `lint:check` chain also passes on this head (transcript above). No gaps; every N/A row above carries its reason.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
