### PR TITLE
test(voice): pin handoff depth retirement for old-only tails and replaced handoffs

### DIFF
--- a/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
+++ b/packages/ui/src/voice/__tests__/voice-session-playback.test.ts
@@ -400,6 +400,65 @@ describe("voice-session streaming PCM playback sink (ScriptProcessor path)", () 
     expect(pb.getStats().queuedSamples).toBe(160);
     await pb.stop();
   });
+  it("retires old-only samples played after a short reply ends mid-crossfade", async () => {
+    const ctx = new FakePlaybackAudioContext(16_000);
+    const onDrained = vi.fn();
+    const pb = await createVoiceSessionPlayback({
+      createAudioContext: () => ctx,
+      preRollMs: 0,
+      onDrained,
+    });
+    await pb.unlock();
+    pb.beginInput();
+    pb.enqueue(pcmFrame(0.8, 512));
+    scriptNodeOf(ctx).render(2);
+    expect(pb.getStats().queuedSamples).toBe(510);
+
+    pb.beginHandoff(20); // 320-sample crossfade at 16 kHz
+    pb.enqueue(pcmFrame(-0.8, 100)); // shorter than the crossfade
+    const out = scriptNodeOf(ctx).render(352);
+    // 100 mixed frames retire 200 samples; the next 252 frames play old audio
+    // alone and must retire one sample each.
+    expect(out[50]).not.toBeCloseTo(0.8, 2);
+    expect(out[200]).toBeCloseTo(0.8, 2);
+    expect(pb.getStats().queuedSamples).toBe(510 + 100 - 200 - 252);
+
+    pb.finishInput();
+    // 158 old samples remain; the extra frames let the sink observe the empty queue.
+    scriptNodeOf(ctx).render(166);
+    expect(pb.getStats().queuedSamples).toBe(0);
+    expect(onDrained).toHaveBeenCalledTimes(1);
+    await pb.stop();
+  });
+  it("retires the abandoned old tail when a handoff is replaced before it completes", async () => {
+    const ctx = new FakePlaybackAudioContext(16_000);
+    const completed = vi.fn();
+    const pb = await createVoiceSessionPlayback({
+      createAudioContext: () => ctx,
+      preRollMs: 0,
+      onHandoffComplete: completed,
+    });
+    await pb.unlock();
+    pb.beginInput();
+    pb.enqueue(pcmFrame(0.8, 512));
+    scriptNodeOf(ctx).render(2);
+
+    pb.beginHandoff(20);
+    pb.enqueue(pcmFrame(-0.8, 512));
+    scriptNodeOf(ctx).render(100); // 100 mixed frames: 410 old and 412 new remain
+    expect(pb.getStats().queuedSamples).toBe(822);
+
+    // Replacing the handoff before its crossfade completes discards the 410
+    // unplayed old samples, which must leave the depth with them.
+    pb.beginHandoff(20);
+    expect(pb.getStats().queuedSamples).toBe(412);
+    pb.enqueue(pcmFrame(0.4, 512));
+    scriptNodeOf(ctx).render(352);
+    // 320 mixed frames (640), the 92-sample abandoned tail, then 32 new-only frames.
+    expect(completed).toHaveBeenCalledTimes(1);
+    expect(pb.getStats().queuedSamples).toBe(412 + 512 - 640 - 92 - 32);
+    await pb.stop();
+  });
   it.each(["autoplay", "startup reserve"])(
     "hands off audio held by %s without replaying the obsolete response",
     async (heldBy) => {

--- a/packages/ui/test/audio-worklets-runtime.test.mjs
+++ b/packages/ui/test/audio-worklets-runtime.test.mjs
@@ -94,6 +94,45 @@ describe("packaged voice AudioWorklets", () => {
     });
   });
 
