### PR TITLE
fix(cloud): check Docker candidates on their captured placement

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-stale-node.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-stale-node.test.ts
@@ -139,3 +139,103 @@ describe("pollSshDockerHealth follows agent re-placement (#15203)", () => {
     getClient.mockRestore();
   });
 });
+
+describe("candidate health before canonical placement commit", () => {
+  const handle = {
+    sandboxId: `agent-${NEW_NODE.agentId}`,
+    bridgeUrl: "http://candidate.example",
+    healthUrl: "http://candidate.example/api",
+    metadata: {
+      provider: "docker",
+      ...NEW_NODE,
+      containerName: `agent-${NEW_NODE.agentId}`,
+      nodeSshPort: 2222,
+      nodeSshUser: "candidate-user",
+      nodeHostKeyFingerprint: "SHA256:candidate-pin",
+    },
+  };
+
+  test("fresh candidate probes its captured node despite retained old canonical placement", async () => {
+    const provider = new DockerSandboxProvider();
+    const internals = provider as unknown as PollInternals;
+    const hydrate = spyOn(internals, "hydrateContainerFromDb").mockResolvedValue(OLD_NODE);
+    const { getClient, probedHosts } = fakeSshByHost(NEW_NODE.hostname);
+    expect(await provider.checkHealth(handle, { kind: "candidate" })).toBe(true);
+    expect(probedHosts).toEqual([NEW_NODE.hostname]);
+    expect(getClient).toHaveBeenCalledWith(
+      NEW_NODE.hostname,
+      2222,
+      "SHA256:candidate-pin",
+      "candidate-user",
+    );
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+
+  test("healthy canonical predecessor cannot certify an unhealthy candidate", async () => {
+    const provider = new DockerSandboxProvider();
+    const hydrate = spyOn(
+      provider as unknown as PollInternals,
+      "hydrateContainerFromDb",
+    ).mockResolvedValue(OLD_NODE);
+    const { probedHosts } = fakeSshByHost(OLD_NODE.hostname);
+    let now = 0;
+    spyOn(Date, "now").mockImplementation(() => {
+      now += 1000;
+      return now;
+    });
+    stubPollWaits();
+    const outcome = await provider.checkHealthDetailed(handle, { kind: "candidate" });
+    expect(outcome).toEqual({ ready: false, verdict: "not_ready" });
+    expect(probedHosts.length).toBeGreaterThan(0);
+    expect(new Set(probedHosts)).toEqual(new Set([NEW_NODE.hostname]));
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+
+  test("failed candidate tailnet keeps SSH fallback on the candidate and reports unresolved ingress", async () => {
+    const provider = new DockerSandboxProvider();
+    const hydrate = spyOn(
+      provider as unknown as PollInternals,
+      "hydrateContainerFromDb",
+    ).mockResolvedValue(OLD_NODE);
+    spyOn(
+      provider as unknown as { pollTailnetHealth: () => Promise<boolean> },
+      "pollTailnetHealth",
+    ).mockResolvedValue(false);
+    const { probedHosts } = fakeSshByHost(NEW_NODE.hostname);
+    const outcome = await provider.checkHealthDetailed(
+      { ...handle, metadata: { ...handle.metadata, headscaleIp: "100.64.0.9" } },
+      { kind: "candidate" },
+    );
+    expect(outcome).toEqual({ ready: false, verdict: "ingress_unresolved" });
+    expect(probedHosts).toEqual([NEW_NODE.hostname]);
+    expect(hydrate).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    { ...handle, metadata: undefined },
+    { ...handle, sandboxId: "agent-different" },
+    { ...handle, metadata: { ...handle.metadata, agentId: "different" } },
+    { ...handle, metadata: { ...handle.metadata, agentId: "bad/id" } },
+    { ...handle, metadata: { ...handle.metadata, nodeSshPort: 0 } },
+    { ...handle, metadata: { ...handle.metadata, nodeSshUser: "" } },
+    { ...handle, metadata: { ...handle.metadata, bridgePort: 0 } },
+    { ...handle, metadata: { ...handle.metadata, hostname: "" } },
+  ])(
+    "incomplete or mismatched candidate rejects before any canonical lookup or SSH",
+    async (candidate) => {
+      const provider = new DockerSandboxProvider();
+      const hydrate = spyOn(
+        provider as unknown as PollInternals,
+        "hydrateContainerFromDb",
+      ).mockResolvedValue(OLD_NODE);
+      const { getClient } = fakeSshByHost(NEW_NODE.hostname);
+      await expect(
+        provider.checkHealthDetailed(candidate, { kind: "candidate" }),
+      ).rejects.toMatchObject({
+        code: "SANDBOX_CANDIDATE_HEALTH_PLACEMENT_INVALID",
+      });
+      expect(hydrate).not.toHaveBeenCalled();
+      expect(getClient).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -113,6 +113,7 @@ import type {
   SandboxExactRestoreCreateConfig,
   SandboxExactRestoreTarget,
   SandboxHandle,
+  SandboxHealthContext,
   SandboxHealthOutcome,
   SandboxProvider,
   SandboxReplacementCleanupLocator,
@@ -4358,6 +4359,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       nodeId,
       hostname,
       ...replacementPlacementMetadata,
+      nodeSshPort: sshPort,
+      nodeSshUser: sshUser,
+      nodeHostKeyFingerprint: hostKeyFingerprint,
       containerName,
       bridgePort,
       webUiPort,
@@ -5751,8 +5755,58 @@ export class DockerSandboxProvider implements SandboxProvider {
     return false;
   }
 
-  async checkHealth(handle: SandboxHandle): Promise<boolean> {
-    return (await this.checkHealthDetailed(handle)).ready;
+  /** Resolve only the candidate handle; canonical placement may still name its predecessor. */
+  private candidateHealthPlacement(handle: SandboxHandle): ContainerMeta {
+    const meta = handle.metadata;
+    const validPort = (value: unknown): value is number =>
+      typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= 65_535;
+    if (
+      !meta ||
+      meta.provider !== "docker" ||
+      typeof meta.nodeId !== "string" ||
+      !meta.nodeId.trim() ||
+      typeof meta.hostname !== "string" ||
+      !meta.hostname.trim() ||
+      typeof meta.agentId !== "string" ||
+      typeof meta.containerName !== "string" ||
+      meta.containerName !== handle.sandboxId ||
+      !validPort(meta.bridgePort) ||
+      !validPort(meta.webUiPort) ||
+      !validPort(meta.nodeSshPort) ||
+      typeof meta.nodeSshUser !== "string" ||
+      !meta.nodeSshUser.trim() ||
+      (meta.nodeHostKeyFingerprint !== undefined && typeof meta.nodeHostKeyFingerprint !== "string")
+    ) {
+      throw new ElizaError("Candidate health requires complete matching Docker placement", {
+        code: "SANDBOX_CANDIDATE_HEALTH_PLACEMENT_INVALID",
+      });
+    }
+    try {
+      if (meta.containerName !== getContainerName(meta.agentId)) {
+        throw new Error("Candidate container does not match its agent");
+      }
+    } catch (cause) {
+      // error-policy:J3 invalid candidate identity must not fall back to canonical placement.
+      throw new ElizaError("Candidate health requires a matching Docker identity", {
+        code: "SANDBOX_CANDIDATE_HEALTH_PLACEMENT_INVALID",
+        cause,
+      });
+    }
+    return {
+      nodeId: meta.nodeId,
+      hostname: meta.hostname,
+      containerName: meta.containerName,
+      agentId: meta.agentId,
+      bridgePort: meta.bridgePort,
+      webUiPort: meta.webUiPort,
+      sshPort: meta.nodeSshPort,
+      sshUser: meta.nodeSshUser,
+      hostKeyFingerprint: meta.nodeHostKeyFingerprint,
+    };
+  }
+
+  async checkHealth(handle: SandboxHandle, context?: SandboxHealthContext): Promise<boolean> {
+    return (await this.checkHealthDetailed(handle, context)).ready;
   }
 
   /**
@@ -5761,8 +5815,14 @@ export class DockerSandboxProvider implements SandboxProvider {
    * reached the container as RETRYABLE rather than a terminal failure. See
    * {@link SandboxHealthVerdict}.
    */
-  async checkHealthDetailed(handle: SandboxHandle): Promise<SandboxHealthOutcome> {
-    const meta = await this.resolveContainer(handle.sandboxId);
+  async checkHealthDetailed(
+    handle: SandboxHandle,
+    context: SandboxHealthContext = { kind: "canonical" },
+  ): Promise<SandboxHealthOutcome> {
+    const meta =
+      context.kind === "candidate"
+        ? this.candidateHealthPlacement(handle)
+        : await this.resolveContainer(handle.sandboxId);
     const deadline = Date.now() + HEALTH_CHECK_TIMEOUT_MS;
 
     // When the agent is reachable over the headscale mesh, validate THAT
@@ -5788,11 +5848,12 @@ export class DockerSandboxProvider implements SandboxProvider {
       const nodeHealth = await this.pollSshDockerHealth(
         meta,
         Date.now() + HEALTH_CHECK_SSH_FALLBACK_TIMEOUT_MS,
+        context,
       );
       return nodeHealth.ready ? { ready: false, verdict: "ingress_unresolved" } : nodeHealth;
     }
 
-    return this.pollSshDockerHealth(meta, deadline);
+    return this.pollSshDockerHealth(meta, deadline, context);
   }
 
   /**
@@ -5805,6 +5866,7 @@ export class DockerSandboxProvider implements SandboxProvider {
   private async pollSshDockerHealth(
     meta: ContainerMeta,
     deadline: number,
+    context: SandboxHealthContext = { kind: "canonical" },
   ): Promise<SandboxHealthOutcome> {
     // The budget varies by caller (full window standalone, short window as the
     // tailnet fallback), so log the actual one instead of a constant.
@@ -5823,9 +5885,9 @@ export class DockerSandboxProvider implements SandboxProvider {
     let reachedContainer = false;
 
     const runOneProbe = async (): Promise<"ready" | "not_ready" | "transport"> => {
-      // Placement-affecting jobs can overlap the health wait, so each probe
-      // reads the current node before dialing docker on that host.
-      current = await this.refreshNodeMeta(current);
+      // Established probes follow committed placement changes. A pre-cutover
+      // candidate must retain its captured node while the predecessor is canonical.
+      if (context.kind === "canonical") current = await this.refreshNodeMeta(current);
       const ssh = DockerSSHClient.getClient(
         current.hostname,
         current.sshPort,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/image-swap.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/image-swap.ts
@@ -538,7 +538,7 @@ export class SandboxImageSwap {
       };
     };
 
-    if (!(await provider.checkHealth(blueHandle))) {
+    if (!(await provider.checkHealth(blueHandle, { kind: "candidate" }))) {
       return await failBeforeUpgradeCutover(
         "Blue health check failed; kept agent on old container",
       );
@@ -1043,7 +1043,7 @@ export class SandboxImageSwap {
       return { success: false, oldNodeId, oldContainerName, error };
     };
 
-    if (!(await provider.checkHealth(blueHandle))) {
+    if (!(await provider.checkHealth(blueHandle, { kind: "candidate" }))) {
       return await failBeforeRollbackCutover(
         "Blue health check failed; kept agent on current image",
       );

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/provision.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/provision.ts
@@ -22,7 +22,10 @@ import { prepareManagedElizaEnvironment } from "../../managed-eliza-env";
 import { applyRemoteDockerRuntimeMode } from "../../remote-docker-runtime-mode";
 import { resolveSandboxContainerLaunchConfig } from "../../sandbox-container-launch-config";
 import { type SandboxHandle, type SandboxProvider } from "../../sandbox-provider";
-import { SandboxReplacementCleanupUnresolvedError } from "../../sandbox-provider-types";
+import {
+  type SandboxHealthContext,
+  SandboxReplacementCleanupUnresolvedError,
+} from "../../sandbox-provider-types";
 import {
   agentConfigForProvision,
   computeManagedAgentDbEnv,
@@ -380,6 +383,7 @@ export class SandboxProvision {
     for (let attempt = 1; attempt <= MAX_PROVISION_ATTEMPTS; attempt++) {
       attemptsMade = attempt;
       let handle;
+      let healthContext: SandboxHealthContext = { kind: "candidate" };
 
       try {
         const retryHandle =
@@ -388,6 +392,7 @@ export class SandboxProvision {
             : null;
         if (retryHandle) {
           handle = retryHandle;
+          healthContext = { kind: "canonical" };
           logger.info(
             "[agent-sandbox] Re-probing persisted provisioning container before create",
             {
@@ -469,9 +474,9 @@ export class SandboxProvision {
         // timeout path.
         const provider = await this.host.getProvider();
         const health = provider.checkHealthDetailed
-          ? await provider.checkHealthDetailed(handle)
+          ? await provider.checkHealthDetailed(handle, healthContext)
           : {
-              ready: await provider.checkHealth(handle),
+              ready: await provider.checkHealth(handle, healthContext),
               verdict: "not_ready" as const,
             };
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/provision-retry.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/provision-retry.test.ts
@@ -8,6 +8,8 @@ import { WARM_POOL_ORG_ID, WARM_POOL_USER_ID } from "../../../db/schemas/agent-s
 import { runWithCloudBindings } from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
 import { apiKeysService } from "../api-keys";
+import { DockerSandboxProvider } from "../docker-sandbox-provider";
+import { DockerSSHClient } from "../docker-ssh";
 import {
   type SandboxProvider,
   SandboxReplacementCleanupUnresolvedError,
@@ -1735,6 +1737,103 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       apiKeySpy.mockRestore();
       ensureStartedSpy.mockRestore();
       getProviderSpy.mockRestore();
+    }
+  });
+
+  test("fresh provision health uses created placement while the canonical predecessor remains", async () => {
+    const { ElizaSandboxService } = await import("../eliza-sandbox.ts?actual");
+    const row: AgentSandbox = {
+      ...provisioningReadyRow(),
+      status: "stopped",
+      sandbox_id: "sandbox-blue-1",
+      bridge_url: "https://runtime-blue.example",
+      health_url: "https://runtime-blue.example/api/health",
+      node_id: "node-blue",
+      container_name: "agent-blue-1",
+      bridge_port: 3333,
+      web_ui_port: 4444,
+      headscale_ip: "100.64.0.42",
+    };
+    const finalRow: AgentSandbox = { ...row, status: "running" };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(row);
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const candidate = {
+      ...providerHandle(),
+      sandboxId: `agent-${AGENT}`,
+      metadata: {
+        ...providerHandle().metadata,
+        containerName: `agent-${AGENT}`,
+        nodeSshPort: 22,
+        nodeSshUser: "root",
+      },
+    };
+    const create = mock(async () => candidate);
+    const docker = new DockerSandboxProvider();
+    const hosts: string[] = [];
+    const sshSpy = spyOn(DockerSSHClient, "getClient").mockImplementation(((hostname: string) => {
+      hosts.push(hostname);
+      return {
+        exec: async () => {
+          if (hostname !== candidate.metadata.hostname) throw new Error("No such container");
+          return "healthy";
+        },
+      } as unknown as DockerSSHClient;
+    }) as typeof DockerSSHClient.getClient);
+    const stop = mock(async () => {});
+
+    const svc = new ElizaSandboxService();
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue(
+      replacementAwareProvider({
+        create,
+        stopForReplacement: stop,
+        stopForDeletion: async () => ({ kind: "not-running-proven" }),
+        checkHealth: docker.checkHealth.bind(docker),
+        checkHealthDetailed: docker.checkHealthDetailed.bind(docker),
+      }),
+    );
+
+    try {
+      const res = await svc.provision(AGENT, ORG);
+
+      expect(res.success).toBe(true);
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(stop).not.toHaveBeenCalled();
+      expect(hosts).toEqual([candidate.metadata.hostname]);
+      const runningWrite = updateSpy.mock.calls.find(
+        ([, data]) => (data as { status?: string }).status === "running",
+      );
+      expect(runningWrite).toBeDefined();
+      if (!runningWrite) {
+        throw new Error("Expected the adopted sandbox running write");
+      }
+      expect((runningWrite[1] as { sandbox_id?: string }).sandbox_id).toBe(candidate.sandboxId);
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+      sshSpy.mockRestore();
     }
   });
 

--- a/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
@@ -55,6 +55,9 @@ export type SandboxHealthVerdict =
   | "transport_unresolved"
   | "ingress_unresolved";
 
+/** Candidate probes retain pre-cutover placement; canonical probes follow committed placement. */
+export type SandboxHealthContext = { kind: "candidate" } | { kind: "canonical" };
+
 export interface SandboxHealthOutcome {
   ready: boolean;
   verdict: SandboxHealthVerdict;
@@ -306,7 +309,7 @@ export interface SandboxProvider {
       "sandboxId" | "nodeId" | "containerName" | "vpnNodeId"
     >,
   ): Promise<void>;
-  checkHealth(handle: SandboxHandle): Promise<boolean>;
+  checkHealth(handle: SandboxHandle, context?: SandboxHealthContext): Promise<boolean>;
   /**
    * Richer readiness probe that distinguishes a genuine `not_ready` from a
    * unresolved transport/managed-ingress exhaustion (see
@@ -314,7 +317,10 @@ export interface SandboxProvider {
    * Optional so providers that cannot fail at a transport layer (memory/local)
    * need not implement it; callers fall back to `checkHealth` when absent.
    */
-  checkHealthDetailed?(handle: SandboxHandle): Promise<SandboxHealthOutcome>;
+  checkHealthDetailed?(
+    handle: SandboxHandle,
+    context?: SandboxHealthContext,
+  ): Promise<SandboxHealthOutcome>;
   runCommand?(sandboxId: string, cmd: string, args?: string[]): Promise<string>;
   /** Tail container logs from the sandbox runtime (e.g. `docker logs --tail N`). */
   fetchLogs?(sandboxId: string, tail: number): Promise<string>;


### PR DESCRIPTION
# Relates to

Fixes #30908. Related investigation: #18627; its staging recovery remains unproven.

Definition of Done: full standard in CONTRIBUTING.md.

- [x] Targets develop; current base141e35 was fetched and confirmed before commit, with no rebase needed.
- [x] Pinned installation and final root verification passed.
- [x] Reviewed evidence shows the changed behavior and its limits.

# Sync with develop

- [x] Current origin/develop141e35; zero conflicts.
- [x] Root verify passed on the final frozen source.

# Risks

Medium: Docker readiness participates in provisioning and image cutover. Candidate checks now require complete matching captured placement and SSH metadata. Established health checks retain canonical refresh; cleanup, lifecycle fences, readiness verdicts and time budgets remain intact. No schema or environment change.

# Background

## What does this PR do?

A fresh Docker candidate is checked on the node returned by creation. Previously the poll could replace that placement with the predecessor's canonical row, rejecting a healthy candidate on a missing old host or accepting an unhealthy candidate because the old host was healthy.

Fresh provisioning and pre-cutover upgrades/downgrades select candidate authority. Persisted retries and established-sandbox reconciliation retain canonical refresh. Invalid candidate identity or placement fails explicitly.

## What kind of change is this?

Bug fix with an additive internal health context parameter.

# Documentation changes needed?

No external configuration or user documentation changes. The internal contract and evidence describe the distinction.

# Testing

## Where should a reviewer start?

Review the local integration results and scope notes below. The real production SSH client executes curl/Docker through a loopback SSH adapter against disposable Docker containers, with controlled database placement.

## Detailed testing steps

Pinned Bun1.3.14 / Node24.15.0: normal install, root verify twice, final cloud-shared typecheck/lint all passed. Focused provider/provision/upgrade/downgrade suites passed84 tests; final provider suite passed14 tests after the complementary negative case. Two independent reviews found no blockers.

The unchanged provider fails the complementary negative regression: an unhealthy candidate is falsely ready because its canonical predecessor is healthy. The fixed provider returns not_ready. The real local proof passed candidate-ready with zero canonical reads, established-ready with refresh, and absent-candidate not_ready after the unchanged360-second budget.

# Evidence Gate

<!-- evidence-head:24565085fe4743e66a4e19ce1e3a9161151be2cb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend health placement only; no rendered surface changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend health placement only; no rendered surface changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend health placement only; no visual user flow changes.

<!-- evidence-row:backend-logs -->
- [x] [Real local SSH/Docker transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30908-exact-24565085-ssh-transcript.log) and [scope/provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30908-exact-24565085-ssh-proof.md).

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or frontend request behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - Docker infrastructure health placement; no model, prompt, action, or inference behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] [Local Docker health results](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30908-exact-24565085-ssh-results.json), [validation inventory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30908-exact-24565085-validation.json), and [review record](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/30908-exact-24565085-review.md).

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - infrastructure placement selection, with no model behavior changes.

## Backend + frontend logs

Backend artifacts above exercise real local SSH, curl and Docker. Database placement is controlled; the loopback SSH server is a test adapter. No Eliza runtime is booted and no hosted staging recovery is claimed. Frontend: N/A - no frontend changes.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI changes.

### After

N/A - no rendered UI changes.

### Walkthrough video

N/A - no visual user flow changes.

## Audio / voice walkthrough

N/A - no audio changes.

## Known gaps / failures

The normal full cloud-shared test runner stopped at batch45/388 with two shared-runtime tests failing: the trusted lifecycle reply assertion and TODO reply grounding. A current unchanged baseline reproduced the exact same two failures (27passed/2failed); its tree equals develop141e35. Later batches were not executed, so the full package lane is not green.

An initial owner run overlapped dependency builds and encountered missing generated modules; it is retained as contaminated, not source evidence. The serialized rerun above owns the result. An early missing login build artifact was resolved by the normal root build; final typecheck passed without a source workaround.

The local integration harness rejected the optional timeout-diagnostics command through its command allowlist; the readiness verdict still completed normally. The source-locked provider diff hash matches the committed source. The original staging missing-container observations do not establish historical placement or this bug's causal relationship to that account. No paid provisioning or daemon deployment was performed for this PR.
