### PR TITLE
fix(cloud): reconcile every chunked group delivery receipt

### DIFF
--- a/packages/cloud/api/__tests__/group-delivery-receipts.integration.test.ts
+++ b/packages/cloud/api/__tests__/group-delivery-receipts.integration.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Exercises chunked provider delivery through the real receipt route and
+ * migrated PGlite authority. Only Telegram's external HTTP API is simulated.
+ */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { sendTelegramReply } from "@elizaos/cloud-services-common/telegram-connector";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV = "test";
+
+const { closeDatabaseConnectionsForTests, getPgliteClientForTests } =
+  await import("@/db/client");
+const { personalSharedGroupsRepository: repository } = await import(
+  "@/db/repositories/personal-shared-groups"
+);
+const { default: app } = await import(
+  "../internal/eliza-app/personal-shared/messages/route"
+);
+const database = getPgliteClientForTests();
+const owner = "71000000-0000-4000-8000-000000000011";
+const organization = "71000000-0000-4000-8000-000000000001";
+
+beforeAll(async () => {
+  await database.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY, is_active boolean NOT NULL DEFAULT true);
+    CREATE TABLE users (
+      id uuid PRIMARY KEY, organization_id uuid REFERENCES organizations(id),
+      steward_user_id text, telegram_id text, phone_number text, phone_verified boolean,
+      is_anonymous boolean, is_active boolean, deleted_at timestamptz
+    );
+  `);
+  for (const migration of [
+    "0297_personal_shared_group_bindings.sql",
+    "0303_personal_shared_group_authority_version.sql",
+    "0304_personal_shared_group_delivery_lease.sql",
+    "0312_personal_shared_group_delivery_attempts.sql",
+    "0311_personal_shared_group_participants.sql",
+    "0320_personal_shared_multi_principal_consent.sql",
+  ]) {
+    await database.exec(
+      await Bun.file(
+        new URL(`../../shared/src/db/migrations/${migration}`, import.meta.url),
+      ).text(),
+    );
+  }
+  await database.query("INSERT INTO organizations (id) VALUES ($1)", [
+    organization,
+  ]);
+  await database.query(
+    "INSERT INTO users (id, organization_id) VALUES ($1, $2)",
+    [owner, organization],
+  );
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+test("reconciles every delivered chunk and releases the reservation for the next group turn", async () => {
+  const destination = {
+    platform: "telegram" as const,
+    project: "eliza-app",
+    connectorAccountId: "telegram:receipt-test",
+    providerChatId: "-100123456789",
+  };
+  await repository.issueClaim({
+    ...destination,
+    codeHash: "chunked-receipt-test",
+    organizationId: organization,
+    ownerUserId: owner,
+    personalAgentId: "personal:receipt-owner",
+    issuedToPlatformUserId: "123456789",
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+  const bound = await repository.consumeClaimAndBind({
+    ...destination,
+    codeHash: "chunked-receipt-test",
+    actorPlatformUserId: "123456789",
+  });
+  if (bound.status !== "bound") throw new Error("Group claim did not bind");
+  const delivery = {
+    ...destination,
+    sourceMessageId: "telegram:eliza-app:chunked-reply",
+    leaseToken: crypto.randomUUID(),
+    authority: {
+      bindingId: bound.binding.id,
+      ownerUserId: owner,
+      personalAgentId: bound.binding.personal_agent_id,
+      version: bound.binding.authority_version,
+    },
+  };
+  expect(
+    await repository.authorizeDelivery({ ...delivery, invocation: "mention" }),
+  ).toMatchObject({ authorized: true });
+  expect(await repository.commitDelivery(delivery)).toBe(true);
+
+  const text = "A complete group response. ".repeat(1800);
+  const sentText: string[] = [];
+  const acceptedIds: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body: unknown = JSON.parse(String(init?.body));
+      if (
+        !body ||
+        typeof body !== "object" ||
+        !("text" in body) ||
+        typeof body.text !== "string"
+      ) {
+        throw new Error("Expected Telegram text send");
+      }
+      sentText.push(body.text);
+      const id = 1000 + sentText.length;
+      acceptedIds.push(String(id));
+      return Response.json({ ok: true, result: { message_id: id } });
+    },
+    { preconnect: originalFetch.preconnect },
+  );
+  let receipt: Awaited<ReturnType<typeof sendTelegramReply>>;
+  try {
+    receipt = await sendTelegramReply(
+      { botToken: "test-token" },
+      {
+        platform: "telegram",
+        messageId: "chunked-reply",
+        platformRecordId: "receipt-test",
+        chatId: destination.providerChatId,
+        chatType: "supergroup",
+        senderId: "123456789",
+        text: "Please explain",
+        isCommand: false,
+        rawPayload: {},
+      },
+      text,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  expect(sentText.join("")).toBe(text);
+  expect(receipt.providerMessageIds.length).toBeGreaterThan(8);
+  expect(receipt.providerMessageIds).toEqual(acceptedIds);
+
+  const submit = (providerMessageIds: string[]) =>
+    app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer receipt-test-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          ...delivery,
+          eventType: "delivery_receipt",
+          chatId: destination.providerChatId,
+          providerMessageIds,
+        }),
+      },
+      { INTERNAL_SECRET: "receipt-test-secret" },
+    );
+  const invalid = await submit([...receipt.providerMessageIds, ""]);
+  expect(invalid.status).toBe(400);
+  expect((await submit([])).status).toBe(400);
+  const response = await submit(receipt.providerMessageIds);
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({
+    success: true,
+    data: { recorded: true, inserted: acceptedIds.length },
+  });
+  const persisted = await database.query<{ provider_message_id: string }>(
+    "SELECT provider_message_id FROM personal_shared_group_delivery_receipts WHERE binding_id = $1",
+    [bound.binding.id],
+  );
+  expect(persisted.rows.map((row) => row.provider_message_id).sort()).toEqual(
+    [...acceptedIds].sort(),
+  );
+  const attempt = await database.query<{ state: string }>(
+    "SELECT state FROM personal_shared_group_delivery_attempts WHERE binding_id = $1 AND source_message_id = $2",
+    [bound.binding.id, delivery.sourceMessageId],
+  );
+  expect(attempt.rows).toEqual([{ state: "reconciled" }]);
+  const replay = await submit(receipt.providerMessageIds);
+  expect(replay.status).toBe(200);
+  expect(await replay.json()).toMatchObject({
+    data: { recorded: true, inserted: 0 },
+  });
+  const binding = await repository.findBindingById(bound.binding.id);
+  expect(binding?.delivery_lease_token).toBeNull();
+  expect(
+    await repository.authorizeDelivery({
+      ...delivery,
+      sourceMessageId: "telegram:eliza-app:next-turn",
+      leaseToken: crypto.randomUUID(),
+      invocation: "mention",
+    }),
+  ).toMatchObject({ authorized: true });
+});

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -234,10 +234,7 @@ const sharedMessageSchema = z.union([
       .trim()
       .min(1)
       .max(GROUP_SOURCE_MESSAGE_ID_MAX_LENGTH),
-    providerMessageIds: z
-      .array(z.string().trim().min(1).max(160))
-      .min(1)
-      .max(8),
+    providerMessageIds: z.array(z.string().trim().min(1).max(160)).min(1),
     leaseToken: z.string().uuid(),
     authority: groupDeliveryAuthoritySchema,
   }),


### PR DESCRIPTION
# Relates to

Related to #25020. This shared messaging fix does not complete Discord owner-bound groups under #29920/#28744.

Definition of Done: [CONTRIBUTING.md](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] Targets `develop`; rebased on `383f5ebdc5435ef559879fddf20a9aa7f7a56b31` without conflicts.
- [x] Pinned Bun 1.3.14 and Node 24.15.0 install and root verification run after sync.
- [x] Behavioral evidence is included below.

# Sync with develop

The current base remains `383f5ebdc5435ef559879fddf20a9aa7f7a56b31`. No rebase changes were needed. Post-sync install and root verification pass.

# Risks

Low scope: one internal request-validation change. Receipt arrays remain nonempty; each ID remains validated. Internal authentication and persisted source, destination, authority and lease checks are unchanged. Provider HTTP is simulated in the integration test; no live provider or deployment claim is made.

# Background

## What does this PR do?

Long Telegram replies can be delivered successfully, then fail receipt persistence because the internal group endpoint rejects more than eight provider message IDs. The committed attempt cannot reconcile and its delivery reservation does not clear normally.

Remove that receipt-count cap. The existing database transaction records every receipt, reconciles the attempt and releases the matching reservation. The new regression uses the actual Telegram chunk sender, real Hono route and migrated PGlite.

## What kind of change is this?

Bug fix with a behavioral integration regression.

# Documentation changes needed?

None. The internal receipt endpoint now accepts the complete receipt set already produced by the connector.

# Testing

## Where should a reviewer start?

Compare the baseline HTTP 400 with the passing integration output below. The test verifies complete sent text, every persisted ID, reconciled attempt state, cleared reservation, replay without new rows and next-turn admission. Empty arrays and malformed IDs remain rejected.

## Detailed testing steps

```sh
bun install
bun run verify
bun run --cwd packages/cloud/api test
bun run --cwd packages/cloud/api typecheck
bun run --cwd packages/cloud/api lint:check
cd packages/cloud/api
bun test __tests__/group-delivery-receipts.integration.test.ts
```

Root verification passed all 373 Turbo tasks and repository audits, including API typecheck, router parity and Worker bundle checks. API lint passed. Adjacent group-route tests passed 129 tests; migrated group-authority tests passed 11 tests. The final receipt regression plus inference-admission rerun passed 69 tests with 466 assertions. These overlapping runs must not be summed as unique coverage. Two independent reviews found no blocker in this two-file change.

The full API lane ran 604 isolated files and reported four failures. The baseline comparison is recorded below; the full lane is not claimed green.

# Evidence Gate

<!-- evidence-head:eff258f850dd0e9d6e8560849337239561fe90ed -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - internal receipt validation has no UI interaction.
<!-- evidence-row:backend-logs -->
- [x] Actual failing and passing route execution, using simulated Telegram HTTP and real local SQL:

<details><summary>Baseline rejection and repaired receipt flow</summary>

Baseline source `383f5ebdc5435ef559879fddf20a9aa7f7a56b31`, before removing the cap:

```text
bun test v1.3.14 (0d9b296a)

__tests__/group-delivery-receipts.integration.test.ts:
120 |     body: JSON.stringify({ ...delivery, eventType: "delivery_receipt", chatId: destination.providerChatId, providerMessageIds }),
121 |   }, { INTERNAL_SECRET: "receipt-test-secret" });
122 |   const invalid = await submit([...receipt.providerMessageIds, ""]);
123 |   expect(invalid.status).toBe(400);
124 |   const response = await submit(receipt.providerMessageIds);
125 |   expect(response.status).toBe(200);
                                ^
