### PR TITLE
feat(cloud): preserve exact restore receipts and liveness over SSH

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Deterministic SSH channel faults exercise cancellation and receipt fencing
+ * in the real client; the separate loopback suite covers native SSH framing.
+ */
 import { describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { DockerSSHClient } from "./docker-ssh";
@@ -30,6 +34,7 @@ class FakeClientChannel extends EventEmitter {
   closeCalls = 0;
   destroyCalls = 0;
   endedWith: Buffer | undefined;
+  writtenWith: Buffer | undefined;
 
   close(): void {
     this.closeCalls += 1;
@@ -42,6 +47,11 @@ class FakeClientChannel extends EventEmitter {
 
   end(input: Buffer): void {
     this.endedWith = input;
+  }
+
+  write(input: Buffer): boolean {
+    this.writtenWith = input;
+    return true;
   }
 }
 
@@ -72,6 +82,7 @@ async function requireError(promise: Promise<unknown>): Promise<Error> {
   try {
     await promise;
   } catch (error) {
+    // error-policy:J1 The assertion boundary requires an explicit rejection.
     if (error instanceof Error) return error;
     throw new Error("Expected an Error rejection");
   }
@@ -129,6 +140,89 @@ describe("DockerSSHClient.connect cancellation", () => {
 });
 
 describe("DockerSSHClient.execStdinAbortable", () => {
+  function receiptExchange(expected = "a".repeat(64)) {
+    const channel = new FakeClientChannel();
+    const session: FakeSshSession = {
+      execCalls: 0,
+      destroyCalls: 0,
+      exec(_command, callback) {
+        this.execCalls += 1;
+        callback(undefined, channel);
+      },
+      destroy() {
+        this.destroyCalls += 1;
+      },
+    };
+    const controller = new AbortController();
+    const input = Buffer.from("private restore frame");
+    const promise = makeConnectedClient(session).execStdinAbortable(
+      "restore-worker",
+      input,
+      controller.signal,
+      5_000,
+      expected,
+    );
+    return { channel, session, controller, input, promise };
+  }
+
+  test("keeps framed stdin open and requires the complete receipt plus exit zero", async () => {
+    const { channel, input, promise } = receiptExchange();
+    expect(channel.writtenWith).toBe(input);
+    expect(channel.endedWith).toBeUndefined();
+    let settled = false;
+    void promise.then(() => {
+      settled = true;
+    });
+    for (const text of ["a".repeat(17), "a".repeat(47)]) {
+      const chunk = Buffer.from(text);
+      channel.emit("data", chunk);
+      expect(chunk.every((byte) => byte === 0)).toBe(true);
+    }
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    channel.emit("close", 0);
+    await promise;
+    expect(settled).toBe(true);
+  });
+
+  test.each([
+    ["short", "a".repeat(63), false, 0],
+    ["wrong", "b".repeat(64), false, 0],
+    ["trailing", `${"a".repeat(64)}\n`, false, 0],
+    ["stderr", "private restore frame", true, 0],
+    ["failed exit", "a".repeat(64), false, 1],
+  ] as const)(
+    "rejects %s acknowledgements without reflecting remote bytes",
+    async (_name, data, stderr, code) => {
+      const { channel, promise } = receiptExchange();
+      const chunk = Buffer.from(data);
+      (stderr ? channel.stderr : channel).emit("data", chunk);
+      channel.emit("close", code);
+      const error = await requireError(promise);
+      expect(chunk.every((byte) => byte === 0)).toBe(true);
+      expect(error.message).not.toContain(data);
+    },
+  );
+
+  test("abort wins even after the full receipt arrived", async () => {
+    const { channel, controller, promise } = receiptExchange();
+    channel.emit("data", Buffer.from("a".repeat(64)));
+    const reason = makeCallerAbortReason("lease lost before exit");
+    controller.abort(reason);
+    channel.emit("close", 0);
+    expect(await requireError(promise)).toBe(reason);
+  });
+
+  test.each(["", "A".repeat(64), `${"a".repeat(64)}\n`, "a".repeat(65)])(
+    "rejects malformed expected receipt before opening a channel (%s)",
+    async (expected) => {
+      const { session, channel, promise } = receiptExchange(expected);
+      expect((await requireError(promise)).message).toBe("Invalid expected SSH restore receipt");
+      expect(session.execCalls).toBe(0);
+      expect(channel.writtenWith).toBeUndefined();
+    },
+  );
+
   test("preserves a pre-aborted signal reason before opening an SSH exec channel", async () => {
     const channel = new FakeClientChannel();
     const session: FakeSshSession = {

--- a/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh-stdin-abort.test.ts
@@ -2,32 +2,10 @@
  * Deterministic SSH channel faults exercise cancellation and receipt fencing
  * in the real client; the separate loopback suite covers native SSH framing.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import { Client } from "ssh2";
 import { DockerSSHClient } from "./docker-ssh";
-
-let connectingSession: FakeConnectingSshClient | undefined;
-
-class FakeConnectingSshClient extends EventEmitter {
-  connectCalls = 0;
-  destroyCalls = 0;
-
-  constructor() {
-    super();
-    connectingSession = this;
-  }
-
-  connect(): void {
-    this.connectCalls += 1;
-  }
-
-  destroy(): this {
-    this.destroyCalls += 1;
-    return this;
-  }
-}
-
-mock.module("ssh2", () => ({ Client: FakeConnectingSshClient }));
 
 class FakeClientChannel extends EventEmitter {
   readonly stderr = new EventEmitter();
@@ -113,7 +91,6 @@ describe("DockerSSHClient.connect cancellation", () => {
   });
 
   test("preserves the exact reason when aborted while connect is in flight", async () => {
-    connectingSession = undefined;
     const client = new DockerSSHClient({
       hostname: "restore-node.example.test",
       privateKey: Buffer.from("unused"),
@@ -122,20 +99,36 @@ describe("DockerSSHClient.connect cancellation", () => {
     const controller = new AbortController();
     const reason = makeCallerAbortReason("cancelled during SSH connect");
 
-    const promise = client.connect(controller.signal);
-
-    for (let attempt = 0; attempt < 100 && !connectingSession; attempt += 1) {
-      await Bun.sleep(1);
+    let notifyConnecting!: () => void;
+    const connecting = new Promise<void>((resolve) => {
+      notifyConnecting = resolve;
+    });
+    // Replace only this test's socket-opening method, not the process-wide ssh2
+    // module: neighbouring integration suites must keep the real Client/Server.
+    const connect = spyOn(Client.prototype, "connect").mockImplementation(function (this: Client) {
+      notifyConnecting();
+      return this;
+    });
+    const destroy = spyOn(Client.prototype, "destroy").mockImplementation(function (this: Client) {
+      return this;
+    });
+    const pending = requireError(client.connect(controller.signal));
+    try {
+      await connecting;
+      expect(connect).toHaveBeenCalledTimes(1);
+      controller.abort(reason);
+      expect(await pending).toBe(reason);
+      expect(destroy).toHaveBeenCalledTimes(1);
+      expect(client.isConnected).toBe(false);
+    } finally {
+      controller.abort(reason);
+      try {
+        await pending;
+      } finally {
+        connect.mockRestore();
+        destroy.mockRestore();
+      }
     }
-    if (!connectingSession) throw new Error("Expected SSH connection attempt to start");
-    expect(connectingSession.connectCalls).toBe(1);
-
-    controller.abort(reason);
-    const error = await requireError(promise);
-
-    expect(error).toBe(reason);
-    expect(connectingSession.destroyCalls).toBe(1);
-    expect(client.isConnected).toBe(false);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/docker-ssh-stdin-receipt.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh-stdin-receipt.integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Real loopback SSH sessions prove framed restore input remains open until
+ * acknowledgement and cancellation closes the peer channel. The server is
+ * test-owned, bound only to loopback, with an ephemeral in-memory host key;
+ * no Docker node, user credential or external infrastructure is involved.
+ */
+import { describe, expect, test } from "bun:test";
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { Server, type ServerChannel, utils } from "ssh2";
+import { DockerSSHClient } from "./docker-ssh";
+
+async function withLoopback(
+  receive: (channel: ServerChannel) => void,
+  exercise: (client: DockerSSHClient) => Promise<void>,
+) {
+  const key = Buffer.from(
+    generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    }).privateKey,
+  );
+  const parsed = utils.parseKey(key);
+  if (parsed instanceof Error || Array.isArray(parsed)) throw new Error("Invalid fixture key");
+  const pin = createHash("sha256").update(parsed.getPublicSSH()).digest("base64");
+  const errors: Error[] = [];
+  const server = new Server({ hostKeys: [key] }, (connection) => {
+    connection.on("error", (error) => errors.push(error));
+    connection.on("authentication", (context) => {
+      if (context.username === "restore-fixture" && context.method === "none") context.accept();
+      else context.reject();
+    });
+    connection.on("session", (accept) => {
+      accept().on("exec", (acceptExec, reject, info) => {
+        if (info.command !== "framed-restore-fixture") {
+          reject();
+          return;
+        }
+        const channel = acceptExec();
+        channel.on("error", (error) => errors.push(error));
+        receive(channel);
+      });
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Missing loopback address");
+  const client = new DockerSSHClient({
+    hostname: "127.0.0.1",
+    port: address.port,
+    username: "restore-fixture",
+    privateKey: key,
+    hostKeyFingerprint: pin,
+  });
+  try {
+    await exercise(client);
+  } finally {
+    await client.disconnect();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+    key.fill(0);
+  }
+  expect(errors).toEqual([]);
+}
+
+describe("framed restore over native SSH", () => {
+  test("receives all bytes without EOF and accepts a fragmented exact receipt", async () => {
+    const frame = Buffer.alloc(256 * 1024, 117);
+    const digest = createHash("sha256").update(frame).digest("hex");
+    let receivedBytes = 0;
+    let earlyEof = false;
+    let acknowledged = false;
+    let receivedDigest = "";
+    await withLoopback(
+      (channel) => {
+        const hash = createHash("sha256");
+        channel.on("end", () => {
+          if (!acknowledged) earlyEof = true;
+        });
+        channel.on("data", (chunk: Buffer) => {
+          hash.update(chunk);
+          receivedBytes += chunk.length;
+          chunk.fill(0);
+          if (receivedBytes !== frame.length) return;
+          receivedDigest = hash.digest("hex");
+          // Let an incorrectly sent SSH EOF arrive before acknowledging.
+          setTimeout(() => {
+            acknowledged = true;
+            channel.write(receivedDigest.slice(0, 13));
+            channel.write(receivedDigest.slice(13));
+            channel.exit(earlyEof ? 1 : 0);
+            channel.end();
+          }, 30);
+        });
+      },
+      async (client) => {
+        await client.execStdinAbortable(
+          "framed-restore-fixture",
+          frame,
+          new AbortController().signal,
+          5_000,
+          digest,
+        );
+      },
+    );
+    expect(receivedBytes).toBe(frame.length);
+    expect(receivedDigest).toBe(digest);
+    expect(earlyEof).toBe(false);
+    expect(acknowledged).toBe(true);
+    frame.fill(0);
+  }, 10_000);
+
+  test("cancellation closes the real peer channel before allowing a retry", async () => {
+    const controller = new AbortController();
+    const reason = new Error("restore lease lost");
+    let peerClosed = false;
+    let inputReceived = false;
+    await withLoopback(
+      (channel) => {
+        channel.on("close", () => {
+          peerClosed = true;
+        });
+        channel.on("data", (chunk: Buffer) => {
+          inputReceived = true;
+          chunk.fill(0);
+          controller.abort(reason);
+        });
+      },
+      async (client) => {
+        await expect(
+          client.execStdinAbortable(
+            "framed-restore-fixture",
+            Buffer.from("owned-frame"),
+            controller.signal,
+            5_000,
+            "a".repeat(64),
+          ),
+        ).rejects.toBe(reason);
+        expect(peerClosed).toBe(true);
+      },
+    );
+    expect(inputReceived).toBe(true);
+  }, 10_000);
+});

--- a/packages/cloud/shared/src/lib/services/docker-ssh.ts
+++ b/packages/cloud/shared/src/lib/services/docker-ssh.ts
@@ -22,6 +22,7 @@
  * Reference: eliza-cloud/backend/services/container-orchestrator.ts (executeSSH)
  */
 
+import { ElizaError } from "@elizaos/core";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
@@ -764,13 +765,27 @@ export class DockerSSHClient {
    * Use a dedicated `DockerSSHClient` for this operation: the fail-closed
    * fallback deliberately destroys the SSH session and would interrupt other
    * commands sharing a pooled client.
+   *
+   * Passing an expected receipt keeps stdin open as a liveness channel for
+   * framed restore workers. Success then requires exactly that lowercase
+   * SHA-256 on stdout, no stderr, and exit zero. Remote bytes are compared
+   * without retaining or converting potentially reflected plaintext.
    */
   async execStdinAbortable(
     command: string,
     input: Buffer,
     signal: AbortSignal,
     timeoutMs?: number,
+    expectedReceiptSha256?: string,
   ): Promise<void> {
+    if (
+      expectedReceiptSha256 !== undefined &&
+      (expectedReceiptSha256.length !== 64 || !/^[0-9a-f]{64}$/.test(expectedReceiptSha256))
+    ) {
+      throw new ElizaError("Invalid expected SSH restore receipt", {
+        code: "DOCKER_SSH_RECEIPT_INVALID",
+      });
+    }
     if (signal.aborted) {
       throw getDockerSshAbortReason(signal, this.hostname);
     }
@@ -787,6 +802,7 @@ export class DockerSSHClient {
 
     return new Promise<void>((resolve, reject) => {
       let outputBytes = 0;
+      let receiptBytes = 0;
       let settled = false;
       let terminalError: unknown;
       let hasTerminalError = false;
@@ -893,9 +909,31 @@ export class DockerSSHClient {
 
         stream = openedStream;
 
-        const observeBoundedOutput = (data: Buffer) => {
+        const observeBoundedOutput = (data: Buffer, stderr: boolean) => {
           try {
             if (hasTerminalError || settled) return;
+            if (expectedReceiptSha256 !== undefined) {
+              let invalid = stderr && data.byteLength > 0;
+              for (const byte of data) {
+                if (
+                  stderr ||
+                  receiptBytes >= 64 ||
+                  byte !== expectedReceiptSha256.charCodeAt(receiptBytes)
+                ) {
+                  invalid = true;
+                  break;
+                }
+                receiptBytes += 1;
+              }
+              if (invalid) {
+                cancel(
+                  new ElizaError("SSH restore receipt was not proven", {
+                    code: "DOCKER_SSH_RECEIPT_UNPROVEN",
+                  }),
+                );
+              }
+              return;
+            }
             outputBytes += data.byteLength;
             if (outputBytes > ABORTABLE_STDIN_MAX_OUTPUT_BYTES) {
               cancel(
@@ -913,10 +951,10 @@ export class DockerSSHClient {
         };
 
         stream.on("data", (data: Buffer) => {
-          observeBoundedOutput(data);
+          observeBoundedOutput(data, false);
         });
         stream.stderr.on("data", (data: Buffer) => {
-          observeBoundedOutput(data);
+          observeBoundedOutput(data, true);
         });
         stream.on("close", (code: number) => {
           if (hasTerminalError) {
@@ -928,6 +966,12 @@ export class DockerSSHClient {
             // must not reflect secret stdin into immutable strings or errors.
             finish(
               new Error(`[docker-ssh] stdin command exited with code ${code} on ${this.hostname}`),
+            );
+          } else if (expectedReceiptSha256 !== undefined && receiptBytes !== 64) {
+            finish(
+              new ElizaError("SSH restore receipt was not proven", {
+                code: "DOCKER_SSH_RECEIPT_UNPROVEN",
+              }),
             );
           } else {
             finish();
@@ -943,7 +987,8 @@ export class DockerSSHClient {
           return;
         }
         try {
-          stream.end(input);
+          if (expectedReceiptSha256 === undefined) stream.end(input);
+          else stream.write(input);
         } catch {
           // error-policy:J1 translate a synchronous SSH writable failure after teardown starts.
           cancel(new Error(`[docker-ssh] stdin write failed on ${this.hostname}`));


### PR DESCRIPTION
# Relates to

Part of #20732 under #20726. Approved split, lot 1/5: receipt-verified SSH transport. Does not close either issue.

This PR is independent of #30820: it includes only the existing SSH continuation commit, not the materialization foundation or the other restore changes.

- [x] Based directly on `develop@357084b3092efb39f95807bcd459baadcc39f095`, with no conflicts.
- [x] Post-sync installation ran with the repository-supported `ELIZA_SKIP_FUSED_INFERENCE_SETUP=1`; no lockfile change.
- [x] Post-sync root verification and final Cloud typecheck pass; observed evidence is below.

## Review correction at 11e9175dd628e2bbd783f64356cd1a7bbc3fc683

Addressed [attentionhead's blocking review](https://github.com/elizaOS/eliza/pull/30926#pullrequestreview-5149775009). The raw two-file Bun run reproduced **20 pass, 1 fail, 1 module-load error**: the test-wide ssh2 module replacement erased the real Server export. Removed the broad module mock instead of changing runner configuration. Only the connection-cancellation test now spies on the actual Client prototype, restoring both spies in finally; all channel-fault assertions remain.

Post-correction verification:
- Raw two-file single-process reproduction: **22/22 pass, 75 assertions**.
- Official wrapper's ordinary batch with these two real files: **22/22 pass, 75 assertions**.
- Final four-file SSH regression command: **35/35 pass, 94 assertions, exit 0 (2.86s)**.
- Final Cloud typecheck and scoped Biome/diff check: exit 0.
- Root verify log reaches **373/373 successful tasks (6m25.74s)** and all final audits, ending with 11,660 test files scanned and zero focused/orphaned skips. The process handle expired before its terminal exit code was collected; the completed log is retained, not represented as a captured exit-code result.
- No production source, workflow, runner, test exclusion or skip change.

The results below from 72cc86af are historical baseline evidence; the original four-file green run did not prove two-file cohabitation. Current-head results above supersede that gap. Hosted checks and earlier approvals must be renewed for this head.

# Sync with develop

Original commit `7f4d660d1c50543d10b93c2851c24a47201b209f` was cherry-picked onto current develop as `72cc86afd4f401e7a22a10d527afd91715a2f9cf`. The original continuation and a pre-split backup ref are preserved. Three named files only; no historical worktree diff was imported.

# Risks

Secret-bearing transport and cancellation boundary. The new behavior is opt-in through the expected receipt argument; existing callers retain EOF-at-end behavior. Review acknowledgement validation, shutdown ordering, reflected-output zeroization and the dedicated-session requirement. An SSH receipt is not proof of remote workload settlement, restored Agent readiness, database commit or route authority.

# Background

## What does this PR do?

- Keeps stdin open as a liveness channel when a framed restore command expects a receipt.
- Requires exactly the expected lowercase SHA-256 receipt on stdout, empty stderr and exit zero.
- Rejects malformed, short, divergent, trailing or failed-exit acknowledgements without reflecting remote bytes in errors.
- Preserves cancellation precedence and the existing channel/session teardown before the caller may zero its input buffer.
- Exercises the real client against both deterministic channel faults and a real loopback SSH server.

## What kind of change is this?

Additive backend transport capability extracted from the existing #20732 implementation. No new default caller, configuration, migration, boot, activation or routing behavior.

# Documentation changes needed?

The method's JSDoc documents the optional receipt contract, dedicated-session requirement and cancellation ownership. No public API or operator configuration changes.

# Testing

## Where should a reviewer start?

`docker-ssh-stdin-receipt.integration.test.ts` uses actual SSH sessions, not a mocked transport. It verifies all 262,144 frame bytes arrive without premature EOF, accepts a fragmented exact receipt and observes peer-channel closure on cancellation. The deterministic channel suite covers hostile/ambiguous responses and teardown races.

## Detailed testing steps

Pinned Node 24.15.0 and Bun 1.3.14, from repository root:

```sh
ELIZA_SKIP_FUSED_INFERENCE_SETUP=1 bun install
bun run --cwd packages/cloud/shared test \
  src/lib/services/docker-ssh-stdin-abort.test.ts \
  src/lib/services/docker-ssh-stdin-receipt.integration.test.ts \
  src/lib/services/docker-ssh-host-verifier.test.ts \
  src/lib/services/__tests__/docker-ssh-probe-classify.test.ts
bun run verify
bun run --cwd packages/cloud/shared typecheck
git diff --check origin/develop...HEAD
```

# Evidence Gate

<!-- evidence-head:11e9175dd628e2bbd783f64356cd1a7bbc3fc683 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend SSH transport only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend SSH transport only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or device workflow; real loopback transport is exercised below.
<!-- evidence-row:backend-logs -->
- [x] Historical baseline test output is included below; current-head verification is recorded in the review correction above. Sensitive worker stdout is not logged.

<details>
<summary>Observed SSH test output, exit 0</summary>

```text
(pass) framed restore over native SSH > receives all bytes without EOF and accepts a fragmented exact receipt
(pass) framed restore over native SSH > cancellation closes the real peer channel before allowing a retry
35 pass
0 fail
94 expect() calls
Ran 35 tests across 4 files. [2.99s]

bun run verify: exit 0
Tasks: 373 successful, 373 total
Time: 4m35.527s
Final repository audits: pass
11,660 test files scanned; 0 focused, 0 orphaned skips

Final Cloud typecheck after dependency build: exit 0
git diff --check origin/develop...HEAD: exit 0
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or view changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this transport unit does not invoke a model or change prompts, actions or Agent behavior. The live restored-fact drill remains in #20732.
<!-- evidence-row:domain-artifacts -->
- [x] Inspected transport outcomes: all 262,144 synthetic frame bytes received with matching SHA-256; no EOF before acknowledgement; fragmented receipt accepted; cancellation closes the peer channel before retry. Fault tests reject short/wrong/trailing/stderr/failed-exit receipts and verify mutable output bytes are zeroed. These are test assertions over actual transport state, not a production restore claim.

<details>
<summary>Consolidated artifact readback from the passing test assertions, not remote stdout</summary>

```text
Real SSH frame: receivedBytes = 262144; received SHA-256 equals the complete sent frame's SHA-256.
Real SSH acknowledgement: earlyEof = false; acknowledged = true; fragmented exact receipt accepted.
Real SSH cancellation: inputReceived = true; peerClosed = true before retry is allowed.
Controlled channel faults: short, divergent, trailing, stderr and failed-exit acknowledgements rejected.
Controlled reflected-output inspection: mutable received chunks contain only zero bytes after handling.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model invocation in this transport-only unit.

## Backend + frontend logs

Backend test results and inspected artifacts are inline above. Frontend: N/A - no frontend changes.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI or device workflow.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

- Initial standalone Cloud typecheck ran before the newly introduced develop dependency `@elizaos/login` had generated `dist` declarations; it reported missing-module and consequent unknown-error diagnostics. Root verify built that dependency, and the unchanged Cloud typecheck then exited 0. No unrelated source change or weakened check was needed.
- Installation explicitly skips optional fused native-inference setup. This does not claim Metal/native-inference build evidence; that subsystem is unchanged and outside this transport unit.
- Real integration evidence is loopback SSH with an ephemeral test key and synthetic bytes. It is not remote Hetzner, Docker, PostgreSQL, Agent boot or staging evidence.
- The remaining generation, boot, quarantine and catalogue/coordinator lots are not included. Feature activation and the separately authorized live restore drill remain incomplete in #20732.

## Maintainer CI exception record

N/A - no exception requested. Independent review and applicable exact-head hosted checks are still required before merge.

AI-assisted implementation with Codex, lane `/root`.

