### PR TITLE
fix(shared): match bare end-of-turn question tags as whole words (#29934)

### DIFF
--- a/packages/shared/src/voice-eot.test.ts
+++ b/packages/shared/src/voice-eot.test.ts
@@ -25,6 +25,20 @@ describe("scoreEndOfTurnHeuristic — canonical heuristic", () => {
     expect(score("that's correct right")).toBe(0.85);
     expect(score("it is ready yeah")).toBe(0.85);
     expect(score("that makes sense correct")).toBe(0.85);
+    expect(score("that's correct, right")).toBe(0.85);
+    expect(score("right")).toBe(0.85);
+  });
+
+  it("rule 3 matches a bare tag only as a whole final word, never as a suffix", () => {
+    // "incorrect" ends in "correct" and "alright"/"copyright" end in "right";
+    // a suffix match would commit these ordinary statements at 0.85.
+    expect(score("no that is incorrect")).toBe(0.5);
+    expect(score("i still need the copyright")).toBe(0.5);
+    expect(score("it turned out alright in the end")).toBe(0.5);
+    expect(score("that was downright rude of them")).toBe(0.5);
+    // A short utterance ending in such a word falls to the short-command rule.
+    expect(score("alright")).toBe(0.7);
+    expect(score("not incorrect")).toBe(0.7);
   });
 
   it("rule 4: trailing conjunction → mid-clause (0.15)", () => {

--- a/packages/shared/src/voice-eot.ts
+++ b/packages/shared/src/voice-eot.ts
@@ -148,6 +148,18 @@ const QUESTION_TAGS = [
 ];
 
 /**
+ * Whether `text` ends with `word` as a whole final word: either the whole text
+ * is the word, or the word is preceded by whitespace. A bare suffix test would
+ * let "right" match "alright", "copyright" and "outright", and "correct" match
+ * "incorrect", scoring an ordinary statement as a completed question tag.
+ */
+function endsWithWord(text: string, word: string): boolean {
+  if (text === word) return true;
+  if (!text.endsWith(word)) return false;
+  return /\s/.test(text.charAt(text.length - word.length - 1));
+}
+
+/**
  * Probability in [0,1] that `transcript` is a COMPLETE turn (the speaker is
  * done). High → commit; low → the utterance trails off, keep listening.
  *
@@ -179,7 +191,7 @@ export function scoreEndOfTurnHeuristic(transcript: string): number {
 
   const lower = text.toLowerCase();
   for (const tag of QUESTION_TAGS) {
-    if (lower.endsWith(tag)) return 0.85;
+    if (endsWithWord(lower, tag)) return 0.85;
   }
 
   const words = lower


### PR DESCRIPTION
# Relates to

Closes #29934.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `29b8e9319dc` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `29b8e9319dc`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. One predicate in the shared end-of-turn heuristic changes; every other rule, the punctuated tags, and both consumers (the UI voice capture path and the local-inference Tier-3 classifier) are untouched.

# Background

## What does this PR do?

`scoreEndOfTurnHeuristic` in `packages/shared/src/voice-eot.ts` matched its bare question tags (`right`, `yeah`, `correct`) with `lower.endsWith(tag)`, so an utterance ending in `incorrect`, `alright`, `copyright`, `downright`, or `outright` scored 0.85 as a completed question tag. The heuristic is the single syntactic end-of-turn source for the UI capture path and the plugin classifier, so "no, that is incorrect" could commit the turn and let the agent barge in. A bare tag now counts only when it is the whole utterance or is preceded by whitespace. "that's correct, right" and a lone "right" still score 0.85.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None; the rule table in the module header already describes tags as suffix words and is unchanged in intent.

# Testing

## Where should a reviewer start?

`packages/shared/src/voice-eot.ts` (`endsWithWord`), then the new case in `packages/shared/src/voice-eot.test.ts`.

## Detailed testing steps

From `packages/shared`:

```bash
bunx vitest run src/voice-eot.test.ts     # 14 passed
bunx @biomejs/biome check src              # 510 files, clean
bun run typecheck                          # exit 0
```

Negative control: with `git show origin/develop:packages/shared/src/voice-eot.ts` swapped in and the head test file kept, the new case fails (`expected 0.85 to be 0.5`), 13 others pass.

# Evidence Gate

<!-- evidence-head:29b8e9319dcafe835df7aa894c370d73f5a8f04b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure scoring function in `@elizaos/shared`, no rendered surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure scoring function in `@elizaos/shared`, no rendered surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow is added or altered; the change is one predicate in a heuristic
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real function:
  <details><summary>Head 29b8e9319dcafe835df7aa894c370d73f5a8f04b</summary>

  ```text
  packages/shared: bunx vitest run src/voice-eot.test.ts
   Test Files  1 passed (1)   Tests  14 passed (14)
  negative control (develop voice-eot.ts + head tests):
   × rule 3 matches a bare tag only as a whole final word, never as a suffix
   AssertionError: expected 0.85 to be 0.5
   Tests  1 failed | 13 passed (14)
  bunx @biomejs/biome check src: Checked 510 files. No fixes applied.
  bun run typecheck: Done!
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state changes; consumers call the same export
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic heuristic, no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted artifact; the output is an in-memory score
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

None. Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
