### PR TITLE
fix(cloud): enable plugin Settings recovery navigation

### DIFF
--- a/.github/workflows/pr-static-smoke.yml
+++ b/.github/workflows/pr-static-smoke.yml
@@ -142,6 +142,10 @@ jobs:
           packages/scripts/__tests__/github-action-pinning.test.ts
           packages/scripts/__tests__/pr-static-smoke-workflow.test.ts
 
+      - name: Check production and smoke view navigation parity
+        working-directory: packages/app-core
+        run: node ../scripts/run-vitest.mjs run --config vitest.config.ts scripts/smoke-view-declarations.test.ts
+
       - name: Upload Bun runtime resolution inventory
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -39,7 +39,7 @@ export const smokeViewDeclarations = [
     "/cloud",
     "CloudView",
     "gui",
-    { header: "fullscreen", capabilities: ["agent-surface"] },
+    { header: "fullscreen", capabilities: ["agent-surface", "navigate"] },
   ],
   ["contacts", "Contacts", "plugin-contacts", "/contacts", "ContactsView"],
   // The decomposed personal-assistant domain views are the real surfaces (the

--- a/packages/app-core/scripts/smoke-view-declarations.mjs
+++ b/packages/app-core/scripts/smoke-view-declarations.mjs
@@ -9,7 +9,9 @@
  * surface for a view production no longer registers — proving nothing. So the
  * declarations live here next to `checkSmokeViewParity`, which fails the moment
  * a declared view's plugin directory is gone or no longer exports the named
- * component. Removed plugin IDs (Shopify, Steward, Social Alpha) are therefore
+ * component. Navigation grants must also match in both directions; unrelated
+ * surface grants are outside this check. Removed plugin IDs
+ * (Shopify, Steward, Social Alpha) are therefore
  * kept out and cannot silently reappear.
  *
  * `resolveBundleProvenance` is the single decision the stub uses when serving a
@@ -152,6 +154,22 @@ function readSourceFiles(dir) {
   return sources;
 }
 
