### PR TITLE
chore(registry): update Coin Railz plugin to 2.6.3

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-coinrailz.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-coinrailz.json
@@ -2,9 +2,9 @@
   "package": "elizaos-plugin-coinrailz",
   "repository": "github:tdnupe3/elizaos-plugin-coinrailz",
   "kind": "plugin",
-  "description": "Agent Treasury + Payments: non-custodial USDC yield on Solana (Kamino, ~3.4% APY) and Base (ERC-4626 routing via Aave/Compound/Morpho), plus 65 live x402 pay-per-call services for inference, IoT data, satellite imagery, and execution.",
+  "description": "Agent Treasury + Payments: non-custodial USDC yield on Solana and Base, plus 80 live x402 pay-per-call services for data, inference, compliance, IoT, and execution.",
   "homepage": "https://coinrailz.com",
-  "version": "2.1.0",
+  "version": "2.6.2",
   "tags": [
     "payments",
     "x402",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1391,14 +1391,14 @@
         "repo": "elizaos-plugin-coinrailz",
         "v0": null,
         "v1": null,
-        "v2": "2.1.0"
+        "v2": "2.6.2"
       },
       "supports": {
         "v0": false,
         "v1": false,
         "v2": true
       },
-      "description": "Agent Treasury + Payments: non-custodial USDC yield on Solana (Kamino, ~3.4% APY) and Base (ERC-4626 routing via Aave/Compound/Morpho), plus 65 live x402 pay-per-call services for inference, IoT data, satellite imagery, and execution.",
+      "description": "Agent Treasury + Payments: non-custodial USDC yield on Solana and Base, plus 80 live x402 pay-per-call services for data, inference, compliance, IoT, and execution.",
       "homepage": "https://coinrailz.com",
       "topics": [
         "payments",


### PR DESCRIPTION
Updates the registry pin from 2.1.0 to exactly 2.6.3.

The 2.6.3 release addresses the maintainer-requested compatibility review:

- fixes the ESM-to-CJS shim so Bun 1.3.14 exposes the default and named plugin exports correctly
- declares the supported ElizaOS v2 peer (`^2.0.3-beta.7`) while retaining 0.25.x compatibility
- adds a release gate that installs the packed artifact with pinned Bun 1.3.14 and passes it through the real `@elizaos/core` `loadPlugin` implementation
- preserves the existing external-consumer checks for CommonJS, native ESM, public types, and all 80 canonical service routes

The registry source and generated artifact are both updated to 2.6.3.