### PR TITLE
fix(core): bound entity lookups in the contacts and roles providers (#30896)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/contacts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/contacts.test.ts
@@ -99,6 +99,65 @@ describe("advancedContactsProvider", () => {
 		);
 	});
 
+	it("bounds concurrent entity lookups while still naming every contact (#30896)", async () => {
+		const contactCount = 64;
+		const mockContacts = Array.from({ length: contactCount }, (_unused, i) => ({
+			entityId: `entity-${i}` as UUID,
+			categories: [i % 2 === 0 ? "friend" : "colleague"],
+			tags: [],
+			customFields: {},
+			preferences: {},
+			lastModified: 1000 + i,
+		}));
+		const relationshipsService = {
+			searchContacts: vi.fn().mockResolvedValue(mockContacts),
+		};
+
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const releases: Array<() => void> = [];
+		const runtime = {
+			getService: vi.fn().mockReturnValue(relationshipsService),
+			getEntityById: vi.fn(async (id: string) => {
+				inFlight += 1;
+				peakInFlight = Math.max(peakInFlight, inFlight);
+				await new Promise<void>((resolve) => {
+					releases.push(resolve);
+				});
+				inFlight -= 1;
+				return { names: [`Name ${id}`] };
+			}),
+			logger: { warn: vi.fn(), error: vi.fn() },
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const pending = advancedContactsProvider.get(
+			runtime,
+			dummyMessage,
+			dummyState,
+		);
+
+		// Drain the gate until every lookup has been admitted and released.
+		let released = 0;
+		while (released < contactCount) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			while (releases.length > 0) {
+				releases.shift()?.();
+				released += 1;
+			}
+		}
+		const result = await pending;
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(contactCount);
+		expect(peakInFlight).toBe(8);
+		expect(result.values?.contactCount).toBe(contactCount);
+		expect(result.values?.friend).toBe(contactCount / 2);
+		expect(result.values?.colleague).toBe(contactCount / 2);
+		for (let i = 0; i < contactCount; i += 1) {
+			expect(result.text).toContain(`Name entity-${i}`);
+		}
+	});
+
 	it("reports error and degrades cleanly when searchContacts throws", async () => {
 		const relationshipsService = {
 			searchContacts: vi.fn().mockRejectedValue(new Error("Database offline")),

--- a/packages/core/src/features/advanced-capabilities/providers/contacts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/contacts.ts
@@ -14,9 +14,18 @@ import type {
 	ProviderResult,
 	State,
 } from "../../../types/index.ts";
+import { mapWithConcurrency } from "../../../utils/bounded-map.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("CONTACTS");
+
+/**
+ * Upper bound on simultaneous entity lookups while resolving contact names.
+ * The contact list is the user's whole relationship set, so resolving every
+ * contact through one `Promise.all` would admit as many concurrent database
+ * reads as there are contacts (#30896).
+ */
+const MAX_CONCURRENT_ENTITY_LOOKUPS = 8;
 
 export const advancedContactsProvider: Provider = {
 	name: spec.name,
@@ -55,8 +64,10 @@ export const advancedContactsProvider: Provider = {
 			}
 
 			// Get entity details and categorize
-			const contactDetails = await Promise.all(
-				contacts.map(async (contact) => {
+			const contactDetails = await mapWithConcurrency(
+				contacts,
+				MAX_CONCURRENT_ENTITY_LOOKUPS,
+				async (contact) => {
 					const entity = await runtime.getEntityById(contact.entityId);
 					const displayName =
 						typeof contact.customFields.displayName === "string"
@@ -70,7 +81,7 @@ export const advancedContactsProvider: Provider = {
 						preferences: contact.preferences,
 						lastModified: contact.lastModified,
 					};
-				}),
+				},
 			);
 
 			// Group by category

--- a/packages/core/src/features/advanced-capabilities/providers/followUps.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/followUps.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the FOLLOW_UPS provider's contact-name resolution. The
+ * runtime and FollowUpService are in-memory doubles; entity lookups are held
+ * at an explicit gate so the admission bound can be measured before any
+ * lookup completes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.js";
+import { followUpsProvider } from "./followUps.js";
+
+describe("followUpsProvider", () => {
+	const dummyMessage = { roomId: "room-1" as UUID } as Memory;
+	const dummyState = {} as State;
+
+	it("bounds concurrent entity lookups while still naming every contact (#30731)", async () => {
+		const contactCount = 64;
+		const followUps = Array.from({ length: contactCount }, (_unused, i) => ({
+			task: {
+				id: `task-${i}` as UUID,
+				metadata: {
+					scheduledAt: new Date(
+						Date.now() + (i + 1) * 86_400_000,
+					).toISOString(),
+					reason: `reason ${i}`,
+				},
+			},
+			contact: { entityId: `entity-${i}` as UUID },
+		}));
+		const followUpService = {
+			getUpcomingFollowUps: vi.fn().mockResolvedValue(followUps),
+			getFollowUpSuggestions: vi.fn().mockResolvedValue([]),
+		};
+
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const releases: Array<() => void> = [];
+		const runtime = {
+			getService: vi.fn().mockReturnValue(followUpService),
+			getEntityById: vi.fn(async (id: string) => {
+				inFlight += 1;
+				peakInFlight = Math.max(peakInFlight, inFlight);
+				await new Promise<void>((resolve) => {
+					releases.push(resolve);
+				});
+				inFlight -= 1;
+				return { names: [`Name ${id}`] };
+			}),
+			logger: { warn: vi.fn(), error: vi.fn() },
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const pending = followUpsProvider.get(runtime, dummyMessage, dummyState);
+
+		// Drain the gate until every lookup has been admitted and released.
+		let released = 0;
+		while (released < contactCount) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			while (releases.length > 0) {
+				releases.shift()?.();
+				released += 1;
+			}
+		}
+		const result = await pending;
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(contactCount);
+		expect(peakInFlight).toBe(8);
+		expect(result.values?.followUpCount).toBe(contactCount);
+		for (let i = 0; i < contactCount; i += 1) {
+			expect(result.text).toContain(`Name entity-${i}`);
+		}
+	});
+
+	it("resolves each unique contact once and labels unknown entities", async () => {
+		const followUps = [
+			{
+				task: {
+					id: "t1" as UUID,
+					metadata: { scheduledAt: new Date(0).toISOString() },
+				},
+				contact: { entityId: "e1" as UUID },
+			},
+			{
+				task: { id: "t2" as UUID, metadata: {} },
+				contact: { entityId: "e1" as UUID },
+			},
+			{
+				task: { id: "t3" as UUID, metadata: {} },
+				contact: { entityId: "e2" as UUID },
+			},
+		];
+		const runtime = {
+			getService: vi.fn().mockReturnValue({
+				getUpcomingFollowUps: vi.fn().mockResolvedValue(followUps),
+				getFollowUpSuggestions: vi.fn().mockResolvedValue([]),
+			}),
+			getEntityById: vi.fn(async (id: string) =>
+				id === "e1" ? { names: ["Alice"] } : null,
+			),
+			logger: { warn: vi.fn(), error: vi.fn() },
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const result = await followUpsProvider.get(
+			runtime,
+			dummyMessage,
+			dummyState,
+		);
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(2);
+		expect(result.text).toContain("Alice");
+		expect(result.text).toContain("Unknown");
+		expect(result.values?.followUpCount).toBe(3);
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/providers/followUps.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/followUps.ts
@@ -15,9 +15,18 @@ import type {
 	ProviderResult,
 	State,
 } from "../../../types/index.ts";
+import { mapWithConcurrency } from "../../../utils/bounded-map.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("FOLLOW_UPS");
+
+/**
+ * Upper bound on simultaneous entity lookups while resolving follow-up
+ * contact names. The follow-up list is data-driven, so resolving every unique
+ * contact through one `Promise.all` would admit as many concurrent database
+ * reads as there are contacts.
+ */
+const MAX_CONCURRENT_ENTITY_LOOKUPS = 8;
 
 export const followUpsProvider: Provider = {
 	name: spec.name,
@@ -62,8 +71,10 @@ export const followUpsProvider: Provider = {
 			const contactIds = Array.from(
 				new Set(upcomingFollowUps.map((f) => f.contact.entityId)),
 			);
-			const entities = await Promise.all(
-				contactIds.map((id) => runtime.getEntityById(id)),
+			const entities = await mapWithConcurrency(
+				contactIds,
+				MAX_CONCURRENT_ENTITY_LOOKUPS,
+				(id) => runtime.getEntityById(id),
 			);
 			const entityNames = new Map<string, string>();
 			for (let i = 0; i < contactIds.length; i += 1) {

--- a/packages/core/src/features/advanced-capabilities/providers/roles.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/roles.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the ROLES provider's entity resolution. The runtime is an
+ * in-memory double; entity lookups are held at an explicit gate so the
+ * admission bound can be measured before any lookup completes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.js";
+import { ChannelType } from "../../../types/index.js";
+import { roleProvider } from "./roles.js";
+
+describe("roleProvider", () => {
+	const roomId = "room-1" as UUID;
+	const worldId = "world-1" as UUID;
+	const dummyMessage = { roomId } as Memory;
+	const dummyState = { data: {} } as unknown as State;
+
+	it("bounds concurrent entity lookups while still listing every role holder (#30896)", async () => {
+		const memberCount = 64;
+		const roles: Record<string, string> = {};
+		for (let i = 0; i < memberCount; i += 1) {
+			roles[`entity-${i}`] = i === 0 ? "OWNER" : i < 4 ? "ADMIN" : "NONE";
+		}
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const releases: Array<() => void> = [];
+		const runtime = {
+			agentId: "agent-1" as UUID,
+			getRoom: vi.fn().mockResolvedValue({
+				id: roomId,
+				type: ChannelType.GROUP,
+				worldId,
+			}),
+			getWorld: vi.fn().mockResolvedValue({
+				id: worldId,
+				metadata: { ownership: { ownerId: "entity-0" }, roles },
+			}),
+			getEntityById: vi.fn(async (id: string) => {
+				inFlight += 1;
+				peakInFlight = Math.max(peakInFlight, inFlight);
+				await new Promise<void>((resolve) => {
+					releases.push(resolve);
+				});
+				inFlight -= 1;
+				return {
+					id,
+					names: [`Name ${id}`],
+					metadata: { username: `user-${id}` },
+				};
+			}),
+		} as unknown as IAgentRuntime;
+
+		const pending = roleProvider.get(runtime, dummyMessage, dummyState);
+
+		// Drain the gate until every lookup has been admitted and released.
+		let released = 0;
+		while (released < memberCount) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			while (releases.length > 0) {
+				releases.shift()?.();
+				released += 1;
+			}
+		}
+		const result = await pending;
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(memberCount);
+		expect(peakInFlight).toBe(8);
+		expect(result.text).toContain("## Owners\nName entity-0 (Name entity-0)");
+		expect(result.text).toContain("## Administrators");
+		expect(result.text).toContain("## Members");
+		for (let i = 0; i < memberCount; i += 1) {
+			expect(result.text).toContain(`Name entity-${i} (Name entity-${i})`);
+		}
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/providers/roles.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/roles.ts
@@ -20,9 +20,18 @@ import type {
 	UUID,
 } from "../../../types/index.ts";
 import { ChannelType } from "../../../types/index.ts";
+import { mapWithConcurrency } from "../../../utils/bounded-map.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("ROLES");
+
+/**
+ * Upper bound on simultaneous entity lookups while resolving role holders.
+ * The role map covers every entity in the world, so resolving all of them
+ * through one `Promise.all` would admit one concurrent database read per
+ * member (#30896).
+ */
+const MAX_CONCURRENT_ENTITY_LOOKUPS = 8;
 
 type RoleUser = { name: string; username: string; names: string[] };
 type IdentityFields = { name?: string; username?: string; userName?: string };
@@ -199,8 +208,10 @@ export const roleProvider: Provider = {
 		const members: RoleUser[] = [];
 
 		const entityIds = Object.keys(roles) as UUID[];
-		const entities = await Promise.all(
-			entityIds.map((entityId) => runtime.getEntityById(entityId)),
+		const entities = await mapWithConcurrency(
+			entityIds,
+			MAX_CONCURRENT_ENTITY_LOOKUPS,
+			(entityId) => runtime.getEntityById(entityId),
 		);
 		const entityMap = new Map<UUID, (typeof entities)[number]>();
 		for (let i = 0; i < entityIds.length; i += 1) {

--- a/packages/core/src/utils/bounded-map.test.ts
+++ b/packages/core/src/utils/bounded-map.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Pins mapWithConcurrency's admission bound, ordering, and failure
+ * propagation. Deterministic: in-flight calls are released by explicit
+ * resolvers rather than timers.
+ */
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "./bounded-map.ts";
+
+function gate() {
+	const releases: Array<() => void> = [];
+	return {
+		hold: () =>
+			new Promise<void>((resolve) => {
+				releases.push(resolve);
+			}),
+		releaseAll: async () => {
+			while (releases.length > 0) {
+				releases.shift()?.();
+				await Promise.resolve();
+			}
+		},
+		pending: () => releases.length,
+	};
+}
+
+describe("mapWithConcurrency", () => {
+	it("never admits more than the limit and keeps input order", async () => {
+		const g = gate();
+		let inFlight = 0;
+		let peak = 0;
+		const items = Array.from({ length: 23 }, (_unused, i) => i);
+		const run = mapWithConcurrency(items, 4, async (item) => {
+			inFlight += 1;
+			peak = Math.max(peak, inFlight);
+			await g.hold();
+			inFlight -= 1;
+			return item * 10;
+		});
+		// Let the workers start; only the first `limit` calls may be waiting.
+		await Promise.resolve();
+		expect(g.pending()).toBe(4);
+		while (inFlight > 0 || g.pending() > 0) {
+			await g.releaseAll();
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		const results = await run;
+		expect(peak).toBe(4);
+		expect(results).toEqual(items.map((i) => i * 10));
+	});
+
+	it("returns an empty array for an empty input without calling fn", async () => {
+		let calls = 0;
+		const results = await mapWithConcurrency([], 3, async () => {
+			calls += 1;
+			return 1;
+		});
+		expect(results).toEqual([]);
+		expect(calls).toBe(0);
+	});
+
+	it("uses fewer workers than the limit when the input is shorter", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		const results = await mapWithConcurrency([1, 2], 8, async (item) => {
+			inFlight += 1;
+			peak = Math.max(peak, inFlight);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			inFlight -= 1;
+			return item;
+		});
+		expect(results).toEqual([1, 2]);
+		expect(peak).toBe(2);
+	});
+
+	it("rejects with the first failure and stops admitting new items", async () => {
+		const started: number[] = [];
+		const run = mapWithConcurrency([0, 1, 2, 3, 4, 5], 2, async (item) => {
+			started.push(item);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			if (item === 1) {
+				throw new Error(`item ${item} failed`);
+			}
+			return item;
+		});
+		await expect(run).rejects.toThrow("item 1 failed");
+		// Items 0 and 1 were admitted first; the worker that hit the failure
+		// stops, and the surviving worker drains at most what it had claimed.
+		expect(started).not.toContain(5);
+	});
+
+	it("rejects a non-positive or fractional limit", async () => {
+		await expect(mapWithConcurrency([1], 0, async (x) => x)).rejects.toThrow(
+			RangeError,
+		);
+		await expect(mapWithConcurrency([1], 1.5, async (x) => x)).rejects.toThrow(
+			RangeError,
+		);
+	});
+});

--- a/packages/core/src/utils/bounded-map.test.ts
+++ b/packages/core/src/utils/bounded-map.test.ts
@@ -36,8 +36,8 @@ describe("mapWithConcurrency", () => {
 			inFlight -= 1;
 			return item * 10;
 		});
-		// Let the workers start; only the first `limit` calls may be waiting.
-		await Promise.resolve();
+		// The first `limit` calls are admitted synchronously; no more until one
+		// of them settles.
 		expect(g.pending()).toBe(4);
 		while (inFlight > 0 || g.pending() > 0) {
 			await g.releaseAll();
@@ -72,20 +72,64 @@ describe("mapWithConcurrency", () => {
 		expect(peak).toBe(2);
 	});
 
-	it("rejects with the first failure and stops admitting new items", async () => {
-		const started: number[] = [];
-		const run = mapWithConcurrency([0, 1, 2, 3, 4, 5], 2, async (item) => {
-			started.push(item);
-			await new Promise((resolve) => setTimeout(resolve, 0));
-			if (item === 1) {
+	it("rejects as soon as one item fails, without waiting for a sibling still in flight", async () => {
+		const g = gate();
+		const started: string[] = [];
+		let siblingSettled = false;
+		const run = mapWithConcurrency(
+			["held", "failing", "never-admitted"],
+			2,
+			async (item) => {
+				started.push(item);
+				if (item === "held") {
+					await g.hold();
+					siblingSettled = true;
+					return item;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				throw new Error(`${item} failed`);
+			},
+		);
+
+		// The map must reject while the sibling is still held at the gate.
+		await expect(run).rejects.toThrow("failing failed");
+		expect(siblingSettled).toBe(false);
+		expect(g.pending()).toBe(1);
+		expect(started).toEqual(["held", "failing"]);
+
+		// Releasing the sibling afterwards admits nothing further and surfaces
+		// no second error.
+		await g.releaseAll();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(siblingSettled).toBe(true);
+		expect(started).toEqual(["held", "failing"]);
+	});
+
+	it("drops a later rejection from an item admitted before the first failure", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const run = mapWithConcurrency([1, 2], 2, async (item) => {
+				await new Promise((resolve) => setTimeout(resolve, item));
 				throw new Error(`item ${item} failed`);
-			}
-			return item;
-		});
-		await expect(run).rejects.toThrow("item 1 failed");
-		// Items 0 and 1 were admitted first; the worker that hit the failure
-		// stops, and the surviving worker drains at most what it had claimed.
-		expect(started).not.toContain(5);
+			});
+			await expect(run).rejects.toThrow("item 1 failed");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
+
+	it("rejects when fn throws synchronously", async () => {
+		await expect(
+			mapWithConcurrency([1], 2, () => {
+				throw new Error("sync boom");
+			}),
+		).rejects.toThrow("sync boom");
 	});
 
 	it("rejects a non-positive or fractional limit", async () => {

--- a/packages/core/src/utils/bounded-map.ts
+++ b/packages/core/src/utils/bounded-map.ts
@@ -3,9 +3,9 @@
  * `Promise.all(items.map(fn))` admits every element at once, so the input
  * length decides how many lookups run simultaneously; callers that resolve one
  * database row per item use this to keep that number fixed. Results keep the
- * input order, and the first rejection rejects the whole map after the
- * workers already in flight settle, matching `Promise.all` semantics closely
- * enough for callers that treat one failure as total.
+ * input order. The first rejection rejects the map immediately and stops
+ * further admission, matching `Promise.all`'s prompt failure; items already in
+ * flight run to completion and their outcomes are dropped.
  */
 
 /**
@@ -13,49 +13,70 @@
  * Returns results in input order. Throws a `RangeError` for a non-positive or
  * non-integer `limit`.
  */
-export async function mapWithConcurrency<T, R>(
+export function mapWithConcurrency<T, R>(
 	items: ReadonlyArray<T>,
 	limit: number,
 	fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
 	if (!Number.isInteger(limit) || limit < 1) {
-		throw new RangeError(
-			`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+		return Promise.reject(
+			new RangeError(
+				`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+			),
 		);
 	}
 	const results: R[] = new Array(items.length);
 	if (items.length === 0) {
-		return results;
+		return Promise.resolve(results);
 	}
-	let nextIndex = 0;
-	const state: { failure: { error: unknown } | null } = { failure: null };
-	const worker = async (): Promise<void> => {
-		while (state.failure === null) {
-			// No await sits between the read and the increment, so each worker
-			// claims a distinct index in the single-threaded loop.
-			const index = nextIndex++;
-			if (index >= items.length) {
+	return new Promise<R[]>((resolve, reject) => {
+		let nextIndex = 0;
+		let inFlight = 0;
+		let settled = false;
+
+		const fail = (error: unknown): void => {
+			if (settled) {
+				// error-policy:J5 the map already rejected with the first failure;
+				// a later rejection from an item admitted before it is observed
+				// here and dropped so it cannot surface as an unhandled rejection.
 				return;
 			}
-			try {
-				results[index] = await fn(items[index], index);
-			} catch (error) {
-				// error-policy:J2 remember the first failure so the map rejects with it once in-flight workers settle
-				if (state.failure === null) {
-					state.failure = { error };
+			settled = true;
+			reject(error);
+		};
+
+		const admit = (): void => {
+			while (!settled && inFlight < limit && nextIndex < items.length) {
+				const index = nextIndex++;
+				inFlight += 1;
+				let pending: Promise<R>;
+				try {
+					pending = fn(items[index], index);
+				} catch (error) {
+					inFlight -= 1;
+					fail(error);
+					return;
 				}
-				return;
+				pending.then(
+					(value) => {
+						inFlight -= 1;
+						if (settled) return;
+						results[index] = value;
+						if (nextIndex >= items.length && inFlight === 0) {
+							settled = true;
+							resolve(results);
+							return;
+						}
+						admit();
+					},
+					(error: unknown) => {
+						inFlight -= 1;
+						fail(error);
+					},
+				);
 			}
-		}
-	};
-	const workers: Array<Promise<void>> = [];
-	const workerCount = Math.min(limit, items.length);
-	for (let i = 0; i < workerCount; i += 1) {
-		workers.push(worker());
-	}
-	await Promise.all(workers);
-	if (state.failure !== null) {
-		throw state.failure.error;
-	}
-	return results;
+		};
+
+		admit();
+	});
 }

--- a/packages/core/src/utils/bounded-map.ts
+++ b/packages/core/src/utils/bounded-map.ts
@@ -1,0 +1,61 @@
+/**
+ * Bounded-concurrency map for fan-out over caller-controlled lists. A plain
+ * `Promise.all(items.map(fn))` admits every element at once, so the input
+ * length decides how many lookups run simultaneously; callers that resolve one
+ * database row per item use this to keep that number fixed. Results keep the
+ * input order, and the first rejection rejects the whole map after the
+ * workers already in flight settle, matching `Promise.all` semantics closely
+ * enough for callers that treat one failure as total.
+ */
+
+/**
+ * Maps `items` through `fn` with at most `limit` calls in flight at once.
+ * Returns results in input order. Throws a `RangeError` for a non-positive or
+ * non-integer `limit`.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: ReadonlyArray<T>,
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	if (!Number.isInteger(limit) || limit < 1) {
+		throw new RangeError(
+			`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+		);
+	}
+	const results: R[] = new Array(items.length);
+	if (items.length === 0) {
+		return results;
+	}
+	let nextIndex = 0;
+	const state: { failure: { error: unknown } | null } = { failure: null };
+	const worker = async (): Promise<void> => {
+		while (state.failure === null) {
+			// No await sits between the read and the increment, so each worker
+			// claims a distinct index in the single-threaded loop.
+			const index = nextIndex++;
+			if (index >= items.length) {
+				return;
+			}
+			try {
+				results[index] = await fn(items[index], index);
+			} catch (error) {
+				// error-policy:J2 remember the first failure so the map rejects with it once in-flight workers settle
+				if (state.failure === null) {
+					state.failure = { error };
+				}
+				return;
+			}
+		}
+	};
+	const workers: Array<Promise<void>> = [];
+	const workerCount = Math.min(limit, items.length);
+	for (let i = 0; i < workerCount; i += 1) {
+		workers.push(worker());
+	}
+	await Promise.all(workers);
+	if (state.failure !== null) {
+		throw state.failure.error;
+	}
+	return results;
+}


### PR DESCRIPTION
# Relates to

Closes #30896. **Stacked on #30895:** the first two commits on this branch are #30895's commits cherry-picked by identity (they add `mapWithConcurrency`); only the last commit is this PR's change. Once #30895 merges, a rebase drops those two commits automatically and this diff shrinks to the two providers and their tests.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` plus the two #30895 commits, zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `33d46884adb` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `33d46884adb`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. Two `Promise.all` fan-outs become bounded maps with the same eight-worker admission the follow-ups provider uses in #30895. Results keep input order and the providers' text, values, and data are byte-for-byte what they were; the existing contacts cases pass unchanged.

# Background

## What does this PR do?

`advancedContactsProvider` resolved every contact returned by `RelationshipsService.searchContacts` through one `Promise.all` of `getEntityById`, and `roleProvider` did the same over every entity in the world's role map. Both run as prompt-context providers on ordinary turns, so a large contact set or a large group admitted one concurrent database read per entity. Both now resolve through `mapWithConcurrency` with a fixed bound of eight, the same class of fix as #30731 / #30895.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

The two call sites (`contacts.ts`, `roles.ts`), then the gated cases: one appended to `contacts.test.ts` and a new `roles.test.ts`. Each holds every `getEntityById` at an explicit gate, drains it, and asserts a peak of eight in-flight lookups over 64 entities while every entity is still named in the output.

## Detailed testing steps

From `packages/core`:

```bash
bunx vitest run src/features/advanced-capabilities/providers/contacts.test.ts src/features/advanced-capabilities/providers/roles.test.ts src/features/advanced-capabilities/providers/followUps.test.ts src/utils/bounded-map.test.ts   # 4 files, 15 passed
bun run lint:check   # exit 0
bun run typecheck    # exit 0
```

Negative control: with `git show origin/develop:.../contacts.ts` and `.../roles.ts` swapped in and the head tests kept, both gated cases fail with `expected 64 to be 8` (the unbounded fan-out admits all 64 at once); the four other cases pass.

# Evidence Gate

<!-- evidence-head:33d46884adb2d7836e74668a31c0597d64af7672 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - prompt-context provider concurrency, no rendered surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - prompt-context provider concurrency, no rendered surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the observable effect is the number of simultaneous entity reads, measured directly by the gated cases
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real providers with gated lookups:
  <details><summary>Head 33d46884adb2d7836e74668a31c0597d64af7672</summary>

  ```text
  packages/core: bunx vitest run contacts.test.ts roles.test.ts followUps.test.ts bounded-map.test.ts
   Test Files  4 passed (4)   Tests  15 passed (15)
  negative control (develop contacts.ts + roles.ts, head tests):
   × bounds concurrent entity lookups while still naming every contact (#30896)   AssertionError: expected 64 to be 8
   × bounds concurrent entity lookups while still listing every role holder (#30896)   AssertionError: expected 64 to be 8
   Tests  2 failed | 4 passed (6)
  bun run lint:check: exit 0
  bun run typecheck: exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - the providers' rendered text is unchanged; no model call is affected
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted artifact; the output is provider text and values, asserted unchanged
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment). The branch carries #30895's two commits until that PR merges (see the top of this description). No other gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