+function propertyInitializer(object, propertyName) {
+  // The last matching property wins. A later spread can replace the policy.
+  for (const property of [...object.properties].reverse()) {
+    if (ts.isSpreadAssignment(property)) return null;
+    const name = property.name;
+    const key =
+      name && (ts.isIdentifier(name) || ts.isStringLiteralLike(name))
+        ? name.text
+        : undefined;
+    if (key === undefined) return null;
+    if (key !== propertyName) continue;
+    return ts.isPropertyAssignment(property) ? property.initializer : null;
+  }
+  return undefined;
+}
+
 function stringProperty(object, propertyName) {
   for (const property of object.properties) {
     if (!ts.isPropertyAssignment(property)) continue;
@@ -168,12 +186,197 @@ function stringProperty(object, propertyName) {
   return undefined;
 }
 
+function literalExpression(node) {
+  while (
+    node &&
+    (ts.isAsExpression(node) ||
+      ts.isSatisfiesExpression(node) ||
+      ts.isParenthesizedExpression(node) ||
+      ts.isTypeAssertionExpression(node))
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+function immutablePolicyInitializer(node) {
+  if (ts.isStringLiteralLike(literalExpression(node))) return true;
+  while (ts.isSatisfiesExpression(node) || ts.isParenthesizedExpression(node)) {
+    node = node.expression;
+  }
+  return (
+    ts.isAsExpression(node) &&
+    ts.isTypeReferenceNode(node.type) &&
+    ts.isIdentifier(node.type.typeName) &&
+    node.type.typeName.text === "const"
+  );
+}
+
+function isModulePolicyReference(node) {
+  for (let parent = node.parent; parent; parent = parent.parent) {
+    if (
+      ts.isFunctionLike(parent) ||
+      ts.isBlock(parent) ||
+      ts.isModuleBlock(parent) ||
+      ts.isClassLike(parent) ||
+      ts.isCaseBlock(parent) ||
+      ts.isForStatement(parent) ||
+      ts.isForInStatement(parent) ||
+      ts.isForOfStatement(parent)
+    )
+      return false;
+  }
+  return true;
+}
+
+function hasUnsupportedPolicyUse(sourceFile, name) {
+  let unsupported = false;
+  const visit = (node) => {
+    if (ts.isIdentifier(node) && node.text === name) {
+      let reference = node;
+      while (
+        reference.parent &&
+        (ts.isAsExpression(reference.parent) ||
+          ts.isSatisfiesExpression(reference.parent) ||
+          ts.isTypeAssertionExpression(reference.parent) ||
+          ts.isParenthesizedExpression(reference.parent))
+      )
+        reference = reference.parent;
+      const parent = reference.parent;
+      if (
+        parent &&
+        (((ts.isPropertyAccessExpression(parent) ||
+          ts.isElementAccessExpression(parent)) &&
+          parent.expression === reference) ||
+          ((ts.isCallExpression(parent) || ts.isNewExpression(parent)) &&
+            parent.arguments?.includes(reference)) ||
+          (ts.isBinaryExpression(parent) && parent.left === reference) ||
+          ts.isDeleteExpression(parent) ||
+          ts.isPostfixUnaryExpression(parent) ||
+          ts.isPrefixUnaryExpression(parent))
+      )
+        unsupported = true;
+    }
+    if (!unsupported) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return unsupported;
+}
+
+function resolvePolicyExpression(node, sources, resolving = new Set()) {
+  node = literalExpression(node);
+  if (!node || !ts.isIdentifier(node)) return node;
+  // This is a static manifest contract, not a lexical binder or mutation analysis.
+  if (!isModulePolicyReference(node)) return null;
+  const sourceFile = node.getSourceFile();
+  if (hasUnsupportedPolicyUse(sourceFile, node.text)) return null;
+  const key = `${sourceFile.fileName}:${node.text}`;
+  if (resolving.has(key)) return null;
+  const next = new Set(resolving).add(key);
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isVariableStatement(statement) &&
+      statement.declarationList.flags & ts.NodeFlags.Const
+    ) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === node.text
+        ) {
+          return declaration.initializer &&
+            immutablePolicyInitializer(declaration.initializer)
+            ? resolvePolicyExpression(declaration.initializer, sources, next)
+            : null;
+        }
+      }
+    }
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteralLike(statement.moduleSpecifier) ||
+      !statement.moduleSpecifier.text.startsWith(".")
+    )
+      continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    const binding = bindings.elements.find(
+      (element) => element.name.text === node.text,
+    );
+    if (!binding) continue;
+    const target = path.resolve(
+      path.dirname(sourceFile.fileName),
+      statement.moduleSpecifier.text,
+    );
+    const imported = sources.find(
+      ({ filePath }) =>
+        filePath === target ||
+        filePath === target.replace(/\.js$/, ".ts") ||
+        filePath === `${target}.ts`,
+    );
+    if (!imported) return null;
+    const importedFile = ts.createSourceFile(
+      imported.filePath,
+      imported.source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const exportedName = binding.propertyName?.text ?? binding.name.text;
+    if (hasUnsupportedPolicyUse(importedFile, exportedName)) return null;
+    for (const importedStatement of importedFile.statements) {
+      if (
+        !ts.isVariableStatement(importedStatement) ||
+        !(importedStatement.declarationList.flags & ts.NodeFlags.Const) ||
+        !importedStatement.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+        )
+      )
+        continue;
+      for (const declaration of importedStatement.declarationList
+        .declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === exportedName
+        ) {
+          return declaration.initializer &&
+            immutablePolicyInitializer(declaration.initializer)
+            ? resolvePolicyExpression(declaration.initializer, sources, next)
+            : null;
+        }
+      }
+    }
+    return null;
+  }
+  return null;
+}
+
+function navigationGrant(object, sources) {
+  const surface = resolvePolicyExpression(
+    propertyInitializer(object, "surface"),
+    sources,
+  );
+  if (surface === undefined) return false;
+  if (!surface || !ts.isObjectLiteralExpression(surface)) return null;
+  const capabilities = resolvePolicyExpression(
+    propertyInitializer(surface, "capabilities"),
+    sources,
+  );
+  if (capabilities === undefined) return false;
+  if (!capabilities || !ts.isArrayLiteralExpression(capabilities)) return null;
+  const grants = capabilities.elements.map((element) =>
+    resolvePolicyExpression(element, sources),
+  );
+  if (!grants.every((grant) => grant && ts.isStringLiteralLike(grant)))
+    return null;
+  return grants.some((grant) => grant.text === "navigate");
+}
+
 function inspectViewDeclarations(
   sourceFiles,
   { id, viewPath, componentExport },
 ) {
   let declaresIdAndPath = false;
   let declaresExactView = false;
+  let grantsNavigation = null;
   for (const { filePath, source } of sourceFiles) {
     const sourceFile = ts.createSourceFile(
       filePath,
@@ -190,6 +393,7 @@ function inspectViewDeclarations(
           declaresIdAndPath = true;
           if (stringProperty(node, "componentExport") === componentExport) {
             declaresExactView = true;
+            grantsNavigation = navigationGrant(node, sourceFiles);
           }
         }
       }
@@ -198,13 +402,15 @@ function inspectViewDeclarations(
     visit(sourceFile);
     if (declaresExactView) break;
   }
-  return { declaresExactView, declaresIdAndPath };
+  return { declaresExactView, declaresIdAndPath, grantsNavigation };
 }
 
 /**
  * Check every smoke view declaration against the plugin that must register it.
  * A declaration is in parity when the plugin directory exists and its source
- * both declares the view `id` and exports the named component. Returns the full
+ * both declares the view `id` and exports the named component. Navigation must
+ * be equally granted or denied by the smoke and production declarations.
+ * Other surface capabilities are not compared. Returns the full
  * declaration list plus the misses so a test can assert the shipped set is
  * clean AND that a removed plugin id would be caught.
  */
@@ -241,6 +447,23 @@ export function checkSmokeViewParity(
         reason: declaration.declaresIdAndPath
           ? "component-export-missing"
           : "view-id-not-declared",
+      });
+    } else if (declaration.grantsNavigation === null) {
+      missing.push({
+        id,
+        pluginDirName,
+        componentExport,
+        reason: "surface-navigation-policy-unresolved",
+      });
+    } else if (
+      declaration.grantsNavigation !==
+      (tuple[6]?.capabilities?.includes("navigate") ?? false)
+    ) {
+      missing.push({
+        id,
+        pluginDirName,
+        componentExport,
+        reason: "surface-navigation-mismatch",
       });
     }
   }

