### PR TITLE
fix(agent): let personal-assistant own composed plugin registration

### DIFF
--- a/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
 import {
   collectPluginNames,
-  orderPersonalAssistantBeforeComposedPlugins,
+  withholdPluginsComposedByPersonalAssistant,
 } from "./plugin-collector.ts";
 
 const PA = "@elizaos/plugin-personal-assistant";
@@ -94,15 +94,14 @@ describe("collectPluginNames personal-assistant host gate (#17023)", () => {
     expect(collectPluginNames(enabledConfig()).has(PA)).toBe(false);
   });
 
-  it("registers the assistant before the calendar and goals plugins it composes (#30943)", () => {
+  it("withholds the standalone calendar and goals entries when the assistant is enabled (#30943)", () => {
     const names = Array.from(collectPluginNames(enabledConfig()));
-    const assistant = names.indexOf(PA);
-    const calendar = names.indexOf("@elizaos/plugin-calendar");
-    expect(assistant).toBeGreaterThanOrEqual(0);
-    expect(calendar).toBeGreaterThanOrEqual(0);
-    expect(assistant).toBeLessThan(calendar);
-    const goals = names.indexOf("@elizaos/plugin-goals");
-    if (goals !== -1) expect(assistant).toBeLessThan(goals);
+    expect(names).toContain(PA);
+    // The assistant's init registers both plugins itself with the composed
+    // CALENDAR, CONFLICT_DETECT, and OWNER_GOALS names withheld; a standalone
+    // entry would register concurrently and win first-wins.
+    expect(names).not.toContain("@elizaos/plugin-calendar");
+    expect(names).not.toContain("@elizaos/plugin-goals");
   });
 
   it("keeps the calendar plugin in place when the assistant is absent", () => {
@@ -112,8 +111,8 @@ describe("collectPluginNames personal-assistant host gate (#17023)", () => {
   });
 });
 
-describe("orderPersonalAssistantBeforeComposedPlugins", () => {
-  it("moves the assistant ahead of the first composed plugin and keeps every other position", () => {
+describe("withholdPluginsComposedByPersonalAssistant", () => {
+  it("removes only the composed plugins and keeps every other position", () => {
     const set = new Set([
       "@elizaos/plugin-sql",
       "@elizaos/plugin-calendar",
@@ -122,27 +121,26 @@ describe("orderPersonalAssistantBeforeComposedPlugins", () => {
       PA,
       "@elizaos/plugin-finances",
     ]);
-    orderPersonalAssistantBeforeComposedPlugins(set);
+    const tracked: string[] = [];
+    withholdPluginsComposedByPersonalAssistant(set, (name) => {
+      tracked.push(name);
+    });
     expect(Array.from(set)).toEqual([
       "@elizaos/plugin-sql",
-      PA,
-      "@elizaos/plugin-calendar",
       "@elizaos/plugin-scheduling",
-      "@elizaos/plugin-goals",
+      PA,
       "@elizaos/plugin-finances",
+    ]);
+    expect(tracked).toEqual([
+      "@elizaos/plugin-calendar",
+      "@elizaos/plugin-goals",
     ]);
   });
 
-  it("is a no-op when the assistant already precedes them or is absent", () => {
-    const already = new Set([PA, "@elizaos/plugin-calendar"]);
-    orderPersonalAssistantBeforeComposedPlugins(already);
-    expect(Array.from(already)).toEqual([PA, "@elizaos/plugin-calendar"]);
-    const absent = new Set([
-      "@elizaos/plugin-calendar",
-      "@elizaos/plugin-goals",
-    ]);
-    orderPersonalAssistantBeforeComposedPlugins(absent);
-    expect(Array.from(absent)).toEqual([
+  it("is a no-op when the assistant is absent", () => {
+    const set = new Set(["@elizaos/plugin-calendar", "@elizaos/plugin-goals"]);
+    withholdPluginsComposedByPersonalAssistant(set);
+    expect(Array.from(set)).toEqual([
       "@elizaos/plugin-calendar",
       "@elizaos/plugin-goals",
     ]);

--- a/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
@@ -8,7 +8,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ElizaConfig } from "../config/config.ts";
-import { collectPluginNames } from "./plugin-collector.ts";
+import {
+  collectPluginNames,
+  orderPersonalAssistantBeforeComposedPlugins,
+} from "./plugin-collector.ts";
 
 const PA = "@elizaos/plugin-personal-assistant";
 
@@ -89,5 +92,59 @@ describe("collectPluginNames personal-assistant host gate (#17023)", () => {
   it("stays out of slim provisioned cloud containers (#8081 image constraint)", () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     expect(collectPluginNames(enabledConfig()).has(PA)).toBe(false);
+  });
+
+  it("registers the assistant before the calendar and goals plugins it composes (#30943)", () => {
+    const names = Array.from(collectPluginNames(enabledConfig()));
+    const assistant = names.indexOf(PA);
+    const calendar = names.indexOf("@elizaos/plugin-calendar");
+    expect(assistant).toBeGreaterThanOrEqual(0);
+    expect(calendar).toBeGreaterThanOrEqual(0);
+    expect(assistant).toBeLessThan(calendar);
+    const goals = names.indexOf("@elizaos/plugin-goals");
+    if (goals !== -1) expect(assistant).toBeLessThan(goals);
+  });
+
+  it("keeps the calendar plugin in place when the assistant is absent", () => {
+    const names = Array.from(collectPluginNames(emptyConfig));
+    expect(names).not.toContain(PA);
+    expect(names).toContain("@elizaos/plugin-calendar");
+  });
+});
+
+describe("orderPersonalAssistantBeforeComposedPlugins", () => {
+  it("moves the assistant ahead of the first composed plugin and keeps every other position", () => {
+    const set = new Set([
+      "@elizaos/plugin-sql",
+      "@elizaos/plugin-calendar",
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-goals",
+      PA,
+      "@elizaos/plugin-finances",
+    ]);
+    orderPersonalAssistantBeforeComposedPlugins(set);
+    expect(Array.from(set)).toEqual([
+      "@elizaos/plugin-sql",
+      PA,
+      "@elizaos/plugin-calendar",
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-goals",
+      "@elizaos/plugin-finances",
+    ]);
+  });
+
+  it("is a no-op when the assistant already precedes them or is absent", () => {
+    const already = new Set([PA, "@elizaos/plugin-calendar"]);
+    orderPersonalAssistantBeforeComposedPlugins(already);
+    expect(Array.from(already)).toEqual([PA, "@elizaos/plugin-calendar"]);
+    const absent = new Set([
+      "@elizaos/plugin-calendar",
+      "@elizaos/plugin-goals",
+    ]);
+    orderPersonalAssistantBeforeComposedPlugins(absent);
+    expect(Array.from(absent)).toEqual([
+      "@elizaos/plugin-calendar",
+      "@elizaos/plugin-goals",
+    ]);
   });
 });

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -1081,6 +1081,17 @@ export function collectPluginNames(
  * silently skipped (#30943). Cross-plugin `override` is deliberately
  * neutralized by the plugin lifecycle (#12658), so registration order is the
  * only lever: the assistant must be registered before either plugin.
+ *
+ * Keep this list in step with the names the assistant withholds in
+ * `plugins/plugin-personal-assistant/src/plugin.ts`
+ * (`ensureLifeOpsCalendarPluginRegistered`, `ensureLifeOpsGoalsPluginRegistered`);
+ * `composed-action-order.test.ts` there registers the collector's own order
+ * and fails if a composed name is lost.
+ *
+ * With an app manifest that marks the assistant `requiredForReady` (the Eliza
+ * app), the resolver's phase partition already loads it in the blocking wave
+ * ahead of every deferred plugin, and this reorder is a no-op; it matters for
+ * the manifest-less standalone agent, where both land in one wave.
  */
 const PERSONAL_ASSISTANT_COMPOSED_PLUGINS: readonly string[] = [
   "@elizaos/plugin-calendar",

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -1067,56 +1067,49 @@ export function collectPluginNames(
   // the launcher-owned development Cloud policy.
   if (devCloudAuthority) applyProviderPrecedence();
 
-  orderPersonalAssistantBeforeComposedPlugins(pluginsToLoad);
+  withholdPluginsComposedByPersonalAssistant(pluginsToLoad, track);
   return pluginsToLoad;
 }
 
 /**
  * Plugins whose same-named actions `@elizaos/plugin-personal-assistant`
  * composes itself: CALENDAR and CONFLICT_DETECT from the calendar plugin,
- * OWNER_GOALS from the goals plugin. The assistant withholds those names when
- * its init registers these plugins, but if either is already in the runtime
- * the runtime's first-wins collision policy keeps the standalone action and
- * the composed surface (travel buffers, approval gateway, bulk_reschedule) is
- * silently skipped (#30943). Cross-plugin `override` is deliberately
- * neutralized by the plugin lifecycle (#12658), so registration order is the
- * only lever: the assistant must be registered before either plugin.
- *
- * Keep this list in step with the names the assistant withholds in
- * `plugins/plugin-personal-assistant/src/plugin.ts`
- * (`ensureLifeOpsCalendarPluginRegistered`, `ensureLifeOpsGoalsPluginRegistered`);
- * `composed-action-order.test.ts` there registers the collector's own order
- * and fails if a composed name is lost.
- *
- * With an app manifest that marks the assistant `requiredForReady` (the Eliza
- * app), the resolver's phase partition already loads it in the blocking wave
- * ahead of every deferred plugin, and this reorder is a no-op; it matters for
- * the manifest-less standalone agent, where both land in one wave.
+ * OWNER_GOALS from the goals plugin. The assistant's init registers both
+ * plugins and withholds those names (`ensureLifeOpsCalendarPluginRegistered`,
+ * `ensureLifeOpsGoalsPluginRegistered` in
+ * `plugins/plugin-personal-assistant/src/plugin.ts`), but only when they are
+ * not already in the runtime. `AgentRuntime.initialize` registers the
+ * non-core plugins concurrently, so a standalone calendar or goals entry in
+ * the same load set registers its actions while the assistant's init is still
+ * awaiting, the runtime's first-wins collision policy keeps the standalone
+ * action, and the composed surface (travel buffers, approval gateway,
+ * bulk_reschedule) is silently skipped (#30943). Cross-plugin `override` is
+ * neutralized by the plugin lifecycle (#12658) and array order does not
+ * survive concurrent registration, so the only deterministic lever is to let
+ * the assistant register these plugins itself.
  */
-const PERSONAL_ASSISTANT_COMPOSED_PLUGINS: readonly string[] = [
+const PLUGINS_COMPOSED_BY_PERSONAL_ASSISTANT: readonly string[] = [
   "@elizaos/plugin-calendar",
   "@elizaos/plugin-goals",
 ];
 
 /**
- * Reorder an insertion-ordered load set in place so the personal assistant
- * precedes every plugin whose actions it composes. Membership is unchanged.
+ * Remove the standalone entries for plugins the personal assistant registers
+ * itself, in place, when the assistant is in the load set. Every other entry
+ * is untouched; without the assistant the set is unchanged.
  */
-export function orderPersonalAssistantBeforeComposedPlugins(
+export function withholdPluginsComposedByPersonalAssistant(
   pluginsToLoad: Set<string>,
+  track?: (pluginName: string, reason: string) => void,
 ): void {
-  const assistant = "@elizaos/plugin-personal-assistant";
-  if (!pluginsToLoad.has(assistant)) return;
-  const ordered = Array.from(pluginsToLoad);
-  const firstComposed = ordered.findIndex((name) =>
-    PERSONAL_ASSISTANT_COMPOSED_PLUGINS.includes(name),
-  );
-  const assistantIndex = ordered.indexOf(assistant);
-  if (firstComposed === -1 || assistantIndex < firstComposed) return;
-  ordered.splice(assistantIndex, 1);
-  ordered.splice(firstComposed, 0, assistant);
-  pluginsToLoad.clear();
-  for (const name of ordered) pluginsToLoad.add(name);
+  if (!pluginsToLoad.has("@elizaos/plugin-personal-assistant")) return;
+  for (const name of PLUGINS_COMPOSED_BY_PERSONAL_ASSISTANT) {
+    if (!pluginsToLoad.delete(name)) continue;
+    track?.(
+      name,
+      "registered by plugin-personal-assistant with its composed action names withheld (#30943)",
+    );
+  }
 }
 
 function resolveCloudPluginRequirement(

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -1067,7 +1067,45 @@ export function collectPluginNames(
   // the launcher-owned development Cloud policy.
   if (devCloudAuthority) applyProviderPrecedence();
 
+  orderPersonalAssistantBeforeComposedPlugins(pluginsToLoad);
   return pluginsToLoad;
+}
+
+/**
+ * Plugins whose same-named actions `@elizaos/plugin-personal-assistant`
+ * composes itself: CALENDAR and CONFLICT_DETECT from the calendar plugin,
+ * OWNER_GOALS from the goals plugin. The assistant withholds those names when
+ * its init registers these plugins, but if either is already in the runtime
+ * the runtime's first-wins collision policy keeps the standalone action and
+ * the composed surface (travel buffers, approval gateway, bulk_reschedule) is
+ * silently skipped (#30943). Cross-plugin `override` is deliberately
+ * neutralized by the plugin lifecycle (#12658), so registration order is the
+ * only lever: the assistant must be registered before either plugin.
+ */
+const PERSONAL_ASSISTANT_COMPOSED_PLUGINS: readonly string[] = [
+  "@elizaos/plugin-calendar",
+  "@elizaos/plugin-goals",
+];
+
+/**
+ * Reorder an insertion-ordered load set in place so the personal assistant
+ * precedes every plugin whose actions it composes. Membership is unchanged.
+ */
+export function orderPersonalAssistantBeforeComposedPlugins(
+  pluginsToLoad: Set<string>,
+): void {
+  const assistant = "@elizaos/plugin-personal-assistant";
+  if (!pluginsToLoad.has(assistant)) return;
+  const ordered = Array.from(pluginsToLoad);
+  const firstComposed = ordered.findIndex((name) =>
+    PERSONAL_ASSISTANT_COMPOSED_PLUGINS.includes(name),
+  );
+  const assistantIndex = ordered.indexOf(assistant);
+  if (firstComposed === -1 || assistantIndex < firstComposed) return;
+  ordered.splice(assistantIndex, 1);
+  ordered.splice(firstComposed, 0, assistant);
+  pluginsToLoad.clear();
+  for (const name of ordered) pluginsToLoad.add(name);
 }
 
 function resolveCloudPluginRequirement(

--- a/packages/agent/src/runtime/plugin-resolver.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver.test.ts
@@ -172,13 +172,11 @@ describe("resolvePlugins manifest discovery", () => {
   });
 
   it("the Eliza app manifest marks the personal assistant requiredForReady and leaves the calendar plugin deferred (#30943)", async () => {
-    // With this manifest the assistant loads in the blocking wave and the
-    // calendar and goals plugins in the deferred one (the generic partition is
-    // pinned by "loads a host-manifest readiness plugin in blocking only"), so
-    // the composed CALENDAR, CONFLICT_DETECT, and OWNER_GOALS register first
-    // there without any collector reorder. The reorder in
-    // orderPersonalAssistantBeforeComposedPlugins is for the manifest-less
-    // standalone agent, where both land in one wave.
+    // With this manifest the assistant loads in the blocking wave (the
+    // generic partition is pinned by "loads a host-manifest readiness plugin
+    // in blocking only"); the collector withholds the standalone calendar and
+    // goals entries whenever the assistant is present, so on both hosts the
+    // assistant's init registers them with the composed names withheld.
     const appPackagePath = path.resolve(
       import.meta.dirname,
       "../../../app/package.json",

--- a/packages/agent/src/runtime/plugin-resolver.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver.test.ts
@@ -171,6 +171,39 @@ describe("resolvePlugins manifest discovery", () => {
     }
   });
 
+  it("the Eliza app manifest marks the personal assistant requiredForReady and leaves the calendar plugin deferred (#30943)", async () => {
+    // With this manifest the assistant loads in the blocking wave and the
+    // calendar and goals plugins in the deferred one (the generic partition is
+    // pinned by "loads a host-manifest readiness plugin in blocking only"), so
+    // the composed CALENDAR, CONFLICT_DETECT, and OWNER_GOALS register first
+    // there without any collector reorder. The reorder in
+    // orderPersonalAssistantBeforeComposedPlugins is for the manifest-less
+    // standalone agent, where both land in one wave.
+    const appPackagePath = path.resolve(
+      import.meta.dirname,
+      "../../../app/package.json",
+    );
+    const appPackage = JSON.parse(
+      await fs.readFile(appPackagePath, "utf8"),
+    ) as {
+      elizaos?: {
+        app?: {
+          defaults?: Record<
+            string,
+            { enabled?: boolean; requiredForReady?: boolean }
+          >;
+        };
+      };
+    };
+    const defaults = appPackage.elizaos?.app?.defaults ?? {};
+    expect(defaults["personal-assistant"]).toMatchObject({
+      enabled: true,
+      requiredForReady: true,
+    });
+    expect(defaults.calendar?.requiredForReady).not.toBe(true);
+    expect(defaults.goals?.requiredForReady).not.toBe(true);
+  });
+
   it("loads a host-manifest readiness plugin in blocking only", async () => {
     const previousCwd = process.cwd();
     const workspace = await mkdtemp(path.join(tmpdir(), "eliza-app-ready-"));

--- a/plugins/plugin-personal-assistant/src/composed-action-order.test.ts
+++ b/plugins/plugin-personal-assistant/src/composed-action-order.test.ts
@@ -1,12 +1,13 @@
 /**
  * Real-runtime check that the personal-assistant's composed CALENDAR,
- * CONFLICT_DETECT, and OWNER_GOALS own those names when the plugins are
- * registered in the order the standalone agent's plugin collector derives for
- * a manifest-less host with the assistant enabled (#30943). Boots a real
- * AgentRuntime on PGlite; cross-plugin `override` is neutralized by the plugin
- * lifecycle (#12658), so the collector's order is the contract under test and
- * a regression in either the collector reorder or the home-tile insertion
- * fails here.
+ * CONFLICT_DETECT, and OWNER_GOALS own those names when the plugins the
+ * standalone agent's collector derives for a manifest-less host are
+ * registered concurrently, the way `AgentRuntime.initialize` registers
+ * non-core plugins (#30943). Cross-plugin `override` is neutralized by the
+ * plugin lifecycle (#12658) and array order does not survive concurrent
+ * registration, so the contract under test is that the collector withholds
+ * the standalone calendar and goals entries and the assistant's init
+ * registers them itself with the composed names withheld.
  */
 import { collectPluginNames } from "@elizaos/agent/runtime/plugin-collector";
 import type { Plugin } from "@elizaos/core";
@@ -25,7 +26,7 @@ function assistantAction(name: string) {
   return action;
 }
 
-/** The three plugins this test can register, keyed by collector name. */
+/** The plugins this test can register, keyed by collector name. */
 const KNOWN: Record<string, Plugin> = {
   "@elizaos/plugin-personal-assistant": personalAssistantPlugin,
   "@elizaos/plugin-calendar": calendarPlugin,
@@ -33,25 +34,25 @@ const KNOWN: Record<string, Plugin> = {
 };
 
 describe("composed action order", () => {
-  it("owns CALENDAR, CONFLICT_DETECT, and OWNER_GOALS in the collector's own order", async () => {
+  it("owns CALENDAR, CONFLICT_DETECT, and OWNER_GOALS when the collector's plugins register concurrently", async () => {
     const config = {
       plugins: { entries: { "personal-assistant": { enabled: true } } },
     } as Parameters<typeof collectPluginNames>[0];
     const collected = Array.from(collectPluginNames(config));
+    expect(collected).toContain("@elizaos/plugin-personal-assistant");
+    // The collector leaves these to the assistant's init; a standalone entry
+    // here would register concurrently and win first-wins.
+    expect(collected).not.toContain("@elizaos/plugin-calendar");
+    expect(collected).not.toContain("@elizaos/plugin-goals");
     const plugins = collected
       .filter((name) => name in KNOWN)
       .map((name) => KNOWN[name]);
-    expect(plugins).toContain(personalAssistantPlugin);
-    expect(plugins).toContain(calendarPlugin);
-    expect(
-      collected.indexOf("@elizaos/plugin-personal-assistant"),
-    ).toBeLessThan(collected.indexOf("@elizaos/plugin-calendar"));
-    // goals is not in the collector's default set; register it after the
-    // assistant the way its init would, so OWNER_GOALS is contested too.
-    if (!plugins.includes(goalsPlugin)) plugins.push(goalsPlugin);
 
-    const { runtime, cleanup } = await createTestRuntime({ plugins });
+    const { runtime, cleanup } = await createTestRuntime({});
     try {
+      await Promise.all(
+        plugins.map((plugin) => runtime.registerPlugin(plugin)),
+      );
       const byName = (name: string) =>
         runtime.actions.filter((action) => action.name === name);
       for (const name of ["CALENDAR", "CONFLICT_DETECT", "OWNER_GOALS"]) {
@@ -59,10 +60,34 @@ describe("composed action order", () => {
         expect(registered).toHaveLength(1);
         expect(registered[0]).toBe(assistantAction(name));
       }
-      // Every other calendar action stays with the standalone plugin.
+      // The assistant registered the calendar plugin itself: its other
+      // actions are present and belong to the standalone plugin object.
+      expect(runtime.plugins.map((plugin) => plugin.name)).toContain(
+        "calendar",
+      );
       const sources = byName("CALENDAR_SOURCES");
       expect(sources).toHaveLength(1);
       expect(calendarPlugin.actions ?? []).toContain(sources[0]);
+    } finally {
+      await cleanup();
+    }
+  }, 240_000);
+
+  it("loses all three names to a standalone calendar and goals entry registered concurrently", async () => {
+    // The mechanism the collector guards against: with the standalone
+    // plugins in the same concurrent wave, first-wins keeps their actions.
+    const { runtime, cleanup } = await createTestRuntime({});
+    try {
+      await Promise.all(
+        [personalAssistantPlugin, calendarPlugin, goalsPlugin].map((plugin) =>
+          runtime.registerPlugin(plugin),
+        ),
+      );
+      for (const name of ["CALENDAR", "CONFLICT_DETECT", "OWNER_GOALS"]) {
+        const registered = runtime.actions.filter((a) => a.name === name);
+        expect(registered).toHaveLength(1);
+        expect(registered[0]).not.toBe(assistantAction(name));
+      }
     } finally {
       await cleanup();
     }

--- a/plugins/plugin-personal-assistant/src/composed-action-order.test.ts
+++ b/plugins/plugin-personal-assistant/src/composed-action-order.test.ts
@@ -1,11 +1,15 @@
 /**
  * Real-runtime check that the personal-assistant's composed CALENDAR,
- * CONFLICT_DETECT, and OWNER_GOALS own those names when the assistant is
- * registered before the standalone calendar and goals plugins, which is the
- * order the standalone agent's plugin collector guarantees (#30943). Boots a
- * real AgentRuntime on PGlite; cross-plugin `override` is neutralized by the
- * plugin lifecycle (#12658), so order is the contract under test.
+ * CONFLICT_DETECT, and OWNER_GOALS own those names when the plugins are
+ * registered in the order the standalone agent's plugin collector derives for
+ * a manifest-less host with the assistant enabled (#30943). Boots a real
+ * AgentRuntime on PGlite; cross-plugin `override` is neutralized by the plugin
+ * lifecycle (#12658), so the collector's order is the contract under test and
+ * a regression in either the collector reorder or the home-tile insertion
+ * fails here.
  */
+import { collectPluginNames } from "@elizaos/agent/runtime/plugin-collector";
+import type { Plugin } from "@elizaos/core";
 import { createTestRuntime } from "@elizaos/core/testing";
 import { calendarPlugin } from "@elizaos/plugin-calendar";
 import { goalsPlugin } from "@elizaos/plugin-goals/plugin";
@@ -21,11 +25,32 @@ function assistantAction(name: string) {
   return action;
 }
 
+/** The three plugins this test can register, keyed by collector name. */
+const KNOWN: Record<string, Plugin> = {
+  "@elizaos/plugin-personal-assistant": personalAssistantPlugin,
+  "@elizaos/plugin-calendar": calendarPlugin,
+  "@elizaos/plugin-goals": goalsPlugin,
+};
+
 describe("composed action order", () => {
-  it("owns CALENDAR, CONFLICT_DETECT, and OWNER_GOALS when registered before the standalone plugins", async () => {
-    const { runtime, cleanup } = await createTestRuntime({
-      plugins: [personalAssistantPlugin, calendarPlugin, goalsPlugin],
-    });
+  it("owns CALENDAR, CONFLICT_DETECT, and OWNER_GOALS in the collector's own order", async () => {
+    const config = {
+      plugins: { entries: { "personal-assistant": { enabled: true } } },
+    } as Parameters<typeof collectPluginNames>[0];
+    const collected = Array.from(collectPluginNames(config));
+    const plugins = collected
+      .filter((name) => name in KNOWN)
+      .map((name) => KNOWN[name]);
+    expect(plugins).toContain(personalAssistantPlugin);
+    expect(plugins).toContain(calendarPlugin);
+    expect(
+      collected.indexOf("@elizaos/plugin-personal-assistant"),
+    ).toBeLessThan(collected.indexOf("@elizaos/plugin-calendar"));
+    // goals is not in the collector's default set; register it after the
+    // assistant the way its init would, so OWNER_GOALS is contested too.
+    if (!plugins.includes(goalsPlugin)) plugins.push(goalsPlugin);
+
+    const { runtime, cleanup } = await createTestRuntime({ plugins });
     try {
       const byName = (name: string) =>
         runtime.actions.filter((action) => action.name === name);

--- a/plugins/plugin-personal-assistant/src/composed-action-order.test.ts
+++ b/plugins/plugin-personal-assistant/src/composed-action-order.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Real-runtime check that the personal-assistant's composed CALENDAR,
+ * CONFLICT_DETECT, and OWNER_GOALS own those names when the assistant is
+ * registered before the standalone calendar and goals plugins, which is the
+ * order the standalone agent's plugin collector guarantees (#30943). Boots a
+ * real AgentRuntime on PGlite; cross-plugin `override` is neutralized by the
+ * plugin lifecycle (#12658), so order is the contract under test.
+ */
+import { createTestRuntime } from "@elizaos/core/testing";
+import { calendarPlugin } from "@elizaos/plugin-calendar";
+import { goalsPlugin } from "@elizaos/plugin-goals/plugin";
+import { describe, expect, it } from "vitest";
+import { personalAssistantPlugin } from "./index";
+
+/** The assistant's own action object for `name`, by identity. */
+function assistantAction(name: string) {
+  const action = (personalAssistantPlugin.actions ?? []).find(
+    (candidate) => candidate.name === name,
+  );
+  if (!action) throw new Error(`assistant does not declare ${name}`);
+  return action;
+}
+
+describe("composed action order", () => {
+  it("owns CALENDAR, CONFLICT_DETECT, and OWNER_GOALS when registered before the standalone plugins", async () => {
+    const { runtime, cleanup } = await createTestRuntime({
+      plugins: [personalAssistantPlugin, calendarPlugin, goalsPlugin],
+    });
+    try {
+      const byName = (name: string) =>
+        runtime.actions.filter((action) => action.name === name);
+      for (const name of ["CALENDAR", "CONFLICT_DETECT", "OWNER_GOALS"]) {
+        const registered = byName(name);
+        expect(registered).toHaveLength(1);
+        expect(registered[0]).toBe(assistantAction(name));
+      }
+      // Every other calendar action stays with the standalone plugin.
+      const sources = byName("CALENDAR_SOURCES");
+      expect(sources).toHaveLength(1);
+      expect(calendarPlugin.actions ?? []).toContain(sources[0]);
+    } finally {
+      await cleanup();
+    }
+  }, 240_000);
+});

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -86,6 +86,9 @@ const agentSourceJsToTsPlugin = {
     if (source === "@elizaos/agent/api/server-helpers") {
       return path.join(agentSourceRoot, "api", "server-helpers.ts");
     }
+    if (source === "@elizaos/agent/runtime/plugin-collector") {
+      return path.join(agentSourceRoot, "runtime", "plugin-collector.ts");
+    }
     if (source === "@elizaos/ui") {
       return path.join(lifeopsTestStubsRoot, "ui.ts");
     }
@@ -281,6 +284,16 @@ export default defineConfig({
       {
         find: /^@elizaos\/agent\/api\/server-helpers$/,
         replacement: path.join(agentSourceRoot, "api", "server-helpers.ts"),
+      },
+      {
+        // The real plugin collector, so a runtime test can register plugins
+        // in the order the standalone agent derives (#30943).
+        find: /^@elizaos\/agent\/runtime\/plugin-collector$/,
+        replacement: path.join(
+          agentSourceRoot,
+          "runtime",
+          "plugin-collector.ts",
+        ),
       },
       {
         find: /^@elizaos\/app-core\/platform\/native-library-policy$/,


### PR DESCRIPTION
A manifest-less agent could register the calendar and goals plugins concurrently with personal-assistant initialization, allowing standalone actions to replace the composed LifeOps actions. The collector now leaves those plugins to the personal-assistant plugin when it is selected. Standalone agents without personal-assistant retain their existing actions.

The runtime regression uses the real collector, concurrent plugin registration and a PGlite-backed runtime to verify action ownership.

Closes #30943.

Validation at `dcf5b62cdb198daeb98a88c019db17d7a49437a3`, rebased onto develop `e2d6d383bc3b10f35ab509748d00788be9b72769`:

- `bun install` and complete `bun run verify`: passed, including all 373 Turbo tasks and final repository audits.
- Focused real-runtime composition and optional-schema tests: 10 passed. The collector/resolver test files and the agent runner’s nine mobile compatibility tests also passed before this rebase.
- Complete agent suite: all 773 test files passed at the preceding head `6dbf83e6be203ba771ad4ecafd1e3756a6e24b3c`; production changes are unchanged; develop now includes the provider-schema correction from #31016.
- Complete personal-assistant suite: 301 files passed, 2,603 tests passed and six skipped at `0ca5720a7e9d7b6d71dae2ddb45eb28385451f6f`, before the latest develop rebase. The rebased head received the fresh focused tests and full root gate above.
- Hosted checks for the final SHA are pending. Do not treat the preceding head's checks as proof for this head.

Evidence: the regression observes the real registered action handlers and persistent runtime assembly. Screenshots/video and frontend logs are N/A because no rendered surface changes. A live-model trajectory is N/A to deterministic registration ownership; this does not claim end-to-end Bettina acceptance or deployment.
