### PR TITLE
Preserve verified replies after redundant record arguments are corrected

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -1151,3 +1151,95 @@ describe("planner-loop failed-operation correlation", () => {
 		expect(runtime.useModel).toHaveBeenCalledTimes(3);
 	});
 });
+
+it.each([
+	["redundant native record metadata", "2026-09-10T00:00:00", true],
+	["different encoded target", "2026-09-12T00:00:00", false],
+	["malformed encoded value", undefined, false],
+] as const)(
+	"retains the correct calendar result after %s",
+	async (_label, encodedStart, recovered) => {
+		const details = {
+			timeMin: "2026-09-10T00:00:00",
+			timeMax: "2026-09-11T00:00:00",
+			timeZone: "America/New_York",
+		};
+		const corrected = {
+			action: "feed",
+			intent: "Read the local calendar for September 10.",
+			details,
+		};
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValue({
+					text: "The failed read remains unresolved.",
+					toolCalls: [],
+				})
+				.mockResolvedValueOnce(
+					plannerToolCall("invalid", "CALENDAR", {
+						...corrected,
+						details: {
+							...details,
+							__eliza_record_entries: [
+								{
+									key: "timemin",
+									value:
+										encodedStart === undefined
+											? "invalid JSON"
+											: JSON.stringify(encodedStart),
+								},
+								{ key: "timemax", value: JSON.stringify(details.timeMax) },
+								{ key: "timezone", value: JSON.stringify(details.timeZone) },
+							],
+						},
+					}),
+				)
+				.mockResolvedValueOnce(
+					plannerToolCall("corrected", "CALENDAR", corrected),
+				),
+		};
+		const verifiedReply =
+			"The calendar read succeeded. Event evt-copper is scheduled for 11:00 to 11:45 AM.";
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "corrected-calendar" },
+			executeToolCall: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					error: "Unexpected argument 'details.__eliza_record_entries'",
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					data: {
+						events: [{ id: "evt-copper", start: "11:00", end: "11:45" }],
+					},
+				}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Remove the rejected representation field and retry.",
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					decision: "FINISH",
+					thought: "The corrected read returned the event.",
+					messageToUser: verifiedReply,
+				}),
+		});
+		if (recovered) {
+			expect(result.finalMessage).toBe(verifiedReply);
+			expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		} else {
+			expect(result.finalMessage).not.toBe(verifiedReply);
+		}
+		const outcomes = result.trajectory.steps
+			.filter((step) => step.result)
+			.map((step) => step.result?.success);
+		expect(outcomes).toContain(false);
+		expect(outcomes).toContain(true);
+	},
+);

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -78,7 +78,7 @@ import {
 	stripReasoningPrefixes,
 } from "../utils/reasoning-tags";
 import { resolveStateDir } from "../utils/state-dir";
