### PR TITLE
fix(ui): recover stale CSS loads without reload loops

### DIFF
--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -125,7 +125,7 @@ const auditAppDropdownEnabled = projectRequested("audit-app-dropdown");
 // accepts them), so the shipped Capacitor iOS WebView / desktop WKWebView
 // engine must run in CI, not only Chromium wearing a Safari viewport.
 const WEBKIT_SMOKE_SPECS =
-  /(browser-workspace|character-editor|wallet-inventory|workflow-editor|ui-smoke|input-modality)\.spec\.ts/;
+  /(auth-email-callback|lazy-css-recovery|browser-workspace|character-editor|wallet-inventory|workflow-editor|ui-smoke|input-modality)\.spec\.ts/;
 const recording = !!process.env.E2E_RECORD;
 const videoMode =
   process.env.ELIZA_UI_SMOKE_DISABLE_VIDEO === "1"

--- a/packages/app/test/ui-smoke/auth-email-callback.spec.ts
+++ b/packages/app/test/ui-smoke/auth-email-callback.spec.ts
@@ -7,9 +7,17 @@
 import { expect, test } from "@playwright/test";
 import { createStewardSessionToken } from "./helpers/test-auth";
 
+const TEST_AUTH_ENABLED =
+  process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
+  process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH === "true";
+
 test("fresh email callback commits its session before navigation and rejects replay", async ({
   page,
 }) => {
+  test.skip(
+    TEST_AUTH_ENABLED,
+    "requires production Steward auth provider; run with VITE_PLAYWRIGHT_TEST_AUTH=false and NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH=false",
+  );
   const email = "callback-browser@example.test";
   const proof = "single-use-browser-proof";
   const token = createStewardSessionToken({ jwt: true, email });

--- a/packages/app/test/ui-smoke/auth-email-callback.spec.ts
+++ b/packages/app/test/ui-smoke/auth-email-callback.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Real hosted callback, Steward SDK, session publication, and browser navigation
+ * against a deterministic one-use HTTP boundary. No email is sent and no
+ * Steward/database verifier runs here. Run with VITE_PLAYWRIGHT_TEST_AUTH=false
+ * so the production auth provider owns the complete callback exchange.
+ */
+import { expect, test } from "@playwright/test";
+import { createStewardSessionToken } from "./helpers/test-auth";
+
+test("fresh email callback commits its session before navigation and rejects replay", async ({
+  page,
+}) => {
+  const email = "callback-browser@example.test";
+  const proof = "single-use-browser-proof";
+  const token = createStewardSessionToken({ jwt: true, email });
+  let consumed = false;
+  let verifyRequests = 0;
+  let sessionRequests = 0;
+  let releaseSession: () => void = () => {
+    throw new Error("Session gate not initialized");
+  };
+  const sessionGate = new Promise<void>((resolve) => {
+    releaseSession = resolve;
+  });
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  await page.route("**/steward/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path.endsWith("/auth/email/verify")) {
+      verifyRequests += 1;
+      const request = route.request().postDataJSON();
+      expect(route.request().method()).toBe("POST");
+      expect(request).toMatchObject({ email, token: proof });
+      const accepted = !consumed;
+      consumed = true;
+      await route.fulfill({
+        status: accepted ? 200 : 401,
+        json: accepted
+          ? { token, user: { id: "ui-smoke-user", email }, expiresIn: 900 }
+          : { error: "One-time credential rejected" },
+      });
+      return;
+    }
+    await route.fulfill({ status: 401, json: { error: "No session" } });
+  });
+  await page.route(/^https?:\/\/[^/]+\/api\//, (route) =>
+    route.fulfill({ status: 401, json: { error: "No fixture session" } }),
+  );
+  await page.route(/^https?:\/\/[^/]+\/api\/auth\//, async (route) => {
+    if (
+      new URL(route.request().url()).pathname.endsWith("/steward-session") &&
+      route.request().method() === "POST"
+    ) {
+      sessionRequests += 1;
+      expect(route.request().postDataJSON()).toMatchObject({ token });
+      await sessionGate;
+      await route.fulfill({
+        status: 200,
+        json: { ok: true },
+        headers: {
+          "Set-Cookie":
+            "callback_session=committed; Path=/; HttpOnly; SameSite=Lax",
+        },
+      });
+      return;
+    }
+    await route.fulfill({ status: 401, json: { error: "No session" } });
+  });
+  const callback = `/auth/callback/email?token=${proof}&email=${encodeURIComponent(email)}`;
+  await page.goto(callback, { waitUntil: "domcontentloaded" });
+  await expect
+    .poll(() => sessionRequests, { timeout: 90_000 })
+    .toBeGreaterThan(0);
+  // Outlast the success redirect while the session response is withheld.
+  // A fire-and-forget cookie sync must not appear to finish authentication.
+  await page.waitForTimeout(2_000);
+  expect(verifyRequests).toBe(1);
+  expect(new URL(page.url()).pathname).toBe("/auth/callback/email");
+  expect(new URL(page.url()).searchParams.has("token")).toBe(false);
+  expect(new URL(page.url()).searchParams.has("email")).toBe(false);
+  const joined = page.waitForURL("**/join");
+  releaseSession();
+  await joined;
+  expect(
+    (await page.context().cookies()).some(
+      (cookie) => cookie.name === "callback_session" && cookie.httpOnly,
+    ),
+  ).toBe(true);
+  // Replay in a signed-out browser document; an existing session otherwise
+  // legitimately triggers its own passive cookie sync during boot.
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  await page.context().clearCookies();
+  const committedRequests = sessionRequests;
+  await page.goto(callback, { waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByRole("heading", { name: "Sign-in failed" }),
+  ).toBeVisible();
+  await expect(page.getByText(/expired or was already used/)).toBeVisible();
+  expect(verifyRequests).toBe(2);
+  expect(sessionRequests).toBe(committedRequests);
+  await page.getByRole("link", { name: /Back to login/ }).click();
+  await expect(page).toHaveURL(/\/login$/);
+  expect(pageErrors).toEqual([]);
+});

