### PR TITLE
test(ui): cover ViewErrorBoundary stale-deploy chunk reload self-heal

### DIFF
--- a/packages/ui/src/components/views/ViewErrorBoundary.test.tsx
+++ b/packages/ui/src/components/views/ViewErrorBoundary.test.tsx
@@ -18,21 +18,59 @@ import {
 } from "../../view-runtime-telemetry";
 import { ViewErrorBoundary } from "./ViewErrorBoundary";
 
+/** Must match CHUNK_RELOAD_AT_KEY in utils/chunk-load-recovery.ts. */
+const RELOAD_MARKER_KEY = "eliza:chunk-reload-attempted-at";
+/** Must match RELOAD_COOLDOWN_MS in utils/chunk-load-recovery.ts. */
+const COOLDOWN_MS = 5 * 60 * 1000;
+
+// The two stale-deploy chunk-fetch message forms the boundary must self-heal:
+// a hashed JS view chunk that 404s after a deploy, and Vite's CSS-preload
+// failure for a stylesheet that moved with the same deploy.
+const CHUNK_FAILURES = [
+  [
+    "JavaScript import",
+    "Failed to fetch dynamically imported module: https://eliza.app/assets/NotesView-Bx1v9qQ3.js",
+  ],
+  ["Vite CSS preload", "Unable to preload CSS for /assets/notes-view-old.css"],
+] as const;
+
+let reloadSpy: ReturnType<typeof vi.fn>;
+const originalLocation = window.location;
+
 beforeEach(() => {
   __resetViewLifecycleForTests();
   __resetViewRuntimeTelemetryForTests();
   installViewRuntimeTelemetryRing();
+  // A stale reload marker from another suite would suppress the one-shot
+  // reload; start every case with an empty cooldown budget.
+  window.sessionStorage.clear();
+  // The recovery path calls window.location.reload(); jsdom cannot navigate,
+  // so stub reload with a spy the way CloudRouteErrorBoundary's suite does.
+  reloadSpy = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, reload: reloadSpy },
+  });
   // jsdom logs the caught error; silence the noise for a clean run.
   vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
   cleanup();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+  window.sessionStorage.clear();
   vi.restoreAllMocks();
 });
 
 function Boom(): React.JSX.Element {
   throw new Error("kaboom");
+}
+
+function ChunkBoom({ message }: { message: string }): React.JSX.Element {
+  throw new Error(message);
 }
 
 function Recoverable({ crash }: { crash: boolean }): React.JSX.Element {
@@ -126,4 +164,82 @@ describe("ViewErrorBoundary", () => {
       "kaboom",
     );
   });