-import { isPlainObject } from "../utils/type-guards";
+import { isObjectRecord, isPlainObject } from "../utils/type-guards";
 import { toWellFormedUnicode } from "../utils/well-formed";
 import {
 	computePrefixHashes,
@@ -5379,8 +5379,60 @@ function parameterNamesNamedByFailure(
 	return names;
 }
 
-// Exported for unit coverage of the correlation contract: the resolver's
-// decision is the deliverable, so tests pin its shapes directly.
+/** Projects only provably redundant, rejected transport metadata for correlation. */
+function withoutRedundantRejectedRecordEncoding(
+	params: Record<string, unknown>,
+	result: PlannerToolResult | undefined,
+): Record<string, unknown> {
+	const error = typeof result?.error === "string" ? result.error : result?.text;
+	if (typeof error !== "string") return params;
+	const path =
+		/Unexpected argument ['"]([^'"]+\.__eliza_record_entries)['"]/.exec(
+			error,
+		)?.[1];
+	if (!path) return params;
+	const segments = path.split(".");
+	let parent = params;
+	const ancestors: Array<{ parent: Record<string, unknown>; key: string }> = [];
+	for (const key of segments.slice(0, -1)) {
+		if (!Object.hasOwn(parent, key) || !isObjectRecord(parent[key]))
+			return params;
+		ancestors.push({ parent, key });
+		parent = parent[key];
+	}
+	const marker = "__eliza_record_entries";
+	const entries = parent[marker];
+	if (!Array.isArray(entries) || entries.length === 0) return params;
+	for (const entry of entries) {
+		if (
+			!isObjectRecord(entry) ||
+			Object.keys(entry).length !== 2 ||
+			typeof entry.key !== "string" ||
+			typeof entry.value !== "string"
+		)
+			return params;
+		const entryKey = entry.key.toLowerCase();
+		const matching = Object.keys(parent).filter(
+			(key) => key !== marker && key.toLowerCase() === entryKey,
+		);
+		if (matching.length !== 1) return params;
+		try {
+			if (!correlationValuesEqual(JSON.parse(entry.value), parent[matching[0]]))
+				return params;
+		} catch {
+			// error-policy:J3 Invalid transport JSON cannot prove redundant content.
+			return params;
+		}
+	}
+	let projected = Object.fromEntries(
+		Object.entries(parent).filter(([key]) => key !== marker),
+	);
+	for (const ancestor of ancestors.reverse()) {
+		projected = { ...ancestor.parent, [ancestor.key]: projected };
+	}
+	return projected;
+}
+
 export function malformedCallSupersededBy(
 	failedCall: PlannerToolCall,
 	failedResult: PlannerToolResult | undefined,
@@ -5411,7 +5463,13 @@ export function malformedCallSupersededBy(
 			),
 		),
 	};
-	for (const [name, value] of Object.entries(failedCall.params ?? {})) {
+	// A rejected native-record wrapper may only disappear when every encoded
+	// value duplicates a surviving sibling. The full arguments remain recorded.
+	const failedParams = withoutRedundantRejectedRecordEncoding(
+		failedCall.params ?? {},
+		failedResult,
+	);
+	for (const [name, value] of Object.entries(failedParams)) {
 		if (name === "eliza_turn_scope") continue;
 		if ((PLANNER_TOOL_DISCRIMINATOR_KEYS as readonly string[]).includes(name)) {
 			continue;


### PR DESCRIPTION
A calendar read rejected a redundant native-record representation field, then succeeded with the same date window and timezone after that field was removed. The stale validation failure still replaced the evaluator's correct final reply, dropping a requested durable ID and spending another model call on failure synthesis.

For malformed-call correlation only, recognize a rejected JSON-string record wrapper as redundant when every encoded key resolves to exactly one surviving sibling and its decoded value matches. Different targets, malformed values and ambiguous keys keep the original failure authority. The complete original arguments and both outcomes remain in the trajectory.

Related: #30965, #24299, #17072.

Validation at `4c4c62999ba138166fde3aebc147ca6e37f5b170`: pinned normal install, root verification, core typecheck/lint, 41 focused planner cases, and full core suite (12,096 passed, three declared skips). The unchanged-base control fails the new planner regression.

The complete captured model/tool sequence from the actual failing local workflow was replayed through the real planner, retaining its continuation markers. The base discarded the verified final reply; the repair preserved it without another synthesis call. This is recorded-model regression evidence, not a fresh end-to-end model run.

<details><summary>Recorded sequence result</summary>

```json
{
  "baseModelCalls": 4,
  "fixedModelCalls": 3,
  "executedOperations": 3,
  "outcomes": [
    true,
    false,
    true
  ],
  "preservedFinalReply": "Done. The todo 'P19 owner scope final cadence check' is saved with no due date or schedule, ID 2ab208ae-eedb-44ef-8ef0-cfe504d87e28.\n\nYour local Eliza calendar for Sep 10, 2026 shows one event:\n- P19 copper meadow dependency review, 11:00 AM to 11:45 AM, with the description 'P19 copper meadow dependency review (todo ID: 00ae5c5a-2d39-40d1-91af-15c93e717e03)'."
}
```
</details>

A separate confined live owner-todo/calendar request delivered the actual saved todo ID and verified calendar times. A literal-JSON error fixture exposed input redaction of record keys; that fixture is retained and is not counted as positive proof for redundant-key recovery.
