### PR TITLE
fix(agent): declare and bundle plugin-todos as an always-loaded view plugin (#30945)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,6 +136,7 @@
         "@elizaos/plugin-scheduling": "workspace:*",
         "@elizaos/plugin-sql": "workspace:*",
         "@elizaos/plugin-task-coordinator": "workspace:*",
+        "@elizaos/plugin-todos": "workspace:*",
         "@elizaos/plugin-video": "workspace:*",
         "@elizaos/plugin-vision": "workspace:*",
         "@elizaos/plugin-wallet": "workspace:*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -358,6 +358,7 @@
     "@elizaos/plugin-notes": "workspace:*",
     "@elizaos/plugin-sql": "workspace:*",
     "@elizaos/plugin-task-coordinator": "workspace:*",
+    "@elizaos/plugin-todos": "workspace:*",
     "@elizaos/plugin-video": "workspace:*",
     "@elizaos/plugin-vision": "workspace:*",
     "@elizaos/plugin-wallet": "workspace:*",

--- a/packages/agent/src/actions/notify.test.ts
+++ b/packages/agent/src/actions/notify.test.ts
@@ -253,7 +253,10 @@ describe("NOTIFY on the planner action surface", () => {
   ): Promise<string[]> {
     const runtime = await makePipelineRuntime([
       stage1Response(contexts, candidates),
-      plannerBody ?? { text: "", toolCalls: [] },
+      plannerBody ?? {
+        text: "I need repository contribution data to identify the top contributors.",
+        toolCalls: [],
+      },
       JSON.stringify({
         success: true,
         decision: "FINISH",

--- a/packages/agent/src/runtime/release-plugin-policy.ts
+++ b/packages/agent/src/runtime/release-plugin-policy.ts
@@ -48,6 +48,7 @@ const BASELINE_PLUGIN_SUPPORT_PACKAGES = [
   "@elizaos/plugin-inbox",
   "@elizaos/plugin-notes",
   "@elizaos/plugin-calendar",
+  "@elizaos/plugin-todos",
 ] as const;
 
 // Plugins excluded from the baseline release that can only be installed on a


### PR DESCRIPTION
## Change

Closes #30945. Targets `develop`.

The agent always loads the Todos view plugin, but its runtime dependency and baseline release bundle policy omitted the package. Add `@elizaos/plugin-todos` to the agent dependency closure and baseline bundle set so packaged agents can resolve that view.

The supporting notification-test fixture now supplies a complete planner reply when it returns no tools. The old empty reply violates the current grounded-reply contract; the unchanged develop control reproduced the same failure. Routing assertions and tool-call expectations remain unchanged. No notification production behavior changed.

## Validation

Base: `3a7f438a9e9d5ba10ea905198723012667bd785d`.
Head: `af9df55dda5e60f7c9252b9b4cdf2f03c0e5b479`.

All commands used Bun 1.3.14 and Node 24.15.0, explicitly pinned in the subprocess PATH.

<details><summary>Executed evidence</summary>

```text
Normal bun install after synchronization:
  Checked 3679 installs across 3955 packages (no changes), exit 0.
  Native embedding install smoke: 384 finite local dimensions.

Focused release-policy and notification tests at final head:
  Test Files 3 passed (3); Tests 15 passed (15), exit 0.

Real release-policy consumer probe:
  discoverAlwaysBundledPackages(agent manifest) followed by
  shouldBundleDiscoveredPackage("@elizaos/plugin-todos", discovered set)
  returned true.

Final-head bun run verify:
  373 successful, 373 total; all subsequent repository audits passed; exit 0.

Notification fixture control at unchanged develop:
  8 passed, 1 failed: grounded conversational reply could not be generated.
  Same result with CEREBRAS_API_KEY removed only from the test subprocess.
  Corrected fixture: 9 passed; routing assertions unchanged.
```

</details>

The full agent package suite completed all 772 isolated test files at normal concurrency 4 and exited 1: five files failed, with 13 failing assertions. Failures are in view search (1), view-id drift / Projects navigation (1), agent message route (2), chat augmentation (1), and chat usage / wallet execution receipts (8). The search fixture failure reproduces on unchanged develop and has an independently reviewed correction awaiting integration. Projects navigation and wallet receipt failures are under review with separate base controls. Exact-head hosted checks are still pending. **Hold merge until these failures are resolved and the final integrated package suite and hosted checks pass.**

## Evidence applicability

<!-- evidence-head:af9df55dda5e60f7c9252b9b4cdf2f03c0e5b479 -->
<!-- evidence-row:before-screenshots -->
- N/A: dependency and release policy change; no rendered view code changed.
<!-- evidence-row:after-screenshots -->
- N/A: dependency and release policy change; no rendered view code changed.
<!-- evidence-row:walkthrough-video -->
- N/A: no interaction flow changed; release-policy execution is recorded above.
<!-- evidence-row:backend-logs -->
- Executed install, focused tests, real packaging-policy consumer, and full root verification are summarized above.
<!-- evidence-row:frontend-logs -->
- N/A: no frontend request or rendering change.
<!-- evidence-row:llm-trajectory -->
- N/A: production agent behavior is unchanged; the notification correction is a deterministic test fixture, not live-model proof.
<!-- evidence-row:domain-artifacts -->
- The lockfile includes the Todos runtime workspace dependency; the real release-policy consumer includes it in the bundle set.
<!-- evidence-row:ocr-review -->
- N/A: no rendered visual surface changed.

## Attribution

Original implementation: TrapLord, using Claude Code / Anthropic claude-fable-5-1 (original author self-report). Current-base review, fixture correction, and validation: Codex. These checks do not establish completion of the broader Project 19 view and native-operation issues.