+});
+
+// Pins the mid-session-deploy chunk-reload self-heal (#15383/#30889) at the
+// app-views boundary: a stale lazy-chunk fetch failure triggers exactly ONE
+// cooldown-guarded reload and does NOT latch the view crashed, while a
+// non-chunk crash and a cooldown-exhausted chunk failure both degrade to the
+// crash card with zero reloads. Without this coverage, dropping the
+// `isChunkLoadError(error) && tryChunkReloadRecovery()` guard in handleError
+// passes CI while reintroducing the #15383 regression (every not-yet-visited
+// view shows a permanent crash card after a deploy).
+describe("ViewErrorBoundary — stale-deploy chunk reload self-heal", () => {
+  it.each(CHUNK_FAILURES)(
+    "reloads exactly once for a %s failure and does NOT mark the view crashed",
+    (_kind, message) => {
+      render(
+        <ViewErrorBoundary viewId="chunk-view">
+          <ChunkBoom message={message} />
+        </ViewErrorBoundary>,
+      );
+
+      // Exactly one reload picks up the current build and heals every view.
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+      // handleError returns BEFORE markCrashed/telemetry — the view is not
+      // latched crashed, so the reloaded shell mounts it fresh. A view never
+      // marked has no lifecycle record (getPhase → null), never "crashed".
+      expect(viewLifecycleController.getPhase("chunk-view")).toBeNull();
+      expect(viewLifecycleController.getPhase("chunk-view")).not.toBe(
+        "crashed",
+      );
+      // No crash telemetry sample is emitted on the recovery path.
+      expect(
+        readViewRuntimeTelemetry().filter(
+          (e) => e.reason === "crash" && e.viewId === "chunk-view",
+        ),
+      ).toHaveLength(0);
+      // The one-shot budget is stamped with a fresh, in-window timestamp.
+      const marker = Number(window.sessionStorage.getItem(RELOAD_MARKER_KEY));
+      expect(marker).toBeGreaterThan(0);
+      expect(Date.now() - marker).toBeLessThan(COOLDOWN_MS);
+    },
+  );
+
+  it("does NOT reload a non-chunk crash: marks it crashed and shows the fallback", () => {
+    render(
+      <ViewErrorBoundary viewId="crasher">
+        <Boom />
+      </ViewErrorBoundary>,
+    );
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    // A plain render crash never touches the chunk-reload cooldown marker.
+    expect(window.sessionStorage.getItem(RELOAD_MARKER_KEY)).toBeNull();
+    // The non-chunk path falls through to markCrashed + telemetry + fallback.
+    expect(viewLifecycleController.getPhase("crasher")).toBe("crashed");
+    expect(screen.getByTestId("view-error-boundary-fallback")).toBeTruthy();
+  });
+
+  it.each(CHUNK_FAILURES)(
+    "degrades a %s failure to the crash card when the reload budget is spent",
+    (_kind, message) => {
+      // A recovery reload already happened moments ago inside the cooldown, so
+      // tryChunkReloadRecovery() returns false and the guard falls through.
+      window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(Date.now()));
+
+      render(
+        <ViewErrorBoundary viewId="chunk-view">
+          <ChunkBoom message={message} />
+        </ViewErrorBoundary>,
+      );
+
+      // One-shot budget pinned: no second reload loop.
+      expect(reloadSpy).not.toHaveBeenCalled();
+      // With the budget spent the boundary owns the failure like any crash:
+      // marks it crashed and renders the fallback instead of a blank shell.
+      expect(viewLifecycleController.getPhase("chunk-view")).toBe("crashed");
+      expect(screen.getByTestId("view-error-boundary-fallback")).toBeTruthy();
+    },
+  );
 });


### PR DESCRIPTION
# Relates to

Closes #30951

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; the owning-package focused test,
      lint, and typecheck were run (full `bun run verify` blocker noted in
      **Known gaps / failures**).
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below (focused vitest output + failing-then-passing
      sanity check).

# Sync with develop

- [x] Branched from and rebased onto the latest `origin/develop`
      (`3a7f438a9e`); zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** for the
      unrelated pre-existing blocker (`@elizaos/login` unbuilt workspace dep).

# Risks

Low. This is a **test-only** change. No production source is modified; the only
touched file is `packages/ui/src/components/views/ViewErrorBoundary.test.tsx`.
The new tests add regression coverage and cannot alter runtime behavior.

# Background

## What does this PR do?

