### PR TITLE
fix(skills): degrade a non-string frontmatter name to a warning

### DIFF
--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -134,7 +134,26 @@ function loadSkillFromFile(
     diagnostics.push({ type: "warning", message: error, path: filePath });
   }
 
-  const name = frontmatter.name || expectedName;
+  // YAML types a bare `name: 123` or `name: true` as a number or boolean.
+  // Such a value is not a usable identifier and would reach string handling
+  // in the name registry and prompt formatter; report it and fall back to the
+  // name the path implies, the same way an omitted name does.
+  const rawName = frontmatter.name;
+  if (
+    rawName !== undefined &&
+    rawName !== null &&
+    typeof rawName !== "string"
+  ) {
+    diagnostics.push({
+      type: "warning",
+      message: `name must be a string (got ${typeof rawName}); using "${expectedName}"`,
+      path: filePath,
+    });
+  }
+  const name =
+    typeof rawName === "string" && rawName.trim() !== ""
+      ? rawName
+      : expectedName;
 
   const nameErrors = validateName(name, expectedName, isSkillMd);
   for (const error of nameErrors) {

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -73,10 +73,18 @@ function validateName(
   return errors;
 }
 
-function validateDescription(description: string | undefined): string[] {
+function validateDescription(description: unknown): string[] {
   const errors: string[] = [];
 
-  if (!description || description.trim() === "") {
+  if (description === undefined || description === null || description === "") {
+    errors.push("description is required");
+  } else if (typeof description !== "string") {
+    // YAML types a bare `description: 123` or `description: true` as a
+    // number or boolean; report it instead of letting string handling throw.
+    errors.push(
+      `description must be a string (got ${typeof description}); skill skipped`,
+    );
+  } else if (description.trim() === "") {
     errors.push("description is required");
   } else if (description.length > MAX_DESCRIPTION_LENGTH) {
     errors.push(
@@ -150,6 +158,13 @@ function loadSkillFromFile(
       path: filePath,
     });
   }
+  if (typeof rawName === "string" && rawName !== "" && rawName.trim() === "") {
+    diagnostics.push({
+      type: "warning",
+      message: `name must not be blank; using "${expectedName}"`,
+      path: filePath,
+    });
+  }
   const name =
     typeof rawName === "string" && rawName.trim() !== ""
       ? rawName
@@ -160,7 +175,8 @@ function loadSkillFromFile(
     diagnostics.push({ type: "warning", message: error, path: filePath });
   }
 
-  if (!frontmatter.description || frontmatter.description.trim() === "") {
+  const description = frontmatter.description;
+  if (typeof description !== "string" || description.trim() === "") {
     return { skill: null, diagnostics };
   }
 
@@ -169,7 +185,7 @@ function loadSkillFromFile(
   return {
     skill: {
       name,
-      description: frontmatter.description,
+      description,
       filePath,
       baseDir: skillDir,
       source,

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -102,6 +102,50 @@ description: Subdirectory skill description
     }
   });
 
+  it("degrades a non-string frontmatter name to a diagnostic instead of failing the load", () => {
+    const tempDir = createTempDir("skill-loader-nonstring-name");
+    try {
+      // YAML types these as a number and a boolean, not strings.
+      const numericDir = join(tempDir, "numeric-name");
+      mkdirSync(numericDir);
+      writeFileSync(
+        join(numericDir, "SKILL.md"),
+        "---\nname: 123\ndescription: Numeric name\n---\nBody\n",
+      );
+      const booleanDir = join(tempDir, "boolean-name");
+      mkdirSync(booleanDir);
+      writeFileSync(
+        join(booleanDir, "SKILL.md"),
+        "---\nname: true\ndescription: Boolean name\n---\nBody\n",
+      );
+      writeFileSync(
+        join(tempDir, "healthy.md"),
+        "---\nname: healthy\ndescription: Healthy sibling\n---\nBody\n",
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+
+      const names = result.skills.map((skill) => skill.name).sort();
+      assert.deepStrictEqual(names, [
+        "boolean-name",
+        "healthy",
+        "numeric-name",
+      ]);
+      for (const skill of result.skills) {
+        assert.strictEqual(typeof skill.name, "string");
+      }
+      const nameWarnings = result.diagnostics.filter((d) =>
+        d.message.includes("name must be a string"),
+      );
+      assert.strictEqual(nameWarnings.length, 2);
+      assert.ok(nameWarnings.every((d) => d.type === "warning"));
+      // The formatter consumes the loaded names; a non-string would throw here.
+      assert.doesNotThrow(() => formatSkillsForPrompt(result.skills));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("defaults flat markdown skill name to filename slug when name is omitted", () => {
     const tempDir = createTempDir("skill-loader-flat-slug");
     try {

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -146,6 +146,69 @@ description: Subdirectory skill description
     }
   });
 
+  it("reports a whitespace-only name and falls back to the path-derived name", () => {
+    const tempDir = createTempDir("skill-loader-blank-name");
+    try {
+      const blankDir = join(tempDir, "blank-name");
+      mkdirSync(blankDir);
+      writeFileSync(
+        join(blankDir, "SKILL.md"),
+        '---\nname: "   "\ndescription: Blank name\n---\nBody\n',
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+
+      assert.deepStrictEqual(
+        result.skills.map((skill) => skill.name),
+        ["blank-name"],
+      );
+      const blankWarnings = result.diagnostics.filter((d) =>
+        d.message.includes("name must not be blank"),
+      );
+      assert.strictEqual(blankWarnings.length, 1);
+      assert.strictEqual(blankWarnings[0].type, "warning");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a skill whose description is not a string without aborting the scan", () => {
+    const tempDir = createTempDir("skill-loader-nonstring-description");
+    try {
+      const numericDir = join(tempDir, "numeric-description");
+      mkdirSync(numericDir);
+      writeFileSync(
+        join(numericDir, "SKILL.md"),
+        "---\nname: numeric-description\ndescription: 123\n---\nBody\n",
+      );
+      const booleanDir = join(tempDir, "boolean-description");
+      mkdirSync(booleanDir);
+      writeFileSync(
+        join(booleanDir, "SKILL.md"),
+        "---\nname: boolean-description\ndescription: true\n---\nBody\n",
+      );
+      writeFileSync(
+        join(tempDir, "healthy.md"),
+        "---\nname: healthy\ndescription: Healthy sibling\n---\nBody\n",
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+
+      // The malformed skills are skipped, the healthy sibling still loads.
+      assert.deepStrictEqual(
+        result.skills.map((skill) => skill.name),
+        ["healthy"],
+      );
+      const descriptionWarnings = result.diagnostics.filter((d) =>
+        d.message.includes("description must be a string"),
+      );
+      assert.strictEqual(descriptionWarnings.length, 2);
+      assert.ok(descriptionWarnings.every((d) => d.type === "warning"));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("defaults flat markdown skill name to filename slug when name is omitted", () => {
     const tempDir = createTempDir("skill-loader-flat-slug");
     try {


### PR DESCRIPTION
# Relates to

Closes #27522.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. `loadSkillFromFile` in `packages/skills/src/loader.ts` gains type checks on the parsed `name` and `description`. Non-blank string names, empty names, and omitted names resolve exactly as before. A number or boolean name, which previously threw out of `validateName`, now yields a warning diagnostic and the path-derived name; a whitespace-only name yields a `name must not be blank` warning before the same fallback (on develop it loaded under the blank name with two validation warnings). A number or boolean description, which previously threw out of `validateDescription` and aborted the scan, now yields a warning and the skill is skipped while its siblings load, the same outcome as a missing description.

# Background

## What does this PR do?

YAML types a bare `name: 123` or `name: true` as a number or boolean. The loader passed that value straight into `validateName`, whose `startsWith` call threw a `TypeError` that escaped `loadSkillsFromDir` and aborted the whole directory scan, taking every healthy sibling skill with it. The loader now reports a `name must be a string` warning for a non-string name and falls back to the name the path implies, the same way an omitted name does, so the skill and its siblings still load and the formatter only ever sees string names. The required `description` field had the same failure mode two lines earlier (`description.trim is not a function`); it is now reported as `description must be a string` and the skill is skipped, so a sibling with a malformed description can no longer take down the scan either.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The `rawName` block in `loadSkillFromFile` in `packages/skills/src/loader.ts`, and `validateDescription` above it, then the three new cases in `packages/skills/test/loader.test.ts`: numeric and boolean names load under the directory name with warnings alongside a healthy sibling; a whitespace-only name is warned about and falls back; numeric and boolean descriptions are skipped with warnings while the healthy sibling loads.

## Detailed testing steps

Package `bun test` plus a red run of the new test against the develop `loader.ts`. The red run shows the `TypeError: name.startsWith is not a function` escaping the loader.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:24997b9eb2322714d19061c30afcdbec6122cc1b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface changes; behavior is covered by the transcripts below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface changes; behavior is covered by the transcripts below.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the skills loader suite on this head (18 tests), pasted below.

  <details>
  <summary>bun test test/loader.test.ts on this head</summary>

  ```
# green: packages/skills $ bun test test/loader.test.ts on head 24997b9eb23
 18 pass
 0 fail
Ran 18 tests across 1 file. [1009.00ms]

$ tsc --noEmit -p tsconfig.build.json   (packages/skills, this head)
skills typecheck exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the new tests against the develop source, pasted below.

  <details>
  <summary>Red run: new test against origin/develop loader.ts</summary>

  ```
TypeError: name.startsWith is not a function. (In 'name.startsWith("-")', 'name.startsWith' is undefined)
(fail) loadSkillsFromDir > degrades a non-string frontmatter name to a diagnostic instead of failing the load [2.71ms]
 15 pass
 1 fail
  ```

  </details>

  <details>
  <summary>Red run: blank-name and non-string-description tests against the previous PR head f7a25e2cc0d</summary>

  ```
AssertionError: Expected values to be strictly equal:
(fail) loadSkillsFromDir > reports a whitespace-only name and falls back to the path-derived name [2.58ms]
TypeError: description.trim is not a function. (In 'description.trim()', 'description.trim' is undefined)
(fail) loadSkillsFromDir > skips a skill whose description is not a string without aborting the scan [1.52ms]
 16 pass
 2 fail
  ```

  </details>

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, a `SKILL.md` with `name: 123` makes `loadSkillsFromDir` throw `TypeError: name.startsWith is not a function`, so no skill in that directory loads (red run above).

### After

The non-string name becomes a warning diagnostic, the skill loads under its directory name, and the healthy siblings load unaffected.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total, 8m36s) after `bun install --frozen-lockfile` reported no changes, run on a throwaway branch built from `origin/develop` `c039b4a455f` plus this commit and the sibling fix commits for #27977 #27773 #27871 (disjoint packages: plugin-native-talkmode, plugin-form, packages/skills, plugin-meetings). This branch is rebased onto that same `origin/develop` `c039b4a455f` with zero conflicts. No gaps; every N/A row above carries its reason. The packages/skills `bun test ./test` lane and `tsc --noEmit -p tsconfig.build.json` pass on this head. The follow-up commit `24997b9eb23` (description guard, blank-name warning) is covered by the package suite and typecheck above; a fresh `bun run verify` on the updated head is recorded in the review thread.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