error: expect(received).toBe(expected)

Expected: 200
Received: 400

      at <anonymous> (packages/cloud/api/__tests__/group-delivery-receipts.integration.test.ts:125:27)
(fail) reconciles every delivered chunk and releases the reservation for the next group turn [27.74ms]

 0 pass
 1 fail
 7 expect() calls
Ran 1 test across 1 file. [1.83s]
```

Repaired behavior, identical runtime code to `eff258f850dd0e9d6e8560849337239561fe90ed`:

```text
bun test v1.3.14 (0d9b296a)

__tests__/group-delivery-receipts.integration.test.ts:
(pass) reconciles every delivered chunk and releases the reservation for the next group turn [36.09ms]

 1 pass
 0 fail
 15 expect() calls
Ran 1 test across 1 file. [1324.00ms]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no inference, action, prompt or model behavior changed; complete response text is a deterministic test input.
<!-- evidence-row:domain-artifacts -->
- [x] Migrated PGlite assertions verify all provider receipt rows, reconciled attempt state, an empty lease, zero replay inserts and next-turn authorization. This is assertion-backed local database evidence, not a live provider receipt.

<details><summary>Database reconciliation regression output</summary>

```text
bun test v1.3.14 (0d9b296a)

__tests__/group-delivery-receipts.integration.test.ts:
(pass) reconciles every delivered chunk and releases the reservation for the next group turn [36.09ms]

 1 pass
 0 fail
 15 expect() calls
Ran 1 test across 1 file. [1324.00ms]
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this change validates receipt metadata after delivery; it does not change model calls.

## Backend + frontend logs

Actual backend test output is inline above. Frontend logs are N/A because no browser path changes.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI or device interaction changes.

## Audio / voice walkthrough

N/A - no audio or voice behavior changes.

## Known gaps / failures

Three full-API failures reproduce on unchanged `383f5ebdc5435ef559879fddf20a9aa7f7a56b31` after restoring the route to baseline for the comparison:

- `__tests__/elizaos-core-stub.test.ts`: stale default-model literal, expected `gemma-4-31b`, actual `qwen-3.8-27b`.
- `__tests__/shared-eliza-runtime.miniflare.test.ts`: TODO fixture returns 500 and a lifecycle reply differs from its old expected fallback.
- `v1/voice/session/__tests__/local-runtime-conversation-fetch.encoding.test.ts`: missing `VOICE_CHANNEL_TYPE` export.

The fourth file, `__tests__/inference-admission-gate.test.ts`, initially lacked a built workspace dependency. It passed after the prerequisite builds on both baseline and candidate. Initial standalone API typecheck likewise lacked built `@elizaos/login`; the subsequent root build/verification completed API typecheck successfully.

No hosted CI result, live Telegram delivery or group-launch certification is claimed. The public provider API is simulated; the sender, route, database migrations and repository transactions are real. No deployment was performed.

## Maintainer CI exception record

N/A - no exception requested.
