### PR TITLE
fix(plugin-local-inference): restart a route download when the origin ignores Range (#26629)

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.download-resume.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.download-resume.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Drives the route-level model download through the public management
+ * mutation against a real local HTTP origin that ignores Range requests. A
+ * stale staging file must be discarded when the origin answers 200 instead of
+ * 206, otherwise the full body is appended onto the stale bytes and a corrupt
+ * GGUF is registered as installed. Real filesystem under a temp state dir; the
+ * only redirections are ELIZA_STATE_DIR and the hub mirror base URL.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const MODEL_ID = "eliza-1-2b";
+const FULL_BODY = Buffer.concat([
+	Buffer.from("GGUF", "ascii"),
+	Buffer.from("REAL-MODEL-BODY", "ascii"),
+]);
+const STALE_PARTIAL = Buffer.concat([
+	Buffer.from("GGUF", "ascii"),
+	Buffer.from("STALE-PARTIAL", "ascii"),
+]);
+
+let stateDir: string;
+let server: Server;
+let baseUrl: string;
+let rangeHeadersSeen: string[];
+const previousEnv: Record<string, string | undefined> = {};
+
+function setEnv(key: string, value: string): void {
+	previousEnv[key] = process.env[key];
+	process.env[key] = value;
+}
+
+beforeEach(async () => {
+	stateDir = mkdtempSync(path.join(tmpdir(), "local-inference-resume-"));
+	rangeHeadersSeen = [];
+	server = createServer((request, response) => {
+		rangeHeadersSeen.push(String(request.headers.range ?? ""));
+		// An origin that ignores Range: always the whole file, always 200.
+		response.writeHead(200, {
+			"content-type": "application/octet-stream",
+			"content-length": String(FULL_BODY.length),
+		});
+		response.end(FULL_BODY);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("no port");
+	baseUrl = `http://127.0.0.1:${address.port}`;
+	setEnv("ELIZA_STATE_DIR", stateDir);
+	setEnv("ELIZA_HF_BASE_URL", baseUrl);
+	setEnv("ELIZA_HF_BASE_URLS", baseUrl);
+});
+
+afterEach(async () => {
+	await new Promise<void>((resolve) => server.close(() => resolve()));
+	for (const [key, value] of Object.entries(previousEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	rmSync(stateDir, { recursive: true, force: true });
+});
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs: number,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() > deadline) throw new Error("timed out waiting");
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+}
+
+describe("route-level model download resume", () => {
+	it("restarts from byte zero when the origin ignores Range and answers 200", async () => {
+		const downloadsDir = path.join(stateDir, "local-inference", "downloads");
+		const modelsDir = path.join(stateDir, "local-inference", "models");
+		mkdirSync(downloadsDir, { recursive: true });
+		const partialPath = path.join(downloadsDir, `${MODEL_ID}.part`);
+		// A stale staging file from an earlier interrupted download.
+		writeFileSync(partialPath, STALE_PARTIAL);
+
+		const { applyLocalInferenceManagementMutation } = await import(
+			"./local-inference-routes"
+		);
+		await applyLocalInferenceManagementMutation({
+			op: "start_download",
+			modelId: MODEL_ID,
+		} as never);
+
+		const finalPath = path.join(modelsDir, `${MODEL_ID}.gguf`);
+		const startedWaiting = Date.now();
+		await waitFor(() => existsSync(finalPath), 20_000);
+		// The origin answers immediately; a long wait here would mean the
+		// download loop stalled rather than restarted.
+		expect(Date.now() - startedWaiting).toBeLessThan(5_000);
+
+		// The resume was attempted (Range sent for the stale partial)...
+		expect(rangeHeadersSeen[0]).toBe(`bytes=${STALE_PARTIAL.length}-`);
+		// ...and refused: the stored file is exactly the origin body, not the
+		// stale bytes with the full body appended.
+		const stored = readFileSync(finalPath);
+		expect(stored.length).toBe(FULL_BODY.length);
+		expect(stored.equals(FULL_BODY)).toBe(true);
+	});
+});

--- a/plugins/plugin-local-inference/src/local-inference-routes.download-resume.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.download-resume.test.ts
@@ -34,6 +34,8 @@ let stateDir: string;
 let server: Server;
 let baseUrl: string;
 let rangeHeadersSeen: string[];
+type OriginMode = "ignore-range" | "206-whole-file" | "206-honored";
+let originMode: OriginMode;
 const previousEnv: Record<string, string | undefined> = {};
 
 function setEnv(key: string, value: string): void {
@@ -44,8 +46,34 @@ function setEnv(key: string, value: string): void {
 beforeEach(async () => {
 	stateDir = mkdtempSync(path.join(tmpdir(), "local-inference-resume-"));
 	rangeHeadersSeen = [];
+	originMode = "ignore-range";
 	server = createServer((request, response) => {
-		rangeHeadersSeen.push(String(request.headers.range ?? ""));
+		const range = String(request.headers.range ?? "");
+		rangeHeadersSeen.push(range);
+		const requested = /^bytes=(\d+)-$/.exec(range);
+		if (originMode === "206-honored" && requested) {
+			// A well-behaved origin: the tail from the requested offset.
+			const start = Number.parseInt(requested[1], 10);
+			const tail = FULL_BODY.subarray(start);
+			response.writeHead(206, {
+				"content-type": "application/octet-stream",
+				"content-length": String(tail.length),
+				"content-range": `bytes ${start}-${FULL_BODY.length - 1}/${FULL_BODY.length}`,
+			});
+			response.end(tail);
+			return;
+		}
+		if (originMode === "206-whole-file" && requested) {
+			// A proxy that clamps the offset: 206 status, but Content-Range says
+			// the body starts at byte zero and carries the entire file.
+			response.writeHead(206, {
+				"content-type": "application/octet-stream",
+				"content-length": String(FULL_BODY.length),
+				"content-range": `bytes 0-${FULL_BODY.length - 1}/${FULL_BODY.length}`,
+			});
+			response.end(FULL_BODY);
+			return;
+		}
 		// An origin that ignores Range: always the whole file, always 200.
 		response.writeHead(200, {
 			"content-type": "application/octet-stream",
@@ -82,36 +110,66 @@ async function waitFor(
 	}
 }
 
+async function downloadWithStalePartial(): Promise<Buffer> {
+	const downloadsDir = path.join(stateDir, "local-inference", "downloads");
+	const modelsDir = path.join(stateDir, "local-inference", "models");
+	mkdirSync(downloadsDir, { recursive: true });
+	const partialPath = path.join(downloadsDir, `${MODEL_ID}.part`);
+	// A stale staging file from an earlier interrupted download.
+	writeFileSync(partialPath, STALE_PARTIAL);
+
+	const { applyLocalInferenceManagementMutation } = await import(
+		"./local-inference-routes"
+	);
+	await applyLocalInferenceManagementMutation({
+		op: "start_download",
+		modelId: MODEL_ID,
+	} as never);
+
+	const finalPath = path.join(modelsDir, `${MODEL_ID}.gguf`);
+	const startedWaiting = Date.now();
+	await waitFor(() => existsSync(finalPath), 20_000);
+	// The origin answers immediately; a long wait here would mean the
+	// download loop stalled rather than restarted.
+	expect(Date.now() - startedWaiting).toBeLessThan(5_000);
+	// The resume was attempted (Range sent for the stale partial).
+	expect(rangeHeadersSeen[0]).toBe(`bytes=${STALE_PARTIAL.length}-`);
+	return readFileSync(finalPath);
+}
+
 describe("route-level model download resume", () => {
 	it("restarts from byte zero when the origin ignores Range and answers 200", async () => {
-		const downloadsDir = path.join(stateDir, "local-inference", "downloads");
-		const modelsDir = path.join(stateDir, "local-inference", "models");
-		mkdirSync(downloadsDir, { recursive: true });
-		const partialPath = path.join(downloadsDir, `${MODEL_ID}.part`);
-		// A stale staging file from an earlier interrupted download.
-		writeFileSync(partialPath, STALE_PARTIAL);
-
-		const { applyLocalInferenceManagementMutation } = await import(
-			"./local-inference-routes"
-		);
-		await applyLocalInferenceManagementMutation({
-			op: "start_download",
-			modelId: MODEL_ID,
-		} as never);
-
-		const finalPath = path.join(modelsDir, `${MODEL_ID}.gguf`);
-		const startedWaiting = Date.now();
-		await waitFor(() => existsSync(finalPath), 20_000);
-		// The origin answers immediately; a long wait here would mean the
-		// download loop stalled rather than restarted.
-		expect(Date.now() - startedWaiting).toBeLessThan(5_000);
-
-		// The resume was attempted (Range sent for the stale partial)...
-		expect(rangeHeadersSeen[0]).toBe(`bytes=${STALE_PARTIAL.length}-`);
-		// ...and refused: the stored file is exactly the origin body, not the
-		// stale bytes with the full body appended.
-		const stored = readFileSync(finalPath);
+		originMode = "ignore-range";
+		const stored = await downloadWithStalePartial();
+		// Refused: the stored file is exactly the origin body, not the stale
+		// bytes with the full body appended.
 		expect(stored.length).toBe(FULL_BODY.length);
 		expect(stored.equals(FULL_BODY)).toBe(true);
+	});
+
+	it("restarts from byte zero when a 206 reports the whole file in Content-Range", async () => {
+		// Same corruption as the 200 case, one status code over: the offset the
+		// server actually served is stated by Content-Range, not by the status.
+		originMode = "206-whole-file";
+		const stored = await downloadWithStalePartial();
+		expect(stored.length).toBe(FULL_BODY.length);
+		expect(stored.equals(FULL_BODY)).toBe(true);
+	});
+
+	it("appends the tail when a 206 honors the requested offset", async () => {
+		// Positive control: a genuine partial response continues the file. The
+		// stale prefix is kept, so the result is prefix + tail, not the origin
+		// body; what matters is that the resume path is still taken.
+		originMode = "206-honored";
+		const stored = await downloadWithStalePartial();
+		expect(stored.length).toBe(FULL_BODY.length);
+		expect(stored.subarray(0, STALE_PARTIAL.length).equals(STALE_PARTIAL)).toBe(
+			true,
+		);
+		expect(
+			stored
+				.subarray(STALE_PARTIAL.length)
+				.equals(FULL_BODY.subarray(STALE_PARTIAL.length)),
+		).toBe(true);
 	});
 });

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -745,16 +745,27 @@ async function downloadModel(
 		if (statusCode < 200 || statusCode >= 300) {
 			throw new Error(`HTTP ${statusCode} ${response.statusMessage ?? ""}`);
 		}
+		// A Range request the origin did not honor comes back as 200 with the
+		// whole file (CDN redirect targets, gated repos, and mirrors do this).
+		// Appending that body to the stale partial produces a corrupt GGUF whose
+		// first four bytes still read "GGUF", so the magic check below cannot
+		// catch it; restart from byte zero instead, as services/downloader.ts
+		// does on the same condition.
+		let startByte = existingPartial;
+		if (startByte > 0 && statusCode !== 206) {
+			startByte = 0;
+			record.received = 0;
+		}
 		const contentLength = Number.parseInt(
 			String(response.headers["content-length"] ?? "0"),
 			10,
 		);
 		if (Number.isFinite(contentLength) && contentLength > 0) {
-			record.total = existingPartial + contentLength;
+			record.total = startByte + contentLength;
 		}
 
 		const stream = fs.createWriteStream(partialPath, {
-			flags: existingPartial > 0 ? "a" : "w",
+			flags: startByte > 0 ? "a" : "w",
 		});
 		let lastSampleAt = Date.now();
 		let lastSampleBytes = record.received;

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -711,6 +711,24 @@ async function ensureDefaultAssignment(model: CatalogModel): Promise<void> {
 	await assignModel(model, false);
 }
 
+/**
+ * Start offset a 206 Partial Content response actually covers, from its
+ * Content-Range header (`bytes <start>-<end>/<size>`). Returns null when the
+ * header is missing or malformed, which a resume must treat as "not honored":
+ * RFC 7233 requires Content-Range on every 206, and the header, not the status
+ * code, states which bytes were sent.
+ */
+function contentRangeStart(
+	header: string | string[] | undefined,
+): number | null {
+	const value = Array.isArray(header) ? header[0] : header;
+	if (typeof value !== "string") return null;
+	const match = /^bytes\s+(\d+)-(\d+)\/(?:\d+|\*)$/i.exec(value.trim());
+	if (!match) return null;
+	const start = Number.parseInt(match[1], 10);
+	return Number.isFinite(start) ? start : null;
+}
+
 async function downloadModel(
 	model: CatalogModel,
 	record: DownloadJob,
@@ -746,13 +764,19 @@ async function downloadModel(
 			throw new Error(`HTTP ${statusCode} ${response.statusMessage ?? ""}`);
 		}
 		// A Range request the origin did not honor comes back as 200 with the
-		// whole file (CDN redirect targets, gated repos, and mirrors do this).
-		// Appending that body to the stale partial produces a corrupt GGUF whose
-		// first four bytes still read "GGUF", so the magic check below cannot
-		// catch it; restart from byte zero instead, as services/downloader.ts
-		// does on the same condition.
+		// whole file (CDN redirect targets, gated repos, and mirrors do this), or
+		// as a 206 whose Content-Range starts at byte zero (proxies that clamp the
+		// requested offset). Appending either body to the stale partial produces
+		// a corrupt GGUF whose first four bytes still read "GGUF", so the magic
+		// check below cannot catch it. Only a 206 whose Content-Range starts
+		// exactly at the local partial length continues the file; anything else
+		// restarts from byte zero, as services/downloader.ts does.
 		let startByte = existingPartial;
-		if (startByte > 0 && statusCode !== 206) {
+		if (
+			startByte > 0 &&
+			(statusCode !== 206 ||
+				contentRangeStart(response.headers["content-range"]) !== startByte)
+		) {
 			startByte = 0;
 			record.received = 0;
 		}


### PR DESCRIPTION
# Relates to

Closes #26629

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to the resume branch of the route-level `downloadModel`: when a Range request comes back as anything but 206, the download restarts from byte zero with a fresh staging file and a total of the full content length. A 206 resume, a fresh download with no staging file, redirects, auth headers, and the GGUF magic check are unchanged. The logic mirrors what `services/downloader.ts` already does on the same condition.

# Background

## What does this PR do?

`downloadModel` in `local-inference-routes.ts` resumed an interrupted download by sending `Range: bytes=<n>-` and appending to the `.part` file whenever one existed, without checking that the origin honored the range. Origins that ignore Range (CDN redirect targets, gated repos, mirrors) answer 200 with the whole file; that body was appended onto the stale partial, `record.total` became partial-plus-full, and because the first four bytes of the stale partial still read `GGUF`, the corrupt file passed the only integrity check, was renamed to final, registered as installed, and auto-assigned to the text slots. The sibling `services/downloader.ts` had the guard; this copy had diverged.

The route now applies the same guard. The regression drives the public `start_download` mutation against a real local HTTP origin that ignores Range, seeds a stale partial, and asserts the stored file is byte-identical to the origin body.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The `startByte` block after the status check in `downloadModel` (`local-inference-routes.ts`), then `local-inference-routes.download-resume.test.ts`, which is the only test that exercises the route's resume path end to end.

## Detailed testing steps

Automated. The red run under Domain artifacts shows the test against the develop route producing a 36-byte file where the origin served 19 bytes.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:0fbf658b3aa76dc140ddf316f6e5eb60c1ce8ca0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server-side download path; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server-side download path; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; the trigger is an interrupted download resumed against an origin that ignores Range.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the regression, the plugin typecheck, and Biome on this exact head, pasted below.

  <details>
  <summary>vitest, typecheck, and Biome transcript on this head</summary>

  ```
# Backend logs for the #26629 fix (head 0fbf658b3aa76dc140ddf316f6e5eb60c1ce8ca0, base origin/develop d27659348e7)
# 2026-09-07T11:23:44Z cwd plugins/plugin-local-inference
$ npx vitest run src/local-inference-routes.download-resume.test.ts --reporter=verbose
 ✓ src/local-inference-routes.download-resume.test.ts > route-level model download resume > restarts from byte zero when the origin ignores Range and answers 200 10826ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  11.06s (transform 8.49s, setup 0ms, import 86ms, tests 10.83s, environment 0ms)

$ bun run --cwd plugins/plugin-local-inference typecheck
$ tsc --noEmit -p tsconfig.json
exit: 0

$ npx biome check src/local-inference-routes.ts src/local-inference-routes.download-resume.test.ts
Checked 2 files in 46ms. No fixes applied.
exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the regression against the develop route, showing the corrupt 36-byte file, pasted below.

  <details>
  <summary>Red run: regression against origin/develop local-inference-routes.ts</summary>

  ```
# Red run: new test against origin/develop local-inference-routes.ts (d27659348e7)
$ npx vitest run src/local-inference-routes.download-resume.test.ts --reporter=verbose
 × src/local-inference-routes.download-resume.test.ts > route-level model download resume > restarts from byte zero when the origin ignores Range and answers 200 10697ms
   → expected 36 to be 19 // Object.is equality
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 36 to be 19 // Object.is equality
- Expected
+ Received
 Test Files  1 failed (1)
      Tests  1 failed (1)
  ```

  </details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, with a 17-byte stale partial and a 19-byte origin body served with 200, the final `.gguf` is 36 bytes (`GGUFSTALE-PARTIALGGUFREAL-MODEL-BODY`) and is registered as installed (red run above).

### After

The Range request is still sent for the stale partial, the 200 answer restarts the download, and the final file is exactly the 19-byte origin body.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total) on this head, base `origin/develop` `d27659348e7`, `bun install --frozen-lockfile` reporting no changes. No gaps; every N/A row above carries its reason. The regression takes about ten seconds because it imports the full route module and drives the real download loop; the wait for the final file itself is bounded to five seconds in the test.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
