### PR TITLE
Preserve authored undated todo instructions and failed-reply authority

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { extractLifeOperationWithLlm } from "./extract-life-operation.js";
 import { extractTaskCreatePlanWithLlm } from "./extract-task-plan.js";
 import {
+  resolveUndatedTodoAuthority,
   textContradictsExplicitUndatedTodo,
   textStatesExplicitUndatedTodo,
   UNDATED_TODO_EXTRACTION_GUIDANCE,
@@ -249,5 +250,106 @@ describe("undated Todo extraction guidance", () => {
     for (const prompt of prompts) {
       expect(prompt).toContain(UNDATED_TODO_EXTRACTION_GUIDANCE);
     }
+  });
+});
+
+describe("named Todo authority inside authored workflows", () => {
+  const title = "Copper meadow review";
+  const selected = `Create a todo titled "${title}" with no due date or schedule.`;
+  it("accepts the exact recorded eight-step owner request", () => {
+    const text =
+      "Complete this workflow in my local Eliza calendar and todos, in this order, using IDs returned by the earlier operations. This is one authorization for all eight steps; do not ask me to continue between steps.\n1. Read my local calendar for September 10, 2026 in America/New_York.\n2. Create an undated todo titled 'P19 copper meadow dependency review', with no due date or schedule.\n3. Create a local calendar event with that title on September 10, 2026 from 11:00 to 11:30 AM America/New_York. Put the returned todo ID in the event description.\n4. Read the same calendar date again to verify that the event exists.\n5. Update the event using its returned event ID so it ends at 11:45 AM instead.\n6. Mark the todo complete using its returned todo ID.\n7. Read the todo back, including completed items, to verify its status.\n8. Read the same calendar date again to verify the final event times and description.\nGive the final todo and event IDs and verified state. If any operation fails, accurately identify completed work and the remaining failure. Use local records only; do not connect external calendars or messaging services.";
+    expect(
+      resolveUndatedTodoAuthority(text, "P19 copper meadow dependency review"),
+    ).toEqual({ explicit: true, contradicts: false, operationScoped: true });
+  });
+  it("keeps a separate calendar operation from scheduling the explicitly undated Todo", () => {
+    const text = `Complete all steps in order.\n1. Read the calendar tomorrow.\n2. ${selected}\n3. Create a calendar event tomorrow at 11:00. Put the returned todo ID in its description.\n4. Update the event to end at 11:45 instead.\n5. Mark the todo complete.`;
+    expect(textStatesExplicitUndatedTodo(text)).toBe(false);
+    expect(resolveUndatedTodoAuthority(text, title)).toEqual({
+      explicit: true,
+      contradicts: false,
+      operationScoped: true,
+    });
+  });
+  it.each([
+    "Actually schedule it tomorrow at 9.",
+    `Actually schedule ${title} tomorrow at 9.`,
+    "Schedule the todo on Friday.",
+    "Do not leave the todo with no due date.",
+  ])(
+    "preserves a later correction even after an independent calendar sentence: %s",
+    (correction) => {
+      const text = `1. ${selected}\n2. Create a calendar event tomorrow at 11:00. ${correction}`;
+      expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(false);
+    },
+  );
+  it("keeps an anaphoric correction in a clause mentioning a calendar", () => {
+    const text = `1. ${selected}\n2. Create a calendar event tomorrow, but actually schedule it on Friday.`;
+    expect(resolveUndatedTodoAuthority(text, title).contradicts).toBe(true);
+  });
+  it("does not borrow another named Todo's no-date authority", () => {
+    const text = `1. Create a todo titled "Copper meadow review".\n2. Create a todo titled "Book the taxi" with no due date.`;
+    expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(false);
+    expect(resolveUndatedTodoAuthority(text, "Book the taxi").explicit).toBe(
+      true,
+    );
+  });
+  it("does not borrow a separate Todo's following sentence", () => {
+    const text = `1. Create a todo titled "Copper meadow review".\n2. Create a todo titled "Book the taxi". Then make it no due date.`;
+    expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(false);
+    expect(resolveUndatedTodoAuthority(text, "Book the taxi").explicit).toBe(
+      true,
+    );
+  });
+  it("retains scheduling assigned to the selected title in a calendar clause", () => {
+    const text = `1. ${selected}\n2. Update the calendar and schedule Copper meadow review tomorrow.`;
+    expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(false);
+  });
+  it.each(["first", "previous", "earlier", "original", "other"])(
+    "preserves a %s Todo cross-reference inside another creation block",
+    (reference) => {
+      const text = `1. ${selected}\n2. Create a todo titled "Book the taxi". Also schedule the ${reference} todo tomorrow.`;
+      expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(false);
+    },
+  );
+  it("retains an ordinal item reference in another Todo block", () => {
+    const text = `1. ${selected}\n2. Create a todo titled "Book the taxi". Also schedule the first one tomorrow.`;
+    expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(false);
+  });
+  it("rejects authored scope when a block creates multiple named Todos", () => {
+    const text = `1. Create a todo titled "Copper meadow review". Create a todo titled "Book the taxi" with no due date.\n2. Read calendar tomorrow.`;
+    const result = resolveUndatedTodoAuthority(text, title);
+    expect(result.operationScoped).toBe(false);
+    expect(result.explicit).toBe(textStatesExplicitUndatedTodo(text));
+    expect(result.explicit).toBe(false);
+  });
+  it("keeps different named Todos' timing independent", () => {
+    const text = `1. ${selected}\n2. Create a todo titled "Book the taxi" tomorrow at 9.`;
+    expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(true);
+    expect(resolveUndatedTodoAuthority(text, "Book the taxi").explicit).toBe(
+      false,
+    );
+  });
+  it("honors a final explicit no-date correction for the selected Todo", () => {
+    const text = `1. ${selected}\n2. Actually schedule it tomorrow.\n3. Actually make it no due date.`;
+    expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(true);
+  });
+  it.each([
+    `1. ${selected}\n2. ${selected}\n3. Create a calendar event tomorrow.`,
+    `${selected} Create a calendar event tomorrow.`,
+    `1. Create a todo titled "Different title" with no due date.\n2. Create a calendar event tomorrow.`,
+  ])(
+    "retains whole-message policy when source identity is ambiguous or missing",
+    (text) => {
+      const result = resolveUndatedTodoAuthority(text, title);
+      expect(result.operationScoped).toBe(false);
+      expect(result.explicit).toBe(textStatesExplicitUndatedTodo(text));
+      expect(result.contradicts).toBe(textContradictsExplicitUndatedTodo(text));
+    },
+  );
+  it("does not accept a selected negated no-date directive", () => {
+    const text = `1. Do not create a todo titled "${title}" with no due date.\n2. Create a calendar event tomorrow.`;
+    expect(resolveUndatedTodoAuthority(text, title).explicit).toBe(false);
   });
 });

