### PR TITLE
fix(core): bound entity lookups in the follow-ups provider

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/followUps.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/followUps.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the FOLLOW_UPS provider's contact-name resolution. The
+ * runtime and FollowUpService are in-memory doubles; entity lookups are held
+ * at an explicit gate so the admission bound can be measured before any
+ * lookup completes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.js";
+import { followUpsProvider } from "./followUps.js";
+
+describe("followUpsProvider", () => {
+	const dummyMessage = { roomId: "room-1" as UUID } as Memory;
+	const dummyState = {} as State;
+
+	it("bounds concurrent entity lookups while still naming every contact (#30731)", async () => {
+		const contactCount = 64;
+		const followUps = Array.from({ length: contactCount }, (_unused, i) => ({
+			task: {
+				id: `task-${i}` as UUID,
+				metadata: {
+					scheduledAt: new Date(
+						Date.now() + (i + 1) * 86_400_000,
+					).toISOString(),
+					reason: `reason ${i}`,
+				},
+			},
+			contact: { entityId: `entity-${i}` as UUID },
+		}));
+		const followUpService = {
+			getUpcomingFollowUps: vi.fn().mockResolvedValue(followUps),
+			getFollowUpSuggestions: vi.fn().mockResolvedValue([]),
+		};
+
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const releases: Array<() => void> = [];
+		const runtime = {
+			getService: vi.fn().mockReturnValue(followUpService),
+			getEntityById: vi.fn(async (id: string) => {
+				inFlight += 1;
+				peakInFlight = Math.max(peakInFlight, inFlight);
+				await new Promise<void>((resolve) => {
+					releases.push(resolve);
+				});
+				inFlight -= 1;
+				return { names: [`Name ${id}`] };
+			}),
+			logger: { warn: vi.fn(), error: vi.fn() },
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const pending = followUpsProvider.get(runtime, dummyMessage, dummyState);
+
+		// Drain the gate until every lookup has been admitted and released.
+		let released = 0;
+		while (released < contactCount) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			while (releases.length > 0) {
+				releases.shift()?.();
+				released += 1;
+			}
+		}
+		const result = await pending;
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(contactCount);
+		expect(peakInFlight).toBe(8);
+		expect(result.values?.followUpCount).toBe(contactCount);
+		for (let i = 0; i < contactCount; i += 1) {
+			expect(result.text).toContain(`Name entity-${i}`);
+		}
+	});
+
+	it("resolves each unique contact once and labels unknown entities", async () => {
+		const followUps = [
+			{
+				task: {
+					id: "t1" as UUID,
+					metadata: { scheduledAt: new Date(0).toISOString() },
+				},
+				contact: { entityId: "e1" as UUID },
+			},
+			{
+				task: { id: "t2" as UUID, metadata: {} },
+				contact: { entityId: "e1" as UUID },
+			},
+			{
+				task: { id: "t3" as UUID, metadata: {} },
+				contact: { entityId: "e2" as UUID },
+			},
+		];
+		const runtime = {
+			getService: vi.fn().mockReturnValue({
+				getUpcomingFollowUps: vi.fn().mockResolvedValue(followUps),
+				getFollowUpSuggestions: vi.fn().mockResolvedValue([]),
+			}),
+			getEntityById: vi.fn(async (id: string) =>
+				id === "e1" ? { names: ["Alice"] } : null,
+			),
+			logger: { warn: vi.fn(), error: vi.fn() },
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const result = await followUpsProvider.get(
+			runtime,
+			dummyMessage,
+			dummyState,
+		);
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(2);
+		expect(result.text).toContain("Alice");
+		expect(result.text).toContain("Unknown");
+		expect(result.values?.followUpCount).toBe(3);
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/providers/followUps.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/followUps.ts
@@ -15,9 +15,18 @@ import type {
 	ProviderResult,
 	State,
 } from "../../../types/index.ts";
+import { mapWithConcurrency } from "../../../utils/bounded-map.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("FOLLOW_UPS");
+
+/**
+ * Upper bound on simultaneous entity lookups while resolving follow-up
+ * contact names. The follow-up list is data-driven, so resolving every unique
+ * contact through one `Promise.all` would admit as many concurrent database
+ * reads as there are contacts.
+ */
+const MAX_CONCURRENT_ENTITY_LOOKUPS = 8;
 
 export const followUpsProvider: Provider = {
 	name: spec.name,
@@ -62,8 +71,10 @@ export const followUpsProvider: Provider = {
 			const contactIds = Array.from(
 				new Set(upcomingFollowUps.map((f) => f.contact.entityId)),
 			);
-			const entities = await Promise.all(
-				contactIds.map((id) => runtime.getEntityById(id)),
+			const entities = await mapWithConcurrency(
+				contactIds,
+				MAX_CONCURRENT_ENTITY_LOOKUPS,
+				(id) => runtime.getEntityById(id),
 			);
 			const entityNames = new Map<string, string>();
 			for (let i = 0; i < contactIds.length; i += 1) {

--- a/packages/core/src/utils/bounded-map.test.ts
+++ b/packages/core/src/utils/bounded-map.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Pins mapWithConcurrency's admission bound, ordering, and failure
+ * propagation. Deterministic: in-flight calls are released by explicit
+ * resolvers rather than timers.
+ */
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "./bounded-map.ts";
+
+function gate() {
+	const releases: Array<() => void> = [];
+	return {
+		hold: () =>
+			new Promise<void>((resolve) => {
+				releases.push(resolve);
+			}),
+		releaseAll: async () => {
+			while (releases.length > 0) {
+				releases.shift()?.();
+				await Promise.resolve();
+			}
+		},
+		pending: () => releases.length,
+	};
+}
+
+describe("mapWithConcurrency", () => {
+	it("never admits more than the limit and keeps input order", async () => {
+		const g = gate();
+		let inFlight = 0;
+		let peak = 0;
+		const items = Array.from({ length: 23 }, (_unused, i) => i);
+		const run = mapWithConcurrency(items, 4, async (item) => {
+			inFlight += 1;
+			peak = Math.max(peak, inFlight);
+			await g.hold();
+			inFlight -= 1;
+			return item * 10;
+		});
+		// Let the workers start; only the first `limit` calls may be waiting.
+		await Promise.resolve();
+		expect(g.pending()).toBe(4);
+		while (inFlight > 0 || g.pending() > 0) {
+			await g.releaseAll();
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		const results = await run;
+		expect(peak).toBe(4);
+		expect(results).toEqual(items.map((i) => i * 10));
+	});
+
+	it("returns an empty array for an empty input without calling fn", async () => {
+		let calls = 0;
+		const results = await mapWithConcurrency([], 3, async () => {
+			calls += 1;
+			return 1;
+		});
+		expect(results).toEqual([]);
+		expect(calls).toBe(0);
+	});
+
+	it("uses fewer workers than the limit when the input is shorter", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		const results = await mapWithConcurrency([1, 2], 8, async (item) => {
+			inFlight += 1;
+			peak = Math.max(peak, inFlight);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			inFlight -= 1;
+			return item;
+		});
+		expect(results).toEqual([1, 2]);
+		expect(peak).toBe(2);
+	});
+
+	it("rejects with the first failure and stops admitting new items", async () => {
+		const started: number[] = [];
+		const run = mapWithConcurrency([0, 1, 2, 3, 4, 5], 2, async (item) => {
+			started.push(item);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			if (item === 1) {
+				throw new Error(`item ${item} failed`);
+			}
+			return item;
+		});
+		await expect(run).rejects.toThrow("item 1 failed");
+		// Items 0 and 1 were admitted first; the worker that hit the failure
+		// stops, and the surviving worker drains at most what it had claimed.
+		expect(started).not.toContain(5);
+	});
+
+	it("rejects a non-positive or fractional limit", async () => {
+		await expect(mapWithConcurrency([1], 0, async (x) => x)).rejects.toThrow(
+			RangeError,
+		);
+		await expect(mapWithConcurrency([1], 1.5, async (x) => x)).rejects.toThrow(
+			RangeError,
+		);
+	});
+});

--- a/packages/core/src/utils/bounded-map.test.ts
+++ b/packages/core/src/utils/bounded-map.test.ts
@@ -36,8 +36,8 @@ describe("mapWithConcurrency", () => {
 			inFlight -= 1;
 			return item * 10;
 		});
-		// Let the workers start; only the first `limit` calls may be waiting.
-		await Promise.resolve();
+		// The first `limit` calls are admitted synchronously; no more until one
+		// of them settles.
 		expect(g.pending()).toBe(4);
 		while (inFlight > 0 || g.pending() > 0) {
 			await g.releaseAll();
@@ -72,20 +72,64 @@ describe("mapWithConcurrency", () => {
 		expect(peak).toBe(2);
 	});
 
-	it("rejects with the first failure and stops admitting new items", async () => {
-		const started: number[] = [];
-		const run = mapWithConcurrency([0, 1, 2, 3, 4, 5], 2, async (item) => {
-			started.push(item);
-			await new Promise((resolve) => setTimeout(resolve, 0));
-			if (item === 1) {
+	it("rejects as soon as one item fails, without waiting for a sibling still in flight", async () => {
+		const g = gate();
+		const started: string[] = [];
+		let siblingSettled = false;
+		const run = mapWithConcurrency(
+			["held", "failing", "never-admitted"],
+			2,
+			async (item) => {
+				started.push(item);
+				if (item === "held") {
+					await g.hold();
+					siblingSettled = true;
+					return item;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				throw new Error(`${item} failed`);
+			},
+		);
+
+		// The map must reject while the sibling is still held at the gate.
+		await expect(run).rejects.toThrow("failing failed");
+		expect(siblingSettled).toBe(false);
+		expect(g.pending()).toBe(1);
+		expect(started).toEqual(["held", "failing"]);
+
+		// Releasing the sibling afterwards admits nothing further and surfaces
+		// no second error.
+		await g.releaseAll();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(siblingSettled).toBe(true);
+		expect(started).toEqual(["held", "failing"]);
+	});
+
+	it("drops a later rejection from an item admitted before the first failure", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const run = mapWithConcurrency([1, 2], 2, async (item) => {
+				await new Promise((resolve) => setTimeout(resolve, item));
 				throw new Error(`item ${item} failed`);
-			}
-			return item;
-		});
-		await expect(run).rejects.toThrow("item 1 failed");
-		// Items 0 and 1 were admitted first; the worker that hit the failure
-		// stops, and the surviving worker drains at most what it had claimed.
-		expect(started).not.toContain(5);
+			});
+			await expect(run).rejects.toThrow("item 1 failed");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
+
+	it("rejects when fn throws synchronously", async () => {
+		await expect(
+			mapWithConcurrency([1], 2, () => {
+				throw new Error("sync boom");
+			}),
+		).rejects.toThrow("sync boom");
 	});
 
 	it("rejects a non-positive or fractional limit", async () => {

--- a/packages/core/src/utils/bounded-map.ts
+++ b/packages/core/src/utils/bounded-map.ts
@@ -3,9 +3,9 @@
  * `Promise.all(items.map(fn))` admits every element at once, so the input
  * length decides how many lookups run simultaneously; callers that resolve one
  * database row per item use this to keep that number fixed. Results keep the
- * input order, and the first rejection rejects the whole map after the
- * workers already in flight settle, matching `Promise.all` semantics closely
- * enough for callers that treat one failure as total.
+ * input order. The first rejection rejects the map immediately and stops
+ * further admission, matching `Promise.all`'s prompt failure; items already in
+ * flight run to completion and their outcomes are dropped.
  */
 
 /**
@@ -13,49 +13,70 @@
  * Returns results in input order. Throws a `RangeError` for a non-positive or
  * non-integer `limit`.
  */
-export async function mapWithConcurrency<T, R>(
+export function mapWithConcurrency<T, R>(
 	items: ReadonlyArray<T>,
 	limit: number,
 	fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
 	if (!Number.isInteger(limit) || limit < 1) {
-		throw new RangeError(
-			`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+		return Promise.reject(
+			new RangeError(
+				`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+			),
 		);
 	}
 	const results: R[] = new Array(items.length);
 	if (items.length === 0) {
-		return results;
+		return Promise.resolve(results);
 	}
-	let nextIndex = 0;
-	const state: { failure: { error: unknown } | null } = { failure: null };
-	const worker = async (): Promise<void> => {
-		while (state.failure === null) {
-			// No await sits between the read and the increment, so each worker
-			// claims a distinct index in the single-threaded loop.
-			const index = nextIndex++;
-			if (index >= items.length) {
+	return new Promise<R[]>((resolve, reject) => {
+		let nextIndex = 0;
+		let inFlight = 0;
+		let settled = false;
+
+		const fail = (error: unknown): void => {
+			if (settled) {
+				// error-policy:J5 the map already rejected with the first failure;
+				// a later rejection from an item admitted before it is observed
+				// here and dropped so it cannot surface as an unhandled rejection.
 				return;
 			}
-			try {
-				results[index] = await fn(items[index], index);
-			} catch (error) {
-				// error-policy:J2 remember the first failure so the map rejects with it once in-flight workers settle
-				if (state.failure === null) {
-					state.failure = { error };
+			settled = true;
+			reject(error);
+		};
+
+		const admit = (): void => {
+			while (!settled && inFlight < limit && nextIndex < items.length) {
+				const index = nextIndex++;
+				inFlight += 1;
+				let pending: Promise<R>;
+				try {
+					pending = fn(items[index], index);
+				} catch (error) {
+					inFlight -= 1;
+					fail(error);
+					return;
 				}
-				return;
+				pending.then(
+					(value) => {
+						inFlight -= 1;
+						if (settled) return;
+						results[index] = value;
+						if (nextIndex >= items.length && inFlight === 0) {
+							settled = true;
+							resolve(results);
+							return;
+						}
+						admit();
+					},
+					(error: unknown) => {
+						inFlight -= 1;
+						fail(error);
+					},
+				);
 			}
-		}
-	};
-	const workers: Array<Promise<void>> = [];
-	const workerCount = Math.min(limit, items.length);
-	for (let i = 0; i < workerCount; i += 1) {
-		workers.push(worker());
-	}
-	await Promise.all(workers);
-	if (state.failure !== null) {
-		throw state.failure.error;
-	}
-	return results;
+		};
+
+		admit();
+	});
 }

--- a/packages/core/src/utils/bounded-map.ts
+++ b/packages/core/src/utils/bounded-map.ts
@@ -1,0 +1,61 @@
+/**
+ * Bounded-concurrency map for fan-out over caller-controlled lists. A plain
+ * `Promise.all(items.map(fn))` admits every element at once, so the input
+ * length decides how many lookups run simultaneously; callers that resolve one
+ * database row per item use this to keep that number fixed. Results keep the
+ * input order, and the first rejection rejects the whole map after the
+ * workers already in flight settle, matching `Promise.all` semantics closely
+ * enough for callers that treat one failure as total.
+ */
+
+/**
+ * Maps `items` through `fn` with at most `limit` calls in flight at once.
+ * Returns results in input order. Throws a `RangeError` for a non-positive or
+ * non-integer `limit`.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: ReadonlyArray<T>,
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	if (!Number.isInteger(limit) || limit < 1) {
+		throw new RangeError(
+			`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+		);
+	}
+	const results: R[] = new Array(items.length);
+	if (items.length === 0) {
+		return results;
+	}
+	let nextIndex = 0;
+	const state: { failure: { error: unknown } | null } = { failure: null };
+	const worker = async (): Promise<void> => {
+		while (state.failure === null) {
+			// No await sits between the read and the increment, so each worker
+			// claims a distinct index in the single-threaded loop.
+			const index = nextIndex++;
+			if (index >= items.length) {
+				return;
+			}
+			try {
+				results[index] = await fn(items[index], index);
+			} catch (error) {
+				// error-policy:J2 remember the first failure so the map rejects with it once in-flight workers settle
+				if (state.failure === null) {
+					state.failure = { error };
+				}
+				return;
+			}
+		}
+	};
+	const workers: Array<Promise<void>> = [];
+	const workerCount = Math.min(limit, items.length);
+	for (let i = 0; i < workerCount; i += 1) {
+		workers.push(worker());
+	}
+	await Promise.all(workers);
+	if (state.failure !== null) {
+		throw state.failure.error;
+	}
+	return results;
+}


### PR DESCRIPTION
# Relates to

Closes #30731.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. `followUpsProvider` swaps one `Promise.all` over unique contact IDs for `mapWithConcurrency`, a new order-preserving bounded map in `packages/core/src/utils/bounded-map.ts` with a fixed pool of eight. Results keep input order, so the name map and the rendered text are unchanged. A lookup that throws rejects the map at once, as `Promise.all` did, stops further admission, and later rejections from lookups admitted before the failure are observed and dropped; the existing `error-policy:J4` catch still turns the failure into the explicit "unavailable" result. The helper is not exported from the package barrel.

# Background

## What does this PR do?

The FOLLOW_UPS provider resolved every unique contact for the next seven days' follow-ups through a single `Promise.all`, so the number of scheduled follow-ups decided how many concurrent `getEntityById` reads hit the database before any settled (the issue measured 512 for 512 follow-ups). The provider now resolves names through `mapWithConcurrency(contactIds, 8, ...)`. The Python distribution named in the issue is not in this repository and is out of scope here.

The sibling providers `contacts.ts` and `roles.ts` carry the same complete-list `Promise.all` over entity IDs; they are untouched in this PR, which stays on the issue's scope, and the helper lives in `utils/` so they can adopt the same bound if maintainers want it there.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`mapWithConcurrency` in `packages/core/src/utils/bounded-map.ts` and its test (the "rejects as soon as one item fails" case holds a sibling at a gate and asserts the map rejects before it is released), then the `MAX_CONCURRENT_ENTITY_LOOKUPS` call in `providers/followUps.ts` and the new `followUps.test.ts`, whose first case holds every lookup at an explicit gate and asserts the peak is exactly eight while all 64 contacts are still named.

## Detailed testing steps

Focused core suites plus a red run of the new provider test against the develop `followUps.ts`. The red run shows the peak concurrency of 64.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b6e1545c914420ad9c5c8ad550134667b5c39582 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI surface; behavior is covered by the transcripts below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface; behavior is covered by the transcripts below.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the bounded-map, followUps, and contacts provider suites plus the core typecheck on this head, pasted below.

  <details>
  <summary>vitest run on this head, plus core typecheck</summary>

  ```
# green: packages/core vitest on head b6e1545c914
 ✓ src/utils/bounded-map.test.ts > mapWithConcurrency > never admits more than the limit and keeps input order 5ms
 ✓ src/utils/bounded-map.test.ts > mapWithConcurrency > returns an empty array for an empty input without calling fn 1ms
 ✓ src/utils/bounded-map.test.ts > mapWithConcurrency > uses fewer workers than the limit when the input is shorter 2ms
 ✓ src/utils/bounded-map.test.ts > mapWithConcurrency > rejects as soon as one item fails, without waiting for a sibling still in flight 5ms
 ✓ src/utils/bounded-map.test.ts > mapWithConcurrency > drops a later rejection from an item admitted before the first failure 12ms
 ✓ src/utils/bounded-map.test.ts > mapWithConcurrency > rejects when fn throws synchronously 0ms
 ✓ src/utils/bounded-map.test.ts > mapWithConcurrency > rejects a non-positive or fractional limit 0ms
 ✓ src/features/advanced-capabilities/providers/followUps.test.ts > followUpsProvider > bounds concurrent entity lookups while still naming every contact (#30731) 15ms
 ✓ src/features/advanced-capabilities/providers/followUps.test.ts > followUpsProvider > resolves each unique contact once and labels unknown entities 1ms
 ✓ src/features/advanced-capabilities/providers/contacts.test.ts > advancedContactsProvider > returns empty result when RelationshipsService is unavailable 2ms
 ✓ src/features/advanced-capabilities/providers/contacts.test.ts > advancedContactsProvider > returns no contacts message when searchContacts returns empty list 1ms
 ✓ src/features/advanced-capabilities/providers/contacts.test.ts > advancedContactsProvider > formats and groups contacts by category with tags and details 1ms
 ✓ src/features/advanced-capabilities/providers/contacts.test.ts > advancedContactsProvider > reports error and degrades cleanly when searchContacts throws 2ms
 Test Files  3 passed (3)
      Tests  13 passed (13)

$ bun run --cwd packages/core typecheck   (head b6e1545c914)
core typecheck exit: 0
  ```

  </details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the provider's prompt text is unchanged; only how contact names are fetched changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the red run of the new provider test against the develop source, pasted below.

  <details>
  <summary>Red run: followUps.test.ts against origin/develop followUps.ts</summary>

  ```
     × bounds concurrent entity lookups while still naming every contact (#30731) 11ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/features/advanced-capabilities/providers/followUps.test.ts > followUpsProvider > bounds concurrent entity lookups while still naming every contact (#30731)
AssertionError: expected 64 to be 8 // Object.is equality
- Expected
+ Received
- 8
+ 64
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
  ```

  </details>

  <details>
  <summary>Red run: prompt-rejection test against the previous PR head e1e87d06ea1 (old helper waits on the held sibling until the 60 s test timeout)</summary>

  ```
     × rejects as soon as one item fails, without waiting for a sibling still in flight 60040ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/utils/bounded-map.test.ts > mapWithConcurrency > rejects as soon as one item fails, without waiting for a sibling still in flight
 Test Files  1 failed (1)
      Tests  1 failed | 6 skipped (7)
  ```

  </details>

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model change.

## Backend + frontend logs

Backend: pasted in the Evidence Gate row above. Frontend: N/A - no frontend code path.

## Screenshots (before / after) + video walkthrough

### Before

On `origin/develop`, 64 unique follow-up contacts produce 64 simultaneous `getEntityById` calls before any settles (red run above: peak 64).

### After

At most eight lookups are in flight at once; every contact is still resolved and named in the summary, and the values/data counts are unchanged.

### Walkthrough video

N/A - no user flow.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

`bun run verify` exited 0 (Turbo: 373 successful, 373 total) on this head `e1e87d06ea1`, base `origin/develop` `c039b4a455f`, after `bun install --frozen-lockfile` reported no changes. The first attempt on this head reached 373/373 in Turbo and was then killed by the host's memory watchdog during the trailing audit scripts; the recorded run is the complete rerun with `RUN_TURBO_CONCURRENCY=4`, which exited 0 end to end. No gaps; every N/A row above carries its reason. The follow-up commit `b6e1545c914` (prompt rejection) is covered by the suites and typecheck above; a fresh `bun run verify` on the updated head is recorded in the review thread.

## Maintainer CI exception record

N/A - no exception requested.

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility:
  `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results:
  `N/A - no exception requested`
- Conflict-free and affected-path failure attestation:
  `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmvFdDfsceXTRjEtphtMbk
