### PR TITLE
fix(elizaos): report non-JSON cloud responses with their status in deploy (#28348)

### DIFF
--- a/packages/elizaos/src/commands/deploy.test.ts
+++ b/packages/elizaos/src/commands/deploy.test.ts
@@ -86,6 +86,54 @@ describe("runDeploy", () => {
     );
   });
 
+  it("reports method, route, and status when a proxy answers with an HTML error page", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_test_key";
+    process.env.ELIZA_CLOUD_API_BASE_URL = "https://cloud.example.test/api/v1";
+    const html =
+      "<html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1></body></html>";
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: vi.fn().mockResolvedValue(html),
+    } as unknown as Response) as unknown as typeof fetch;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runDeploy({ appId: "app-1" });
+
+    expect(code).toBe(1);
+    const printed = errorSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(printed).toContain("POST /apps/app-1/deploy failed (502)");
+    expect(printed).toContain("502 Bad Gateway");
+    expect(printed).not.toMatch(/Unexpected token|SyntaxError|JSON/);
+  });
+
+  it("reports a non-JSON success body with its status instead of a parser error", async () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_test_key";
+    process.env.ELIZA_CLOUD_API_BASE_URL = "https://cloud.example.test/api/v1";
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue("<!doctype html><title>Sign in</title>"),
+    } as unknown as Response) as unknown as typeof fetch;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runDeploy({ appId: "app-1" });
+
+    expect(code).toBe(1);
+    const printed = errorSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(printed).toContain(
+      "POST /apps/app-1/deploy returned 200 with a non-JSON body",
+    );
+    expect(printed).toContain("Sign in");
+    expect(printed).not.toMatch(/Unexpected token|SyntaxError/);
+  });
+
   it.each(["-1", "1.5", "2147483648"])(
     "rejects malformed poll interval %s before any network call",
     async (interval) => {

--- a/packages/elizaos/src/commands/deploy.ts
+++ b/packages/elizaos/src/commands/deploy.ts
@@ -277,13 +277,50 @@ async function cloudRequest<T>(
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
   const text = await response.text();
-  const parsed = text ? JSON.parse(text) : {};
+  // A proxy or load balancer can answer with an HTML error page, so the body
+  // is parsed only after the status is known and a non-JSON body is reported
+  // with the method, route, and status instead of a bare SyntaxError (#28348).
+  const parsed = parseCloudBody(text);
   if (!response.ok) {
+    const summary =
+      parsed.kind === "json" ? jsonSummary(parsed.value) : parsed.excerpt;
     throw new Error(
-      `${method} ${routePath} failed (${response.status}): ${jsonSummary(parsed)}`,
+      `${method} ${routePath} failed (${response.status}): ${summary}`,
     );
   }
-  return parsed as T;
+  if (parsed.kind !== "json") {
+    throw new Error(
+      `${method} ${routePath} returned ${response.status} with a non-JSON body: ${parsed.excerpt}`,
+    );
+  }
+  return parsed.value as T;
+}
+
+const CLOUD_BODY_EXCERPT_LENGTH = 200;
+
+type ParsedCloudBody =
+  | { kind: "json"; value: unknown }
+  | { kind: "text"; excerpt: string };
+
+/**
+ * Parse a Cloud API body without letting a non-JSON payload escape as a
+ * parser error. An empty body is an empty JSON object, matching the routes
+ * that answer 2xx without content.
+ */
+function parseCloudBody(text: string): ParsedCloudBody {
+  if (!text) return { kind: "json", value: {} };
+  try {
+    return { kind: "json", value: JSON.parse(text) };
+  } catch {
+    // error-policy:J3 a non-JSON body becomes an explicit text result that the
+    // caller reports with its HTTP status; it is never treated as a payload.
+    const collapsed = text.replace(/\s+/g, " ").trim();
+    const excerpt =
+      collapsed.length > CLOUD_BODY_EXCERPT_LENGTH
+        ? `${collapsed.slice(0, CLOUD_BODY_EXCERPT_LENGTH)}…`
+        : collapsed;
+    return { kind: "text", excerpt: excerpt || "(empty)" };
+  }
 }
 
 async function resolveAppId(


### PR DESCRIPTION
# Relates to

Closes #28348.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `aba9d9184d1` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `aba9d9184d1`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. Only the response-handling tail of `cloudRequest` in the `elizaos deploy` command changes. JSON responses, empty 2xx bodies, and the existing failure message format for JSON error bodies are unchanged; the 41 existing deploy cases still pass.

# Background

## What does this PR do?

`cloudRequest` in `packages/elizaos/src/commands/deploy.ts` called `JSON.parse` on every response body before checking the HTTP status. When the Cloud API is reached through a proxy or load balancer that answers 502 or 503 with an HTML page, the parser threw first, and the operator saw only `Unexpected token '<'` with no method, route, or status.

The body now goes through `parseCloudBody`, which returns either a JSON value or an explicit text excerpt (whitespace collapsed, capped at 200 characters). A failed status reports `METHOD /route failed (status): <summary>` where the summary is the JSON error as before or the text excerpt. A 2xx with a non-JSON body is reported as `returned <status> with a non-JSON body` instead of being returned as the typed payload. An empty body is still an empty object.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

`cloudRequest` and `parseCloudBody` in `packages/elizaos/src/commands/deploy.ts`, then the two new cases in `deploy.test.ts`, which drive the real `runDeploy` with a stubbed `fetch` and assert the printed error.

## Detailed testing steps

From `packages/elizaos`:

```bash
bunx vitest run src/commands/deploy.test.ts   # 41 passed
bun run lint:check                            # exit 0
bun run typecheck                             # exit 0
```

Negative control: with `git show origin/develop:packages/elizaos/src/commands/deploy.ts` swapped in and the head test file kept, both new cases fail (the printed error is the parser message), 39 pass.

# Evidence Gate

<!-- evidence-head:aba9d9184d17ec65b29029c9bdf6dfa702b2e008 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI error reporting, no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI error reporting, no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the user-visible effect is the printed error line, asserted directly below
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real `runDeploy` path:
  <details><summary>Head aba9d9184d17ec65b29029c9bdf6dfa702b2e008</summary>

  ```text
  packages/elizaos: bunx vitest run src/commands/deploy.test.ts
   Tests  41 passed (41)
  new cases assert the printed error:
   502 HTML  → "POST /apps/app-1/deploy failed (502): <html><head><title>502 Bad Gateway…" and no SyntaxError text
   200 HTML  → "POST /apps/app-1/deploy returned 200 with a non-JSON body: <!doctype html><title>Sign in</title>"
  negative control (develop deploy.ts + head tests):
   × reports method, route, and status when a proxy answers with an HTML error page
   × reports a non-JSON success body with its status instead of a parser error
   Tests  2 failed | 39 passed (41)
  bun run lint:check: exit 0
  bun run typecheck: exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted artifact; the output is the CLI error line
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

None. Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
