### PR TITLE
fix(cloud): surface terminal no-response turns in private Telegram

### DIFF
--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -9,7 +9,10 @@ import {
   spyOn,
   test,
 } from "bun:test";
-import { PERSONAL_SHARED_FAILURE_REPLY } from "@elizaos/cloud-services-common/personal-shared-failure";
+import {
+  PERSONAL_SHARED_FAILURE_REPLY,
+  PERSONAL_SHARED_NO_RESPONSE_REPLY,
+} from "@elizaos/cloud-services-common/personal-shared-failure";
 import { __resetTelegramIdentityAttestationCacheForTests } from "@elizaos/cloud-services-common/telegram-connector";
 import { Hono } from "hono";
 import { logger } from "@/lib/utils/logger";
@@ -879,39 +882,74 @@ describe("Personal Shared Telegram edge", () => {
     },
   );
 
-  test("reopens a rejected fallback send without claiming ambiguous delivery", async () => {
-    const ledger = namespace();
-    const turn = mock(
-      async () =>
-        new Response("terminal", {
-          status: 500,
-          headers: { "X-Eliza-Retryable": "false" },
-        }),
+  test.each([
+    ["group", telegramGroupRequest()],
+    ["membership", telegramMembershipRequest()],
+  ])("keeps a completed empty %s update silent", async (_name, request) => {
+    const turn = mock(async () =>
+      Response.json({
+        data: { reply: "", responded: false, responseReason: "no_response" },
+      }),
     );
-    let rejectFallback = true;
-    let acceptedFallbacks = 0;
-    globalThis.fetch = mock(async (input, init) => {
+    const sentTexts: string[] = [];
+    globalThis.fetch = mock(async (_input, init) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
-      if (String(input).endsWith("/sendMessage") && body.text) {
-        if (rejectFallback) {
-          rejectFallback = false;
-          return Response.json({
-            ok: false,
-            error_code: 400,
-            description: "provider rejected message",
-          });
-        }
-        acceptedFallbacks += 1;
-        return Response.json({ ok: true, result: { message_id: 9007 } });
-      }
+      if (body.text) sentTexts.push(body.text);
       return Response.json({ ok: true, result: true });
     }) as unknown as typeof fetch;
-
-    expect((await run(ledger, turn, telegramRequest(81617))).status).toBe(500);
-    expect((await run(ledger, turn, telegramRequest(81617))).status).toBe(200);
-    expect(turn).toHaveBeenCalledTimes(2);
-    expect(acceptedFallbacks).toBe(1);
+    expect((await run(namespace(), turn, request)).status).toBe(200);
+    expect(sentTexts).toEqual([]);
   });
+
+  test.each([false, true])(
+    "reopens a rejected fallback without ambiguous delivery (completed=%j)",
+    async (completed) => {
+      const ledger = namespace();
+      const turn = mock(async () =>
+        completed
+          ? Response.json({
+              data: {
+                reply: "",
+                responded: false,
+                responseReason: "no_response",
+              },
+            })
+          : new Response("terminal", {
+              status: 500,
+              headers: { "X-Eliza-Retryable": "false" },
+            }),
+      );
+      let rejectFallback = true;
+      let acceptedFallbacks = 0;
+      globalThis.fetch = mock(async (input, init) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          text?: string;
+        };
+        if (String(input).endsWith("/sendMessage") && body.text) {
+          if (rejectFallback) {
+            rejectFallback = false;
+            return Response.json({
+              ok: false,
+              error_code: 400,
+              description: "provider rejected message",
+            });
+          }
+          acceptedFallbacks += 1;
+          return Response.json({ ok: true, result: { message_id: 9007 } });
+        }
+        return Response.json({ ok: true, result: true });
+      }) as unknown as typeof fetch;
+
+      expect((await run(ledger, turn, telegramRequest(81617))).status).toBe(
+        500,
+      );
+      expect((await run(ledger, turn, telegramRequest(81617))).status).toBe(
+        200,
+      );
+      expect(turn).toHaveBeenCalledTimes(2);
+      expect(acceptedFallbacks).toBe(1);
+    },
+  );
 
   test("refuses replay when fallback acceptance becomes ambiguous", async () => {
     const ledger = namespace();
@@ -984,11 +1022,37 @@ describe("Personal Shared Telegram edge", () => {
   });
 
   test.each([
-    ["malformed JSON", () => new Response("not json")],
-    ["missing reply", () => Response.json({ data: {} })],
+    [
+      "malformed JSON",
+      () => new Response("not json"),
+      PERSONAL_SHARED_FAILURE_REPLY,
+    ],
+    [
+      "missing reply",
+      () => Response.json({ data: {} }),
+      PERSONAL_SHARED_FAILURE_REPLY,
+    ],
+    [
+      "empty reply",
+      () => Response.json({ data: { reply: "" } }),
+      PERSONAL_SHARED_NO_RESPONSE_REPLY,
+    ],
+    [
+      "blank reply",
+      () => Response.json({ data: { reply: " \n\t" } }),
+      PERSONAL_SHARED_NO_RESPONSE_REPLY,
+    ],
+    [
+      "explicit no-response terminal",
+      () =>
+        Response.json({
+          data: { reply: "", responded: false, responseReason: "no_response" },
+        }),
+      PERSONAL_SHARED_NO_RESPONSE_REPLY,
+    ],
   ])(
     "delivers one fallback for a successful turn with %s",
-    async (_name, response) => {
+    async (_name, response, expectedReply) => {
       const ledger = namespace();
       const turn = mock(async () => response());
       const sentTexts: string[] = [];
@@ -1010,7 +1074,7 @@ describe("Personal Shared Telegram edge", () => {
         200,
       );
       expect(turn).toHaveBeenCalledTimes(1);
-      expect(sentTexts).toEqual([PERSONAL_SHARED_FAILURE_REPLY]);
+      expect(sentTexts).toEqual([expectedReply]);
     },
   );
 

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -1078,6 +1078,36 @@ describe("Personal Shared Telegram edge", () => {
     },
   );
 
+  test.each(["", " \n\t"])(
+    "delivers media-only private reply %j once",
+    async (reply) => {
+      const ledger = namespace();
+      const mediaUrl = "https://cdn.example/artifact.png";
+      const turn = mock(async () =>
+        Response.json({ data: { reply, mediaUrls: [mediaUrl] } }),
+      );
+      const sentTexts: string[] = [];
+      globalThis.fetch = mock(async (_input, init) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          text?: string;
+        };
+        if (body.text) sentTexts.push(body.text);
+        return Response.json({
+          ok: true,
+          result: body.text ? { message_id: 9012 } : true,
+        });
+      }) as unknown as typeof fetch;
+      expect((await run(ledger, turn, telegramRequest(81640))).status).toBe(
+        200,
+      );
+      expect((await run(ledger, turn, telegramRequest(81640))).status).toBe(
+        200,
+      );
+      expect(turn).toHaveBeenCalledTimes(1);
+      expect(sentTexts).toEqual([mediaUrl]);
+    },
+  );
+
   test("delivers one fallback when a voice note cannot be resolved before the turn", async () => {
     const ledger = namespace();
     const turn = mock(async () =>

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -26,6 +26,7 @@ import {
   type TelegramConnectorConfig,
   type TelegramConnectorEvent,
   TelegramIdentityAttestationError,
+  telegramReplyWithMedia,
   verifyTelegramWebhook,
 } from "@elizaos/cloud-services-common/telegram-connector";
 import {
@@ -1138,17 +1139,29 @@ export async function handlePersonalTelegramEdge(
                   "Personal Shared edge turn returned no reply",
                 );
               }
+              const deliveredReply =
+                event.chatType === "private" && !event.membershipChange
+                  ? telegramReplyWithMedia(
+                      candidate,
+                      payload &&
+                        typeof payload === "object" &&
+                        "data" in payload
+                        ? (payload.data as { mediaUrls?: unknown } | null)
+                            ?.mediaUrls
+                        : undefined,
+                    )
+                  : candidate;
               if (
                 event.chatType === "private" &&
                 !event.membershipChange &&
-                candidate.trim().length === 0
+                deliveredReply.trim().length === 0
               ) {
                 throw new PersonalTelegramPreEgressError(
                   "Personal Shared private turn completed without a reply",
                   { failure: personalSharedNoResponseFailure() },
                 );
               }
-              reply = candidate;
+              reply = deliveredReply;
             }
           } catch (error) {
             // error-policy:J4 only the typed, expected pre-egress failure

--- a/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
+++ b/packages/cloud/api/eliza-app/webhook/_telegram-edge.ts
@@ -10,7 +10,8 @@ import {
   identityLinkReply,
 } from "@elizaos/cloud-services-common/identity-link-code";
 import {
-  PERSONAL_SHARED_FAILURE_REPLY,
+  personalSharedFailureReply,
+  personalSharedNoResponseFailure,
   readPersonalSharedFailureMetadata,
 } from "@elizaos/cloud-services-common/personal-shared-failure";
 import { executeResponseAttempts } from "@elizaos/cloud-services-common/response-attempts";
@@ -1137,6 +1138,16 @@ export async function handlePersonalTelegramEdge(
                   "Personal Shared edge turn returned no reply",
                 );
               }
+              if (
+                event.chatType === "private" &&
+                !event.membershipChange &&
+                candidate.trim().length === 0
+              ) {
+                throw new PersonalTelegramPreEgressError(
+                  "Personal Shared private turn completed without a reply",
+                  { failure: personalSharedNoResponseFailure() },
+                );
+              }
               reply = candidate;
             }
           } catch (error) {
@@ -1179,7 +1190,7 @@ export async function handlePersonalTelegramEdge(
             await sendTelegramReply(
               config,
               event,
-              PERSONAL_SHARED_FAILURE_REPLY,
+              personalSharedFailureReply(fallbackFailure),
               logger,
               deliveryHooks,
             );

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -487,6 +487,19 @@ describe("personal Shared messaging deliveries", () => {
     expect(resolvePersonalDelivery).not.toHaveBeenCalled();
   });
 
+  test("preserves the safe no-response terminal for the Telegram transport", async () => {
+    sharedRestMessageSend.mockImplementationOnce(async () => ({
+      text: "",
+      responded: false,
+      responseReason: "no_response" as const,
+    }));
+    const response = await request(valid);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      data: { reply: "", responded: false, responseReason: "no_response" },
+    });
+  });
+
   test("uses one account-native identity and platform funding", async () => {
     const response = await request(valid);
     expect(response.status).toBe(200);

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -1961,6 +1961,9 @@ app.post("/", async (c) => {
           organizationId: account.organizationId,
         },
         reply: guardGroupReply(result.text, groupParticipantRoster),
+        ...(result.responded === false
+          ? { responded: false, responseReason: result.responseReason }
+          : {}),
         ...(result.mediaUrls ? { mediaUrls: result.mediaUrls } : {}),
         ...(groupDeliveryAuthority
           ? {

--- a/packages/cloud/services/_common/src/personal-shared-failure.ts
+++ b/packages/cloud/services/_common/src/personal-shared-failure.ts
@@ -15,6 +15,19 @@ export const ELIZA_RETRYABLE_HEADER = "X-Eliza-Retryable";
 export const PERSONAL_SHARED_FAILURE_REPLY =
   "I couldn't complete that request just now. Please try again in a moment.";
 
+/** Completed actions may have landed even when the turn produced no visible reply. */
+export const PERSONAL_SHARED_NO_RESPONSE_REPLY =
+  "I couldn't produce a reply for that turn. If you asked me to change something, check its status before trying again.";
+
+/** Both transports use the same stable wording for each terminal classification. */
+export function personalSharedFailureReply(
+  failure: PersonalSharedFailureMetadata | null,
+): string {
+  return failure?.causeName === "SharedRuntimeNoReplyError"
+    ? PERSONAL_SHARED_NO_RESPONSE_REPLY
+    : PERSONAL_SHARED_FAILURE_REPLY;
+}
+
 const SAFE_FAILURE_STAGES = new Set([
   "account_claim",
   "account_resolution",
@@ -62,6 +75,18 @@ export interface PersonalSharedFailureMetadata {
   causeName: string | null;
   retryable: boolean;
   retryAfterSeconds: number | null;
+}
+
+/** A completed turn without a reply must not replay possibly committed actions. */
+export function personalSharedNoResponseFailure(): PersonalSharedFailureMetadata {
+  return {
+    status: 200,
+    stage: "shared_runtime",
+    name: "SharedRuntimeTurnError",
+    causeName: "SharedRuntimeNoReplyError",
+    retryable: false,
+    retryAfterSeconds: null,
+  };
 }
 
 function safeClassification(

--- a/packages/cloud/services/_common/src/telegram-connector.ts
+++ b/packages/cloud/services/_common/src/telegram-connector.ts
@@ -738,6 +738,29 @@ function telegramThreadParams(event: TelegramConnectorEvent): {
   return { message_thread_id: messageThreadId };
 }
 
+/** Preserve HTTPS artifact links through Telegram's receipt-backed text delivery path. */
+export function telegramReplyWithMedia(
+  text: string,
+  mediaUrls: unknown,
+): string {
+  if (!Array.isArray(mediaUrls)) return text;
+  const links = mediaUrls.flatMap((value): string[] => {
+    if (typeof value !== "string") return [];
+    try {
+      const url = new URL(value.trim());
+      return url.protocol === "https:" ? [url.toString()] : [];
+    } catch {
+      // error-policy:J3 ignore malformed artifact references at the transport boundary.
+      return [];
+    }
+  });
+  const existing = new Set(text.split("\n").map((line) => line.trim()));
+  const missing = [...new Set(links)].filter((link) => !existing.has(link));
+  return missing.length
+    ? [text.trim(), ...missing].filter(Boolean).join("\n")
+    : text;
+}
+
 export async function sendTelegramReply(
   config: TelegramConnectorConfig,
   event: TelegramConnectorEvent,

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -1,6 +1,9 @@
 /** Exercises gateway webhook routing with deterministic cloud-service fixtures. */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { PERSONAL_SHARED_FAILURE_REPLY } from "@elizaos/cloud-services-common/personal-shared-failure";
+import {
+  PERSONAL_SHARED_FAILURE_REPLY,
+  PERSONAL_SHARED_NO_RESPONSE_REPLY,
+} from "@elizaos/cloud-services-common/personal-shared-failure";
 import type {
   ChatEvent,
   PlatformAdapter,
@@ -1279,6 +1282,73 @@ describe("gateway webhook handler e2e routing", () => {
     expect(sendReply).toHaveBeenCalledTimes(1);
     expect(sendReply.mock.calls[0]?.[2]).toBe(PERSONAL_SHARED_FAILURE_REPLY);
   });
+
+  test.each(["", " \n\t"])(
+    "delivers one Telegram fallback for a completed blank reply %j",
+    async (reply) => {
+      configureTelegramIdentity();
+      const event: ChatEvent = {
+        platform: "telegram",
+        messageId: "update-terminal-before-egress",
+        platformRecordId: "message-terminal-before-egress",
+        chatId: "chat-1",
+        chatType: "private",
+        senderId: "sender-1",
+        senderName: "Ada",
+        text: "remove that reminder",
+        rawPayload: {},
+      };
+      const sendReply = mock(async () => undefined);
+      const adapter: PlatformAdapter = {
+        platform: "telegram",
+        getDedupeScope: () => "scope",
+        verifyWebhook: mock(async () => true),
+        extractEvent: mock(async () => event),
+        sendTypingIndicator: mock(async () => undefined),
+        sendReply,
+        sendReplyWithReceipt: mock(async (config, replyEvent, text, hooks) => {
+          await sendReply(config, replyEvent, text, hooks);
+          return { providerMessageIds: ["provider-terminal-1"] };
+        }),
+      };
+      const redis = new MemoryRedis();
+      redis.store.set(
+        "identity:telegram:sender-1",
+        JSON.stringify({ notFound: true }),
+      );
+      let sharedAttempts = 0;
+      globalThis.fetch = mock(
+        withTelegramIdentity(async () => {
+          sharedAttempts += 1;
+          return Response.json({
+            data: { reply, responded: false, responseReason: "no_response" },
+          });
+        }),
+      ) as typeof fetch;
+      const request = () =>
+        new Request("https://gateway.example/webhook/eliza-app/telegram", {
+          method: "POST",
+          body: "{}",
+        });
+      const deps = {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      };
+
+      expect(
+        (await handleWebhook(request(), adapter, deps, "eliza-app")).status,
+      ).toBe(200);
+      expect(
+        (await handleWebhook(request(), adapter, deps, "eliza-app")).status,
+      ).toBe(200);
+      expect(sharedAttempts).toBe(1);
+      expect(sendReply).toHaveBeenCalledTimes(1);
+      expect(sendReply.mock.calls[0]?.[2]).toBe(
+        PERSONAL_SHARED_NO_RESPONSE_REPLY,
+      );
+    },
+  );
 
   test("delivers one Telegram fallback when private voice resolution fails", async () => {
     configureTelegramIdentity();

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -1350,6 +1350,85 @@ describe("gateway webhook handler e2e routing", () => {
     },
   );
 
+  test.each(["", " \n\t"])(
+    "delivers media-only Telegram reply %j",
+    async (reply) => {
+      configureTelegramIdentity();
+      const event: ChatEvent = {
+        platform: "telegram",
+        messageId: "update-terminal-before-egress",
+        platformRecordId: "message-terminal-before-egress",
+        chatId: "chat-1",
+        chatType: "private",
+        senderId: "sender-1",
+        senderName: "Ada",
+        text: "remove that reminder",
+        rawPayload: {},
+      };
+      const sendReply = mock(async () => undefined);
+      const adapter: PlatformAdapter = {
+        platform: "telegram",
+        getDedupeScope: () => "scope",
+        verifyWebhook: mock(async () => true),
+        extractEvent: mock(async () => event),
+        sendTypingIndicator: mock(async () => undefined),
+        sendReply,
+        sendReplyWithReceipt: mock(
+          async (config, replyEvent, text, hooks, mediaUrls) => {
+            await sendReply(config, replyEvent, text, hooks, mediaUrls);
+            return { providerMessageIds: ["provider-terminal-1"] };
+          },
+        ),
+      };
+      const redis = new MemoryRedis();
+      redis.store.set(
+        "identity:telegram:sender-1",
+        JSON.stringify({ notFound: true }),
+      );
+      let sharedAttempts = 0;
+      globalThis.fetch = mock(
+        withTelegramIdentity(async () => {
+          sharedAttempts += 1;
+          return Response.json({
+            data: {
+              reply,
+              mediaUrls: Array.from(
+                { length: 6 },
+                (_, i) => `https://cdn.example/artifact-${i}.png`,
+              ),
+            },
+          });
+        }),
+      ) as typeof fetch;
+      const request = () =>
+        new Request("https://gateway.example/webhook/eliza-app/telegram", {
+          method: "POST",
+          body: "{}",
+        });
+      const deps = {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      };
+
+      expect(
+        (await handleWebhook(request(), adapter, deps, "eliza-app")).status,
+      ).toBe(200);
+      expect(
+        (await handleWebhook(request(), adapter, deps, "eliza-app")).status,
+      ).toBe(200);
+      expect(sharedAttempts).toBe(1);
+      expect(sendReply).toHaveBeenCalledTimes(1);
+      expect(sendReply.mock.calls[0]?.[4]).toEqual(
+        Array.from(
+          { length: 6 },
+          (_, i) => `https://cdn.example/artifact-${i}.png`,
+        ),
+      );
+      expect(sendReply.mock.calls[0]?.[2]).toBe("");
+    },
+  );
+
   test("delivers one Telegram fallback when private voice resolution fails", async () => {
     configureTelegramIdentity();
     const event: ChatEvent = {

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.test.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.test.ts
@@ -576,6 +576,33 @@ describe("telegramAdapter outbound delivery", () => {
     expect(receipt).toEqual({ providerMessageIds: ["77"] });
   });
 
+  test.each(["", " ", "https://cdn.example/artifact.png"])(
+    "preserves private artifact links with text %j",
+    async (text) => {
+      const bodies: { text?: string }[] = [];
+      globalThis.fetch = mock(async (_input, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return jsonOk({ message_id: 78 });
+      }) as unknown as typeof fetch;
+      const receipt = await telegramAdapter.sendReplyWithReceipt?.(
+        { botToken: "9008:reply" },
+        { ...telegramEvent, chatType: "private" },
+        text,
+        undefined,
+        [
+          "https://cdn.example/artifact.png",
+          "https://cdn.example/artifact.png",
+          "javascript:alert(1)",
+          "invalid",
+        ],
+      );
+      expect(bodies.map((body) => body.text)).toEqual([
+        "https://cdn.example/artifact.png",
+      ]);
+      expect(receipt).toEqual({ providerMessageIds: ["78"] });
+    },
+  );
+
   test("retries without Markdown after a formatting rejection", async () => {
     const warnSpy = spyOn(logger, "warn");
     const bodies: unknown[] = [];

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -12,6 +12,7 @@ import {
   TELEGRAM_VOICE_MAX_DURATION_SECONDS,
   TelegramApiResponseError,
   type TelegramConnectorEvent,
+  telegramReplyWithMedia,
   verifyTelegramWebhook,
 } from "@elizaos/cloud-services-common/telegram-connector";
 import { resolveConnectorAccountId } from "../connector-account";
@@ -153,21 +154,31 @@ export const telegramAdapter: PlatformAdapter = {
     return resolveTelegramVoiceNote(config, asTelegramEvent(event));
   },
 
-  async sendReply(config, event, text, deliveryHooks): Promise<void> {
+  async sendReply(
+    config,
+    event,
+    text,
+    deliveryHooks,
+    mediaUrls,
+  ): Promise<void> {
     await sendTelegramReply(
       config,
       asTelegramEvent(event),
-      text,
+      event.chatType === "private" && !event.membershipChange
+        ? telegramReplyWithMedia(text, mediaUrls)
+        : text,
       logger,
       deliveryHooks,
     );
   },
 
-  async sendReplyWithReceipt(config, event, text, deliveryHooks) {
+  async sendReplyWithReceipt(config, event, text, deliveryHooks, mediaUrls) {
     return sendTelegramReply(
       config,
       asTelegramEvent(event),
-      text,
+      event.chatType === "private" && !event.membershipChange
+        ? telegramReplyWithMedia(text, mediaUrls)
+        : text,
       logger,
       deliveryHooks,
     );

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -154,19 +154,11 @@ export const telegramAdapter: PlatformAdapter = {
     return resolveTelegramVoiceNote(config, asTelegramEvent(event));
   },
 
-  async sendReply(
-    config,
-    event,
-    text,
-    deliveryHooks,
-    mediaUrls,
-  ): Promise<void> {
+  async sendReply(config, event, text, deliveryHooks): Promise<void> {
     await sendTelegramReply(
       config,
       asTelegramEvent(event),
-      event.chatType === "private" && !event.membershipChange
-        ? telegramReplyWithMedia(text, mediaUrls)
-        : text,
+      text,
       logger,
       deliveryHooks,
     );

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -5,8 +5,9 @@ import {
   truncateWellFormed,
 } from "@elizaos/cloud-services-common";
 import {
-  PERSONAL_SHARED_FAILURE_REPLY,
   type PersonalSharedFailureMetadata,
+  personalSharedFailureReply,
+  personalSharedNoResponseFailure,
   readPersonalSharedFailureMetadata,
 } from "@elizaos/cloud-services-common/personal-shared-failure";
 import {
@@ -906,7 +907,7 @@ async function processMessage(
           adapter,
           config,
           event,
-          PERSONAL_SHARED_FAILURE_REPLY,
+          personalSharedFailureReply(error.failure),
           deliveryHooks,
         );
         return;
@@ -1462,6 +1463,17 @@ async function sendPersonalSharedReply(
   if (typeof reply !== "string") {
     throw new PersonalSharedPreEgressError(
       "personal Shared chat returned no reply",
+    );
+  }
+  if (
+    adapter.platform === "telegram" &&
+    event.chatType === "private" &&
+    !event.membershipChange &&
+    reply.trim().length === 0
+  ) {
+    throw new PersonalSharedPreEgressError(
+      "personal Shared private turn completed without a reply",
+      { failure: personalSharedNoResponseFailure() },
     );
   }
   const replyMediaUrls = parsePersonalSharedMediaUrls(data);

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -189,19 +189,19 @@ function parseGroupDeliveryDirective(
 
 function parsePersonalSharedMediaUrls(
   data: Record<string, unknown> | null,
+  preserveAll = false,
 ): string[] {
   if (!Array.isArray(data?.mediaUrls)) return [];
-  return data.mediaUrls
-    .flatMap((value) => {
-      if (typeof value !== "string") return [];
-      try {
-        const url = new URL(value.trim());
-        return url.protocol === "https:" ? [url.toString()] : [];
-      } catch {
-        return [];
-      }
-    })
-    .slice(0, 4);
+  const urls = data.mediaUrls.flatMap((value) => {
+    if (typeof value !== "string") return [];
+    try {
+      const url = new URL(value.trim());
+      return url.protocol === "https:" ? [url.toString()] : [];
+    } catch {
+      return [];
+    }
+  });
+  return preserveAll ? [...new Set(urls)] : urls.slice(0, 4);
 }
 
 interface MessageTraceContext {
@@ -1465,18 +1465,24 @@ async function sendPersonalSharedReply(
       "personal Shared chat returned no reply",
     );
   }
+  const replyMediaUrls = parsePersonalSharedMediaUrls(
+    data,
+    adapter.platform === "telegram" &&
+      event.chatType === "private" &&
+      !event.membershipChange,
+  );
   if (
     adapter.platform === "telegram" &&
     event.chatType === "private" &&
     !event.membershipChange &&
-    reply.trim().length === 0
+    reply.trim().length === 0 &&
+    replyMediaUrls.length === 0
   ) {
     throw new PersonalSharedPreEgressError(
       "personal Shared private turn completed without a reply",
       { failure: personalSharedNoResponseFailure() },
     );
   }
-  const replyMediaUrls = parsePersonalSharedMediaUrls(data);
   const replyText = reply
     .split("\n")
     .filter((line) => !replyMediaUrls.includes(line.trim()))
@@ -1485,7 +1491,15 @@ async function sendPersonalSharedReply(
   // Empty is the agent's deliberate shouldRespond=no result. Membership
   // changes and stale turns intentionally take this path with no authority
   // token because there will be no provider egress to authorize.
-  if (reply.length === 0) {
+  if (
+    reply.length === 0 &&
+    !(
+      adapter.platform === "telegram" &&
+      event.chatType === "private" &&
+      !event.membershipChange &&
+      replyMediaUrls.length > 0
+    )
+  ) {
     return {
       cloudMs,
       cloudAttempts: attemptResult.attempts,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -339,6 +339,29 @@ describe("shared-rest-adapter — messages", () => {
     });
   });
 
+  test("POST preserves a no-response terminal for connector delivery policy", async () => {
+    coordinateSharedBridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "silent-turn",
+      result: { text: "", responded: false, reason: "private model detail" },
+    });
+    const out = await sharedRestMessageSend(
+      SHARED_AGENT,
+      AGENT,
+      "hello",
+      "Eliza",
+      EXECUTION_CTX,
+      NAMESPACE,
+    );
+    expect(out).toEqual({
+      text: "",
+      agentName: "Eliza",
+      responded: false,
+      responseReason: "no_response",
+    });
+    expect(JSON.stringify(out)).not.toContain("private model detail");
+  });
+
   test("POST preserves generated media URLs as structured connector output", async () => {
     coordinateSharedBridge.mockResolvedValue({
       jsonrpc: "2.0",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -585,6 +585,8 @@ export async function sharedRestMessageSend(
   agentName: string;
   timing?: SharedProviderTimingReceipt;
   mediaUrls?: string[];
+  responded?: false;
+  responseReason?: "no_response";
 }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
@@ -624,6 +626,7 @@ export async function sharedRestMessageSend(
     text?: unknown;
     timing?: unknown;
     actionResults?: unknown;
+    responded?: unknown;
   };
   const replyText = typeof result.text === "string" ? result.text : "";
   const mediaUrls = Array.isArray(result.actionResults)
@@ -645,6 +648,9 @@ export async function sharedRestMessageSend(
   return {
     text: replyText,
     agentName: agentName || "Eliza",
+    ...(result.responded === false
+      ? { responded: false as const, responseReason: "no_response" as const }
+      : {}),
     ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
     ...(timing ? { timing } : {}),
   };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -2134,6 +2134,30 @@ describe("SharedRuntimeChatService", () => {
     expect(h.history()).toHaveLength(historyAfterFirst);
   });
 
+  test("replays a completed no-response turn without redispatching the runtime", async () => {
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    const { store } = memoryTurnClaims();
+    turn = {
+      ...turn,
+      degraded: false,
+      responded: false,
+      reply: "",
+      history: [{ role: "user", content: "hello" }],
+    };
+    const options = { ...h, turnClaims: store };
+    const first = await service.bridge(agent, keyedRpc, options);
+    await Promise.all(h.background);
+    // A connector whose provider rejected egress asks for the same turn again.
+    const replay = await service.bridge(agent, keyedRpc, options);
+    await Promise.all(h.background);
+    expect(first.result).toMatchObject({ text: "", responded: false });
+    expect(replay.result).toMatchObject({ text: "", responded: false });
+    expect(turnCalls).toBe(1);
+    expect(admitOrganizationInference).toHaveBeenCalledTimes(1);
+    expect(billCalls).toHaveLength(1);
+  });
+
   test("isolates concurrent rooms sharing a clientMessageId and replays within one room", async () => {
     process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
     const service = new SharedRuntimeChatService();


### PR DESCRIPTION
# Relates to

Related to #29764; part of #29919. This addresses the terminal empty-response residual only and does not close either issue.

- [x] Targets develop, synced without conflicts to `3a7f438a9e9d5ba10ea905198723012667bd785d`.
- [x] Frozen install and root `bun run verify` passed using Bun 1.3.14 / Node 24.15.0.
- [ ] Provider-backed acceptance remains pending; this PR stays draft.

# Sync with develop

Exact candidate: `1a6580d821d2908267b7894f18aa0d4f7700c8d5`. Base: `3a7f438a9e9d5ba10ea905198723012667bd785d`. Rebase reports up to date; root verification passed on this content.

# Risks

A completed turn may have committed actions despite producing no text. The fallback explicitly asks the user to check any requested change before trying again. It uses existing delivery claims and receipt handling. Tests cover provider rejection recovery and preservation of ambiguous-send replay protection. Live delivery remains unverified.

# Media-only review repair

The reproduced review finding is fixed: private Telegram replies with empty/whitespace text and valid HTTPS media URLs are delivered as artifact links through the existing `sendMessage` and durable receipt path, in both Worker edge and the actual gateway Telegram adapter. This does not add native attachment uploads. Gateway no-response classification and early-return logic now account for media. All distinct artifact links are retained in private Telegram (including more than four); group/membership and other-provider behavior stays scoped out.

Red: two new media-only cases failed in each edge/gateway suite on the rebased pre-repair candidate. Green: edge43, gateway47, actual Telegram adapter44, Shared REST34, Shared route59, runtime replay54, connector delivery4, delivery ledger7, Worker ledger12 =304 tests. The adapter coverage also verifies duplicate/invalid URLs and provider receipts. Two independent final-content reviews found no remaining issue after fixing the gateway four-link limit.

The runtime replay test pins existing protection; it is not a claim that this patch introduced runtime idempotency. The additive no-response wire classification remains a safe diagnostic; transports classify actual deliverable content so a media result cannot be reported as empty even if its text is blank.

# Background

## What does this PR do?

When Personal Shared returns an empty or whitespace-only reply in a private Telegram conversation, edge and gateway previously skipped delivery or sent whitespace. Both transports now send a visible terminal notice through their existing delivery path. The Shared REST adapter and route retain a fixed `responded: false` / `responseReason: no_response` classification without exposing raw runtime reasons.

The completed runtime result remains replayable by its original turn key: retrying a rejected fallback does not execute the completed turn again. Groups and membership events retain their existing silence behavior.

## What kind of change is this?

Bug fix at the private Telegram delivery boundary.

# Documentation changes needed?

No setup or operator procedure changes. The additive internal response classification and transport behavior are covered by boundary tests.

# Testing

## Where should a reviewer start?

`packages/cloud/api/eliza-app/webhook/_telegram-edge.ts`, `packages/cloud/services/gateway-webhook/src/webhook-handler.ts`, and `packages/cloud/services/_common/src/personal-shared-failure.ts`.

## Detailed testing steps

Run each test file separately with `bun test --conditions=eliza-source`:

| Test file | Passed |
| --- | ---: |
| packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts | 34 |
| packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts | 59 |
| packages/cloud/api/__tests__/personal-telegram-edge.test.ts | 43 |
| packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts | 47 |
| packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts | 54 |
| packages/cloud/services/_common/tests/telegram-delivery.test.ts + packages/cloud/api/src/personal-telegram-delivery.test.ts | 19 |

304 passed, zero failures. These are deterministic tests with simulated provider responses, not live provider E2E evidence. The actual SharedRuntimeChatService replay test proves one runtime dispatch, one admission and one billing operation across two requests sharing a completed no-response turn key.

Before the fix, targeted regressions reproduced missing terminal metadata and empty/whitespace delivery failures. After the fix, the listed suites pass. Root `bun run verify` passed, including owning workspace typechecks and lint; separate gateway typecheck also passed. Frozen installation used `ELIZA_SKIP_FUSED_INFERENCE_SETUP=1` for the unrelated native fused-inference setup.

Independent bug and security reviews examined the final diff with no remaining actionable findings. Hosted CI [run 34413328688](https://github.com/elizaOS/eliza/actions/runs/34413328688) completed SUCCESS on this exact media-repair head, all five checks passed. Previous run 34284708986 belongs only to the superseded head. No merge exception requested.

# Evidence Gate

<!-- evidence-head:1a6580d821d2908267b7894f18aa0d4f7700c8d5 -->

<!-- evidence-row:before-screenshots -->
- [ ] Pending authorized provider capture; historical negative receipts on #29764 are not current-head proof.
<!-- evidence-row:after-screenshots -->
- [ ] Pending authorized live Telegram readback on deployed candidate.
<!-- evidence-row:walkthrough-video -->
- [ ] Pending provider-backed first/repeat/reconnect flow under #29919.
<!-- evidence-row:backend-logs -->
- [ ] Pending current deployed-source live delivery receipt; deterministic results above are local evidence only.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no application frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Pending authorized live runtime/provider evidence; deterministic terminal-turn fixtures do not replace it.
<!-- evidence-row:domain-artifacts -->
- [ ] Pending real provider delivery/readback receipts; no live identities or fixtures were used.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered application UI component changed; provider capture remains pending above.

# Evidence Details

## Real LLM-call trajectory

Pending. The runtime replay regression uses the actual service with simulated turn output; it is not a live-model trajectory.

## Backend + frontend logs

Local verification: 304 tests passed, root verify exit 0, gateway typecheck exit 0, diff check clean. No live backend/provider logs were collected. Frontend logs N/A because application frontend code is unchanged.

## Screenshots (before / after) + video walkthrough

Before, after and provider walkthrough remain pending custody/fixture prerequisites and exact just-in-time authorization. No current provider acceptance is claimed.

## Audio / voice walkthrough

N/A - no audio or voice behavior changed.

## Known gaps / failures

Live evidence, custody/identity prerequisites and deployed-source attestation remain outstanding under #29764, #25025/#27867 and #29919. No provider message, OAuth, identity mutation, deployment or lifecycle operation was performed. These are blockers to acceptance; this PR is deliberately a draft. Native fused inference was skipped during installation because this change concerns cloud transport behavior. No failing local required gate remains.

## Maintainer CI exception record

N/A - no exception requested. No merge, promotion or deployment requested.
