### PR TITLE
fix(logger): render shared references instead of marking them circular (#25125)

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -746,6 +746,35 @@ describe("secret redaction", () => {
     expect(logs).toContain('"type":"Map"');
   });
 
+  it("bounds the expansion of a wide shared graph on both paths", () => {
+    // Nine distinct objects, no cycle: each of eight levels has eight keys
+    // that all point at the same next-level object, so there are 8^8
+    // reference paths. Cycle detection alone would re-walk the shared child
+    // once per path and serialize a multi-megabyte line; the repeat budget
+    // keeps the walk and its output proportional to the payload.
+    let next: Record<string, unknown> = { leaf: true };
+    for (let level = 0; level < 8; level += 1) {
+      const node: Record<string, unknown> = {};
+      for (let key = 0; key < 8; key += 1) node[`k${key}`] = next;
+      next = node;
+    }
+    const logger = redactLogger();
+
+    const payloadStart = performance.now();
+    logger.info({ graph: next }, "wide-graph");
+    const payloadMs = performance.now() - payloadStart;
+    const trailingStart = performance.now();
+    logger.info("wide-graph-trailing", { graph: next });
+    const trailingMs = performance.now() - trailingStart;
+
+    const logs = recentLogs();
+    expect(logs).toContain("[Shared]");
+    expect(logs).not.toContain("[Circular]");
+    expect(logs.length).toBeLessThan(500_000);
+    expect(payloadMs).toBeLessThan(1_000);
+    expect(trailingMs).toBeLessThan(1_000);
+  });
+
   it("renders shared references in full through trailing args", () => {
     const logger = redactLogger();
     const shared = { region: "us-east" };

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -694,6 +694,67 @@ describe("secret redaction", () => {
     expect(recentLogs()).toContain("[Circular]");
   });
 
+  // A reference is circular only when it re-enters a container still being
+  // walked. The walker used to keep a permanent visited set, so a subobject
+  // referenced from two siblings rendered as `[Circular]` at its second
+  // reference although nothing was cyclic (#25125).
+  it("renders a subobject shared by two siblings in full at each reference", () => {
+    const logger = redactLogger();
+    const shared = { region: "us-east", retries: 3 };
+    logger.info({ config: shared, retryConfig: shared }, "shared-siblings");
+    const logs = recentLogs();
+    expect(logs).toContain('config={"region":"us-east","retries":3}');
+    expect(logs).toContain('retryConfig={"region":"us-east","retries":3}');
+    expect(logs).not.toContain("[Circular]");
+  });
+
+  it("renders a nested diamond without a circular marker", () => {
+    const logger = redactLogger();
+    const leaf = { zone: "shared-leaf" };
+    logger.info({ outer: { inner: leaf }, direct: leaf }, "nested-diamond");
+    const logs = recentLogs();
+    expect(logs).toContain('outer={"inner":{"zone":"shared-leaf"}}');
+    expect(logs).toContain('direct={"zone":"shared-leaf"}');
+    expect(logs).not.toContain("[Circular]");
+  });
+
+  it("collapses only the back-edge of a mutual cycle", () => {
+    const logger = redactLogger();
+    const a: Record<string, unknown> = { name: "node-a" };
+    const b: Record<string, unknown> = { name: "node-b", peer: a };
+    a.peer = b;
+    logger.info({ a, b }, "mutual-cycle");
+    const logs = recentLogs();
+    expect(logs).toContain(
+      'a={"name":"node-a","peer":{"name":"node-b","peer":"[Circular]"}}',
+    );
+    expect(logs).toContain(
+      'b={"name":"node-b","peer":{"name":"node-a","peer":"[Circular]"}}',
+    );
+  });
+
+  it("still collapses array and Map self-references", () => {
+    const logger = redactLogger();
+    const list: unknown[] = ["head"];
+    list.push(list);
+    const map = new Map<string, unknown>();
+    map.set("self", map);
+    logger.info({ list, map }, "container-cycles");
+    const logs = recentLogs();
+    expect(logs).toContain('list=["head","[Circular]"]');
+    expect(logs).toContain("[Circular]");
+    expect(logs).toContain('"type":"Map"');
+  });
+
+  it("renders shared references in full through trailing args", () => {
+    const logger = redactLogger();
+    const shared = { region: "us-east" };
+    logger.info("trailing", { config: shared, retryConfig: shared });
+    const logs = recentLogs();
+    expect(logs.split("us-east").length - 1).toBe(2);
+    expect(logs).not.toContain("[Circular]");
+  });
+
   it("masks webhook, connection-string, and concatenated key shapes (W5-026)", () => {
     const logger = redactLogger();
     logger.info(

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -217,12 +217,18 @@ function shouldLog(messageLevel: string, currentLevel: string): boolean {
  */
 function safeStringify(obj: unknown): string {
   try {
-    const seen = new WeakSet();
-    return JSON.stringify(obj, (_, value) => {
-      if (typeof value === "object" && value !== null) {
-        if (seen.has(value)) return "[Circular]";
-        seen.add(value);
+    // The replacer receives the holder as `this`, so the ancestor path can be
+    // rebuilt by popping until the holder is on top: only a value that is
+    // already on that path is circular. A visited set would also mark a
+    // subobject referenced by two siblings as circular.
+    const ancestors: object[] = [];
+    return JSON.stringify(obj, function replacer(this: unknown, _, value) {
+      if (typeof value !== "object" || value === null) return value;
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop();
       }
+      if (ancestors.includes(value)) return "[Circular]";
+      ancestors.push(value);
       return value;
     });
   } catch {
@@ -625,8 +631,25 @@ function redactLogValue(
   if (value === null || typeof value !== "object") return value;
   if (seen.has(value)) return "[Circular]";
   if (depth >= MAX_REDACT_DEPTH) return REDACTED_VALUE;
+  // `seen` is the active ancestor path, not a visited set: a reference is
+  // circular only when it re-enters a container that is still being walked.
+  // Removing the entry on the way out lets a subobject shared by two siblings
+  // render in full at each reference, as JSON.stringify does for DAG-shaped
+  // values, while self, mutual, array, and Map cycles still collapse.
   seen.add(value);
+  try {
+    return redactContainer(value, seen, depth);
+  } finally {
+    seen.delete(value);
+  }
+}
 
+/** Clone one container `value` already on the ancestor path in `seen`. */
+function redactContainer(
+  value: object,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
   if (value instanceof Error) {
     const clone = new Error(redactSensitiveLogText(value.message));
     clone.name = redactSensitiveLogText(value.name);

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -218,16 +218,26 @@ function shouldLog(messageLevel: string, currentLevel: string): boolean {
 function safeStringify(obj: unknown): string {
   try {
     // The replacer receives the holder as `this`, so the ancestor path can be
-    // rebuilt by popping until the holder is on top: only a value that is
-    // already on that path is circular. A visited set would also mark a
-    // subobject referenced by two siblings as circular.
+    // rebuilt by popping until the holder is on top: only a value already on
+    // that path is circular. A value rendered before but not on the path is a
+    // shared reference; it is expanded again while the repeat budget lasts
+    // and marked `[Shared]` afterwards, so a wide graph of a few objects
+    // cannot expand into a multi-megabyte line (see MAX_SHARED_EXPANSIONS).
     const ancestors: object[] = [];
+    const rendered = new WeakSet<object>();
+    let repeatBudget = MAX_SHARED_EXPANSIONS;
     return JSON.stringify(obj, function replacer(this: unknown, _, value) {
       if (typeof value !== "object" || value === null) return value;
       while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
         ancestors.pop();
       }
-      if (ancestors.includes(value)) return "[Circular]";
+      if (ancestors.includes(value)) return CIRCULAR_VALUE;
+      if (rendered.has(value)) {
+        if (repeatBudget <= 0) return SHARED_VALUE;
+        repeatBudget -= 1;
+      } else {
+        rendered.add(value);
+      }
       ancestors.push(value);
       return value;
     });
@@ -352,6 +362,18 @@ const REDACTED_VALUE = "[REDACTED]";
 const REDACTION_FAILED_VALUE = "[REDACTED: redaction failed]";
 /** Bound on recursion so a pathological payload cannot hang the process. */
 const MAX_REDACT_DEPTH = 8;
+const CIRCULAR_VALUE = "[Circular]";
+const SHARED_VALUE = "[Shared]";
+/**
+ * How many times a walk may expand an object it has already rendered once.
+ * Cycle detection tracks only the active ancestor path, so a shared subobject
+ * renders in full at each reference the way JSON.stringify renders a DAG; but
+ * the depth cap bounds depth, not fan-out, and a graph of nine objects where
+ * every key at every level points at the same next object has 8^8 reference
+ * paths. The budget keeps the walk and its rendered size proportional to the
+ * payload a caller can see; references past it render as `[Shared]`.
+ */
+const MAX_SHARED_EXPANSIONS = 256;
 
 /**
  * Separator-free substrings that mark an object key as holding a credential.
@@ -598,6 +620,24 @@ function redactSensitiveLogText(text: string): string {
   return next;
 }
 
+/** Per-walk bookkeeping for one top-level redaction. */
+interface RedactWalk {
+  /** Containers currently being walked; re-entering one is a cycle. */
+  ancestors: WeakSet<object>;
+  /** Containers already rendered once; a second reference is shared, not circular. */
+  rendered: WeakSet<object>;
+  /** Remaining expansions of already-rendered containers. */
+  repeatBudget: number;
+}
+
+function createRedactWalk(): RedactWalk {
+  return {
+    ancestors: new WeakSet<object>(),
+    rendered: new WeakSet<object>(),
+    repeatBudget: MAX_SHARED_EXPANSIONS,
+  };
+}
+
 /**
  * Deep-clone a log argument, masking every value under a credential-named key
  * at any depth. The clone is what gets logged, so redaction never mutates the
@@ -620,7 +660,7 @@ function redactSensitiveLogText(text: string): string {
  */
 function redactLogValue(
   value: unknown,
-  seen: WeakSet<object>,
+  walk: RedactWalk,
   depth: number,
 ): unknown {
   if (typeof value === "string") return redactSensitiveLogText(value);
@@ -629,25 +669,31 @@ function redactLogValue(
   // survive into a sink.
   if (typeof value === "function") return null;
   if (value === null || typeof value !== "object") return value;
-  if (seen.has(value)) return "[Circular]";
+  if (walk.ancestors.has(value)) return CIRCULAR_VALUE;
   if (depth >= MAX_REDACT_DEPTH) return REDACTED_VALUE;
-  // `seen` is the active ancestor path, not a visited set: a reference is
-  // circular only when it re-enters a container that is still being walked.
-  // Removing the entry on the way out lets a subobject shared by two siblings
-  // render in full at each reference, as JSON.stringify does for DAG-shaped
-  // values, while self, mutual, array, and Map cycles still collapse.
-  seen.add(value);
+  // A reference is circular only when it re-enters a container still being
+  // walked. A container rendered earlier in this walk is a shared reference:
+  // it renders in full again while the repeat budget lasts, so an ordinary
+  // diamond reads correctly at both references, and as `[Shared]` afterwards,
+  // so a wide graph cannot expand exponentially. Self, mutual, array, and Map
+  // cycles still collapse to one marker per back-edge.
+  if (walk.rendered.has(value)) {
+    if (walk.repeatBudget <= 0) return SHARED_VALUE;
+    walk.repeatBudget -= 1;
+  }
+  walk.ancestors.add(value);
   try {
-    return redactContainer(value, seen, depth);
+    return redactContainer(value, walk, depth);
   } finally {
-    seen.delete(value);
+    walk.ancestors.delete(value);
+    walk.rendered.add(value);
   }
 }
 
 /** Clone one container `value` already on the ancestor path in `seen`. */
 function redactContainer(
   value: object,
-  seen: WeakSet<object>,
+  walk: RedactWalk,
   depth: number,
 ): unknown {
   if (value instanceof Error) {
@@ -655,10 +701,10 @@ function redactContainer(
     clone.name = redactSensitiveLogText(value.name);
     if (value.stack) clone.stack = redactSensitiveLogText(value.stack);
     if (value.cause !== undefined) {
-      clone.cause = redactLogValue(value.cause, seen, depth + 1);
+      clone.cause = redactLogValue(value.cause, walk, depth + 1);
     }
     const target = clone as unknown as Record<string, unknown>;
-    redactOwnPropertiesInto(value, target, seen, depth + 1);
+    redactOwnPropertiesInto(value, target, walk, depth + 1);
     return clone;
   }
 
@@ -666,7 +712,7 @@ function redactContainer(
     // Avoid the caller's potentially overridden `map` and species constructor.
     const result = new Array<unknown>(value.length);
     for (let index = 0; index < value.length; index += 1) {
-      result[index] = redactLogValue(value[index], seen, depth + 1);
+      result[index] = redactLogValue(value[index], walk, depth + 1);
     }
     return result;
   }
@@ -697,11 +743,11 @@ function redactContainer(
     Map.prototype.forEach.call(
       value,
       (entryValue: unknown, entryKey: unknown) => {
-        const safeKey = redactLogValue(entryKey, seen, depth + 1);
+        const safeKey = redactLogValue(entryKey, walk, depth + 1);
         const safeValue =
           typeof entryKey === "string" && isSensitiveLogKey(entryKey)
             ? REDACTED_VALUE
-            : redactLogValue(entryValue, seen, depth + 1);
+            : redactLogValue(entryValue, walk, depth + 1);
         entries.push([safeKey, safeValue]);
       },
     );
@@ -713,7 +759,7 @@ function redactContainer(
   if (value instanceof Set) {
     const values: unknown[] = [];
     Set.prototype.forEach.call(value, (entryValue: unknown) => {
-      values.push(redactLogValue(entryValue, seen, depth + 1));
+      values.push(redactLogValue(entryValue, walk, depth + 1));
     });
     const result = Object.create(null) as Record<string, unknown>;
     defineSafeProperty(result, "type", "Set");
@@ -728,7 +774,7 @@ function redactContainer(
   // ever emits own enumerable properties anyway, and walking them here masks
   // credentials stashed on config/response wrappers (axios-style).
   const result = Object.create(null) as Record<string, unknown>;
-  redactOwnPropertiesInto(value, result, seen, depth + 1);
+  redactOwnPropertiesInto(value, result, walk, depth + 1);
   return result;
 }
 
@@ -757,7 +803,7 @@ function defineSafeProperty(
 function redactOwnPropertiesInto(
   source: object,
   target: Record<string, unknown>,
-  seen: WeakSet<object>,
+  walk: RedactWalk,
   depth: number,
 ): void {
   for (const key of Object.keys(source)) {
@@ -772,7 +818,7 @@ function redactOwnPropertiesInto(
       // can reconstitute the very secrets the walk just masked. JSON.stringify
       // omits function props anyway, so the clone drops them outright.
       if (typeof entry === "function") continue;
-      defineSafeProperty(target, key, redactLogValue(entry, seen, depth));
+      defineSafeProperty(target, key, redactLogValue(entry, walk, depth));
     } catch {
       // error-policy:J7 logging must never break the runtime; a throwing
       // getter fails closed on this one key, never emits the raw value.
@@ -792,7 +838,7 @@ function redactTrailingArgs(args: readonly unknown[]): unknown[] {
     if (arg === null || (typeof arg !== "object" && typeof arg !== "function"))
       return arg;
     try {
-      return redactLogValue(arg, new WeakSet<object>(), 0);
+      return redactLogValue(arg, createRedactWalk(), 0);
     } catch {
       // error-policy:J7 logging must never break the runtime; fail closed so
       // an unwalkable payload is marked, never emitted unredacted (W5-028).
@@ -1456,7 +1502,7 @@ function sealAdze(base: Record<string, unknown>): ReturnType<typeof adze.seal> {
   // logger.child({ apiKey }) must not print the key on each subsequent line.
   let safeMeta: Record<string, unknown>;
   try {
-    safeMeta = redactLogValue(metaBase, new WeakSet<object>(), 0) as Record<
+    safeMeta = redactLogValue(metaBase, createRedactWalk(), 0) as Record<
       string,
       unknown
     >;
@@ -1588,7 +1634,7 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
       obj: Record<string, unknown>,
     ): Record<string, unknown> => {
       try {
-        return redactLogValue(obj, new WeakSet<object>(), 0) as Record<
+        return redactLogValue(obj, createRedactWalk(), 0) as Record<
           string,
           unknown
         >;
@@ -1759,7 +1805,7 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
     obj: Record<string, unknown>,
   ): Record<string, unknown> => {
     try {
-      return redactLogValue(obj, new WeakSet<object>(), 0) as Record<
+      return redactLogValue(obj, createRedactWalk(), 0) as Record<
         string,
         unknown
       >;


### PR DESCRIPTION
# Relates to

Closes #25125

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is the bookkeeping of one traversal in `packages/logger`: an ancestor path for cycles, a rendered set with a bounded repeat budget for shared references, and the same in the `safeStringify` replacer. Cost is proportional to the payload plus at most 256 repeat expansions per walk; the wide-graph regression pins both time and rendered size. No redaction decision changes: credential-key masking, the depth cap, and the binary, Error, Map, Set, and function handling are untouched, and every existing logger test still passes. True cycles still collapse to one `[Circular]` per back-edge, pinned for self, mutual, array, and Map cycles. The walker is single-threaded and synchronous, so the `try`/`finally` removal cannot interleave with another walk.

# Background

## What does this PR do?

`redactLogValue` kept a permanent visited set while cloning a log payload, so any second reference to the same subobject rendered as `[Circular]` even when nothing was cyclic. `logger.info({ config: shared, retryConfig: shared }, ...)` rendered `retryConfig=[Circular]`; a leaf reached through a nested path and directly lost its content at the direct reference; the second node of a mutual cycle collapsed entirely instead of only at its back-edge. Nothing throws, so the false marker shipped verbatim into the ring buffer, the log routes, the file line, and the console. `safeStringify`, used when formatting trailing arguments, had the same visited-set shape.

The walker now tracks the active ancestor path and removes each container on the way out, so a reference is circular only when it re-enters a container still being walked. The replacer reconstructs that path by popping until its holder (`this`) is on top.

Review follow-up (second commit): the ancestor path alone removed the deduplication the visited set had provided, so a wide graph re-walked a shared subtree once per reference path (8^8 for the reviewers' nine-object graph) and serialized to hundreds of megabytes. A rendered set with a repeat budget (`MAX_SHARED_EXPANSIONS = 256`) now expands an already-rendered container again while the budget lasts, so an ordinary diamond still reads in full at both references, and renders `[Shared]` afterwards, a true statement about the data. `safeStringify` applies the same budget.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`redactLogValue` and `safeStringify` in `packages/logger/src/logger.ts`, then the six new cases after "collapses cycles instead of recursing forever" in `logger.test.ts` (the last one is the reviewers' wide graph), which go through the real `createLogger(...).info(...)` seam and read back `recentLogs()`.

## Detailed testing steps

Automated tests. The red run under Domain artifacts shows the new cases against the develop walker.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:4a0e9e815f8295baf14ae9ffe52bfc988f410b70 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - log serialization; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - log serialization; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the logger suite, typecheck, and Biome on this exact head, pasted below. The rendered log lines in the transcript are the sink output itself.

  <details>
  <summary>vitest, typecheck, and Biome transcript on this head</summary>

  ```
# Backend logs for the #25125 fix (head 4a0e9e815f8295baf14ae9ffe52bfc988f410b70, base origin/develop d27659348e7)
# 2026-09-07T11:37:28Z cwd packages/logger
$ npx vitest run src/logger.test.ts --reporter=verbose
 Info       shared-siblings (config={"region":"us-east","retries":3}, retryConfig={"region":"us-east","retries":3})
 Info       nested-diamond (outer={"inner":{"zone":"shared-leaf"}}, direct={"zone":"shared-leaf"})
 Info       mutual-cycle (a={"name":"node-a","peer":{"name":"node-b","peer":"[Circular]"}}, b={"name":"node-b","peer":{"name":"node-a","peer":"[Circular]"}})
 ✓ src/logger.test.ts > in-memory buffer retention (maxMemoryLogs) > does not wipe the shared buffer when a sized logger is constructed 1ms
 ✓ src/logger.test.ts > in-memory buffer retention (maxMemoryLogs) > an invalid cap on one logger cannot wipe another logger's shared history 1ms
 ✓ src/logger.test.ts > secret redaction > redacts objects passed as trailing args 1ms
 ✓ src/logger.test.ts > secret redaction > collapses cycles instead of recursing forever 1ms
 ✓ src/logger.test.ts > secret redaction > renders a subobject shared by two siblings in full at each reference 1ms
 ✓ src/logger.test.ts > secret redaction > renders a nested diamond without a circular marker 1ms
 ✓ src/logger.test.ts > secret redaction > collapses only the back-edge of a mutual cycle 1ms
 ✓ src/logger.test.ts > secret redaction > still collapses array and Map self-references 1ms
 ✓ src/logger.test.ts > secret redaction > bounds the expansion of a wide shared graph on both paths 12ms
 ✓ src/logger.test.ts > secret redaction > renders shared references in full through trailing args 1ms
 Test Files  1 passed (1)
      Tests  64 passed (64)

$ bun run --cwd packages/logger typecheck
$ tsc --noEmit -p tsconfig.json
exit: 0

$ npx biome check src/logger.ts src/logger.test.ts
Checked 2 files in 56ms. No fixes applied.
exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the new tests against the develop walker, pasted below.

  <details>
  <summary>Red run: new tests against origin/develop logger.ts</summary>

  ```
# Red run: new logger tests against origin/develop logger.ts (867f0909eab)
$ (packages/logger) npx vitest run src/logger.test.ts --reporter=verbose
 ✓ src/logger.test.ts > in-memory buffer retention (maxMemoryLogs) > does not wipe the shared buffer when a sized logger is constructed 1ms
 ✓ src/logger.test.ts > in-memory buffer retention (maxMemoryLogs) > an invalid cap on one logger cannot wipe another logger's shared history 1ms
 ✓ src/logger.test.ts > secret redaction > redacts objects passed as trailing args 1ms
 ✓ src/logger.test.ts > secret redaction > collapses cycles instead of recursing forever 1ms
 × src/logger.test.ts > secret redaction > renders a subobject shared by two siblings in full at each reference 3ms
 × src/logger.test.ts > secret redaction > renders a nested diamond without a circular marker 2ms
 × src/logger.test.ts > secret redaction > collapses only the back-edge of a mutual cycle 1ms
 ✓ src/logger.test.ts > secret redaction > still collapses array and Map self-references 1ms
 × src/logger.test.ts > secret redaction > renders shared references in full through trailing args 3ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
Expected: "retryConfig={"region":"us-east","retries":3}"
Received: "2026-09-07T10:32:18.163Z info shared-siblings (config={"region":"us-east","retries":3}, retryConfig=[Circular])"
Expected: "direct={"zone":"shared-leaf"}"
Received: "2026-09-07T10:32:18.166Z info nested-diamond (outer={"inner":{"zone":"shared-leaf"}}, direct=[Circular])"
Expected: "b={"name":"node-b","peer":{"name":"node-a","peer":"[Circular]"}}"
Received: "2026-09-07T10:32:18.168Z info mutual-cycle (a={"name":"node-a","peer":{"name":"node-b","peer":"[Circular]"}}, b=[Circular])"
- Expected
+ Received
 Test Files  1 failed (1)
      Tests  4 failed | 59 passed (63)
  ```

  </details>

  <details>
  <summary>Red run: wide-graph regression against the previous head a312925a989 (no repeat budget)</summary>

  ```
# Red run: wide-graph regression against the previous head a312925a989 (ancestor path without a repeat budget)
$ npx vitest run src/logger.test.ts -t "wide shared graph" --reporter=verbose
 × src/logger.test.ts > secret redaction > bounds the expansion of a wide shared graph on both paths 4676ms
   → expected '2026-09-07T11:36:50.785Z info wide-gr…' to contain '[Shared]'
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected '2026-09-07T11:36:50.785Z info wide-gr…' to contain '[Shared]'
- Expected
+ Received
 Test Files  1 failed (1)
      Tests  1 failed | 63 skipped (64)
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, `retryConfig=[Circular]`, `direct=[Circular]`, and `b=[Circular]` for the three inputs in the issue (red run above).

### After

```
shared-siblings (config={"region":"us-east","retries":3}, retryConfig={"region":"us-east","retries":3})
nested-diamond (outer={"inner":{"zone":"shared-leaf"}}, direct={"zone":"shared-leaf"})
mutual-cycle (a={"name":"node-a","peer":{"name":"node-b","peer":"[Circular]"}}, b={"name":"node-b","peer":{"name":"node-a","peer":"[Circular]"}})
```

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total) on this head `4a0e9e815f8` (base `origin/develop` `d27659348e7`, `bun install --frozen-lockfile` reporting no changes), rerun after the review follow-up commit. No gaps; every N/A row above carries its reason.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