--- a/packages/app/test/ui-smoke/lazy-css-recovery.spec.ts
+++ b/packages/app/test/ui-smoke/lazy-css-recovery.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Builds a lazy route with real Vite CSS preloading and the production cloud
+ * error boundary. A removed deployment asset must trigger one document reload
+ * and render the available stylesheet, with persistent failures bounded by the
+ * same recovery cooldown.
+ */
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { build } from "vite";
+
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+const origin = "https://eliza.app";
+let fixtureRoot: string;
+
+test.beforeAll(async () => {
+  fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "eliza-lazy-css-"));
+  await writeFile(
+    path.join(fixtureRoot, "index.html"),
+    '<meta name="viewport" content="width=device-width, initial-scale=1"><div id="root"></div><script type="module" src="/entry.tsx"></script>',
+  );
+  await writeFile(
+    path.join(fixtureRoot, "entry.tsx"),
+    `import React, { lazy, Suspense } from "react";
+import { createRoot } from "react-dom/client";
+import { CloudRouteErrorBoundary } from ${JSON.stringify(path.join(repoRoot, "packages/ui/src/cloud/shell/CloudRouteErrorBoundary.tsx"))};
+const Page = lazy(() => import("./page"));
+createRoot(document.getElementById("root")).render(
+  <CloudRouteErrorBoundary routePath="login">
+    <Suspense fallback={<p>Loading</p>}><Page /></Suspense>
+  </CloudRouteErrorBoundary>
+);`,
+  );
+  await writeFile(
+    path.join(fixtureRoot, "page.tsx"),
+    'import React from "react"; import "./page.css"; export default function Page() { return <h1>Recovered login</h1>; }',
+  );
+  for (const [version, color] of [
+    ["old", "rgb(111, 22, 33)"],
+    ["current", "rgb(12, 34, 56)"],
+  ]) {
+    await writeFile(
+      path.join(fixtureRoot, "page.css"),
+      `h1 { color: ${color}; }`,
+    );
+    await build({
+      root: fixtureRoot,
+      configFile: false,
+      logLevel: "silent",
+      esbuild: { jsx: "automatic" },
+      resolve: {
+        alias: {
+          react: path.join(repoRoot, "node_modules/react"),
+          "react-dom": path.join(repoRoot, "node_modules/react-dom"),
+        },
+      },
+      build: { outDir: version, modulePreload: false },
+    });
+  }
+});
+
+test.afterAll(async () => {
+  if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true });
+});
+
+for (const mode of ["recover", "persistent", "getItem", "setItem"] as const) {
+  const persistentFailure = mode === "persistent";
+  const storageDenied = mode === "getItem" || mode === "setItem";
+  test(
+    storageDenied
+      ? `unavailable sessionStorage.${mode} leaves CSS recovery to manual Reload`
+      : persistentFailure
+        ? "a persistently missing lazy stylesheet stops auto-reloading and offers manual recovery"
+        : "a missing lazy stylesheet reloads once and renders the recovered route with its CSS",
+    async ({ page }) => {
+      let documents = 0;
+      let cssRequests = 0;
+      await page.route(`${origin}/**`, async (route) => {
+        const pathname = new URL(route.request().url()).pathname;
+        if (pathname.endsWith(".css")) {
+          cssRequests += 1;
+          if (persistentFailure || cssRequests === 1) {
+            await route.fulfill({ status: 404, body: "Asset removed" });
+            return;
+          }
+        }
+        const file = pathname.startsWith("/assets/")
+          ? pathname.slice(1)
+          : "index.html";
+        if (route.request().isNavigationRequest()) documents += 1;
+        // The first document has the retired deployment's chunk graph.
+        // Reload receives a new shell and genuinely different hashed CSS.
+        const version = documents <= 1 ? "old" : "current";
+        await route.fulfill({
+          body: await readFile(path.join(fixtureRoot, version, file)),
+          contentType: file.endsWith(".css")
+            ? "text/css"
+            : file.endsWith(".js")
+              ? "text/javascript"
+              : "text/html",
+        });
+      });
+
+      if (storageDenied) {
+        await page.addInitScript((operation) => {
+          Object.defineProperty(Storage.prototype, operation, {
+            configurable: true,
+            value() {
+              throw new DOMException("Storage denied", "SecurityError");
+            },
+          });
+        }, mode);
+      }
+      await page.goto(`${origin}/login`);
+      if (storageDenied) {
+        await expect(
+          page.getByTestId("cloud-route-error-reload"),
+        ).toBeVisible();
+        expect(documents).toBe(1);
+        expect(cssRequests).toBe(1);
+        await page.getByTestId("cloud-route-error-reload").click();
+      }
+      if (persistentFailure) {
+        await expect(
+          page.getByTestId("cloud-route-error-reload"),
+        ).toBeVisible();
+        await expect(
+          page.getByTestId("cloud-route-error-fallback"),
+        ).toContainText("Unable to preload CSS for");
+        await expect(
+          page.getByRole("heading", { name: "Recovered login" }),
+        ).toHaveCount(0);
+        await expect.poll(() => cssRequests).toBe(2);
+        expect(documents).toBe(2);
+        await page.getByTestId("cloud-route-error-reload").click();
+        await expect.poll(() => cssRequests).toBe(3);
+        await expect(
+          page.getByTestId("cloud-route-error-reload"),
+        ).toBeVisible();
+        expect(documents).toBe(3);
+      } else {
+        const recovered = page.getByRole("heading", {
+          name: "Recovered login",
+        });
+        await expect(recovered).toBeVisible();
+        await expect(recovered).toHaveCSS("color", "rgb(12, 34, 56)");
+        await expect(
+          page.getByTestId("cloud-route-error-fallback"),
+        ).toHaveCount(0);
+        expect(documents).toBe(2);
+        expect(cssRequests).toBe(2);
+      }
+    },
+  );
+}