--- a/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.ts
@@ -421,6 +421,115 @@ export function textContradictsExplicitUndatedTodo(text: string): boolean {
   return undatedTodoDirectiveState(text) === "scheduled_after_explicit";
 }
 
+export interface UndatedTodoAuthority {
+  explicit: boolean;
+  contradicts: boolean;
+  operationScoped: boolean;
+}
+
+function escapedTitle(title: string): string {
+  return title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Attribute no-date authority to an explicitly named Todo in an authored list.
+ * This projection is only for deterministic write authorization: callers keep
+ * the complete user message in every model prompt. Unknown target relationships
+ * remain in the policy input, so an unbound later correction cannot disappear.
+ */
+export function resolveUndatedTodoAuthority(
+  text: string,
+  title: string | null | undefined,
+): UndatedTodoAuthority {
+  const result = (
+    source: string,
+    operationScoped: boolean,
+  ): UndatedTodoAuthority => {
+    const state = undatedTodoDirectiveState(source);
+    return {
+      explicit: state === "explicit",
+      contradicts: state === "scheduled_after_explicit",
+      operationScoped,
+    };
+  };
+  if (!title?.trim()) return result(text, false);
+  const listStart = /^\s*(?:\d+[.)]|[-*])\s+/u;
+  const blocks = text.split(/(?=^\s*(?:\d+[.)]|[-*])\s+)/mu);
+  if (blocks.filter((block) => listStart.test(block)).length < 2)
+    return result(text, false);
+  const clauses = blocks.flatMap((block) => {
+    const listed = listStart.test(block);
+    return block
+      .replace(listStart, "")
+      .split(/(?<=[.!?;])\s+|\n/u)
+      .map((source) => ({ source, listed, block }));
+  });
+  const namedCreation = new RegExp(
+    String.raw`\b(?:create|add|save|make)\s+(?:an?\s+)?(?:owner\s+)?(?:(?:undated|unscheduled)\s+)?(?:todo|task)\s+(?:titled|named|called)\s*["'“‘]${escapedTitle(title.trim())}["'”’](?=\s|[.,;!?]|$)`,
+    "iu",
+  );
+  const selected = clauses.filter(
+    (clause) => clause.listed && namedCreation.test(clause.source),
+  );
+  if (selected.length !== 1) return result(text, false);
+  const creationsInSelectedBlock = selected[0].block.match(
+    /\b(?:create|add|save|make)\s+(?:an?\s+)?(?:owner\s+)?(?:(?:undated|unscheduled)\s+)?(?:todo|task)\s+(?:titled|named|called)\s*["'“‘]/giu,
+  );
+  if (creationsInSelectedBlock?.length !== 1) return result(text, false);
+  const selectedTitle = normalizeKeywordMatchText(title);
+  const namesSelectedTitle = (source: string) =>
+    new RegExp(
+      `(?<![\\p{L}\\p{N}_])${escapedTitle(selectedTitle)}(?![\\p{L}\\p{N}_])`,
+      "u",
+    ).test(normalizeKeywordMatchText(source));
+  const authorityClauses = clauses.filter((clause) => {
+    if (clause.block === selected[0].block) return true;
+    const source = clause.source;
+    const otherTodo = clause.block.match(
+      /\b(?:todo|task)\s+(?:titled|named|called)\s+(?:"([^"\n]+)"|“([^”\n]+)”|'([^'\n]+)'|‘([^’\n]+)’)(?=\s|[.,;!?]|$)/iu,
+    );
+    const otherTitle =
+      otherTodo?.[1] ?? otherTodo?.[2] ?? otherTodo?.[3] ?? otherTodo?.[4];
+    const crossTodoReference =
+      /\b(?:first|previous|earlier|original|other|former|latter|second|third|last|that)\s+(?:todo|task|one|item)\b|\b(?:todo|task|item)\s+(?:from|in)\s+(?:step|item)\s+\d+\b/iu.test(
+        source,
+      );
+    if (
+      otherTitle &&
+      normalizeKeywordMatchText(otherTitle) !== selectedTitle &&
+      !namesSelectedTitle(source) &&
+      !crossTodoReference
+    )
+      return false;
+    // A second directive with a pronoun or the selected title may correct the
+    // Todo even when its sentence also mentions a different resource.
+    const correction = source.match(
+      /\b(?:but|actually|instead|rather|however|then|and)\b([\s\S]*)/iu,
+    );
+    if (
+      correction &&
+      (/\b(?:it|its|this|that|todo|task)\b/iu.test(correction[1]) ||
+        namesSelectedTitle(correction[1]))
+    )
+      return true;
+    const explicitCalendarOperation =
+      /\b(?:create|add|read|list|update|change|move|reschedule|verify|check|open)\b[\s\S]*\b(?:calendar|event)\b/iu.test(
+        source,
+      );
+    if (
+      explicitCalendarOperation &&
+      !/\b(?:todo|task)\b/iu.test(source) &&
+      !namesSelectedTitle(source)
+    )
+      return false;
+    return true;
+  });
+  return result(
+    authorityClauses.map((clause) => clause.source).join("\n"),
+    true,
+  );
+}
+
 const PROMPT_EXAMPLES = LOCALE_POLICIES.map(
   (policy) => `${policy.label}: ${policy.promptExample}`,
 ).join("; ");
