### PR TITLE
fix(core): retain later failures when recovering planner replies

### DIFF
--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -6862,8 +6862,11 @@ function deterministicSuccessfulToolRelay(
 	trajectory: PlannerTrajectory,
 ): string | undefined {
 	for (const step of [...trajectory.steps].reverse()) {
-		if (!step.toolCall || step.result?.success !== true) continue;
-		if (isTerminalToolCall(step.toolCall)) continue;
+		if (!step.toolCall || !step.result || isTerminalToolCall(step.toolCall))
+			continue;
+		// A failed later read or write prevents an earlier success from owning
+		// the final reply when the provider cannot finish the workflow.
+		if (step.result.success !== true) return undefined;
 		const candidate =
 			getNonEmptyString(step.result.userFacingText) ??
 			(step.result.modelReplyRequired === true
@@ -7099,10 +7102,9 @@ function previewWasCommitted(
  * `verifiedUserFacing` opt-in is unambiguous: exactly one completed tool step
  * set `verifiedUserFacing: true` with a non-empty `userFacingText`.
  *
- * Failed steps are intentionally ignored unless they are explicit
- * confirmation-required previews. A plan whose first tool errored and whose
- * second tool emitted a verified canonical reply must still echo the verified
- * reply. LifeOps can draft more than once while refining a request; the latest
+ * Earlier failed steps do not invalidate a later verified canonical reply.
+ * A failure after the successful step does prevent that earlier reply from
+ * owning the turn. Explicit confirmation-required previews retain authority. LifeOps can draft more than once while refining a request; the latest
  * verified preview is the user-complete state even though `success:false`
  * correctly records that nothing was persisted yet. A later canonical commit
  * for every keyed preview operation releases that preview's reply authority.
@@ -7137,10 +7139,22 @@ export function singleVerifiedUserFacingToolResultText(
 		}
 	}
 
-	const successfulToolSteps = allTrajectorySteps(trajectory).filter(
+	const successfulToolSteps = steps.filter(
 		(step) => step.toolCall && step.result?.success === true,
 	);
 	if (successfulToolSteps.length !== 1) return undefined;
+	const successfulIndex = steps.indexOf(successfulToolSteps[0]);
+	if (
+		steps.some(
+			(step, index) =>
+				index > successfulIndex &&
+				step.toolCall &&
+				!isTerminalToolCall(step.toolCall) &&
+				step.result?.success === false,
+		)
+	) {
+		return undefined;
+	}
 	const result = successfulToolSteps[0]?.result;
 	if (result?.verifiedUserFacing !== true) return undefined;
 	if (

--- a/packages/core/src/services/message.preserved-tool-result.test.ts
+++ b/packages/core/src/services/message.preserved-tool-result.test.ts
@@ -144,7 +144,7 @@ async function createHarness(options: {
 				name: "action",
 				description: "Lookup operation",
 				required: true,
-				schema: { type: "string", enum: ["create"] },
+				schema: { type: "string", enum: ["create", "verify"] },
 			},
 		],
 		validate: async () => true,
@@ -545,6 +545,90 @@ describe("planner-loop death after a completed tool", () => {
 		expect(harness.reportedScopes).toContain("MessageService.plannerLoop");
 	});
 
+	it("does not rescue an older success after failed verification and a provider outage", async () => {
+		const harness = await createHarness({ actionResult: { success: true } });
+		const action = harness.runtime.actions.find(
+			(entry) => entry.name === "LOOKUP",
+		);
+		if (!action) throw new Error("Lookup action missing from harness");
+
+		const executed: string[] = [];
+		action.handler = async (_runtime, _message, _state, options) => {
+			const operation = options?.parameters?.action;
+			if (typeof operation !== "string") throw new Error("Missing operation");
+			executed.push(operation);
+			return operation === "create"
+				? {
+						success: true,
+						userFacingText: USER_FACING,
+						verifiedUserFacing: true,
+					}
+				: {
+						success: false,
+						text: "Verification lookup did not find the completed record.",
+						userFacingText:
+							"Verification lookup did not find the completed record.",
+						verifiedUserFacing: true,
+						turnComplete: true,
+						data: { readOnlyOperation: true },
+					};
+		};
+		let responseCalls = 0;
+		harness.runtime.registerModel(
+			ModelType.RESPONSE_HANDLER,
+			async () => {
+				if (++responseCalls === 1) return stageOneToolTurn();
+				return JSON.stringify({
+					decision: "CONTINUE",
+					success: executed.length < 2,
+					thought: "Continue with the remaining requested read.",
+				});
+			},
+			"failed-verification-test",
+			200,
+		);
+		let plannerCalls = 0;
+		harness.runtime.registerModel(
+			ModelType.ACTION_PLANNER,
+			async () => {
+				++plannerCalls;
+				if (executed.length >= 2)
+					throw Object.assign(
+						new Error(
+							"Too Many Requests: Tokens per minute limit exceeded - too many tokens processed.",
+						),
+						{ status: 429 },
+					);
+				return {
+					completed: false,
+					toolCalls: [
+						{
+							id: `entry-${plannerCalls}`,
+							name: "LOOKUP",
+							args: { action: executed.length === 0 ? "create" : "verify" },
+						},
+					],
+				};
+			},
+			"failed-verification-test",
+			200,
+		);
+		const result = await new DefaultMessageService().handleMessage(
+			harness.runtime,
+			makeMessage(
+				harness.runtime,
+				"Create the entry, verify it, then read the final calendar.",
+			),
+			harness.callback,
+		);
+		expect(executed).toEqual(["create", "verify"]);
+		expect(visibleTexts(harness.callbacks)).not.toContain(USER_FACING);
+		expect(result.responseContent?.text).not.toBe(USER_FACING);
+		expect(result.responseContent?.text).toBe(
+			"Verification lookup did not find the completed record.",
+		);
+	});
+
 	it("keeps the canned failure line when no tool produced user-facing text", async () => {
 		const harness = await createHarness({
 			actionResult: {
@@ -695,6 +779,38 @@ describe("preservedSettledToolResult candidate selection", () => {
 			new Set(),
 		);
 		expect(picked?.userFacingText).toBe(USER_FACING);
+	});
+
+	it("does not select an older successful operation past a failed verification", () => {
+		expect(
+			preservedSettledToolResult(
+				[
+					settle("LOOKUP", { userFacingText: USER_FACING }),
+					settle("VERIFY", {
+						success: false,
+						userFacingText: "Verification failed.",
+					}),
+				],
+				new Set(),
+			),
+		).toBeUndefined();
+	});
+
+	it("retains a successful recovery after an earlier failed verification", () => {
+		const recovered = preservedSettledToolResult(
+			[
+				settle("LOOKUP", {
+					success: false,
+					userFacingText: "Verification failed.",
+				}),
+				settle("LOOKUP", {
+					success: true,
+					userFacingText: "The saved entry is verified.",
+				}),
+			],
+			new Set(),
+		);
+		expect(recovered?.userFacingText).toBe("The saved entry is verified.");
 	});
 
 	it("skips failed results, terminals, and results without user-facing text", () => {

--- a/packages/core/src/services/message/reply-policy.ts
+++ b/packages/core/src/services/message/reply-policy.ts
@@ -77,8 +77,11 @@ export function preservedSettledToolResult(
 ): (PlannerToolResult & { userFacingText: string }) | undefined {
 	for (let index = settled.length - 1; index >= 0; index--) {
 		const entry = settled[index];
-		if (entry?.result.success !== true) continue;
 		if (isTerminalPlannerToolName(entry.name)) continue;
+		// A later failed operation makes earlier success prose incomplete.
+		// Keep the failure boundary unless a subsequent successful result owns
+		// the reply; never discard the intervening failure while scanning back.
+		if (entry.result.success !== true) return undefined;
 		const candidate = entry.result.userFacingText?.trim();
 		if (!candidate) continue;
 		// A text the user already saw via an action callback must not be


### PR DESCRIPTION
A later verification failure followed by a provider outage could cause the final reply to repeat an earlier successful operation. Successful-result recovery now stops at a later failed operation in the planner and message-service fallback paths. A single earlier verified result also loses final-reply authority after a later failure. Earlier failures followed by a successful recovery and single-operation post-evaluator-outage recovery remain supported.

Refs #30970 and #24299.

The defect was observed in a confined actual-model workflow: a todo completed, its verification failed, the provider returned HTTP429, and the final reply only said the todo was marked done. The regression drives the real AgentRuntime, planner, message service, action execution and delivery with controlled model transport. Before the fix it delivered the old success; afterward the verified failure stays visible, with no repeated write. Complete tool data and existing effects remain intact.

Validation at 1a19427ef2eb4674b1cf02bf55222b1f8bbb0c4b: 28 message-service checks and 87 planner reply/happy-path controls passed; full core passed 12,099 tests with 3 declared skips (933 files); normal pinned install and root verify passed, including owning typecheck/lint. Rebased head `b02874a94153510166602e9d479a12160e51eaae` is based on current develop `8e292e1c4c4a3823242768d3ef966f4e5e3aabec`; the complete core package is byte-identical to the full-suite-tested source. Normal pinned install and root verify passed again after rebase. Hosted checks remain required before merge. Screenshots/video/native capture: N/A for this failure-delivery contract; actual emitted reply and model/tool trajectory are the evidence.
