### PR TITLE
fix(ui): skip same-origin cloud console websocket retries

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -316,6 +316,73 @@ describe("ElizaClient websocket connection policy", () => {
     expect(client.getConnectionState().state).toBe("connected");
   });
 
+  it.each([
+    ["cloud-staging.eliza.app", ""],
+    ["cloud.eliza.app", ""],
+  ])(
+    "keeps the same-origin console on %s with base %s connected without websocket retries",
+    (host, base) => {
+      vi.useFakeTimers();
+      try {
+        stubWindowOrigin("https:", host);
+        const instances = stubWebSocketWithInstances();
+        const client = new ElizaClient(base);
+        client.connectWs();
+        // Drive failed upgrades if the client incorrectly dials the console.
+        for (let i = 0; i < 15 && instances.length > 0; i++) {
+          instances[instances.length - 1].onclose?.();
+          if (i < 14) vi.runOnlyPendingTimers();
+        }
+        expect(client.getConnectionState().state).toBe("connected");
+        expect(instances).toHaveLength(0);
+        client.resetConnection();
+        expect(client.getConnectionState().state).toBe("connected");
+        expect(instances).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("preserves selected-agent websocket failures on a cloud console page", () => {
+    vi.useFakeTimers();
+    try {
+      stubWindowOrigin("https:", "cloud-staging.eliza.app");
+      const instances = stubWebSocketWithInstances();
+      const client = new ElizaClient("https://agent.example.test");
+      client.connectWs();
+      expect(instances[0].url).toContain("wss://agent.example.test/ws");
+      for (let i = 0; i < 15; i++) {
+        instances[instances.length - 1].onclose?.();
+        if (i < 14) vi.runOnlyPendingTimers();
+      }
+      expect(client.getConnectionState().state).toBe("failed");
+      client.disconnectWs();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["", "/api", "api"])(
+    "keeps a separate injected websocket target with cloud client base %s",
+    (base) => {
+      stubWindowOrigin("https:", "cloud-staging.eliza.app");
+      Object.defineProperty(window, "__ELIZA_WS_BASE__", {
+        configurable: true,
+        value: "wss://realtime.example.test",
+      });
+      try {
+        const instances = stubWebSocketWithInstances();
+        const client = new ElizaClient(base);
+        client.connectWs();
+        expect(instances[0].url).toContain("wss://realtime.example.test/ws");
+        client.disconnectWs();
+      } finally {
+        Reflect.deleteProperty(window, "__ELIZA_WS_BASE__");
+      }
+    },
+  );
+
   it("still goes failed for a non-cloud agent base after WS exhaustion (overlay preserved)", () => {
     vi.useFakeTimers();
     try {

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -363,22 +363,40 @@ describe("ElizaClient websocket connection policy", () => {
     }
   });
 
-  it.each(["", "/api", "api"])(
-    "keeps a separate injected websocket target with cloud client base %s",
-    (base) => {
-      stubWindowOrigin("https:", "cloud-staging.eliza.app");
+  it.each(
+    ["app.example.test", "cloud-staging.eliza.app"].flatMap((host) =>
+      ["", "/api", "api"].flatMap((base) =>
+        [
+          "wss://realtime.example.test",
+          "wss://abc123.cloud.eliza.app",
+          "wss://cloud.eliza.app",
+        ].map((target) => ({ host, base, target })),
+      ),
+    ),
+  )(
+    "preserves injected $target on $host with API base '$base' through retry exhaustion",
+    ({ host, base, target }) => {
+      vi.useFakeTimers();
+      stubWindowOrigin("https:", host);
       Object.defineProperty(window, "__ELIZA_WS_BASE__", {
         configurable: true,
-        value: "wss://realtime.example.test",
+        value: target,
       });
       try {
         const instances = stubWebSocketWithInstances();
         const client = new ElizaClient(base);
         client.connectWs();
-        expect(instances[0].url).toContain("wss://realtime.example.test/ws");
+        expect(instances[0]?.url).toContain(`${target}/ws`);
+        for (let i = 0; i < 15; i++) {
+          instances[instances.length - 1].onclose?.();
+          if (i < 14) vi.runOnlyPendingTimers();
+        }
+        expect(instances).toHaveLength(15);
+        expect(client.getConnectionState().state).toBe("failed");
         client.disconnectWs();
       } finally {
         Reflect.deleteProperty(window, "__ELIZA_WS_BASE__");
+        vi.useRealTimers();
       }
     },
   );

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -2322,12 +2322,16 @@ export class ElizaClient {
   }
 
   connectWs(): void {
-    // An empty API base uses the page origin unless realtime has its own
-    // injected target. Explicit bases keep their existing transport policy.
+    // Infer REST-only policy from the page only for implicit same-origin
+    // clients. An injected realtime target keeps its existing socket and
+    // retry policy, even when its hostname resembles a REST-only API host.
     const effectiveBase =
       this.baseUrl ||
-      getInjectedWsBase() ||
-      (typeof window !== "undefined" ? window.location.origin : "");
+      (getInjectedWsBase()
+        ? ""
+        : typeof window !== "undefined"
+          ? window.location.origin
+          : "");
     if (shouldTreatAsConnectedWithoutWebSocket(effectiveBase)) {
       this.backoffMs = 500;
       this.reconnectAttempt = 0;

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -2322,7 +2322,13 @@ export class ElizaClient {
   }
 
   connectWs(): void {
-    if (shouldTreatAsConnectedWithoutWebSocket(this.baseUrl)) {
+    // An empty API base uses the page origin unless realtime has its own
+    // injected target. Explicit bases keep their existing transport policy.
+    const effectiveBase =
+      this.baseUrl ||
+      getInjectedWsBase() ||
+      (typeof window !== "undefined" ? window.location.origin : "");
+    if (shouldTreatAsConnectedWithoutWebSocket(effectiveBase)) {
       this.backoffMs = 500;
       this.reconnectAttempt = 0;
       this.disconnectedAt = null;
@@ -2545,10 +2551,10 @@ export class ElizaClient {
         // connected-over-REST state and keep probing in the background (see
         // scheduleReconnect's 30s loop) so live updates resume on WS recovery.
         if (
-          isDedicatedCloudAgentBase(this.baseUrl) ||
+          isDedicatedCloudAgentBase(effectiveBase) ||
           // Control-plane hosts serve chat over REST/SSE and can never
           // complete a WS upgrade (#18172) — same non-fatal degrade.
-          isElizaCloudControlPlaneBase(this.baseUrl)
+          isElizaCloudControlPlaneBase(effectiveBase)
         ) {
           this.connectionState = "connected";
           this.disconnectedAt = null;


### PR DESCRIPTION
The cloud console now recognizes its own origin as an HTTP-only backend when its API base is empty and no separate WebSocket target is injected. Previously it tried `/ws` fifteen times and blocked working Agents, Billing, and Account pages with “Lost backend connection.” Explicit API bases and injected realtime targets retain their existing transport policy.

Relates to #30897 and #18627. Neither issue should close automatically before staging verification.

The guard infers page-origin policy only for implicit same-origin clients. An injected WebSocket target remains authoritative even when its hostname matches a managed Cloud host, and retains its previous failure state after retry exhaustion. Existing self-hosted, Dedicated/shared REST-only, native, and relay behavior is preserved. No authentication, provisioning, or backend deployment configuration changes.

Base `012df281e932a6a0a7ff71735b5de84df0ff6276`; head `7fedd5a4550848e3b4da7e130457bf191c08eee5`. The branch was rebased with patch identity preserved, installation passed with pinned Bun/Node, and final root verification passed. Definition of Done: full standard in `CONTRIBUTING.md`.

## Validation

- 50 WebSocket policy tests passed on the final rebased head. The injection matrix covers 18 origin/base/target combinations and verifies socket creation plus exhausted-retry behavior.
- The original console regression fails twice against the original client. The subsequent injected-target correction fails four matrix cases before that correction and passes afterward.
- `bun run verify` passed 373/373 tasks, including UI typecheck and lint.
- The complete UI suite has 14,016 passing tests, 42 failed assertions, seven skips, one suite-loading failure, and two auth errors. All 43 failure entries reproduce on clean `0128d758`; SQL comparison found zero candidate-only failures. This remains a nongreen full suite. It ran before the audit-only rebase and was not repeated solely for that base change.
- Two independent reviewers cleared the injected-target correction after the public review finding was reproduced and fixed.
- Final full app audit passed on this head: 222 browser checks, zero broken/needs-work views, and packaged OCR with 204 verified, 12 needs-eyeball, zero broken or regressions. All eight affected Cloud captures were manually inspected. Hosted CI passed on the exact reviewed head. The stale audit readiness repair is already merged as #30901.

The recording uses the real client and production connection overlay against a local TLS server rejecting WebSocket upgrades. It waits the natural fifteen-attempt retry sequence and exercises Retry Connection. The corrected client creates zero WebSockets. Account content and the context adapter are fixtures; this is not a hosted account E2E test. Source hashes captured before commit/rebase match the final committed source. The live staging reproduction is recorded in #30897.

Final audit evidence: [final-app-audit.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-final-app-audit.log) · [final-app-audit-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-final-app-audit-report.json) · [final-app-audit-ocr.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-final-app-audit-ocr.json) · [final-app-audit-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-final-app-audit-review.md) · [final-renderer-build.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-final-renderer-build.json) · [ui-baseline-failure-comparison.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-ui-baseline-failure-comparison.json)

## Evidence Gate

<!-- evidence-head:7fedd5a4550848e3b4da7e130457bf191c08eee5 -->

<!-- evidence-row:before-screenshots -->
- [x] [v4-desktop-before.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-v4-desktop-before.png) · [v4-mobile-before.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-v4-mobile-before.png)
<!-- evidence-row:after-screenshots -->
- [x] [v4-desktop-after.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-v4-desktop-after.png) · [v4-mobile-after.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-v4-mobile-after.png)
<!-- evidence-row:walkthrough-video -->
- [x] [desktop-connection-walkthrough-v4.mp4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-desktop-connection-walkthrough-v4.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changes; local TLS upgrade responses are included in the network log.
<!-- evidence-row:frontend-logs -->
- [x] [v4-desktop-console-network.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-v4-desktop-console-network.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent action changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain-state mutations.
<!-- evidence-row:ocr-review -->
- [x] [v4-README.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-v4-README.md) · [v4-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30898-v4-ocr.txt)

## Remaining verification

Exact-head re-review approved and all hosted checks passed. Merged as `4fa1ed25ad9d4bb82ca8cdb4999b075a6591377d`; staging deployment and browser verification passed: [receipt](https://github.com/elizaOS/eliza/issues/30897#issuecomment-5573093859). Fresh-account running-agent verification remains an open item for #18627; the old Runtime/Created column requirement was superseded by #22535/#22546.
