### PR TITLE
fix(plugin-native-talkmode): keep a torn-down session idle when speech ends late

### DIFF
--- a/plugins/plugin-native-talkmode/src/web.test.ts
+++ b/plugins/plugin-native-talkmode/src/web.test.ts
@@ -265,6 +265,91 @@ describe("TalkModeWeb fallback", () => {
     });
   });
 
+  it("does not resurrect listening when an utterance ends after stop() (#27977)", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+    const complete = vi.fn();
+    await plugin.addListener("speakComplete", complete);
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    const speaking = plugin.speak({ text: "Here is your answer." });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "speaking",
+      statusText: "Speaking",
+    });
+
+    // The user turns talk mode off while the reply is still being spoken.
+    await plugin.stop();
+    expect(synthesis.cancel).toHaveBeenCalledTimes(1);
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+
+    // The browser delivers the cancelled utterance's completion afterwards.
+    // Before the fix this wrote "listening" over the idle state the teardown
+    // had set, showing a live session that no longer existed.
+    utterances[0]?.onend?.();
+    await expect(speaking).resolves.toEqual({
+      completed: true,
+      interrupted: false,
+      usedSystemTts: true,
+    });
+    expect(complete).toHaveBeenCalledWith({ completed: true });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+    await expect(plugin.isEnabled()).resolves.toEqual({ enabled: false });
+  });
+
+  it("keeps the idle teardown state when a cancelled utterance errors after stop()", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    const speaking = plugin.speak({ text: "Here is your answer." });
+    await plugin.stop();
+
+    // Browsers report a cancelled utterance as an "interrupted" error.
+    utterances[0]?.onerror?.({ error: "interrupted" });
+    await expect(speaking).resolves.toMatchObject({
+      completed: false,
+      interrupted: true,
+      usedSystemTts: true,
+    });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+  });
+
   it("restarts the recognizer on a spontaneous onend while listening (regression)", async () => {
     const synthesis = { cancel: vi.fn(), speak: vi.fn(), speaking: false };
     setWindow({

--- a/plugins/plugin-native-talkmode/src/web.test.ts
+++ b/plugins/plugin-native-talkmode/src/web.test.ts
@@ -316,6 +316,78 @@ describe("TalkModeWeb fallback", () => {
     await expect(plugin.isEnabled()).resolves.toEqual({ enabled: false });
   });
 
+  it("returns to listening when stopSpeaking() interrupts a live session and the utterance ends late", async () => {
+    const utterances: FakeUtterance[] = [];
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn((value: FakeUtterance) => {
+        utterances.push(value);
+      }),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.start()).resolves.toEqual({ started: true });
+    const speaking = plugin.speak({ text: "A long reply the user cuts off." });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "speaking",
+      statusText: "Speaking",
+    });
+
+    // The user interrupts speech; the session itself stays on.
+    await expect(plugin.stopSpeaking()).resolves.toEqual({
+      interruptedAt: undefined,
+    });
+    expect(synthesis.cancel).toHaveBeenCalledTimes(1);
+    await expect(plugin.isEnabled()).resolves.toEqual({ enabled: true });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "listening",
+      statusText: "Listening",
+    });
+
+    // The cancelled utterance's late end or error event must leave that
+    // listening state alone, and must still settle the speak() promise.
+    utterances[0]?.onerror?.({ error: "interrupted" });
+    await expect(speaking).resolves.toEqual({
+      completed: false,
+      interrupted: true,
+      usedSystemTts: true,
+      error: "interrupted",
+    });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "listening",
+      statusText: "Listening",
+    });
+  });
+
+  it("does not touch state when stopSpeaking() runs on a session that is off", async () => {
+    const synthesis = {
+      cancel: vi.fn(),
+      speaking: false,
+      speak: vi.fn(),
+    };
+    setWindow({
+      SpeechRecognition: FakeRecognition,
+      speechSynthesis: synthesis,
+    });
+    setNavigator({});
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+
+    await expect(plugin.stopSpeaking()).resolves.toEqual({});
+    expect(synthesis.cancel).not.toHaveBeenCalled();
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+  });
+
   it("keeps the idle teardown state when a cancelled utterance errors after stop()", async () => {
     const utterances: FakeUtterance[] = [];
     const synthesis = {

--- a/plugins/plugin-native-talkmode/src/web.test.ts
+++ b/plugins/plugin-native-talkmode/src/web.test.ts
@@ -204,6 +204,11 @@ describe("TalkModeWeb fallback", () => {
       isSystemTts: true,
     });
     expect(complete).toHaveBeenCalledWith({ completed: true });
+    await expect(plugin.isEnabled()).resolves.toEqual({ enabled: false });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
   });
 
   it.each(["end", "error"] as const)(
@@ -246,6 +251,33 @@ describe("TalkModeWeb fallback", () => {
       await plugin.stop();
     },
   );
+
+  it("keeps standalone TTS off after interruption", async () => {
+    let utterance: FakeUtterance | undefined;
+    setWindow({
+      speechSynthesis: {
+        cancel: () => utterance?.onend?.(),
+        speak: (value: FakeUtterance) => {
+          utterance = value;
+        },
+        speaking: false,
+      },
+    });
+    vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+    const plugin = new TalkModeWeb();
+    const reply = plugin.speak({ text: "Standalone reply" });
+    await plugin.stopSpeaking();
+    await expect(reply).resolves.toEqual({
+      completed: false,
+      interrupted: true,
+      usedSystemTts: true,
+    });
+    await expect(plugin.isEnabled()).resolves.toEqual({ enabled: false });
+    await expect(plugin.getState()).resolves.toEqual({
+      state: "idle",
+      statusText: "Off",
+    });
+  });
 
   it.each(["stop", "stopSpeaking"] as const)(
     "%s marks the complete browser queue interrupted before synchronous cancel callbacks",

--- a/plugins/plugin-native-talkmode/src/web.test.ts
+++ b/plugins/plugin-native-talkmode/src/web.test.ts
@@ -206,6 +206,85 @@ describe("TalkModeWeb fallback", () => {
     expect(complete).toHaveBeenCalledWith({ completed: true });
   });
 
+  it.each(["end", "error"] as const)(
+    "preserves a newer reply when the replaced utterance reports %s",
+    async (completion) => {
+      const utterances: FakeUtterance[] = [];
+      setWindow({
+        SpeechRecognition: FakeRecognition,
+        speechSynthesis: {
+          cancel: vi.fn(),
+          speaking: false,
+          speak: (utterance: FakeUtterance) => utterances.push(utterance),
+        },
+      });
+      setNavigator({});
+      vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+      const plugin = new TalkModeWeb();
+      const states: string[] = [];
+      await plugin.addListener("stateChange", (event) =>
+        states.push(event.state),
+      );
+      await plugin.start();
+      const first = plugin.speak({ text: "First reply" });
+      const next = plugin.speak({ text: "Next reply" });
+      const statesBeforeCompletion = [...states];
+      if (completion === "end") utterances[0]?.onend?.();
+      else utterances[0]?.onerror?.({ error: "interrupted" });
+      await expect(first).resolves.toMatchObject({ usedSystemTts: true });
+      expect(states).toEqual(statesBeforeCompletion);
+      await expect(plugin.getState()).resolves.toEqual({
+        state: "speaking",
+        statusText: "Speaking",
+      });
+      utterances[1]?.onend?.();
+      await expect(next).resolves.toMatchObject({ completed: true });
+      await expect(plugin.getState()).resolves.toEqual({
+        state: "listening",
+        statusText: "Listening",
+      });
+      await plugin.stop();
+    },
+  );
+
+  it.each(["stop", "stopSpeaking"] as const)(
+    "%s marks the complete browser queue interrupted before synchronous cancel callbacks",
+    async (operation) => {
+      const utterances: FakeUtterance[] = [];
+      setWindow({
+        SpeechRecognition: FakeRecognition,
+        speechSynthesis: {
+          cancel: () => {
+            for (const utterance of utterances) utterance.onend?.();
+          },
+          speaking: false,
+          speak: (utterance: FakeUtterance) => utterances.push(utterance),
+        },
+      });
+      setNavigator({});
+      vi.stubGlobal("SpeechSynthesisUtterance", FakeUtterance);
+      const plugin = new TalkModeWeb();
+      const completed: boolean[] = [];
+      await plugin.addListener("speakComplete", (event) =>
+        completed.push(event.completed),
+      );
+      await plugin.start();
+      const first = plugin.speak({ text: "Queued first reply" });
+      const second = plugin.speak({ text: "Queued next reply" });
+      await plugin[operation]();
+      expect(await Promise.all([first, second])).toEqual([
+        { completed: false, interrupted: true, usedSystemTts: true },
+        { completed: false, interrupted: true, usedSystemTts: true },
+      ]);
+      expect(completed).toEqual([false, false]);
+      await expect(plugin.getState()).resolves.toEqual(
+        operation === "stop"
+          ? { state: "idle", statusText: "Off" }
+          : { state: "listening", statusText: "Listening" },
+      );
+    },
+  );
+
   it("restarts the recognizer when the session ends mid-utterance while speaking (issue #22369)", async () => {
     const utterances: FakeUtterance[] = [];
     const synthesis = {
@@ -304,11 +383,11 @@ describe("TalkModeWeb fallback", () => {
     // had set, showing a live session that no longer existed.
     utterances[0]?.onend?.();
     await expect(speaking).resolves.toEqual({
-      completed: true,
-      interrupted: false,
+      completed: false,
+      interrupted: true,
       usedSystemTts: true,
     });
-    expect(complete).toHaveBeenCalledWith({ completed: true });
+    expect(complete).toHaveBeenCalledWith({ completed: false });
     await expect(plugin.getState()).resolves.toEqual({
       state: "idle",
       statusText: "Off",

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -212,7 +212,11 @@ export class TalkModeWeb extends WebPlugin {
         this.notifyListeners("speakComplete", {
           completed: !outcome.cancelled,
         });
-        if (!stale) this.setState("listening", "Listening");
+        if (!stale)
+          this.setState(
+            this.enabled ? "listening" : "idle",
+            this.enabled ? "Listening" : "Off",
+          );
         resolve({
           completed: !outcome.cancelled,
           interrupted: outcome.cancelled,
@@ -243,9 +247,10 @@ export class TalkModeWeb extends WebPlugin {
       this.cancelPendingSpeech();
       // The cancelled utterance's own end event is stale from here on, so the
       // resumed listening state is set here rather than by that handler.
-      if (this.enabled) {
-        this.setState("listening", "Listening");
-      }
+      this.setState(
+        this.enabled ? "listening" : "idle",
+        this.enabled ? "Listening" : "Off",
+      );
       return { interruptedAt: undefined };
     }
     return {};

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -31,6 +31,10 @@ export class TalkModeWeb extends WebPlugin {
   private statusText = "Off";
   private synthesis: SpeechSynthesis | null = null;
   private currentUtterance: SpeechSynthesisUtterance | null = null;
+  private pendingSpeech = new Map<
+    SpeechSynthesisUtterance,
+    { cancelled: boolean }
+  >();
   private recognition: SpeechRecognitionInstance | null = null;
   private enabled = false;
 
@@ -140,8 +144,7 @@ export class TalkModeWeb extends WebPlugin {
     this.enabled = false;
     this.recognition?.stop();
     this.recognition = null;
-    this.synthesis?.cancel();
-    this.currentUtterance = null;
+    this.cancelPendingSpeech();
     this.setState("idle", "Off");
   }
 
@@ -181,6 +184,8 @@ export class TalkModeWeb extends WebPlugin {
     return new Promise((resolve) => {
       const utterance = new SpeechSynthesisUtterance(text);
       this.currentUtterance = utterance;
+      const outcome = { cancelled: false };
+      this.pendingSpeech.set(utterance, outcome);
 
       // Always set language — fallback to en-US if directive doesn't specify.
       // Without this, the browser uses the system locale, which may read
@@ -196,30 +201,34 @@ export class TalkModeWeb extends WebPlugin {
         utterance.rate = options.directive.speed;
       }
 
-      // stop() and stopSpeaking() null `currentUtterance` when they cancel
-      // synthesis, and the browser delivers this utterance's end or error
-      // event afterwards. A stale handler must still settle the promise and
-      // notify listeners, but must not write "listening" or "Speech error"
-      // over the state the caller already set: idle for a teardown, listening
-      // for an interruption of a live session.
+      // Replaced replies may finish normally; explicitly cancelled replies may
+      // not claim successful speech even if the browser later reports an end.
       const isStale = () => this.currentUtterance !== utterance;
 
       utterance.onend = () => {
         const stale = isStale();
+        this.pendingSpeech.delete(utterance);
         if (!stale) this.currentUtterance = null;
-        this.notifyListeners("speakComplete", { completed: true });
+        this.notifyListeners("speakComplete", {
+          completed: !outcome.cancelled,
+        });
         if (!stale) this.setState("listening", "Listening");
-        resolve({ completed: true, interrupted: false, usedSystemTts: true });
+        resolve({
+          completed: !outcome.cancelled,
+          interrupted: outcome.cancelled,
+          usedSystemTts: true,
+        });
       };
 
       utterance.onerror = (event) => {
         const stale = isStale();
+        this.pendingSpeech.delete(utterance);
         if (!stale) this.currentUtterance = null;
         this.notifyListeners("speakComplete", { completed: false });
         if (!stale) this.setState("idle", "Speech error");
         resolve({
           completed: false,
-          interrupted: event.error === "interrupted",
+          interrupted: outcome.cancelled || event.error === "interrupted",
           usedSystemTts: true,
           error: event.error,
         });
@@ -231,8 +240,7 @@ export class TalkModeWeb extends WebPlugin {
 
   async stopSpeaking(): Promise<{ interruptedAt?: number }> {
     if (this.synthesis && this.currentUtterance) {
-      this.synthesis.cancel();
-      this.currentUtterance = null;
+      this.cancelPendingSpeech();
       // The cancelled utterance's own end event is stale from here on, so the
       // resumed listening state is set here rather than by that handler.
       if (this.enabled) {
@@ -241,6 +249,14 @@ export class TalkModeWeb extends WebPlugin {
       return { interruptedAt: undefined };
     }
     return {};
+  }
+
+  private cancelPendingSpeech(): void {
+    // cancel() affects the whole browser queue and may synchronously call back.
+    for (const outcome of this.pendingSpeech.values()) outcome.cancelled = true;
+    this.pendingSpeech.clear();
+    this.currentUtterance = null;
+    this.synthesis?.cancel();
   }
 
   async isSpeaking(): Promise<{ speaking: boolean }> {

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -196,11 +196,12 @@ export class TalkModeWeb extends WebPlugin {
         utterance.rate = options.directive.speed;
       }
 
-      // stop() and interruptSpeech() null `currentUtterance` when they tear
-      // the session down, and the browser delivers this utterance's end or
-      // error event afterwards. A stale handler must still settle the promise
-      // and notify listeners, but must not write "listening" or "Speech error"
-      // over the idle state the teardown set.
+      // stop() and stopSpeaking() null `currentUtterance` when they cancel
+      // synthesis, and the browser delivers this utterance's end or error
+      // event afterwards. A stale handler must still settle the promise and
+      // notify listeners, but must not write "listening" or "Speech error"
+      // over the state the caller already set: idle for a teardown, listening
+      // for an interruption of a live session.
       const isStale = () => this.currentUtterance !== utterance;
 
       utterance.onend = () => {
@@ -232,6 +233,11 @@ export class TalkModeWeb extends WebPlugin {
     if (this.synthesis && this.currentUtterance) {
       this.synthesis.cancel();
       this.currentUtterance = null;
+      // The cancelled utterance's own end event is stale from here on, so the
+      // resumed listening state is set here rather than by that handler.
+      if (this.enabled) {
+        this.setState("listening", "Listening");
+      }
       return { interruptedAt: undefined };
     }
     return {};

--- a/plugins/plugin-native-talkmode/src/web.ts
+++ b/plugins/plugin-native-talkmode/src/web.ts
@@ -196,17 +196,26 @@ export class TalkModeWeb extends WebPlugin {
         utterance.rate = options.directive.speed;
       }
 
+      // stop() and interruptSpeech() null `currentUtterance` when they tear
+      // the session down, and the browser delivers this utterance's end or
+      // error event afterwards. A stale handler must still settle the promise
+      // and notify listeners, but must not write "listening" or "Speech error"
+      // over the idle state the teardown set.
+      const isStale = () => this.currentUtterance !== utterance;
+
       utterance.onend = () => {
-        this.currentUtterance = null;
+        const stale = isStale();
+        if (!stale) this.currentUtterance = null;
         this.notifyListeners("speakComplete", { completed: true });
-        this.setState("listening", "Listening");
+        if (!stale) this.setState("listening", "Listening");
         resolve({ completed: true, interrupted: false, usedSystemTts: true });
       };
 
       utterance.onerror = (event) => {
-        this.currentUtterance = null;
+        const stale = isStale();
+        if (!stale) this.currentUtterance = null;
         this.notifyListeners("speakComplete", { completed: false });
-        this.setState("idle", "Speech error");
+        if (!stale) this.setState("idle", "Speech error");
         resolve({
           completed: false,
           interrupted: event.error === "interrupted",


### PR DESCRIPTION
Stopping TalkMode while a browser utterance is outstanding must keep the session Off when its late completion arrives. The original author repair guards the current utterance and restores listening directly on an explicit speech interruption. This revision retains those two authored commits and adds truthful cancellation receipts: every pending utterance affected by browser queue cancellation reports interrupted, including when the browser delivers an end event. A replaced but uncancelled utterance can still complete normally without overwriting the newer reply's state.

Closes #27977. This is the web SpeechSynthesis fallback, not native audio or buffered Cloud/ElevenLabs playback acceptance.

## Candidate and validation

- Base: `4985223ea31c01d6eec22c5d6aea7d79913ef896`.
- Head: `052153e0a2012ce5ef4fb676bafdfe151f6a4e71`.
- Author history retained: original two commits rebased; scoped cancellation followup added separately.
- Normal install: Node 24.15.0 / Bun 1.3.14, current-base install passed in 17.97s. Current-base root verification passed, 373/373 tasks and all final audits; earlier f6a verification also passed.
- Owning package:29tests/3files pass; typecheck and lint pass.
- Exact public develop source with regression harness:5failures/21passes. Original PR source with truthful cancelled-completion assertion:1failure/25passes. Both source controls restored before subsequent validation.
- Root verification: passed, 373/373 tasks and all final repository audits; exit0.

The four extra cases exercise old end/error callbacks after a replacement reply begins, its normal completion, and whole-queue cancellation with synchronous callbacks for stop and stopSpeaking. Pending entries are cleared before browser cancellation; individual callback closures preserve their cancellation result. No new timer, retry, permission or speech backend.

## Actual browser synthesis and rendered consumer evidence

Real Chromium SpeechSynthesis (installed system voices), real TalkModeWeb, actual synthesis start/interrupted/end events and rendered state/event consumer. Only recognition is substituted, avoiding microphone access. Desktop1440×900 andmobile390×844 each ran exactpublicdevelop before andcandidate after, then a naturally completed next utterance.

| Consumer result | Public develop | Candidate |
| --- | --- | --- |
| Stop while actual synthesis speaks | Speech error (incorrect) | Off |
| Cancelled result | completed:false/interrupted:true | completed:false/interrupted:true |
| Next utterance naturally completes | Listening/success | Listening/success |
| Browser errors |0|0|

The native browser actually delivered interrupted errors after Stop; the deterministic real-event control separately proves truthful cancellation when a browser reports end instead. Complete nativeevents, results, state transitions and pageerror logs accompany full-page desktop/mobile screenshots and four MP4 walkthroughs. This is a scoped plugin consumer harness, not the full Eliza shell. Browser speech completion events do not establish physical audibility, ASR, installednative output, or bufferedCloud/ElevenLabs acceptance.

The earlier event-control harness first rejected a missing required SpeechSynthesisEvent initialization argument; that setupfailure was retained and corrected. No provider/network calls or microphonepermissions were used. Source and exactbase were restored after the counterfactual bundle build.

Independent root source review approved the final cancellation/pointer handling. Central merge review remains required; no merge or deployment is claimed.

Standalone supported TTS without starting recognition also stays Off after normal completion or explicit cancellation. Real Chromium start/end and start/interrupted receipts confirm both outcomes with enabled:false. The added fixture reproduced the earlier incorrect Listening state.

Captures were recorded at f6a99685dce6a22c5473bb55819c29124bbfc7e3. The rebased candidate has identical TalkMode package source, and the public-base change leaves TalkMode and its UI voice consumer unchanged. Current candidate provenance will accompany the final gate receipt.

<!-- evidence-head:052153e0a2012ce5ef4fb676bafdfe151f6a4e71 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [Desktop stopped](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-desktop-before-stopped.png), [Desktop recovered](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-desktop-before-recovered.png), [Mobile stopped](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-mobile-before-stopped.png), [Mobile recovered](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-mobile-before-recovered.png).

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [Desktop stopped](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-desktop-after-stopped.png), [Desktop recovered](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-desktop-after-recovered.png), [Mobile stopped](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-mobile-after-stopped.png), [Mobile recovered](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-mobile-after-recovered.png).

<!-- evidence-row:walkthrough-video -->
- [x] MP4 walkthroughs: [desktop-before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-desktop-before-walkthrough.mp4), [desktop-after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-052153e-desktop-after-faststart.mp4), [mobile-before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-052153e-mobile-before-faststart.mp4), [mobile-after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-mobile-after-walkthrough.mp4).

<!-- evidence-row:frontend-logs -->
- [x] Browser events, state and console: [desktop-before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-desktop-before-receipt.json), [desktop-after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-desktop-after-receipt.json), [mobile-before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-mobile-before-receipt.json), [mobile-after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-mobile-after-receipt.json).

<!-- evidence-row:domain-artifacts -->
- [x] Actual standalone speech results: [Standalone receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-standalone.json), [29 passing tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-green-final.log), [Capture manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-f6a9968-manifest.json).

<!-- evidence-row:backend-logs -->
- [x] N/A: this browser-only plugin has no backend execution; native browser events are recorded above.

<!-- evidence-row:llm-trajectory -->
- [x] N/A: no model path changes or model calls.

<!-- evidence-row:ocr-review -->
- [x] [Tesseract OCR text readout](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-052153e-ocr.txt). All eight desktop/mobile captures reviewed individually; state, cancellation result and recovered result are readable. Scoped consumer harness, not full application or native-ASR proof.

Current candidate receipts: [normal install](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-052153e-install), [root verify](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-052153e-verify), [29 package tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-052153e-tests), [source/capture provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-052153e-provenance.json). Two MP4s were container-only faststart remuxes for evidence-prefix validation; decoded frame hashes are identical.


## Current develop integration proof

Published head remains `052153e0a2012ce5ef4fb676bafdfe151f6a4e71`; all five [hosted checks](https://github.com/elizaOS/eliza/actions/runs/34502215049) passed. Against develop `1020b4f9fb7f7b96418242d2c0c5393692f4c286`, clean local preview `1f41682e8325544d5719c8ad07b79f9c816e73c1` has tree `b7f8b2f77e576e501369b39e84b351a373e9d94d`, exactly equal to the Git merge tree of that base and the published head. TalkMode and its UI voice source are byte-identical to the published candidate, so the reviewed browser captures remain applicable.

The preview passed normal installation with Node24.15.0/Bun1.3.14, all373 repository tasks and final audits, and29 tests in3 package files. These are preview-head gates, distinct from hosted checks on the published head. Receipts: [install](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-1f41682-preview-install.log), [verify](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-1f41682-preview-verify.log), [package tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-1f41682-preview-tests.log), [exact provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30891-1f41682-preview-provenance.json). Central merge coordination remains in effect.
