### PR TITLE
perf(core): fix ReDoS backtracking in extractUserText regexes

### DIFF
--- a/packages/core/src/utils/message-text-scaling.test.ts
+++ b/packages/core/src/utils/message-text-scaling.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression coverage for the linear-time contract of `extractUserText`. The
+ * document-augmentation unwrapper and the language-instruction suffix stripper
+ * once placed a greedy whitespace quantifier next to an unbounded body, which
+ * backtracked super-linearly (ReDoS-class) on long whitespace runs — a shape
+ * pasted logs and transcripts produce on their own, blocking the event loop for
+ * seconds. These assertions pin both the output correctness after the regex
+ * change and a bounded wall-clock ceiling so the backtracking cannot silently
+ * return. The harness is deterministic and real (no mocks).
+ */
+import { describe, expect, it } from "vitest";
+import { getUserMessageText } from "./message-text";
+
+const AUGMENTATION_PREFIX =
+	"Answer the user request using the contextual documents";
+
+// A generous ceiling: the fixed patterns complete in well under a millisecond,
+// while the former quadratic/cubic behavior took tens of seconds on these
+// inputs. 200ms leaves ample slack for slow CI without admitting the ReDoS.
+const CEILING_MS = 200;
+
+describe("extractUserText scaling (ReDoS regression)", () => {
+	it("does not backtrack on an unclosed <user_request> trailed by a long space run", () => {
+		// Cubic-backtracking shape for the former /\s*([\s\S]*?)\s*/ wrapper:
+		// an opening tag with no closer, followed by thousands of spaces.
+		const raw = `${AUGMENTATION_PREFIX}\n<user_request>${" ".repeat(3000)}`;
+		const message = { content: { text: raw } } as never;
+
+		const start = performance.now();
+		const result = getUserMessageText(message);
+		const elapsed = performance.now() - start;
+
+		// No closing tag means no unwrap; the whole (trimmed) text is returned.
+		expect(result).toBe(`${AUGMENTATION_PREFIX}\n<user_request>`);
+		expect(elapsed).toBeLessThan(CEILING_MS);
+	});
+
+	it("does not backtrack stripping the language suffix off a huge newline run", () => {
+		// Quadratic shape for the former leading /\n*/ of the suffix pattern:
+		// ~100k newlines walked backwards from every offset.
+		const raw = `${"\n".repeat(100_000)}x`;
+		const message = { content: { text: raw } } as never;
+
+		const start = performance.now();
+		const result = getUserMessageText(message);
+		const elapsed = performance.now() - start;
+
+		// The trailing `.trim()` collapses the newline run; only the tail remains.
+		expect(result).toBe("x");
+		expect(elapsed).toBeLessThan(CEILING_MS);
+	});
+
+	it("still strips a real language-instruction suffix after a newline block", () => {
+		const raw = `keep this${"\n".repeat(5000)}\n[language instruction: reply in English]`;
+		const message = { content: { text: raw } } as never;
+
+		const start = performance.now();
+		const result = getUserMessageText(message);
+		const elapsed = performance.now() - start;
+
+		expect(result).toBe(`keep this${"\n".repeat(5000)}`.trim());
+		expect(result).not.toContain("language instruction");
+		expect(elapsed).toBeLessThan(CEILING_MS);
+	});
+
+	it("unwraps a well-formed envelope and trims the capture (behavior preserved)", () => {
+		const raw = `${AUGMENTATION_PREFIX}\n<user_request>\n  hello world  \n</user_request>`;
+		const message = { content: { text: raw } } as never;
+
+		expect(getUserMessageText(message)).toBe("hello world");
+	});
+
+	it("keeps the full text for an empty/whitespace-only envelope (guard unchanged)", () => {
+		const raw = `${AUGMENTATION_PREFIX}\n<user_request>\n   \n</user_request>`;
+		const message = { content: { text: raw } } as never;
+
+		// A whitespace-only capture must remain falsy after trimming, so the
+		// original envelope text (trimmed) is returned rather than an empty
+		// string — matching the pre-fix `if (match?.[1])` guard behavior.
+		expect(getUserMessageText(message)).toBe(raw);
+	});
+});

--- a/packages/core/src/utils/message-text.ts
+++ b/packages/core/src/utils/message-text.ts
@@ -9,15 +9,21 @@ import type { Memory } from "../types/memory";
 
 const DOCUMENT_AUGMENTATION_PREFIX =
 	"Answer the user request using the contextual documents";
