### PR TITLE
fix(plugin-calendar): keep a settled auto-join task from being recreated mid-meeting (#29961)

### DIFF
--- a/plugins/plugin-calendar/src/meetings/auto-join.test.ts
+++ b/plugins/plugin-calendar/src/meetings/auto-join.test.ts
@@ -404,6 +404,76 @@ describe("reconcileMeetingAutoJoin", () => {
     );
   });
 
+  it("retries a failed join in ask mode under the owner's completed approval without re-prompting", async () => {
+    await writeMeetingAutoJoinPolicy(harness.runtime, "ask");
+    const event = makeEvent();
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => NOW,
+    });
+    const initial = await autoJoinTasks(harness.runner);
+    const approval = initial.find((t) => t.kind === "approval");
+    const join = initial.find((t) => t.kind === "custom");
+    if (!approval || !join) throw new Error("approval pair missing");
+    // The owner approves, then the join fails (the runner's terminal
+    // transition when dispatch escalation is exhausted).
+    await harness.runner.apply(approval.taskId, "complete", {
+      reason: "owner approved",
+    });
+    await harness.runner.pipeline(join.taskId, "failed");
+
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => new Date("2026-07-03T15:02:00.000Z"),
+    });
+    const tasks = await autoJoinTasks(harness.runner);
+    const approvals = tasks.filter((t) => t.kind === "approval");
+    const joins = tasks.filter((t) => t.kind === "custom");
+    // No second prompt: the completed approval is the only approval.
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0].state.status).toBe("completed");
+    // The failed join is retried once, anchored at the event start rather
+    // than chained to an approval that can no longer transition.
+    expect(joins).toHaveLength(2);
+    const retry = joins.find((t) => t.state.status === "scheduled");
+    expect(retry).toBeDefined();
+    expect(retry?.trigger).toEqual({
+      kind: "relative_to_anchor",
+      anchorKey: eventStartAnchorKey(event.id),
+      offsetMinutes: JOIN_OFFSET_MINUTES,
+    });
+    expect(retry?.metadata?.autoJoinMode).toBe("ask");
+  });
+
+  it("retries a failed join in all mode on the next sync", async () => {
+    await writeMeetingAutoJoinPolicy(harness.runtime, "all");
+    const event = makeEvent();
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => NOW,
+    });
+    const [join] = await autoJoinTasks(harness.runner);
+    await harness.runner.pipeline(join.taskId, "failed");
+
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => new Date("2026-07-03T15:02:00.000Z"),
+    });
+    const tasks = await autoJoinTasks(harness.runner);
+    expect(tasks.map((t) => t.state.status).sort()).toEqual([
+      "failed",
+      "scheduled",
+    ]);
+  });
+
   it("policy change all→ask dismisses the direct join and creates the approval pair", async () => {
     await writeMeetingAutoJoinPolicy(harness.runtime, "all");
     const event = makeEvent();

--- a/plugins/plugin-calendar/src/meetings/auto-join.test.ts
+++ b/plugins/plugin-calendar/src/meetings/auto-join.test.ts
@@ -317,6 +317,93 @@ describe("reconcileMeetingAutoJoin", () => {
     });
   });
 
