### PR TITLE
fix(plugin-meetings): correlate ASR responses to the submission they answer

### DIFF
--- a/plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts
+++ b/plugins/plugin-meetings/src/pipeline/__tests__/speaker-streams.test.ts
@@ -26,6 +26,7 @@ interface Harness {
     speakerKey: string;
     samples: number;
     purpose: AsrSubmissionPurpose;
+    generation: number;
   }>;
   confirmed: ConfirmedSegmentEvent[];
 }
@@ -36,8 +37,13 @@ function harness(
   const manager = new SpeakerStreamManager(config);
   const submissions: Harness["submissions"] = [];
   const confirmed: ConfirmedSegmentEvent[] = [];
-  manager.onSegmentReady = (speakerKey, _name, audio, purpose) => {
-    submissions.push({ speakerKey, samples: audio.length, purpose });
+  manager.onSegmentReady = (speakerKey, _name, audio, purpose, generation) => {
+    submissions.push({
+      speakerKey,
+      samples: audio.length,
+      purpose,
+      generation,
+    });
   };
   manager.onSegmentConfirmed = (event) => {
     confirmed.push(event);
@@ -65,7 +71,7 @@ describe("SpeakerStreamManager", () => {
     h.manager.feedAudio("a", seconds(1.5));
     vi.advanceTimersByTime(2000);
     expect(h.submissions).toEqual([
-      { speakerKey: "a", samples: 2.5 * SR, purpose: "interim" },
+      { speakerKey: "a", samples: 2.5 * SR, purpose: "interim", generation: 0 },
     ]);
 
     // In-flight — no double submission
@@ -206,7 +212,7 @@ describe("SpeakerStreamManager", () => {
     h.manager.feedAudio("a", seconds(1)); // below cadence minimum
     vi.advanceTimersByTime(16_000); // > 15s idle
     expect(h.submissions).toEqual([
-      { speakerKey: "a", samples: SR, purpose: "final" },
+      { speakerKey: "a", samples: SR, purpose: "final", generation: 0 },
     ]);
 
     h.manager.handleTranscriptionResult("a", "short final remark");
@@ -253,6 +259,93 @@ describe("SpeakerStreamManager", () => {
     );
     expect(h.confirmed).toHaveLength(0);
     expect(h.manager.getPendingSnapshot("a")).toBeNull();
+  });
+
+  describe("reset while a request is in flight, then the same speaker resubmits (#27871)", () => {
+    /**
+     * Drives the race from the issue: the orphaned generation-0 request is
+     * still outstanding when the speaker is flushed and then feeds fresh audio,
+     * so a generation-1 submission is in flight by the time the old response
+     * lands. Returns the generations the harness saw for each submission.
+     */
+    async function raceHarness() {
+      const h = harness();
+      h.manager.addSpeaker("a", "Alice");
+      h.manager.feedAudio("a", seconds(2));
+      vi.advanceTimersByTime(2000);
+      expect(h.submissions).toHaveLength(1);
+
+      await h.manager.flushSpeaker("a");
+
+      h.manager.feedAudio("a", seconds(2));
+      vi.advanceTimersByTime(2000);
+      expect(h.submissions).toHaveLength(2);
+      const [orphan, live] = h.submissions;
+      return { h, orphan, live };
+    }
+
+    it("discards the orphaned response even though a newer submission is outstanding", async () => {
+      const { h, orphan, live } = await raceHarness();
+
+      for (let i = 0; i < 2; i += 1) {
+        h.manager.handleTranscriptionResult(
+          "a",
+          "stale text from old context",
+          2.0,
+          [seg("stale text from old context", 0, 2.0)],
+          orphan.generation,
+        );
+      }
+
+      expect(h.confirmed.map((c) => c.text)).not.toContain(
+        "stale text from old context",
+      );
+      expect(h.manager.getPendingSnapshot("a")).toBeNull();
+      // The reset advanced the generation, which is what told the two apart.
+      expect(live.generation).toBeGreaterThan(orphan.generation);
+    });
+
+    it("still confirms the live submission's response normally", async () => {
+      const { h, orphan, live } = await raceHarness();
+
+      h.manager.handleTranscriptionResult(
+        "a",
+        "stale text from old context",
+        2.0,
+        [seg("stale text from old context", 0, 2.0)],
+        orphan.generation,
+      );
+      for (let i = 0; i < 2; i += 1) {
+        h.manager.handleTranscriptionResult(
+          "a",
+          "fresh words after the handoff",
+          2.0,
+          [seg("fresh words after the handoff", 0, 2.0)],
+          live.generation,
+        );
+      }
+
+      expect(h.confirmed.map((c) => c.text)).toEqual([
+        "fresh words after the handoff",
+      ]);
+    });
+
+    it("keeps the live request in flight so the cadence cannot double-submit", async () => {
+      const { h, orphan } = await raceHarness();
+
+      h.manager.handleTranscriptionResult(
+        "a",
+        "stale text from old context",
+        2.0,
+        [seg("stale text from old context", 0, 2.0)],
+        orphan.generation,
+      );
+
+      // The live generation-1 request has not answered; another interval must
+      // not start a concurrent submission for the same speaker.
+      vi.advanceTimersByTime(2000);
+      expect(h.submissions).toHaveLength(2);
+    });
   });
 
   it("speaker-change flush emits the forming transcript immediately", async () => {

--- a/plugins/plugin-meetings/src/pipeline/pipeline.ts
+++ b/plugins/plugin-meetings/src/pipeline/pipeline.ts
@@ -155,8 +155,9 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
       _speakerName,
       audio,
       purpose,
+      generation,
     ) => {
-      this.transcribeWindow(speakerKey, audio, purpose);
+      this.transcribeWindow(speakerKey, audio, purpose, generation);
     };
 
     this.manager.onSegmentConfirmed = (event) => {
@@ -421,6 +422,7 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
     speakerKey: string,
     audio: Float32Array,
     purpose: "interim" | "final",
+    generation: number,
   ): void {
     const wav = float32ToWav(audio, MEETING_AUDIO_SAMPLE_RATE);
     const prompt = this.manager.getLastConfirmedText(speakerKey);
@@ -436,7 +438,13 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
           } catch (err) {
             if (isMeetingInsufficientCreditsError(err)) {
               this.options.onSpendCapReached?.(err);
-              this.manager.handleTranscriptionResult(speakerKey, "");
+              this.manager.handleTranscriptionResult(
+                speakerKey,
+                "",
+                undefined,
+                undefined,
+                generation,
+              );
               return;
             }
             throw err;
@@ -461,6 +469,7 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
           result.text,
           segmentEndSec,
           segments,
+          generation,
         );
       } catch (err) {
         // error-policy:J7 a single ASR window failing (already retried in the
@@ -478,7 +487,13 @@ class MeetingPipeline implements MeetingTranscriptionPipeline {
           speakerKey,
         });
         // Clear the in-flight flag so the stream keeps moving.
-        this.manager.handleTranscriptionResult(speakerKey, "");
+        this.manager.handleTranscriptionResult(
+          speakerKey,
+          "",
+          undefined,
+          undefined,
+          generation,
+        );
       }
       this.notify([]);
     })();

--- a/plugins/plugin-meetings/src/pipeline/speaker-streams.ts
+++ b/plugins/plugin-meetings/src/pipeline/speaker-streams.ts
@@ -106,13 +106,20 @@ export class SpeakerStreamManager {
   private readonly sampleRate: number;
   private readonly now: () => number;
 
-  /** Called when unconfirmed audio needs transcription. */
+  /**
+   * Called when unconfirmed audio needs transcription. `generation` is the
+   * speaker buffer's generation at submission time; the consumer must hand it
+   * back to {@link handleTranscriptionResult} so a response that outlives a
+   * reset is matched to the submission it answers, not to whichever request
+   * is current when it lands.
+   */
   onSegmentReady:
     | ((
         speakerKey: string,
         speakerName: string,
         audio: Float32Array,
         purpose: AsrSubmissionPurpose,
+        generation: number,
       ) => void)
     | null = null;
 
@@ -192,16 +199,22 @@ export class SpeakerStreamManager {
     transcript: string,
     segmentEndSec?: number,
     segments?: ReadonlyArray<AsrSegment>,
+    generation?: number,
   ): void {
     const buffer = this.buffers.get(speakerKey);
     if (!buffer) return;
 
-    buffer.inFlight = false;
-
-    // Discard stale responses: buffer was fully reset while this request was
-    // in flight — accepting it would poison lastTranscript with old text.
-    const submitGen = this.submitGeneration.get(speakerKey);
+    // Discard stale responses: the buffer was fully reset while this request
+    // was in flight — accepting it would poison lastTranscript with old text.
+    // The generation echoed by the caller identifies the submission that this
+    // response answers. A reset does not cancel the orphaned request, and the
+    // same speaker may already have a newer submission outstanding, so the
+    // per-speaker record of the latest submission cannot stand in for it.
+    // Bail before touching inFlight: that flag belongs to the live request.
+    const submitGen = generation ?? this.submitGeneration.get(speakerKey);
     if (submitGen !== undefined && submitGen < buffer.generation) return;
+
+    buffer.inFlight = false;
 
     if (!transcript || transcript.trim().length === 0) {
       if (buffer.idleSubmitted) this.fullReset(buffer);
@@ -525,6 +538,7 @@ export class SpeakerStreamManager {
         buffer.speakerName,
         combined,
         purpose,
+        buffer.generation,
       );
     } catch (err) {
       buffer.inFlight = false;


### PR DESCRIPTION
# Relates to

Closes #27871.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low to moderate. `onSegmentReady` gains a fifth `generation` argument and `handleTranscriptionResult` an optional fifth parameter; the only in-repo consumer is `pipeline.ts`, updated here on all three completion paths (success, insufficient credits, ASR error). Callers that do not pass a generation keep the previous per-speaker `submitGeneration` check. The stale check now runs before `inFlight` is cleared, which is what stops the orphaned response from freeing the slot of the live request.

# Background

## What does this PR do?

A speaker flush during an in-flight ASR request bumps the buffer generation but cannot cancel the request. When the same speaker fed fresh audio before that orphaned response arrived, the next submission overwrote the per-speaker `submitGeneration` slot, so the late response compared equal to the current generation, was accepted, and its old-context text was confirmed into the meeting transcript. It also cleared `inFlight` for the genuinely outstanding request, letting the 2s cadence start a second concurrent submission for the same speaker. `onSegmentReady` now carries the buffer generation at submission time and the pipeline echoes it back through `handleTranscriptionResult`, so each response is judged against its own submission and stale ones are dropped before `inFlight` is touched.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`handleTranscriptionResult` and `submitBuffer` in `plugins/plugin-meetings/src/pipeline/speaker-streams.ts`, the `transcribeWindow` call sites in `pipeline.ts`, then the three new cases under "reset while a request is in flight, then the same speaker resubmits (#27871)" in `speaker-streams.test.ts`: the orphaned response is discarded, the live response still confirms, and the live request stays in flight so the cadence cannot double-submit.

## Detailed testing steps

Package lane plus a red run of the new tests against the develop `speaker-streams.ts`/`pipeline.ts`. The red run shows the stale text confirmed into the transcript and a third concurrent submission starting.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:967b6afeb5a34ddba260edbb2b902443821cabe9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface changes; behavior is covered by the transcripts below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface changes; behavior is covered by the transcripts below.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the speaker-streams suite on this head (15 tests) and the full plugin-meetings lane, pasted below.

  <details>
  <summary>vitest run speaker-streams.test.ts on this head, plus the package lane summary</summary>

  ```
# green: plugin-meetings speaker-streams.test.ts
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > submits only unconfirmed audio on the 2s cadence once ≥2s buffered 7ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > LocalAgreement-2 word-prefix confirmation > confirms the stable word prefix across growing re-submissions and advances the offset 4ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > LocalAgreement-2 word-prefix confirmation > does not emit a corrected (unstable) tail 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > LocalAgreement-2 word-prefix confirmation > carries word timings onto confirmed segments as absolute ms 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > full-text double-match fallback > confirms after two identical submissions and dedups re-emissions 2ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > full-text double-match fallback > filters hallucinations before they enter confirmation 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > idle timeout makes one final submission and emits its result immediately 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > hard cap force-flushes an unconfirmed transcript at 30s 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > discards stale in-flight results after a full reset (generation bump) 2ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > reset while a request is in flight, then the same speaker resubmits (#27871) > discards the orphaned response even though a newer submission is outstanding 2ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > reset while a request is in flight, then the same speaker resubmits (#27871) > still confirms the live submission's response normally 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > reset while a request is in flight, then the same speaker resubmits (#27871) > keeps the live request in flight so the cadence cannot double-submit 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > speaker-change flush emits the forming transcript immediately 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > keeps independent multi-speaker streams interleaved without cross-talk 1ms
 ✓ src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > removeSpeaker emits the leftover forming transcript and clears timers 1ms
 Test Files  1 passed (1)
      Tests  15 passed (15)

$ bun run --cwd plugins/plugin-meetings test   (lane summary, this head)
 Test Files  28 passed (28)
      Tests  266 passed (266)
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the new tests against the develop source, pasted below.

  <details>
  <summary>Red run: new tests against origin/develop speaker-streams.ts and pipeline.ts</summary>

  ```
       × discards the orphaned response even though a newer submission is outstanding 12ms
       × keeps the live request in flight so the cadence cannot double-submit 6ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > reset while a request is in flight, then the same speaker resubmits (#27871) > discards the orphaned response even though a newer submission is outstanding
AssertionError: expected [ 'stale text from old context' ] to not include 'stale text from old context'
    298|       }
    299|
    300|       expect(h.confirmed.map((c) => c.text)).not.toContain(
    301|         "stale text from old context",
    302|       );
 FAIL  src/pipeline/__tests__/speaker-streams.test.ts > SpeakerStreamManager > reset while a request is in flight, then the same speaker resubmits (#27871) > keeps the live request in flight so the cadence cannot double-submit
AssertionError: expected [ { speakerKey: 'a', …(3) }, …(2) ] to have a length of 2 but got 3
- Expected
+ Received
- 2
+ 3
    345|       // not start a concurrent submission for the same speaker.
    346|       vi.advanceTimersByTime(2000);
    347|       expect(h.submissions).toHaveLength(2);
    348|     });
    349|   });
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed | 12 skipped (15)
  ```

  </details>

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, the orphaned generation-0 response is confirmed as `stale text from old context` and its arrival frees `inFlight`, so the next interval starts a third submission (red run above).

### After

The orphaned response is discarded, the live submission's response confirms normally, and the interval does not start a concurrent submission while the live request is outstanding.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total, 8m36s) after `bun install --frozen-lockfile` reported no changes, run on a throwaway branch built from `origin/develop` `c039b4a455f` plus this commit and the sibling fix commits for #27977 #27773 #27522 (disjoint packages: plugin-native-talkmode, plugin-form, packages/skills, plugin-meetings). This branch is rebased onto that same `origin/develop` `c039b4a455f` with zero conflicts. No gaps; every N/A row above carries its reason. The full plugin-meetings lane (`bun run --cwd plugins/plugin-meetings test`) passes on this head: 28 files, 266 tests.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