-const USER_REQUEST_WRAPPER = /<user_request>\s*([\s\S]*?)\s*<\/user_request>/i;
-const LANGUAGE_INSTRUCTION_SUFFIX = /\n*\[language instruction:[^\]]*\]\s*$/i;
+// Both patterns avoid an unbounded whitespace quantifier adjacent to another
+// unbounded body, which triggered catastrophic backtracking (ReDoS-class,
+// super-linear match time) on long whitespace runs such as pasted logs. The
+// wrapper trims its capture explicitly; the suffix relies on the caller's
+// trailing `.trim()` to drop the newlines the former leading `\n*` matched.
+const USER_REQUEST_WRAPPER = /<user_request>([\s\S]*?)<\/user_request>/i;
+const LANGUAGE_INSTRUCTION_SUFFIX = /\[language instruction:[^\]]*\]\s*$/i;
 
 export function extractUserText(raw: string): string {
 	let text = raw;
 	if (text.trimStart().startsWith(DOCUMENT_AUGMENTATION_PREFIX)) {
 		const match = text.match(USER_REQUEST_WRAPPER);
-		if (match?.[1]) {
-			text = match[1];
+		const captured = match?.[1]?.trim();
+		if (captured) {
+			text = captured;
 		}
 	}
 	return text.replace(LANGUAGE_INSTRUCTION_SUFFIX, "").trim();


### PR DESCRIPTION
# Relates to

Closes #30903

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package tests, typecheck, and lint were run after sync (output below). `bun run verify` was not run in full on this constrained device; the touched package's gates all pass and the change is a two-regex edit plus a new test.
- [x] A reviewer can confirm the change works without reading the code, from the before/after timing and test output attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (branch was up to date with `origin/develop`).
- [ ] `bun run verify` full run — see **Known gaps / failures**. Focused `@elizaos/core` test + typecheck + biome all pass.

# Risks

Low. The change narrows two regexes and preserves observable output. All 8 existing `message-text.test.ts` assertions pass byte-identically (including the ~1.1M-char passthrough and the empty-envelope guard), and the `prompt-integrity-policy.test.ts` gate that forbids `MAX_MESSAGE_TEXT_LENGTH` in this file still passes — no input-length cap was introduced.

# Background

## What does this PR do?

`packages/core/src/utils/message-text.ts` declared two regexes that placed a greedy whitespace quantifier next to an unbounded body, causing catastrophic backtracking (ReDoS-class, super-linear match time) on long whitespace runs:

- `USER_REQUEST_WRAPPER = /<user_request>\s*([\s\S]*?)\s*<\/user_request>/i` — two unbounded quantifiers compound to cubic when `<user_request>` is unclosed followed by many spaces.
- `LANGUAGE_INSTRUCTION_SUFFIX = /\n*\[language instruction:[^\]]*\]\s*$/i` — the unanchored leading `\n*` is walked backwards from every offset → quadratic, and this runs unconditionally on **every** inbound message via `text.replace(LANGUAGE_INSTRUCTION_SUFFIX, "").trim()`.

These helpers run per inbound message (`extractUserText`/`getUserMessageText` are exported from `@elizaos/core` and reached from `packages/core/src/services/message.ts` and via `inferContextRoutingFromText` in `context-routing.ts`), so a message with a long blank-line run — which pasted logs/transcripts produce on their own — blocked the single-threaded Node event loop for **tens of seconds**.

`LANGUAGE_INSTRUCTION_SUFFIX` has a second consumer this fix also protects: `stripAugmentationForPersistence` calls `LANGUAGE_INSTRUCTION_SUFFIX.test(rendered)` while persisting an inbound message. The old leading `\n*` made that `.test()` quadratic on the same long-newline input; the match set is unchanged (`\n*` is optional, so both patterns accept exactly the same strings), so this path is fixed with no behavior change.

The fix:

1. `USER_REQUEST_WRAPPER` → `/<user_request>([\s\S]*?)<\/user_request>/i`, trimming the captured group explicitly.
2. `LANGUAGE_INSTRUCTION_SUFFIX` → `/\[language instruction:[^\]]*\]\s*$/i`; the leading `\n*` only widened the match and the existing trailing `.trim()` already removes those newlines.
3. Guard preserved: the empty/whitespace-only `<user_request></user_request>` envelope previously yielded `match[1] === ""` (falsy) and kept the full envelope. After dropping the surrounding `\s*`, the capture may be whitespace, so the guard now trims before the truthiness check (`match?.[1]?.trim()`) — keeping the exact prior behavior.

No input-length cap / `MAX_MESSAGE_TEXT_LENGTH` was added; commit `423aea34a0` (#24134) deliberately removed the 100k-char slice and `message-text.test.ts` locks a ~1.1M-char passthrough. The regex change stands on its own.

## What kind of change is this?

Bug fix (non-breaking) — removes a ReDoS-class super-linear time complexity on the per-message hot path.

# Documentation changes needed?

No. Internal utility behavior is unchanged for all valid inputs; only the pathological time complexity changes.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/message-text-scaling.test.ts` (new) — asserts both output correctness and a bounded 200ms ceiling on the two previously-pathological inputs. Then `packages/core/src/utils/message-text.ts` for the two-line regex change and the guard tweak.

## Detailed testing steps

```bash
cd packages/core
bun run test src/utils/message-text.test.ts src/utils/message-text-scaling.test.ts
bun run typecheck
bunx @biomejs/biome check ./src/utils/message-text.ts ./src/utils/message-text-scaling.test.ts
```

# Evidence Gate

<!-- evidence-head:454e36d840a9fe7dadc12240fff90a4255bb6e8a -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - core string-utility change; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - core string-utility change; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - core string-utility change; no user-facing flow to record.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the changed path is a pure synchronous string transform with no logger output; the reproduction below is the end-to-end proof of the code path.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes; the regex fix does not alter model-facing content for any valid input.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the applicable artifacts (before/after ReDoS timing + full focused-test output) are inlined verbatim under Evidence Details and reposted verbatim in a PR comment on this thread. Gate-accepted artifact hosting is unreachable from the authoring account: the elizaOS/eliza pr-evidence release rejects uploads (repo permission is pull only — HTTP 404 on gh release upload), and github.com/user-attachments file URLs require a browser session this API token cannot mint. No immutable asset URL can be produced, so the proof is delivered inline and in-thread instead.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changes.

## Backend + frontend logs

N/A - pure synchronous string transform on the message hot path; no logger lines. The reproduction below exercises the exact `getUserMessageText` → `extractUserText` path.

### Before/after reproduction (the two pathological inputs)

Measured on this branch by pinning the exact regex literals before and after the change:

```
node v22.22.2

# BEFORE (original regexes)
USER_REQUEST_WRAPPER unclosed+3k spaces: 20067.1106 ms
LANGUAGE_INSTRUCTION_SUFFIX 100k newlines: 22589.1392 ms

# AFTER (this PR's regexes)
USER_REQUEST_WRAPPER unclosed+3k spaces: 0.2731 ms
LANGUAGE_INSTRUCTION_SUFFIX 100k newlines: 0.1251 ms
```

~20s → 0.27ms and ~23s → 0.13ms — a >70,000x reduction; both inputs now complete well under a millisecond. Re-verified on this branch at head `454e36d8` by pinning the exact OLD/NEW regex literals side by side and timing each with `process.hrtime`.

### Focused test output (all pass)

```
 Test Files  3 passed (3)
      Tests  22 passed (22)
```

Re-verified at head `454e36d8` (`node ../scripts/run-vitest.mjs run --reporter=verbose`): `message-text.test.ts` 8 passed (pre-existing, byte-identical — includes the ~1.1M-char passthrough and the empty-envelope guard), `message-text-scaling.test.ts` 5 passed (new scaling/regression tripwires), and `src/__tests__/prompt-integrity-policy.test.ts` 9 passed (the gate forbidding `MAX_MESSAGE_TEXT_LENGTH` in this file — confirms no input-length cap was reintroduced). The full per-test verbose listing is in the PR comment on this thread.

## Domain artifacts

The domain artifacts for this ReDoS fix are the before/after regex timings and the focused test output above. Both are reproduced verbatim — including the standalone reproduction method and the full 22-test verbose listing — in a PR comment on this thread, so a reviewer has the complete proof without an external asset host. As noted in the domain-artifacts row, gate-accepted artifact hosting (the `elizaOS/eliza` release assets and `github.com/user-attachments`) is not reachable from the authoring account (`pull`-only repository permission).

## Known gaps / failures

- Full `bun run verify` was not run on this Raspberry Pi device (resource/time constrained). The owning package's `test` (focused), `typecheck`, and `biome check` all pass, and the diff is limited to two regex literals, one guard tweak, and a new test file. This is a `N/A - unrelated environment constraint`, not a code blocker.

## Maintainer CI exception record

N/A - no exception requested.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@454e36d840a9fe7dadc12240fff90a4255bb6e8a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@454e36d840a9fe7dadc12240fff90a4255bb6e8a:packages/skills/skills/contribute-to-eliza"} -->


