### PR TITLE
fix(cloud): remove affiliate settlement balance readback

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
@@ -133,6 +135,19 @@ beforeAll(async () => {
     };
     const { apply } = await pushSchema(schema as never, dbWrite as never);
     await apply();
+    // pushSchema derives DDL from the drizzle schema, which cannot express the
+    // 0177 balance-revision trigger. Apply the real migration file (its
+    // statements are IF NOT EXISTS / OR REPLACE safe on top of pushSchema) so
+    // the fenced settlement is proven against the same trigger production
+    // deploys, and a real credit_balance debit advances balance_revision.
+    const migration0177 = readFileSync(
+      join(import.meta.dir, "../../../db/migrations/0177_organization_balance_revision.sql"),
+      "utf8",
+    );
+    for (const statement of migration0177.split("--> statement-breakpoint")) {
+      const trimmed = statement.trim();
+      if (trimmed) await dbWrite.execute(trimmed);
+    }
   } catch (error) {
     pgliteReady = false;
     console.error("[affiliate-payout-outbox.test] PGlite schema initialization failed", error);
@@ -341,7 +356,7 @@ describe("affiliate payout outbox", () => {
     expect(await balance(attribution.affiliateUserId)).toBeCloseTo(0.05, 6);
   });
 
-  test("fenced affiliate settlement stays warm and lowers before its authoritative republish", async () => {
+  test("fenced affiliate settlement publishes its committed debit result without a balance readback", async () => {
     if (!pgliteReady) return;
     const attribution = await seedAttribution();
     const [payerOrg] = await dbWrite
@@ -363,19 +378,18 @@ describe("affiliate payout outbox", () => {
     const initial = await creditsService.getOrganizationBalanceSnapshot(payerOrg.id);
     await writeOrgBalanceHint(payerOrg.id, initial.balanceUsd, Date.now(), initial.revision);
 
-    const snapshotStarted = Promise.withResolvers<void>();
-    const releaseSnapshot = Promise.withResolvers<void>();
-    const originalSnapshot = creditsService.getOrganizationBalanceSnapshot.bind(creditsService);
-    const snapshotSpy = spyOn(creditsService, "getOrganizationBalanceSnapshot").mockImplementation(
-      async (organizationId) => {
-        snapshotStarted.resolve();
-        await releaseSnapshot.promise;
-        return await originalSnapshot(organizationId);
-      },
-    );
+    // The settlement path must publish the atomic debit's returned
+    // balance/revision and issue NO balance readback. Count every snapshot read
+    // and pause on the fence publication instead of the removed readback.
+    const snapshotSpy = spyOn(creditsService, "getOrganizationBalanceSnapshot");
+    const publicationStarted = Promise.withResolvers<void>();
+    const releasePublication = Promise.withResolvers<void>();
     const inferenceBalanceFence = {
       lowerCommittedBalance: mock(async () => undefined),
-      publishAuthoritativeBalance: mock(async () => undefined),
+      publishAuthoritativeBalance: mock(async () => {
+        publicationStarted.resolve();
+        await releasePublication.promise;
+      }),
     };
     const params = {
       organizationId: payerOrg.id,
@@ -392,47 +406,159 @@ describe("affiliate payout outbox", () => {
 
     try {
       const settlement = creditsService.collectAffiliateInferenceFallback(params);
-      await snapshotStarted.promise;
+      await publicationStarted.promise;
       expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(
         0.1,
         expect.stringMatching(/^(0|[1-9]\d*)$/),
       );
 
-      // The debit committed, but its revisioned snapshot is deliberately
-      // paused. A concurrent admission sees the committed lower balance, not
-      // the old $1 projection and not an absent warming key.
+      // The debit committed and its authoritative publication is already in
+      // flight, yet the settlement never issued a balance snapshot read. A
+      // concurrent admission sees the committed lower balance, not the old $1
+      // projection and not an absent warming key.
       expect(await readOrgBalanceHint(payerOrg.id)).toMatchObject({
         balanceUsd: 0.1,
         balanceRevision: initial.revision,
       });
+      expect(snapshotSpy).not.toHaveBeenCalled();
 
-      releaseSnapshot.resolve();
+      releasePublication.resolve();
       await expect(settlement).resolves.toMatchObject({
         actualCost: 0.9,
         collectedAmount: 0.9,
         adjustmentType: "none",
       });
-      const published = await readOrgBalanceHint(payerOrg.id);
-      const authoritative = await originalSnapshot(payerOrg.id);
-      expect(published?.balanceUsd).toBeCloseTo(0.1, 6);
-      expect(published?.balanceRevision).toBe(authoritative.revision);
-      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenCalledWith(
+
+      // The debit advanced the revision atomically. The published balance and
+      // revision come straight from that transaction result: the lower and the
+      // publish must carry the same committed revision, and it must be strictly
+      // newer than the pre-debit revision.
+      const publishCall = inferenceBalanceFence.publishAuthoritativeBalance.mock.calls[0] as [
+        number,
+        string,
+      ];
+      const committedRevision = publishCall[1];
+      expect(publishCall[0]).toBeCloseTo(0.1, 6);
+      expect(BigInt(committedRevision) > BigInt(initial.revision)).toBe(true);
+      expect(inferenceBalanceFence.lowerCommittedBalance).toHaveBeenLastCalledWith(
         0.1,
-        authoritative.revision,
+        committedRevision,
       );
-      expect(inferenceBalanceFence.publishAuthoritativeBalance).toHaveBeenCalledWith(
-        authoritative.balanceUsd,
-        authoritative.revision,
-      );
+      const published = await readOrgBalanceHint(payerOrg.id);
+      expect(published?.balanceUsd).toBeCloseTo(0.1, 6);
+      expect(published?.balanceRevision).toBe(committedRevision);
+      // Zero balance readbacks across the entire settlement.
+      expect(snapshotSpy).not.toHaveBeenCalled();
     } finally {
-      releaseSnapshot.resolve();
+      releasePublication.resolve();
       snapshotSpy.mockRestore();
     }
 
+    // The published revision matches the true authoritative DB revision,
+    // confirming the transaction result was itself authoritative.
+    const authoritative = await creditsService.getOrganizationBalanceSnapshot(payerOrg.id);
+    expect((await readOrgBalanceHint(payerOrg.id))?.balanceRevision).toBe(authoritative.revision);
+
     // Alarm/live replay of the same identity retains a present authoritative
-    // hint instead of repeating the post-stream billing_cache_warming flap.
-    await creditsService.collectAffiliateInferenceFallback(params);
+    // hint instead of repeating the post-stream billing_cache_warming flap, and
+    // still performs no balance readback.
+    const replaySpy = spyOn(creditsService, "getOrganizationBalanceSnapshot");
+    try {
+      await creditsService.collectAffiliateInferenceFallback(params);
+      expect(replaySpy).not.toHaveBeenCalled();
+    } finally {
+      replaySpy.mockRestore();
+    }
     expect((await readOrgBalanceHint(payerOrg.id))?.balanceUsd).toBeCloseTo(0.1, 6);
+  });
+
+  test("concurrent newer-revision debit cannot leak into a fenced affiliate publication", async () => {
+    if (!pgliteReady) return;
+    const attribution = await seedAttribution();
+    const [payerOrg] = await dbWrite
+      .insert(organizations)
+      .values({
+        name: "Affiliate revision-fence payer",
+        slug: uniq("affiliate-revision-fence"),
+        credit_balance: "1.000000",
+      })
+      .returning();
+    const [payer] = await dbWrite
+      .insert(users)
+      .values({
+        steward_user_id: uniq("affiliate-revision-user"),
+        organization_id: payerOrg.id,
+      })
+      .returning();
+    const { writeOrgBalanceHint } = await import("../inference-auth-cache");
+    // Bind the real snapshot before spying so the test's own reads never count
+    // against the settlement's must-be-zero readback budget.
+    const originalSnapshot = creditsService.getOrganizationBalanceSnapshot.bind(creditsService);
+    const initial = await originalSnapshot(payerOrg.id);
+    await writeOrgBalanceHint(payerOrg.id, initial.balanceUsd, Date.now(), initial.revision);
+
+    const snapshotSpy = spyOn(creditsService, "getOrganizationBalanceSnapshot");
+    const publicationStarted = Promise.withResolvers<void>();
+    const releasePublication = Promise.withResolvers<void>();
+    const inferenceBalanceFence = {
+      lowerCommittedBalance: mock(async () => undefined),
+      publishAuthoritativeBalance: mock(async () => {
+        publicationStarted.resolve();
+        await releasePublication.promise;
+      }),
+    };
+    const params = {
+      organizationId: payerOrg.id,
+      userId: payer.id,
+      requestId: uniq("affiliate-revision-request"),
+      model: "openai/test-model",
+      provider: "openai",
+      billingSource: "cloud",
+      actualCost: 0.9,
+      reservationMetadata: reservationMetadata(uniq("affiliate-revision-source"), attribution),
+      preserveInferenceBalanceHint: true,
+      inferenceBalanceFence,
+    };
+
+    try {
+      const settlement = creditsService.collectAffiliateInferenceFallback(params);
+      await publicationStarted.promise;
+      const committedRevision = (
+        inferenceBalanceFence.lowerCommittedBalance.mock.calls[0] as [number, string]
+      )[1];
+
+      // An unrelated debit commits while the fenced publication is paused,
+      // advancing the organization to a strictly newer revision and a different
+      // balance. A balance readback would observe this newer state; the pinned
+      // transaction result must not.
+      await dbWrite
+        .update(organizations)
+        .set({ credit_balance: "0.030000" })
+        .where(eq(organizations.id, payerOrg.id));
+      const concurrent = await originalSnapshot(payerOrg.id);
+      expect(BigInt(concurrent.revision) > BigInt(committedRevision)).toBe(true);
+      expect(concurrent.balanceUsd).toBeCloseTo(0.03, 6);
+
+      releasePublication.resolve();
+      await settlement;
+
+      // The publication carried this debit's own committed balance/revision,
+      // never the concurrent newer revision or its 0.03 balance.
+      expect(inferenceBalanceFence.publishAuthoritativeBalance).toHaveBeenCalledWith(
+        0.1,
+        committedRevision,
+      );
+      expect(inferenceBalanceFence.publishAuthoritativeBalance).not.toHaveBeenCalledWith(
+        concurrent.balanceUsd,
+        concurrent.revision,
+      );
+      // Removing the readback is precisely what keeps the concurrent revision
+      // out of the publication: the settlement issued zero snapshot reads.
+      expect(snapshotSpy).not.toHaveBeenCalled();
+    } finally {
+      releasePublication.resolve();
+      snapshotSpy.mockRestore();
+    }
   });
 
   test("alarm and late-settlement races retain the first committed affiliate amount", async () => {

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -2168,24 +2168,28 @@ export class CreditsService {
     if (params.preserveInferenceBalanceHint) {
       try {
         // The actual affiliate debit may exceed the estimate held by the
-        // Durable Object. Publish the committed lower ceiling before the
-        // authoritative read so a concurrent lease cannot spend that delta.
+        // Durable Object. Publish the committed lower ceiling first so a
+        // concurrent lease cannot spend that delta before the revision advances.
         await params.inferenceBalanceFence?.lowerCommittedBalance(
           outcome.newBalance,
           outcome.balanceRevision,
         );
         await lowerOrgBalanceHint(params.organizationId, outcome.newBalance, Date.now());
         const balanceAt = Date.now();
-        const snapshot = await this.getOrganizationBalanceSnapshot(params.organizationId);
+        // The atomic debit transaction already returned the authoritative
+        // post-debit balance and revision; publish that result directly rather
+        // than issuing a redundant balance snapshot read on the settlement path,
+        // exactly as the direct deferred settler (republishOrgBalanceHintAfterDebit)
+        // already does with its committed debit result.
         await params.inferenceBalanceFence?.publishAuthoritativeBalance(
-          snapshot.balanceUsd,
-          snapshot.revision,
+          outcome.newBalance,
+          outcome.balanceRevision,
         );
         await republishOrgBalanceHint(
           params.organizationId,
-          snapshot.balanceUsd,
+          outcome.newBalance,
           balanceAt,
-          snapshot.revision,
+          outcome.balanceRevision,
         );
       } catch (cause) {
         // error-policy:J2 preserve the failed publication after invalidating its cache projection.


### PR DESCRIPTION
# Relates to

Closes #30865

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package tests, lint, and typecheck were run (see evidence). `bun run verify` blocker recorded under **Known gaps**.
- [x] A reviewer can confirm the change works from the before/after test evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` — not run to completion on this machine; the affected package's focused tests + lint + typecheck were run instead (see **Known gaps**).

# Risks

Low. A single asynchronous accounting readback is removed from one lane
(`collectAffiliateInferenceFallback`), replaced with the value the debit
transaction already committed and returned. No schema, funding-ownership, or
flag changes. The synchronous pre-provider SQL policy checks and all other
gateway overhead are untouched.

# Background

## What does this PR do?

The fenced affiliate inference settlement in `collectAffiliateInferenceFallback`
(`packages/cloud/shared/src/lib/services/credits.ts`) issued a **second**
`organizations` balance query (`getOrganizationBalanceSnapshot`) **after** its
atomic debit transaction had already returned the authoritative post-debit
balance and revision. Ordinary deferred/direct settlement already publishes its
committed debit result directly via `republishOrgBalanceHintAfterDebit` without
a readback.

This PR makes the affiliate lane behave identically: it publishes the
transaction's own `outcome.newBalance` / `outcome.balanceRevision` to the
admission fence (`publishAuthoritativeBalance`) and to the warm-cache republish
(`republishOrgBalanceHint`), issuing **zero** `getOrganizationBalanceSnapshot`
calls on the settlement path.

Because the publication is now pinned to this debit's own committed transaction
result, a **concurrent newer-revision debit** committing during the fenced
handoff can no longer leak into this settlement's authoritative publication —
previously the readback could observe and publish that unrelated newer
balance/revision.

Preserved unchanged: revision-aware admission fencing (`lowerCommittedBalance`
still fires first with the committed revision), collection/payout accounting,
replay handling (idempotent debit key), warm-cache handoff, and the
publication-failure cache cleanup (`invalidateOrgBalanceHint` on the
`error-policy:J2` path).

## What kind of change is this?

Bug fix / performance (removes a redundant SQL read on a hot settlement path)
plus a correctness hardening (revision pinning).

# Documentation changes needed?

No. No public API, schema, or behavior contract changes; only the internal
settlement readback is removed.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts`
— the real in-memory PGlite settlement suite, now seeded with the real
`0177_organization_balance_revision.sql` trigger so committed `balance_revision`
values actually advance on each debit.

## Detailed testing steps

Focused, from repo root:

```bash
bun test packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
bun test packages/cloud/shared/src/lib/services/inference-admission-recovery.test.ts
cd packages/cloud/shared && bunx @biomejs/biome check \
  src/lib/services/credits.ts \
  src/lib/services/__tests__/affiliate-payout-outbox.test.ts
```

New / extended coverage in the affiliate suite (all real DB-backed):
- **fenced affiliate settlement publishes its committed debit result without a balance readback** — pauses on the fence publication (not the removed readback), asserts the warm hint shows the committed lower balance mid-flight, asserts the published balance/revision equal the transaction's committed values, and asserts `getOrganizationBalanceSnapshot` is called **0** times across the whole settlement.
- **concurrent newer-revision debit cannot leak into a fenced affiliate publication** — commits an unrelated newer-revision debit while the publication is paused and proves the fence still receives this debit's own committed balance/revision, never the concurrent `0.03`/newer revision, with **0** snapshot reads.
- Existing initial-debit, replay, insufficient/uncollected-overage collection, and alarm/late-settlement race tests remain and pass.

# Evidence Gate

<!-- evidence-head:c61935ed170cee0363bc3f3aa2dc227fe27ae05a -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend accounting change in @elizaos/cloud-shared; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend accounting change; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; internal settlement readback removal.`
<!-- evidence-row:backend-logs -->
- [x] Focused package test output — readback PRESENT (2 targeted tests FAIL, snapshot called once) vs REMOVED (full suite 19/19 PASS, zero snapshot calls). Mirror also at [before-readback-present.log](https://github.com/agent-cortex/eliza/releases/download/pr-30914-evidence/before-readback-present.log) / [after-no-readback.log](https://github.com/agent-cortex/eliza/releases/download/pr-30914-evidence/after-no-readback.log).

```text
BEFORE (readback present):
423 |       expect(snapshotSpy).not.toHaveBeenCalled();
error: expect(received).not.toHaveBeenCalled()
Expected number of calls: 0
Received number of calls: 1
(fail) affiliate payout outbox > fenced affiliate settlement publishes its committed debit result without a balance readback [84.55ms]
557 |       expect(snapshotSpy).not.toHaveBeenCalled();
error: expect(received).not.toHaveBeenCalled()
Expected number of calls: 0
Received number of calls: 1
(fail) affiliate payout outbox > concurrent newer-revision debit cannot leak into a fenced affiliate publication [140.77ms]
Ran 2 tests across 1 file. [66.30s]

AFTER (readback removed — full suite):
(pass) affiliate payout outbox > pglite applied (loud, never a silent skip) [0.11ms]
(pass) affiliate payout outbox > lost ledger acknowledgement retries one globally keyed payout [96.97ms]
(pass) affiliate payout outbox > credit reservation settlement atomically creates the payout intent [171.65ms]
(pass) affiliate payout outbox > code ownership changes cannot redirect an enqueued payout [72.52ms]
(pass) affiliate payout outbox > uncollected overage only enqueues affiliate markup actually collected [98.59ms]
(pass) affiliate payout outbox > fractional payout precision always rounds down and never overpays [36.14ms]
(pass) affiliate payout outbox > refused deferred hold atomically collects a partial charge and payout [99.79ms]
(pass) affiliate payout outbox > fenced affiliate settlement publishes its committed debit result without a balance readback [55.38ms]
(pass) affiliate payout outbox > concurrent newer-revision debit cannot leak into a fenced affiliate publication [36.16ms]
(pass) affiliate payout outbox > alarm and late-settlement races retain the first committed affiliate amount [42.98ms]
(pass) affiliate payout outbox > deleted affiliate code cannot unwind a pinned full fallback payout [44.77ms]
(pass) affiliate payout outbox > sub-ledger-unit markup is not recorded as a successful zero payout [13.92ms]
(pass) affiliate payout outbox > blank source identities fail at both service and database boundaries [17.52ms]
(pass) affiliate payout outbox > deduplicated ledger replay validates owner, amount, description, and metadata [187.08ms]
(pass) affiliate payout outbox > two concurrent processors report exactly one completed transition [45.58ms]
(pass) affiliate payout outbox > an already-processed outbox replay revalidates its immutable ledger projection [34.81ms]
(pass) affiliate payout outbox > a pending payout prevents beneficiary deletion instead of erasing the liability [18.52ms]
(pass) affiliate payout outbox > an exact enqueue replay returns the original single intent [17.26ms]
(pass) affiliate payout outbox > a conflicting replay fails the surrounding transaction [15.76ms]
 19 pass
 0 fail
Ran 19 tests across 1 file. [67.05s]
```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite settlement assertions over `organizations.credit_balance`, the 0177-trigger `balance_revision`, and `affiliate_payout_outbox` rows; recovery lane (`inference-admission-recovery.test.ts`) unaffected. Mirror at [recovery.log](https://github.com/agent-cortex/eliza/releases/download/pr-30914-evidence/recovery.log).

```text
(pass) direct recovery replays one deterministic debit and returns the persisted winner [1.18ms]
(pass) an uncollected direct debit consumes the lease estimate without switching lanes [0.17ms]
(pass) affiliate recovery replays the atomic debit and payout identity [0.81ms]
(pass) affiliate replay keeps an older partial winner consumed by the current lease [0.15ms]
(pass) malformed affiliate identity fails before any accounting mutation [1.27ms]
(pass) app recovery pins dispatch-time policy and settles the full conservative hold [0.99ms]
(pass) app reservation amount mismatch cannot release the admission lease [0.23ms]
(pass) deleted app recovery uses pinned economics and skips FK-backed shadows [0.30ms]
(pass) app recovery releases only reconciled actual cost after a refund [0.38ms]
(pass) app uncollected overage retains the larger actual cost in the gate [0.30ms]
Ran 10 tests across 1 file. [229.00ms]
```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Lint (Biome) on changed files:

```text
Checked 2 files in 147ms. No fixes applied.
```

Frontend: N/A - no frontend involved.

## Screenshots (before / after) + video walkthrough

N/A - backend accounting change with no rendered UI surface.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI flow.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- `bun run verify` (full repo gate) was not run to completion on this
  Raspberry Pi worktree; instead the owning package's focused tests, Biome lint,
  and `tsc --noEmit` were run. `tsc --noEmit` for `@elizaos/cloud-shared` reports
  3 pre-existing errors in untouched files (`server-wallets.ts`,
  `steward-client.ts`) about the unbuilt `@elizaos/login` workspace; these
  reproduce identically on `origin/develop` without this change (verified by
  stashing the diff), so they are not introduced here.
- Running multiple cloud PGlite test files in a single `bun test` invocation
  shows cross-file schema pollution; this is pre-existing (reproduces on
  `origin/develop`) because the package's `run-bun-tests.mjs` isolates each file
  in its own process. Each affected file passes in isolation.
- Immutable `user-attachments` upload via the swarm tooling could not
  authenticate on this host, so the log mirrors are attached to a fork release
  in addition to the inline transcripts above.

## Maintainer CI exception record

N/A - no exception requested.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c61935ed170cee0363bc3f3aa2dc227fe27ae05a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c61935ed170cee0363bc3f3aa2dc227fe27ae05a:packages/skills/skills/contribute-to-eliza"} -->
