### PR TITLE
fix(cloud): decode Node worker health diagnostic frames

### DIFF
--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.mjs
@@ -82,58 +82,113 @@ function healthObservation(diagnostics) {
   };
 }
 
+// Decode only string literals emitted by console inspection, never expressions.
+// The suffix remains unconsumed so abbreviation and executable syntax are rejected.
+function consoleString(text) {
+  const quote = text[0];
+  if (!['"', "'", "`"].includes(quote)) return null;
+  let value = "";
+  for (let index = 1; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === quote) return { value, suffix: text.slice(index + 1) };
+    if (
+      character.charCodeAt(0) < 32 ||
+      (quote === "`" && character === "$" && text[index + 1] === "{")
+    )
+      return null;
+    if (character !== "\\") {
+      value += character;
+      continue;
+    }
+    const escapedCharacter = text[++index];
+    const escapes = { n: "\n", r: "\r", t: "\t", b: "\b", f: "\f", v: "\v" };
+    if (Object.hasOwn(escapes, escapedCharacter))
+      value += escapes[escapedCharacter];
+    else if (['"', "'", "`", "\\", "/"].includes(escapedCharacter))
+      value += escapedCharacter;
+    else if (escapedCharacter === "0" && !/[0-9]/.test(text[index + 1] ?? ""))
+      value += "\0";
+    else if (escapedCharacter === "x" || escapedCharacter === "u") {
+      const length = escapedCharacter === "x" ? 2 : 4;
+      const digits = text.slice(index + 1, index + 1 + length);
+      if (digits.length !== length || !/^[0-9a-f]+$/i.test(digits)) return null;
+      value += String.fromCharCode(Number.parseInt(digits, 16));
+      index += length;
+    } else return null;
+  }
+  return null;
+}
+
 /** Parses only complete console frames; unexpected/interleaved lines discard attribution. */
 export function summarizeHealthFrames(messages, targetDigest) {
   const all = healthSummary();
   const target = targetDigest ? { frames: 0, observations: [] } : null;
-  let frame = [];
+  let frame = null;
   for (const message of messages) {
     for (const line of message.split("\n")) {
-      if (line === "[docker-sandbox] Health timeout diagnostics {") {
-        if (frame.length) all.malformedFrames += 1;
-        frame = [line];
+      if (
+        /^\[docker-sandbox\] Health timeout diagnostics (?:\[Object: null prototype\] )?\{$/.test(
+          line,
+        )
+      ) {
+        if (frame) all.malformedFrames += 1;
+        frame = { phase: "container", container: "", diagnostics: "" };
         continue;
       }
-      if (!frame.length) continue;
-      const expected = [
-        null,
-        /^ {2}containerName: "agent-[A-Za-z0-9_.-]+",$/,
-        /^ {2}nodeId: "(?:[^"\\]|\\.)*",$/,
-        /^ {2}diagnostics: "(?:[^"\\]|\\.)*",$/,
-        /^}$/,
-      ][frame.length];
-      if (!expected?.test(line)) {
-        all.malformedFrames += 1;
-        frame = [];
-        continue;
-      }
-      frame.push(line);
-      if (frame.length !== 5) continue;
-      try {
-        const container = JSON.parse(
-          frame[1].slice("  containerName: ".length, -1),
-        );
-        const diagnostics = JSON.parse(
-          frame[3].slice("  diagnostics: ".length, -1),
-        );
-        const observation = healthObservation(diagnostics);
+      if (!frame) continue;
+      if (frame.phase === "close" && line === "}") {
+        const observation = healthObservation(frame.diagnostics);
         all.frames += 1;
         all.observations.push(observation);
         if (
           target &&
-          createHash("sha256").update(container).digest("hex") === targetDigest
+          createHash("sha256").update(frame.container).digest("hex") ===
+            targetDigest
         ) {
           target.frames += 1;
           target.observations.push(observation);
         }
-      } catch {
-        // error-policy:J3 Unsupported console escaping is explicitly unparsed, never evaluated.
-        all.malformedFrames += 1;
+        frame = null;
+        continue;
       }
-      frame = [];
+      const prefix = {
+        container: "  containerName: ",
+        node: "  nodeId: ",
+        diagnostics: "  diagnostics: ",
+        continuation: "    ",
+      }[frame.phase];
+      const fragment =
+        prefix && line.startsWith(prefix)
+          ? consoleString(line.slice(prefix.length))
+          : null;
+      if (
+        fragment &&
+        frame.phase === "container" &&
+        fragment.suffix === "," &&
+        /^agent-[A-Za-z0-9_.-]+$/.test(fragment.value)
+      ) {
+        frame.container = fragment.value;
+        frame.phase = "node";
+      } else if (
+        fragment &&
+        frame.phase === "node" &&
+        fragment.suffix === ","
+      ) {
+        frame.phase = "diagnostics";
+      } else if (
+        fragment &&
+        ["diagnostics", "continuation"].includes(frame.phase) &&
+        ["", ",", " +"].includes(fragment.suffix)
+      ) {
+        frame.diagnostics += fragment.value;
+        frame.phase = fragment.suffix === " +" ? "continuation" : "close";
+      } else {
+        all.malformedFrames += 1;
+        frame = null;
+      }
     }
   }