+  it("does not recreate a completed join task while the meeting is still in progress", async () => {
+    await writeMeetingAutoJoinPolicy(harness.runtime, "all");
+    const event = makeEvent();
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => NOW,
+    });
+    const [join] = await autoJoinTasks(harness.runner);
+    // The join fired and the agent is in the meeting.
+    await harness.runner.apply(join.taskId, "complete", { reason: "joined" });
+
+    // A routine feed sync five minutes into the meeting must not schedule a
+    // second, immediately-due join for the same event.
+    const midMeeting = new Date("2026-07-03T15:05:00.000Z");
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => midMeeting,
+    });
+    const tasks = await autoJoinTasks(harness.runner);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].taskId).toBe(join.taskId);
+    expect(tasks[0].state.status).toBe("completed");
+  });
+
+  it("schedules a fresh join when a joined event is rescheduled to a new start", async () => {
+    await writeMeetingAutoJoinPolicy(harness.runtime, "all");
+    const event = makeEvent();
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => NOW,
+    });
+    const [join] = await autoJoinTasks(harness.runner);
+    await harness.runner.apply(join.taskId, "complete", { reason: "joined" });
+
+    const moved = makeEvent({
+      startAt: "2026-07-10T15:00:00.000Z",
+      endAt: "2026-07-10T15:30:00.000Z",
+    });
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [moved],
+      now: () => NOW,
+    });
+    const tasks = await autoJoinTasks(harness.runner);
+    expect(tasks).toHaveLength(2);
+    const live = tasks.filter((t) => t.state.status === "scheduled");
+    expect(live).toHaveLength(1);
+    expect(live[0].metadata?.eventStartAt).toBe(moved.startAt);
+  });
+
+  it("does not re-prompt an approval the owner already dismissed", async () => {
+    await writeMeetingAutoJoinPolicy(harness.runtime, "ask");
+    const event = makeEvent();
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => NOW,
+    });
+    const before = await autoJoinTasks(harness.runner);
+    const approval = before.find((t) => t.kind === "approval");
+    expect(approval).toBeDefined();
+    if (!approval) throw new Error("approval task missing");
+    await harness.runner.apply(approval.taskId, "dismiss", {
+      reason: "owner declined",
+    });
+
+    await reconcileMeetingAutoJoin({
+      runtime: harness.runtime,
+      agentId: AGENT_ID,
+      events: [event],
+      now: () => new Date("2026-07-03T14:50:00.000Z"),
+    });
+    const after = await autoJoinTasks(harness.runner);
+    expect(after.filter((t) => t.kind === "approval")).toHaveLength(1);
+    expect(after.filter((t) => t.state.status === "scheduled")).toHaveLength(
+      before.length - 1,
+    );
+  });
+
   it("policy change all→ask dismisses the direct join and creates the approval pair", async () => {
     await writeMeetingAutoJoinPolicy(harness.runtime, "all");
     const event = makeEvent();

--- a/plugins/plugin-calendar/src/meetings/auto-join.ts
+++ b/plugins/plugin-calendar/src/meetings/auto-join.ts
@@ -294,31 +294,35 @@ async function reconcileEvent(
   }
   const current = live.filter((task) => taskMode(task) === policy);
 
-  // A task that already reached a terminal state for this same event start
-  // under the current policy is settled: the agent joined, or the owner
-  // answered the approval, and the meeting is still in progress. Recreating it
-  // would anchor a fresh join at start - 1 min, which is already due, so the
-  // agent would join the same meeting a second time (#29961). A rescheduled
-  // event carries a new startAt and is reconciled afresh.
-  const settled = existing.some(
-    (task) =>
-      !isLive(task) &&
-      task.state.status !== "failed" &&
-      taskMode(task) === policy &&
-      task.metadata?.eventStartAt === event.startAt,
-  );
-  if (settled) return current;
+  // A task of the same role that already reached a terminal state for this
+  // same event start under the current policy is settled: the agent joined,
+  // or the owner answered the approval, and the meeting is still in progress.
+  // Recreating it would anchor a fresh join at start - 1 min, which is already
+  // due, so the agent would join the same meeting a second time (#29961). A
+  // failed task is not settled, so a failed join stays retryable; settlement
+  // is per role, so a completed approval never settles the join on its behalf.
+  // A rescheduled event carries a new startAt and is reconciled afresh.
+  const findSettled = (role: "join" | "approval"): ScheduledTask | undefined =>
+    existing.find(
+      (task) =>
+        !isLive(task) &&
+        task.state.status !== "failed" &&
+        taskRole(task) === role &&
+        taskMode(task) === policy &&
+        task.metadata?.eventStartAt === event.startAt,
+    );
+  const joinAtStart = (mode: MeetingAutoJoinPolicy): ScheduledTaskInput =>
+    joinTaskInput(event, parsed, mode, {
+      kind: "relative_to_anchor",
+      anchorKey: eventStartAnchorKey(event.id),
+      offsetMinutes: JOIN_OFFSET_MINUTES,
+    });
 
   if (policy === "all") {
     const join = current.find((task) => taskRole(task) === "join");
     if (join) return [join];
-    const scheduled = await runner.schedule(
-      joinTaskInput(event, parsed, "all", {
-        kind: "relative_to_anchor",
-        anchorKey: eventStartAnchorKey(event.id),
-        offsetMinutes: JOIN_OFFSET_MINUTES,
-      }),
-    );
+    if (findSettled("join")) return current;
+    const scheduled = await runner.schedule(joinAtStart("all"));
     logger.info(
       {
         src: "calendar:meeting-auto-join",
@@ -333,7 +337,8 @@ async function reconcileEvent(
 
   // policy === "ask"
   let approval = current.find((task) => taskRole(task) === "approval");
-  if (!approval) {
+  const settledApproval = findSettled("approval");
+  if (!approval && !settledApproval) {
     approval = await runner.schedule(approvalTaskInput(event, parsed));
     logger.info(
       {
@@ -345,25 +350,46 @@ async function reconcileEvent(
     );
   }
   let join = current.find((task) => taskRole(task) === "join");
-  if (!join) {
-    join = await runner.schedule(
-      joinTaskInput(event, parsed, "ask", {
-        kind: "after_task",
-        taskId: approval.taskId,
-        outcome: "completed",
-      }),
-    );
-    logger.info(
-      {
-        src: "calendar:meeting-auto-join",
-        eventId: event.id,
-        taskId: join.taskId,
-        approvalTaskId: approval.taskId,
-      },
-      `${LOG_PREFIX} Scheduled approval-gated meeting join for event ${event.id}.`,
-    );
+  if (!join && !findSettled("join")) {
+    if (approval) {
+      join = await runner.schedule(
+        joinTaskInput(event, parsed, "ask", {
+          kind: "after_task",
+          taskId: approval.taskId,
+          outcome: "completed",
+        }),
+      );
+      logger.info(
+        {
+          src: "calendar:meeting-auto-join",
+          eventId: event.id,
+          taskId: join.taskId,
+          approvalTaskId: approval.taskId,
+        },
+        `${LOG_PREFIX} Scheduled approval-gated meeting join for event ${event.id}.`,
+      );
+    } else if (settledApproval?.state.status === "completed") {
+      // The owner already approved and the join itself failed. An after_task
+      // child only fires when its parent transitions, and that approval is
+      // already terminal, so the retry is anchored at the event start instead
+      // of re-prompting an owner who has answered.
+      join = await runner.schedule(joinAtStart("ask"));
+      logger.info(
+        {
+          src: "calendar:meeting-auto-join",
+          eventId: event.id,
+          taskId: join.taskId,
+          approvalTaskId: settledApproval.taskId,
+        },
+        `${LOG_PREFIX} Rescheduled failed meeting join for event ${event.id} under the owner's existing approval.`,
+      );
+    }
+    // An approval the owner dismissed, skipped, or let expire grants nothing;
+    // no join is scheduled for it.
   }
-  return [approval, join];
+  return [approval, join].filter(
+    (task): task is ScheduledTask => task !== undefined,
+  );
 }
 
 export interface ReconcileMeetingAutoJoinArgs {

--- a/plugins/plugin-calendar/src/meetings/auto-join.ts
+++ b/plugins/plugin-calendar/src/meetings/auto-join.ts
@@ -294,6 +294,21 @@ async function reconcileEvent(
   }
   const current = live.filter((task) => taskMode(task) === policy);
 
+  // A task that already reached a terminal state for this same event start
+  // under the current policy is settled: the agent joined, or the owner
+  // answered the approval, and the meeting is still in progress. Recreating it
+  // would anchor a fresh join at start - 1 min, which is already due, so the
+  // agent would join the same meeting a second time (#29961). A rescheduled
+  // event carries a new startAt and is reconciled afresh.
+  const settled = existing.some(
+    (task) =>
+      !isLive(task) &&
+      task.state.status !== "failed" &&
+      taskMode(task) === policy &&
+      task.metadata?.eventStartAt === event.startAt,
+  );
+  if (settled) return current;
+
   if (policy === "all") {
     const join = current.find((task) => taskRole(task) === "join");
     if (join) return [join];


### PR DESCRIPTION
# Relates to

Closes #29961.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `d02df871e7d` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `d02df871e7d`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. One early return in `reconcileEvent`; the policy branches, task shapes, anchors, dismissal on policy change or event end, and the scheduler itself are unchanged. Settlement is per role and a `failed` task is never settled, so a failed join is retried on the next sync in both modes; in ask mode the retry under an already-completed approval is anchored at the event start instead of re-prompting the owner (see the review thread).

# Background

## What does this PR do?

`reconcileEvent` in `plugins/plugin-calendar/src/meetings/auto-join.ts` decided whether an event already had its join or approval task by looking only at live tasks (`scheduled`, `fired`, `acknowledged`). Once the join task fired and completed, the next routine feed sync during the meeting saw no live task and scheduled a fresh join anchored at start - 1 min. That anchor was already in the past, so the task was immediately due and the agent joined the same meeting a second time. In ask mode, an approval the owner had dismissed was re-prompted the same way.

A task of the same role that reached a terminal state other than `failed` for the same event start under the same policy now counts as settled and is not recreated. The check is keyed on role, `autoJoinMode`, and `eventStartAt`, so a policy change still replaces tasks, a rescheduled event still gets a fresh join, and a completed approval never settles the join on its behalf. When the owner already approved and the join failed, the retry is anchored at the event start rather than chained to the terminal approval, because an `after_task` child only fires when its parent transitions.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None; the module header's "exactly one join task per event" contract is what this restores.

# Testing

## Where should a reviewer start?

The settled block in `plugins/plugin-calendar/src/meetings/auto-join.ts`, then the five new cases in `plugins/plugin-calendar/src/meetings/auto-join.test.ts`, which run through the real `@elizaos/plugin-scheduling` runner (in-memory store, real schedule/list/apply).

## Detailed testing steps

From `plugins/plugin-calendar`:

```bash
bunx vitest run src/meetings/auto-join.test.ts   # 17 passed
bunx vitest run                                  # 87 files passed, 840 tests passed, 4 skipped
bun run lint:check                               # 179 files, clean
bun run typecheck                                # exit 0
```

Negative control: with `git show origin/develop:plugins/plugin-calendar/src/meetings/auto-join.ts` swapped in and the head test file kept, the completed-join, dismissed-approval, and ask-mode failed-join cases fail (3 failed, 14 passed); the rescheduled-event and all-mode retry cases pass on both, which is intended: they pin that the settled check does not over-block. Against the previous head `14b22a23ec0` (per-event settle) only the ask-mode failed-join case fails, which is the gap attentionhead reported.

# Evidence Gate

<!-- evidence-head:d02df871e7da6d2676a3600494e3063728546802 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - scheduler reconciliation logic with no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - scheduler reconciliation logic with no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the user-visible effect is the agent joining a meeting twice; the regression drives the same sync sequence through the real runner
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution through the real scheduled-task runner:
  <details><summary>Head d02df871e7da6d2676a3600494e3063728546802</summary>

  ```text
  plugins/plugin-calendar: bunx vitest run src/meetings/auto-join.test.ts
   Test Files  1 passed (1)   Tests  17 passed (17)
  negative control (develop auto-join.ts + head tests):
   × does not recreate a completed join task while the meeting is still in progress
   × does not re-prompt an approval the owner already dismissed
   × retries a failed join in ask mode under the owner's completed approval without re-prompting
   Tests  3 failed | 14 passed (17)
  control (previous head 14b22a23ec0 auto-join.ts + head tests): 1 failed (ask-mode failed join) | 16 passed
  bunx vitest run (whole package): Test Files 87 passed | 2 skipped, Tests 840 passed | 4 skipped
  bun run lint:check: Checked 179 files. No fixes applied.
  bun run typecheck: exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call; reconciliation is structural on typed task fields
<!-- evidence-row:domain-artifacts -->
- [x] The scheduled-task rows are the artifact: after the completed join and a mid-meeting sync, `runner.list()` holds exactly one auto-join task for the event, status `completed`, same `taskId` (asserted in the first new case); after a reschedule it holds the completed task plus one `scheduled` task whose `metadata.eventStartAt` is the new start.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

None. Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
