### PR TITLE
fix(plugin-native-swabble): release the mic when stop() lands while start() awaits getUserMedia (#29236)

### DIFF
--- a/plugins/plugin-native-swabble/src/web.test.ts
+++ b/plugins/plugin-native-swabble/src/web.test.ts
@@ -608,6 +608,120 @@ describe("SwabbleWeb fallback", () => {
     }
   });
 
+  it("releases the microphone and never starts recognition when stop() lands while the mic is being acquired", async () => {
+    vi.useFakeTimers();
+    try {
+      FakeAudioContext.instances = [];
+      const { stream, stop } = makeMicStream();
+      let resolveMic: (value: MediaStream) => void = () => undefined;
+      const getUserMedia = vi.fn(
+        () =>
+          new Promise<MediaStream>((resolve) => {
+            resolveMic = resolve;
+          }),
+      );
+      vi.stubGlobal("AudioContext", FakeAudioContext);
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: { getUserMedia } as unknown as MediaDevices,
+      });
+
+      const plugin = new SwabbleWeb();
+      const audioLevels = vi.fn();
+      const states = vi.fn();
+      await plugin.addListener("audioLevel", audioLevels);
+      await plugin.addListener("stateChange", states);
+
+      // start() is parked on getUserMedia when stop() arrives.
+      const starting = plugin.start({ config: { triggers: ["eliza"] } });
+      const recognition = FakeRecognition.latest;
+      expect(getUserMedia).toHaveBeenCalledTimes(1);
+      await plugin.stop();
+      expect(states).toHaveBeenLastCalledWith({ state: "idle" });
+
+      resolveMic(stream);
+      await expect(starting).resolves.toEqual({
+        started: false,
+        error: "Speech recognition was stopped before it started",
+      });
+
+      // The recognizer never started, the plugin is idle, and the microphone
+      // track opened for the retired start() was released.
+      expect(recognition?.start).not.toHaveBeenCalled();
+      await expect(plugin.isListening()).resolves.toEqual({
+        listening: false,
+      });
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(states).toHaveBeenLastCalledWith({ state: "idle" });
+      expect(states).not.toHaveBeenCalledWith({ state: "listening" });
+
+      audioLevels.mockClear();
+      vi.advanceTimersByTime(300);
+      expect(audioLevels).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps only the replacement's microphone when start() is called again before the first mic resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      FakeAudioContext.instances = [];
+      const firstMic = makeMicStream();
+      const secondMic = makeMicStream();
+      const pending: Array<(value: MediaStream) => void> = [];
+      const getUserMedia = vi.fn(
+        () =>
+          new Promise<MediaStream>((resolve) => {
+            pending.push(resolve);
+          }),
+      );
+      vi.stubGlobal("AudioContext", FakeAudioContext);
+      setWindow({ SpeechRecognition: FakeRecognition });
+      setNavigator({
+        mediaDevices: { getUserMedia } as unknown as MediaDevices,
+      });
+
+      const plugin = new SwabbleWeb();
+      const audioLevels = vi.fn();
+      await plugin.addListener("audioLevel", audioLevels);
+
+      const firstStart = plugin.start({ config: { triggers: ["eliza"] } });
+      const firstRecognition = FakeRecognition.latest;
+      await plugin.stop();
+      const secondStart = plugin.start({ config: { triggers: ["eliza"] } });
+      const secondRecognition = FakeRecognition.latest;
+      expect(secondRecognition).not.toBe(firstRecognition);
+      expect(pending).toHaveLength(2);
+
+      // The replacement's microphone resolves first; the retired start()'s
+      // microphone resolves afterwards and must not displace it.
+      pending[1](secondMic.stream);
+      await expect(secondStart).resolves.toEqual({ started: true });
+      pending[0](firstMic.stream);
+      await expect(firstStart).resolves.toEqual({
+        started: false,
+        error: "Speech recognition was stopped before it started",
+      });
+
+      expect(firstRecognition?.start).not.toHaveBeenCalled();
+      expect(secondRecognition?.start).toHaveBeenCalledTimes(1);
+      expect(firstMic.stop).toHaveBeenCalledTimes(1);
+      expect(secondMic.stop).not.toHaveBeenCalled();
+      await expect(plugin.isListening()).resolves.toEqual({ listening: true });
+
+      audioLevels.mockClear();
+      vi.advanceTimersByTime(100);
+      expect(audioLevels).toHaveBeenCalled();
+
+      await plugin.stop();
+      expect(secondMic.stop).toHaveBeenCalledTimes(1);
+      expect(firstMic.stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("ignores callbacks from a retired recognizer after a replacement starts", async () => {
     vi.useFakeTimers();
     try {

--- a/plugins/plugin-native-swabble/src/web.ts
+++ b/plugins/plugin-native-swabble/src/web.ts
@@ -461,7 +461,16 @@ export class SwabbleWeb extends WebPlugin {
     };
 
     this.recognition = recognition;
-    await this.startAudioLevelMonitoring();
+    const owned = await this.startAudioLevelMonitoring(recognition);
+    if (!owned) {
+      // stop() or a replacement start() ran while the microphone was being
+      // acquired. The recognizer was never started and the level meter this
+      // call opened has been released, so the plugin stays idle.
+      return {
+        started: false,
+        error: "Speech recognition was stopped before it started",
+      };
+    }
     recognition.start();
     return { started: true };
   }
@@ -536,7 +545,16 @@ export class SwabbleWeb extends WebPlugin {
     }
   }
 
-  private async startAudioLevelMonitoring(): Promise<void> {
+  /**
+   * Opens the level-meter microphone for `owner` and installs it only while
+   * `owner` is still the live recognizer. getUserMedia is always asynchronous,
+   * so stop() or a replacement start() can run before it resolves; a stream
+   * acquired for a retired recognizer is released here instead of outliving
+   * the idle state. Returns whether `owner` still owns capture.
+   */
+  private async startAudioLevelMonitoring(
+    owner: SpeechRecognitionInstance,
+  ): Promise<boolean> {
     // error-policy:J5 the level meter is a non-essential visual augmentation to
     // the Web Speech path; a denied mic is already surfaced through
     // recognition.onerror ("not-allowed"), so a failure here degrades the meter
@@ -544,7 +562,13 @@ export class SwabbleWeb extends WebPlugin {
     const stream = await navigator.mediaDevices
       .getUserMedia({ audio: true })
       .catch(() => null);
-    if (!stream) return;
+    if (this.recognition !== owner) {
+      stream?.getTracks().forEach((t) => {
+        t.stop();
+      });
+      return false;
+    }
+    if (!stream) return true;
 
     this.mediaStream = stream;
     this.audioContext = new AudioContext();
@@ -563,6 +587,7 @@ export class SwabbleWeb extends WebPlugin {
         peak: Math.max(...dataArray) / 255,
       });
     }, 100);
+    return true;
   }
 
   private stopAudioLevelMonitoring(): void {


### PR DESCRIPTION
# Relates to

Closes #29236.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `6c1099d3ca2` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `6c1099d3ca2`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. Only the Web Speech fallback path in `SwabbleWeb` changes, and only in the window between `start()` assigning a recognizer and `getUserMedia` resolving. The native desktop bridge path, recognizer callbacks, and the existing retired-recognizer guards are untouched.

# Background

## What does this PR do?

`SwabbleWeb.start()` assigned `this.recognition`, awaited `startAudioLevelMonitoring()` (which awaits `getUserMedia`), and then called `recognition.start()` unconditionally. A `stop()` that ran during that await set `isActive = false`, nulled the recognizer, and called `stopAudioLevelMonitoring()` while no stream existed yet. When `start()` resumed it installed the newly opened `MediaStream` and its 100 ms level interval and started a recognizer the plugin no longer owned: the browser microphone indicator stayed on and `audioLevel` events kept firing while `isListening()` reported false.

The level-meter acquisition now takes the recognizer it serves and re-checks ownership after `getUserMedia` resolves. A stream opened for a retired recognizer is stopped on the spot and `start()` returns `{ started: false, error }` without starting recognition. When a replacement `start()` wins the race, the retired call releases only its own stream and the replacement keeps its microphone and level meter.

## What kind of change is this?

Bug fix (non-breaking). The `SwabbleStartResult` contract already carries `started: false` with an `error` string.

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-swabble/src/web.ts` (`start()` and `startAudioLevelMonitoring()`), then the two new cases at the end of `plugins/plugin-native-swabble/src/web.test.ts`, which drive the real `SwabbleWeb` state machine with a deferred `getUserMedia`.

## Detailed testing steps

From `plugins/plugin-native-swabble`:

```bash
bunx vitest run src/web.test.ts   # 21 passed
bun run lint:check                # 7 files, clean
bun run typecheck                 # exit 0
```

Negative control: with `git show origin/develop:plugins/plugin-native-swabble/src/web.ts` swapped in and the head test file kept, both new cases fail and the 19 existing cases pass.

# Evidence Gate

<!-- evidence-head:6c1099d3ca2abce8070c21feb419596bf11b0cf5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered surface changes; the defect is a microphone/recognizer ownership race inside the Capacitor web plugin
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable effect is the browser mic indicator staying on after stop(); the deterministic regression below drives the same interleaving through the real state machine
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real plugin state machine:
  <details><summary>Head 6c1099d3ca2abce8070c21feb419596bf11b0cf5</summary>

  ```text
  plugins/plugin-native-swabble: bunx vitest run src/web.test.ts
   Test Files  1 passed (1)   Tests  21 passed (21)
  negative control (develop web.ts + head tests):
   × releases the microphone and never starts recognition when stop() lands while the mic is being acquired
   × keeps only the replacement's microphone when start() is called again before the first mic resolves
   Tests  2 failed | 19 passed (21)
  bun run lint:check: Checked 7 files. No fixes applied.
  bun run typecheck: exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request or response surface; the plugin's stateChange/audioLevel events are asserted directly in the regression
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

None. Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
