### PR TITLE
fix(local-inference): resume a model download only when the 206 Content-Range starts at the partial (#30939)

### DIFF
--- a/packages/ui/src/services/local-inference/downloader.content-range.test.ts
+++ b/packages/ui/src/services/local-inference/downloader.content-range.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Pins the Content-Range parser the UI model downloader uses to decide whether
+ * a 206 actually continues a partial file. Pure function, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { contentRangeStart } from "./downloader";
+
+describe("contentRangeStart", () => {
+  it("reads the start offset of a well-formed Content-Range", () => {
+    expect(contentRangeStart("bytes 17-1023/1024")).toBe(17);
+    expect(contentRangeStart("bytes 0-1023/1024")).toBe(0);
+    expect(contentRangeStart("bytes 5-9/*")).toBe(5);
+    expect(contentRangeStart(["bytes 42-99/100"])).toBe(42);
+    expect(contentRangeStart("  BYTES 3-4/5 ")).toBe(3);
+  });
+
+  it("treats a missing or malformed header as not honored", () => {
+    expect(contentRangeStart(undefined)).toBeNull();
+    expect(contentRangeStart([])).toBeNull();
+    expect(contentRangeStart("")).toBeNull();
+    expect(contentRangeStart("bytes */1024")).toBeNull();
+    expect(contentRangeStart("bytes=17-")).toBeNull();
+    expect(contentRangeStart("items 0-9/10")).toBeNull();
+  });
+});

--- a/packages/ui/src/services/local-inference/downloader.ts
+++ b/packages/ui/src/services/local-inference/downloader.ts
@@ -289,6 +289,24 @@ async function partialSize(stagingPath: string): Promise<number> {
   }
 }
 
+/**
+ * Start offset a 206 Partial Content response actually covers, from its
+ * Content-Range header (`bytes <start>-<end>/<size>`). Returns null when the
+ * header is missing or malformed, which a resume must treat as "not honored":
+ * RFC 7233 requires Content-Range on every 206, and the header, not the status
+ * code, states which bytes were sent (#30939).
+ */
+export function contentRangeStart(
+  header: string | string[] | undefined,
+): number | null {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (typeof value !== "string") return null;
+  const match = /^bytes\s+(\d+)-(\d+)\/(?:\d+|\*)$/i.exec(value.trim());
+  if (!match) return null;
+  const start = Number.parseInt(match[1], 10);
+  return Number.isFinite(start) ? start : null;
+}
+
 export class Downloader {
   private readonly active = new Map<string, ActiveJob>();
   private readonly terminal = new Map<string, DownloadJob>();
@@ -535,7 +553,12 @@ export class Downloader {
         );
       }
       let effectiveStartByte = startByte;
-      if (effectiveStartByte > 0 && response.statusCode !== 206) {
+      if (
+        effectiveStartByte > 0 &&
+        (response.statusCode !== 206 ||
+          contentRangeStart(response.headers["content-range"]) !==
+            effectiveStartByte)
+      ) {
         effectiveStartByte = 0;
         record.job.received = 0;
       }
@@ -829,7 +852,11 @@ export class Downloader {
         `HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}/${remotePath}`,
       );
     }
