### PR TITLE
test(core): reject declarative view state as inspection

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1054,6 +1054,21 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 	});
 
 	it.each([
+		"the window is open",
+		"this window remains open",
+		"the current view stays open",
+		"if the window is open, leave it alone",
+		'preserve the text "the window is open"',
+	])(
+		"does not mistake declarative view state for inspection: %s",
+		(message) => {
+			expect(
+				inferDirectCurrentRequestCandidateInference([viewsAction], message),
+			).toEqual({ names: ["VIEWS"], kind: "view-surface" });
+		},
+	);
+
+	it.each([
 		[
 			"create / and / inspection-first",
 			"identify the current view and add a new panel",


### PR DESCRIPTION
This test-only change prevents declarative, conditional, or quoted view state from being mistaken for a read-only inspection request. It adds five inputs to the actual routing-function suite. The consumer is Stage 1: misclassifying these messages can suppress normal view-action consideration before the planner runs.

Existing coverage already owns natural “which view is open?” questions and compound inspection-plus-navigation requests, so those duplicate additions were removed. The retained controls protect the requirement for an actual interrogative phrase in the predicate-order inspection grammar.

The quality check changed the production grammar in a disposable checkout by removing that interrogative requirement. All 121 existing heuristic tests and all four higher-level Stage-1 current-view cases still passed. The five retained cases failed on the same mutant. Restoring production source made all 126 focused tests pass. No mutated production source is part of this PR.

Develop already contains the production behavior in a4e28d5b1263f9af1d17477f97094f2a04ca2cdd. This PR makes no provider-overflow, runtime-routing repair, or live-model outcome claim.

Replacement for #29880; refs #17072. Independent review rebased this PR onto develop `88106f05234d3b77c3e30316d78673fab0df53c1`; current head is `b646adb020f62c7773df8d3575d60ad81e14dac3`. In an isolated worktree with private dependencies and pinned Bun 1.3.14 / Node 24.15.0, normal `bun install`, root `bun run verify`, owning core typecheck, core lint (no errors), and all 126 focused heuristic tests passed. The reviewer independently reproduced the mutation control: five added cases fail while all 121 pre-existing heuristic cases and all four higher-level Stage-1 cases pass. Production source was restored and the working tree is clean. The full core suite also passed on this head: 12,098 passed, 3 declared skips across 933 files (931 passed / 2 skipped), exit 0 in 943.33 seconds. Exact-head hosted checks remain the merge gate.

Screenshots, video, native capture, and domain side effects: N/A; only deterministic parser regression tests change. Live-model evidence: N/A for this test-only scope; no provider or action implementation changes.