+  it("retires old-only samples played after a short reply ends mid-crossfade", () => {
+    const downlink = processor("eliza-voice-session-downlink");
+    const send = (data) => downlink.port.onmessage({ data });
+    send({ type: "pcm", pcm: new Float32Array(32).fill(0.8), sequence: 1 });
+    downlink.process([], [[new Float32Array(2)]]);
+    send({ type: "handoff", crossfadeSamples: 20, sequence: 2 });
+    send({ type: "pcm", pcm: new Float32Array(8).fill(-0.8), sequence: 3 });
+    const output = new Float32Array(22);
+    downlink.process([], [[output]]);
+    // 8 mixed frames retire 16 samples; the next 14 frames play old audio
+    // alone and must retire one sample each, leaving 8 of the original 30.
+    expect(output[12]).toBeCloseTo(0.8);
+    send({ type: "pcm", pcm: new Float32Array(2), sequence: 4 });
+    expect(downlink.port.postMessage).toHaveBeenLastCalledWith({
+      type: "queue-depth",
+      queuedSamples: 10,
+      sequence: 4,
+    });
+  });
+
+  it("retires the abandoned old tail when a handoff is replaced before it completes", () => {
+    const downlink = processor("eliza-voice-session-downlink");
+    const send = (data) => downlink.port.onmessage({ data });
+    send({ type: "pcm", pcm: new Float32Array(32).fill(0.8), sequence: 1 });
+    downlink.process([], [[new Float32Array(2)]]);
+    send({ type: "handoff", crossfadeSamples: 20, sequence: 2 });
+    send({ type: "pcm", pcm: new Float32Array(32).fill(-0.8), sequence: 3 });
+    downlink.process([], [[new Float32Array(10)]]);
+    // 10 mixed frames retired 20: 20 old and 22 new samples remain.
+    send({ type: "handoff", crossfadeSamples: 20, sequence: 4 });
+    send({ type: "pcm", pcm: new Float32Array(32).fill(0.4), sequence: 5 });
+    // The 20 unplayed old samples left with the replaced handoff: 22 + 32.
+    expect(downlink.port.postMessage).toHaveBeenLastCalledWith({
+      type: "queue-depth",
+      queuedSamples: 54,
+      sequence: 5,
+    });
+  });
+
   it("captures the playback reference as averaged mono PCM", () => {
     const tap = processor("eliza-playback-reference-tap");
 


### PR DESCRIPTION
Follow-through on #30830 (merged as `24a3bb1469`). That PR made both playback backends retire crossfaded samples, old-only samples, and discarded handoff tails from queue depth, so telemetry stops reporting audio that can no longer play. Two of the four accounting lines it added per backend are unpinned by the merged suites: the old-only retirement, and the retirement of the tail abandoned when a handoff is replaced before its crossfade completes. Test-only; no runtime source is touched.

## What was unpinned (reproduced on clean develop before the fix)

| mutant (line deleted) | develop suite | with this PR |
| --- | --- | --- |
| ScriptProcessor: `consumedSamples += 1` in the old-only branch (`voice-session-playback.ts`) | 29 pass | **1 failed** |
| ScriptProcessor: `sinkQueuedSamples -= …` on `beginHandoff` (abandoned tail) | 29 pass | **1 failed** |
| AudioWorklet: `queuedSamples - 1` in the old-only branch (`voice-session-downlink.js`) | 4 pass | **1 failed** |
| AudioWorklet: `queuedSamples -= …` in the `handoff` handler (abandoned tail) | 4 pass | **1 failed** |

The other two lines from #30830 (mixed frames retire two samples; the tail discarded at crossfade completion) are already pinned by the merged crossfade cases and stay pinned here.

## Why the merged cases could not see them

Both merged crossfade cases enqueue a new reply at least as long as the crossfade and never issue a second handoff, so the old-only branch is never entered and the `handoff`-time subtraction always runs against an empty handoff queue. The two new cases per backend model the scenarios the lines exist for: a reply shorter than the crossfade, so the old tail plays alone before the queue drains; and a second `beginHandoff` issued mid-crossfade, so the unplayed old samples are discarded with the replaced handoff. Each asserts the depth the sink reports afterwards (`getStats().queuedSamples` on the ScriptProcessor path; the `queue-depth` port message on the worklet path), and the ScriptProcessor old-only case also drives the sink to empty and checks `onDrained` fires once.

## Current maintainer verification

The author commit is retained on develop `e2d6d383bc3b10f35ab509748d00788be9b72769`; candidate `bc37244bfecdfb4e45f883a781c59ef2809fe581` retains the two-file test-only scope. Both test files and their production consumers are byte-identical to the independently qualified candidate `d7f1fdee5d2410a58f71dc1fff5174b01e1081f3`. At that candidate, normal installation, package lint, all37 focused tests, all373 repository tasks and final audits passed. Independently repeated all four mutations against its develop base and candidate: the base's33tests passed every mutation, while each candidate run failed exactly the intended test with36others passing. All temporary mutations were restored and a final37-test run passed. An independent reviewer approved the queue/drain consumer coverage and inspected every mutation result.

Later integration candidates on f722 and1020 also passed normal installation, all373 repository tasks and final audits. The final e2d6 candidate passed normal installation, all373 repository tasks and every final audit (exit0). Hosted checks must finish successfully before merge.

The original author validation below is retained as historical evidence and does not substitute for current-head checks.

## Original author verification

- `cd packages/ui && bunx vitest run src/voice/__tests__/voice-session-playback.test.ts test/audio-worklets-runtime.test.mjs` — 37/37 at this head
- Each of the four mutants above re-applied at this head: exactly the intended test fails, nothing else
- `biome check` on both files; `packages/ui` typecheck; root `bun run verify`
- Environment: disposable worktree at `origin/develop` (`357084b309`), Bun 1.3.14, `bun install --frozen-lockfile`

## Test-only gate

- **Realistic regression prevented:** a later edit to either backend's crossfade loop or handoff handler that drops one of these retirements reintroduces the #30830 defect for the two scenarios it did not model, with every suite green.
- **Observing consumer:** the playback stats surface — `VoiceSessionPlaybackStats.queuedSamples` / `maxQueuedSamples`, emitted on `finished` and `underrun` through `VoiceSessionClient`'s `onPlaybackStats` — and, on the worklet path, the `queue-depth` messages the sink folds into that surface. An over-count there reports audio that can never play, which is the failure #30830 set out to remove.
- **Why existing coverage does not own it:** demonstrated by mutation above — the merged cases pass with either line deleted in either backend.

Refs: #30830 (merged), #29492.

<!-- evidence-head:bc37244bfecdfb4e45f883a781c59ef2809fe581 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - test-only change; no rendered UI surface exists before or after.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - test-only change; no rendered UI surface exists before or after.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow changes; the deliverable is the mutation-kill matrix below.`
<!-- evidence-row:backend-logs -->
- [x] The source-identical maintainer candidate d7f1 passed the real suites; source identity and current integration checks are described above:

```text
$ cd packages/ui && bunx vitest run src/voice/__tests__/voice-session-playback.test.ts test/audio-worklets-runtime.test.mjs
 Test Files  2 passed (2)
      Tests  37 passed (37)
```

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend runtime code is touched; both edits are test files.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model call, prompt, or planner path is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — mutation-kill matrix, each mutant applied and reverted independently, before (qualified develop base498) and after (source-identical candidate d7f1):

```text
MUTANT A - delete `sinkQueuedSamples -= …` in beginHandoff (ScriptProcessor, voice-session-playback.ts)
  develop:   Tests  29 passed (29)                    <- survives
  this head: × retires the abandoned old tail when a handoff is replaced before it completes
             Tests  1 failed | 36 passed (37)         <- killed

MUTANT B - delete `consumedSamples += 1` in the old-only branch (ScriptProcessor)
  develop:   Tests  29 passed (29)                    <- survives
  this head: × retires old-only samples played after a short reply ends mid-crossfade
             Tests  1 failed | 36 passed (37)         <- killed

MUTANT C - delete `this.queuedSamples -= …` in the handoff handler (AudioWorklet, voice-session-downlink.js)
  develop:   Tests  4 passed (4)                      <- survives
  this head: × retires the abandoned old tail when a handoff is replaced before it completes
             Tests  1 failed | 36 passed (37)         <- killed

MUTANT D - delete `this.queuedSamples = Math.max(0, this.queuedSamples - 1)` in the old-only branch (AudioWorklet)
  develop:   Tests  4 passed (4)                      <- survives
  this head: × retires old-only samples played after a short reply ends mid-crossfade
             Tests  1 failed | 36 passed (37)         <- killed
```

<!-- evidence-row:surface-ocr -->
- [x] OCR visual text review: `N/A - test-only change has no rendered visual surface to review.`

Compute receipt: 4817306 project-attributed tokens (exact; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5-1
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza
Attribution status: self-reported
— [kenjohnscreates]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5-1","client":"claude-code","skill_revision":"elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M20QD71SGXD8V0EYDTMNW6H6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-09-08T14:40:29.242Z","completed_at":"2026-09-08T14:56:07.943Z","skill_sha256":"ede00e21ecb0e86f710c76ab00ab60f9c39e0f33cb3a4ab8514af38585385c0e","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T14:40:31.262Z"},"usage":{"source":"ccusage-session-v20","confidence":"exact","input_tokens":20,"output_tokens":9005,"cache_creation_tokens":12663,"cache_read_tokens":4795618,"total_tokens":4817306,"cost_micro_usd":"2749664","session_count":1},"trajectory_sha256":"c5ad09c6eb88bd3f6fb9a0b6adcb4acf4fac8880bb6a95e62a9c5e5973c771f2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"c04d0f71-30c2-4111-ab10-f1dec3f17873","object_id":"sha256:c5ad09c6eb88bd3f6fb9a0b6adcb4acf4fac8880bb6a95e62a9c5e5973c771f2","sha256":"c5ad09c6eb88bd3f6fb9a0b6adcb4acf4fac8880bb6a95e62a9c5e5973c771f2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAHBoGfBNRJEhRkQvHY6AcB2oVJyScySjClifWLRVPl28","device_key_id":"e6f31ab600bfb4b6612dfa8af8aec495ea789bb7fa02be582d03179b4a835899","device_signature":"7KlebQi_YLsxOtE92d-_c7Z1zG90i1P9xhI6Ro48WS5VCR2C6CBiNue9_GW4TtG9bymmYmiMK1jrqYxH4Mt7Bg"}} -->


## Final integration receipt

All five hosted checks passed on published head `bc37244bfecdfb4e45f883a781c59ef2809fe581` ([run34508223239](https://github.com/elizaOS/eliza/actions/runs/34508223239)). Develop advanced only by the independently qualified billing guard #28765. Local integration `009e0879e358e37cd3b5319859c0b4b21b1adb62` on develop `56e337710ba165b7f1a4d8869b9b6aa53e191493` has tree `a92da36d91f909e0fc0ce6fcac1671acc72bb134`, exactly equal to the merge tree of that base and the published head. Normal installation passed on the joined tree. All UI source and tests remain byte-identical to the candidate that passed the current root gate and scoped mutation controls; the three added Cloud files have the separate merged billing full-suite and root evidence. This is explicit composed integration proof, not a claim that the full root suite was rerun on local009e.