-    if (startByte > 0 && response.statusCode !== 206) {
+    if (
+      startByte > 0 &&
+      (response.statusCode !== 206 ||
+        contentRangeStart(response.headers["content-range"]) !== startByte)
+    ) {
       startByte = 0;
       record.job.received = baseBytes;
     }

--- a/packages/ui/src/services/local-inference/downloader.ts
+++ b/packages/ui/src/services/local-inference/downloader.ts
@@ -307,6 +307,58 @@ export function contentRangeStart(
   return Number.isFinite(start) ? start : null;
 }
 
+type ResumeDecision = "continue" | "restart" | "refetch";
+
+/**
+ * What to do with the response to a `Range: bytes=<startByte>-` request.
+ * `continue` appends the body to the partial: a 206 whose Content-Range starts
+ * at the partial, or a 206 without a usable Content-Range, which is trusted
+ * the way it always was. `restart` truncates and writes the body from byte
+ * zero, which is only safe when the body actually starts there: a 200 (the
+ * whole entity) or a 206 reporting `bytes 0-`. `refetch` covers every other
+ * 206: its start is neither the partial nor zero, so the body cannot be
+ * placed and must be discarded in favour of a fresh unranged request.
+ */
+function resumeDecision(
+  response: {
+    statusCode: number;
+    headers: Record<string, string | string[] | undefined>;
+  },
+  startByte: number,
+): ResumeDecision {
+  if (startByte <= 0) return "continue";
+  if (response.statusCode !== 206) return "restart";
+  const start = contentRangeStart(response.headers["content-range"]);
+  if (start === null || start === startByte) return "continue";
+  return start === 0 ? "restart" : "refetch";
+}
+
+/** Release a response body without reading it into the staging file. */
+async function discardBody(body: AsyncIterable<Buffer>): Promise<void> {
+  const iterator = body[Symbol.asyncIterator]();
+  await iterator.return?.();
+}
+
+/**
+ * An unranged request must yield the whole entity. A 206 that still reports
+ * a non-zero start is an origin defect this downloader cannot place, so it
+ * fails closed instead of writing the bytes at offset zero.
+ */
+function assertWholeEntity(
+  response: {
+    statusCode: number;
+    headers: Record<string, string | string[] | undefined>;
+  },
+  remotePath: string,
+): void {
+  if (response.statusCode !== 206) return;
+  const start = contentRangeStart(response.headers["content-range"]);
+  if (start === null || start === 0) return;
+  throw new Error(
+    `Model hub answered an unranged request for ${remotePath} with bytes from offset ${start}`,
+  );
+}
+
 export class Downloader {
   private readonly active = new Map<string, ActiveJob>();
   private readonly terminal = new Map<string, DownloadJob>();
@@ -541,7 +593,7 @@ export class Downloader {
         headers.range = `bytes=${startByte}-`;
       }
 
-      const response = await httpClient.request(url, {
+      let response = await httpClient.request(url, {
         method: "GET",
         headers,
         signal: record.abortController.signal,
@@ -553,12 +605,23 @@ export class Downloader {
         );
       }
       let effectiveStartByte = startByte;
-      if (
-        effectiveStartByte > 0 &&
-        (response.statusCode !== 206 ||
-          contentRangeStart(response.headers["content-range"]) !==
-            effectiveStartByte)
-      ) {
+      const decision = resumeDecision(response, effectiveStartByte);
+      if (decision === "refetch") {
+        await discardBody(response.body);
+        delete headers.range;
+        response = await httpClient.request(url, {
+          method: "GET",
+          headers,
+          signal: record.abortController.signal,
+        });
+        if (response.statusCode >= 400) {
+          throw new Error(
+            `HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}`,
+          );
+        }
+        assertWholeEntity(response, catalogEntry.ggufFile);
+      }
+      if (decision !== "continue") {
         effectiveStartByte = 0;
         record.job.received = 0;
       }
@@ -841,7 +904,7 @@ export class Downloader {
 
     const httpClient = await this.loadHttpClient();
     const url = buildHuggingFaceResolveUrlForPath(catalogEntry, remotePath);
-    const response = await httpClient.request(url, {
+    let response = await httpClient.request(url, {
       method: "GET",
       headers,
       signal: record.abortController.signal,
@@ -852,11 +915,23 @@ export class Downloader {
         `HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}/${remotePath}`,
       );
     }
-    if (
-      startByte > 0 &&
-      (response.statusCode !== 206 ||
-        contentRangeStart(response.headers["content-range"]) !== startByte)
-    ) {
+    const decision = resumeDecision(response, startByte);
+    if (decision === "refetch") {
+      await discardBody(response.body);
+      delete headers.range;
+      response = await httpClient.request(url, {
+        method: "GET",
+        headers,
+        signal: record.abortController.signal,
+      });
+      if (response.statusCode >= 400) {
+        throw new Error(
+          `HTTP ${response.statusCode} from model hub for ${catalogEntry.hfRepo}/${remotePath}`,
+        );
+      }
+      assertWholeEntity(response, remotePath);
+    }
+    if (decision !== "continue") {
       startByte = 0;
       record.job.received = baseBytes;
     }

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -249,14 +249,20 @@ function installRangeAwareFetchFixture(
 		 * `honor` answers a Range request with the requested tail (the
 		 * HuggingFace CDN); `clamp-to-zero` answers 206 with the whole file and
 		 * `Content-Range: bytes 0-…`, the way a proxy that ignores the requested
-		 * offset but still reports partial content does (#30939).
+		 * offset but still reports partial content does; `honor-no-cr` sends the
+		 * correct tail as a 206 without any Content-Range header; `block-aligned`
+		 * answers from eight bytes before the requested offset, the way a range
+		 * cache that aligns down does (#30939).
 		 */
-		rangeMode?: "honor" | "clamp-to-zero";
+		rangeMode?: "honor" | "clamp-to-zero" | "honor-no-cr" | "block-aligned";
 	} = {},
 ): {
 	rangeRequests: Map<string, string[]>;
+	/** Bytes actually read from each 206 body, in request order, per path. */
+	rangeBodyReads: Map<string, number[]>;
 } {
 	const rangeRequests = new Map<string, string[]>();
+	const rangeBodyReads = new Map<string, number[]>();
 	const rangeMode = options.rangeMode ?? "honor";
 	globalThis.fetch = vi.fn(
 		async (url: string | URL | Request, init?: RequestInit) => {
@@ -273,7 +279,12 @@ function installRangeAwareFetchFixture(
 				rangeRequests.set(remotePath, seen);
 				const match = /^bytes=(\d+)-$/.exec(range);
 				const requestedStart = match?.[1] ? Number.parseInt(match[1], 10) : 0;
-				const start = rangeMode === "clamp-to-zero" ? 0 : requestedStart;
+				const start =
+					rangeMode === "clamp-to-zero"
+						? 0
+						: rangeMode === "block-aligned"
+							? Math.max(0, requestedStart - 8)
+							: requestedStart;
 				const buf = Buffer.from(body);
 				if (start >= buf.length) {
 					return new Response("range not satisfiable", {
@@ -282,11 +293,31 @@ function installRangeAwareFetchFixture(
 					});
 				}
 				const tail = buf.subarray(start);
-				return new Response(tail, {
+				const reads = rangeBodyReads.get(remotePath) ?? [];
+				const readIndex = reads.push(0) - 1;
+				rangeBodyReads.set(remotePath, reads);
+				const counted = new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(new Uint8Array(tail));
+						controller.close();
+					},
+				}).pipeThrough(
+					new TransformStream<Uint8Array, Uint8Array>({
+						transform(chunk, controller) {
+							reads[readIndex] += chunk.length;
+							controller.enqueue(chunk);
+						},
+					}),
+				);
+				return new Response(counted, {
 					status: 206,
 					headers: {
 						"content-length": String(tail.length),
-						"content-range": `bytes ${start}-${buf.length - 1}/${buf.length}`,
+						...(rangeMode === "honor-no-cr"
+							? {}
+							: {
+									"content-range": `bytes ${start}-${buf.length - 1}/${buf.length}`,
+								}),
 					},
 				});
 			}
@@ -296,7 +327,7 @@ function installRangeAwareFetchFixture(
 			});
 		},
 	) as unknown as typeof fetch;
-	return { rangeRequests };
+	return { rangeRequests, rangeBodyReads };
 }
 
 async function startRangeServer(files: Map<string, string>): Promise<{
@@ -1481,6 +1512,88 @@ describe("local inference downloader stale-content robustness", () => {
 		).toBe(freshBundleBytes.text);
 		const main = readOwnedRegistryModels().find((m) => m.id === model.id);
 		expect(main?.sha256).toBe(sha256(freshBundleBytes.text));
+	});
+
+	it("keeps resuming a 206 that omits Content-Range, as before (#30939)", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		const model = findCatalogModel("eliza-1-2b");
+		if (!model) throw new Error("missing test catalog model");
+		const { rangeRequests } = installRangeAwareFetchFixture(
+			freshBundleFixtureFiles(),
+			{ rangeMode: "honor-no-cr" },
+		);
+		const prefixLen = 17;
+		const textPart = eliza1StagingPartPath(root, CANONICAL_TEXT_PATH);
+		fs.mkdirSync(path.dirname(textPart), { recursive: true });
+		fs.writeFileSync(textPart, freshBundleBytes.text.slice(0, prefixLen));
+		fs.writeFileSync(`${textPart}.expected`, sha256(freshBundleBytes.text));
+
+		const downloader = new Downloader({
+			probeDeviceCaps: async () => cpuOnlyCaps,
+		});
+		const completed = waitForTerminal(downloader, model.id);
+		await downloader.start(model.id);
+		const job = await completed;
+
+		expect(job.state).toBe("completed");
+		// One Range request, appended, no second fetch.
+		expect(
+			rangeRequests.get(eliza1BundleRemotePath(CANONICAL_TEXT_PATH)),
+		).toEqual([`bytes=${prefixLen}-`]);
+		const textFetches = (
+			globalThis.fetch as ReturnType<typeof vi.fn>
+		).mock.calls.filter(
+			([url]) =>
+				remotePathOf(url as string | URL | Request) ===
+				eliza1BundleRemotePath(CANONICAL_TEXT_PATH),
+		);
+		expect(textFetches).toHaveLength(1);
+		expect(
+			fs.readFileSync(eliza1BundleFinalPath(root, CANONICAL_TEXT_PATH), "utf8"),
+		).toBe(freshBundleBytes.text);
+	});
+
+	it("never writes a 206 body whose Content-Range starts below the partial; it refetches unranged (#30939)", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		const model = findCatalogModel("eliza-1-2b");
+		if (!model) throw new Error("missing test catalog model");
+		const { rangeRequests, rangeBodyReads } = installRangeAwareFetchFixture(
+			freshBundleFixtureFiles(),
+			{ rangeMode: "block-aligned" },
+		);
+		const prefixLen = 17;
+		const textPart = eliza1StagingPartPath(root, CANONICAL_TEXT_PATH);
+		fs.mkdirSync(path.dirname(textPart), { recursive: true });
+		fs.writeFileSync(textPart, freshBundleBytes.text.slice(0, prefixLen));
+		fs.writeFileSync(`${textPart}.expected`, sha256(freshBundleBytes.text));
+
+		const downloader = new Downloader({
+			probeDeviceCaps: async () => cpuOnlyCaps,
+		});
+		const completed = waitForTerminal(downloader, model.id);
+		await downloader.start(model.id);
+		const job = await completed;
+
+		expect(job.state).toBe("completed");
+		const remotePath = eliza1BundleRemotePath(CANONICAL_TEXT_PATH);
+		// The origin answered `bytes 9-` to a request for 17-: that body was
+		// discarded unread and the file was fetched once more without a Range.
+		expect(rangeRequests.get(remotePath)).toEqual([`bytes=${prefixLen}-`]);
+		expect(rangeBodyReads.get(remotePath)).toEqual([0]);
+		const textFetches = (
+			globalThis.fetch as ReturnType<typeof vi.fn>
+		).mock.calls.filter(
+			([url]) => remotePathOf(url as string | URL | Request) === remotePath,
+		);
+		expect(textFetches).toHaveLength(2);
+		const secondHeaders = (textFetches[1]?.[1] as RequestInit | undefined)
+			?.headers as Record<string, string> | undefined;
+		expect(secondHeaders?.range).toBeUndefined();
+		expect(
+			fs.readFileSync(eliza1BundleFinalPath(root, CANONICAL_TEXT_PATH), "utf8"),
+		).toBe(freshBundleBytes.text);
 	});
 
 	it("still range-resumes a valid .part recorded against the current manifest sha", async () => {

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -242,10 +242,22 @@ function installFetchFixture(files: Map<string, string>): void {
  * Returns the ranges each remote path was requested with, so tests can assert
  * resume-vs-fresh behavior.
  */
-function installRangeAwareFetchFixture(files: Map<string, string>): {
+function installRangeAwareFetchFixture(
+	files: Map<string, string>,
+	options: {
+		/**
+		 * `honor` answers a Range request with the requested tail (the
+		 * HuggingFace CDN); `clamp-to-zero` answers 206 with the whole file and
+		 * `Content-Range: bytes 0-…`, the way a proxy that ignores the requested
+		 * offset but still reports partial content does (#30939).
+		 */
+		rangeMode?: "honor" | "clamp-to-zero";
+	} = {},
+): {
 	rangeRequests: Map<string, string[]>;
 } {
 	const rangeRequests = new Map<string, string[]>();
+	const rangeMode = options.rangeMode ?? "honor";
 	globalThis.fetch = vi.fn(
 		async (url: string | URL | Request, init?: RequestInit) => {
 			const remotePath = remotePathOf(url);
@@ -260,7 +272,8 @@ function installRangeAwareFetchFixture(files: Map<string, string>): {
 				seen.push(range);
 				rangeRequests.set(remotePath, seen);
 				const match = /^bytes=(\d+)-$/.exec(range);
-				const start = match?.[1] ? Number.parseInt(match[1], 10) : 0;
+				const requestedStart = match?.[1] ? Number.parseInt(match[1], 10) : 0;
+				const start = rangeMode === "clamp-to-zero" ? 0 : requestedStart;
 				const buf = Buffer.from(body);
 				if (start >= buf.length) {
 					return new Response("range not satisfiable", {
@@ -1419,6 +1432,55 @@ describe("local inference downloader stale-content robustness", () => {
 		// No staging residue (part or sidecar) left behind.
 		expect(fs.existsSync(textPart)).toBe(false);
 		expect(fs.existsSync(`${textPart}.expected`)).toBe(false);
+	});
+
+	it("restarts from byte zero when a 206 reports a Content-Range that does not start at the partial (#30939)", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-download-test-"));
+		process.env.ELIZA_STATE_DIR = root;
+		const model = findCatalogModel("eliza-1-2b");
+		if (!model) throw new Error("missing test catalog model");
+		const { rangeRequests } = installRangeAwareFetchFixture(
+			freshBundleFixtureFiles(),
+			{ rangeMode: "clamp-to-zero" },
+		);
+
+		// A genuine interrupted download of the CURRENT content, exactly as in
+		// the valid-resume case above; only the origin differs.
+		const prefixLen = 17;
+		const textPart = eliza1StagingPartPath(root, CANONICAL_TEXT_PATH);
+		fs.mkdirSync(path.dirname(textPart), { recursive: true });
+		fs.writeFileSync(textPart, freshBundleBytes.text.slice(0, prefixLen));
+		fs.writeFileSync(`${textPart}.expected`, sha256(freshBundleBytes.text));
+
+		const downloader = new Downloader({
+			probeDeviceCaps: async () => cpuOnlyCaps,
+		});
+		const completed = waitForTerminal(downloader, model.id);
+		await downloader.start(model.id);
+		const job = await completed;
+
+		expect(job.state).toBe("completed");
+		// The resume was attempted from the partial's offset ...
+		expect(
+			rangeRequests.get(eliza1BundleRemotePath(CANONICAL_TEXT_PATH)),
+		).toEqual([`bytes=${prefixLen}-`]);
+		// ... but the 206 covered bytes 0-, so that one response was written
+		// from byte zero instead of appended onto the partial. Without the
+		// Content-Range check the appended file fails its hash and the whole
+		// file is fetched a second time, so exactly one request is the pin.
+		const textFetches = (
+			globalThis.fetch as ReturnType<typeof vi.fn>
+		).mock.calls.filter(
+			([url]) =>
+				remotePathOf(url as string | URL | Request) ===
+				eliza1BundleRemotePath(CANONICAL_TEXT_PATH),
+		);
+		expect(textFetches).toHaveLength(1);
+		expect(
+			fs.readFileSync(eliza1BundleFinalPath(root, CANONICAL_TEXT_PATH), "utf8"),
+		).toBe(freshBundleBytes.text);
+		const main = readOwnedRegistryModels().find((m) => m.id === model.id);
+		expect(main?.sha256).toBe(sha256(freshBundleBytes.text));
 	});
 
 	it("still range-resumes a valid .part recorded against the current manifest sha", async () => {

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -561,6 +561,24 @@ async function promoteCompletePartial(
 	return { path: finalPath, sizeBytes, sha256 };
 }
 
+/**
+ * Start offset a 206 Partial Content response actually covers, from its
+ * Content-Range header (`bytes <start>-<end>/<size>`). Returns null when the
+ * header is missing or malformed, which a resume must treat as "not honored":
+ * RFC 7233 requires Content-Range on every 206, and the header, not the status
+ * code, states which bytes were sent (#30939).
+ */
+export function contentRangeStart(
+	header: string | string[] | undefined,
+): number | null {
+	const value = Array.isArray(header) ? header[0] : header;
+	if (typeof value !== "string") return null;
+	const match = /^bytes\s+(\d+)-(\d+)\/(?:\d+|\*)$/i.exec(value.trim());
+	if (!match) return null;
+	const start = Number.parseInt(match[1], 10);
+	return Number.isFinite(start) ? start : null;
+}
+
 export class Downloader {
 	private readonly active = new Map<string, ActiveJob>();
 	private readonly terminal = new Map<string, DownloadJob>();
@@ -1176,7 +1194,12 @@ export class Downloader {
 					signal: record.abortController.signal,
 				});
 				let effectiveStartByte = startByte;
-				if (effectiveStartByte > 0 && response.statusCode !== 206) {
+				if (
+					effectiveStartByte > 0 &&
+					(response.statusCode !== 206 ||
+						contentRangeStart(response.headers["content-range"]) !==
+							effectiveStartByte)
+				) {
 					effectiveStartByte = 0;
 					record.job.received = 0;
 				}
@@ -1594,7 +1617,11 @@ export class Downloader {
 					headers,
 					signal: record.abortController.signal,
 				});
-				if (startByte > 0 && response.statusCode !== 206) {
+				if (
+					startByte > 0 &&
+					(response.statusCode !== 206 ||
+						contentRangeStart(response.headers["content-range"]) !== startByte)
+				) {
 					startByte = 0;
 					record.job.received = baseBytes;
 				}

--- a/plugins/plugin-local-inference/src/services/downloader.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.ts
@@ -579,6 +579,58 @@ export function contentRangeStart(
 	return Number.isFinite(start) ? start : null;
 }
 
+type ResumeDecision = "continue" | "restart" | "refetch";
+
+/**
+ * What to do with the response to a `Range: bytes=<startByte>-` request.
+ * `continue` appends the body to the partial: a 206 whose Content-Range starts
+ * at the partial, or a 206 without a usable Content-Range, which is trusted
+ * the way it always was. `restart` truncates and writes the body from byte
+ * zero, which is only safe when the body actually starts there: a 200 (the
+ * whole entity) or a 206 reporting `bytes 0-`. `refetch` covers every other
+ * 206: its start is neither the partial nor zero, so the body cannot be
+ * placed and must be discarded in favour of a fresh unranged request.
+ */
+function resumeDecision(
+	response: {
+		statusCode: number;
+		headers: Record<string, string | string[] | undefined>;
+	},
+	startByte: number,
+): ResumeDecision {
+	if (startByte <= 0) return "continue";
+	if (response.statusCode !== 206) return "restart";
+	const start = contentRangeStart(response.headers["content-range"]);
+	if (start === null || start === startByte) return "continue";
+	return start === 0 ? "restart" : "refetch";
+}
+
+/** Release a response body without reading it into the staging file. */
+async function discardBody(body: AsyncIterable<Buffer>): Promise<void> {
+	const iterator = body[Symbol.asyncIterator]();
+	await iterator.return?.();
+}
+
+/**
+ * An unranged request must yield the whole entity. A 206 that still reports
+ * a non-zero start is an origin defect this downloader cannot place, so it
+ * fails closed instead of writing the bytes at offset zero.
+ */
+function assertWholeEntity(
+	response: {
+		statusCode: number;
+		headers: Record<string, string | string[] | undefined>;
+	},
+	remotePath: string,
+): void {
+	if (response.statusCode !== 206) return;
+	const start = contentRangeStart(response.headers["content-range"]);
+	if (start === null || start === 0) return;
+	throw new Error(
+		`Model hub answered an unranged request for ${remotePath} with bytes from offset ${start}`,
+	);
+}
+
 export class Downloader {
 	private readonly active = new Map<string, ActiveJob>();
 	private readonly terminal = new Map<string, DownloadJob>();
@@ -1187,19 +1239,26 @@ export class Downloader {
 					headers.range = `bytes=${startByte}-`;
 				}
 
-				const { response } = await this.requestHubFile({
+				let { response } = await this.requestHubFile({
 					catalogEntry,
 					remotePath: catalogEntry.ggufFile,
 					headers,
 					signal: record.abortController.signal,
 				});
 				let effectiveStartByte = startByte;
-				if (
-					effectiveStartByte > 0 &&
-					(response.statusCode !== 206 ||
-						contentRangeStart(response.headers["content-range"]) !==
-							effectiveStartByte)
-				) {
+				const decision = resumeDecision(response, effectiveStartByte);
+				if (decision === "refetch") {
+					await discardBody(response.body);
+					delete headers.range;
+					({ response } = await this.requestHubFile({
+						catalogEntry,
+						remotePath: catalogEntry.ggufFile,
+						headers,
+						signal: record.abortController.signal,
+					}));
+					assertWholeEntity(response, catalogEntry.ggufFile);
+				}
+				if (decision !== "continue") {
 					effectiveStartByte = 0;
 					record.job.received = 0;
 				}
@@ -1611,17 +1670,25 @@ export class Downloader {
 					headers.range = `bytes=${startByte}-`;
 				}
 
-				const { response } = await this.requestHubFile({
+				let { response } = await this.requestHubFile({
 					catalogEntry,
 					remotePath,
 					headers,
 					signal: record.abortController.signal,
 				});
-				if (
-					startByte > 0 &&
-					(response.statusCode !== 206 ||
-						contentRangeStart(response.headers["content-range"]) !== startByte)
-				) {
+				const decision = resumeDecision(response, startByte);
+				if (decision === "refetch") {
+					await discardBody(response.body);
+					delete headers.range;
+					({ response } = await this.requestHubFile({
+						catalogEntry,
+						remotePath,
+						headers,
+						signal: record.abortController.signal,
+					}));
+					assertWholeEntity(response, remotePath);
+				}
+				if (decision !== "continue") {
 					startByte = 0;
 					record.job.received = baseBytes;
 				}


### PR DESCRIPTION
# Relates to

Closes #30939. Same defect class as #26629 (route downloader, fixed in #30888) and #29456; this PR covers the two service downloaders those did not touch.

- [x] Targets `develop`; branched from `origin/develop` at `357084b3092` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for this base; `RUN_TURBO_CONCURRENCY=4 bun run verify` passed at head `3c948b587ba` (373/373 tasks, exit 0).
- [x] A reviewer can confirm the change from the transcripts below without reading the code.

# Sync with develop

- [x] Branched from the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passed post-sync at head `3c948b587ba`: 373 successful, 373 total, exit 0.

# Provider and Model Disclosure

- **Client:** Claude Code
- **Provider:** Anthropic
- **Model:** claude-fable-5-1
- **Attribution status:** self-reported

# Risks

Low. Each resume site now takes one of three paths. Append, as before, when the 206's `Content-Range` starts at the partial or is absent (a correct tail without the header keeps resuming in one request, pinned). Truncate and write from byte zero only when the body really starts there: a 200, or a 206 reporting `bytes 0-` (the clamping-proxy case). Otherwise the body is discarded unread and the file is re-requested without a `Range` header, so a 206 with an unknown or non-zero start never reaches the staging file.

# Background

## What does this PR do?

`plugins/plugin-local-inference/src/services/downloader.ts` (single-file and bundle paths) and its UI twin `packages/ui/src/services/local-inference/downloader.ts` (consumed by `services/local-inference/service.ts`) each decided whether to append to a partial staging file with `startByte > 0 && response.statusCode !== 206`. A 206 whose `Content-Range` reports `bytes 0-…` with the whole body, which a proxy that clamps or ignores the requested `Range` produces, was therefore appended onto the partial. On the hash-verified bundle path the corrupt file failed its check and the whole file was fetched a second time; on a path with no hash the corrupt file was kept.

Each site now parses `Content-Range` (`contentRangeStart`, the same parser #30888 added to the route downloader) and decides via `resumeDecision`: continue (start equals the partial, or no usable header), restart from zero (200, or start reported as 0), or refetch (any other start: the body is released without being read and the file is requested again without `Range`; a 206 with a non-zero start to that unranged request fails closed).

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

The four guards (search `contentRangeStart(response.headers`), then the three new cases in `plugins/plugin-local-inference/src/services/downloader.test.ts`, which drive the real `Downloader` with a stubbed origin in the new `clamp-to-zero`, `honor-no-cr`, and `block-aligned` range modes (the fixture also counts the bytes read from each 206 body), and the parser cases in `packages/ui/src/services/local-inference/downloader.content-range.test.ts`.

## Detailed testing steps

```bash
# plugins/plugin-local-inference
bunx vitest run src/services/downloader.test.ts   # 31 passed
bun run typecheck && bun run lint:check           # exit 0 / exit 0
# packages/ui
bunx vitest run src/services/local-inference/downloader.content-range.test.ts   # 2 passed
bun run typecheck                                 # exit 0
```

Negative controls with the head tests kept: against `origin/develop`'s `downloader.ts` the clamp-to-zero case fails (two fetches after the hash retry) and the block-aligned case fails (`rangeBodyReads` shows the misaligned tail was read into the file); against this PR's previous head `22dcac70126` the honor-no-cr case fails (two fetches, the regression attentionhead measured) and the block-aligned case fails the same way. All three pass at this head.

The UI downloader has no existing suite; its guard is byte-for-byte the plugin's, and the parser it uses is pinned directly. I did not run the desktop app against a clamping proxy.

# Evidence Gate

<!-- evidence-head:3c948b587ba64f546846352717f75f3b4bf651e4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - download transport logic, no rendered surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - download transport logic, no rendered surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - the user-visible effect is a second full download (or a corrupt model) after an interrupted one; the regression drives the real Downloader against a clamping origin
<!-- evidence-row:backend-logs -->
- [x] Exact-head execution of the real Downloader:
  <details><summary>Head 3c948b587ba64f546846352717f75f3b4bf651e4</summary>

  ```text
  plugins/plugin-local-inference: bunx vitest run src/services/downloader.test.ts
   Tests  31 passed (31)
  negative control (develop downloader.ts + head tests, -t 30939):
   × restarts from byte zero when a 206 reports a Content-Range that does not start at the partial
   × never writes a 206 body whose Content-Range starts below the partial; it refetches unranged
   (honor-no-cr passes on develop, as intended)
  control (previous head 22dcac70126 downloader.ts + head tests):
   × keeps resuming a 206 that omits Content-Range, as before   expected [...] to have a length of 1 but got 2
   × never writes a 206 body whose Content-Range starts below the partial   expected [ 41 ] to deeply equal [ +0 ]
  packages/ui: bunx vitest run src/services/local-inference/downloader.content-range.test.ts -> 2 passed
  plugin typecheck exit 0, lint:check exit 0; ui typecheck exit 0
  RUN_TURBO_CONCURRENCY=4 bun run verify: Tasks 373 successful, 373 total; exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no request, response, or UI state surface
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model call
<!-- evidence-row:domain-artifacts -->
- [x] The staged file is the artifact: after a clamped 206 the installed text model equals the origin bytes and the registry records its hash, with a single request for the file (asserted in the new case).
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Known gaps / failures

Root `bun run verify` at this head: 373 successful, 373 total, exit 0 (posted as a comment). No live proxy run against the desktop app. No other gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvQaGsZkm1nyhxPFYFqaxU
