### PR TITLE
fix(core): classify redirect budget and loop violations as SSRF policy blocks (#29931)

### DIFF
--- a/packages/core/src/integrations/managed-provider/http-client.test.ts
+++ b/packages/core/src/integrations/managed-provider/http-client.test.ts
@@ -889,11 +889,16 @@ describe("transport failure mapping", () => {
 			.requestJson(client.url("/v1/geocode"), {}, payloadSchema)
 			.catch((caught: unknown) => caught);
 
+		// A redirect past the budget is a deterministic policy block; retrying
+		// it can never succeed, so it must not surface as a retryable network
+		// failure (#29931).
 		expect(error).toMatchObject({
 			name: "ManagedProviderError",
-			code: "PROVIDER_NETWORK",
+			code: "ENDPOINT_BLOCKED",
 		});
-		expect((error as ManagedProviderError).cause).toBeInstanceOf(Error);
+		expect((error as ManagedProviderError).cause).toBeInstanceOf(
+			SsrfBlockedError,
+		);
 		expect(String((error as ManagedProviderError).cause)).toContain("redirect");
 	});
 

--- a/packages/core/src/network/fetch-guard.test.ts
+++ b/packages/core/src/network/fetch-guard.test.ts
@@ -153,6 +153,43 @@ describe("fetchWithSsrfGuard teardown and cancellation", () => {
 		expect(cancelCalls).toBe(1);
 	});
 
+	it("reports a redirect budget violation as a policy block, not a transport error", async () => {
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(null, {
+					status: 302,
+					headers: { location: "https://example.com/next" },
+				}),
+		);
+		await expect(
+			fetchWithSsrfGuard({
+				url: "https://example.com/page",
+				fetchImpl,
+				maxRedirects: 0,
+			}),
+		).rejects.toBeInstanceOf(SsrfBlockedError);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports a redirect loop as a policy block, not a transport error", async () => {
+		const fetchImpl = vi.fn(async (url: string) => {
+			const target = url.endsWith("/a")
+				? "https://example.com/b"
+				: "https://example.com/a";
+			return new Response(null, {
+				status: 302,
+				headers: { location: target },
+			});
+		});
+		const error = await fetchWithSsrfGuard({
+			url: "https://example.com/a",
+			fetchImpl,
+			maxRedirects: 5,
+		}).catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(SsrfBlockedError);
+		expect((error as Error).message).toBe("Redirect loop detected");
+	});
+
 	it("keeps the missing-location error when the redirect body cancel rejects", async () => {
 		const fetchImpl = vi.fn(
 			async () =>

--- a/packages/core/src/network/fetch-guard.ts
+++ b/packages/core/src/network/fetch-guard.ts
@@ -429,7 +429,12 @@ export async function fetchWithSsrfGuard(
 				if (redirectCount > maxRedirects) {
 					cancelResponseBody(response);
 					await release();
-					throw new Error(`Too many redirects (limit: ${maxRedirects})`);
+					// A redirect budget violation is a network-policy block, not a
+					// transient transport failure: retrying the same request can never
+					// succeed, so callers must classify it as blocked (#29931).
+					throw new SsrfBlockedError(
+						`Too many redirects (limit: ${maxRedirects})`,
+					);
 				}
 				// No redirect response body is consumed by this guard. Dispose it
 				// before parsing or validating the next hop so malformed Location
@@ -439,7 +444,7 @@ export async function fetchWithSsrfGuard(
 				const nextUrl = nextParsedUrl.toString();
 				if (visited.has(nextUrl)) {
 					await release();
-					throw new Error("Redirect loop detected");
+					throw new SsrfBlockedError("Redirect loop detected");
 				}
 				visited.add(nextUrl);
 				// 301/302 on a POST, and any 303, are rewritten to a bodyless GET


### PR DESCRIPTION
# Relates to

Closes #29931.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `87f1126f7c5` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `87f1126f7c5`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. Two `throw` sites in `fetchWithSsrfGuard` change class from `Error` to `SsrfBlockedError` (a subclass of `Error`, same messages). Consumers that already branch on `SsrfBlockedError` (`ManagedProviderHttpClient`, the Google Maps adapter) start classifying these as blocked instead of retryable; consumers that match on the message or catch `Error` are unaffected. No other package matches these messages against the core guard (the orchestrator's `safeFetch` and cloud `safe-fetch` are separate implementations).

# Background

## What does this PR do?

`fetchWithSsrfGuard` in `packages/core/src/network/fetch-guard.ts` threw a plain `Error` for its two redirect-policy violations, `Too many redirects (limit: N)` and `Redirect loop detected`. `ManagedProviderHttpClient` maps `SsrfBlockedError` to `ENDPOINT_BLOCKED` (non-retryable) and every other failure to `PROVIDER_NETWORK` (retryable), and the Maps adapter does the same with `MAPS_ENDPOINT_BLOCKED`, so a provider that answered a `maxRedirects: 0` request with a 302 was retried even though the same request can never succeed. Both violations are deterministic network-policy blocks and now throw `SsrfBlockedError` with the same messages. The missing-`Location` case stays a plain error: it is a malformed response, not a policy decision.

## What kind of change is this?

Bug fix (non-breaking for message-based consumers; a deliberate classification change for the two consumers that branch on the error class, which is the point of the fix).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

The two throw sites in `packages/core/src/network/fetch-guard.ts`, the two new cases in `fetch-guard.test.ts`, and the updated zero-hop-budget case in `managed-provider/http-client.test.ts` (it previously pinned `PROVIDER_NETWORK` for a redirect and now pins `ENDPOINT_BLOCKED` with an `SsrfBlockedError` cause).

## Detailed testing steps

From `packages/core`:

```bash
bunx vitest run src/network/fetch-guard.test.ts src/integrations/managed-provider/http-client.test.ts   # 2 files, 79 passed
bun run lint:check    # exit 0
bun run typecheck     # exit 0
```

Negative control: with `git show origin/develop:packages/core/src/network/fetch-guard.ts` swapped in and the head tests kept, three cases fail (the two new guard cases and the http-client zero-hop case), 76 pass. `plugins/plugin-agent-orchestrator` `__tests__/unit/ssrf-guard.test.ts` (its own `safeFetch`) still passes 19/19 on the head tree.

# Evidence Gate

<!-- evidence-head:87f1126f7c5e89458e50e8637bcf18abea5b5a81 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - transport guard with no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - transport guard with no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the user-visible effect is a provider call retrying a blocked redirect; the http-client case drives the real client against a redirecting fetch
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real guard and the real managed-provider client:
  <details><summary>Head 87f1126f7c5e89458e50e8637bcf18abea5b5a81</summary>

  ```text
  packages/core: bunx vitest run src/network/fetch-guard.test.ts src/integrations/managed-provider/http-client.test.ts
   Test Files  2 passed (2)   Tests  79 passed (79)
  negative control (develop fetch-guard.ts + head tests):
   × refuses to follow redirects past the zero-hop budget
   × reports a redirect budget violation as a policy block, not a transport error
   × reports a redirect loop as a policy block, not a transport error
   Tests  3 failed | 76 passed (79)
  plugins/plugin-agent-orchestrator: bunx vitest run __tests__/unit/ssrf-guard.test.ts -> 19 passed
  bun run lint:check: exit 0
  bun run typecheck: exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state surface changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted artifact; the output is an error class
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

None. Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
