### PR TITLE
fix(plugin-scheduling): scope pipeline cycle detection to the recursion path (#29938)

### DIFF
--- a/plugins/plugin-scheduling/src/scheduled-task/validation.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/validation.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Pins the pipeline reference walk in validateScheduledTaskInput: task refs
+ * shared across branches or fanned into from two children form a DAG and are
+ * accepted, a genuine cycle is rejected, and the nesting cap still holds.
+ * Deterministic, real registries, no runtime.
+ */
+import { describe, expect, it } from "vitest";
+import { createCompletionCheckRegistry } from "./completion-check-registry.js";
+import { createEscalationLadderRegistry } from "./escalation.js";
+import { createTaskGateRegistry } from "./gate-registry.js";
+import type {
+  ScheduledTask,
+  ScheduledTaskInput,
+  ScheduledTaskRef,
+} from "./types.js";
+import { validateScheduledTaskInput } from "./validation.js";
+
+const deps = {
+  gates: createTaskGateRegistry(),
+  completionChecks: createCompletionCheckRegistry(),
+  ladders: createEscalationLadderRegistry(),
+};
+
+function input(
+  overrides: Partial<ScheduledTaskInput> = {},
+): ScheduledTaskInput {
+  return {
+    kind: "reminder",
+    promptInstructions: "do the thing",
+    trigger: { kind: "manual" },
+    priority: "medium",
+    respectsGlobalPause: true,
+    source: "user_chat",
+    createdBy: "tester",
+    ownerVisible: true,
+    ...overrides,
+  };
+}
+
+let nextId = 0;
+function taskRef(overrides: Partial<ScheduledTaskInput> = {}): ScheduledTask {
+  nextId += 1;
+  return {
+    ...input(overrides),
+    taskId: `task_${nextId}`,
+    state: { status: "scheduled", followupCount: 0 },
+  };
+}
+
+// The validator accepts a plain task input as a pipeline ref at runtime (it
+// strips server-managed fields only when `taskId`/`state` are present), and
+// in-process pipeline builders pass exactly that shape, so the DAG cases are
+// pinned for both shapes.
+function inputRef(
+  overrides: Partial<ScheduledTaskInput> = {},
+): ScheduledTaskRef {
+  return input(overrides) as unknown as ScheduledTaskRef;
+}
+
+describe("validateScheduledTaskInput pipeline refs", () => {
+  it("accepts one plain child input shared by two pipeline branches (#29938)", () => {
+    const shared = inputRef({ promptInstructions: "shared follow-up" });
+    const parent = input({
+      pipeline: { onComplete: [shared], onSkip: [shared] },
+    });
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([]);
+  });
+
+  it("accepts plain-input fan-in on one grandchild (#29938)", () => {
+    const grandchild = inputRef({ promptInstructions: "fan-in target" });
+    const left = inputRef({ pipeline: { onComplete: [grandchild] } });
+    const right = inputRef({ pipeline: { onComplete: [grandchild] } });
+    const parent = input({ pipeline: { onComplete: [left, right] } });
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([]);
+  });
+
+  it("rejects a plain child input that refers back to its parent", () => {
+    const parent = input();
+    const child = input({
+      pipeline: { onComplete: [parent as unknown as ScheduledTaskRef] },
+    });
+    parent.pipeline = { onComplete: [child as unknown as ScheduledTaskRef] };
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([
+      "task.pipeline.onComplete[0].pipeline.onComplete[0] must not contain a cyclic task ref",
+    ]);
+  });
+
+  it("accepts one child ref shared by two pipeline branches", () => {
+    const shared = taskRef({ promptInstructions: "shared follow-up" });
+    const parent = input({
+      pipeline: { onComplete: [shared], onSkip: [shared] },
+    });
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([]);
+  });
+
+  it("accepts fan-in where two children reference the same grandchild", () => {
+    const grandchild = taskRef({ promptInstructions: "fan-in target" });
+    const left = taskRef({ pipeline: { onComplete: [grandchild] } });
+    const right = taskRef({ pipeline: { onComplete: [grandchild] } });
+    const parent = input({ pipeline: { onComplete: [left, right] } });
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([]);
+  });
+
+  it("accepts the same ref repeated inside one branch", () => {
+    const child = taskRef();
+    const parent = input({ pipeline: { onComplete: [child, child] } });
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([]);
+  });
+
+  it("rejects a two-task cycle", () => {
+    const first = taskRef();
+    const second = taskRef({ pipeline: { onComplete: [first] } });
+    first.pipeline = { onComplete: [second] };
+    const parent = input({ pipeline: { onComplete: [first] } });
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([
+      "task.pipeline.onComplete[0].pipeline.onComplete[0].pipeline.onComplete[0] must not contain a cyclic task ref",
+    ]);
+  });
+
+  it("rejects a ref that cycles back to itself", () => {
+    const child = taskRef();
+    child.pipeline = { onComplete: [child] };
+    const parent = input({ pipeline: { onComplete: [child] } });
+    expect(validateScheduledTaskInput(parent, deps)).toEqual([
+      "task.pipeline.onComplete[0].pipeline.onComplete[0] must not contain a cyclic task ref",
+    ]);
+  });
+
+  it("keeps the nesting cap", () => {
+    let leaf = taskRef();
+    for (let level = 0; level < 8; level += 1) {
+      leaf = taskRef({ pipeline: { onComplete: [leaf] } });
+    }
+    const parent = input({ pipeline: { onComplete: [leaf] } });
+    const issues = validateScheduledTaskInput(parent, deps);
+    expect(
+      issues.some((issue) => /nesting exceeds 8 levels$/.test(issue)),
+    ).toBe(true);
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/validation.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/validation.ts
@@ -281,11 +281,21 @@ function validateTaskRef(
     "taskId" in ref || "state" in ref
       ? stripServerManaged(ref as ScheduledTask)
       : (ref as ScheduledTaskInput);
-  return validateScheduledTaskInput(input, deps, {
-    path,
-    depth: depth + 1,
-    seen,
-  });
+  // A task-shaped ref is validated through a stripped copy, so the original
+  // object must join the path itself for a cycle back to it to be visible; a
+  // plain input ref is the object the recursive call tracks, so it must not
+  // be pre-marked or every child would read as its own cycle.
+  const trackRef = input !== ref;
+  if (trackRef) seen.add(ref);
+  try {
+    return validateScheduledTaskInput(input, deps, {
+      path,
+      depth: depth + 1,
+      seen,
+    });
+  } finally {
+    if (trackRef) seen.delete(ref);
+  }
 }
 
 export function validateScheduledTaskInput(
@@ -526,5 +536,9 @@ export function validateScheduledTaskInput(
     }
   }
 
+  // Path-scoped: only objects on the current recursion path stay in `seen`,
+  // so a child referenced from two pipeline branches, or a grandchild shared
+  // by two children, is a DAG and not a cycle (#29938).
+  seen.delete(input);
   return issues;
 }


### PR DESCRIPTION
# Relates to

Closes #29938.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `e00571d9d9d` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `e00571d9d9d`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. Only the bookkeeping of the `seen` set in `validateScheduledTaskInput` and `validateTaskRef` changes; every field check, the issue strings, and the depth cap are untouched. The whole plugin-scheduling suite (37 files, 647 tests) passes.

# Background

## What does this PR do?

`validateScheduledTaskInput` in `plugins/plugin-scheduling/src/scheduled-task/validation.ts` added each visited object to a `WeakSet` and never removed it, so the cycle guard degenerated to "was this object visited anywhere before" instead of "is this object on the current recursion path". A child input shared by `pipeline.onComplete` and `pipeline.onSkip`, or a grandchild that two children both reference, was rejected with `must not contain a cyclic task ref` even though the reference graph is acyclic. In-process pipeline builders (curator code, seeds, import round-trips that reuse task objects) hit this at `runner.schedule` and `importTask`; JSON payloads over REST did not, because parsing creates fresh objects.

Task-shaped refs (`taskId`/`state` present) had the opposite gap: they are validated through a `stripServerManaged` copy, so the original object never joined the set and a genuine cycle between two task refs was only stopped by the eight-level depth cap, reported as a nesting error rather than a cycle.

Each object now leaves the set when its subtree returns, and a task-shaped ref joins the path for the duration of its own walk (a plain input ref is the object the recursive call already tracks, so it is not pre-marked).

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

The `seen` handling at the end of `validateScheduledTaskInput` and in `validateTaskRef`, then the new `plugins/plugin-scheduling/src/scheduled-task/validation.test.ts` (nine cases: shared child, fan-in, and repeated ref for both plain-input and task-shaped refs; a two-task cycle; a self-cycle; a plain child referring back to its parent; the nesting cap).

## Detailed testing steps

From `plugins/plugin-scheduling`:

```bash
bunx vitest run src/scheduled-task/validation.test.ts   # 9 passed
bunx vitest run                                          # 37 files, 647 passed
bun run lint:check                                       # 86 files, clean
bun run typecheck                                        # exit 0
```

Negative control: with `git show origin/develop:plugins/plugin-scheduling/src/scheduled-task/validation.ts` swapped in and the head test file kept, four cases fail: the two plain-input DAG cases (false cyclic rejection, the reported defect) and the two task-shaped cycle cases (develop reports the nesting cap instead of a cycle). The task-shaped DAG cases pass on develop as well, which is intended: they pin that the fix does not regress the copy-based path.

# Evidence Gate

<!-- evidence-head:e00571d9d9d257c43dc82ce0b1cd77a7deac3c7c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - validator logic with no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - validator logic with no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the user-visible effect is a 400 from the scheduled-task API for a valid pipeline; the regression drives the same validator the runner calls
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real validator with real registries:
  <details><summary>Head e00571d9d9d257c43dc82ce0b1cd77a7deac3c7c</summary>

  ```text
  plugins/plugin-scheduling: bunx vitest run src/scheduled-task/validation.test.ts
   Tests  9 passed (9)
  negative control (develop validation.ts + head tests):
   × accepts one plain child input shared by two pipeline branches (#29938)
   × accepts plain-input fan-in on one grandchild (#29938)
   × rejects a two-task cycle
   × rejects a ref that cycles back to itself
   Tests  4 failed | 5 passed (9)
  bunx vitest run (whole package): Test Files 37 passed, Tests 647 passed
  bun run lint:check: Checked 86 files. No fixes applied.
  bun run typecheck: exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - validation happens before persistence; no row is written
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

None. Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