@@ -431,5 +540,6 @@ export const UNDATED_TODO_EXTRACTION_GUIDANCE = [
   `    Explicit examples by locale: ${PROMPT_EXAMPLES}.`,
   "    Interpret corrections in order: the last explicit no-date or negated no-date directive wins.",
   "    After the final no-date directive, any non-negated date, weekday, time, recurrence, or relative offset means the Todo is scheduled. A merely omitted date is not unscheduled.",
+  "    In a numbered workflow, bind each directive to its named Todo; timing explicitly assigned to a separate calendar event or a different named Todo does not schedule this Todo. Later corrections to this Todo still win.",
   "    Temporal words in the Todo title are not a schedule (for example, a title named Tomorrow followed by an explicit no-date request).",
 ].join("\n");

--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -1500,7 +1500,7 @@ describe("runLifeOperationHandler clarification contract", () => {
     expect(serviceState.createCalls).toHaveLength(0);
   });
 
-  it("marks a missing reminder schedule as user-facing and awaiting owner input", async () => {
+  it("keeps a missing reminder schedule available for grounded owner clarification", async () => {
     const clarification = "What day and time should I use?";
     const runtime = makeRuntime((prompt) => {
       if (
@@ -1542,7 +1542,8 @@ describe("runLifeOperationHandler clarification contract", () => {
     expect(result).toMatchObject({
       success: false,
       text: "When should it happen?",
-      userFacingText: "When should it happen?",
+      transcriptVisibility: "internal",
+      turnComplete: false,
       values: {
         success: false,
         error: "MISSING_DEFINITION_FIELD",
@@ -1558,7 +1559,88 @@ describe("runLifeOperationHandler clarification contract", () => {
       },
     });
     expect(retry.effectReceipts).toEqual(result.effectReceipts);
+    expect(result.userFacingText).toBeUndefined();
     expect(serviceState.createCalls).toHaveLength(0);
+  });
+
+  it("does not deliver a renderer's saved claim for a rejected reminder create", async () => {
+    const draft =
+      "I've saved the report reminder. Ready to continue when you are.";
+    vi.spyOn(agent, "renderGroundedActionReply").mockResolvedValue({
+      kind: "model",
+      text: draft,
+    });
+    const runtime = makeRuntime(() =>
+      taskPlanJson({ mode: "respond", response: "When?", title: "Report" }),
+    );
+    const callback = vi.fn(async () => []);
+    const result = await runLifeOperationHandler(
+      runtime,
+      makeMessage("Create a report reminder; I have not specified when."),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          intent: "Create a report reminder",
+          title: "Report",
+          ownerSurface: "OWNER_REMINDERS",
+        },
+      } as HandlerOptions,
+      callback,
+    );
+    expect(result).toMatchObject({
+      success: false,
+      text: draft,
+      transcriptVisibility: "internal",
+      verifiedUserFacing: false,
+      turnComplete: false,
+      values: { error: "MISSING_DEFINITION_FIELD", missingField: "schedule" },
+    });
+    expect(result.userFacingText).toBeUndefined();
+    expect(result.effectReceipts).toMatchObject([{ outcome: "preview" }]);
+    expect(callback).not.toHaveBeenCalled();
+    expect(serviceState.createCalls).toHaveLength(0);
+  });
+
+  it("preserves observation recovery when a failed review has a model draft", async () => {
+    const { LifeOpsService, LifeOpsServiceError } = await import(
+      "../lifeops/service.js"
+    );
+    vi.spyOn(LifeOpsService.prototype, "listDefinitions").mockRejectedValue(
+      new LifeOpsServiceError("Definitions are unavailable", 503),
+    );
+    const draft = "I checked everything and there are no reminders.";
+    vi.spyOn(agent, "renderGroundedActionReply").mockResolvedValue({
+      kind: "model",
+      text: draft,
+    });
+    const callback = vi.fn(async () => []);
+    const result = await runLifeOperationHandler(
+      makeRuntime(() => ""),
+      makeMessage("Review my reminders."),
+      undefined,
+      {
+        parameters: {
+          action: "review",
+          intent: "Review my reminders",
+          ownerSurface: "OWNER_REMINDERS",
+        },
+      } as HandlerOptions,
+      callback,
+    );
+    expect(result).toMatchObject({
+      success: false,
+      text: draft,
+      transcriptVisibility: "internal",
+      verifiedUserFacing: false,
+      turnComplete: false,
+      data: { readOnlyOperation: true },
+      effectReceipts: [
+        { outcome: "failed", failure: { acceptance: "rejected" } },
+      ],
+    });
+    expect(result.userFacingText).toBeUndefined();
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it("rejects a model-invented date when the owner explicitly withheld timing", async () => {

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -139,7 +139,7 @@ import {
   applyOwnerPolicySetReminder,
 } from "./lib/owner-policy-writes.js";
 import {
-  textContradictsExplicitUndatedTodo,
+  resolveUndatedTodoAuthority,
   textStatesExplicitUndatedTodo,
 } from "./lib/undated-todo-intent.js";
 
@@ -3407,6 +3407,7 @@ function shouldRequireLifeCreateConfirmation(args: {
   cadence?: LifeOpsCadence;
   multiStep?: boolean;
   explicitUndated?: boolean;
+  operationScopedUndated?: boolean;
   previewRequested?: boolean;
 }): boolean {
   if (args.messageSource === "autonomy") {
@@ -3433,13 +3434,12 @@ function shouldRequireLifeCreateConfirmation(args: {
   // halves — the item AND that it has no date ("add a todo: X, no deadline") —
   // a preview would ask them to confirm exactly what they just said. Scoped to
   // an EXPLICIT textual no-date statement (the same canonical authority that
-  // guards the unscheduled-cadence wipe), single-step asks only, mirroring the
-  // #16941 over-trigger guard. An extraction-inferred unscheduled cadence
-  // without the explicit statement still previews.
+  // guards the unscheduled-cadence wipe). Multi-step requests need a unique
+  // authored Todo clause; model-only scope cannot bypass confirmation.
   if (
     args.cadence?.kind === "unscheduled" &&
     args.explicitUndated === true &&
-    !args.multiStep
+    (!args.multiStep || args.operationScopedUndated === true)
   ) {
     return false;
   }
@@ -4896,17 +4896,17 @@ async function runLifeOperationHandlerInner(
           await invalidateDeferredLifeDraftCache(runtime, message);
         }
       }
+      const undatedAuthority = resolveUndatedTodoAuthority(currentText, title);
       const confirmsValidatedUndatedDraft =
         deferredDraftReuseMode === "confirm" &&
         deferredDefinitionDraft?.request.cadence?.kind === "unscheduled";
       if (
         (editingDeferredDefinitionDraft &&
           deferredDefinitionDraft.request.cadence?.kind === "unscheduled" &&
-          textContradictsExplicitUndatedTodo(currentText)) ||
+          undatedAuthority.contradicts) ||
         (cadence?.kind === "unscheduled" &&
           (ownerSurfaceActionName !== "OWNER_TODOS" ||
-            (!confirmsValidatedUndatedDraft &&
-              !textStatesExplicitUndatedTodo(currentText))))
+            (!confirmsValidatedUndatedDraft && !undatedAuthority.explicit)))
       ) {
         cadence = undefined;
         if (editingDeferredDefinitionDraft) {
@@ -5193,8 +5193,8 @@ async function runLifeOperationHandlerInner(
           // skip is for the owner's fresh "add a todo: X, no deadline" ask,
           // where the preview would echo back exactly what they just said.
           explicitUndated:
-            !editingDeferredDefinitionDraft &&
-            textStatesExplicitUndatedTodo(currentText),
+            !editingDeferredDefinitionDraft && undatedAuthority.explicit,
+          operationScopedUndated: undatedAuthority.operationScoped,
           previewRequested: LIFE_TEXT_REQUESTS_PREVIEW_RE.test(currentText),
         })
       ) {

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -4254,9 +4254,8 @@ async function runLifeOperationHandlerInner(
     | LifeParams
     | undefined;
   const params = rawParams ?? ({} as LifeParams);
-  const currentText = normalizeLifeInputText(
-    extractPrimaryLifeInputText(messageText(message)),
-  );
+  const authoredText = extractPrimaryLifeInputText(messageText(message));
+  const currentText = normalizeLifeInputText(authoredText);
   const details = params.details;
   const stateDeferredDraft = latestDeferredLifeDraft(state);
   const cachedDeferredDraftState = await readDeferredLifeDraftCacheState(
@@ -4896,7 +4895,18 @@ async function runLifeOperationHandlerInner(
           await invalidateDeferredLifeDraftCache(runtime, message);
         }
       }
-      const undatedAuthority = resolveUndatedTodoAuthority(currentText, title);
+      const undatedAuthority = resolveUndatedTodoAuthority(authoredText, title);
+      // A uniquely authored no-date directive supplies the cadence even when
+      // the planner omits it; timing on another operation cannot fill this slot.
+      if (
+        ownerSurfaceActionName === "OWNER_TODOS" &&
+        !editingDeferredDefinitionDraft &&
+        cadence === undefined &&
+        undatedAuthority.operationScoped &&
+        undatedAuthority.explicit
+      ) {
+        cadence = { kind: "unscheduled" };
+      }
       const confirmsValidatedUndatedDraft =
         deferredDraftReuseMode === "confirm" &&
         deferredDefinitionDraft?.request.cadence?.kind === "unscheduled";

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -1767,6 +1767,19 @@ function settleLifeActionReply(result: PendingLifeActionResult): ActionResult {
       ...(typeof userFacingText === "string" ? { userFacingText } : {}),
     };
   }
+  if (outcome.success === false && text.kind === "model") {
+    // A renderer's prose is not verification of a rejected operation. Keep
+    // the complete draft with its typed failure for the planner to resolve.
+    return applyGroundedActionReply(
+      {
+        ...outcome,
+        transcriptVisibility: "internal",
+        verifiedUserFacing: false,
+        turnComplete: false,
+      },
+      text,
+    );
+  }
   return applyGroundedActionReply(
     {
       ...outcome,
@@ -6744,9 +6757,6 @@ export async function runLifeOperationHandler(
     options,
     result,
   });
-  if (result.replyFailure) {
-    return { ...result, effectReceipts: [receipt] };
-  }
   // A rejected lookup leaves no write to reconcile. Preserve its failure and
   // diagnostics while allowing the planner's existing observation recovery.
   const observationFailure =
@@ -6754,11 +6764,16 @@ export async function runLifeOperationHandler(
     lifeRequestedOperation(options) === "review" &&
     receipt.outcome === "failed" &&
     receipt.failure.acceptance === "rejected";
-  return completeLifeOpsEffect(
-    callback,
-    observationFailure
-      ? { ...result, data: { ...result.data, readOnlyOperation: true } }
-      : result,
-    receipt,
-  );
+  const settledResult = observationFailure
+    ? { ...result, data: { ...result.data, readOnlyOperation: true } }
+    : result;
+  if (
+    result.replyFailure ||
+    (result.transcriptVisibility === "internal" &&
+      result.success === false &&
+      result.userFacingText === undefined)
+  ) {
+    return { ...settledResult, effectReceipts: [receipt] };
+  }
+  return completeLifeOpsEffect(callback, settledResult, receipt);
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/owner-todo-lifecycle.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner-todo-lifecycle.pglite.integration.test.ts
@@ -180,83 +180,89 @@ it.each(["sequential", "interleaved"])(
   180000,
 );
 
-it("creates only the named undated Todo from an authorized compound workflow", async () => {
-  const host = await createLifeOpsTestRuntime();
-  const runtime = host.runtime;
-  const owner = crypto.randomUUID() as UUID;
-  const worldId = crypto.randomUUID() as UUID;
-  const title = "P19 copper meadow dependency review";
-  const message: Memory = {
-    id: crypto.randomUUID() as UUID,
-    agentId: runtime.agentId,
-    entityId: owner,
-    roomId: crypto.randomUUID() as UUID,
-    worldId,
-    content: {
-      source: "dashboard",
-      text: "Complete this workflow in my local Eliza calendar and todos, in this order, using IDs returned by the earlier operations. This is one authorization for all eight steps; do not ask me to continue between steps.\n1. Read my local calendar for September 10, 2026 in America/New_York.\n2. Create an undated todo titled 'P19 copper meadow dependency review', with no due date or schedule.\n3. Create a local calendar event with that title on September 10, 2026 from 11:00 to 11:30 AM America/New_York. Put the returned todo ID in the event description.\n4. Read the same calendar date again to verify that the event exists.\n5. Update the event using its returned event ID so it ends at 11:45 AM instead.\n6. Mark the todo complete using its returned todo ID.\n7. Read the todo back, including completed items, to verify its status.\n8. Read the same calendar date again to verify the final event times and description.\nGive the final todo and event IDs and verified state. If any operation fails, accurately identify completed work and the remaining failure. Use local records only; do not connect external calendars or messaging services.",
-    },
-  };
-  try {
-    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", owner);
-    await runtime.ensureConnection({
+it.each(["explicit", "omitted"])(
+  "creates only the named undated Todo from an authorized compound workflow with %s cadence",
+  async (cadenceSource) => {
+    const host = await createLifeOpsTestRuntime();
+    const runtime = host.runtime;
+    const owner = crypto.randomUUID() as UUID;
+    const worldId = crypto.randomUUID() as UUID;
+    const title = "P19 copper meadow dependency review";
+    const message: Memory = {
+      id: crypto.randomUUID() as UUID,
+      agentId: runtime.agentId,
       entityId: owner,
-      roomId: message.roomId,
+      roomId: crypto.randomUUID() as UUID,
       worldId,
-      worldName: "Compound workflow",
-      userName: "workflow-owner",
-      name: "Workflow owner",
-      source: "dashboard",
-      type: ChannelType.DM,
-      channelId: message.roomId,
-    });
-    const dispatch = () =>
-      executePlannedToolCall(
-        runtime,
-        { message, activeContexts: ["tasks"] },
-        {
-          name: "OWNER_TODOS",
-          params: {
-            action: "create",
-            title,
-            intent: `Create a todo titled "${title}" with no due date or schedule.`,
-            details: {
-              kind: "task",
-              cadence: { kind: "unscheduled" },
-              timeZone: "America/New_York",
+      content: {
+        source: "dashboard",
+        text: "Complete this workflow in my local Eliza calendar and todos, in this order, using IDs returned by the earlier operations. This is one authorization for all eight steps; do not ask me to continue between steps.\n1. Read my local calendar for September 10, 2026 in America/New_York.\n2. Create an undated todo titled 'P19 copper meadow dependency review', with no due date or schedule.\n3. Create a local calendar event with that title on September 10, 2026 from 11:00 to 11:30 AM America/New_York. Put the returned todo ID in the event description.\n4. Read the same calendar date again to verify that the event exists.\n5. Update the event using its returned event ID so it ends at 11:45 AM instead.\n6. Mark the todo complete using its returned todo ID.\n7. Read the todo back, including completed items, to verify its status.\n8. Read the same calendar date again to verify the final event times and description.\nGive the final todo and event IDs and verified state. If any operation fails, accurately identify completed work and the remaining failure. Use local records only; do not connect external calendars or messaging services.",
+      },
+    };
+    try {
+      runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", owner);
+      await runtime.ensureConnection({
+        entityId: owner,
+        roomId: message.roomId,
+        worldId,
+        worldName: "Compound workflow",
+        userName: "workflow-owner",
+        name: "Workflow owner",
+        source: "dashboard",
+        type: ChannelType.DM,
+        channelId: message.roomId,
+      });
+      const dispatch = () =>
+        executePlannedToolCall(
+          runtime,
+          { message, activeContexts: ["tasks"] },
+          {
+            name: "OWNER_TODOS",
+            params: {
+              action: "create",
+              title,
+              intent: `Create a todo titled "${title}" with no due date or schedule.`,
+              details: {
+                kind: "task",
+                ...(cadenceSource === "explicit"
+                  ? { cadence: { kind: "unscheduled" } }
+                  : {}),
+                timeZone: "America/New_York",
+              },
             },
           },
-        },
-        { actions: [ownerTodosAction] },
-      );
-    const created = await dispatch();
-    expect(created.success).toBe(true);
-    const id = created.effectReceipts?.[0].resource.id;
-    if (!id) throw new Error("Compound creation omitted durable ID");
-    const service = new LifeOpsService(runtime, { ownerEntityId: owner });
-    expect((await service.getDefinition(id)).definition).toMatchObject({
-      title,
-      cadence: { kind: "unscheduled" },
-      status: "active",
-    });
-    expect(
-      await service.repository.listOccurrencesForDefinition(
-        runtime.agentId,
-        id,
-      ),
-    ).toEqual([]);
-    expect(await service.getTodos()).toEqual([
-      expect.objectContaining({ id, dueDate: null, status: "pending" }),
-    ]);
-    message.content.text += "\n6. Actually schedule the todo tomorrow at 9.";
-    const denied = await dispatch();
-    expect(
-      denied.effectReceipts?.some((receipt) => receipt.outcome === "applied"),
-    ).not.toBe(true);
-    expect(
-      (await service.listDefinitions()).map((row) => row.definition.id),
-    ).toEqual([id]);
-  } finally {
-    await host.cleanup();
-  }
-}, 180000);
+          { actions: [ownerTodosAction] },
+        );
+      const created = await dispatch();
+      expect(created.success).toBe(true);
+      const id = created.effectReceipts?.[0].resource.id;
+      if (!id) throw new Error("Compound creation omitted durable ID");
+      const service = new LifeOpsService(runtime, { ownerEntityId: owner });
+      expect((await service.getDefinition(id)).definition).toMatchObject({
+        title,
+        cadence: { kind: "unscheduled" },
+        status: "active",
+      });
+      expect(
+        await service.repository.listOccurrencesForDefinition(
+          runtime.agentId,
+          id,
+        ),
+      ).toEqual([]);
+      expect(await service.getTodos()).toEqual([
+        expect.objectContaining({ id, dueDate: null, status: "pending" }),
+      ]);
+      message.content.text += "\n6. Actually schedule the todo tomorrow at 9.";
+      const denied = await dispatch();
+      expect(
+        denied.effectReceipts?.some((receipt) => receipt.outcome === "applied"),
+      ).not.toBe(true);
+      expect(
+        (await service.listDefinitions()).map((row) => row.definition.id),
+      ).toEqual([id]);
+    } finally {
+      await host.cleanup();
+    }
+  },
+  180000,
+);

--- a/plugins/plugin-personal-assistant/src/lifeops/owner-todo-lifecycle.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner-todo-lifecycle.pglite.integration.test.ts
@@ -179,3 +179,84 @@ it.each(["sequential", "interleaved"])(
   },
   180000,
 );
+
+it("creates only the named undated Todo from an authorized compound workflow", async () => {
+  const host = await createLifeOpsTestRuntime();
+  const runtime = host.runtime;
+  const owner = crypto.randomUUID() as UUID;
+  const worldId = crypto.randomUUID() as UUID;
+  const title = "P19 copper meadow dependency review";
+  const message: Memory = {
+    id: crypto.randomUUID() as UUID,
+    agentId: runtime.agentId,
+    entityId: owner,
+    roomId: crypto.randomUUID() as UUID,
+    worldId,
+    content: {
+      source: "dashboard",
+      text: "Complete this workflow in my local Eliza calendar and todos, in this order, using IDs returned by the earlier operations. This is one authorization for all eight steps; do not ask me to continue between steps.\n1. Read my local calendar for September 10, 2026 in America/New_York.\n2. Create an undated todo titled 'P19 copper meadow dependency review', with no due date or schedule.\n3. Create a local calendar event with that title on September 10, 2026 from 11:00 to 11:30 AM America/New_York. Put the returned todo ID in the event description.\n4. Read the same calendar date again to verify that the event exists.\n5. Update the event using its returned event ID so it ends at 11:45 AM instead.\n6. Mark the todo complete using its returned todo ID.\n7. Read the todo back, including completed items, to verify its status.\n8. Read the same calendar date again to verify the final event times and description.\nGive the final todo and event IDs and verified state. If any operation fails, accurately identify completed work and the remaining failure. Use local records only; do not connect external calendars or messaging services.",
+    },
+  };
+  try {
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", owner);
+    await runtime.ensureConnection({
+      entityId: owner,
+      roomId: message.roomId,
+      worldId,
+      worldName: "Compound workflow",
+      userName: "workflow-owner",
+      name: "Workflow owner",
+      source: "dashboard",
+      type: ChannelType.DM,
+      channelId: message.roomId,
+    });
+    const dispatch = () =>
+      executePlannedToolCall(
+        runtime,
+        { message, activeContexts: ["tasks"] },
+        {
+          name: "OWNER_TODOS",
+          params: {
+            action: "create",
+            title,
+            intent: `Create a todo titled "${title}" with no due date or schedule.`,
+            details: {
+              kind: "task",
+              cadence: { kind: "unscheduled" },
+              timeZone: "America/New_York",
+            },
+          },
+        },
+        { actions: [ownerTodosAction] },
+      );
+    const created = await dispatch();
+    expect(created.success).toBe(true);
+    const id = created.effectReceipts?.[0].resource.id;
+    if (!id) throw new Error("Compound creation omitted durable ID");
+    const service = new LifeOpsService(runtime, { ownerEntityId: owner });
+    expect((await service.getDefinition(id)).definition).toMatchObject({
+      title,
+      cadence: { kind: "unscheduled" },
+      status: "active",
+    });
+    expect(
+      await service.repository.listOccurrencesForDefinition(
+        runtime.agentId,
+        id,
+      ),
+    ).toEqual([]);
+    expect(await service.getTodos()).toEqual([
+      expect.objectContaining({ id, dueDate: null, status: "pending" }),
+    ]);
+    message.content.text += "\n6. Actually schedule the todo tomorrow at 9.";
+    const denied = await dispatch();
+    expect(
+      denied.effectReceipts?.some((receipt) => receipt.outcome === "applied"),
+    ).not.toBe(true);
+    expect(
+      (await service.listDefinitions()).map((row) => row.definition.id),
+    ).toEqual([id]);
+  } finally {
+    await host.cleanup();
+  }
+}, 180000);

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-todos-unscheduled.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-todos-unscheduled.test.ts
@@ -1,30 +1,17 @@
+/**
+ * Exercises the todo HTTP projection against real LifeOps services and PGlite.
+ * Persisted undated status and caller ownership must survive route serialization.
+ */
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
-import type { AgentRuntime } from "@elizaos/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { LifeOpsRouteContext } from "./lifeops-routes.js";
-
-const { getOverview, listDefinitions } = vi.hoisted(() => ({
-  getOverview: vi.fn(async () => ({ owner: { occurrences: [] } })),
-  listDefinitions: vi.fn(async () => [] as Array<Record<string, unknown>>),
-}));
-
-vi.mock("@elizaos/plugin-calendar/routes/calendar-routes", () => ({
-  handleCalendarRoutes: vi.fn(async () => false),
-}));
-
-vi.mock("../lifeops/service.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../lifeops/service.js")>();
-  return {
-    ...actual,
-    LifeOpsService: class MockLifeOpsService {
-      getOverview = getOverview;
-      listDefinitions = listDefinitions;
-    },
-  };
-});
-
-const { handleLifeOpsRoutes } = await import("./lifeops-routes.js");
+import type { AgentRuntime, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { createLifeOpsTestRuntime } from "../../test/helpers/runtime.js";
+import { LifeOpsService } from "../lifeops/service.js";
+import {
+  handleLifeOpsRoutes,
+  type LifeOpsRouteContext,
+} from "./lifeops-routes.js";
 
 interface CapturedResponse {
   statusCode?: number;
@@ -32,7 +19,11 @@ interface CapturedResponse {
   ended: boolean;
 }
 
-function buildCtx(search = ""): {
+function buildCtx(
+  runtime: AgentRuntime,
+  owner: string,
+  search = "",
+): {
   ctx: LifeOpsRouteContext;
   res: CapturedResponse;
 } {
@@ -68,8 +59,8 @@ function buildCtx(search = ""): {
     pathname: "/api/lifeops/todos",
     url: new URL(`http://localhost/api/lifeops/todos${search}`),
     state: {
-      runtime: { agentId: "agent-1" } as unknown as AgentRuntime,
-      adminEntityId: null,
+      runtime,
+      adminEntityId: owner,
     },
     json(r, data, status = 200) {
       r.statusCode = status;
@@ -95,56 +86,89 @@ function buildCtx(search = ""): {
   return { ctx, res };
 }
 
-describe("GET /api/lifeops/todos unscheduled tasks", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    listDefinitions.mockResolvedValue([]);
+describe("GET /api/lifeops/todos persisted owner records", () => {
+  it("serializes the durable todo status without manufacturing an occurrence", async () => {
+    const host = await createLifeOpsTestRuntime();
+    const owner = crypto.randomUUID() as UUID;
+    try {
+      const service = new LifeOpsService(host.runtime, {
+        ownerEntityId: owner,
+      });
+      const created = await service.createDefinition({
+        title: "Read the complete draft",
+        kind: "task",
+        cadence: { kind: "unscheduled" },
+        timezone: "UTC",
+      });
+      const id = created.definition.id;
+      const pending = buildCtx(host.runtime, owner);
+      await handleLifeOpsRoutes(pending.ctx);
+      expect(pending.res.statusCode).toBe(200);
+      expect(JSON.parse(pending.res.body ?? "invalid").todos).toEqual([
+        expect.objectContaining({
+          id,
+          targetKind: "definition",
+          title: "Read the complete draft",
+          status: "pending",
+          dueDate: null,
+        }),
+      ]);
+      await service.completeTodo(id);
+      const completed = buildCtx(host.runtime, owner);
+      await handleLifeOpsRoutes(completed.ctx);
+      expect(JSON.parse(completed.res.body ?? "invalid").todos).toEqual([
+        expect.objectContaining({
+          id,
+          targetKind: "definition",
+          status: "completed",
+          dueDate: null,
+        }),
+      ]);
+      expect(
+        await service.repository.listOccurrencesForDefinition(
+          host.runtime.agentId,
+          id,
+        ),
+      ).toEqual([]);
+    } finally {
+      await host.cleanup();
+    }
   });
 
-  it("includes active owner unscheduled tasks without manufacturing scheduled occurrences", async () => {
-    listDefinitions.mockResolvedValue([
-      {
-        definition: {
-          id: "undated",
-          title: "Read the draft",
-          kind: "task",
-          subjectType: "owner",
-          status: "active",
-          cadence: { kind: "unscheduled" },
-        },
-      },
-    ]);
-    const { ctx, res } = buildCtx();
-    await handleLifeOpsRoutes(ctx);
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body ?? "{}").todos).toEqual([
-      {
-        id: "undated",
-        title: "Read the draft",
-        status: "pending",
-        dueDate: null,
-        progress: null,
-      },
-    ]);
-  });
-
-  it("excludes agent operations, inactive tasks, and scheduled definitions from the unscheduled projection", async () => {
-    const base = {
-      id: "excluded",
-      title: "Hidden",
-      kind: "task",
-      subjectType: "owner",
-      status: "active",
-      cadence: { kind: "unscheduled" },
-    };
-    listDefinitions.mockResolvedValue([
-      { definition: { ...base, subjectType: "agent" } },
-      { definition: { ...base, status: "archived" } },
-      { definition: { ...base, cadence: { kind: "once" } } },
-      { definition: { ...base, kind: "routine" } },
-    ]);
-    const { ctx, res } = buildCtx();
-    await handleLifeOpsRoutes(ctx);
-    expect(JSON.parse(res.body ?? "{}").todos).toEqual([]);
+  it("does not expose another owner's persisted todo through the route", async () => {
+    const host = await createLifeOpsTestRuntime();
+    const owner = crypto.randomUUID() as UUID;
+    const other = crypto.randomUUID() as UUID;
+    try {
+      const ownService = new LifeOpsService(host.runtime, {
+        ownerEntityId: owner,
+      });
+      const otherService = new LifeOpsService(host.runtime, {
+        ownerEntityId: other,
+      });
+      const own = await ownService.createDefinition({
+        title: "Visible owner record",
+        kind: "task",
+        cadence: { kind: "unscheduled" },
+        timezone: "UTC",
+      });
+      await otherService.createDefinition({
+        title: "Other owner private record",
+        kind: "task",
+        cadence: { kind: "unscheduled" },
+        timezone: "UTC",
+      });
+      const request = buildCtx(host.runtime, owner);
+      await handleLifeOpsRoutes(request.ctx);
+      expect(request.res.statusCode).toBe(200);
+      expect(JSON.parse(request.res.body ?? "invalid").todos).toEqual([
+        expect.objectContaining({
+          id: own.definition.id,
+          title: "Visible owner record",
+        }),
+      ]);
+    } finally {
+      await host.cleanup();
+    }
   });
 });

--- a/plugins/plugin-personal-assistant/test/ftu-evaluators-merged-call.test.ts
+++ b/plugins/plugin-personal-assistant/test/ftu-evaluators-merged-call.test.ts
@@ -31,10 +31,14 @@ interface CapturedModelCall {
 function createEvaluatorRuntime(modelOutput: Record<string, unknown>): {
   runtime: IAgentRuntime;
   calls: CapturedModelCall[];
+  memories: Memory[];
 } {
   const calls: CapturedModelCall[] = [];
+  const memories: Memory[] = [];
   const runtime = createOwnerRuntimeStub({
     evaluators: [ftuGoalDiscoveryEvaluator, anticipationFeedbackEvaluator],
+    getMemories: async ({ roomId }: { roomId: string }) =>
+      memories.filter((memory) => memory.roomId === roomId),
     useModel: (async (
       _modelType: string,
       params: {
@@ -57,7 +61,7 @@ function createEvaluatorRuntime(modelOutput: Record<string, unknown>): {
       error: () => {},
     } as never,
   } as never);
-  return { runtime, calls };
+  return { runtime, calls, memories };
 }
 
 function ownerMessage(runtime: IAgentRuntime, text: string): Memory {
@@ -73,7 +77,7 @@ function ownerMessage(runtime: IAgentRuntime, text: string): Memory {
 
 describe("FTU + anticipation evaluators through the real merged EvaluatorService call", () => {
   it("runs both evaluators in one model call, persists via processors, then never reprocesses", async () => {
-    const { runtime, calls } = createEvaluatorRuntime({
+    const { runtime, calls, memories } = createEvaluatorRuntime({
       ftu_goal_discovery: {
         goalFound: true,
         goal: "Stay on top of email and family follow-ups",
@@ -97,6 +101,7 @@ describe("FTU + anticipation evaluators through the real merged EvaluatorService
       runtime,
       "Yes please — mostly I need help staying on top of email and family follow-ups.",
     );
+    memories.push(message);
     const result = await service.run(message, undefined, { didRespond: true });
 
     expect(result.skipped).toBe(false);
@@ -113,6 +118,7 @@ describe("FTU + anticipation evaluators through the real merged EvaluatorService
     // Exactly ONE merged model call, whose prompt and schema carry both
     // evaluator sections.
     expect(calls).toHaveLength(1);
+    expect(calls[0]?.prompt).toContain(message.content.text);
     expect(calls[0]?.prompt).toContain("### ftu_goal_discovery");
     expect(calls[0]?.prompt).toContain("### anticipation_feedback");
     expect(Object.keys(calls[0]?.schema?.properties ?? {}).sort()).toEqual([
@@ -151,7 +157,7 @@ describe("FTU + anticipation evaluators through the real merged EvaluatorService
   });
 
   it("keeps discovery open when the merged output is low-confidence", async () => {
-    const { runtime, calls } = createEvaluatorRuntime({
+    const { runtime, calls, memories } = createEvaluatorRuntime({
       ftu_goal_discovery: {
         goalFound: true,
         goal: "Maybe something with fitness?",
@@ -164,11 +170,12 @@ describe("FTU + anticipation evaluators through the real merged EvaluatorService
     await firstRun.complete();
 
     const service = (await EvaluatorService.start(runtime)) as EvaluatorService;
-    const result = await service.run(
-      ownerMessage(runtime, "eh, I sometimes think about the gym"),
-      undefined,
-      { didRespond: true },
+    const message = ownerMessage(
+      runtime,
+      "eh, I sometimes think about the gym",
     );
+    memories.push(message);
+    const result = await service.run(message, undefined, { didRespond: true });
 
     // Only the goal evaluator was active (no proactive marker), it ran, and
     // low confidence left the pipeline open for the next turn.


### PR DESCRIPTION
A numbered request that creates an undated todo and then schedules a separate calendar event could ask for a todo deadline, because handler normalization removed the list boundaries and treated the event time as todo authority. Failed action reply drafts could also be marked verified and imply that an unsuccessful save had completed.

Preserve the authored list boundaries for deterministic operation attribution, retain corrections and ambiguous references, and derive a missing unscheduled cadence only from explicit authority attached to the selected todo. Failed model drafts remain complete internal diagnostics rather than verified user-facing replies. Existing explicit previews, draft editing and separate todo targets keep their guards.

Related: #30959, #24299.

Validation: pinned Node 24.15.0 / Bun 1.3.14 normal install and root verification passed at `5ca1f3905b79d138230589ff0d9d458f04b035e4`. The identical personal-assistant package tree passed all 299 unit files (2,578 tests, 6 declared skips), and is being rerun on this final combined base before merge. 222 focused cases and four real PGlite lifecycle cases passed, including supplied/omitted cadence and a later scheduling correction. Exact-base controls reproduce the lost-boundary and missing-cadence failures.

A confined real-model/PGlite host created the named owner todo with an unscheduled cadence and returned its durable ID. That run separately exposed final-message recovery issue #30965 after a calendar retry; this PR does not claim that broader reply/workflow issue is resolved. Two baseline fixtures were repaired without weakening assertions: evaluator persisted-memory input and actual todo-route state/owner isolation.
