### PR TITLE
fix(elizaos): normalize ssh ports and path suffixes in plugin repository urls (#28346)

### DIFF
--- a/packages/elizaos/src/commands/plugins.test.ts
+++ b/packages/elizaos/src/commands/plugins.test.ts
@@ -50,6 +50,14 @@ describe("submitPluginToRegistry", () => {
     ["git+ssh://git@github.com/acme/plugin-weather.git"],
     ["ssh://git@github.com/acme/plugin-weather.git"],
     ["git://github.com/acme/plugin-weather.git"],
+    // An explicit ssh port must not become the owner segment (#28346).
+    ["git+ssh://git@github.com:22/acme/plugin-weather.git"],
+    ["ssh://git@github.com:2222/acme/plugin-weather.git"],
+    // A /tree or /blob path after `.git` must not leave `.git` on the name.
+    ["https://github.com/acme/plugin-weather.git/tree/main/src"],
+    ["https://github.com/acme/plugin-weather.git/blob/main/README.md"],
+    ["https://github.com/acme/plugin-weather.git#readme"],
+    ["https://github.com/acme/plugin-weather/"],
   ])("normalizes the npm repository url form %s", async (repositoryUrl) => {
     const dir = makePluginPackage({
       name: "@acme/plugin-weather",

--- a/packages/elizaos/src/commands/plugins.test.ts
+++ b/packages/elizaos/src/commands/plugins.test.ts
@@ -57,7 +57,11 @@ describe("submitPluginToRegistry", () => {
     ["https://github.com/acme/plugin-weather.git/tree/main/src"],
     ["https://github.com/acme/plugin-weather.git/blob/main/README.md"],
     ["https://github.com/acme/plugin-weather.git#readme"],
+    ["https://github.com/acme/plugin-weather.git/extra/segment"],
     ["https://github.com/acme/plugin-weather/"],
+    // scp shorthand with an ssh scheme pasted on is tolerated, as before.
+    ["ssh://git@github.com:acme/plugin-weather.git"],
+    ["git+ssh://git@github.com:acme/plugin-weather"],
   ])("normalizes the npm repository url form %s", async (repositoryUrl) => {
     const dir = makePluginPackage({
       name: "@acme/plugin-weather",

--- a/packages/elizaos/src/commands/plugins.ts
+++ b/packages/elizaos/src/commands/plugins.ts
@@ -271,20 +271,19 @@ function normalizeGithubRepo(value: string | null | undefined): string | null {
   }
   // Host prefixes first. An ssh URL may carry an explicit port
   // (`ssh://git@github.com:22/owner/name`), which must not survive as the
-  // owner segment. Then the fragment and any `/tree/` or `/blob/` path, and
-  // only then the trailing `.git`, so `name.git/tree/main` still yields
-  // `owner/name`.
+  // owner segment; the `[:/]` class after it keeps accepting the scp-style
+  // `ssh://git@github.com:owner/name` shape that hand-written manifests carry.
+  // The fragment goes next, then the repository name is read from its own
+  // segment with a trailing `.git` removed, so `name.git/tree/main`,
+  // `name.git/blob/...`, and any other path suffix all yield `owner/name`.
   input = input
     .replace(/^https?:\/\/github\.com\//, "")
-    .replace(/^ssh:\/\/git@github\.com(?::\d+)?\//, "")
+    .replace(/^ssh:\/\/git@github\.com(?::\d+)?[:/]/, "")
     .replace(/^git:\/\/github\.com\//, "")
     .replace(/^git@github\.com:/, "")
-    .replace(/#.*$/, "")
-    .replace(/\/tree\/.*$/, "")
-    .replace(/\/blob\/.*$/, "")
-    .replace(/\/$/, "")
-    .replace(/\.git$/, "");
-  const [owner, repo] = input.split("/");
+    .replace(/#.*$/, "");
+  const [owner, repoSegment] = input.split("/");
+  const repo = repoSegment?.replace(/\.git$/, "");
   return owner && repo ? `${owner}/${repo}` : null;
 }
 

--- a/packages/elizaos/src/commands/plugins.ts
+++ b/packages/elizaos/src/commands/plugins.ts
@@ -269,15 +269,21 @@ function normalizeGithubRepo(value: string | null | undefined): string | null {
   } else if (input.startsWith("git+")) {
     input = input.slice("git+".length);
   }
+  // Host prefixes first. An ssh URL may carry an explicit port
+  // (`ssh://git@github.com:22/owner/name`), which must not survive as the
+  // owner segment. Then the fragment and any `/tree/` or `/blob/` path, and
+  // only then the trailing `.git`, so `name.git/tree/main` still yields
+  // `owner/name`.
   input = input
     .replace(/^https?:\/\/github\.com\//, "")
-    .replace(/^ssh:\/\/git@github\.com[:/]/, "")
+    .replace(/^ssh:\/\/git@github\.com(?::\d+)?\//, "")
     .replace(/^git:\/\/github\.com\//, "")
     .replace(/^git@github\.com:/, "")
-    .replace(/\.git$/, "")
+    .replace(/#.*$/, "")
     .replace(/\/tree\/.*$/, "")
     .replace(/\/blob\/.*$/, "")
-    .replace(/#.*$/, "");
+    .replace(/\/$/, "")
+    .replace(/\.git$/, "");
   const [owner, repo] = input.split("/");
   return owner && repo ? `${owner}/${repo}` : null;
 }


### PR DESCRIPTION
# Relates to

Closes #28346.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `c364b3c8db2` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `c364b3c8db2`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. One private normalizer in the `elizaos plugins submit` path changes. Every URL form develop accepted still yields the same `owner/name`, including the scp shorthand with an `ssh://` scheme pasted on (`ssh://git@github.com:acme/plugin-weather.git`), which the first revision of this PR broke and which is now pinned by two rows (see the review thread). The lenient handling of extra path segments (first two segments win) is unchanged.

# Background

## What does this PR do?

`normalizeGithubRepo` in `packages/elizaos/src/commands/plugins.ts` turns a package's `repository.url` (or homepage, or git remote) into the `owner/name` recorded in registry metadata. Two legal npm URL shapes were mis-parsed:

- `git+ssh://git@github.com:22/acme/plugin-weather.git`: the host strip consumed one character after `github.com`, so the port digits survived and became the owner, giving `22/acme`, which passes the shape check and points registry validation at a different repository.
- `https://github.com/acme/plugin-weather.git/tree/main/src` (and `/blob/`): `.git` was stripped before the path suffix, so the name kept `.git`.

The host strip now accepts an optional `:port` while keeping the `[:/]` separator class, the fragment is removed, and the repository name is read from its own path segment with a trailing `.git` stripped, so `name.git/tree/main`, `name.git/blob/...`, and any other suffix all yield `owner/name`.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

The replace chain in `normalizeGithubRepo` (`packages/elizaos/src/commands/plugins.ts`), then the nine new rows in the `it.each` table in `plugins.test.ts`, which run the real `submitPluginToRegistry` dry-run against a temporary package and read the printed metadata.

## Detailed testing steps

From `packages/elizaos`:

```bash
bunx vitest run src/commands/plugins.test.ts   # 17 passed
bun run lint:check                             # exit 0
bun run typecheck                              # exit 0
```

Negative control: with `git show origin/develop:packages/elizaos/src/commands/plugins.ts` swapped in and the head test file kept, six rows fail (both port forms, the `/tree`, `/blob`, and `/extra/segment` suffix forms, and the fragment form); the trailing-slash and two scp-shorthand rows pass on both and pin existing behaviour. Against the previous head `c62205df000`, the two scp-shorthand rows and the `/extra/segment` row fail, which is the regression attentionhead reported plus the gap they flagged.

# Evidence Gate

<!-- evidence-head:c364b3c8db24745c0d6073bcba64f193e44ff0e2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI metadata normalization, no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI metadata normalization, no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the user-visible effect is the `repository` field of the dry-run metadata JSON, asserted directly below
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real submit dry-run:
  <details><summary>Head c364b3c8db24745c0d6073bcba64f193e44ff0e2</summary>

  ```text
  packages/elizaos: bunx vitest run src/commands/plugins.test.ts
   Tests  17 passed (17)
  negative control (develop plugins.ts + head tests):
   × git+ssh://git@github.com:22/acme/plugin-weather.git
   × ssh://git@github.com:2222/acme/plugin-weather.git
   × https://github.com/acme/plugin-weather.git/tree/main/src
   × https://github.com/acme/plugin-weather.git/blob/main/README.md
   × https://github.com/acme/plugin-weather.git#readme
   × https://github.com/acme/plugin-weather.git/extra/segment
   Tests  6 failed | 11 passed (17)
  control (previous head c62205df000 plugins.ts + head tests): 3 failed (two scp-shorthand rows, /extra/segment) | 14 passed
  bun run lint:check: exit 0
  bun run typecheck: exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call
<!-- evidence-row:domain-artifacts -->
- [x] The generated registry metadata is the artifact: each new row asserts `metadata.repository === "github:acme/plugin-weather"` from the dry-run output.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

None. Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