--- a/packages/ui/src/cloud/shell/CloudRouteErrorBoundary.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouteErrorBoundary.test.tsx
@@ -49,8 +49,17 @@ const COOLDOWN_MS = 5 * 60 * 1000;
 const CHUNK_ERROR_MESSAGE =
   "Failed to fetch dynamically imported module: https://elizacloud.ai/assets/BillingPage-Bx1v9qQ3.js";
 
-function ChunkBoom(): React.JSX.Element {
-  throw new Error(CHUNK_ERROR_MESSAGE);
+const CHUNK_FAILURES = [
+  ["JavaScript import", CHUNK_ERROR_MESSAGE],
+  ["Vite CSS preload", "Unable to preload CSS for /assets/login-old.css"],
+] as const;
+
+function ChunkBoom({
+  message = CHUNK_ERROR_MESSAGE,
+}: {
+  message?: string;
+}): React.JSX.Element {
+  throw new Error(message);
 }
 
 function PlainBoom(): React.JSX.Element {
@@ -81,41 +90,65 @@ afterEach(() => {
 });
 
 describe("CloudRouteErrorBoundary — chunk-load recovery", () => {
-  it("reloads exactly once on a chunk-load error and stamps the cooldown marker", () => {
-    render(
-      <CloudRouteErrorBoundary routePath="cloud/billing">
-        <ChunkBoom />
-      </CloudRouteErrorBoundary>,
-    );
+  it.each(CHUNK_FAILURES)(
+    "reloads exactly once for %s and stamps the cooldown marker",
+    (_kind, message) => {
+      render(
+        <CloudRouteErrorBoundary routePath="cloud/billing">
+          <ChunkBoom message={message} />
+        </CloudRouteErrorBoundary>,
+      );
 
-    expect(reloadSpy).toHaveBeenCalledTimes(1);
-    const marker = Number(window.sessionStorage.getItem(RELOAD_MARKER_KEY));
-    // Timestamped (not a latched boolean) so a LATER deploy in the same
-    // session can auto-heal again after the cooldown lapses.
-    expect(marker).toBeGreaterThan(0);
-    expect(Date.now() - marker).toBeLessThan(COOLDOWN_MS);
-  });
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+      const marker = Number(window.sessionStorage.getItem(RELOAD_MARKER_KEY));
+      // Timestamped (not a latched boolean) so a LATER deploy in the same
+      // session can auto-heal again after the cooldown lapses.
+      expect(marker).toBeGreaterThan(0);
+      expect(Date.now() - marker).toBeLessThan(COOLDOWN_MS);
+    },
+  );
 
-  it("does NOT auto-reload again inside the cooldown: shows the manual Reload card", () => {
-    // A recovery attempt already happened moments ago (marker = now).
-    window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(Date.now()));
+  it.each(CHUNK_FAILURES)(
+    "keeps %s inside the cooldown on the manual Reload card",
+    (_kind, message) => {
+      // A recovery attempt already happened moments ago (marker = now).
+      window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(Date.now()));
 
-    render(
-      <CloudRouteErrorBoundary routePath="cloud/billing">
-        <ChunkBoom />
-      </CloudRouteErrorBoundary>,
-    );
+      render(
+        <CloudRouteErrorBoundary routePath="cloud/billing">
+          <ChunkBoom message={message} />
+        </CloudRouteErrorBoundary>,
+      );
 
-    // No reload loop: the budget is spent, so the failure degrades to the
-    // designed card with an explicit user-initiated Reload affordance.
-    expect(reloadSpy).not.toHaveBeenCalled();
-    expect(screen.getByTestId("cloud-route-error-fallback")).toBeTruthy();
-    const reloadButton = screen.getByTestId("cloud-route-error-reload");
-    expect(reloadButton.textContent).toContain("Reload");
+      // No reload loop: the budget is spent, so the failure degrades to the
+      // designed card with an explicit user-initiated Reload affordance.
+      expect(reloadSpy).not.toHaveBeenCalled();
+      expect(screen.getByTestId("cloud-route-error-fallback")).toBeTruthy();
+      const reloadButton = screen.getByTestId("cloud-route-error-reload");
+      expect(reloadButton.textContent).toContain("Reload");
 
-    fireEvent.click(reloadButton);
-    expect(reloadSpy).toHaveBeenCalledTimes(1);
-  });
+      fireEvent.click(reloadButton);
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["getItem", "setItem"] as const)(
+    "keeps CSS recovery manual when sessionStorage.%s is denied",
+    (operation) => {
+      vi.spyOn(Storage.prototype, operation).mockImplementation(() => {
+        throw new DOMException("Storage denied", "SecurityError");
+      });
+      render(
+        <CloudRouteErrorBoundary routePath="login">
+          <ChunkBoom message="Unable to preload CSS for /assets/login-old.css" />
+        </CloudRouteErrorBoundary>,
+      );
+
+      expect(reloadSpy).not.toHaveBeenCalled();
+      fireEvent.click(screen.getByTestId("cloud-route-error-reload"));
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("allows one more auto-reload after the cooldown lapses", () => {
     const staleAttempt = Date.now() - (COOLDOWN_MS + 60_000);

--- a/packages/ui/src/utils/chunk-load-recovery.ts
+++ b/packages/ui/src/utils/chunk-load-recovery.ts
@@ -26,6 +26,7 @@ export function isChunkLoadError(error: unknown): boolean {
     const message = error.message;
     if (
       error.name === "ChunkLoadError" ||
+      message.startsWith("Unable to preload CSS for ") ||
       message.includes("Failed to fetch dynamically imported module") ||
       message.includes("Importing a module script failed") ||
       message.includes("error loading dynamically imported module") ||
@@ -52,19 +53,20 @@ export function tryChunkReloadRecovery(): boolean {
       window.sessionStorage.getItem(CHUNK_RELOAD_AT_KEY) ?? "0",
     );
   } catch {
-    // error-policy:J3 storage denied (private mode) → an unreadable marker is
-    // explicitly "never attempted"; worst case is one extra reload.
-    lastAttempt = 0;
+    // error-policy:J4 unavailable cooldown state leaves recovery to the
+    // explicit Reload control instead of risking a loop across documents.
+    return false;
   }
   if (Date.now() - lastAttempt < RELOAD_COOLDOWN_MS) return false;
   try {
     window.sessionStorage.setItem(CHUNK_RELOAD_AT_KEY, String(Date.now()));
   } catch (err) {
-    // error-policy:J6 marker write is best-effort; without it we may reload
-    // once more than intended, never loop (the navigation itself rate-limits).
+    // error-policy:J4 an unpersisted attempt cannot bound the next document;
+    // keep the existing manual Reload control available instead.
     logger.debug(
       `[ChunkLoadRecovery] could not persist reload marker: ${err instanceof Error ? err.message : String(err)}`,
     );
+    return false;
   }
   window.location.reload();
   return true;


### PR DESCRIPTION
Failed lazy CSS preloads now use the existing document-reload recovery. If the browser cannot store the retry marker, the page offers manual Reload instead of risking repeated automatic reloads. Chromium and WebKit regressions cover this recovery and email callback sequencing/replay rejection.

# Relates to

Follow-up to #18627; does not close it automatically. Live email/Google staging evidence is recorded [on the issue](https://github.com/elizaOS/eliza/issues/18627#issuecomment-5569940591). Fresh-account agent listing remains outstanding.

Definition of Done: full standard in `CONTRIBUTING.md`.

# Sync with develop

- Base: `c039b4a455f769b53ee9fa1b793428ad6aaa7e79`.
- Candidate: `9d7b49f04540cb79812a9a2225596f1f78a88bcb`.
- Rebased without conflicts; `bun install` completed with no dependency changes.
- Final `bun run verify` passed after sync/install on this exact candidate.

# Risks

The shared helper serves Cloud and application error boundaries. It reloads the document for recognized asset failures, while storage-denied browsers retain manual recovery. No production authentication provider, API, database, deployment configuration, or provisioning behavior changes.

# Background

## What does this PR do?

- Recognizes Vite’s real `Unable to preload CSS for ...` failure.
- Requires a readable and persisted cooldown marker before automatic reload.
- Tests old-to-current deployment asset graphs, persistent missing assets, and denied storage in Chromium and WebKit.
- Tests the production email callback/provider/SDK with a controlled one-use HTTP response: verification once, token removal, session acknowledgement before navigation, and explicit consumed-link recovery. The test skips auth-bypass builds because they intentionally replace that provider.

## What kind of change is this?

Bug fix with browser regressions.

# Documentation changes needed?

No public configuration or workflow changes.

# Testing

## Where should a reviewer start?

The before/after evidence shows an actual Vite-generated CSS failure reaching the production error boundary. The permanent browser regression additionally swaps old/current hashed deployment graphs. These are renderer fixtures, not a claim of hosted CDN verification.

## Detailed testing steps

```sh
bun run --cwd packages/ui test src/cloud/shell/CloudRouteErrorBoundary.test.tsx src/utils/__tests__/chunk-load-recovery-standalone.test.ts src/components/views/ViewErrorBoundary.test.tsx src/components/ui/error-boundary.test.tsx
VITE_PLAYWRIGHT_TEST_AUTH=false NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH=false bun run --cwd packages/app test:e2e auth-email-callback.spec.ts lazy-css-recovery.spec.ts --project=chromium --project=desktop-webkit
bun run verify
```

The combined local browser run used the same Playwright config against the candidate’s Vite dev server, with `ELIZA_UI_SMOKE_REUSE_SERVER=1` and a dedicated port. The standard command above starts its own app stack.

- 26 focused UI boundary/recovery tests passed.
- 10 combined Chromium/WebKit browser tests passed on the candidate.
- Production-auth mode passes; either auth-bypass flag intentionally skips the email-only regression.
- Two independent reviewers cleared the final candidate after the storage and test-mode findings were fixed.

# Evidence Gate

<!-- evidence-head:9d7b49f04540cb79812a9a2225596f1f78a88bcb -->

<!-- evidence-row:before-screenshots -->
- [x] [chromium desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-before-chromium-desktop.png) · [chromium mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-before-chromium-mobile.png) · [webkit desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-before-webkit-desktop.png) · [webkit mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-before-webkit-mobile.png)
<!-- evidence-row:after-screenshots -->
- [x] [chromium desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-after-chromium-desktop.png) · [chromium mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-after-chromium-mobile.png) · [webkit desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-after-webkit-desktop.png) · [webkit mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-after-webkit-mobile.png)
<!-- evidence-row:walkthrough-video -->
- [x] [Continuous desktop MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/30889-full-recovery-desktop-v2.mp4) · [Continuous mobile MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/30889-full-recovery-mobile-v2.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - production fix is renderer-only; asset fixture responses are included with frontend network logs. Live auth backend evidence is linked on #18627.
<!-- evidence-row:frontend-logs -->
- [x] [Console and network logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-closure-console-network.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, agent action, prompt, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database or other domain-state mutation in this patch.
<!-- evidence-row:ocr-review -->
- [x] [Tesseract OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-closure-ocr.txt) · [Capture scope and visual review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-10/30889-README.md)

# Evidence Details

## Real LLM-call trajectory

N/A - no inference path changes.

## Backend + frontend logs

The CSS fixture uses real Vite builds and browser requests. Its first CSS 404 and associated console error are intentional. The email regression uses deterministic HTTP responses; real AgentMail delivery and Safari/Brave Private verification were tested separately on deployed staging revision c039.

## Screenshots (before / after) + video walkthrough

[Walkthrough scope](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-closure-walkthrough-scope.md) · [Desktop walkthrough logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-full-recovery-desktop-v1-console-network.txt) · [Mobile walkthrough logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-full-recovery-mobile-v1-console-network.txt) · [Desktop walkthrough OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-full-recovery-desktop-v1-ocr.txt) · [Mobile walkthrough OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-full-recovery-mobile-v1-ocr.txt)

The uploaded v2 MP4 files are lossless fast-start remuxes of the inspected v1 recordings, suitable for web playback.

The attached recovery captures isolate the production boundary so its failure/reload result is visible. They do not depict a real-account login. Both browser engines and desktop/mobile sizes were inspected.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

Baseline comparison images: [connected baseline](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-closure-baseline-plugin-cloud-gui.png) / [candidate](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-closure-candidate-plugin-cloud-gui.png), [signed-out baseline](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-closure-baseline-plugin-cloud-signed-out-gui.png) / [candidate](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-closure-candidate-plugin-cloud-signed-out-gui.png).

[Clean-base audit comparison](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/30889-eliza-css-audit-baseline-comparison.md) · [Final SQLite evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30889-closure-evidence-v2.sqlite)


- Full `audit:app` capture completed, but the aggregate gate failed on eight Cloud-view readiness checks (two views across four sizes). A clean detached c039 build reproduces both affected desktop cases with byte-identical screenshots. The predicate expects an absent “Eliza Cloud” heading. The other six viewport findings were not rerun on baseline. This remains a failed audit, not a passing result.
- The audit build manifest records pre-commit c039. Direct inspection of its emitted helper confirms the final CSS recognition and both storage-denial guards; later commits snapshot that production source and add tests.
- This follow-up is not yet merged or deployed. Live staging success/replay evidence applies to c039, not this candidate.
- #18627 still needs fresh-account running-agent evidence and reconciliation with the intentional dashboard simplification in #22546.

## Maintainer CI exception record

N/A - no exception requested.
