### PR TITLE
fix(cloud): prevent retry and cache replay of stateful RPC calls

### DIFF
--- a/packages/cloud/shared/src/lib/services/proxy/fetch.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/fetch.error-policy.test.ts
@@ -16,6 +16,7 @@ afterEach(() => {
 });
 
 const baseOpts: RetryFetchOptions = {
+  replayPolicy: "idempotent",
   url: "https://api.example.com/v2/secret-key",
   init: { method: "POST" },
   maxRetries: 3,

--- a/packages/cloud/shared/src/lib/services/proxy/fetch.transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/fetch.transport.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Exercises proxy replay and cancellation against a real local HTTP server.
+ * The RPC tests redirect only the provider URL; handler, retry, and fetch run unchanged.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { type RetryFetchOptions, retryFetch } from "./fetch";
+import { rpcHandlerForChain } from "./services/rpc";
+import type { HandlerContext, ProxyRequestBody } from "./types";
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  ALCHEMY_API_KEY: process.env.ALCHEMY_API_KEY,
+  ALCHEMY_MAX_RETRIES: process.env.ALCHEMY_MAX_RETRIES,
+  ALCHEMY_INITIAL_RETRY_DELAY_MS: process.env.ALCHEMY_INITIAL_RETRY_DELAY_MS,
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function options(url: string, signal?: AbortSignal): RetryFetchOptions {
+  return {
+    url,
+    init: { signal },
+    maxRetries: 3,
+    initialDelayMs: 1,
+    timeoutMs: 1000,
+    serviceTag: "Local transport",
+    replayPolicy: "idempotent",
+  };
+}
+
+function context(body: ProxyRequestBody): HandlerContext {
+  return {
+    body,
+    searchParams: new URLSearchParams(),
+    auth: { user: { id: "local-user", organization_id: "local-org" } },
+  };
+}
+
+describe("EVM stateful request replay", () => {
+  for (const method of [
+    "eth_sendRawTransaction",
+    "eth_newFilter",
+    "eth_newBlockFilter",
+    "eth_newPendingTransactionFilter",
+    "eth_getFilterChanges",
+    "eth_uninstallFilter",
+    "eth_subscribe",
+    "eth_unsubscribe",
+  ]) {
+    it(`does not replay ${method} after an ambiguous gateway failure`, async () => {
+      let requests = 0;
+      const received: unknown[] = [];
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        async fetch(request) {
+          requests += 1;
+          received.push(await request.json());
+          return Response.json({ error: "gateway lost response after execution" }, { status: 502 });
+        },
+      });
+      try {
+        process.env.ALCHEMY_API_KEY = "local-fixture";
+        process.env.ALCHEMY_MAX_RETRIES = "3";
+        process.env.ALCHEMY_INITIAL_RETRY_DELAY_MS = "1";
+        globalThis.fetch = (_input, init) => originalFetch(server.url, init);
+        const mutation = { jsonrpc: "2.0", id: 1, method, params: [] };
+        const read = { jsonrpc: "2.0", id: 2, method: "eth_blockNumber", params: [] };
+        for (const body of [mutation, [read, mutation]]) {
+          const before = requests;
+          const { response } = await rpcHandlerForChain("ethereum")(context(body));
+          expect(response.status).toBe(502);
+          expect(requests - before).toBe(1);
+          expect(received.at(-1)).toEqual(body);
+        }
+      } finally {
+        server.stop(true);
+      }
+    });
+  }
+
+  it("still retries read-only batches after a gateway failure", async () => {
+    let requests = 0;
+    const expected = [{ jsonrpc: "2.0", id: 1, result: "0x10" }];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch() {
+        requests += 1;
+        return requests === 1
+          ? new Response("gateway unavailable", { status: 503 })
+          : Response.json(expected);
+      },
+    });
+    try {
+      process.env.ALCHEMY_API_KEY = "local-fixture";
+      process.env.ALCHEMY_MAX_RETRIES = "3";
+      process.env.ALCHEMY_INITIAL_RETRY_DELAY_MS = "1";
+      globalThis.fetch = (_input, init) => originalFetch(server.url, init);
+      const { response } = await rpcHandlerForChain("ethereum")(
+        context([{ jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] }]),
+      );
+      expect(await response.json()).toEqual(expected);
+      expect(requests).toBe(2);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe("caller cancellation", () => {
+  it("does not replay a non-idempotent request whose provider times out", async () => {
+    let requests = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch() {
+        requests += 1;
+        await Bun.sleep(80);
+        return new Response("response arrived after provider execution");
+      },
+    });
+    try {
+      await expect(
+        retryFetch({
+          ...options(String(server.url)),
+          replayPolicy: "never",
+          timeoutMs: 20,
+        }),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+      expect(requests).toBe(1);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("never dispatches an already canceled request", async () => {
+    let requests = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch() {
+        requests += 1;
+        return new Response("unexpected request");
+      },
+    });
+    try {
+      const controller = new AbortController();
+      const reason = new Error("caller canceled");
+      controller.abort(reason);
+      await expect(retryFetch(options(String(server.url), controller.signal))).rejects.toBe(reason);
+      expect(requests).toBe(0);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("preserves cancellation during backoff even when its reason is TimeoutError", async () => {
+    let requests = 0;
+    const controller = new AbortController();
+    const reason = new DOMException("caller deadline expired", "TimeoutError");
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch() {
+        requests += 1;
+        setTimeout(() => controller.abort(reason), 20);
+        return new Response("gateway unavailable", { status: 503 });
+      },
+    });
+    try {
+      await expect(
+        retryFetch({ ...options(String(server.url), controller.signal), initialDelayMs: 1000 }),
+      ).rejects.toBe(reason);
+      expect(requests).toBe(1);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it("cancels an active request without replaying it", async () => {
+    let requests = 0;
+    const controller = new AbortController();
+    const reason = new Error("caller left");
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch() {
+        requests += 1;
+        controller.abort(reason);
+        await Bun.sleep(20);
+        return new Response("late response");
+      },
+    });
+    try {
+      await expect(retryFetch(options(String(server.url), controller.signal))).rejects.toBe(reason);
+      expect(requests).toBe(1);
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/fetch.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/fetch.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service fetch behavior behind route handlers.
+/** Retries explicitly replayable proxy requests while preserving caller cancellation. */
 import { logger } from "../../utils/logger";
 
 export interface RetryFetchOptions {
@@ -9,6 +9,7 @@ export interface RetryFetchOptions {
   timeoutMs: number;
   serviceTag: string;
   nonRetriableStatuses?: number[];
+  replayPolicy: "idempotent" | "never";
 }
 
 /**
@@ -25,6 +26,22 @@ function sanitizeUrl(url: string): string {
     .replace(/api-key=[^&]+/gi, "api-key=***") // Helius: ?api-key=xxx
     .replace(/\/v2\/[^/?]+/, "/v2/***") // Alchemy RPC: /v2/{key}
     .replace(/\/v3\/[^/?]+/, "/v3/***"); // Alchemy NFT: /v3/{key}/...
+}
+
+/** Stop the backoff promptly when its caller no longer wants the request. */
+function waitForRetry(delayMs: number, signal?: AbortSignal | null): Promise<void> {
+  return new Promise((resolve, reject) => {
+    signal?.throwIfAborted();
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
@@ -62,10 +79,13 @@ export async function retryFetch(opts: RetryFetchOptions, attempt: number = 1): 
     nonRetriableStatuses = [400, 404],
   } = opts;
 
+  init.signal?.throwIfAborted();
   try {
     const response = await fetch(url, {
       ...init,
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: init.signal
+        ? AbortSignal.any([init.signal, AbortSignal.timeout(timeoutMs)])
+        : AbortSignal.timeout(timeoutMs),
     });
 
     const sanitizedUrl = sanitizeUrl(url);
@@ -79,14 +99,14 @@ export async function retryFetch(opts: RetryFetchOptions, attempt: number = 1): 
       return response;
     }
 
-    if (attempt < maxRetries) {
+    if (opts.replayPolicy === "idempotent" && attempt < maxRetries) {
       const delayMs = initialDelayMs * 2 ** (attempt - 1);
       logger.warn(`[${serviceTag}] Retriable error, retrying`, {
         attempt,
         status: response.status,
         delayMs,
       });
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await waitForRetry(delayMs, init.signal);
       return retryFetch(opts, attempt + 1);
     }
 
@@ -96,18 +116,19 @@ export async function retryFetch(opts: RetryFetchOptions, attempt: number = 1): 
     // rethrows the original error (and any non-timeout error immediately) so the
     // caller's proxy handler translates it to a typed failure. Fails closed: never
     // returns a fabricated default in place of a failed fetch.
+    init.signal?.throwIfAborted();
     const sanitizedUrl = sanitizeUrl(url);
 
     if (error instanceof Error && error.name === "TimeoutError") {
       logger.warn(`[${serviceTag}] Timeout`, { attempt, url: sanitizedUrl });
 
-      if (attempt < maxRetries) {
+      if (opts.replayPolicy === "idempotent" && attempt < maxRetries) {
         const delayMs = initialDelayMs * 2 ** (attempt - 1);
         logger.info(`[${serviceTag}] Retrying after timeout`, {
           attempt,
           delayMs,
         });
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        await waitForRetry(delayMs, init.signal);
         return retryFetch(opts, attempt + 1);
       }
     }

--- a/packages/cloud/shared/src/lib/services/proxy/rpc-cache.transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/rpc-cache.transport.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Exercises the real proxy engine, RPC handler, and shipped memory cache backend
+ * against local HTTP. Auth, price, credit reservation, and usage are test seams;
+ * no external provider or financial operation is used.
+ */
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import * as authActual from "../../auth";
+import * as cacheActual from "../../cache/client";
+import * as creditsActual from "../credits";
+import * as usageActual from "../usage";
+
+const realCache = { ...cacheActual };
+const isolatedCache = new cacheActual.CacheClient();
+mock.module("../../cache/client", () => ({ ...realCache, cache: isolatedCache }));
+
+const realAuth = { ...authActual };
+const realCredits = { ...creditsActual };
+const realUsage = { ...usageActual };
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+const USER_ID = "00000000-0000-4000-8000-0000000000bb";
+
+const reconcile = mock<(actualCost: number) => Promise<void>>();
+const reserve = mock<(args: unknown) => Promise<{ reconcile: typeof reconcile }>>();
+const usageCreate = mock<(args: unknown) => Promise<void>>();
+
+mock.module("../../auth", () => ({
+  ...realAuth,
+  requireAuth: async () => ({ id: USER_ID, organization_id: ORG_ID }),
+}));
+
+mock.module("../credits", () => ({
+  ...realCredits,
+  assertCreditRefundWithinReservation: realCredits.assertCreditRefundWithinReservation,
+  assertValidCreditSettlementCosts: realCredits.assertValidCreditSettlementCosts,
+  creditsService: { ...realCredits.creditsService, reserve },
+}));
+
+mock.module("../usage", () => ({
+  ...realUsage,
+  usageService: { ...realUsage.usageService, create: usageCreate },
+}));
+
+const { createHandler } = await import("./engine");
+const { rpcConfigForChain, rpcHandlerForChain } = await import("./services/rpc");
+const originalFetch = globalThis.fetch;
+const envNames = ["CACHE_BACKEND", "ALCHEMY_API_KEY", "ALCHEMY_MAX_RETRIES"] as const;
+const originalEnv = Object.fromEntries(envNames.map((name) => [name, process.env[name]]));
+
+beforeEach(() => {
+  process.env.CACHE_BACKEND = "memory";
+  process.env.ALCHEMY_API_KEY = "local-cache-fixture";
+  process.env.ALCHEMY_MAX_RETRIES = "1";
+  reconcile.mockReset();
+  reserve.mockReset();
+  usageCreate.mockReset();
+  reconcile.mockResolvedValue(undefined);
+  reserve.mockResolvedValue({ reconcile });
+  usageCreate.mockResolvedValue(undefined);
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+afterAll(() => {
+  mock.module("../../cache/client", () => realCache);
+  mock.module("../../auth", () => realAuth);
+  mock.module("../credits", () => realCredits);
+  mock.module("../usage", () => realUsage);
+  for (const key of envNames) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function request(method: string, id: string): Request {
+  return new Request("https://local-fixture.invalid/rpc", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Cache-Control": "max-age=30" },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params: [] }),
+  });
+}
+
+for (const method of [
+  "eth_newFilter",
+  "eth_newBlockFilter",
+  "eth_newPendingTransactionFilter",
+  "eth_getFilterChanges",
+  "eth_uninstallFilter",
+  "eth_subscribe",
+  "eth_unsubscribe",
+  "eth_sendRawTransaction",
+  "eth_getBalance",
+]) {
+  test(`${method} preserves its provider execution contract when cache is requested`, async () => {
+    let executions = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        executions += 1;
+        const body = await req.json();
+        return Response.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: `provider-result-${executions}`,
+        });
+      },
+    });
+    try {
+      globalThis.fetch = (_input, init) => originalFetch(server.url, init);
+      const config = rpcConfigForChain("ethereum");
+      const handler = createHandler(
+        { ...config, auth: "session", rateLimit: undefined, getCost: async () => 1 },
+        rpcHandlerForChain("ethereum"),
+      );
+      const id = crypto.randomUUID();
+      const first = await handler(request(method, id));
+      const second = await handler(request(method, id));
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      const firstPayload = await first.json();
+      const secondPayload = await second.json();
+      expect(firstPayload.result).toBe("provider-result-1");
+      if (method === "eth_getBalance") {
+        expect(executions).toBe(1);
+        expect(secondPayload.result).toBe("provider-result-1");
+        expect(second.headers.get("X-Cache")).toBe("HIT");
+      } else {
+        expect(executions).toBe(2);
+        expect(secondPayload.result).toBe("provider-result-2");
+        expect(second.headers.get("X-Cache")).not.toBe("HIT");
+      }
+    } finally {
+      server.stop(true);
+    }
+  });
+}

--- a/packages/cloud/shared/src/lib/services/proxy/services/README.md
+++ b/packages/cloud/shared/src/lib/services/proxy/services/README.md
@@ -172,6 +172,7 @@ export const twitterHandler: ServiceHandler = async ({ body }) => {
   const path = PROVIDER_PATHS[method];
 
   const response = await retryFetch({
+    replayPolicy: "idempotent", // Only for requests safe to execute again.
     url: `https://api.twitter.com${path}`,
     init: {
       method: "GET",

--- a/packages/cloud/shared/src/lib/services/proxy/services/chain-data.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/chain-data.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service chain data behavior behind route handlers.
+/** Translates chain data queries into provider requests with read-only replay policy. */
 import { logger } from "../../../utils/logger";
 import { getProxyConfig } from "../config";
 import { retryFetch } from "../fetch";
@@ -175,6 +175,7 @@ export const chainDataHandler: ServiceHandler = async ({ body }) => {
       const url = `${baseUrl}${path}?${queryParams.toString()}`;
 
       const response = await retryFetch({
+        replayPolicy: "idempotent",
         url,
         init: {
           method: "GET",
@@ -220,6 +221,7 @@ export const chainDataHandler: ServiceHandler = async ({ body }) => {
     const url = `${baseUrl}${path}`;
 
     const response = await retryFetch({
+      replayPolicy: "idempotent",
       url,
       init: {
         method: "POST",

--- a/packages/cloud/shared/src/lib/services/proxy/services/market-data.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/market-data.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service market data behavior behind route handlers.
+/** Translates market data queries into replayable provider requests. */
 import { logger } from "../../../utils/logger";
 import { getProxyConfig } from "../config";
 import { retryFetch } from "../fetch";
@@ -130,6 +130,7 @@ export async function executeMarketDataProviderRequest({
 
   try {
     const response = await retryFetch({
+      replayPolicy: "idempotent",
       url,
       init: {
         method: "GET",

--- a/packages/cloud/shared/src/lib/services/proxy/services/rpc.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/services/rpc.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service rpc behavior behind route handlers.
+/** Routes priced EVM and Solana JSON-RPC requests through configured providers. */
 import { getCloudAwareEnv } from "../../../runtime/cloud-bindings";
 import { logger } from "../../../utils/logger";
 import { getProxyConfig } from "../config";
@@ -98,17 +98,47 @@ const EVM_ALLOWED_METHODS = new Set([
  * EVM methods that should not be cached
  *
  * WHY these are non-cacheable:
- * - Mutations: sendRawTransaction (changes blockchain state)
+ * - Stateful methods are excluded separately by the shared replay classification.
  * - Rapidly changing: blockNumber, gasPrice, maxPriorityFeePerGas (update every block)
  * - Caching these = stale data misleads users while still costing 50%
  */
 const EVM_NON_CACHEABLE_METHODS = new Set([
-  "eth_sendRawTransaction",
   "eth_blockNumber",
   "eth_gasPrice",
   "eth_maxPriorityFeePerGas",
   "eth_blobBaseFee",
 ]);
+
+// Filter polling consumes pending changes; creating/removing filters and
+// subscriptions also changes provider state even though no transaction is sent.
+const EVM_NON_REPLAYABLE_METHODS = new Set([
+  "eth_sendRawTransaction",
+  "eth_newFilter",
+  "eth_newBlockFilter",
+  "eth_newPendingTransactionFilter",
+  "eth_getFilterChanges",
+  "eth_uninstallFilter",
+  "eth_subscribe",
+  "eth_unsubscribe",
+]);
+
+function isReplayableEvmRequest(body: unknown): boolean {
+  return (
+    body !== null &&
+    typeof body === "object" &&
+    !Array.isArray(body) &&
+    "method" in body &&
+    typeof body.method === "string" &&
+    EVM_ALLOWED_METHODS.has(body.method) &&
+    !EVM_NON_REPLAYABLE_METHODS.has(body.method)
+  );
+}
+
+function isReplayableEvmBody(body: unknown): boolean {
+  return Array.isArray(body)
+    ? body.length > 0 && body.every(isReplayableEvmRequest)
+    : isReplayableEvmRequest(body);
+}
 
 /**
  * Extract method from JSON-RPC request body (EVM)
@@ -169,7 +199,8 @@ function buildEvmRpcConfig(): ServiceConfig {
     },
     cache: {
       maxTTL: 60,
-      isMethodCacheable: (method) => !EVM_NON_CACHEABLE_METHODS.has(method),
+      isMethodCacheable: (method) =>
+        !EVM_NON_REPLAYABLE_METHODS.has(method) && !EVM_NON_CACHEABLE_METHODS.has(method),
       maxResponseSize: 65536,
       hitCostMultiplier: 0.5,
     },
@@ -222,6 +253,7 @@ function buildEvmRpcHandler(chain: string): ServiceHandler {
 
     try {
       const response = await retryFetch({
+        replayPolicy: isReplayableEvmBody(body) ? "idempotent" : "never",
         url,
         init: {
           method: "POST",


### PR DESCRIPTION
## Problem and behavior

A stateful EVM RPC call could be executed again after an ambiguous gateway failure or timeout. A filter poll could consume pending events on its first execution, retry, and return an empty success. With client caching enabled, filter creation/polling and subscription mutations could also return the previous call's result without executing the new operation.

One canonical stateful-method classification now prevents both retries and caching, including mixed batches. Read-only requests retain retries and caching. Every proxy retry caller declares its replay policy. Supplied caller cancellation is preserved before dispatch, during fetch, and during backoff.

This is a bounded current-develop extraction from the RPC family reviewed in #30229, coordinated under #30125. It does not reland that PR's broader retry framework or migration changes, and does not close its umbrella acceptance. Incoming `HandlerContext` does not carry `Request.signal`; cancellation evidence here covers a supplied `retryFetch` signal.

## Evidence

Candidate: `9b952f775fffd7601c4e3a1299074da6307b9a98`  
Base: `3a7f438a9e9d5ba10ea905198723012667bd785d`  
Runtime: Bun1.3.14 / Node24.15.0.

Actual original-production transport reproduction used a local HTTP server, not a fetch mock:

```json
{
  "filterPollAfterAmbiguous502": {
    "providerExecutions": 2,
    "clientStatus": 200,
    "clientResult": []
  },
  "alreadyCanceledRequest": {
    "providerExecutions": 1,
    "clientStatus": 200
  }
}
```

The new transport suite runs the real RPC handler/retry/fetch with only the provider URL redirected to local HTTP. All eight stateful methods, separately and inside mixed batches, execute once after an ambiguous502. Read-only batches retry and return the healthy response. A non-idempotent provider timeout does not replay. Already-canceled, active, and backoff cancellation preserve the original reason and stop further requests.

The cache suite runs the real proxy engine, RPC handler/config, and an isolated instance of the shipped `CacheClient`/`MemoryCacheAdapter` against local HTTP. Authentication, pricing, credits, and usage are fixture collaborators; there are no live financial operations.

```text
Cache regression before fix: 2 pass, 7 fail, exit1
  State-changing second requests incorrectly reused provider-result-1;
  provider executions: expected2, actual1.

Cache regression after fix: 9 pass, 0 fail, 54 assertions, exit0
  Stateful second requests execute and return provider-result-2.
  Read-only balance control still returns provider-result-1 with X-Cache:HIT.
```

Final focused suites, each in its own Bun process:

| Suite | Passed | Assertions |
| --- | ---: | ---: |
| Real HTTP retry/cancellation | 13 | 58 |
| Real engine/cache/HTTP | 9 | 54 |
| Existing retry error contract | 5 | 12 |
| Existing EVM RPC contract | 6 | 10 |
| Chain-data caller contract | 8 | 14 |
| Market-data caller contract | 5 | 10 |
| Total | 46 | 158 |

All six processes exited0. Chain-data supported methods were reviewed: two NFT GETs plus token-balance, token-metadata and asset-transfer queries; market-data uses GET. Provider URLs/authentication and the existing Solana transport are unchanged.

Pinned normal `bun install` passed (6803 packages,59.47s), including normal scripts. Initial `bun run verify` passed373/373 tasks with no cache hits and all subsequent audits. Final exact-head `bun run verify` also exited0:373/373 tasks,0 cache hits,2m36.22s, followed by all repository audits. Owning package typecheck/lint passed in that gate. Root review independently inspected source, cancellation, canonical classification and the mixed-batch cache exclusion.

Screenshots/video: N/A, server transport/cache behavior with no frontend changes. Live chain mutation: N/A, the changed transport/cache contract is exercised through actual local HTTP; no transactions were sent.

**Hold merge until terminal hosted checks pass for this exact head.**
