### PR TITLE
fix(core): preserve complete promoted tool contracts without duplicate schemas

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -3007,7 +3007,7 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
-	it("hard-enforces an umbrella candidate when retrieval exposes only its promoted child", async () => {
+	it("hard-enforces an umbrella candidate through its canonical operation schema", async () => {
 		const runtime = makeRuntime([
 			stage1Response({
 				thought: "A repository review requires delegated coding work.",
@@ -3031,8 +3031,8 @@ describe("runV5MessageRuntimeStage1", () => {
 				toolCalls: [
 					{
 						id: "spawn-reviewer",
-						name: "TASKS_SPAWN_AGENT",
-						args: { task: "Review PR 18106." },
+						name: "TASKS",
+						args: { action: "spawn_agent", task: "Review PR 18106." },
 					},
 				],
 			},

--- a/packages/core/src/actions/promote-subactions.ts
+++ b/packages/core/src/actions/promote-subactions.ts
@@ -85,7 +85,7 @@ interface PromotedAction extends Action {
 
 /**
  * The umbrella parent's `routingHint` for a promoted virtual, carried on the
- * non-enumerable promotion marker rather than on the virtual itself so tool
+ * symbol promotion marker rather than on the virtual itself so tool
  * rendering (which prepends `routingHint` to each tool's description) never
  * duplicates it across every virtual. The planner's routing-hints block reads
  * it through this accessor and dedupes by parent, so a promoted family like
@@ -97,6 +97,11 @@ export function promotedParentRoutingHint(
 	const marker = (action as PromotedAction)[PROMOTED_MARKER];
 	const hint = marker?.parentRoutingHint?.trim();
 	return marker && hint ? { parent: marker.parent, hint } : undefined;
+}
+
+/** Returns the registered umbrella identity for a generated dispatch alias. */
+export function promotedSubactionParent(action: Action): string | undefined {
+	return (action as PromotedAction)[PROMOTED_MARKER]?.parent;
 }
 
 /**
@@ -441,15 +446,17 @@ export function promoteSubactionsToActions(
 			connectorAccountPolicy: parent.connectorAccountPolicy,
 			accountPolicy: parent.accountPolicy,
 		};
+		// Symbol metadata survives owner/context gate object spreads while JSON
+		// serializers still omit it from model-facing action descriptions.
 		Object.defineProperty(virtual, PROMOTED_MARKER, {
 			value: {
 				parent: parent.name,
 				virtuals: [virtualName],
 				parentRoutingHint: parent.routingHint,
 			},
-			enumerable: false,
+			enumerable: true,
 			configurable: false,
-			writable: false,
+			writable: true,
 		});
 		return virtual;
 	});

--- a/packages/core/src/services/message.canonical-tools.test.ts
+++ b/packages/core/src/services/message.canonical-tools.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Exercises lossless promoted-family tool rendering and dispatch against real
+ * action handlers. No model or connector is called; provider wire and live
+ * planner behavior are verified separately by the integration workflow.
+ */
+import { describe, expect, it } from "vitest";
+import { actionToJsonSchema, type JsonSchema } from "../actions/action-schema";
+import { promoteSubactionsToActions } from "../actions/promote-subactions";
+import { validateSchema } from "../actions/validate-tool-args";
+import { AgentRuntime } from "../runtime";
+import { createContextObject } from "../runtime/context-object";
+import type { Action, ActionParameter } from "../types/components";
+import {
+	collectActionsFromContext,
+	collectCanonicalPlannerActions,
+	collectPlannerTools,
+} from "./message/planned-tool";
+
+function fixture() {
+	const stored = new Map<string, string>();
+	const parent: Action = {
+		name: "RECORDS",
+		description: "Create and update complete records.",
+		parameters: [
+			{
+				name: "action",
+				description: "Operation",
+				required: true,
+				schema: { type: "string", enum: ["create", "update"] },
+			},
+			{
+				name: "id",
+				description: "Record identity",
+				required: true,
+				schema: { type: "string" },
+			},
+			{
+				name: "text",
+				description: "Complete record text",
+				required: true,
+				schema: { type: "string" },
+			},
+		],
+		handler: async (_runtime, _message, _state, options) => {
+			const params = options?.parameters;
+			if (typeof params?.id !== "string" || typeof params.text !== "string")
+				throw new Error("Missing record input");
+			if (params.action === "update" && !stored.has(params.id))
+				return { success: false, error: "Record absent" };
+			stored.set(params.id, params.text);
+			return { success: true, data: { savedText: stored.get(params.id) } };
+		},
+	};
+	// Mirrors owner/context admission wrappers that spread registered Actions.
+	const actions = promoteSubactionsToActions(parent, {
+		overrides: {
+			create: {
+				description: "Creation must preserve the supplied record boundary.",
+			},
+		},
+	}).map((action) => ({
+		...action,
+	}));
+	const context = createContextObject({
+		id: "canonical-tools",
+		events: actions.map((action) => ({
+			id: `tool:${action.name}`,
+			type: "tool",
+			tool: { name: action.name, action },
+		})),
+	});
+	return { actions, context, stored };
+}
+
+describe("canonical promoted-family planner surface", () => {
+	it("retains complete arguments and dispatches successive operations through the umbrella", async () => {
+		const { actions, context, stored } = fixture();
+		const tools = collectPlannerTools(context, undefined, {
+			canonicalFamilies: true,
+		});
+		expect(tools.map((tool) => tool.name)).toEqual([
+			"RECORDS",
+			"REPLY",
+			"IGNORE",
+			"STOP",
+		]);
+		const wire = JSON.parse(JSON.stringify(tools));
+		const text = `${"complete payload ".repeat(12000)}last record boundary`;
+		const runtime = new AgentRuntime({
+			character: { name: "Canonical dispatch" },
+			disableBasicCapabilities: true,
+		});
+		for (const action of actions) runtime.registerAction(action);
+		expect(collectCanonicalPlannerActions(actions, [])).toEqual([actions[0]]);
+		for (const action of ["create", "update"]) {
+			const params = { action, id: "record", text: `${action}: ${text}` };
+			const errors: string[] = [];
+			validateSchema(wire[0].parameters as JsonSchema, params, "", errors);
+			expect(errors).toEqual([]);
+			const result = await actions[0].handler?.(
+				runtime,
+				{
+					agentId: runtime.agentId,
+					entityId: runtime.agentId,
+					roomId: runtime.agentId,
+					content: { text: "Save the complete record" },
+				},
+				undefined,
+				{ parameters: params },
+			);
+			expect(result).toMatchObject({
+				success: true,
+				data: { savedText: params.text },
+			});
+			expect(stored.get("record")).toBe(params.text);
+		}
+		expect(collectActionsFromContext(context)).toEqual(actions);
+	});
+
+	it("keeps an explicitly selected generated alias callable with its implicit operation", async () => {
+		const { actions, context, stored } = fixture();
+		const tools = collectPlannerTools(context, undefined, {
+			canonicalFamilies: true,
+			candidateActions: ["RECORDS_CREATE"],
+		});
+		expect(tools.some((tool) => tool.name === "RECORDS_CREATE")).toBe(true);
+		const selected = collectCanonicalPlannerActions(actions, [
+			"RECORDS_CREATE",
+		]);
+		const alias = selected.find((action) => action.name === "RECORDS_CREATE");
+		const runtime = new AgentRuntime({
+			character: { name: "Alias dispatch" },
+			disableBasicCapabilities: true,
+		});
+		const result = await alias?.handler?.(
+			runtime,
+			{
+				agentId: runtime.agentId,
+				entityId: runtime.agentId,
+				roomId: runtime.agentId,
+				content: { text: "Create" },
+			},
+			undefined,
+			{ parameters: { id: "alias", text: "complete alias receipt" } },
+		);
+		expect(result).toMatchObject({ success: true });
+		expect(stored.get("alias")).toBe("complete alias receipt");
+	});
+
+	it("does not hide an authorized alias when its umbrella is denied", () => {
+		const { actions } = fixture();
+		const authorized = actions.filter((action) => action.name !== "RECORDS");
+		expect(collectCanonicalPlannerActions(authorized, [])).toEqual(authorized);
+	});
+
+	it("keeps independently implemented children even when named like generated aliases", () => {
+		const child: Action = {
+			name: "RECORDS_EXPORT",
+			description: "Independent export",
+			handler: async () => ({ success: true, data: { exported: true } }),
+		};
+		const { actions } = fixture();
+		actions[0].subActions?.push(child);
+		const retained = collectCanonicalPlannerActions([...actions, child], []);
+		expect(retained).toEqual([actions[0], child]);
+	});
+
+	it("retains an alias if the admitted parent no longer declares its dispatch relation", () => {
+		const { actions } = fixture();
+		actions[0].subActions = [];
+		expect(collectCanonicalPlannerActions(actions, [])).toEqual(actions);
+	});
+	it("does not consolidate a family with an unauthorized sibling", () => {
+		const { actions } = fixture();
+		const authorized = actions.filter(
+			(action) => action.name !== "RECORDS_UPDATE",
+		);
+		expect(collectCanonicalPlannerActions(authorized, [])).toEqual(authorized);
+	});
+	it("reconstructs each alias parameter contract from complete parent schemas and retained guidance", () => {
+		const { actions, context } = fixture();
+		const tool = collectPlannerTools(context, undefined, {
+			canonicalFamilies: true,
+		})[0];
+		const contracts: Array<{
+			name: string;
+			description: string;
+			parameters: Array<
+				ActionParameter & { schemaFromParentParameter?: string }
+			>;
+		}> = JSON.parse(tool.description.split("\n").at(-1) ?? "invalid");
+		for (const contract of contracts) {
+			const original = actions.find((action) => action.name === contract.name);
+			if (!original)
+				throw new Error("Alias action missing from dispatch context");
+			expect(contract.description).toBe(original.description);
+			const parameters = contract.parameters.map(
+				({ schemaFromParentParameter, ...parameter }) => ({
+					...parameter,
+					schema: schemaFromParentParameter
+						? actions[0].parameters?.find(
+								(entry) => entry.name === schemaFromParentParameter,
+							)?.schema
+						: parameter.schema,
+				}),
+			);
+			// Reassembled schemas retain pinned discriminator rejection and every
+			// shared field, rather than accepting another operation under an alias.
+			const schema = actionToJsonSchema({ ...original, parameters });
+			const validErrors: string[] = [];
+			const operation = original.parameters?.find(
+				(parameter) => parameter.name === "action",
+			)?.schema?.enum?.[0];
+			validateSchema(
+				schema,
+				{ action: operation, id: "record", text: "complete boundary" },
+				"",
+				validErrors,
+			);
+			expect(validErrors).toEqual([]);
+			const invalidErrors: string[] = [];
+			validateSchema(
+				schema,
+				{
+					action: "unrelated-operation",
+					id: "record",
+					text: "complete boundary",
+				},
+				"",
+				invalidErrors,
+			);
+			expect(invalidErrors.length).toBeGreaterThan(0);
+		}
+	});
+	it("keeps an alias direct if its umbrella requires a parameter excluded from that operation", () => {
+		const parent: Action = {
+			name: "FILES",
+			description: "File operations",
+			parameters: [
+				{
+					name: "action",
+					description: "Operation",
+					required: true,
+					schema: { type: "string", enum: ["create", "list"] },
+				},
+				{
+					name: "body",
+					description: "New file body",
+					required: true,
+					subactions: ["create"],
+					schema: { type: "string" },
+				},
+			],
+		};
+		const actions = [...promoteSubactionsToActions(parent)];
+		expect(
+			collectCanonicalPlannerActions(actions, []).map((action) => action.name),
+		).toContain("FILES_LIST");
+	});
+});

--- a/packages/core/src/services/message.canonical-tools.test.ts
+++ b/packages/core/src/services/message.canonical-tools.test.ts
@@ -9,7 +9,7 @@ import { promoteSubactionsToActions } from "../actions/promote-subactions";
 import { validateSchema } from "../actions/validate-tool-args";
 import { AgentRuntime } from "../runtime";
 import { createContextObject } from "../runtime/context-object";
-import type { Action, ActionParameter } from "../types/components";
+import type { Action } from "../types/components";
 import {
 	collectActionsFromContext,
 	collectCanonicalPlannerActions,
@@ -185,28 +185,29 @@ describe("canonical promoted-family planner surface", () => {
 		const contracts: Array<{
 			name: string;
 			description: string;
-			parameters: Array<
-				ActionParameter & { schemaFromParentParameter?: string }
-			>;
+			parameters: JsonSchema & {
+				parentParameterNames: string[];
+				propertyOverrides: Record<string, JsonSchema>;
+			};
 		}> = JSON.parse(tool.description.split("\n").at(-1) ?? "invalid");
 		for (const contract of contracts) {
 			const original = actions.find((action) => action.name === contract.name);
 			if (!original)
 				throw new Error("Alias action missing from dispatch context");
 			expect(contract.description).toBe(original.description);
-			const parameters = contract.parameters.map(
-				({ schemaFromParentParameter, ...parameter }) => ({
-					...parameter,
-					schema: schemaFromParentParameter
-						? actions[0].parameters?.find(
-								(entry) => entry.name === schemaFromParentParameter,
-							)?.schema
-						: parameter.schema,
-				}),
-			);
-			// Reassembled schemas retain pinned discriminator rejection and every
-			// shared field, rather than accepting another operation under an alias.
-			const schema = actionToJsonSchema({ ...original, parameters });
+			const { parentParameterNames, propertyOverrides, ...outerSchema } =
+				contract.parameters;
+			const parentSchema = actionToJsonSchema(actions[0]);
+			const schema = {
+				...outerSchema,
+				properties: Object.fromEntries(
+					parentParameterNames.map((name) => [
+						name,
+						propertyOverrides[name] ?? parentSchema.properties[name],
+					]),
+				),
+			};
+			expect(schema).toEqual(actionToJsonSchema(original));
 			const validErrors: string[] = [];
 			const operation = original.parameters?.find(
 				(parameter) => parameter.name === "action",

--- a/packages/core/src/services/message/pipeline.ts
+++ b/packages/core/src/services/message/pipeline.ts
@@ -1128,7 +1128,14 @@ export async function runV5MessageRuntimeStage1(
 				),
 			logger: args.runtime.logger as PlannerRuntime["logger"],
 		};
-		const plannerTools = collectPlannerTools(plannerContextWithDecision);
+		const plannerTools = collectPlannerTools(
+			plannerContextWithDecision,
+			undefined,
+			{
+				canonicalFamilies: true,
+				candidateActions: getMessageHandlerCandidateActions(messageHandler),
+			},
+		);
 		const budgetedPlannerContextWithDecision = plannerContextWithDecision;
 		const plannerProviderAttributionState = plannerState;
 		const benchmarkForcingToolCall = isBenchmarkForcingToolCall(args.message);

--- a/packages/core/src/services/message/planned-tool.ts
+++ b/packages/core/src/services/message/planned-tool.ts
@@ -1,5 +1,6 @@
 /** Adapts planner tool calls to the existing action executor and settles stream events and evidence-sensitive provider caches. */
 
+import { normalizeActionJsonSchema } from "../../actions/action-schema";
 import { promotedSubactionParent } from "../../actions/promote-subactions";
 import {
 	buildPlannerToolsFromTieredActions,
@@ -579,26 +580,28 @@ export function collectPlannerTools(
 					promotedSubactionParent(action) === parent.name,
 			);
 			if (aliases.length === 0) continue;
-			const aliasContracts = aliases.map((alias) => ({
-				name: alias.name,
-				description: alias.description,
-				routingHint: alias.routingHint,
-				strict: alias.toolSchemaStrict ?? true,
-				allowAdditionalParameters: alias.allowAdditionalParameters ?? false,
-				parameters: alias.parameters?.map(({ schema, ...parameter }) => {
-					const original = parent.parameters?.find(
-						(entry) => entry.name === parameter.name,
-					);
-					return {
-						...parameter,
-						...(original &&
-						JSON.stringify(original.schema) === JSON.stringify(schema)
-							? { schemaFromParentParameter: parameter.name }
-							: { schema }),
-					};
-				}),
-			}));
-			parentTool.description += `\nGenerated aliases represented by this umbrella: call this tool using the alias's pinned discriminator. Each schemaFromParentParameter refers losslessly to that parameter's complete schema above. All alias descriptions, applicable parameters, required flags, and schema overrides follow:\n${JSON.stringify(aliasContracts)}`;
+			const parentSchema = normalizeActionJsonSchema(parent);
+			const aliasContracts = aliases.map((alias) => {
+				const { properties = {}, ...schema } = normalizeActionJsonSchema(alias);
+				return {
+					name: alias.name,
+					description: alias.description,
+					routingHint: alias.routingHint,
+					strict: alias.toolSchemaStrict ?? true,
+					parameters: {
+						...schema,
+						parentParameterNames: Object.keys(properties),
+						propertyOverrides: Object.fromEntries(
+							Object.entries(properties).filter(
+								([name, property]) =>
+									JSON.stringify(property) !==
+									JSON.stringify(parentSchema.properties?.[name]),
+							),
+						),
+					},
+				};
+			});
+			parentTool.description += `\nGenerated aliases represented by this umbrella: call this tool using the alias's pinned discriminator. Each alias parameter object uses exactly parentParameterNames from this tool's complete properties, including descriptions and defaults; propertyOverrides replaces only differing properties. Other schema fields (including required) are explicit. Complete alias contracts:\n${JSON.stringify(aliasContracts)}`;
 		}
 	}
 	const terminalNames = new Set(

--- a/packages/core/src/services/message/planned-tool.ts
+++ b/packages/core/src/services/message/planned-tool.ts
@@ -1,5 +1,6 @@
 /** Adapts planner tool calls to the existing action executor and settles stream events and evidence-sensitive provider caches. */
 
+import { promotedSubactionParent } from "../../actions/promote-subactions";
 import {
 	buildPlannerToolsFromTieredActions,
 	CORE_PLANNER_TERMINALS,
@@ -538,7 +539,11 @@ export function subPlannerResultToPlannerToolResult(
 export function collectPlannerTools(
 	context: ContextObject,
 	narrowedActions?: ReadonlyArray<Action>,
-	options: { expandSubActions?: boolean } = {},
+	options: {
+		expandSubActions?: boolean;
+		canonicalFamilies?: boolean;
+		candidateActions?: readonly string[];
+	} = {},
 ): ToolDefinition[] {
 	const hasAnyAction = context.events.some(
 		(event) =>
@@ -551,13 +556,51 @@ export function collectPlannerTools(
 	if (!hasAnyAction) return [];
 	const actions = narrowedActions ?? collectActionsFromContext(context);
 	const tierAParents = readTierAParentsFromContext(context);
-	const actionTools = buildPlannerToolsFromTieredActions(actions, {
+	const wireActions = options.canonicalFamilies
+		? collectCanonicalPlannerActions(actions, options.candidateActions ?? [])
+		: actions;
+	const actionTools = buildPlannerToolsFromTieredActions(wireActions, {
 		tierAParents,
-		expandSubActions: options.expandSubActions,
+		expandSubActions: options.canonicalFamilies
+			? false
+			: options.expandSubActions,
 		actionLookup: new Map(
 			actions.map((action) => [action.name, action] as const),
 		),
 	});
+	if (options.canonicalFamilies) {
+		const wireNames = new Set(wireActions.map((action) => action.name));
+		for (const parentTool of actionTools) {
+			const parent = actions.find((action) => action.name === parentTool.name);
+			if (!parent) continue;
+			const aliases = actions.filter(
+				(action) =>
+					!wireNames.has(action.name) &&
+					promotedSubactionParent(action) === parent.name,
+			);
+			if (aliases.length === 0) continue;
+			const aliasContracts = aliases.map((alias) => ({
+				name: alias.name,
+				description: alias.description,
+				routingHint: alias.routingHint,
+				strict: alias.toolSchemaStrict ?? true,
+				allowAdditionalParameters: alias.allowAdditionalParameters ?? false,
+				parameters: alias.parameters?.map(({ schema, ...parameter }) => {
+					const original = parent.parameters?.find(
+						(entry) => entry.name === parameter.name,
+					);
+					return {
+						...parameter,
+						...(original &&
+						JSON.stringify(original.schema) === JSON.stringify(schema)
+							? { schemaFromParentParameter: parameter.name }
+							: { schema }),
+					};
+				}),
+			}));
+			parentTool.description += `\nGenerated aliases represented by this umbrella: call this tool using the alias's pinned discriminator. Each schemaFromParentParameter refers losslessly to that parameter's complete schema above. All alias descriptions, applicable parameters, required flags, and schema overrides follow:\n${JSON.stringify(aliasContracts)}`;
+		}
+	}
 	const terminalNames = new Set(
 		CORE_PLANNER_TERMINALS.map((tool) => normalizeActionIdentifier(tool.name)),
 	);
@@ -571,6 +614,49 @@ export function collectPlannerTools(
 		),
 		...CORE_PLANNER_TERMINALS,
 	];
+}
+
+/**
+ * Represents generated aliases once through their complete authorized umbrella.
+ * Independent child actions and explicitly requested aliases remain direct. The
+ * caller retains every original context action for execution and trajectories.
+ */
+export function collectCanonicalPlannerActions(
+	actions: readonly Action[],
+	candidateActions: readonly string[],
+): Action[] {
+	const lookup = buildRuntimeActionLookup({ actions });
+	const directCandidates = new Set(
+		candidateActions.map((name) => resolveRuntimeAction(lookup, name)?.name),
+	);
+	const authorized = new Map(actions.map((action) => [action.name, action]));
+	return actions.filter((action) => {
+		if (directCandidates.has(action.name)) return true;
+		const parentName = promotedSubactionParent(action);
+		if (!parentName) return true;
+		const parent = authorized.get(parentName);
+		// An umbrella requiring a field absent from this alias cannot represent
+		// that alias's valid calls without manufacturing an extra argument.
+		if (
+			parent?.parameters?.some(
+				(parameter) =>
+					parameter.required &&
+					!action.parameters?.some((entry) => entry.name === parameter.name),
+			)
+		)
+			return true;
+		if (
+			parent?.subActions?.some(
+				(child) =>
+					!authorized.has(typeof child === "string" ? child : child.name),
+			)
+		)
+			return true;
+		return !parent?.subActions?.some(
+			(child) =>
+				(typeof child === "string" ? child : child.name) === action.name,
+		);
+	});
 }
 
 export type UmbrellaPlannerBudgetDecision =


### PR DESCRIPTION
## Change

Related to #17072 and #24299. Generated subaction aliases currently repeat complete umbrella parameter schemas in the native planner request. A real owner workflow exceeded Cerebras's 131072-token input window before its first tool operation.

The chat pipeline now represents fully authorized generated families through their complete umbrella tool, retaining complete alias descriptions and exact rendered schema differences. Identical parameter properties reference the parent property; explicit alias candidates stay direct. Independent children, partially authorized families, aliases without an authorized parent, and aliases whose parent requires unavailable arguments remain direct. All original context actions, routing hints, retrieval data, and execution routes remain available.

The existing symbol promotion metadata now survives runtime/gate object spreads and canonical registration. No user message, history, provider output, schema constraint, or unique alias guidance is capped or truncated.

## Verification

Base: `1486b7a110fa23bc2eaee14cf0db6a05f87cc108`; head: `33c3cb1b7eefc77a0e48b0600c7cab77f85f5014`. Bun 1.3.14 / Node 24.15.0.

- Normal `bun install`: passed.
- Root `bun run verify`: passed.
- Full core suite: 12093 passed,3 skipped across933 files.
- Focused promotion, canonical tool, candidate-surface, and full Stage1 suites:284 passed. Reassembly tests reconstruct each complete original alias schema and exercise valid/invalid discriminator inputs, complete large values, direct alias dispatch, missing authority, and independent children.
- Real final-head `generateChatResponse` → AgentRuntime → PGlite + native embeddings + Cerebras: actual write followed by actual read, persisted exact value and final model reply inspected. Complete 117,079-character nested schema guidance reached both planner requests. No mocks replaced the runtime, provider, database, or action dispatcher.
- An unconfigured-caller control was denied with zero record effects. The authorized fixture completed; six requests returned HTTP200.
- UI/native playback evidence: N/A; this change affects the core planner's provider request representation.

The synthetic fixture uses one persisted action family and is not completion evidence for the broader eight-step owner workflow. That workflow now reaches tool dispatch without overflow but has a separate scoped Todo-authority issue tracked in #30959. No latency-improvement percentage is claimed.

<details><summary>Actual final-head input, effect receipts, provider wire summary, and final reply</summary>

```json
{
  "source": "33c3cb1b7eefc77a0e48b0600c7cab77f85f5014",
  "provider": "cerebras",
  "model": "qwen-3.8-27b",
  "prompt": "Use RECORDS to execute write_1 with key audit-proof and payload text exactly \"Copper meadow retains every record boundary.\". Then read audit-proof using RECORDS. Report the exact persisted value after reading it. This is a synthetic isolated record fixture; complete both operations now.",
  "operations": [
    {
      "operation": "write_1",
      "key": "audit-proof",
      "value": "Copper meadow retains every record boundary."
    },
    {
      "operation": "read",
      "key": "audit-proof",
      "value": "Copper meadow retains every record boundary."
    }
  ],
  "persisted": "Copper meadow retains every record boundary.",
  "finalReply": "Done. I wrote audit-proof with the exact text and read it back. The persisted value is: \"Copper meadow retains every record boundary.\"",
  "httpStatuses": [
    200,
    200,
    200,
    200,
    200,
    200
  ],
  "reportedTotalTokens": 130117,
  "schemaGuidanceCharacters": 117079,
  "schemaGuidanceSha256": "153c5fb7189cccacc26ea7b32cb5a512bd9966f4d798a8b1511c07a8a5caf968",
  "plannerRequests": [
    {
      "toolNames": [
        "RECORDS",
        "RECORDS_READ",
        "REPLY",
        "IGNORE",
        "STOP"
      ],
      "requestCharacters": 269983,
      "fullSchemaGuidancePresent": true
    },
    {
      "toolNames": [
        "RECORDS",
        "RECORDS_READ",
        "REPLY",
        "IGNORE",
        "STOP"
      ],
      "requestCharacters": 271137,
      "fullSchemaGuidancePresent": true
    }
  ]
}
```

The complete synthetic schema description is deterministically `"Complete schema guidance starts. " + "The record text is stored without changing its meaning or bytes. ".repeat(1800) + "Complete schema boundary CANONICAL-SCHEMA-END."`; its exact SHA256 is recorded above. This shared property is referenced losslessly by the generated aliases and remains complete in each planner request.

</details>

Hosted checks for this exact head remain required before merge. The broader issues remain open until their independent acceptance criteria are met.
