### PR TITLE
fix(core): keep streaming chunks well-formed UTF-16 across surrogate pairs (#30904)

### DIFF
--- a/packages/core/src/utils/__tests__/streaming-field-events.test.ts
+++ b/packages/core/src/utils/__tests__/streaming-field-events.test.ts
@@ -542,6 +542,72 @@ describe("ResponseSkeletonStreamExtractor", () => {
 		expect(chunks.join("")).toBe("Hi \ufffd");
 	});
 
+	// Regression for the P2 review finding: withholding only a *trailing* high
+	// surrogate leaves interior unpaired surrogates in the releasable prefix. An
+	// interior lone high followed by ASCII (`A\ud83dB`) previously shipped as a
+	// malformed `\ud83dB` chunk. Every chunk and the accumulated callback value
+	// must be well-formed, with the lone unit replaced by U+FFFD.
+	it("replaces an interior lone high surrogate followed by more text", () => {
+		const chunks: string[] = [];
+		const accumulated: string[] = [];
+		const extractor = new ResponseSkeletonStreamExtractor({
+			skeleton,
+			streamFields: ["replyText"],
+			onChunk: (chunk, _field, acc) => {
+				chunks.push(chunk);
+				accumulated.push(acc);
+			},
+		});
+
+		// A single JSON escape for a lone high surrogate immediately followed by an
+		// ASCII `B`. The `B` releases the prefix, so the high surrogate can never
+		// pair and must be sanitized rather than emitted raw.
+		extractor.push(
+			'{"shouldRespond":"RESPOND","contexts":[],"intents":[],"replyText":"A\\ud83dB","facts":[]}',
+		);
+		extractor.flush();
+
+		for (const c of chunks) {
+			expect(c.isWellFormed()).toBe(true);
+		}
+		for (const a of accumulated) {
+			expect(a.isWellFormed()).toBe(true);
+		}
+		expect(chunks.join("")).toBe("A\ufffdB");
+		expect(accumulated[accumulated.length - 1]).toBe("A\ufffdB");
+	});
+
+	// Regression for the P2 review finding: an isolated *low* surrogate is never
+	// held back (only high surrogates are), so on `develop` it shipped raw and
+	// malformed. It must be replaced by U+FFFD in both the chunk and the
+	// accumulated value.
+	it("replaces an isolated low surrogate", () => {
+		const chunks: string[] = [];
+		const accumulated: string[] = [];
+		const extractor = new ResponseSkeletonStreamExtractor({
+			skeleton,
+			streamFields: ["replyText"],
+			onChunk: (chunk, _field, acc) => {
+				chunks.push(chunk);
+				accumulated.push(acc);
+			},
+		});
+
+		extractor.push(
+			'{"shouldRespond":"RESPOND","contexts":[],"intents":[],"replyText":"A\\ude00B","facts":[]}',
+		);
+		extractor.flush();
+
+		for (const c of chunks) {
+			expect(c.isWellFormed()).toBe(true);
+		}
+		for (const a of accumulated) {
+			expect(a.isWellFormed()).toBe(true);
+		}
+		expect(chunks.join("")).toBe("A\ufffdB");
+		expect(accumulated[accumulated.length - 1]).toBe("A\ufffdB");
+	});
+
 	it("keeps ASCII/BMP text byte-identical (no surrogate handling regression)", () => {
 		const chunks: string[] = [];
 		const extractor = new ResponseSkeletonStreamExtractor({

--- a/packages/core/src/utils/__tests__/streaming-field-events.test.ts
+++ b/packages/core/src/utils/__tests__/streaming-field-events.test.ts
@@ -469,4 +469,97 @@ describe("ResponseSkeletonStreamExtractor", () => {
 		extractor.push("ignored");
 		expect(events.filter((e) => e.eventType === "error")).toHaveLength(1);
 	});
+
+	// Regression for #30904: a non-BMP code point (emoji) must never be split
+	// into its two UTF-16 surrogate code units across separate onChunk chunks.
+	// Clients encode each chunk into UTF-8 SSE / WebSocket text / JSON.stringify,
+	// which corrupts a lone surrogate. Every emitted chunk must be well-formed
+	// UTF-16 and the join of all chunks must reconstruct the original string.
+	it("never emits a lone surrogate for a JSON-escaped emoji in a single push", () => {
+		const chunks: string[] = [];
+		const extractor = new ResponseSkeletonStreamExtractor({
+			skeleton,
+			streamFields: ["replyText"],
+			onChunk: (chunk) => chunks.push(chunk),
+		});
+
+		// The whole escaped surrogate pair `\ud83d\ude00` (😀) arrives in one push,
+		// so the split cannot be rescued by chunk-boundary luck — the escaped path
+		// itself must funnel the lead surrogate into the pending buffer.
+		extractor.push(
+			'{"shouldRespond":"RESPOND","contexts":[],"intents":[],"replyText":"Hi \\ud83d\\ude00!","facts":[]}',
+		);
+		extractor.flush();
+
+		for (const c of chunks) {
+			expect(c.isWellFormed()).toBe(true);
+		}
+		expect(chunks.join("")).toBe("Hi \u{1f600}!");
+	});
+
+	it("never emits a lone surrogate for a literal emoji split across push boundaries", () => {
+		const chunks: string[] = [];
+		const extractor = new ResponseSkeletonStreamExtractor({
+			skeleton,
+			streamFields: ["replyText"],
+			onChunk: (chunk) => chunks.push(chunk),
+		});
+
+		const emoji = "\u{1f600}"; // 😀 as literal surrogate pair \ud83d\ude00
+		const head = `{"shouldRespond":"RESPOND","contexts":[],"intents":[],"replyText":"Hi ${emoji[0]}`;
+		// Split the emoji: the high surrogate ends push #1, the low surrogate
+		// starts push #2, so a naive one-code-unit-at-a-time consumer would emit
+		// each half as its own chunk.
+		extractor.push(head);
+		extractor.push(`${emoji[1]}!","facts":[]}`);
+		extractor.flush();
+
+		for (const c of chunks) {
+			expect(c.isWellFormed()).toBe(true);
+		}
+		expect(chunks.join("")).toBe("Hi \u{1f600}!");
+	});
+
+	it("replaces a genuinely lone trailing high surrogate at end-of-stream", () => {
+		const chunks: string[] = [];
+		const extractor = new ResponseSkeletonStreamExtractor({
+			skeleton,
+			streamFields: ["replyText"],
+			onChunk: (chunk) => chunks.push(chunk),
+		});
+
+		// The reply ends on a lone high surrogate whose low half never arrives.
+		// It is held back while streaming, then flushed as U+FFFD so the emitted
+		// stream stays well-formed rather than dropping or leaking the code unit.
+		extractor.push(
+			'{"shouldRespond":"RESPOND","contexts":[],"intents":[],"replyText":"Hi \\ud83d","facts":[]}',
+		);
+		extractor.flush();
+
+		for (const c of chunks) {
+			expect(c.isWellFormed()).toBe(true);
+		}
+		expect(chunks.join("")).toBe("Hi \ufffd");
+	});
+
+	it("keeps ASCII/BMP text byte-identical (no surrogate handling regression)", () => {
+		const chunks: string[] = [];
+		const extractor = new ResponseSkeletonStreamExtractor({
+			skeleton,
+			streamFields: ["replyText"],
+			onChunk: (chunk) => chunks.push(chunk),
+		});
+
+		extractor.push('{"shouldRespond":"RESPOND","contexts":[],"intents":[],');
+		extractor.push('"replyText":"Hello, ');
+		extractor.push('world \u2728!","facts":[]}'); // includes a BMP sparkle
+		extractor.flush();
+
+		for (const c of chunks) {
+			expect(c.isWellFormed()).toBe(true);
+		}
+		expect(chunks.join("")).toBe("Hello, world \u2728!");
+		// BMP text still streams incrementally rather than collapsing to one chunk.
+		expect(chunks.length).toBeGreaterThan(1);
+	});
 });

--- a/packages/core/src/utils/streaming.ts
+++ b/packages/core/src/utils/streaming.ts
@@ -17,6 +17,16 @@ import type {
 	IStreamExtractor,
 	StructuredFieldEventCallbacks,
 } from "../types/streaming";
+import { toWellFormedUnicode } from "./well-formed";
+
+/**
+ * True when `code` is a UTF-16 high (lead) surrogate. A chunk ending on one is
+ * the first half of a non-BMP code point (e.g. an emoji); emitting it alone
+ * produces a lone surrogate that corrupts UTF-8/JSON serialization downstream.
+ */
+function isHighSurrogate(code: number): boolean {
+	return code >= 0xd800 && code <= 0xdbff;
+}
 
 // ============================================================================
 // StreamError - Standardized error handling for streaming
@@ -690,6 +700,7 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 			if (flushed) {
 				this.appendVisibleAndEmit(field, flushed);
 			}
+			this.flushPendingSurrogate(field);
 		}
 		this.activeStringField = null;
 		this.pendingEscape = "";
@@ -1071,16 +1082,65 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 		const next = `${this.fieldContents.get(field) ?? ""}${value}`;
 		this.fieldContents.set(field, next);
 		const previous = this.emittedContent.get(field) ?? "";
-		const chunk = next.slice(previous.length);
+		let chunk = next.slice(previous.length);
 		if (!chunk) {
 			return;
 		}
-		this.emittedContent.set(field, next);
-		this.config.onChunk(chunk, field, next, this.streamRevision);
+		// Never split a surrogate pair across chunks. When the tail of this chunk
+		// is a lone high surrogate (the lead half of a non-BMP code point that is
+		// serialized either as a `\uXXXX\uXXXX` escape pair decoded one escape at a
+		// time, or as literal code units split across a `push()` boundary), hold it
+		// back so the trailing low surrogate joins it on the next emission. Both the
+		// escaped and literal paths funnel through here, so buffering once fixes
+		// both. `emittedContent` therefore stays well-formed and is the running
+		// join of emitted chunks; the held code unit is flushed at end-of-stream.
+		if (isHighSurrogate(chunk.charCodeAt(chunk.length - 1))) {
+			chunk = chunk.slice(0, -1);
+			if (!chunk) {
+				return;
+			}
+		}
+		const emitted = previous + chunk;
+		this.emittedContent.set(field, emitted);
+		this.config.onChunk(chunk, field, emitted, this.streamRevision);
 		this.emitEvent({
 			eventType: "chunk",
 			field,
 			chunk,
+			timestamp: Date.now(),
+		});
+	}
+
+	/**
+	 * At genuine end-of-stream, emit any code unit that `appendVisibleAndEmit`
+	 * held back. The only unemitted tail it can leave is a single lone high
+	 * surrogate whose low half never arrived, so this is a truly malformed
+	 * trailing code unit. Follow the codebase's well-formed convention and
+	 * replace it with U+FFFD rather than dropping a real character or shipping a
+	 * lone surrogate; the sanitized value is also written back into
+	 * `fieldContents` so the validated field content stays well-formed.
+	 */
+	private flushPendingSurrogate(field: string): void {
+		const content = this.fieldContents.get(field);
+		if (content === undefined) {
+			return;
+		}
+		const emitted = this.emittedContent.get(field) ?? "";
+		if (content.length <= emitted.length) {
+			return;
+		}
+		const remainder = toWellFormedUnicode(content.slice(emitted.length));
+		if (!remainder) {
+			return;
+		}
+		const finalContent = emitted + remainder;
+		this.fieldContents.set(field, finalContent);
+		this.emittedContent.set(field, finalContent);
+		this.config.onChunk(remainder, field, finalContent, this.streamRevision);
+		this.emitEvent({
+			eventType: "chunk",
+			field,
+			chunk: remainder,
 			timestamp: Date.now(),
 		});
 	}

--- a/packages/core/src/utils/streaming.ts
+++ b/packages/core/src/utils/streaming.ts
@@ -1079,11 +1079,14 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 	}
 
 	private appendVisibleAndEmit(field: string, value: string): void {
-		const next = `${this.fieldContents.get(field) ?? ""}${value}`;
-		this.fieldContents.set(field, next);
 		const previous = this.emittedContent.get(field) ?? "";
-		let chunk = next.slice(previous.length);
+		// `fieldContents` holds the well-formed emitted prefix followed by at most
+		// one raw high surrogate held back from the previous emission (see below).
+		// Appending `value` lets a held lead unit rejoin its trailing low half.
+		const raw = `${this.fieldContents.get(field) ?? ""}${value}`;
+		let chunk = raw.slice(previous.length);
 		if (!chunk) {
+			this.fieldContents.set(field, raw);
 			return;
 		}
 		// Never split a surrogate pair across chunks. When the tail of this chunk
@@ -1092,16 +1095,32 @@ export class ResponseSkeletonStreamExtractor implements IStreamExtractor {
 		// time, or as literal code units split across a `push()` boundary), hold it
 		// back so the trailing low surrogate joins it on the next emission. Both the
 		// escaped and literal paths funnel through here, so buffering once fixes
-		// both. `emittedContent` therefore stays well-formed and is the running
-		// join of emitted chunks; the held code unit is flushed at end-of-stream.
+		// both. The held unit is kept raw in `fieldContents` and flushed at
+		// end-of-stream if its low half never arrives.
+		let pending = "";
 		if (isHighSurrogate(chunk.charCodeAt(chunk.length - 1))) {
+			pending = chunk.slice(-1);
 			chunk = chunk.slice(0, -1);
-			if (!chunk) {
-				return;
-			}
+		}
+		// Holding back only the final high surrogate leaves interior unpaired
+		// surrogates in the releasable prefix — an interior lone high not followed
+		// by a low (`A\ud83dB`) or an isolated low (`A\ude00B`). Replace those with
+		// U+FFFD so every emitted chunk, and the accumulated value handed to
+		// `onChunk`, is well-formed UTF-16. The replacement is 1:1 by code unit, so
+		// the length-based emission cursor (`previous.length`) stays valid.
+		chunk = toWellFormedUnicode(chunk);
+		if (!chunk) {
+			// Nothing releasable yet; keep the raw pending surrogate stored so it can
+			// pair on the next push or be flushed at end-of-stream.
+			this.fieldContents.set(field, previous + pending);
+			return;
 		}
 		const emitted = previous + chunk;
 		this.emittedContent.set(field, emitted);
+		// Stored content mirrors the well-formed emitted value plus the still-raw
+		// pending high surrogate, so validated field content never carries an
+		// interior lone surrogate.
+		this.fieldContents.set(field, emitted + pending);
 		this.config.onChunk(chunk, field, emitted, this.streamRevision);
 		this.emitEvent({
 			eventType: "chunk",


### PR DESCRIPTION
# Relates to

Relates to #30904 — fixes the JSON-escaped and literal-split paths in the constrained `ResponseSkeletonStreamExtractor` (`processActiveString` → `appendVisibleAndEmit`) that the issue reproduces. Kept as `Relates to` rather than `Closes` so #30904 stays open to track the pre-existing passthrough/prose-mode split: `drainPassthrough` (`streaming.ts:751`) emits its buffer verbatim, so a literal surrogate pair split across `push()` boundaries in passthrough mode is still delivered malformed. That path is explicitly scoped out here (see Risks) and is the same holdback shape applied to a different drain; flagged by @hermesagent270-commits' executed review at `ef9ca36` and left as a follow-up.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; package `test`, `typecheck`, `lint`, and both build targets pass (see evidence). Full `bun run verify` not run on this ARM dev box — the change is scoped to one core module and its unit tests.
- [x] A reviewer can confirm the change works from the failing→passing test output below.

# Sync with develop

- [x] Based on latest `origin/develop` (`git rev-list --count HEAD..origin/develop` = 0 at push time); zero conflicts.
- [x] Focused package checks pass post-sync. Full `bun run verify` is a repo-wide gate; scoped verification is documented under Known gaps.

# Risks

Low. The change is confined to `ResponseSkeletonStreamExtractor.appendVisibleAndEmit` (chunk-boundary logic) plus a new end-of-stream `flushPendingSurrogate` step in `flush()`. Field routing, ordering, span parsing, reasoning-tag filtering, and passthrough mode are untouched. For any content with no lone surrogate at a chunk boundary the behavior is byte-identical (the ASCII/BMP control test proves this). The only observable change is that an emitted chunk is now always well-formed UTF-16: a trailing lone high surrogate is held back for its low half, and any other unpaired surrogate is replaced with U+FFFD.

# Background

## What does this PR do?

`ResponseSkeletonStreamExtractor` (`packages/core/src/utils/streaming.ts`) is the per-token stream handed to clients (constructed in the model dispatcher, feeding `downstreamChunk` → `paramsChunk`/`ctxChunk`). It could deliver a chunk that is not well-formed UTF-16: a non-BMP code point (e.g. an emoji 😀) was split into its two UTF-16 surrogate code units emitted as two separate `onChunk` chunks. Two independent paths caused it:

1. **Escaped path** — when a provider serializes a non-BMP char as a JSON escape pair (`\uXXXX\uXXXX`), `processActiveString` decoded each `\uXXXX` escape independently and called `appendAndEmit` immediately, so the two halves emitted as separate chunks inside a single `push()`.
2. **Literal path** — the loop consumes one UTF-16 code unit at a time, so an unescaped emoji split whenever a `push()` boundary fell between its halves.

Clients encode each individual chunk into UTF-8 SSE frames / WebSocket text frames / `JSON.stringify`, all of which corrupt a lone surrogate.

**Fix:** both paths funnel through `appendVisibleAndEmit`, so the surrogate handling lives there once. When the chunk about to be emitted ends on a lone high surrogate, that code unit is held back and prepended to the next emission once its trailing low surrogate arrives. Any *interior* unpaired surrogate that remains in the releasable prefix — an interior lone high not followed by a low (`A\ud83dB`) or an isolated low (`A\ude00B`) — is replaced with U+FFFD via `toWellFormedUnicode` before emission; the replacement is 1:1 by code unit, so the length-based emission cursor stays valid. `emittedContent` therefore stays well-formed and is the running join of emitted chunks (also passed as the `accumulated` argument, which stays consistent and well-formed), and `fieldContents` mirrors the well-formed emitted value plus at most one still-raw pending high surrogate. At genuine end-of-stream, `flushPendingSurrogate` emits any still-held lone high surrogate as U+FFFD — matching the codebase's existing well-formed convention — rather than dropping a real character or shipping a lone surrogate.

This second sanitization step closes the P2 review finding ([`ss251`](https://github.com/elizaOS/eliza/pull/30919#pullrequestreview)): withholding only a *trailing* high surrogate left non-trailing unpaired surrogates reaching `onChunk` unchanged.

No character is lost or duplicated: joining all emitted chunks for a field reconstructs the original decoded string; only chunk boundaries within a field change so they never fall between surrogate halves.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior of a public streaming utility is made correct (well-formed chunks) without changing its API.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/__tests__/streaming-field-events.test.ts` — six regression tests in the `ResponseSkeletonStreamExtractor` describe block. They fail on `develop` and pass with this change.

## Detailed testing steps

```bash
cd packages/core
bun run test src/utils/__tests__/streaming-field-events.test.ts
```

Covered: escaped emoji `\ud83d\ude00` in a single `push()`; literal emoji split across two `push()` boundaries; a genuinely lone trailing high surrogate at `flush()` (→ U+FFFD); and an ASCII/BMP control that stays byte-identical and still streams incrementally. Each test asserts `c.isWellFormed()` for every emitted chunk and that `chunks.join("")` reconstructs the original string.

# Evidence Gate

<!-- evidence-head:ef9ca3681dc175ba2e765c796295e0711c021c03 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this changes a core streaming utility's chunk boundaries.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this changes a core streaming utility's chunk boundaries.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow; verification is deterministic unit tests over the extractor contract.`
<!-- evidence-row:backend-logs -->
- [x] After the fix, the extractor's `onChunk` output for the exact contract — every emitted chunk is well-formed UTF-16 and the whole regression file passes:

```text
 RUN  v4.1.10 /packages/core
 Test Files  1 passed (1)
      Tests  24 passed (24)
   Duration  625ms (transform 228ms, import 270ms, tests 127ms)
```

The two added tests (`replaces an interior lone high surrogate followed by more text`, `replaces an isolated low surrogate`) assert `isWellFormed()` on every emitted chunk **and** on the accumulated callback value, and that the lone unit is replaced by U+FFFD.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response; the corrupted-surrogate symptom is on the server-side chunk stream, verified via unit test.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no provider/prompt/model behavior changes. The extractor consumes an already-produced token stream; tests feed deterministic streams that reproduce real provider serializations (escaped pair and literal split).`
<!-- evidence-row:domain-artifacts -->
- [x] Failing reproduction with `streaming.ts` reverted to `origin/develop` (no surrogate handling) while keeping the new test file — the five well-formedness tests fail while the ASCII/BMP control passes, proving the tests isolate the defect:

```text
 ❯ src/utils/__tests__/streaming-field-events.test.ts (24 tests | 5 failed)
     × never emits a lone surrogate for a JSON-escaped emoji in a single push
     × never emits a lone surrogate for a literal emoji split across push boundaries
     × replaces a genuinely lone trailing high surrogate at end-of-stream
     × replaces an interior lone high surrogate followed by more text
     × replaces an isolated low surrogate
 Test Files  1 failed (1)
      Tests  5 failed | 19 passed (24)
```

Domain output — driving the real `ResponseSkeletonStreamExtractor` over the surrogate shapes at head `ef9ca36` and printing the exact `onChunk` boundaries with per-chunk `isWellFormed()` (`\u{fffd}` is U+FFFD; `join` reconstructs the accumulated value):

```text
=== combined A\ud83dB\ude00C (interior high + isolated low) ===
  chunk[0]: "A"          isWellFormed=true
  chunk[1]: "\u{fffd}B"   isWellFormed=true
  chunk[2]: "\u{fffd}"    isWellFormed=true
  chunk[3]: "C"          isWellFormed=true
  join/accumulated: "A\u{fffd}B\u{fffd}C"  isWellFormed=true

=== escaped emoji \ud83d\ude00 in one push ===
  chunk[0]: "Hi "        isWellFormed=true
  chunk[1]: "\u{1f600}"   isWellFormed=true
  chunk[2]: "!"          isWellFormed=true
  join/accumulated: "Hi \u{1f600}!"       isWellFormed=true

=== literal emoji split across push boundaries ===
  chunk[0]: "Hi "        isWellFormed=true
  chunk[1]: "\u{1f600}!"  isWellFormed=true
  join/accumulated: "Hi \u{1f600}!"       isWellFormed=true

=== trailing lone high surrogate at end-of-stream ===
  chunk[0]: "Hi "        isWellFormed=true
  chunk[1]: "\u{fffd}"    isWellFormed=true
  join/accumulated: "Hi \u{fffd}"         isWellFormed=true
```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.` The fix is a pure UTF-16 chunk-boundary correction on the token stream after model output; tests reproduce the two real provider serializations (JSON `\uXXXX\uXXXX` escape pair and literal split code units).

## Backend + frontend logs

Failing→passing test output for the new regression tests.

**Before (streaming.ts reverted to `origin/develop`, new tests kept — 5 well-formedness tests fail):**

```
 ❯ src/utils/__tests__/streaming-field-events.test.ts (24 tests | 5 failed)
     × never emits a lone surrogate for a JSON-escaped emoji in a single push
     × never emits a lone surrogate for a literal emoji split across push boundaries
     × replaces a genuinely lone trailing high surrogate at end-of-stream
     × replaces an interior lone high surrogate followed by more text
     × replaces an isolated low surrogate
 Test Files  1 failed (1)
      Tests  5 failed | 19 passed (24)
```

The ASCII/BMP control passes before the fix, confirming the tests isolate the surrogate defect rather than any incidental behavior.

**After (with fix — all pass):**

```
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

The P2 interior/isolated-surrogate finding is covered by the two added tests, which assert `isWellFormed()` on every emitted chunk and on the accumulated callback value. `typecheck` is clean and Biome is clean on both changed files at this head.

Frontend: `N/A - server-side stream corruption; no browser request/response involved.`

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

### Before

`N/A - no UI change.`

### After

`N/A - no UI change.`

### Walkthrough video

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Full `bun run verify` was not run on this ARM64 dev box: it is a repo-wide multi-package gate and this change is confined to one core module. Instead ran the owning package's `test` on the surrogate suite (failing→passing, `24 passed (24)` at this head), `typecheck` (clean), and `lint`/Biome on the two changed files (clean). The 18 Biome warnings from the package-wide `lint` are pre-existing `as any` uses in unrelated files, not in the two files this PR touches. Note: the wider `src/utils/` run also shows 15 `formatRelativeTime`/`formatTimestamp` failures on this box; they are environmental (locale/timezone) and reproduce with this change reverted, so they are unrelated to this PR.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@ef9ca3681dc175ba2e765c796295e0711c021c03:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@ef9ca3681dc175ba2e765c796295e0711c021c03:packages/skills/skills/contribute-to-eliza"} -->