--- a/packages/app-core/scripts/smoke-view-declarations.test.ts
+++ b/packages/app-core/scripts/smoke-view-declarations.test.ts
@@ -53,7 +53,7 @@ describe("smoke view declaration parity (#15791)", () => {
           "/cloud",
           "CloudView",
           "gui",
-          { header: "fullscreen", capabilities: ["agent-surface"] },
+          { header: "fullscreen", capabilities: ["agent-surface", "navigate"] },
         ],
         ["notes", "Notes", "plugin-notes", "/notes", "NotesView"],
         [

--- a/packages/app-core/scripts/smoke-view-declarations.test.ts
+++ b/packages/app-core/scripts/smoke-view-declarations.test.ts
@@ -5,6 +5,14 @@
  * production-declared view can never be served as a fabricated bundle in audit
  * mode. Guards issue #15791.
  */
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -102,6 +110,171 @@ describe("smoke view declaration parity (#15791)", () => {
     const { ok, missing } = checkSmokeViewParity(repoRoot, wrongComponent);
     expect(ok).toBe(false);
     expect(missing[0]?.reason).toBe("component-export-missing");
+  });
+});
+
+describe("smoke navigation grants match production (#30900)", () => {
+  const cloud = smokeViewDeclarations.find(([id]) => id === "cloud");
+  if (!cloud) throw new Error("Cloud smoke declaration is required");
+  const source = readFileSync(
+    path.join(repoRoot, "plugins/plugin-elizacloud/src/index.ts"),
+    "utf8",
+  );
+  const surface =
+    /surface: \{ header: "fullscreen", capabilities: \["agent-surface", "navigate"\] \},/;
+
+  function checkPolicy(
+    productionSurface: string,
+    declarations = [cloud],
+    extraSource = "",
+    prefix = "",
+    template = source,
+  ) {
+    const fixture = mkdtempSync(path.join(os.tmpdir(), "smoke-navigation-"));
+    const pluginSource = path.join(fixture, "plugins/plugin-elizacloud/src");
+    mkdirSync(pluginSource, { recursive: true });
+    try {
+      expect(template).toMatch(surface);
+      writeFileSync(
+        path.join(pluginSource, "index.ts"),
+        prefix + template.replace(surface, productionSurface),
+      );
+      writeFileSync(path.join(pluginSource, "surface.ts"), extraSource);
+      return checkSmokeViewParity(fixture, declarations);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  }
+
+  it.each(['surface: { capabilities: ["agent-surface"] },', ""])(
+    "rejects a production navigation removal: %s",
+    (policy) => {
+      expect(checkPolicy(policy).missing).toEqual([
+        expect.objectContaining({
+          id: "cloud",
+          reason: "surface-navigation-mismatch",
+        }),
+      ]);
+    },
+  );
+
+  it.each([{ capabilities: ["agent-surface"] }, undefined])(
+    "rejects removal of the smoke navigation grant: %s",
+    (smokeSurface) => {
+      const changed = [...cloud];
+      changed[6] = smokeSurface;
+      expect(
+        checkPolicy('surface: { capabilities: ["navigate"] },', [changed])
+          .missing,
+      ).toEqual([
+        expect.objectContaining({ reason: "surface-navigation-mismatch" }),
+      ]);
+    },
+  );
+
+  it("compares navigation as a grant, without changing unrelated capabilities", () => {
+    expect(
+      checkPolicy('surface: { capabilities: ["navigate", "storage"] },').ok,
+    ).toBe(true);
+  });
+
+  it("resolves local and named relative constants without executing plugin imports", () => {
+    expect(
+      checkPolicy(
+        "surface: POLICY,",
+        [cloud],
+        "",
+        'const POLICY = { capabilities: ["navigate"] } as const;',
+      ).ok,
+    ).toBe(true);
+    expect(
+      checkPolicy(
+        "surface: POLICY,",
+        [cloud],
+        'const grants = ["navigate"] as const; export const SHARED = { capabilities: grants } as const satisfies SurfaceManifest;',
+        'import { SHARED as POLICY } from "./surface.js";',
+      ).ok,
+    ).toBe(true);
+  });
+
+  it("fails explicitly on cyclic constants and imports outside the plugin sources", () => {
+    for (const prefix of [
+      "const POLICY = OTHER; const OTHER = POLICY;",
+      'import { POLICY } from "../../../../outside.js";',
+    ]) {
+      expect(
+        checkPolicy("surface: POLICY,", [cloud], "", prefix).missing,
+      ).toEqual([
+        expect.objectContaining({
+          reason: "surface-navigation-policy-unresolved",
+        }),
+      ]);
+    }
+  });
+
+  it("rejects a policy reference shadowed inside a function", () => {
+    const template = `const POLICY = { capabilities: ["navigate"] } as const;
+      function build(POLICY) { return { id: "cloud", path: "/cloud", componentExport: "CloudView",
+        surface: { header: "fullscreen", capabilities: ["agent-surface", "navigate"] },
+      }; }`;
+    expect(
+      checkPolicy("surface: POLICY,", [cloud], "", "", template).missing,
+    ).toEqual([
+      expect.objectContaining({
+        reason: "surface-navigation-policy-unresolved",
+      }),
+    ]);
+  });
+
+  it.each([
+    'const POLICY = { capabilities: ["navigate"] }; POLICY.capabilities = [];',
+    'const POLICY = { capabilities: ["navigate"] } as const; POLICY.capabilities = [];',
+    'const POLICY = { capabilities: ["navigate"] } as const; POLICY.capabilities.pop();',
+    'const POLICY = { capabilities: ["navigate"] } as const; (<{capabilities:string[]}>POLICY).capabilities = [];',
+    'const POLICY = { capabilities: ["navigate"] } as const; mutate(POLICY);',
+  ])("rejects mutable or escaped named policies: %s", (prefix) => {
+    expect(
+      checkPolicy("surface: POLICY,", [cloud], "", prefix).missing,
+    ).toEqual([
+      expect.objectContaining({
+        reason: "surface-navigation-policy-unresolved",
+      }),
+    ]);
+  });
+
+  it("rejects direct mutations of either an imported alias or exported policy", () => {
+    for (const [extra, importer] of [
+      ["", "POLICY.capabilities = [];"],
+      ["SHARED.capabilities = [];", ""],
+    ]) {
+      expect(
+        checkPolicy(
+          "surface: POLICY,",
+          [cloud],
+          `export const SHARED = { capabilities: ["navigate"] } as const;${extra}`,
+          `import { SHARED as POLICY } from "./surface.js";${importer}`,
+        ).missing,
+      ).toEqual([
+        expect.objectContaining({
+          reason: "surface-navigation-policy-unresolved",
+        }),
+      ]);
+    }
+  });
+
+  it.each([
+    "surface: loadPolicy(),",
+    "surface: { capabilities: grants },",
+    'surface: { capabilities: ["navigate", ...grants] },',
+    'surface: { capabilities: ["navigate"], ...policy },',
+    'surface: { capabilities: ["navigate"], [key]: policy },',
+    'surface: { capabilities: ["navigate"] }, ...policy,',
+  ])("fails explicitly on unresolved navigation policy: %s", (policy) => {
+    expect(checkPolicy(policy).missing).toEqual([
+      expect.objectContaining({
+        reason: "surface-navigation-policy-unresolved",
+      }),
+    ]);
   });
 });
 

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -2427,6 +2427,19 @@ test.describe("all-views aesthetic audit (#8796)", () => {
               `without overflow-x:hidden)`,
           ).toBeLessThanOrEqual(HORIZONTAL_OVERFLOW_TOLERANCE_PX);
         }
+        if (view.fixtureState === "cloud-signed-out") {
+          await viewRoot
+            .getByRole("button", { name: "Connect in Settings", exact: true })
+            .click();
+          await expect(page).toHaveURL(/\/settings(?:[?#]|$)/);
+          const settingsRoot = page.locator(
+            '[data-view-lifecycle-slot="settings"][data-view-hidden="false"]',
+          );
+          await expect(settingsRoot).toBeVisible();
+          await expect(
+            settingsRoot.getByText("Voice", { exact: true }).first(),
+          ).toBeVisible();
+        }
       });
     }
   }

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -357,7 +357,7 @@ export const elizaOSCloudPlugin: Plugin = {
       modalities: ["gui"],
       bundlePath: "dist/views/bundle.js",
       componentExport: "CloudView",
-      surface: { header: "fullscreen", capabilities: ["agent-surface"] },
+      surface: { header: "fullscreen", capabilities: ["agent-surface", "navigate"] },
       tags: ["cloud", "billing", "credits", "account", "api-keys", "agents"],
       visibleInManager: true,
       desktopTabEnabled: true,


### PR DESCRIPTION
The signed-out remote Cloud plugin can now open Settings through its recovery button. Previously the button displayed “Navigation is unavailable right now” because the view called host navigation without declaring the required capability.

Relates to #30900 and #18627. The audit readiness repair is already merged as #30901.

The production Cloud manifest and matching smoke declaration now grant the existing `navigate` capability. This permits general shell navigation under the current capability model; the changed consumer uses the fixed `/settings` destination. The broker, undeclared-capability denial, and existing destination handling remain unchanged. No storage, external-link, billing, or lifecycle grant is added.

The browser regression clicks the actual bundled recovery button and waits for the Settings route, visible lifecycle slot, and rendered Settings content. The existing declaration checker now compares production and smoke navigation grants in both directions, and the required Source static smoke job runs that suite. It supports a bounded static declaration subset and explicitly rejects unresolved policies; it does not compare unrelated capabilities or execute plugin code.

Base `4fa1ed25ad9d4bb82ca8cdb4999b075a6591377d`; head `b1390d5eca2b75585fccc7a6081ae6932b6f2262`. Rebase preserved the reviewed patch. Pinned installation and post-rebase root verification passed. Definition of Done: full standard in `CONTRIBUTING.md`.

## Validation

- Root `bun run verify` passed 373/373 tasks on the rebased source.
- Plugin tests: 642 passed, five skipped; five real distribution checks passed.
- Broker grant/denial tests: 26 passed. Declaration parity: 28 passed with the exact CI command on the final head. Removing the grant or entire surface from either production or smoke now fails. Workflow contracts: six passed; actionlint 1.7.12 passed.
- Plugin and app-core typecheck/lint passed.
- Real bundled navigation reached usable Settings at all four viewport sizes. Desktop/mobile before-error and after-Settings images, OCR, recordings, and console/network evidence are attached below.
- Two independent reviews cleared the capability declaration, browser interaction, and final parity/CI follow-up after resolving shadowing and direct-mutation false positives.
- The final renderer built at `b1390d5eca` and its full combined app audit passed: 222 browser checks, zero broken or needs-work findings, and packaged OCR with 204 verified, 12 needs-eyeball, zero broken or regressions. All eight Cloud views are OCR verified and manually inspected; all four Settings CTA flows passed. Exact-head re-review approved. Hosted CI passed all five required checks in run [34139016468](https://github.com/elizaOS/eliza/actions/runs/34139016468).

Broader owner suites are nongreen in untouched areas. The app Bun lane passed 950 tests with two skips; its Vitest lane passed 1,626 and failed six renderer-HMR/iOS-source assertions. App-core passed 4,547, skipped 25, failed three assertions, and had three loader errors involving provider-model expectations, desktop catalogs, and Node/Bun test discovery. The affected source/tests/configuration are unchanged from the base, with narrow failures reproduced; a complete clean-base run of both broad suites was not performed. These failures are disclosed rather than counted as passing validation.

The before captures use the real production plugin bundle and host broker with deterministic local HTTP fixtures and a reused renderer. Final after screenshots and the full audit use the renderer freshly built at `b1390d5eca`, with matching build stamps in all four CTA traces. The walkthrough recordings retain their `29c401fe` provenance; the navigation plugin, broker, and CTA test are unchanged. This demonstrates grant/denial and navigation behavior, not hosted login or fresh-account provisioning.

Earlier `29c401fe` audit (preserved): [exact-29c-renderer-build.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-29c-renderer-build.json) · [exact-29c-audit.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-29c-audit.log) · [exact-29c-capture-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-29c-capture-report.json) · [exact-29c-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-29c-ocr-triage.json)

## Evidence Gate

<!-- evidence-head:b1390d5eca2b75585fccc7a6081ae6932b6f2262 -->

<!-- evidence-row:before-screenshots -->
- [x] [interaction-v1-before-desktop.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-interaction-v1-before-desktop.png) · [interaction-v1-before-mobile.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-interaction-v1-before-mobile.png)
<!-- evidence-row:after-screenshots -->
- [x] [exact-b139-settings-desktop.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-settings-after-cta-desktop-landscape.png) · [exact-b139-settings-mobile.png](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-settings-after-cta-mobile-portrait.png)
<!-- evidence-row:walkthrough-video -->
- [x] [exact-29c-after-desktop.mp4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-29c-after-desktop.mp4) · [exact-29c-after-mobile.mp4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-29c-after-mobile.mp4)
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changes; local fixture request evidence is included with frontend logs.
<!-- evidence-row:frontend-logs -->
- [x] [exact-29c-console-network.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-29c-console-network.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain-state mutations.
<!-- evidence-row:ocr-review -->
- [x] [exact-b139-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-review.md) · [interaction-v1-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-interaction-v1-ocr.txt)

Final parity/CI proof: [follow-up scope](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-parity-b139-scope.md) · [focused checks](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-parity-b139-focused.log) · [root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-parity-b139-verify.log). Exact-head re-review approved; hosted CI passed.

Final combined build and audit: [renderer manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-renderer-build.json) · [audit log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-audit.log) · [capture report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-capture-report.json) · [OCR](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-ocr-triage.json) · [inspection and run provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30902-exact-b139-review.md). The first capture had one Goals asset-load failure with `ERR_NETWORK_CHANGED`; its focused retry and the full 222-case repeat passed without code changes.

Merged as `e14071f00998f4d10f937015e3060196b991ad4d`. The exact merged revision deployed successfully to staging in [run 34142406941](https://github.com/elizaOS/eliza/actions/runs/34142406941). API health and the staging certificate match the merge; Pages freshness and routing checks passed. Scoped issue #30900 is closed with [verification details and browser limits](https://github.com/elizaOS/eliza/issues/30900#issuecomment-5573522821).
