### PR TITLE
fix(plugin-form): require a filled value before a required field counts as satisfied

### DIFF
--- a/plugins/plugin-form/src/service-required-pending.test.ts
+++ b/plugins/plugin-form/src/service-required-pending.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Pins that a required control is satisfied only by a filled field. A field
+ * whose external activation is still pending, or whose value is uncertain,
+ * must neither flip the session to ready nor pass submission. Exercises the
+ * real FormService against an in-memory component store; no transport.
+ */
+import type { Component, IAgentRuntime, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FormService } from "./service";
+import type { FieldState, FormDefinition } from "./types";
+
+const entityId = "00000000-0000-4000-8000-000000000201" as UUID;
+const roomId = "00000000-0000-4000-8000-000000000202" as UUID;
+const agentId = "00000000-0000-4000-8000-000000000203" as UUID;
+
+function makeRuntime() {
+  const components = new Map<string, Component>();
+  const keyFor = (entity: UUID, type: string) => `${entity}:${type}`;
+  return {
+    agentId,
+    getRoom: vi.fn(async () => ({ id: roomId, worldId: agentId })),
+    getComponent: vi.fn(async (entity: UUID, type: string) =>
+      components.get(keyFor(entity, type)),
+    ),
+    getComponents: vi.fn(async (entity: UUID) =>
+      Array.from(components.values()).filter((c) => c.entityId === entity),
+    ),
+    createComponent: vi.fn(async (component: Component) => {
+      components.set(keyFor(component.entityId, component.type), component);
+    }),
+    updateComponent: vi.fn(async (component: Component) => {
+      components.set(keyFor(component.entityId, component.type), component);
+    }),
+    deleteComponent: vi.fn(async (id: UUID) => {
+      for (const [key, component] of components) {
+        if (component.id === id) components.delete(key);
+      }
+    }),
+    emitEvent: vi.fn(async () => undefined),
+    registerTaskWorker: vi.fn(),
+    logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+const form: FormDefinition = {
+  id: "payment",
+  name: "Payment",
+  controls: [
+    { key: "wallet", label: "Wallet", type: "text", required: true },
+    { key: "note", label: "Note", type: "text", required: false },
+  ],
+};
+
+describe("required fields that are not yet filled", () => {
+  let service: FormService;
+
+  beforeEach(async () => {
+    service = (await FormService.start(makeRuntime())) as FormService;
+    service.registerForm(form);
+  });
+
+  async function sessionWithRequiredState(state: FieldState): Promise<string> {
+    const session = await service.startSession("payment", entityId, roomId);
+    session.fields.wallet = state;
+    await service.saveSession(session);
+    return session.id;
+  }
+
+  it.each([
+    ["pending external activation", { status: "pending" } satisfies FieldState],
+    [
+      "an uncertain value",
+      { status: "uncertain", value: "0xabc", confidence: 0.3 } as FieldState,
+    ],
+  ])(
+    "does not become ready or submit while the wallet is %s",
+    async (_label, state) => {
+      const sessionId = await sessionWithRequiredState(state);
+
+      // Filling the optional field re-evaluates readiness; the required field
+      // has no committed value yet, so the session must stay active.
+      await service.updateField(sessionId, entityId, "note", "hi", 1, "user");
+      const session = await service.getActiveSession(entityId, roomId);
+      expect(session?.status).toBe("active");
+
+      await expect(service.submit(sessionId, entityId)).rejects.toThrow(
+        /Not all required fields are filled/,
+      );
+    },
+  );
+
+  it("becomes ready and submits once the required field is filled", async () => {
+    const session = await service.startSession("payment", entityId, roomId);
+    await service.updateField(
+      session.id,
+      entityId,
+      "wallet",
+      "0xabc",
+      1,
+      "user",
+    );
+    const ready = await service.getActiveSession(entityId, roomId);
+    expect(ready?.status).toBe("ready");
+    const submission = await service.submit(session.id, entityId);
+    expect(submission.values.wallet).toBe("0xabc");
+  });
+});

--- a/plugins/plugin-form/src/service.ts
+++ b/plugins/plugin-form/src/service.ts
@@ -1661,12 +1661,13 @@ export class FormService extends Service {
     for (const control of form.controls) {
       if (!control.required) continue;
 
+      // Only a filled field satisfies a required control. A field whose
+      // external activation is still pending, or whose value is uncertain,
+      // has no committed value yet; treating either as filled let the
+      // session flip to ready and submit while the required value was still
+      // in flight, and skipping a required control is refused upstream.
       const fieldState = session.fields[control.key];
-      if (
-        !fieldState ||
-        fieldState.status === "empty" ||
-        fieldState.status === "invalid"
-      ) {
+      if (fieldState?.status !== "filled") {
         return false;
       }
     }


### PR DESCRIPTION
# Relates to

Closes #27773.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One predicate changes: `checkAllRequiredFilled` in `plugins/plugin-form/src/service.ts` now requires `status === "filled"` for a required control instead of merely not `"skipped"`. Optional controls are untouched, and `skipField` already refused required controls, so the only observable change is that a pending or uncertain required field no longer counts as satisfied.

# Background

## What does this PR do?

A required control whose field state was `pending` (external activation, no value yet) or `uncertain` (low-confidence value) satisfied the readiness check, so the session flipped to `ready` and `submit` proceeded without a committed value. The predicate now accepts only `filled`. Pending and uncertain required fields keep the session `active` and `submit` rejects with the existing "Not all required fields are filled" error until a value is filled.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`checkAllRequiredFilled` in `plugins/plugin-form/src/service.ts`, then `plugins/plugin-form/src/service-required-pending.test.ts`, which drives a real `FormService` over an in-memory component store: a pending and an uncertain required field each keep the session active and make `submit` throw, and a filled one makes it ready and submits.

## Detailed testing steps

Package suite plus a red run of the new test file against the develop `service.ts`. The red run shows the session reported as `ready` with a pending or uncertain required field.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:a6c743701841db6cea1fb43a1b1995d68571cde0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface changes; behavior is covered by the transcripts below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface changes; behavior is covered by the transcripts below.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the new test file and the full plugin-form lane on this head, pasted below.

  <details>
  <summary>vitest run src/service-required-pending.test.ts on this head, plus the package lane summary</summary>

  ```
# green: plugin-form service-required-pending.test.ts
 ✓ src/service-required-pending.test.ts > required fields that are not yet filled > does not become ready or submit while the wallet is pending external activation 13ms
 ✓ src/service-required-pending.test.ts > required fields that are not yet filled > does not become ready or submit while the wallet is an uncertain value 2ms
 ✓ src/service-required-pending.test.ts > required fields that are not yet filled > becomes ready and submits once the required field is filled 2ms
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ bun run --cwd plugins/plugin-form test   (lane summary, this head)
 Test Files  11 passed (11)
      Tests  148 passed (148)
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the new tests against the develop source, pasted below.

  <details>
  <summary>Red run: service-required-pending.test.ts against origin/develop service.ts</summary>

  ```
     × does not become ready or submit while the wallet is pending external activation 14ms
     × does not become ready or submit while the wallet is an uncertain value 3ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 'ready' to be 'active' // Object.is equality
Expected: "active"
Received: "ready"
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
  ```

  </details>

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, a required field in `pending` or `uncertain` state satisfies readiness: the session is `ready` and `submit` succeeds without a value (red run above).

### After

Only a `filled` required field satisfies readiness; pending and uncertain required fields keep the session active and `submit` rejects.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total, 8m36s) after `bun install --frozen-lockfile` reported no changes, run on a throwaway branch built from `origin/develop` `c039b4a455f` plus this commit and the sibling fix commits for #27977 #27522 #27871 (disjoint packages: plugin-native-talkmode, plugin-form, packages/skills, plugin-meetings). This branch is rebased onto that same `origin/develop` `c039b4a455f` with zero conflicts. No gaps; every N/A row above carries its reason. The full plugin-form lane (`bun run --cwd plugins/plugin-form test`) passes on this head: 11 files, 148 tests.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