`ViewErrorBoundary` implements the mid-session-deploy chunk-reload self-heal
(#15383/#30889) for every routed Eliza app view: in `handleError` it calls
`isChunkLoadError(error) && tryChunkReloadRecovery()` and, on a chunk-load
error, logs `[ViewLifecycle] … reloading to the current build` and `return`s
**before** `viewLifecycleController.markCrashed(viewId)` / crash telemetry /
the fallback card. A non-chunk error falls through to the crash card.

The existing 6-test suite covered crash containment, `markCrashed`, telemetry,
Retry recovery, and fallback rendering — but **never** exercised a chunk-load
error, the recovery util, or a reload. So dropping/reordering the recovery
guard (dropped import, reordered guard, refactored callback) passed CI silently
while reintroducing the exact #15383 user-facing regression: after a
mid-session deploy, every not-yet-visited view 404s its lazy chunk and shows a
permanent crash card. `CloudRouteErrorBoundary.test.tsx` and the
`lazy-css-recovery` Playwright lane target `CloudRouteErrorBoundary` only; the
standalone `chunk-load-recovery-standalone.test.ts` covers `isChunkLoadError`
message detection only, not this call site.

This PR adds 5 tests (parameterized across both chunk-fetch message forms) that
own that contract at the app-views boundary. It matches
`CloudRouteErrorBoundary.test.tsx`'s established mocking style: a `vi.fn()`
reload spy installed via `Object.defineProperty(window, "location", …)`, a
`sessionStorage`-driven cooldown, and full spy/global restoration between tests.

Assertions:

1. **Chunk-load error, BOTH message forms** (`Failed to fetch dynamically
   imported module: …` and Vite `Unable to preload CSS for …`): exactly ONE
   `window.location.reload()` fires, the view is NOT marked crashed
   (`getPhase → null`), NO crash telemetry sample is emitted, and the cooldown
   marker is stamped with a fresh in-window timestamp.
2. **Non-chunk error**: NO reload fires, the cooldown marker is untouched, the
   view IS marked crashed, and the fallback card renders
   (`data-testid="view-error-boundary-fallback"`).
3. **Cooldown-exhausted chunk failure** (budget spent): NO second reload, the
   boundary degrades to the crash card and marks the view crashed — pinning the
   one-shot reload budget at this boundary.

## What kind of change is this?

Improvements — test coverage for an existing, previously untested recovery
contract. No functional/behavioral change.

# Documentation changes needed?

My changes do not require a change to the project documentation (test-only).

# Testing

## Where should a reviewer start?

`packages/ui/src/components/views/ViewErrorBoundary.test.tsx` — the new
`describe("ViewErrorBoundary — stale-deploy chunk reload self-heal")` block.

## Detailed testing steps

```bash
cd packages/ui
NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" \
  npx vitest run src/components/views/ViewErrorBoundary.test.tsx
```

To prove the tests own the contract, temporarily disable the recovery guard in
`ViewErrorBoundary.tsx` (`if (isChunkLoadError(error) && tryChunkReloadRecovery())`
→ `if (false)`): the two reload assertions fail. Output captured below.

# Evidence Gate

<!-- evidence-head:21a894790df687be6c19898066e80bbd4ae32ee4 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only change; the diff touches only ViewErrorBoundary.test.tsx (test code, no rendered .tsx/.css/.svg surface).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only change; no rendered UI surface modified.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - test-only change; no user-facing flow modified. The self-heal behavior is exercised by the added jsdom tests below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only jsdom test, no backend path. Real recovery-path frontend logger lines ([ViewLifecycle] ... reloading to the current build) are pasted inline under Evidence Details.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - focused vitest output (11 passed, incl. the real [ViewLifecycle] ... reloading to the current build recovery-path logs) is pasted inline under Evidence Details; re-run at head 21a894790d on 2026. Immutable release URL unavailable: this environment's GitHub identity has pull-only access to elizaOS/eliza (repos permissions push:false), so scripts/pr-evidence.mjs cannot upload to the pr-evidence release (HTTP 404), and github.com/user-attachments URLs require an interactive browser session no headless token can mint.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - failing-then-passing reproduction (recovery guard disabled -> the 2 reload assertions FAIL; guard restored -> all 11 pass) is pasted inline under Evidence Details; re-run at head 21a894790d. Same pull-only hosting constraint as frontend-logs: no gate-accepted immutable host (elizaOS/eliza pr-evidence release or github.com/user-attachments) is reachable from this environment.
<!-- evidence-row:ocr-review -->
- [x] `N/A - test-only change with no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Focused vitest run (all 11 tests green — 6 pre-existing + 5 new). The
`[ViewLifecycle] view "chunk-view" hit a stale-deploy chunk failure — reloading
to the current build` lines confirm the real recovery code path firing:

<details><summary>vitest run — ViewErrorBoundary.test.tsx (11 passed)</summary>

```
 ✓ ViewErrorBoundary > contains a crash: shows the fallback while a sibling stays mounted
 ✓ ViewErrorBoundary > marks the view crashed on the lifecycle controller
 ✓ ViewErrorBoundary > emits a crash telemetry sample
 ✓ ViewErrorBoundary > recovers when Retry is pressed and the child no longer throws
 ✓ ViewErrorBoundary > renders a non-blank fallback card (message + retry), never an empty container
 ✓ ViewErrorBoundary > uses a caller-supplied richer fallback when provided
 ✓ ViewErrorBoundary — stale-deploy chunk reload self-heal > reloads exactly once for a JavaScript import failure and does NOT mark the view crashed
 ✓ ViewErrorBoundary — stale-deploy chunk reload self-heal > reloads exactly once for a Vite CSS preload failure and does NOT mark the view crashed
 ✓ ViewErrorBoundary — stale-deploy chunk reload self-heal > does NOT reload a non-chunk crash: marks it crashed and shows the fallback
 ✓ ViewErrorBoundary — stale-deploy chunk reload self-heal > degrades a JavaScript import failure to the crash card when the reload budget is spent
 ✓ ViewErrorBoundary — stale-deploy chunk reload self-heal > degrades a Vite CSS preload failure to the crash card when the reload budget is spent

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

</details>

<details><summary>lint + typecheck (changed file)</summary>

```
=== biome lint (changed file) ===
Checked 1 file in 33ms. No fixes applied.

=== typecheck ===
(no ViewErrorBoundary errors — the change introduces zero type errors)
```

The 113 remaining repo-wide `tsc` errors are all pre-existing and unrelated:
they resolve from `@elizaos/login` being an unbuilt workspace dep in this
checkout (`Cannot find module '@elizaos/login'` and its downstream `cloud/login`
implicit-any fallout). None reference the changed file.

</details>

<details><summary>Failing-then-passing sanity check (recovery guard disabled locally, then reverted)</summary>

```
=== SANITY CHECK: recovery guard disabled in ViewErrorBoundary.tsx (local only, reverted after) ===
     × reloads exactly once for a JavaScript import failure and does NOT mark the view crashed
     × reloads exactly once for a Vite CSS preload failure and does NOT mark the view crashed
⎯⎯⎯ Failed Tests 2 ⎯⎯⎯
 FAIL ... > reloads exactly once for a JavaScript import failure and does NOT mark the view crashed
 FAIL ... > reloads exactly once for a Vite CSS preload failure and does NOT mark the view crashed
 Test Files  1 failed (1)
      Tests  2 failed | 9 passed (11)
```

With the guard restored, all 11 pass. This proves the new tests actually own
the recovery contract rather than passing vacuously.

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - test-only change; no rendered UI surface modified.`

### After

`N/A - test-only change; no rendered UI surface modified.`

### Walkthrough video

`N/A - test-only change; no user-facing flow modified.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- Full `bun run verify` was not run to completion on this machine: `tsc` for
  `@elizaos/ui` reports 113 pre-existing errors that all resolve from the
  `@elizaos/login` workspace dependency not being built in this checkout
  (`Cannot find module '@elizaos/login'`). These are unrelated to and predate
  this change, which touches only a test file and introduces zero new type
  errors (verified: no `tsc` diagnostic references `ViewErrorBoundary.test.tsx`).
- Evidence artifacts are pasted inline as text rather than minted as GitHub
  attachment URLs because the attachment uploader could not reach an
  authenticated session in this environment. All logs are real, captured
  output from the commands shown above.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@3a7f438a9e9d5ba10ea905198723012667bd785d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@3a7f438a9e9d5ba10ea905198723012667bd785d:packages/skills/skills/contribute-to-eliza"} -->


