### PR TITLE
registry: add elizaos-plugin-oblique-markets (x402 pay-per-call market data on Base)

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-oblique-markets.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-oblique-markets.json
@@ -1,0 +1,17 @@
+{
+  "package": "elizaos-plugin-oblique-markets",
+  "repository": "github:oblique-markets/elizaos-plugin-oblique-markets",
+  "kind": "plugin",
+  "description": "Pay-per-call market data for elizaOS agents over x402 (USDC on Base): live x402 Bazaar market pulse, category heat, price stats, seller rank, new listings and day-over-day deltas, plus Base chain lookups (gas, block, tx status, USDC balance and transfer checks), crypto prices, X post search and Solana priority fees. No accounts, no API keys; a per-call dollar cap bounds spend.",
+  "homepage": "https://oblique.markets",
+  "tags": [
+    "x402",
+    "micropayments",
+    "base",
+    "usdc",
+    "market-data",
+    "bazaar",
+    "agent-economy",
+    "onchain"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1560,6 +1560,54 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-oblique-markets": {
+      "git": {
+        "repo": "oblique-markets/elizaos-plugin-oblique-markets",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-oblique-markets",
+        "v0": null,
+        "v1": null,
+        "v2": null
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Pay-per-call market data for elizaOS agents over x402 (USDC on Base): live x402 Bazaar market pulse, category heat, price stats, seller rank, new listings and day-over-day deltas, plus Base chain lookups (gas, block, tx status, USDC balance and transfer checks), crypto prices, X post search and Solana priority fees. No accounts, no API keys; a per-call dollar cap bounds spend.",
+      "homepage": "https://oblique.markets",
+      "topics": [
+        "x402",
+        "micropayments",
+        "base",
+        "usdc",
+        "market-data",
+        "bazaar",
+        "agent-economy",
+        "onchain"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-quantumscan": {
       "git": {
         "repo": "quantumscan-io/elizaos-plugin-quantumscan",


### PR DESCRIPTION
## Add `elizaos-plugin-oblique-markets` to the community registry

Third-party plugin entry per `packages/registry/README.md`: one source file under `entries/third-party/` and the regenerated `generated-registry.json` (same transform as `generate.ts`, entry inserted in sorted key order).

**What the plugin does:** exposes the 23 GET routes of the [Oblique Markets](https://oblique.markets) paid catalog as native elizaOS actions, settled per call over x402 (USDC on Base). x402 Bazaar market data (pulse, trending, new listings, deltas, category heat, price stats, seller rank, listing lint), Base chain lookups (gas, block, tx status, USDC balance and transfer checks), crypto prices, X post search, Solana priority fees. A catalog provider tells the agent what exists and what it costs; `OBLIQUE_MAX_PRICE_USD` (default $0.05) caps spend per call before any signature is produced; without a buyer key every action returns the exact payment terms (discovery mode).

- Repository: https://github.com/oblique-markets/elizaos-plugin-oblique-markets (MIT, TypeScript, ESM + CJS via tsup, `@elizaos/core` as a type-only peer)
- Action table is generated from the shop's own x402 catalog and OpenAPI (`scripts/sync-catalog.mjs`), never typed by hand
- Paid path verified end to end against the live shop from the built package (a $0.01 `/time` settlement on Base, tx `0xed19e30f6e431ac482fa42f92b03aa960b7f2861dfc25e7db4c763cb8f944bed`)
- Keywords include `elizaos` for runtime auto-discovery; `version` is omitted until the npm publish lands (install from the GitHub repository meanwhile)

Discovery documents: https://oblique.markets/.well-known/x402.json · https://api.oblique.markets/openapi.json
