### PR TITLE
fix(cloud): decode Node/redactor health frames in staging worker diagnostic

### DIFF
--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
@@ -54,10 +54,15 @@ function healthSummary() {
 const BUN_HEALTH_HEADER = "[docker-sandbox] Health timeout diagnostics {";
 const NODE_HEALTH_HEADER =
   "[docker-sandbox] Health timeout diagnostics [Object: null prototype] {";
-// A complete single- or double-quoted console string literal on one rendered
-// line. `\\.` consumes an escaped character without crossing the closing quote,
-// so an embedded quote or comma inside the value never terminates the field.
-const NODE_QUOTED = String.raw`'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"`;
+// A complete single-, double-, or backtick-quoted console string literal on one
+// rendered line. `\\.` consumes an escaped character without crossing the closing
+// quote, so an embedded quote or comma inside the value never terminates the
+// field. Node's util.inspect selects backticks when a value contains both a
+// single and a double quote but no backtick (and no `${`), so a diagnostics line
+// such as `option 'mode' received "invalid"` renders backtick-delimited; without
+// this alternative that whole health frame would be rejected as malformed.
+const NODE_BACKTICK = "`";
+const NODE_QUOTED = String.raw`'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|${NODE_BACKTICK}(?:[^${NODE_BACKTICK}\\]|\\.)*${NODE_BACKTICK}`;
 const NODE_CONTAINER_LINE = new RegExp(
   `^ {2}containerName: (${NODE_QUOTED}),$`,
 );

--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
@@ -44,7 +44,124 @@ function healthSummary() {
   return { frames: 0, malformedFrames: 0, observations: [] };
 }
 
-function healthObservation(diagnostics) {
+// Bun renders the health-timeout context as an ordinary object (double-quoted,
+// JSON-decodable values on one line each). Node renders the production redactor's
+// null-prototype clone differently: a `[Object: null prototype] {` header,
+// single-quoted values, and a multiline string emitted as `'part\n' +`
+// continuation lines that Node's console sink caps at 10000 characters with a
+// `'…'... N more characters` marker. Both headers below are complete worker log
+// lines, never substrings of container diagnostics.
+const BUN_HEALTH_HEADER = "[docker-sandbox] Health timeout diagnostics {";
+const NODE_HEALTH_HEADER =
+  "[docker-sandbox] Health timeout diagnostics [Object: null prototype] {";
+// A complete single- or double-quoted console string literal on one rendered
+// line. `\\.` consumes an escaped character without crossing the closing quote,
+// so an embedded quote or comma inside the value never terminates the field.
+const NODE_QUOTED = String.raw`'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"`;
+const NODE_CONTAINER_LINE = new RegExp(
+  `^ {2}containerName: (${NODE_QUOTED}),$`,
+);
+const NODE_NODEID_LINE = new RegExp(`^ {2}nodeId: (${NODE_QUOTED}),$`);
+// The multiline continuation of a diagnostics string ends either with ` +` (more
+// lines follow), with the truncation marker Node appends past its string cap, or
+// with nothing (the final complete line).
+const NODE_TRUNCATION = String.raw`\.\.\. [0-9]+ more characters?`;
+const NODE_DIAGNOSTICS_FIRST = new RegExp(
+  `^ {2}diagnostics: (${NODE_QUOTED})(?:( \\+)|(${NODE_TRUNCATION}))?$`,
+);
+const NODE_DIAGNOSTICS_CONT = new RegExp(
+  `^ {4}(${NODE_QUOTED})(?:( \\+)|(${NODE_TRUNCATION}))?$`,
+);
+
+// Decodes one Node console string literal (the value still wrapped in its
+// quotes) into its original text. Only the escape sequences Node's util.inspect
+// actually emits are accepted; any other backslash sequence returns null so the
+// caller rejects the frame rather than guessing — the raw literal is never
+// evaluated. (error-policy:J3)
+function decodeNodeString(literal) {
+  const body = literal.slice(1, -1);
+  let out = "";
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    if (char !== "\\") {
+      out += char;
+      continue;
+    }
+    const esc = body[index + 1];
+    index += 1;
+    if (esc === "n") out += "\n";
+    else if (esc === "r") out += "\r";
+    else if (esc === "t") out += "\t";
+    else if (esc === "b") out += "\b";
+    else if (esc === "f") out += "\f";
+    else if (esc === "v") out += "\v";
+    else if (esc === "0") out += "\0";
+    else if (esc === "\\" || esc === "'" || esc === '"' || esc === "`")
+      out += esc;
+    else if (esc === "x") {
+      const hex = body.slice(index + 1, index + 3);
+      if (!/^[0-9a-fA-F]{2}$/.test(hex)) return null;
+      out += String.fromCharCode(Number.parseInt(hex, 16));
+      index += 2;
+    } else if (esc === "u") {
+      if (body[index + 1] === "{") {
+        const end = body.indexOf("}", index + 2);
+        const hex = end < 0 ? "" : body.slice(index + 2, end);
+        if (!/^[0-9a-fA-F]{1,6}$/.test(hex)) return null;
+        const code = Number.parseInt(hex, 16);
+        if (code > 0x10ffff) return null;
+        out += String.fromCodePoint(code);
+        index = end;
+      } else {
+        const hex = body.slice(index + 1, index + 5);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex)) return null;
+        out += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 4;
+      }
+    } else return null;
+  }
+  return out;
+}
+
+/**
+ * Decodes a complete Node console frame (header line through the closing `}`) into
+ * the raw containerName and diagnostics text, or null when the collected lines do
+ * not form exactly the expected null-prototype object. The diagnostics string is
+ * losslessly reassembled from its continuation lines; `truncated` records that
+ * Node's console sink capped the value, so any later boot signals were never
+ * emitted and their absence must not read as proof of absence.
+ */
+function decodeNodeFrame(lines) {
+  if (lines.length < 5 || lines[lines.length - 1] !== "}") return null;
+  const containerMatch = NODE_CONTAINER_LINE.exec(lines[1]);
+  const nodeIdMatch = NODE_NODEID_LINE.exec(lines[2]);
+  if (!containerMatch || !nodeIdMatch) return null;
+  const container = decodeNodeString(containerMatch[1]);
+  if (container === null || decodeNodeString(nodeIdMatch[1]) === null)
+    return null;
+  const diagnosticsLines = lines.slice(3, -1);
+  const parts = [];
+  let expectMore = true;
+  let truncated = false;
+  for (let index = 0; index < diagnosticsLines.length; index += 1) {
+    if (!expectMore) return null;
+    const match = (
+      index === 0 ? NODE_DIAGNOSTICS_FIRST : NODE_DIAGNOSTICS_CONT
+    ).exec(diagnosticsLines[index]);
+    if (!match) return null;
+    const decoded = decodeNodeString(match[1]);
+    if (decoded === null) return null;
+    parts.push(decoded);
+    if (match[3]) {
+      truncated = true;
+      expectMore = false;
+    } else expectMore = Boolean(match[2]);
+  }
+  if (expectMore) return null;
+  return { container, diagnostics: parts.join(""), truncated };
+}
+
+function healthObservation(diagnostics, truncated = false) {
   const inspect = diagnostics.split("--- authkey marker ---")[0];
   const state =
     /^state=(created|running|paused|restarting|removing|exited|dead) health=(healthy|unhealthy|starting|) exit=([0-9]{1,3}) error=([^\n]*)$/m.exec(
@@ -70,6 +187,10 @@ function healthObservation(diagnostics) {
     exitCode: state && Number(state[3]) <= 255 ? Number(state[3]) : null,
     inspectErrorPresent: state ? state[4].length > 0 : null,
     authKeyMarker: marker ? marker[1] : "unknown",
+    // Node's console sink caps the diagnostics string at 10000 characters, so a
+    // truncated frame's boot signals cover only the surviving prefix; the flag
+    // keeps a false signal from being read as a confirmed absence.
+    diagnosticsTruncated: truncated,
     bootSignals:
       logs === undefined
         ? null
@@ -86,15 +207,43 @@ function healthObservation(diagnostics) {
 export function summarizeHealthFrames(messages, targetDigest) {
   const all = healthSummary();
   const target = targetDigest ? { frames: 0, observations: [] } : null;
+  const record = (container, diagnostics, truncated) => {
+    const observation = healthObservation(diagnostics, truncated);
+    all.frames += 1;
+    all.observations.push(observation);
+    if (
+      target &&
+      createHash("sha256").update(container).digest("hex") === targetDigest
+    ) {
+      target.frames += 1;
+      target.observations.push(observation);
+    }
+  };
   let frame = [];
+  let mode = null;
   for (const message of messages) {
     for (const line of message.split("\n")) {
-      if (line === "[docker-sandbox] Health timeout diagnostics {") {
+      if (line === BUN_HEALTH_HEADER || line === NODE_HEALTH_HEADER) {
         if (frame.length) all.malformedFrames += 1;
         frame = [line];
+        mode = line === NODE_HEALTH_HEADER ? "node" : "bun";
         continue;
       }
       if (!frame.length) continue;
+      if (mode === "node") {
+        // The null-prototype object spans a variable number of continuation
+        // lines, so collect until the closing brace, then validate the whole
+        // block; any interleaved or malformed line fails decodeNodeFrame.
+        frame.push(line);
+        if (line !== "}") continue;
+        const decoded = decodeNodeFrame(frame);
+        if (decoded)
+          record(decoded.container, decoded.diagnostics, decoded.truncated);
+        else all.malformedFrames += 1;
+        frame = [];
+        mode = null;
+        continue;
+      }
       const expected = [
         null,
         /^ {2}containerName: "agent-[A-Za-z0-9_.-]+",$/,
@@ -105,6 +254,7 @@ export function summarizeHealthFrames(messages, targetDigest) {
       if (!expected?.test(line)) {
         all.malformedFrames += 1;
         frame = [];
+        mode = null;
         continue;
       }
       frame.push(line);
@@ -116,21 +266,13 @@ export function summarizeHealthFrames(messages, targetDigest) {
         const diagnostics = JSON.parse(
           frame[3].slice("  diagnostics: ".length, -1),
         );
-        const observation = healthObservation(diagnostics);
-        all.frames += 1;
-        all.observations.push(observation);
-        if (
-          target &&
-          createHash("sha256").update(container).digest("hex") === targetDigest
-        ) {
-          target.frames += 1;
-          target.observations.push(observation);
-        }
+        record(container, diagnostics, false);
       } catch {
         // error-policy:J3 Unsupported console escaping is explicitly unparsed, never evaluated.
         all.malformedFrames += 1;
       }
       frame = [];
+      mode = null;
     }
   }
   if (frame.length) all.malformedFrames += 1;

--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
@@ -160,6 +160,33 @@ test("Node frames carrying control-character and alternate-quote escapes decode 
   assert.equal(JSON.stringify(result).includes(name), false);
 });
 
+test("Node frames whose diagnostics render with backtick delimiters still decode their health facts", () => {
+  const name = "agent-55555555-5555-4555-8555-555555555555";
+  const digest = createHash("sha256").update(name).digest("hex");
+  // A diagnostics line containing both a single and a double quote (but no
+  // backtick and no `${`) forces Node's util.inspect to select backtick
+  // delimiters for that continuation line. The frame must still decode instead
+  // of being discarded as malformed along with its preceding inspect facts.
+  const frame = nodeFrame(
+    name,
+    "--- inspect ---\nstate=exited health=unhealthy exit=1 error=private-secret\n--- authkey marker ---\nauthkey-marker=absent\n--- logs ---\noption 'mode' received \"invalid\"; Cannot find module private-module.invalid\n",
+  );
+  // Prove the rendered frame really uses the backtick form this fix targets.
+  assert.match(frame, /`[^`]*'mode'[^`]*"invalid"[^`]*`/);
+  const result = summarizeHealthFrames([frame], digest);
+  assert.equal(result.all.frames, 1);
+  assert.equal(result.all.malformedFrames, 0);
+  assert.equal(result.target.frames, 1);
+  const observation = result.target.observations[0];
+  assert.equal(observation.containerState, "exited");
+  assert.equal(observation.exitCode, 1);
+  assert.equal(observation.inspectErrorPresent, true);
+  assert.equal(observation.authKeyMarker, "absent");
+  assert.equal(observation.bootSignals.module_resolution, true);
+  assert.equal(JSON.stringify(result).includes("private"), false);
+  assert.equal(JSON.stringify(result).includes(name), false);
+});
+
 test("malformed, interleaved, and incomplete Node frames never certify a target", () => {
   const name = "agent-33333333-3333-4333-8333-333333333333";
   const digest = createHash("sha256").update(name).digest("hex");

--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
@@ -32,6 +32,32 @@ function consoleFrame(containerName, diagnostics) {
   return result.stderr.trimEnd();
 }
 
+// Reproduces exactly how the production worker logs the health-timeout context:
+// the object is passed through the real core redactor (redactLogArgs) and
+// rendered by Node's console sink, which prints the null-prototype clone with a
+// distinct header, single-quoted values, and multiline strings concatenated over
+// `'part\n' +` continuation lines. The frame is generated from the real redactor
+// so a future format drift in either producer or console is caught here rather
+// than in a hand-written literal.
+function nodeFrame(containerName, diagnostics) {
+  const context = {
+    containerName,
+    nodeId: "private-node.invalid",
+    diagnostics,
+  };
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `import { redactLogArgs } from "@elizaos/core/edge";\nconsole.warn(...redactLogArgs([${JSON.stringify("[docker-sandbox] Health timeout diagnostics")}, ${JSON.stringify(context)}]));`,
+    ],
+    { encoding: "utf8", cwd: new URL(".", import.meta.url) },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  return result.stderr.trimEnd();
+}
+
 test("real Bun console frames retain health facts while removing identifiers and log text", () => {
   const name = "agent-11111111-1111-4111-8111-111111111111";
   const digest = createHash("sha256").update(name).digest("hex");
@@ -52,6 +78,119 @@ test("real Bun console frames retain health facts while removing identifiers and
     assert.equal(JSON.stringify(result).includes("private"), false);
     assert.equal(JSON.stringify(result).includes(name), false);
   }
+});
+
+test("real Node redactor frames decode the same health facts the Bun path extracts while removing identifiers and log text", () => {
+  const name = "agent-11111111-1111-4111-8111-111111111111";
+  const digest = createHash("sha256").update(name).digest("hex");
+  const frame = nodeFrame(
+    name,
+    "--- inspect ---\nstate=exited health=unhealthy exit=1 error=private-secret\n--- authkey marker ---\nauthkey-marker=absent\n--- logs ---\nCannot find module private-module.invalid; token=private-secret\n",
+  );
+  // The Node header and single quotes must be present, proving the frame is the
+  // real production shape and not the Bun rendering.
+  assert.match(frame, /\[Object: null prototype\] \{/);
+  assert.match(frame, /diagnostics: '--- inspect ---\\n' \+/);
+  for (const messages of [[frame], frame.split("\n")]) {
+    const result = summarizeHealthFrames(messages, digest);
+    assert.equal(result.all.frames, 1);
+    assert.equal(result.all.malformedFrames, 0);
+    assert.equal(result.target.frames, 1);
+    const observation = result.target.observations[0];
+    assert.equal(observation.containerState, "exited");
+    assert.equal(observation.health, "unhealthy");
+    assert.equal(observation.exitCode, 1);
+    assert.equal(observation.inspectErrorPresent, true);
+    assert.equal(observation.authKeyMarker, "absent");
+    assert.equal(observation.diagnosticsTruncated, false);
+    assert.equal(observation.bootSignals.module_resolution, true);
+    assert.equal(observation.bootSignals.out_of_memory, false);
+    assert.equal(JSON.stringify(result).includes("private"), false);
+    assert.equal(JSON.stringify(result).includes(name), false);
+  }
+});
+
+test("a Node frame whose diagnostics exceeds the console string cap still yields the surviving inspect facts flagged as truncated", () => {
+  const name = "agent-22222222-2222-4222-8222-222222222222";
+  const digest = createHash("sha256").update(name).digest("hex");
+  let diagnostics =
+    "--- inspect ---\nstate=exited health=unhealthy exit=137 error=\n--- authkey marker ---\nauthkey-marker=present\n--- logs ---\nCannot find module private-early.invalid\n";
+  // Push well past Node's 10000-character console string cap so the tail (and
+  // any late signal in it) is dropped by the sink, not by our parser.
+  for (let index = 0; index < 300; index += 1) {
+    diagnostics += `logline ${index} routine private-chatter padding padding padding\n`;
+  }
+  diagnostics += "OutOfMemory private-late-signal\n";
+  const frame = nodeFrame(name, diagnostics);
+  assert.match(frame, /\.\.\. [0-9]+ more characters$/m);
+  const result = summarizeHealthFrames([frame], digest);
+  assert.equal(result.all.frames, 1);
+  assert.equal(result.target.frames, 1);
+  const observation = result.target.observations[0];
+  assert.equal(observation.containerState, "exited");
+  assert.equal(observation.exitCode, 137);
+  assert.equal(observation.authKeyMarker, "present");
+  assert.equal(observation.diagnosticsTruncated, true);
+  // The early boot signal survived; the truncated-away tail signal is honestly
+  // absent rather than fabricated.
+  assert.equal(observation.bootSignals.module_resolution, true);
+  assert.equal(observation.bootSignals.out_of_memory, false);
+  assert.equal(JSON.stringify(result).includes("private"), false);
+  assert.equal(JSON.stringify(result).includes(name), false);
+});
+
+test("Node frames carrying control-character and alternate-quote escapes decode without evaluating the literal", () => {
+  const name = "agent-44444444-4444-4444-8444-444444444444";
+  const digest = createHash("sha256").update(name).digest("hex");
+  // Node renders control characters as \xNN and switches to double quotes for a
+  // line containing a single quote; both must be decoded, never eval'd.
+  const frame = nodeFrame(
+    name,
+    "--- inspect ---\nstate=exited health=unhealthy exit=2 error=tab\there\u0007bell\n--- authkey marker ---\nauthkey-marker=absent\n--- logs ---\nquote='single-private' and value here\n",
+  );
+  assert.match(frame, /\\x07/);
+  assert.match(frame, /"quote='single-private'/);
+  const result = summarizeHealthFrames([frame], digest);
+  assert.equal(result.all.frames, 1);
+  assert.equal(result.all.malformedFrames, 0);
+  assert.equal(result.target.frames, 1);
+  assert.equal(result.target.observations[0].exitCode, 2);
+  assert.equal(result.target.observations[0].inspectErrorPresent, true);
+  assert.equal(JSON.stringify(result).includes("private"), false);
+  assert.equal(JSON.stringify(result).includes(name), false);
+});
+
+test("malformed, interleaved, and incomplete Node frames never certify a target", () => {
+  const name = "agent-33333333-3333-4333-8333-333333333333";
+  const digest = createHash("sha256").update(name).digest("hex");
+  const frame = nodeFrame(
+    name,
+    "--- inspect ---\nstate=running health=healthy exit=0 error=\n--- authkey marker ---\nauthkey-marker=present\n--- logs ---\n",
+  );
+  // A non-target digest decodes the frame but attributes nothing to the target.
+  const otherDigest = createHash("sha256").update("agent-other").digest("hex");
+  const unmatched = summarizeHealthFrames([frame], otherDigest);
+  assert.equal(unmatched.all.frames, 1);
+  assert.equal(unmatched.target.frames, 0);
+
+  const lines = frame.split("\n");
+  const incomplete = summarizeHealthFrames(lines.slice(0, -1), digest);
+  assert.equal(incomplete.all.frames, 0);
+  assert.equal(incomplete.all.malformedFrames, 1);
+  assert.equal(incomplete.target.frames, 0);
+
+  const interleaved = summarizeHealthFrames(
+    [
+      ...lines.slice(0, 3),
+      "[another subsystem] unrelated private message",
+      ...lines.slice(3),
+    ],
+    digest,
+  );
+  assert.equal(interleaved.all.frames, 0);
+  assert.equal(interleaved.all.malformedFrames, 1);
+  assert.equal(interleaved.target.frames, 0);
+  assert.equal(JSON.stringify(interleaved).includes("private"), false);
 });
 
 test("missing containers and unsupported inspect output remain distinct from healthy state", () => {


### PR DESCRIPTION
# Relates to

Closes #30905

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (base is the current `origin/develop` tip `e14071f009`; `git rev-list --count HEAD..origin/develop` = 0).
- [ ] `bun install` and `bun run verify` were run after sync — see **Known gaps / failures**: `bun install` was run; the repo-wide `bun run verify` gate was not completed on this machine. Focused owning-package gates (Biome + both owning test files) all pass and are pasted below.
- [x] A reviewer can confirm the change works without reading the code, from the before/after reproduction and test output below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` — not completed on this machine (repo-wide lane); focused gates documented in **Known gaps / failures**.

# Risks

Low. The change is confined to one read-only diagnostic parser (`packages/cloud/scripts/admin/staging-worker-diagnostic.mjs`) and its test. It is additive: the existing Bun-format branch is unchanged, and the new branch only activates on the distinct Node null-prototype header. No runtime/service code, no schema, no network or privileged path is altered. The parser never evaluates log text (error-policy:J3) and continues to emit categorical, identifier-free output only.

# Background

## What does this PR do?

The read-only staging worker diagnostic decodes the deployed worker's health-timeout frames via `summarizeHealthFrames(messages, targetDigest)`. That parser recognized only **Bun**'s `console` rendering of an ordinary object — a fixed 5-line, double-quoted, JSON-decodable frame.

In production the worker runs under **Node** and logs through the core redactor: the call site is `logger.warn("[docker-sandbox] Health timeout diagnostics", { containerName, nodeId, diagnostics })` in `packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts`, and the cloud logger pipes every argument through `redactLogArgs` from `@elizaos/core/edge` before `console.warn`. Node renders that redacted **null-prototype** object very differently from Bun:

- header line `[docker-sandbox] Health timeout diagnostics [Object: null prototype] {`
- **single-quoted** string values
- a multiline `diagnostics` string emitted as `'part\n' +` continuation lines, which Node's console sink caps at 10000 characters with a `'…'... N more characters` marker (a real concern here because the producer runs `docker logs --tail 160`).

The old 5-line/double-quote matcher therefore decoded **zero** frames from real staging output (it did not even count them malformed — it silently ignored them).

This PR extends `summarizeHealthFrames` to also recognize the Node frame shape:

- A dedicated Node branch collects the null-prototype object until its closing `}`, then validates and decodes the whole block; interleaved/malformed/incomplete blocks increment `malformedFrames` and never certify a target.
- The multiline `diagnostics` string is reassembled **losslessly** from its continuation lines. Console string literals are decoded by an explicit escape table (`\n \r \t \b \f \v \0 \\ \' \" \` \xNN \uNNNN \u{…}`); any unsupported sequence returns `null` so the frame is rejected — the raw literal is never `eval`'d (error-policy:J3).
- Truncated frames (past the 10000-char console cap) are decoded from their surviving prefix and flagged `diagnosticsTruncated: true`, so an absent boot signal in a clipped tail is not misread as a confirmed absence (honest DTO state rather than a healthy-looking false).
- The existing SHA-256 `containerName` → target-digest association and the categorical, identifier-free output are preserved for the Node path.

Extracted facts are identical to the Bun path: `containerState`, `health`, `exitCode`, `inspectErrorPresent`, `authKeyMarker`, `bootSignals`.

## What kind of change is this?

Bug fix (non-breaking; the Node path was previously undecodable).

# Documentation changes needed?

No. Behavior of the read-only diagnostic is unchanged for operators; it now decodes an additional (production) frame format. No user-facing docs describe the internal frame grammar.

# Testing

## Where should a reviewer start?

`packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs` — the new `nodeFrame` helper builds each frame through the **real** `redactLogArgs` + Node `console.warn` (mirroring the existing Bun `consoleFrame` helper), so the test exercises the actual producer-to-parser boundary rather than a hand-written literal.

## Detailed testing steps

```bash
# owning parser tests (node's built-in runner, as the existing suite uses)
node --test packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
# consumer that also imports summarizeJournal
bun test packages/cloud/scripts/admin/personal-dedicated-rereview-staging.test.ts
# format/lint on the two changed files
npx biome check packages/cloud/scripts/admin/staging-worker-diagnostic.mjs packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
```

The final acceptance bullet in the issue — rerunning the read-only staging diagnostic against the unchanged daemon via the `deploy-eliza-provisioning-worker` `workflow_dispatch` (`mode: diagnose`) — requires staging infrastructure and privileged host reads I cannot and must not trigger. The code + boundary-test deliverable is complete; the staging rerun is left to a maintainer. The modified code path is reachable in that context: the `diagnose` job base64-streams this exact `.mjs` to the host, where `summarizeJournal` → `summarizeHealthFrames` parses the journal.

# Evidence Gate

<!-- evidence-head:8284e7d0d8fcb4650d1ce98e13d47133c59750ee -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a read-only Node CLI parser.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this is a read-only Node CLI parser.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user flow; command-line parser change proven by before/after reproduction below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - artifact-upload session unavailable in this environment; equivalent real producer output and the before/after decode (develop=0 frames, this PR=1 frame) are pasted inline under Evidence Details > Backend + frontend logs.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact-upload session unavailable; the decoded diagnostic JSON (before: 0 frames; after: 1 frame + full observation) is pasted inline under Evidence Details > Backend + frontend logs.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

The frame below is produced by the **real** core redactor rendered by Node's console — `console.warn(...redactLogArgs(["[docker-sandbox] Health timeout diagnostics", context]))` — exactly as the worker logs it. The old `develop` parser decodes **0** frames; this PR decodes **1** and associates the target, with no `private*` substring and no raw container name in the output.

<details><summary>Real Node frame → before (develop, 0 frames) → after (this PR, 1 frame)</summary>

```
### Real production-shaped frame (redactLogArgs + Node console.warn) ###
[docker-sandbox] Health timeout diagnostics [Object: null prototype] {
  containerName: 'agent-11111111-1111-4111-8111-111111111111',
  nodeId: 'private-node.invalid',
  diagnostics: '--- inspect ---\n' +
    'state=exited health=unhealthy exit=1 error=private-secret\n' +
    '--- authkey marker ---\n' +
    'authkey-marker=absent\n' +
    '--- logs ---\n' +
    'Cannot find module private-module.invalid; token=private-secret\n'
}

### BEFORE (origin/develop parser) — decodes ZERO frames ###
{
  "frames": 0,
  "malformedFrames": 0,
  "targetFrames": 0
}

### AFTER (this PR parser) — decodes the frame and associates the target ###
{
  "frames": 1,
  "malformedFrames": 0,
  "targetFrames": 1,
  "observation": {
    "containerState": "exited",
    "health": "unhealthy",
    "exitCode": 1,
    "inspectErrorPresent": true,
    "authKeyMarker": "absent",
    "diagnosticsTruncated": false,
    "bootSignals": {
      "module_resolution": true,
      "address_in_use": false,
      "permission_denied": false,
      "database_authentication": false,
      "database_schema": false,
      "out_of_memory": false
    }
  },
  "leaksPrivate": false,
  "leaksName": false
}
```

</details>

<details><summary>Focused test runs — node --test parser suite (16 pass) + bun consumer suite (16 pass)</summary>

```
### node --test staging-worker-diagnostic.test.mjs ###
# Subtest: real Bun console frames retain health facts while removing identifiers and log text
ok 1 - real Bun console frames retain health facts while removing identifiers and log text
# Subtest: real Node redactor frames decode the same health facts the Bun path extracts while removing identifiers and log text
ok 2 - real Node redactor frames decode the same health facts the Bun path extracts while removing identifiers and log text
# Subtest: a Node frame whose diagnostics exceeds the console string cap still yields the surviving inspect facts flagged as truncated
ok 3 - a Node frame whose diagnostics exceeds the console string cap still yields the surviving inspect facts flagged as truncated
# Subtest: Node frames carrying control-character and alternate-quote escapes decode without evaluating the literal
ok 4 - Node frames carrying control-character and alternate-quote escapes decode without evaluating the literal
# Subtest: malformed, interleaved, and incomplete Node frames never certify a target
ok 5 - malformed, interleaved, and incomplete Node frames never certify a target
# Subtest: missing containers and unsupported inspect output remain distinct from healthy state
ok 6 - missing containers and unsupported inspect output remain distinct from healthy state
# Subtest: container log text cannot replace the auth marker or hide later boot signals
ok 7 - container log text cannot replace the auth marker or hide later boot signals
# Subtest: unmatched targets, incomplete frames and unexpected interleaving never certify a target
ok 8 - unmatched targets, incomplete frames and unexpected interleaving never certify a target
# Subtest: embedded timeout messages cannot attribute another container's diagnostics to a target
ok 9 - embedded timeout messages cannot attribute another container's diagnostics to a target
# Subtest: invalid target correlation digest rejects before privileged reads
ok 10 - invalid target correlation digest rejects before privileged reads
# Subtest: host reads produce only public image facts and worker-level category counts
ok 11 - host reads produce only public image facts and worker-level category counts
# Subtest: invalid expected source rejects before any host read
ok 12 - invalid expected source rejects before any host read
# Subtest: source or process replacement during collection prevents certification
ok 13 - source or process replacement during collection prevents certification
# Subtest: private or malformed image references never escape the boundary
ok 14 - private or malformed image references never escape the boundary
# Subtest: malformed journal records cannot become healthy-looking empty observations
ok 15 - malformed journal records cannot become healthy-looking empty observations
# Subtest: stdin CLI rejects hostile source input without emitting it or invoking host reads
ok 16 - stdin CLI rejects hostile source input without emitting it or invoking host reads
# tests 16
# suites 0
# pass 16
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1575.243097

### bun test personal-dedicated-rereview-staging.test.ts ###
(pass) account preview correlation selects the same canonical container in worker evidence without exposing its identity [679.51ms]
(pass) personal Dedicated staging re-review operator > reports lifecycle before a missing selection prevents review [3.07ms]
(pass) personal Dedicated staging re-review operator > reports a provisioning failure without returning raw errors or locators [2.67ms]
(pass) personal Dedicated staging re-review operator > publishes only validated official image digests through the operator evidence [3.79ms]
(pass) personal Dedicated staging re-review operator > distinguishes sandbox readiness expiry without interpreting stack paths as failures [7.48ms]
(pass) personal Dedicated staging re-review operator > classifies zero, one, and invariant-breaking receipt counts [0.46ms]
(pass) personal Dedicated staging re-review operator > bootstraps only one canonical restore authority in ambiguous inventory [0.66ms]
(pass) personal Dedicated staging re-review operator > reports expected preview decisions neutrally without weakening execute [0.17ms]
(pass) personal Dedicated staging re-review operator > returns identifier-free preview evidence and does not execute [0.49ms]
(pass) personal Dedicated staging re-review operator > requires the prior exact preview digest and reviewed confirmation [0.50ms]
(pass) personal Dedicated staging re-review operator > uses a distinct digest-bound confirmation for missing-receipt bootstrap [0.38ms]
(pass) personal Dedicated staging re-review operator > binds every resolved selector and replacement decision into approval [0.51ms]
(pass) personal Dedicated staging re-review operator > rejects a preview for a different operation before snapshot or execute [0.18ms]
(pass) personal Dedicated staging re-review operator > binds approval to current inventory and refuses compute or job drift [0.32ms]
(pass) personal Dedicated staging re-review operator > rejects deployment mismatch before resolving account identity [0.22ms]
(pass) personal Dedicated staging re-review operator > requires explicit staging opt-in and validates execute authority inputs [0.29ms]
 packages/core/src/lifeops-passive-connectors.ts                                                        |    0.00 |   10.17 | 30-43,47-50,54-66,71-75,85-92,104-112
 packages/core/src/services/message/failures.ts                                                         |    0.00 |    2.61 | 23-315,326-368
 packages/core/src/types/action-failure.ts                                                              |    0.00 |    2.47 | 33-35,40-101,111-124
 16 pass
 0 fail
Ran 16 tests across 1 file. [1380.00ms]
```

</details>

<details><summary>Biome check on the two changed files (clean)</summary>

```
Checked 2 files in 47ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface (read-only Node CLI parser).`

### After

`N/A - no UI surface (read-only Node CLI parser).`

### Walkthrough video

`N/A - no user flow; before/after decode reproduction is inline above.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun run verify` (repo-wide parity/dependency/type/lint/audit lane) was **not** completed on this machine due to time/resource limits. The focused owning-package gates were run and pass: Biome check on both changed files (clean), `node --test` parser suite (16/16), and the `bun test` consumer suite that imports `summarizeJournal` (16/16). All output is pasted above.
- Staging `diagnose` rerun (`deploy-eliza-provisioning-worker` `workflow_dispatch`) is a maintainer-side operation requiring staging infra and privileged host reads; intentionally not attempted. See **Detailed testing steps**.
- Evidence artifacts are pasted inline rather than attached as files because the artifact-upload session was unavailable in this environment; the same content is included above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@e14071f00998f4d10f937015e3060196b991ad4d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@e14071f00998f4d10f937015e3060196b991ad4d:packages/skills/skills/contribute-to-eliza"} -->