-  if (frame.length) all.malformedFrames += 1;
+  if (frame) all.malformedFrames += 1;
   return { association: "complete-adjacent-worker-log-frame", all, target };
 }
 

--- a/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
+++ b/packages/cloud/scripts/admin/staging-worker-diagnostic.test.mjs
@@ -1,6 +1,7 @@
 /**
  * Exercises journal privacy and stable source/process admission for the staging
- * diagnostic using hostile input and deterministic read-boundary responses.
+ * diagnostic using real Bun/Node console producers, the production redactor,
+ * hostile input, and deterministic host read-boundary responses.
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
@@ -31,6 +32,112 @@ function consoleFrame(containerName, diagnostics) {
   assert.equal(result.status, 0);
   return result.stderr.trimEnd();
 }
+
+function redactedNodeFrame(containerName, diagnostics) {
+  const redactor = new URL(
+    "../../../core/src/security/redact.ts",
+    import.meta.url,
+  );
+  const result = spawnSync(
+    "node",
+    [
+      "--input-type=module",
+      "-e",
+      `
+    import {readFileSync} from "node:fs";
+    import {redactLogArgs} from ${JSON.stringify(redactor.href)};
+    console.warn(...redactLogArgs(["[docker-sandbox] Health timeout diagnostics", JSON.parse(readFileSync(0, "utf8"))]));
+  `,
+    ],
+    {
+      encoding: "utf8",
+      input: JSON.stringify({
+        containerName,
+        nodeId: "private-node.invalid",
+        diagnostics,
+      }),
+    },
+  );
+  assert.equal(result.status, 0);
+  return result.stderr.trimEnd();
+}
+
+const NODE_DIAGNOSTICS =
+  "--- inspect ---\nstate=exited health=unhealthy exit=1 error=private-detail\n--- authkey marker ---\nauthkey-marker=absent\n--- logs ---\n";
+
+test("production redactor through Node console preserves categorical facts and exact target association", () => {
+  const name = "agent-target";
+  const digest = createHash("sha256").update(name).digest("hex");
+  for (const extra of [
+    "Cannot find module private-module\n",
+    "Cannot find module 'private-module'\n",
+    "Cannot find module 'private-module' with \"quotes\"\n",
+    `Cannot find module private-module; literal \${process.exit()} and backtick \`\n`,
+    "\x00\x01\x1b\x7f\u0085\ud800\t\r\b\f\v Cannot find module private-module\n",
+  ]) {
+    const frame = redactedNodeFrame(name, NODE_DIAGNOSTICS + extra);
+    for (const messages of [[frame], frame.split("\n")]) {
+      const journal = messages
+        .map((MESSAGE) => JSON.stringify({ MESSAGE }))
+        .join("\n");
+      const result = summarizeJournal(journal, digest).healthTimeouts;
+      assert.equal(result.all.frames, 1);
+      assert.equal(result.all.malformedFrames, 0);
+      assert.equal(result.target.frames, 1);
+      assert.equal(result.target.observations[0].containerState, "exited");
+      assert.equal(result.target.observations[0].authKeyMarker, "absent");
+      assert.equal(
+        result.target.observations[0].bootSignals.module_resolution,
+        true,
+      );
+      assert.equal(JSON.stringify(result).includes("private"), false);
+      assert.equal(JSON.stringify(result).includes(name), false);
+    }
+    assert.equal(
+      summarizeHealthFrames(
+        [frame],
+        createHash("sha256").update("agent-other").digest("hex"),
+      ).target.frames,
+      0,
+    );
+  }
+});
+
+test("Node incomplete, interleaved, abbreviated and executable-looking frames never certify a target", () => {
+  const digest = createHash("sha256").update("agent-target").digest("hex");
+  const frame = redactedNodeFrame(
+    "agent-target",
+    `${NODE_DIAGNOSTICS}Cannot find module private-module\n`,
+  );
+  const lines = frame.split("\n");
+  const abbreviated = redactedNodeFrame(
+    "agent-target",
+    `${NODE_DIAGNOSTICS}${"x".repeat(11000)}OutOfMemory`,
+  );
+  for (const malformed of [
+    lines.slice(0, -1),
+    [...lines.slice(0, 3), "[other worker] interleaved", ...lines.slice(3)],
+    [abbreviated],
+    [...lines.slice(0, 3), "  diagnostics: process.exit(0)", "}"],
+    [
+      ...lines.slice(0, 3),
+      `  diagnostics: \`literal \${process.exit(0)}\``,
+      "}",
+    ],
+    [...lines.slice(0, 3), String.raw`  diagnostics: '\q'`, "}"],
+    [...lines.slice(0, 3), String.raw`  diagnostics: '\xZZ'`, "}"],
+    [...lines.slice(0, 3), "  diagnostics: 'unterminated", "}"],
+  ]) {
+    const result = summarizeHealthFrames(malformed, digest);
+    assert.equal(result.all.frames, 0);
+    assert.equal(result.all.malformedFrames, 1);
+    assert.equal(result.target.frames, 0);
+    const recovered = summarizeHealthFrames([...malformed, frame], digest);
+    assert.equal(recovered.all.frames, 1);
+    assert.equal(recovered.all.malformedFrames, 1);
+    assert.equal(recovered.target.frames, 1);
+  }
+});
 
 test("real Bun console frames retain health facts while removing identifiers and log text", () => {
   const name = "agent-11111111-1111-4111-8111-111111111111";


### PR DESCRIPTION
The staging worker diagnostic now decodes complete health frames emitted by the production redactor and Node console. Previously those messages were counted but their health details were discarded because the collector expected Bun formatting.

Relates to #30905 and #18627. The fix supports Node's null-prototype object header, quoted strings and multiline string concatenation, while retaining the existing Bun format. It rejects incomplete, interleaved, abbreviated or unsupported expressions without evaluating them. Target association requires a complete frame; the report remains categorical and does not expose container names, node identifiers or log contents.

The worker, provisioning behavior, health deadlines, source/process checks and deployment permissions are unchanged. The updated collector can run through the existing read-only diagnostic workflow against the unchanged deployed worker.

Exact head `035339070b1c0f86bb4c4cac8d16637b34241d26`, based on `e14071f00998f4d10f937015e3060196b991ad4d`. Pinned installation and root `bun run verify` passed. Real producer/collector tests passed 14/14; independent downstream caller/workflow tests passed 30/30. Touched-file Biome and whitespace checks passed. Two independent reviews found no blocking issues. Definition of Done: full standard in CONTRIBUTING.md.


The same synthetic production-redactor → Node 24.15.0 sample decodes zero frames on the base and one correctly classified frame on this change. This proves the serialization boundary locally. The previous [read-only live diagnostic](https://github.com/elizaOS/eliza/actions/runs/34141656421) counted timeout messages but decoded no frames; the corrected live run remains pending after merge. No live sandbox root cause is claimed.

[Verification details](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30905-035339-review.md) · [producer comparison](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30905-035339-producer-boundary.txt) · [focused tests](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30905-035339-focused.log) · [root verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30905-035339-verify.log)

## Evidence Gate

<!-- evidence-head:035339070b1c0f86bb4c4cac8d16637b34241d26 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - standalone diagnostic collector has no rendered interface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - standalone diagnostic collector has no rendered interface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no browser or native interaction changes.
<!-- evidence-row:backend-logs -->
- [x] [Actual producer/collector command transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30905-035339-producer-test-transcript.log), using synthetic diagnostic content through the production redactor and actual Node console. This is local integration evidence; live diagnostic follow-up remains pending.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network interaction changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt or runtime agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain changes; diagnostic report evidence is linked above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual output.

Merged as `141e35ae98cfee1499ca2c4d064e4ee2546e16dc` after all hosted checks passed in [run 34144163962](https://github.com/elizaOS/eliza/actions/runs/34144163962). The corrected [read-only staging diagnostic](https://github.com/elizaOS/eliza/actions/runs/34144836420) passed against the unchanged deployed worker. It decoded three complete target frames with zero malformed frames; all report a missing container on the checked host. The deployment job was skipped. #30905 is closed; the remaining sandbox lifecycle investigation stays in #18627.
