### PR TITLE
feat(core,discord): FAILURE_REPLY_POLICY keeps canned failure replies out of public rooms

### DIFF
--- a/packages/core/src/__tests__/failure-reply-policy.test.ts
+++ b/packages/core/src/__tests__/failure-reply-policy.test.ts
@@ -1,0 +1,203 @@
+/**
+ * FAILURE_REPLY_POLICY parsing and the shared should-emit gate. Pure logic:
+ * no runtime, no connector. The connector and message-service tests cover
+ * the wiring; this pins the contract they share.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	DEFAULT_FAILURE_REPLY_POLICY,
+	isPrivateFailureReplyChannel,
+	parseFailureReplyPolicy,
+	resetFailureReplyPolicyWarnings,
+	resolveFailureReplyPolicy,
+	shouldEmitFailureReply,
+} from "../failure-reply-policy";
+
+describe("parseFailureReplyPolicy", () => {
+	it("accepts the canonical values case-insensitively", () => {
+		expect(parseFailureReplyPolicy("dm-only")).toBe("dm-only");
+		expect(parseFailureReplyPolicy("DM_ONLY")).toBe("dm-only");
+		expect(parseFailureReplyPolicy(" All ")).toBe("all");
+		expect(parseFailureReplyPolicy("off")).toBe("off");
+	});
+
+	it("accepts obvious aliases", () => {
+		expect(parseFailureReplyPolicy("dm")).toBe("dm-only");
+		expect(parseFailureReplyPolicy("private")).toBe("dm-only");
+		expect(parseFailureReplyPolicy("always")).toBe("all");
+		expect(parseFailureReplyPolicy("everywhere")).toBe("all");
+		expect(parseFailureReplyPolicy("none")).toBe("off");
+		expect(parseFailureReplyPolicy("never")).toBe("off");
+		expect(parseFailureReplyPolicy("silent")).toBe("off");
+	});
+
+	it("returns null for unknown, empty, or non-string values", () => {
+		expect(parseFailureReplyPolicy("public")).toBeNull();
+		expect(parseFailureReplyPolicy("")).toBeNull();
+		expect(parseFailureReplyPolicy(undefined)).toBeNull();
+		expect(parseFailureReplyPolicy(null)).toBeNull();
+		expect(parseFailureReplyPolicy(true)).toBeNull();
+		expect(parseFailureReplyPolicy(1)).toBeNull();
+	});
+});
+
+describe("resolveFailureReplyPolicy", () => {
+	beforeEach(() => {
+		resetFailureReplyPolicyWarnings();
+	});
+	afterEach(() => {
+		resetFailureReplyPolicyWarnings();
+	});
+
+	it("defaults to dm-only when nothing is configured", () => {
+		expect(DEFAULT_FAILURE_REPLY_POLICY).toBe("dm-only");
+		expect(resolveFailureReplyPolicy(undefined, { env: {} })).toBe("dm-only");
+		expect(
+			resolveFailureReplyPolicy({ getSetting: () => undefined }, { env: {} }),
+		).toBe("dm-only");
+	});
+
+	it("prefers the runtime setting over the env", () => {
+		expect(
+			resolveFailureReplyPolicy(
+				{ getSetting: (key) => (key === "FAILURE_REPLY_POLICY" ? "all" : "") },
+				{ env: { FAILURE_REPLY_POLICY: "off" } },
+			),
+		).toBe("all");
+	});
+
+	it("falls back to the env when the runtime setting is unset", () => {
+		expect(
+			resolveFailureReplyPolicy(
+				{ getSetting: () => undefined },
+				{ env: { FAILURE_REPLY_POLICY: "off" } },
+			),
+		).toBe("off");
+	});
+
+	it("fails closed to dm-only on an unrecognized value and warns once per value", () => {
+		const warn = vi.fn();
+		const runtime = { getSetting: () => "loud" };
+		expect(
+			resolveFailureReplyPolicy(runtime, { env: {}, logger: { warn } }),
+		).toBe("dm-only");
+		expect(
+			resolveFailureReplyPolicy(runtime, { env: {}, logger: { warn } }),
+		).toBe("dm-only");
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toMatchObject({
+			setting: "FAILURE_REPLY_POLICY",
+			value: "loud",
+			fallback: "dm-only",
+		});
+		// A different bad value gets its own single warning.
+		expect(
+			resolveFailureReplyPolicy(
+				{ getSetting: () => "public" },
+				{ env: {}, logger: { warn } },
+			),
+		).toBe("dm-only");
+		expect(warn).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("isPrivateFailureReplyChannel", () => {
+	it("treats DM, VOICE_DM, SELF and API as private", () => {
+		for (const type of ["DM", "VOICE_DM", "SELF", "API", "dm"]) {
+			expect(isPrivateFailureReplyChannel(type)).toBe(true);
+		}
+	});
+
+	it("treats every group-style room and unknown input as public", () => {
+		for (const type of [
+			"GROUP",
+			"THREAD",
+			"VOICE_GROUP",
+			"FORUM",
+			"WORLD",
+			"FEED",
+			"",
+			undefined,
+			null,
+		]) {
+			expect(isPrivateFailureReplyChannel(type)).toBe(false);
+		}
+	});
+});
+
+describe("shouldEmitFailureReply", () => {
+	it("dm-only: emits in private rooms, suppresses in public rooms", () => {
+		expect(shouldEmitFailureReply({ policy: "dm-only", isDm: true })).toEqual({
+			emit: true,
+		});
+		expect(shouldEmitFailureReply({ policy: "dm-only", isDm: false })).toEqual({
+			emit: false,
+			reason: "policy-dm-only-public-room",
+		});
+		expect(
+			shouldEmitFailureReply({ policy: "dm-only", channelType: "DM" }).emit,
+		).toBe(true);
+		expect(
+			shouldEmitFailureReply({ policy: "dm-only", channelType: "API" }).emit,
+		).toBe(true);
+		expect(
+			shouldEmitFailureReply({ policy: "dm-only", channelType: "GROUP" }).emit,
+		).toBe(false);
+		expect(
+			shouldEmitFailureReply({ policy: "dm-only", channelType: "THREAD" }).emit,
+		).toBe(false);
+	});
+
+	it("dm-only: an explicit isDm verdict wins over channelType", () => {
+		expect(
+			shouldEmitFailureReply({
+				policy: "dm-only",
+				isDm: false,
+				channelType: "DM",
+			}).emit,
+		).toBe(false);
+		expect(
+			shouldEmitFailureReply({
+				policy: "dm-only",
+				isDm: true,
+				channelType: "GROUP",
+			}).emit,
+		).toBe(true);
+	});
+
+	it("dm-only: unknown room kind fails closed to silence", () => {
+		expect(shouldEmitFailureReply({ policy: "dm-only" })).toEqual({
+			emit: false,
+			reason: "policy-dm-only-public-room",
+		});
+	});
+
+	it("dm-only: autonomous turns keep the failure text", () => {
+		expect(
+			shouldEmitFailureReply({
+				policy: "dm-only",
+				channelType: "GROUP",
+				isAutonomous: true,
+			}).emit,
+		).toBe(true);
+	});
+
+	it("all: emits everywhere", () => {
+		expect(shouldEmitFailureReply({ policy: "all", isDm: false }).emit).toBe(
+			true,
+		);
+		expect(
+			shouldEmitFailureReply({ policy: "all", channelType: "GROUP" }).emit,
+		).toBe(true);
+	});
+
+	it("off: suppresses everywhere, including DMs and autonomous turns", () => {
+		expect(shouldEmitFailureReply({ policy: "off", isDm: true })).toEqual({
+			emit: false,
+			reason: "policy-off",
+		});
+		expect(
+			shouldEmitFailureReply({ policy: "off", isAutonomous: true }).emit,
+		).toBe(false);
+	});
+});

--- a/packages/core/src/failure-reply-policy.ts
+++ b/packages/core/src/failure-reply-policy.ts
@@ -1,0 +1,191 @@
+/**
+ * Failure-reply policy: where a canned "generation failed / timed out" reply
+ * may be posted when a turn dies before producing an answer.
+ *
+ * The connector and the core message service both synthesize short failure
+ * texts ("I timed out while generating that reply. Please retry.", the
+ * structured rate-limit apology, ...) when the model path fails. In a DM the
+ * user is alone with the agent, so silence reads as a hang and the notice is
+ * the kinder outcome. In a public room (guild channel, thread, group) the
+ * same notice is noise: every reader sees the outage, nobody can act on it,
+ * and a multi-hour provider incident turns into a wall of identical apologies
+ * (observed live: five "I timed out" posts into a shared Discord channel
+ * during a 29h broker outage). The public failure signal is the error
+ * reaction / typing stop, not text.
+ *
+ * `FAILURE_REPLY_POLICY` (runtime setting, env fallback):
+ *   - `dm-only` (default): failure text only in DM / API / SELF style rooms
+ *     and on autonomous turns; public rooms stay silent.
+ *   - `all`: legacy behavior, failure text everywhere it was previously sent.
+ *   - `off`: never post failure text; rely on reactions / logs alone.
+ *
+ * Unrecognized values fail closed to `dm-only` and are logged once per
+ * process so a typo in config does not silently re-enable public spam.
+ */
+
+export const FAILURE_REPLY_POLICIES = ["dm-only", "all", "off"] as const;
+export type FailureReplyPolicy = (typeof FAILURE_REPLY_POLICIES)[number];
+export const DEFAULT_FAILURE_REPLY_POLICY: FailureReplyPolicy = "dm-only";
+export const FAILURE_REPLY_POLICY_SETTING = "FAILURE_REPLY_POLICY";
+
+type SettingsReader = {
+	getSetting?: (key: string) => unknown;
+};
+
+type EnvLike = Record<string, string | undefined>;
+
+type PolicyLogger = {
+	warn?: (context: Record<string, unknown>, message: string) => void;
+};
+
+function defaultEnv(): EnvLike {
+	const globalWithProcess = globalThis as {
+		process?: { env?: EnvLike };
+	};
+	return globalWithProcess.process?.env ?? {};
+}
+
+const warnedInvalidValues = new Set<string>();
+
+/** Test-only: forget which invalid values have already been logged. */
+export function resetFailureReplyPolicyWarnings(): void {
+	warnedInvalidValues.clear();
+}
+
+/**
+ * Normalize a raw setting value into a policy. Accepts a few obvious aliases
+ * (`dm`, `dms`, `private`, `always`, `everywhere`, `none`, `never`, `silent`)
+ * so the setting is forgiving without being ambiguous. Anything else returns
+ * `null` so the caller can log and fall back.
+ */
+export function parseFailureReplyPolicy(
+	value: unknown,
+): FailureReplyPolicy | null {
+	if (value === undefined || value === null) return null;
+	if (typeof value !== "string") return null;
+	const normalized = value.trim().toLowerCase().replace(/_/g, "-");
+	if (normalized === "") return null;
+	switch (normalized) {
+		case "dm-only":
+		case "dm":
+		case "dms":
+		case "private":
+			return "dm-only";
+		case "all":
+		case "always":
+		case "everywhere":
+			return "all";
+		case "off":
+		case "none":
+		case "never":
+		case "silent":
+			return "off";
+		default:
+			return null;
+	}
+}
+
+/**
+ * Resolve the effective policy from the runtime setting first, then the
+ * process env, then the default. Invalid values fail closed to `dm-only` and
+ * are reported once per distinct value.
+ */
+export function resolveFailureReplyPolicy(
+	runtime?: SettingsReader | null,
+	options: { env?: EnvLike; logger?: PolicyLogger } = {},
+): FailureReplyPolicy {
+	const env = options.env ?? defaultEnv();
+	const raw =
+		runtime?.getSetting?.(FAILURE_REPLY_POLICY_SETTING) ??
+		env[FAILURE_REPLY_POLICY_SETTING];
+	if (raw === undefined || raw === null || raw === "") {
+		return DEFAULT_FAILURE_REPLY_POLICY;
+	}
+	const parsed = parseFailureReplyPolicy(raw);
+	if (parsed) return parsed;
+	const key = String(raw);
+	if (!warnedInvalidValues.has(key)) {
+		warnedInvalidValues.add(key);
+		options.logger?.warn?.(
+			{
+				src: "core:failure-reply-policy",
+				setting: FAILURE_REPLY_POLICY_SETTING,
+				value: key,
+				fallback: DEFAULT_FAILURE_REPLY_POLICY,
+				accepted: FAILURE_REPLY_POLICIES,
+			},
+			"Unrecognized FAILURE_REPLY_POLICY value; failing closed to dm-only",
+		);
+	}
+	return DEFAULT_FAILURE_REPLY_POLICY;
+}
+
+/**
+ * Room kinds where the user is effectively alone with the agent. A failure
+ * notice there is a courtesy, not a broadcast. Matches the core
+ * always-respond channel set plus voice DMs.
+ */
+const PRIVATE_CHANNEL_TYPES: ReadonlySet<string> = new Set([
+	"DM",
+	"VOICE_DM",
+	"SELF",
+	"API",
+]);
+
+/** True when the given core `ChannelType` string is a private (1:1) room. */
+export function isPrivateFailureReplyChannel(
+	channelType: string | null | undefined,
+): boolean {
+	if (!channelType) return false;
+	return PRIVATE_CHANNEL_TYPES.has(String(channelType).trim().toUpperCase());
+}
+
+export interface ShouldEmitFailureReplyArgs {
+	policy: FailureReplyPolicy;
+	/**
+	 * Explicit privacy verdict. When provided it wins over `channelType`.
+	 * Connectors that know their transport (Discord DM vs guild channel) pass
+	 * this directly.
+	 */
+	isDm?: boolean;
+	/** Core `ChannelType` of the room, used when `isDm` is not supplied. */
+	channelType?: string | null;
+	/**
+	 * Autonomous / self-driven turns have no human audience to spam; they keep
+	 * the failure text under `dm-only` so the autonomy loop can see it.
+	 */
+	isAutonomous?: boolean;
+}
+
+export type FailureReplySuppressionReason =
+	| "policy-off"
+	| "policy-dm-only-public-room";
+
+export interface FailureReplyDecision {
+	emit: boolean;
+	reason?: FailureReplySuppressionReason;
+}
+
+/**
+ * Decide whether a canned failure reply may be posted for this turn.
+ *
+ * - `all`: always emit.
+ * - `off`: never emit.
+ * - `dm-only`: emit only when the room is private (`isDm` / private
+ *   `channelType`) or the turn is autonomous. Unknown room kind with no
+ *   `isDm` hint is treated as PUBLIC (fail closed: silence is the safe
+ *   default when we cannot prove the audience is one person).
+ */
+export function shouldEmitFailureReply(
+	args: ShouldEmitFailureReplyArgs,
+): FailureReplyDecision {
+	if (args.policy === "all") return { emit: true };
+	if (args.policy === "off") return { emit: false, reason: "policy-off" };
+	if (args.isAutonomous) return { emit: true };
+	const privateRoom =
+		typeof args.isDm === "boolean"
+			? args.isDm
+			: isPrivateFailureReplyChannel(args.channelType);
+	if (privateRoom) return { emit: true };
+	return { emit: false, reason: "policy-dm-only-public-room" };
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -53,6 +53,7 @@ export * from "./entities";
 // barrel so browser consumers resolve the same canonical truthy set.
 export * from "./env-utils";
 export * from "./errors";
+export * from "./failure-reply-policy";
 export * from "./features/advanced-memory";
 export { AutonomyService } from "./features/autonomy/index";
 export {

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -115,6 +115,7 @@ export {
 	type ReportedError,
 	toElizaError,
 } from "./errors";
+export * from "./failure-reply-policy";
 export {
 	roleAction,
 	updateRoleAction,

--- a/packages/core/src/services/message.character-failure-templates.test.ts
+++ b/packages/core/src/services/message.character-failure-templates.test.ts
@@ -155,7 +155,13 @@ function makeFailingRuntime(
 			error: vi.fn(),
 			trace: vi.fn(),
 		} as unknown as IAgentRuntime["logger"],
-		getSetting: vi.fn(() => undefined),
+		// These tests pin the failure-reply TEXT on an addressed group turn.
+		// FAILURE_REPLY_POLICY defaults to dm-only (public rooms stay silent);
+		// opt into `all` so the template path is exercised. Suppression itself
+		// is covered by message.runtime-failure-suppression.test.ts.
+		getSetting: vi.fn((key: string) =>
+			key === "FAILURE_REPLY_POLICY" ? "all" : undefined,
+		),
 		getService: vi.fn(() => null),
 		getModel: vi.fn(() =>
 			hasModelProvider

--- a/packages/core/src/services/message.context-overflow-reply.test.ts
+++ b/packages/core/src/services/message.context-overflow-reply.test.ts
@@ -110,7 +110,13 @@ function makeFailingRuntime(
 			error: vi.fn(),
 			trace: vi.fn(),
 		} as unknown as IAgentRuntime["logger"],
-		getSetting: vi.fn(() => undefined),
+		// These tests pin the failure-reply TEXT on an addressed group turn.
+		// FAILURE_REPLY_POLICY defaults to dm-only (public rooms stay silent);
+		// opt into `all` so the template path is exercised. Suppression itself
+		// is covered by message.runtime-failure-suppression.test.ts.
+		getSetting: vi.fn((key: string) =>
+			key === "FAILURE_REPLY_POLICY" ? "all" : undefined,
+		),
 		getService: vi.fn(() => null),
 		getModel: vi.fn(() => async () => {
 			throw failure;

--- a/packages/core/src/services/message.credit-exhaustion-reply.test.ts
+++ b/packages/core/src/services/message.credit-exhaustion-reply.test.ts
@@ -104,7 +104,13 @@ function makeFailingRuntime(
 			error: vi.fn(),
 			trace: vi.fn(),
 		} as unknown as IAgentRuntime["logger"],
-		getSetting: vi.fn(() => undefined),
+		// These tests pin the failure-reply TEXT on an addressed group turn.
+		// FAILURE_REPLY_POLICY defaults to dm-only (public rooms stay silent);
+		// opt into `all` so the template path is exercised. Suppression itself
+		// is covered by message.runtime-failure-suppression.test.ts.
+		getSetting: vi.fn((key: string) =>
+			key === "FAILURE_REPLY_POLICY" ? "all" : undefined,
+		),
 		getService: vi.fn(() => null),
 		getModel: vi.fn(() => async () => {
 			throw failure;

--- a/packages/core/src/services/message.runtime-failure-suppression.test.ts
+++ b/packages/core/src/services/message.runtime-failure-suppression.test.ts
@@ -71,7 +71,10 @@ function makeState(): State {
 	return { values: {}, data: {}, text: "" };
 }
 
-function makeFailingRuntime(room: Room): IAgentRuntime {
+function makeFailingRuntime(
+	room: Room,
+	settings: Record<string, string> = {},
+): IAgentRuntime {
 	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
 	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
 		responseHandlerFieldRegistry.register(evaluator);
@@ -89,7 +92,7 @@ function makeFailingRuntime(room: Room): IAgentRuntime {
 			error: vi.fn(),
 			trace: vi.fn(),
 		} as unknown as IAgentRuntime["logger"],
-		getSetting: vi.fn(() => undefined),
+		getSetting: vi.fn((key: string) => settings[key]),
 		getService: vi.fn(() => null),
 		getModel: vi.fn(() => async () => {
 			throw RATE_LIMIT_ERROR;
@@ -134,8 +137,12 @@ function makeRoom(type: ChannelType): Room {
 	} as Room;
 }
 
-async function runTurn(message: Memory, room: Room) {
-	const runtime = makeFailingRuntime(room);
+async function runTurn(
+	message: Memory,
+	room: Room,
+	settings: Record<string, string> = {},
+) {
+	const runtime = makeFailingRuntime(room, settings);
 	const service = new DefaultMessageService();
 	const deliveries: Content[] = [];
 	const result = await service.handleMessage(
@@ -180,8 +187,12 @@ describe("v5 runtime failure before a respond decision", () => {
 		expect(terminal?.actions).toEqual(["IGNORE"]);
 	});
 
-	it("still surfaces the failure reply when the agent was platform-mentioned", async () => {
-		const { result, visibleTexts } = await runTurn(
+	it("stays silent on a platform mention in a group room under the default dm-only policy", async () => {
+		// A mention qualifies the turn as addressed, but FAILURE_REPLY_POLICY
+		// defaults to dm-only: a public room must not receive the canned
+		// outage apology (observed live: five identical "I timed out" posts
+		// into a shared channel during a 29h broker outage).
+		const { runtime, result, deliveries, visibleTexts } = await runTurn(
 			makeMessage({
 				text: "@Remilio what's the plan?",
 				mentionContext: { isMention: true },
@@ -189,11 +200,74 @@ describe("v5 runtime failure before a respond decision", () => {
 			makeRoom(ChannelType.GROUP),
 		);
 
+		expect(visibleTexts).toEqual([]);
+		expect(result.didRespond).toBe(false);
+		const terminal = deliveries.find((content) =>
+			Array.isArray(content.actions),
+		);
+		expect(terminal?.actions).toEqual(["IGNORE"]);
+		expect(runtime.logger.info).toHaveBeenCalledWith(
+			expect.objectContaining({
+				reason: "policy",
+				policy: "dm-only",
+				policyReason: "policy-dm-only-public-room",
+				addressed: true,
+			}),
+			"v5 runtime failed on an addressed turn; suppressing failure reply",
+		);
+	});
+
+	it("still surfaces the failure reply on a platform mention when FAILURE_REPLY_POLICY=all", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage({
+				text: "@Remilio what's the plan?",
+				mentionContext: { isMention: true },
+			}),
+			makeRoom(ChannelType.GROUP),
+			{ FAILURE_REPLY_POLICY: "all" },
+		);
+
 		expect(result.didRespond).toBe(true);
 		expect(visibleTexts).toHaveLength(1);
 		// buildStructuredFailureReply lands on the rate-limited template since
 		// every model call in this turn is rate-limited.
 		expect(visibleTexts[0].toLowerCase()).toContain("rate-limit");
+	});
+
+	it("keeps the DM failure reply under the default dm-only policy", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage({ channelType: ChannelType.DM }),
+			makeRoom(ChannelType.DM),
+		);
+
+		expect(result.didRespond).toBe(true);
+		expect(visibleTexts).toHaveLength(1);
+		expect(visibleTexts[0].toLowerCase()).toContain("rate-limit");
+	});
+
+	it("silences the DM failure reply when FAILURE_REPLY_POLICY=off", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage({ channelType: ChannelType.DM }),
+			makeRoom(ChannelType.DM),
+			{ FAILURE_REPLY_POLICY: "off" },
+		);
+
+		expect(visibleTexts).toEqual([]);
+		expect(result.didRespond).toBe(false);
+	});
+
+	it("fails closed to dm-only on an unrecognized FAILURE_REPLY_POLICY value", async () => {
+		const { result, visibleTexts } = await runTurn(
+			makeMessage({
+				text: "@Remilio what's the plan?",
+				mentionContext: { isMention: true },
+			}),
+			makeRoom(ChannelType.GROUP),
+			{ FAILURE_REPLY_POLICY: "loud" },
+		);
+
+		expect(visibleTexts).toEqual([]);
+		expect(result.didRespond).toBe(false);
 	});
 
 	it.each([
@@ -572,107 +646,123 @@ describe("planner failure after a promoted stage-1 answer", () => {
 		},
 	);
 
-	it("delivers the failure reply on an unaddressed group turn once stage-1 committed to respond", async () => {
-		// Stage 1 commits to RESPOND on a bare group message but produces no
-		// preservable answer (empty replyText, promoted to planning), and the
-		// planner then dies. The deterministic addressing gate alone would
-		// suppress the failure reply — the model's own RESPOND decision must
-		// qualify the turn for a visible failure instead of dead silence.
-		const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
-		for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
-			responseHandlerFieldRegistry.register(evaluator);
-		}
-		let stage1Served = false;
-		const runtime = createMockRuntime({
-			agentId: AGENT,
-			character: { name: "Remilio", bio: "test agent" },
-			logger: {
-				debug: vi.fn(),
-				info: vi.fn(),
-				warn: vi.fn(),
-				error: vi.fn(),
-				trace: vi.fn(),
-			} as unknown as IAgentRuntime["logger"],
-			getSetting: vi.fn(() => undefined),
-			getService: vi.fn(() => null),
-			getModel: vi.fn(() => async () => {
-				throw RATE_LIMIT_ERROR;
-			}),
-			useModel: vi.fn(async (modelType: unknown) => {
-				if (String(modelType) === "RESPONSE_HANDLER" && !stage1Served) {
-					stage1Served = true;
-					return {
-						text: "",
-						toolCalls: [
-							{
-								id: "handle-response-1",
-								name: "HANDLE_RESPONSE",
-								arguments: {
-									shouldRespond: "RESPOND",
-									thought: "",
-									contexts: ["general"],
-									intents: [],
-									candidateActionNames: [],
-									replyText: "",
-									facts: [],
-									relationships: [],
-									addressedTo: [],
+	it.each([
+		["all", true],
+		["dm-only", false],
+	])(
+		"stage-1 RESPOND on an unaddressed group turn, then planner death, under FAILURE_REPLY_POLICY=%s: visible failure=%s",
+		async (policy, expectVisible) => {
+			// Stage 1 commits to RESPOND on a bare group message but produces no
+			// preservable answer (empty replyText, promoted to planning), and the
+			// planner then dies. The deterministic addressing gate alone would
+			// suppress the failure reply — the model's own RESPOND decision
+			// qualifies the turn for a visible failure under `all`. Under the
+			// default `dm-only` the room is still public, so it stays silent.
+			const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
+			for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
+				responseHandlerFieldRegistry.register(evaluator);
+			}
+			let stage1Served = false;
+			const runtime = createMockRuntime({
+				agentId: AGENT,
+				character: { name: "Remilio", bio: "test agent" },
+				logger: {
+					debug: vi.fn(),
+					info: vi.fn(),
+					warn: vi.fn(),
+					error: vi.fn(),
+					trace: vi.fn(),
+				} as unknown as IAgentRuntime["logger"],
+				getSetting: vi.fn((key: string) =>
+					key === "FAILURE_REPLY_POLICY" ? policy : undefined,
+				),
+				getService: vi.fn(() => null),
+				getModel: vi.fn(() => async () => {
+					throw RATE_LIMIT_ERROR;
+				}),
+				useModel: vi.fn(async (modelType: unknown) => {
+					if (String(modelType) === "RESPONSE_HANDLER" && !stage1Served) {
+						stage1Served = true;
+						return {
+							text: "",
+							toolCalls: [
+								{
+									id: "handle-response-1",
+									name: "HANDLE_RESPONSE",
+									arguments: {
+										shouldRespond: "RESPOND",
+										thought: "",
+										contexts: ["general"],
+										intents: [],
+										candidateActionNames: [],
+										replyText: "",
+										facts: [],
+										relationships: [],
+										addressedTo: [],
+									},
 								},
-							},
-						],
-					};
-				}
-				throw RATE_LIMIT_ERROR;
-			}),
-			composeState: vi.fn(async () => makeState()),
-			runActionsByMode: vi.fn(async () => undefined),
-			applyPipelineHooks: vi.fn(async () => undefined),
-			emitEvent: vi.fn(async () => undefined),
-			reportError: vi.fn(),
-			startRun: vi.fn(() => RUN_ID),
-			getCurrentRunId: vi.fn(() => RUN_ID),
-			endRun: vi.fn(),
-			getMemoryById: vi.fn(async () => null),
-			createMemory: vi.fn(async () => asUUID(v4())),
-			updateMemory: vi.fn(async () => true),
-			queueEmbeddingGeneration: vi.fn(async () => undefined),
-			getParticipantUserState: vi.fn(async () => null),
-			getRoom: vi.fn(async () => makeRoom(ChannelType.GROUP)),
-			getRoomsByIds: vi.fn(async () => [makeRoom(ChannelType.GROUP)]),
-			getMemories: vi.fn(async () => []),
-			isCheckShouldRespondEnabled: vi.fn(() => true),
-			turnControllers: new TurnControllerRegistry(),
-			responseHandlerFieldRegistry,
-			responseHandlerFieldEvaluators: [
-				...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
-			],
-			responseHandlerEvaluators: [
-				{
-					name: "test-clobber-to-ack",
-					priority: 100,
-					shouldRun: () => true,
-					evaluate: () => ({ reply: "On it.", requiresTool: true }),
+							],
+						};
+					}
+					throw RATE_LIMIT_ERROR;
+				}),
+				composeState: vi.fn(async () => makeState()),
+				runActionsByMode: vi.fn(async () => undefined),
+				applyPipelineHooks: vi.fn(async () => undefined),
+				emitEvent: vi.fn(async () => undefined),
+				reportError: vi.fn(),
+				startRun: vi.fn(() => RUN_ID),
+				getCurrentRunId: vi.fn(() => RUN_ID),
+				endRun: vi.fn(),
+				getMemoryById: vi.fn(async () => null),
+				createMemory: vi.fn(async () => asUUID(v4())),
+				updateMemory: vi.fn(async () => true),
+				queueEmbeddingGeneration: vi.fn(async () => undefined),
+				getParticipantUserState: vi.fn(async () => null),
+				getRoom: vi.fn(async () => makeRoom(ChannelType.GROUP)),
+				getRoomsByIds: vi.fn(async () => [makeRoom(ChannelType.GROUP)]),
+				getMemories: vi.fn(async () => []),
+				isCheckShouldRespondEnabled: vi.fn(() => true),
+				turnControllers: new TurnControllerRegistry(),
+				responseHandlerFieldRegistry,
+				responseHandlerFieldEvaluators: [
+					...BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+				],
+				responseHandlerEvaluators: [
+					{
+						name: "test-clobber-to-ack",
+						priority: 100,
+						shouldRun: () => true,
+						evaluate: () => ({ reply: "On it.", requiresTool: true }),
+					},
+				],
+			} as never);
+
+			const service = new DefaultMessageService();
+			const deliveries: Content[] = [];
+			const result = await service.handleMessage(
+				runtime,
+				makeMessage({}),
+				async (content) => {
+					deliveries.push(content);
+					return [];
 				},
-			],
-		} as never);
+			);
 
-		const service = new DefaultMessageService();
-		const deliveries: Content[] = [];
-		const result = await service.handleMessage(
-			runtime,
-			makeMessage({}),
-			async (content) => {
-				deliveries.push(content);
-				return [];
-			},
-		);
+			const visibleTexts = deliveries
+				.map((content) =>
+					typeof content.text === "string" ? content.text : "",
+				)
+				.filter((text) => text.trim().length > 0);
 
-		const visibleTexts = deliveries
-			.map((content) => (typeof content.text === "string" ? content.text : ""))
-			.filter((text) => text.trim().length > 0);
-
-		expect(result.didRespond).toBe(true);
-		expect(visibleTexts).toHaveLength(1);
-		expect(visibleTexts[0].toLowerCase()).toContain("rate-limit");
-	});
+			if (expectVisible) {
+				expect(result.didRespond).toBe(true);
+				expect(visibleTexts).toHaveLength(1);
+				expect(visibleTexts[0].toLowerCase()).toContain("rate-limit");
+			} else {
+				expect(result.didRespond).toBe(false);
+				expect(visibleTexts).toEqual([]);
+			}
+		},
+	);
 });

--- a/packages/core/src/services/message/processor.ts
+++ b/packages/core/src/services/message/processor.ts
@@ -3,6 +3,10 @@
 import { v4 } from "uuid";
 import { createUniqueUuid } from "../../entities";
 import { ElizaError } from "../../errors";
+import {
+	resolveFailureReplyPolicy,
+	shouldEmitFailureReply,
+} from "../../failure-reply-policy";
 import { decideReplyGate } from "../../features/advanced-capabilities/personality";
 import { getPersonalityStore } from "../../features/advanced-capabilities/personality/services/personality-store.ts";
 import {
@@ -927,7 +931,45 @@ export class MessageProcessor {
 				// turn before the runtime died — that is the model evaluation the
 				// deterministic gate defers to, so the anti-spam suppression
 				// (which exists for pre-decision throws) does not apply.
-				if (failureGate.addressed || stage1DecidedRespond) {
+				//
+				// On top of addressing, FAILURE_REPLY_POLICY decides WHERE a canned
+				// failure text is acceptable at all. Under the default `dm-only`
+				// an addressed turn in a public room (guild channel, thread, group)
+				// still stays silent: every reader would see the same outage
+				// apology and nobody can act on it. Private rooms and autonomous
+				// turns keep the reply, where silence reads as a hang.
+				const failureReplyPolicy = resolveFailureReplyPolicy(runtime, {
+					logger: runtime.logger,
+				});
+				const failureReplyDecision = shouldEmitFailureReply({
+					policy: failureReplyPolicy,
+					channelType:
+						(message.content?.channelType as string | undefined) ??
+						(room?.type as string | undefined) ??
+						null,
+					isAutonomous,
+				});
+				if (
+					(failureGate.addressed || stage1DecidedRespond) &&
+					!failureReplyDecision.emit
+				) {
+					runtime.logger.info(
+						{
+							src: "service:message",
+							agentId: runtime.agentId,
+							roomId: message.roomId,
+							reason: "policy",
+							policy: failureReplyPolicy,
+							policyReason: failureReplyDecision.reason,
+							channelType: message.content?.channelType ?? room?.type,
+							addressed: failureGate.addressed,
+							stage1DecidedRespond,
+						},
+						"v5 runtime failed on an addressed turn; suppressing failure reply",
+					);
+					shouldRespondToMessage = false;
+					terminalDecision = "IGNORE";
+				} else if (failureGate.addressed || stage1DecidedRespond) {
 					shouldRespondToMessage = true;
 					terminalDecision = null;
 					// Distinguish WHY the runtime died so the failure reply names

--- a/plugins/plugin-discord/__tests__/failure-reply-policy.test.ts
+++ b/plugins/plugin-discord/__tests__/failure-reply-policy.test.ts
@@ -1,0 +1,360 @@
+/**
+ * FAILURE_REPLY_POLICY on the Discord generation-failure path.
+ *
+ * When generation times out or the provider throws, the connector used to
+ * post a canned "I timed out while generating that reply. Please retry." /
+ * "I hit a provider issue ..." into whatever channel the inbound came from.
+ * In a guild channel that is public noise: every reader sees the outage and
+ * nobody can act on it (observed live: five identical timeout posts into a
+ * shared channel during a 29h provider outage). Under the default `dm-only`
+ * policy a public room now gets the error reaction only; DMs keep the text.
+ *
+ * Drives the REAL `MessageManager.handleMessage` with a hanging or throwing
+ * messageService; only the discord.js surface is stubbed.
+ */
+import type { Content, Memory, UUID } from "@elizaos/core";
+import { ChannelType } from "@elizaos/core";
+import type { Message as DiscordMessage } from "discord.js";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageManager } from "../messages.ts";
+import type { ICompatRuntime, IDiscordService } from "../types.ts";
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as UUID;
+const CLIENT_ID = "888000000000000000";
+const GUILD_ID = "999000000000000000";
+const noop = () => {};
+
+const INBOUND_MEMORY: Memory = {
+	id: "12345678-1234-1234-1234-123456789abc" as UUID,
+	entityId: "87654321-4321-4321-4321-cba987654321" as UUID,
+	agentId: AGENT_ID,
+	roomId: "11111111-2222-3333-4444-555555555555" as UUID,
+	content: { text: "a real question that takes a while", source: "discord" },
+};
+
+interface Sent {
+	content?: string;
+}
+
+type LogEntry = [Record<string, unknown>, string];
+
+const canonicalRoomMethods = (type: ChannelType) => ({
+	getRoom: async () => ({ id: INBOUND_MEMORY.roomId, type }),
+	getParticipantsForRoom: async () => [INBOUND_MEMORY.entityId, AGENT_ID],
+	reportError: noop,
+});
+
+/**
+ * `mode` selects how the dispatch dies: `hang` never resolves (the generation
+ * timeout fires), `throw` rejects immediately (provider issue).
+ */
+function makeRuntime(options: {
+	mode: "hang" | "throw";
+	roomType: ChannelType;
+	settings?: Record<string, string>;
+}): { runtime: ICompatRuntime; infos: LogEntry[]; warns: LogEntry[] } {
+	const infos: LogEntry[] = [];
+	const warns: LogEntry[] = [];
+	const settings: Record<string, string> = {
+		ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "false",
+		DISCORD_GENERATION_TIMEOUT_MS: "30000",
+		...(options.settings ?? {}),
+	};
+	const runtime = {
+		agentId: AGENT_ID,
+		character: { name: "Eliza" },
+		logger: {
+			debug: noop,
+			info: (...args: unknown[]) => infos.push(args as LogEntry),
+			warn: (...args: unknown[]) => warns.push(args as LogEntry),
+			error: noop,
+		},
+		getSetting: (key: string) => settings[key],
+		getService: () => null,
+		ensureConnection: async () => {},
+		...canonicalRoomMethods(options.roomType),
+		getMemoryById: async () => null,
+		createMemory: async (memory: Memory) => memory.id,
+		messageService: {
+			handleMessage: (
+				_runtime: unknown,
+				_message: Memory,
+				_callback: (content: Content) => Promise<unknown>,
+			) => {
+				if (options.mode === "throw") {
+					return Promise.reject(new Error("provider exploded"));
+				}
+				return new Promise<never>(() => {});
+			},
+		},
+	} as unknown as ICompatRuntime;
+	return { runtime, infos, warns };
+}
+
+function makeChannel(kind: "dm" | "guild" | "thread", sends: Sent[]) {
+	const base = {
+		id: "777000000000000000",
+		client: { user: { id: CLIENT_ID } },
+		send: async (options: Sent) => {
+			sends.push(options);
+			return { id: `99000000000000000${sends.length}`, ...options };
+		},
+		sendTyping: async () => {},
+	};
+	if (kind === "dm") {
+		return { ...base, type: DiscordChannelType.DM, isThread: () => false };
+	}
+	const guild = {
+		id: GUILD_ID,
+		name: "Test Guild",
+		ownerId: "444000000000000000",
+		members: { cache: new Map([[CLIENT_ID, { id: CLIENT_ID }]]) },
+	};
+	return {
+		...base,
+		type:
+			kind === "thread"
+				? DiscordChannelType.PublicThread
+				: DiscordChannelType.GuildText,
+		name: "development",
+		guild,
+		isThread: () => kind === "thread",
+		permissionsFor: () => ({ has: () => true }),
+	};
+}
+
+function makeDiscordService(roomType: ChannelType): IDiscordService {
+	return {
+		client: { user: { id: CLIENT_ID } },
+		accountId: "default",
+		getChannelType: async () => roomType,
+		discordSettings: {
+			autoReply: true,
+			dmPolicy: "open",
+			shouldIgnoreBotMessages: true,
+			shouldIgnoreDirectMessages: false,
+			shouldRespondOnlyToMentions: false,
+			replyToMode: "off",
+		},
+		buildMemoryFromMessage: async () => INBOUND_MEMORY,
+	} as unknown as IDiscordService;
+}
+
+function makeInbound(
+	channel: ReturnType<typeof makeChannel>,
+	reactionEvents: string[],
+): DiscordMessage {
+	const activeReactions = new Map<
+		string,
+		{ users: { remove: () => Promise<void> } }
+	>();
+	const guild = "guild" in channel ? channel.guild : undefined;
+	const users = new Map<string, { id: string }>();
+	// Always address the bot so a guild room reaches dispatch on the
+	// respond-only-to-mentions safe side; the policy must still silence it.
+	users.set(CLIENT_ID, { id: CLIENT_ID });
+	return {
+		id: "666000000000000000",
+		content: `<@${CLIENT_ID}> a real question that takes a while`,
+		createdTimestamp: Date.now(),
+		author: {
+			id: "555000111222333444",
+			bot: false,
+			username: "tester",
+			globalName: "Tester",
+			displayName: "Tester",
+			discriminator: "0",
+			displayAvatarURL: () => "https://cdn.example/avatar.png",
+		},
+		member: { displayName: "Tester" },
+		channel,
+		client: { user: { id: CLIENT_ID } },
+		react: async (emoji: string) => {
+			reactionEvents.push(`add:${emoji}`);
+			activeReactions.set(emoji, {
+				users: {
+					remove: async () => {
+						reactionEvents.push(`remove:${emoji}`);
+						activeReactions.delete(emoji);
+					},
+				},
+			});
+		},
+		reactions: { resolve: (emoji: string) => activeReactions.get(emoji) },
+		guild,
+		interaction: null,
+		reference: undefined,
+		embeds: [],
+		stickers: { size: 0 },
+		attachments: { size: 0 },
+		mentions: {
+			users,
+			repliedUser: undefined,
+			has: () => true,
+		},
+	} as unknown as DiscordMessage;
+}
+
+async function runFailure(options: {
+	channel: "dm" | "guild" | "thread";
+	mode: "hang" | "throw";
+	settings?: Record<string, string>;
+}) {
+	const sends: Sent[] = [];
+	const reactionEvents: string[] = [];
+	const roomType =
+		options.channel === "dm" ? ChannelType.DM : ChannelType.GROUP;
+	const channel = makeChannel(options.channel, sends);
+	const { runtime, infos, warns } = makeRuntime({
+		mode: options.mode,
+		roomType,
+		settings: options.settings,
+	});
+	const manager = new MessageManager(makeDiscordService(roomType), runtime);
+	const handled = manager.handleMessage(makeInbound(channel, reactionEvents));
+	await vi.advanceTimersByTimeAsync(0);
+	if (options.mode === "hang") {
+		await vi.advanceTimersByTimeAsync(30_000);
+	}
+	await handled;
+	await vi.advanceTimersByTimeAsync(0);
+	return { sends, reactionEvents, infos, warns };
+}
+
+const failureTexts = (sends: Sent[]) =>
+	sends.filter(
+		(s) =>
+			String(s.content).includes("timed out") ||
+			String(s.content).includes("provider issue"),
+	);
+
+describe("Discord FAILURE_REPLY_POLICY", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	describe("default (dm-only)", () => {
+		it("guild channel timeout: no channel.send, error reaction set, suppression logged", async () => {
+			const { sends, reactionEvents, infos } = await runFailure({
+				channel: "guild",
+				mode: "hang",
+			});
+			expect(failureTexts(sends)).toHaveLength(0);
+			expect(sends).toHaveLength(0);
+			expect(reactionEvents).toContain("add:❌");
+			const suppressed = infos.find(
+				([ctx]) => ctx.code === "DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC",
+			);
+			expect(suppressed).toBeDefined();
+			expect(suppressed?.[0]).toMatchObject({
+				channelId: "777000000000000000",
+				cause: "timeout",
+				policy: "dm-only",
+				reason: "policy-dm-only-public-room",
+				isDm: false,
+			});
+		});
+
+		it("guild channel provider error: no channel.send, cause=provider", async () => {
+			const { sends, reactionEvents, infos } = await runFailure({
+				channel: "guild",
+				mode: "throw",
+			});
+			expect(sends).toHaveLength(0);
+			expect(reactionEvents).toContain("add:❌");
+			const suppressed = infos.find(
+				([ctx]) => ctx.code === "DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC",
+			);
+			expect(suppressed?.[0]).toMatchObject({ cause: "provider" });
+		});
+
+		it("public thread timeout: silent like its parent guild channel", async () => {
+			const { sends, reactionEvents } = await runFailure({
+				channel: "thread",
+				mode: "hang",
+			});
+			expect(sends).toHaveLength(0);
+			expect(reactionEvents).toContain("add:❌");
+		});
+
+		it("DM timeout: failure reply still sent", async () => {
+			const { sends, reactionEvents, infos } = await runFailure({
+				channel: "dm",
+				mode: "hang",
+			});
+			const replies = failureTexts(sends);
+			expect(replies).toHaveLength(1);
+			expect(replies[0].content).toContain("timed out");
+			expect(reactionEvents).toContain("add:❌");
+			expect(
+				infos.some(
+					([ctx]) => ctx.code === "DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC",
+				),
+			).toBe(false);
+		});
+
+		it("DM provider error: failure reply still sent", async () => {
+			const { sends } = await runFailure({ channel: "dm", mode: "throw" });
+			const replies = failureTexts(sends);
+			expect(replies).toHaveLength(1);
+			expect(replies[0].content).toContain("provider issue");
+		});
+	});
+
+	describe("FAILURE_REPLY_POLICY=all", () => {
+		it("guild channel timeout: legacy behavior, failure reply sent", async () => {
+			const { sends, reactionEvents } = await runFailure({
+				channel: "guild",
+				mode: "hang",
+				settings: { FAILURE_REPLY_POLICY: "all" },
+			});
+			const replies = failureTexts(sends);
+			expect(replies).toHaveLength(1);
+			expect(replies[0].content).toContain("timed out");
+			expect(reactionEvents).toContain("add:❌");
+		});
+	});
+
+	describe("FAILURE_REPLY_POLICY=off", () => {
+		it("DM timeout: silent too, error reaction still set", async () => {
+			const { sends, reactionEvents, infos } = await runFailure({
+				channel: "dm",
+				mode: "hang",
+				settings: { FAILURE_REPLY_POLICY: "off" },
+			});
+			expect(sends).toHaveLength(0);
+			expect(reactionEvents).toContain("add:❌");
+			const suppressed = infos.find(
+				([ctx]) => ctx.code === "DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC",
+			);
+			expect(suppressed?.[0]).toMatchObject({
+				policy: "off",
+				reason: "policy-off",
+				isDm: true,
+			});
+		});
+	});
+
+	describe("unrecognized value", () => {
+		it("fails closed to dm-only: guild silent, DM replies, warning logged", async () => {
+			const guild = await runFailure({
+				channel: "guild",
+				mode: "hang",
+				settings: { FAILURE_REPLY_POLICY: "loud" },
+			});
+			expect(guild.sends).toHaveLength(0);
+			const dm = await runFailure({
+				channel: "dm",
+				mode: "hang",
+				settings: { FAILURE_REPLY_POLICY: "loud" },
+			});
+			expect(failureTexts(dm.sends)).toHaveLength(1);
+		});
+	});
+});

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -21,10 +21,12 @@ import {
 	type Media,
 	type Memory,
 	MemoryType,
+	resolveFailureReplyPolicy,
 	type SendHandlerPersistenceFailure,
 	type SendHandlerReceipt,
 	type Service,
 	ServiceType,
+	shouldEmitFailureReply,
 	stringToUuid,
 	TurnAbortedError,
 	toWellFormedUnicode,
@@ -2214,7 +2216,83 @@ export class MessageManager {
 				}
 			};
 
-			const sendFailureReply = async (text: string) => {
+			const sendFailureReply = async (
+				text: string,
+				cause: "timeout" | "provider" = "provider",
+			) => {
+				// FAILURE_REPLY_POLICY (default `dm-only`): a canned failure notice
+				// is a courtesy in a DM and noise in a guild channel, where every
+				// reader sees the outage and nobody can act on it. In a public room
+				// the failure signal is the error reaction (already set by the
+				// caller); the text is dropped. The lease bookkeeping still runs:
+				// a claimed slot that never delivers must be released, otherwise the
+				// crash sweeper re-dispatches this edge and the bot-lane budget
+				// stays spent.
+				const failurePolicy = resolveFailureReplyPolicy(this.runtime, {
+					logger: this.runtime.logger,
+				});
+				const failureDecision = shouldEmitFailureReply({
+					policy: failurePolicy,
+					isDm: isDM,
+				});
+				if (!failureDecision.emit) {
+					this.runtime.logger.info(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							code: "DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC",
+							channelId: message.channel.id,
+							messageId: message.id,
+							cause,
+							policy: failurePolicy,
+							reason: failureDecision.reason,
+							isDm: isDM,
+						},
+						"Suppressing Discord failure reply under FAILURE_REPLY_POLICY",
+					);
+					if (speakerLease) {
+						try {
+							await releaseSpeakerLease(
+								this.runtime,
+								speakerLease,
+								"failure-reply-suppressed",
+							);
+							await emitCoordinationReceipt(this.runtime, {
+								kind: "delivery-reconciled",
+								channelId: message.channel.id,
+								edgeMessageId: message.id,
+								roomId,
+								entityId: newMessage.entityId,
+								worldId,
+								outcome: "failure-reply-suppressed",
+								generation: speakerLease.generation,
+								holderToken: speakerLease.contenderToken,
+								edgeEpoch: speakerLease.edgeEpoch,
+								detail: {
+									cause,
+									policy: failurePolicy,
+									reason: failureDecision.reason,
+								},
+								scope: coordinationScope,
+							});
+						} catch (leaseError) {
+							this.runtime.logger.warn(
+								{
+									src: "plugin:discord",
+									agentId: this.runtime.agentId,
+									channelId: message.channel.id,
+									messageId: message.id,
+									error:
+										leaseError instanceof Error
+											? leaseError.message
+											: String(leaseError),
+								},
+								"Failed to release speaker lease after suppressing failure reply",
+							);
+						}
+					}
+					return;
+				}
 				try {
 					const fenced = await verifyFencedOutboundSend("failure-reply");
 					if (!fenced) {
@@ -3141,6 +3219,7 @@ export class MessageManager {
 						generationTimedOut
 							? "I timed out while generating that reply. Please retry."
 							: "I hit a provider issue while generating the reply. Please retry.",
+						generationTimedOut ? "timeout" : "provider",
 					);
 				}
 				if (!inboundMemoryCommitted) {

--- a/plugins/plugin-discord/test/messages-group-coordination-pglite.test.ts
+++ b/plugins/plugin-discord/test/messages-group-coordination-pglite.test.ts
@@ -20,6 +20,8 @@
  *   (e) bot-reply budget                 -> the human answer does NOT spend it
  *   (f) redelivery/retry                 -> cannot double-send
  *   (g) IGNORE/no-reply                  -> slot released, not resurrected
+ *   (h) FAILURE_REPLY_POLICY             -> suppressed public failure text
+ *                                           still releases the slot + receipt
  */
 import { randomUUID } from "node:crypto";
 import {
@@ -469,6 +471,15 @@ describe("group coordination on the real SQL path — latest-human-edge-wins", (
 				throw new Error("provider exploded");
 			},
 		});
+		// The fence sits immediately before channel.send. Under the default
+		// FAILURE_REPLY_POLICY=dm-only a guild failure never reaches the send
+		// (covered in the FAILURE_REPLY_POLICY suite below); opt into `all` so
+		// this test keeps proving the pre-send fence on the failure-reply path.
+		const baseGetSetting = runtime.getSetting.bind(runtime);
+		runtime.getSetting = ((key: string) =>
+			key === "FAILURE_REPLY_POLICY"
+				? "all"
+				: baseGetSetting(key)) as typeof runtime.getSetting;
 		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
 		const manager = new MessageManager(
 			makeService(runtime, CLIENT_A, channelId),
@@ -695,5 +706,90 @@ describe("group coordination on the real SQL path — retry and no-reply", () =>
 		// Left `claimed`, this would expire and the sweeper would re-dispatch an
 		// edge the agent chose not to answer, forever.
 		expect(slots[0].state).toBe("released");
+	});
+});
+
+describe("group coordination on the real SQL path — FAILURE_REPLY_POLICY", () => {
+	it("a provider failure under the default dm-only policy releases the slot without a public send", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+		const runtime = makeRuntime(AGENT_A, "instance-a", {
+			onGenerate: async () => {
+				throw new Error("provider exploded");
+			},
+		});
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId),
+			runtime,
+		);
+
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000040",
+				mentionsBotId: CLIENT_A,
+			}),
+		);
+
+		// No canned failure text in the guild channel.
+		expect(sends).toHaveLength(0);
+		// The claimed slot must not be left dangling: `claimed` would expire
+		// and the sweeper would re-dispatch the failed edge.
+		const slots = await slotsFor(channelId);
+		expect(slots).toHaveLength(1);
+		expect(slots[0].state).toBe("released");
+		expect(slots[0].delivered_message_id).toBeNull();
+		// Other participants still see a terminal receipt for this edge.
+		const reconciled = await receiptsFor(channelId, "delivery-reconciled");
+		expect(reconciled).toHaveLength(1);
+		expect(reconciled[0].outcome).toBe("failure-reply-suppressed");
+		expect(
+			(runtime.logger.info as ReturnType<typeof vi.fn>).mock.calls.some(
+				([ctx]) =>
+					(ctx as Record<string, unknown>).code ===
+					"DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC",
+			),
+		).toBe(true);
+	});
+
+	it("FAILURE_REPLY_POLICY=all keeps the legacy fenced failure reply in a guild channel", async () => {
+		const channelId = freshChannelId();
+		const sends: Sent[] = [];
+		const runtime = makeRuntime(AGENT_A, "instance-a", {
+			onGenerate: async () => {
+				throw new Error("provider exploded");
+			},
+		});
+		const baseGetSetting = runtime.getSetting.bind(runtime);
+		runtime.getSetting = ((key: string) =>
+			key === "FAILURE_REPLY_POLICY"
+				? "all"
+				: baseGetSetting(key)) as typeof runtime.getSetting;
+		const chan = makeGuildChannel(AGENT_A, CLIENT_A, channelId, sends);
+		const manager = new MessageManager(
+			makeService(runtime, CLIENT_A, channelId),
+			runtime,
+		);
+
+		await manager.handleMessage(
+			makeInbound({
+				channel: chan.channel,
+				guild: chan.guild,
+				channelId,
+				messageId: "222000000000000041",
+				mentionsBotId: CLIENT_A,
+			}),
+		);
+
+		expect(sends).toHaveLength(1);
+		expect(sends[0].content).toContain("provider issue");
+		const slots = await slotsFor(channelId);
+		expect(slots[0].state).toBe("delivered");
+		const reconciled = await receiptsFor(channelId, "delivery-reconciled");
+		expect(reconciled).toHaveLength(1);
+		expect(reconciled[0].outcome).toBe("failure-reply");
 	});
 });


### PR DESCRIPTION
# Relates to

Follow-up to the addressed-turn failure gate in `MessageProcessor` (the "91 canned-failure sends in 2 days" fix) and the Discord generation-timeout reply. No issue filed; observed live: five "I timed out while generating that reply. Please retry." posts from one agent into a shared guild channel between Sep 6 and Sep 8 during a 29h provider outage.

Definition of Done: [CONTRIBUTING.md](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] Targets `develop`; branched from `357084b3092efb39f95807bcd459baadcc39f095` with no conflicts.
- [x] Frozen install on Bun 1.4.0 / Node 24.14.0; touched-package tests, biome and tsc run after sync.
- [x] Behavioral evidence is included below (before/after test runs on clean develop vs this head).

# Sync with develop

Base is `357084b3092efb39f95807bcd459baadcc39f095` (current `origin/develop` at branch time). No rebase needed.

# Risks

Behavior change with a new default. Under `FAILURE_REPLY_POLICY=dm-only` (default) an addressed turn in a public room that dies before producing a reply now stays silent (error reaction only on Discord) instead of posting a canned failure notice. DMs, VOICE_DM, API, SELF rooms and autonomous turns are unchanged. Operators who want the old behavior set `FAILURE_REPLY_POLICY=all`. Unknown values fail closed to `dm-only` with a one-time warning.

On the Discord group-coordination path the suppressed failure still releases the speaker lease (`state=released`) and writes a `delivery-reconciled` receipt with `outcome=failure-reply-suppressed`, so the crash sweeper does not re-dispatch the edge and other contenders see it close. Covered on the real PGlite path.

Telegram is not touched.

# Background

## What does this PR do?

Adds a shared, vendor-neutral `FAILURE_REPLY_POLICY` runtime setting (runtime.getSetting, env fallback) in `packages/core/src/failure-reply-policy.ts`:

- `dm-only` (default): canned failure text only in DM / VOICE_DM / API / SELF rooms and autonomous turns
- `all`: legacy behavior, failure text everywhere
- `off`: never post failure text

Two producers consult it:

1. **core** `MessageProcessor`: the existing deterministic-addressing gate decides *whether the turn addressed the agent*; the policy now decides *whether that room may receive failure text at all*. Suppression logs the existing "suppressing failure reply" pattern with `reason=policy`, `policy`, `policyReason`, `channelType`, and terminates as IGNORE.
2. **plugin-discord** `sendFailureReply` (timeout and provider-error paths): under `dm-only` in a guild channel or thread it still sets the ❌ reaction, aborts the pending draft, runs the inbound-memory release, releases the speaker lease and writes the coordination receipt, but never calls `channel.send`. Logs at info with `code=DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC`, `channelId`, `cause` (`timeout` | `provider`).

## What kind of change is this?

Feature with a behavior-changing default, plus regression tests.

# Documentation changes needed?

Setting is documented in the module docblock. No user-facing docs page lists connector env vars for this path yet; happy to add one if maintainers point at the right file.

# Testing

## Where should a reviewer start?

`packages/core/src/failure-reply-policy.ts` (the whole policy, ~200 lines), then the two call sites: `packages/core/src/services/message/processor.ts` (structured-failure gate) and `plugins/plugin-discord/messages.ts` (`sendFailureReply`).

## Detailed testing steps

```sh
bun install --frozen-lockfile
# core
bunx vitest run --config packages/core/vitest.config.ts \
  packages/core/src/__tests__/failure-reply-policy.test.ts \
  packages/core/src/services/message.runtime-failure-suppression.test.ts
bunx vitest run --config packages/core/vitest.config.ts packages/core/src/services
# discord
cd plugins/plugin-discord && bunx vitest run
```

Bidirectional proof (same new test files copied onto a clean `357084b3092` worktree, fix absent):

| suite | clean develop | this head |
|---|---|---|
| plugin-discord full (`bunx vitest run`) | 6 failed / 869 passed (875), 2 files | 875 passed (875), 100 files |
| plugin-discord `__tests__/failure-reply-policy.test.ts` | 5 failed / 3 passed | 8 passed |
| plugin-discord `test/messages-group-coordination-pglite.test.ts` | 1 failed / 9 passed | 10 passed |
| core `message.runtime-failure-suppression.test.ts` | 4 failed / 16 passed | 20 passed |
| core `__tests__/failure-reply-policy.test.ts` | n/a (new module) | 15 passed |
| core `packages/core/src/services` sweep + touched runtime tests | not run | 1864 passed (1864), 107 files |

The 3 passing-on-baseline cases in the new Discord file are the legacy-behavior pins (DM keeps reply, `all` keeps reply); the 5 failing ones are exactly the suppression cases. Three existing core tests that pin failure-reply TEXT on an addressed group turn (`message.character-failure-templates`, `message.context-overflow-reply`, `message.credit-exhaustion-reply`) opt into `FAILURE_REPLY_POLICY=all` so they keep exercising the template path; the existing pglite "fences the provider-error reply" test does the same.

# Evidence Gate

<!-- evidence-head:530c1b3832c514e63c98d39f3f1471cb0c645153 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - connector and message-service logic, no UI interaction.
<!-- evidence-row:backend-logs -->
- [x] Real `MessageManager.handleMessage` and `DefaultMessageService.handleMessage` runs on clean develop vs this head:

<details><summary>plugin-discord, clean develop 357084b3092 (fix absent, new tests present)</summary>

```text
 × guild channel timeout: no channel.send, error reaction set, suppression logged
 × guild channel provider error: no channel.send, cause=provider
 × public thread timeout: silent like its parent guild channel
 ✓ DM timeout: failure reply still sent
 ✓ DM provider error: failure reply still sent
 ✓ guild channel timeout: legacy behavior, failure reply sent   (FAILURE_REPLY_POLICY=all)
 × DM timeout: silent too, error reaction still set             (FAILURE_REPLY_POLICY=off)
 × fails closed to dm-only: guild silent, DM replies, warning logged
 × a provider failure under the default dm-only policy releases the slot without a public send   (pglite)
 ✓ FAILURE_REPLY_POLICY=all keeps the legacy fenced failure reply in a guild channel              (pglite)

 Test Files  2 failed | 98 passed (100)
      Tests  6 failed | 869 passed (875)
```

</details>

<details><summary>plugin-discord, this head</summary>

```text
 Test Files  100 passed (100)
      Tests  875 passed (875)
```

</details>

<details><summary>core message.runtime-failure-suppression, clean develop vs this head</summary>

```text
clean develop:
 × stays silent on a platform mention in a group room under the default dm-only policy
 ✓ still surfaces the failure reply on a platform mention when FAILURE_REPLY_POLICY=all
 ✓ keeps the DM failure reply under the default dm-only policy
 × silences the DM failure reply when FAILURE_REPLY_POLICY=off
 × fails closed to dm-only on an unrecognized FAILURE_REPLY_POLICY value
 ✓ stage-1 RESPOND ... under FAILURE_REPLY_POLICY=all: visible failure=true
 × stage-1 RESPOND ... under FAILURE_REPLY_POLICY=dm-only: visible failure=false
 Tests  4 failed | 16 passed (20)

this head:
 Tests  20 passed (20)

core services sweep (this head):
 Test Files  107 passed (107)
      Tests  1864 passed (1864)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser or frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model or action behavior changed. The gate runs only after the model call has already thrown; tests drive the real pipeline with `useModel` rejecting the way a rate-limited provider does.
<!-- evidence-row:domain-artifacts -->
- [x] Migrated PGlite assertions on the Discord coordination schema (`discord_coordination_reply_slots`, `discord_coordination_receipts`): after a suppressed guild failure the reply slot is `state=released` with `delivered_message_id IS NULL`, and exactly one `delivery-reconciled` receipt with `outcome=failure-reply-suppressed` exists for the edge. Local database evidence, not a live Discord receipt.

<details><summary>Real SQL path, this head</summary>

```text
bunx vitest run test/messages-group-coordination-pglite.test.ts -t "FAILURE_REPLY_POLICY" --reporter=verbose

 ✓ group coordination on the real SQL path — FAILURE_REPLY_POLICY > a provider failure under the default dm-only policy releases the slot without a public send 108ms
     sends.length === 0
     slots[0].state === "released", slots[0].delivered_message_id === null
     receipts(kind=delivery-reconciled).length === 1, outcome === "failure-reply-suppressed"
     logger.info called with code=DISCORD_FAILURE_REPLY_SUPPRESSED_PUBLIC
 ✓ group coordination on the real SQL path — FAILURE_REPLY_POLICY > FAILURE_REPLY_POLICY=all keeps the legacy fenced failure reply in a guild channel 33ms
     sends[0].content includes "provider issue"
     slots[0].state === "delivered"
     receipts(kind=delivery-reconciled)[0].outcome === "failure-reply"

 Test Files  1 passed (1)
      Tests  2 passed | 8 skipped (10)

clean develop 357084b3092 (same test file): the first case fails at `expect(sends).toHaveLength(0)` (received 1: the canned "provider issue" text was sent into the guild channel).
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.
