### PR TITLE
fix(app): audit current Cloud account states

### DIFF
--- a/packages/app/test/audit/ocr-triage-provenance.test.ts
+++ b/packages/app/test/audit/ocr-triage-provenance.test.ts
@@ -376,7 +376,7 @@ describe("ocr-triage CLI (end-to-end provenance)", () => {
         ocrLine(
           "mobile-portrait",
           "plugin-cloud-gui",
-          "Eliza Cloud Credits",
+          "Connected Credits $42.50 Hosted agents Research agent running",
         ),
         ocrLine(
           "ipad-portrait",

--- a/packages/app/test/audit/ocr-view-expectations.test.ts
+++ b/packages/app/test/audit/ocr-view-expectations.test.ts
@@ -109,29 +109,6 @@ describe("aesthetic audit semantic OCR policy coverage", () => {
     }
   });
 
-  it("keeps separate connected and signed-out Cloud semantic contracts", () => {
-    expect(resolveViewOcrPolicy("plugin-cloud-gui")).toEqual({
-      kind: "expectation",
-      expectation: {
-        requireAll: ["Eliza Cloud"],
-        requireAny: ["Credits", "Hosted agents", "API keys", "Connected"],
-      },
-    });
-    expect(resolveViewOcrPolicy("plugin-cloud-signed-out-gui")).toEqual({
-      kind: "expectation",
-      expectation: {
-        requireAll: ["Eliza Cloud", "Connect in Settings"],
-        requireAny: [
-          "credits",
-          "hosted agents",
-          "API keys",
-          "billing",
-          "Connect in Settings",
-        ],
-      },
-    });
-  });
-
   it("recognizes plugin-owned Contacts by stable empty-state content", () => {
     const policy = resolveViewOcrPolicy("plugin-contacts-gui");
     expect(policy.kind).toBe("expectation");

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -2257,6 +2257,26 @@ test.describe("all-views aesthetic audit (#8796)", () => {
             viewRoot.getByText("Connected", { exact: true }),
           ).toHaveCount(0);
         }
+        if (view.id === "cloud") {
+          const oppositePolicy = resolveViewOcrPolicy(
+            view.fixtureState === "cloud-signed-out"
+              ? "plugin-cloud-gui"
+              : "plugin-cloud-signed-out-gui",
+          );
+          if (oppositePolicy.kind !== "expectation") {
+            throw new Error(
+              "Cloud account states must declare semantic content",
+            );
+          }
+          await expect(
+            readViewPaint(
+              viewRoot,
+              page.locator(overlaySelector),
+              oppositePolicy.expectation,
+            ),
+            "the rendered Cloud account must not satisfy the opposite auth state",
+          ).resolves.toMatchObject({ semanticReady: false });
+        }
         await settleHomeEntrance(page);
         const { readableChars, semanticReady, overlayPresent } = paint;
         const renderStateIssues = [

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -228,13 +228,13 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["Ocean Deep", "Alpine Dawn", "Ember Night"],
   }),
   "plugin-cloud-gui": expected({
-    requireAll: ["Eliza Cloud"],
-    requireAny: ["Credits", "Hosted agents", "API keys", "Connected"],
+    requireAll: ["Connected", "Credits"],
+    requireAny: ["Hosted agents", "API keys"],
   }),
   // Preserve the disconnected state as a separate production-bundle capture;
   // connected account fixtures must not erase sign-in recovery coverage.
   "plugin-cloud-signed-out-gui": expected({
-    requireAll: ["Eliza Cloud", "Connect in Settings"],
+    requireAll: ["Connect to view credits", "Connect in Settings"],
     requireAny: [
       "credits",
       "hosted agents",


### PR DESCRIPTION
The app audit now recognizes the current connected and signed-out Cloud views. Its old readiness check required an optional heading hidden by the normal page composition, so eight healthy captures always failed the strict aggregate.

Relates to #30899 and #18627. The Settings button capability fix is tracked separately in #30900.

The connected check requires visible status and account content; the signed-out check requires its explanation and recovery control. Each real browser capture must also reject the opposite account-state policy. The strict gate and loading/hidden-content checks remain intact. A unit test that only copied policy literals is replaced by the browser behavior check, and the OCR provenance fixture uses current rendered text without changing its provenance or regression assertions.

## Validation

- 192 audit unit tests passed.
- Eight real-bundle Cloud view cases passed across four viewport sizes, plus the existing negative readiness browser case.
- Eleven CloudView behavior tests passed.
- App typecheck, lint, and formatting passed.
- Root verification passed again on the committed revision. Full `audit:app` passed all 222 browser checks and packaged OCR: 204 verified, 12 needs-eyeball, zero broken, zero regressions. All eight affected Cloud views are OCR verified and manually inspected.

The browser account responses are deterministic fixtures. This validates the audit producer and rendered plugin states; it does not establish live account authentication or provisioning.

Definition of Done: full standard in `CONTRIBUTING.md`.

Base: `0128d7581b2c7870c3cf264d61e66b78556f381f`. Head: `4435b01928b516dfd0727a0ada23c6b7a71c1d21`. Installation completed with the pinned toolchain and no dependency changes. Independent review found no blockers in the final patch.

The supplementary [evidence.sqlite](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-evidence.sqlite) contains queryable measurements. The document evidence rows below use the textual comparison and JSON reports because the document gate requires UTF-8 artifacts.

## Evidence Gate

<!-- evidence-head:4435b01928b516dfd0727a0ada23c6b7a71c1d21 -->

<!-- evidence-row:before-screenshots -->
- [x] [baseline-desktop-landscape-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-desktop-landscape-plugin-cloud-gui.png) · [baseline-desktop-landscape-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-desktop-landscape-plugin-cloud-signed-out-gui.png) · [baseline-ipad-portrait-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-ipad-portrait-plugin-cloud-gui.png) · [baseline-ipad-portrait-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-ipad-portrait-plugin-cloud-signed-out-gui.png) · [baseline-mobile-landscape-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-mobile-landscape-plugin-cloud-gui.png) · [baseline-mobile-landscape-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-mobile-landscape-plugin-cloud-signed-out-gui.png) · [baseline-mobile-portrait-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-mobile-portrait-plugin-cloud-gui.png) · [baseline-mobile-portrait-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-baseline-mobile-portrait-plugin-cloud-signed-out-gui.png)
<!-- evidence-row:after-screenshots -->
- [x] [candidate-desktop-landscape-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-desktop-landscape-plugin-cloud-gui.png) · [candidate-desktop-landscape-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-desktop-landscape-plugin-cloud-signed-out-gui.png) · [candidate-ipad-portrait-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-ipad-portrait-plugin-cloud-gui.png) · [candidate-ipad-portrait-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-ipad-portrait-plugin-cloud-signed-out-gui.png) · [candidate-mobile-landscape-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-mobile-landscape-plugin-cloud-gui.png) · [candidate-mobile-landscape-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-mobile-landscape-plugin-cloud-signed-out-gui.png) · [candidate-mobile-portrait-plugin-cloud-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-mobile-portrait-plugin-cloud-gui.png) · [candidate-mobile-portrait-plugin-cloud-signed-out-gui](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-candidate-mobile-portrait-plugin-cloud-signed-out-gui.png)
<!-- evidence-row:walkthrough-video -->
- [x] N/A - test-only readiness/provenance repair changes no application interaction or pixels. Actual production-bundle captures and audit reports establish the changed classification.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changes; account responses are deterministic audit fixtures.
<!-- evidence-row:frontend-logs -->
- [x] [audit-app.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-audit-app.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [comparison.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-comparison.txt) · [capture-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-capture-report.json) · [final-renderer-build.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-final-renderer-build.json)
<!-- evidence-row:ocr-review -->
- [x] [README.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-README.md) · [cloud-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-cloud-ocr.txt) · [ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-ocr-triage.json) · [ocr-summary.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30901-ocr-summary.json)

All eight Cloud screenshots are byte-identical between baseline and candidate. The final committed build passes their readiness checks; the full audit and OCR stages both completed successfully.
