### PR TITLE
feat(core): add unregister/unregisterMany to ContextRegistry

### DIFF
--- a/packages/core/src/runtime/__tests__/context-registry.test.ts
+++ b/packages/core/src/runtime/__tests__/context-registry.test.ts
@@ -82,6 +82,93 @@ describe("context registry", () => {
 		expect(satisfiesRoleGate(["MEMBER"], { minRole: "ADMIN" })).toBe(false);
 	});
 
+	it("unregisters a leaf context and reflects removal in has/get", () => {
+		const registry = new ContextRegistry([
+			{ id: "alpha", subcontexts: ["beta"] },
+			{ id: "beta" },
+			{ id: "gamma" },
+		]);
+
+		expect(registry.has("gamma")).toBe(true);
+		expect(registry.unregister("gamma")).toBe(true);
+		expect(registry.has("gamma")).toBe(false);
+		expect(registry.get("gamma")).toBeUndefined();
+		// Unrelated definitions survive.
+		expect(registry.has("alpha")).toBe(true);
+		expect(registry.has("beta")).toBe(true);
+	});
+
+	it("normalizes ids before removal", () => {
+		const registry = new ContextRegistry([{ id: "screen_time" }]);
+		expect(registry.unregister(" Screen-Time ")).toBe(true);
+		expect(registry.has("screen_time")).toBe(false);
+	});
+
+	it("returns false when unregistering an unknown id", () => {
+		const registry = new ContextRegistry([{ id: "alpha" }]);
+		expect(registry.unregister("nope")).toBe(false);
+		expect(registry.has("alpha")).toBe(true);
+	});
+
+	it("partitions unregisterMany into removed and missing", () => {
+		const registry = new ContextRegistry([{ id: "alpha" }, { id: "beta" }]);
+
+		const result = registry.unregisterMany(["alpha", "absent", "beta"]);
+		expect(result.removed).toEqual(["alpha", "beta"]);
+		expect(result.missing).toEqual(["absent"]);
+		expect(registry.has("alpha")).toBe(false);
+		expect(registry.has("beta")).toBe(false);
+	});
+
+	it("throws and leaves state intact when removal would orphan an edge", () => {
+		const registry = new ContextRegistry([
+			{ id: "parent_ctx", subcontexts: ["child_ctx"] },
+			{ id: "child_ctx" },
+		]);
+
+		expect(() => registry.unregister("child_ctx")).toThrow(
+			ContextRegistryError,
+		);
+		// The failed validation must not mutate the registry.
+		expect(registry.has("child_ctx")).toBe(true);
+		expect(registry.has("parent_ctx")).toBe(true);
+		expect(registry.get("parent_ctx")?.subcontexts).toEqual(["child_ctx"]);
+	});
+
+	it("throws when a surviving parent edge would dangle", () => {
+		const registry = new ContextRegistry([
+			{ id: "root_ctx" },
+			{ id: "leaf_ctx", parent: "root_ctx" },
+		]);
+
+		expect(() => registry.unregister("root_ctx")).toThrow(ContextRegistryError);
+		expect(registry.has("root_ctx")).toBe(true);
+		expect(registry.has("leaf_ctx")).toBe(true);
+	});
+
+	it("removes a context together with its referencing definition", () => {
+		const registry = new ContextRegistry([
+			{ id: "parent_ctx", subcontexts: ["child_ctx"] },
+			{ id: "child_ctx" },
+			{ id: "other_ctx" },
+		]);
+
+		const result = registry.unregisterMany(["parent_ctx", "child_ctx"]);
+		expect(result.removed).toEqual(["parent_ctx", "child_ctx"]);
+		expect(result.missing).toEqual([]);
+		expect(registry.has("parent_ctx")).toBe(false);
+		expect(registry.has("child_ctx")).toBe(false);
+		expect(registry.has("other_ctx")).toBe(true);
+	});
+
+	it("reports only missing ids without mutating when nothing is removed", () => {
+		const registry = new ContextRegistry([{ id: "alpha" }]);
+		const result = registry.unregisterMany(["x", "y"]);
+		expect(result.removed).toEqual([]);
+		expect(result.missing).toEqual(["x", "y"]);
+		expect(registry.has("alpha")).toBe(true);
+	});
+
 	it("detects parent and subcontext cycles", () => {
 		const definitions: ContextDefinition[] = [
 			{ id: "alpha", subcontexts: ["beta"] },

--- a/packages/core/src/runtime/__tests__/context-registry.test.ts
+++ b/packages/core/src/runtime/__tests__/context-registry.test.ts
@@ -181,6 +181,30 @@ describe("context registry", () => {
 		expect(registry.has("parent_ctx")).toBe(true);
 	});
 
+	it("de-duplicates repeated ids so each lands in exactly one partition", () => {
+		const registry = new ContextRegistry([{ id: "alpha" }, { id: "beta" }]);
+
+		// A repeated present id must not appear in both partitions: the first
+		// delete succeeds, and a naive second pass would report the same id as
+		// `missing`, breaking the removed/missing partition contract.
+		const present = registry.unregisterMany(["alpha", "alpha"]);
+		expect(present.removed).toEqual(["alpha"]);
+		expect(present.missing).toEqual([]);
+		expect(registry.has("alpha")).toBe(false);
+
+		// A repeated absent id is reported once, not once per occurrence.
+		const absent = registry.unregisterMany(["ghost", "ghost"]);
+		expect(absent.removed).toEqual([]);
+		expect(absent.missing).toEqual(["ghost"]);
+
+		// Normalization applies before de-duplication, so surface variants of the
+		// same id collapse to a single partition entry.
+		const variants = registry.unregisterMany(["beta", " Beta "]);
+		expect(variants.removed).toEqual(["beta"]);
+		expect(variants.missing).toEqual([]);
+		expect(registry.has("beta")).toBe(false);
+	});
+
 	it("reports only missing ids without mutating when nothing is removed", () => {
 		const registry = new ContextRegistry([{ id: "alpha" }]);
 		const result = registry.unregisterMany(["x", "y"]);

--- a/packages/core/src/runtime/__tests__/context-registry.test.ts
+++ b/packages/core/src/runtime/__tests__/context-registry.test.ts
@@ -161,6 +161,26 @@ describe("context registry", () => {
 		expect(registry.has("other_ctx")).toBe(true);
 	});
 
+	it("rolls back the whole batch when one requested removal would orphan an edge", () => {
+		const registry = new ContextRegistry([
+			{ id: "parent_ctx", subcontexts: ["child_ctx"] },
+			{ id: "child_ctx" },
+			{ id: "removable_ctx" },
+		]);
+
+		// child_ctx is still referenced by parent_ctx, so removing it is invalid;
+		// removable_ctx is unrelated and would drop cleanly on its own.
+		expect(() =>
+			registry.unregisterMany(["removable_ctx", "child_ctx"]),
+		).toThrow(ContextRegistryError);
+
+		// Atomic rollback: the otherwise-removable sibling in the same batch is
+		// not dropped when a later id fails validation.
+		expect(registry.has("removable_ctx")).toBe(true);
+		expect(registry.has("child_ctx")).toBe(true);
+		expect(registry.has("parent_ctx")).toBe(true);
+	});
+
 	it("reports only missing ids without mutating when nothing is removed", () => {
 		const registry = new ContextRegistry([{ id: "alpha" }]);
 		const result = registry.unregisterMany(["x", "y"]);

--- a/packages/core/src/runtime/context-registry.ts
+++ b/packages/core/src/runtime/context-registry.ts
@@ -126,6 +126,60 @@ export class ContextRegistry {
 	}
 
 	/**
+	 * Remove a single context definition. Returns true when an entry with the
+	 * given id existed and was removed, false when it was not present. The id is
+	 * normalized (like `get`/`has`) before lookup.
+	 *
+	 * Removal is validated: if a surviving definition still references the
+	 * removed context through a `parent`/`parents`/`subcontext` edge, this throws
+	 * `ContextRegistryError` and leaves `#definitions` untouched. This lets a
+	 * narrow-domain deployment trim the seeded first-party catalog without
+	 * leaving the registry in an inconsistent, dangling-edge state.
+	 */
+	unregister(id: AgentContext): boolean {
+		return this.unregisterMany([id]).removed.length > 0;
+	}
+
+	/**
+	 * Batch removal, atomic like `registerMany`. Partitions the requested ids
+	 * into `removed` (present and dropped) and `missing` (not registered), then
+	 * commits the surviving map only after edge revalidation succeeds.
+	 *
+	 * Ids are normalized before lookup. If any surviving definition still
+	 * references a removed context via `parent`/`parents`/`subcontexts`, this
+	 * throws `ContextRegistryError` naming the referencing id and the missing
+	 * target, and `#definitions` is left unchanged. Removing a context together
+	 * with every definition that references it in a single call therefore
+	 * succeeds.
+	 */
+	unregisterMany(ids: readonly AgentContext[]): {
+		removed: AgentContext[];
+		missing: AgentContext[];
+	} {
+		const removed: AgentContext[] = [];
+		const missing: AgentContext[] = [];
+		const next = new Map(this.#definitions);
+		for (const id of ids) {
+			const normalized = normalizeContextId(id);
+			if (next.delete(normalized)) {
+				removed.push(normalized);
+			} else {
+				missing.push(normalized);
+			}
+		}
+		if (removed.length === 0) {
+			return { removed, missing };
+		}
+		assertNoUnknownEdges(next);
+		assertNoContextCycles(next);
+		this.#definitions.clear();
+		for (const [id, definition] of next) {
+			this.#definitions.set(id, definition);
+		}
+		return { removed, missing };
+	}
+
+	/**
 	 * Return all context definitions whose role gate (if any) is satisfied by
 	 * the supplied caller role(s). Contexts without a role gate are always
 	 * included. The order matches `list()` for stable prompt rendering.

--- a/packages/core/src/runtime/context-registry.ts
+++ b/packages/core/src/runtime/context-registry.ts
@@ -145,7 +145,9 @@ export class ContextRegistry {
 	 * into `removed` (present and dropped) and `missing` (not registered), then
 	 * commits the surviving map only after edge revalidation succeeds.
 	 *
-	 * Ids are normalized before lookup. If any surviving definition still
+	 * Ids are normalized and de-duplicated before lookup, so a repeated id lands
+	 * in exactly one partition rather than being reported as both removed and
+	 * missing. If any surviving definition still
 	 * references a removed context via `parent`/`parents`/`subcontexts`, this
 	 * throws `ContextRegistryError` naming the referencing id and the missing
 	 * target, and `#definitions` is left unchanged. Removing a context together
@@ -158,9 +160,14 @@ export class ContextRegistry {
 	} {
 		const removed: AgentContext[] = [];
 		const missing: AgentContext[] = [];
+		const seen = new Set<AgentContext>();
 		const next = new Map(this.#definitions);
 		for (const id of ids) {
 			const normalized = normalizeContextId(id);
+			if (seen.has(normalized)) {
+				continue;
+			}
+			seen.add(normalized);
 			if (next.delete(normalized)) {
 				removed.push(normalized);
 			} else {


### PR DESCRIPTION
# Relates to

Closes #30858

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync. Focused package test, typecheck, and
      lint pass (output below). `bun run verify` is a full-repo gate; the
      affected surface is one leaf module in `@elizaos/core` and its unit test,
      exercised directly below.
- [x] A reviewer can confirm the change works from the evidence attached below.

# Sync with develop

- [x] Branched from and current with `origin/develop` at `c039b4a455`; zero conflicts.
- [x] Focused core checks pass post-sync (see Evidence). Full `bun run verify`
      was not run end-to-end on this machine; the change is confined to
      `packages/core/src/runtime/context-registry.ts` and its test, both of
      which pass typecheck + lint + unit tests.

# Risks

Low. Purely additive: two new public methods on `ContextRegistry` plus tests.
No existing method, signature, or seeded catalog behavior changes. Removal is
edge-validated and atomic, so a rejected removal cannot corrupt `#definitions`.

# Background

## What does this PR do?

`ContextRegistry` seeds ~39 first-party context definitions at boot and, prior
to this change, exposed no removal path (`#definitions` is a genuine private
field). A narrow-domain agent (e.g. a trading/social-posting agent with no
email/calendar/health plugins) therefore rendered the full catalog into every
Stage-1 routing prompt via `{{availableContexts}}`, spending tokens on
categories it can never act on, with no supported way to trim the catalog short
of patching core.

This adds a supported removal API mirroring the existing registration style:

- `unregister(id: AgentContext): boolean` — remove one definition; returns
  `true` if it existed and was removed, `false` otherwise. Normalizes the id via
  `normalizeContextId` (same as `get`/`has`).
- `unregisterMany(ids): { removed: AgentContext[]; missing: AgentContext[] }` —
  batch removal, atomic like `registerMany`, partitioning requested ids.

Correctness guarantee: removal builds a candidate `next` map without the removed
ids, runs `assertNoUnknownEdges`/`assertNoContextCycles` on it, and only commits
(clear-then-repopulate, mirroring `registerMany`) if validation passes. If a
surviving definition still references a removed context via
`parent`/`parents`/`subcontexts`, it throws `ContextRegistryError` naming the
offending edge and leaves `#definitions` untouched. Removing a context together
with every definition that references it in one `unregisterMany` call therefore
succeeds.

Scope is deliberately confined to the registry methods + tests. The alternative
`Character.contexts.exclude` option mentioned in the issue is intentionally out
of scope — `unregister`/`unregisterMany` are the clean, minimal supported
extension point.

## What kind of change is this?

Features (non-breaking change which adds a supported extension point).

# Documentation changes needed?

No separate docs site change. Both public methods carry JSDoc matching the
surrounding `tryRegister`/`tryRegisterMany` style, documenting the atomic-commit
and edge-revalidation contract.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/context-registry.ts` (the two new methods) and the
added cases in `packages/core/src/runtime/__tests__/context-registry.test.ts`.

## Detailed testing steps

```bash
bun install
cd packages/core
node ../scripts/run-vitest.mjs run src/runtime/__tests__/context-registry.test.ts
bunx tsc --noEmit -p ./tsconfig.json
bunx @biomejs/biome check ./src/runtime/context-registry.ts ./src/runtime/__tests__/context-registry.test.ts
```

New tests cover: leaf removal reflected by `has`/`get`; id normalization on
removal; unknown-id returns `false`; `unregisterMany` `removed`/`missing`
partition; removing a still-referenced `subcontext` throws and leaves state
intact; removing a still-referenced `parent` throws; removing a context with its
referencing definition in one call succeeds; a no-op batch reports only
`missing` without mutating; and repeated ids de-duplicated so each lands in exactly one partition.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:99a2988e5fed61a637cae1d492e20b1bc93b8621 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; change is a core runtime module and its unit test.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; change is a core runtime module and its unit test.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow; library method on ContextRegistry.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no server path exercised; deterministic unit test proves the contract (output below).`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; pure registry data-structure method.`
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic verification transcript captured at the reviewed head `99a2988e5fed61a637cae1d492e20b1bc93b8621` (focused test, typecheck, lint). This fork account lacks push access to `elizaOS/eliza`, so a `pr-evidence` release upload returns HTTP 404 and the `user-attachments` route requires the web uploader; per the evidence gate's documented fork-contributor floor the proof is pasted inline instead of linked:

```
$ node ../scripts/run-vitest.mjs run src/runtime/__tests__/context-registry.test.ts --reporter verbose   # cwd: packages/core
 ✓ context registry > unregisters a leaf context and reflects removal in has/get
 ✓ context registry > normalizes ids before removal
 ✓ context registry > returns false when unregistering an unknown id
 ✓ context registry > partitions unregisterMany into removed and missing
 ✓ context registry > throws and leaves state intact when removal would orphan an edge
 ✓ context registry > throws when a surviving parent edge would dangle
 ✓ context registry > removes a context together with its referencing definition
 ✓ context registry > rolls back the whole batch when one requested removal would orphan an edge
 ✓ context registry > de-duplicates repeated ids so each lands in exactly one partition
 ✓ context registry > reports only missing ids without mutating when nothing is removed

 Test Files  1 passed (1)
      Tests  16 passed (16)

$ bunx tsc --noEmit -p ./tsconfig.json ; echo exit=$?
exit=0

$ bunx @biomejs/biome check ./src/runtime/context-registry.ts ./src/runtime/__tests__/context-registry.test.ts
Checked 2 files. No fixes applied.
exit=0
```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

`N/A - no server or frontend path.` Deterministic unit-test output:

<details>
<summary>Focused test — 16 passed (verbose, head 99a2988)</summary>

```
 RUN  v4.1.10 packages/core

 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > unregisters a leaf context and reflects removal in has/get
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > normalizes ids before removal
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > returns false when unregistering an unknown id
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > partitions unregisterMany into removed and missing
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > throws and leaves state intact when removal would orphan an edge
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > throws when a surviving parent edge would dangle
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > removes a context together with its referencing definition
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > rolls back the whole batch when one requested removal would orphan an edge
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > de-duplicates repeated ids so each lands in exactly one partition
 ✓ src/runtime/__tests__/context-registry.test.ts > context registry > reports only missing ids without mutating when nothing is removed

 Test Files  1 passed (1)
      Tests  16 passed (16)
```
</details>

<details>
<summary>Typecheck (exit 0) and lint (clean)</summary>

```
=== TYPECHECK: bunx tsc --noEmit -p ./tsconfig.json ===
exit=0
=== LINT: bunx @biomejs/biome check src/runtime/context-registry.ts src/runtime/__tests__/context-registry.test.ts ===
Checked 2 files. No fixes applied.
exit=0
```
</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/audio change.`

## Known gaps / failures

Full `bun run verify` (whole-repo parity/audit gate) was not executed end-to-end
on this constrained machine. The diff is a single additive leaf module in
`@elizaos/core` plus its unit test; the owning package's focused test, `tsc`
typecheck, and Biome lint all pass (output above), which fully exercises the
changed contract.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@99a2988e5fed61a637cae1d492e20b1bc93b8621:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@99a2988e5fed61a637cae1d492e20b1bc93b8621:packages/skills/skills/contribute-to-eliza"} -->

