### PR TITLE
fix(todos): allow exact completed owner record readback

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
@@ -306,6 +306,35 @@ describe("LifeOps definition review isolation", () => {
     expect(result.text).not.toContain("File taxes");
   });
 
+  it.each(["foreign-owner", "other-domain", "other-surface"])(
+    "does not disclose a completed ID outside the caller's review scope: %s",
+    async (scope) => {
+      const record = definitionRecord({
+        id: "completed-private-record",
+        kind: "task",
+        status: "completed",
+        title: "Private completed item",
+        ownerSurface:
+          scope === "other-surface" ? "OWNER_REMINDERS" : "OWNER_TODOS",
+        domain: scope === "other-domain" ? "agent_ops" : "user_lifeops",
+      });
+      if (scope === "foreign-owner") {
+        record.definition.subjectId = "00000000-0000-0000-0000-000000000099";
+      }
+      serviceState.definitions.push(record);
+      const result = await review({
+        ownerSurface: "OWNER_TODOS",
+        target: record.definition.id,
+      });
+      expect(result).toMatchObject({
+        success: false,
+        data: { definitions: [], error: "LIFEOPS_DEFINITION_NOT_FOUND" },
+      });
+      expect(result.text).not.toContain(record.definition.title);
+      expect(result.text).not.toContain("File taxes");
+    },
+  );
+
   it("returns exactly one structurally allowed target", async () => {
     const result = await review({
       ownerSurface: "OWNER_TODOS",

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -6508,11 +6508,13 @@ async function runLifeOperationHandlerInner(
         };
       }
       const reviewDomain = domain ?? "user_lifeops";
-      const active = (await listCallerDefinitions(service)).filter(
+      const scoped = (await listCallerDefinitions(service)).filter(
         (record) =>
-          record.definition.status === "active" &&
           record.definition.domain === reviewDomain &&
           definitionReviewSurface(record) === surface,
+      );
+      const active = scoped.filter(
+        (record) => record.definition.status === "active",
       );
       let selected = active;
       // A list-shaped review sometimes arrives with the planner's own list
@@ -6527,7 +6529,19 @@ async function runLifeOperationHandlerInner(
           targetName.trim(),
         );
       if (targetName && !isListVerbiageTarget) {
-        const resolved = resolveDefinitionInRecords(active, targetName);
+        // A returned todo ID remains readable after completion. Keep ordinary
+        // lists and fuzzy title resolution restricted to active definitions.
+        const completedTodo =
+          surface === "OWNER_TODOS"
+            ? scoped.find(
+                (record) =>
+                  record.definition.id === targetName &&
+                  record.definition.status === "completed",
+              )
+            : undefined;
+        const resolved = completedTodo
+          ? { match: completedTodo, ambiguousCandidates: [] }
+          : resolveDefinitionInRecords(active, targetName);
         if (resolved.ambiguousCandidates.length > 0) {
           const fallback = `Multiple ${definitionReviewSurfaceLabel(surface)} match "${targetName}": ${resolved.ambiguousCandidates.join(", ")}. Which one did you mean?`;
           return {
@@ -6579,13 +6593,18 @@ async function runLifeOperationHandlerInner(
         };
       }
       const listed = selected.map((record) => ({
+        id: record.definition.id,
         title: record.definition.title,
+        status: record.definition.status,
         cadence: summarizeCadence(record.definition.cadence),
         kind: record.definition.kind,
       }));
       const fallback = [
         `You're tracking ${selected.length} ${definitionReviewSurfaceLabel(surface)} item${selected.length === 1 ? "" : "s"}:`,
-        ...listed.map((item) => `- ${item.title} (${item.cadence})`),
+        ...listed.map(
+          (item) =>
+            `- ${item.title} (${item.status}; ${item.cadence}; ID: ${item.id})`,
+        ),
         ...(selected.length > listed.length
           ? [`…and ${selected.length - listed.length} more.`]
           : []),

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -6510,6 +6510,10 @@ async function runLifeOperationHandlerInner(
       const reviewDomain = domain ?? "user_lifeops";
       const scoped = (await listCallerDefinitions(service)).filter(
         (record) =>
+          (record.definition.status === "active" ||
+            (surface === "OWNER_TODOS" &&
+              record.definition.status === "completed" &&
+              record.definition.id === targetName)) &&
           record.definition.domain === reviewDomain &&
           definitionReviewSurface(record) === surface,
       );

--- a/plugins/plugin-personal-assistant/src/lifeops/owner-todo-lifecycle.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner-todo-lifecycle.pglite.integration.test.ts
@@ -105,6 +105,14 @@ it.each(["sequential", "interleaved"])(
       expect((await service.getDefinition(id)).definition.status).toBe(
         "completed",
       );
+      const reviewed = await dispatch({ action: "review", target: id });
+      expect(reviewed.success).toBe(true);
+      expect(reviewed.data).toMatchObject({
+        definitions: [{ id, status: "completed" }],
+      });
+      const activeList = await dispatch({ action: "review" });
+      expect(activeList.success).toBe(true);
+      expect(activeList.data).toMatchObject({ definitions: [] });
       const repeated = await dispatch({ action: "complete", target: id });
       expect(repeated.effectReceipts?.[0]).toMatchObject({
         outcome: "noop",


### PR DESCRIPTION
An owner todo could be created and completed successfully, then its review action reported the returned ID missing because only active definitions were eligible. A targeted review now admits that exact completed owner-todo ID while preserving active-only lists and fuzzy title resolution. Caller, domain, and surface filtering still apply. Reply context includes the actual ID and status.

Refs #30968 and #24299.

Evidence:

- Real LifeOps/PGlite lifecycle reproduced the bug in both sequential and interleaved completion cases (2 failed, 2 passed before the fix). All four lifecycle cases pass with the correction, including readback, active-list exclusion, and reopen behavior.
- Focused review/reminder tests: 153 passed, including completed records owned by another caller or belonging to another domain/surface remaining undisclosed.
- A confined actual-model host read the previously completed todo `bdea2b9a-d2fe-4fcd-b5aa-db961eca7022`, returned status `completed`, then verified its existing local calendar event at 11:00–11:45 America/New_York with that todo ID in the description. Nine model calls; no records were created or changed by this readback. This run used the same readback change with separately reviewed integration fixes.

Full owning-package validation passed: 2,581 tests, 6 existing skips across 299 files, plus all four real PGlite lifecycle checks. The complete personal-assistant package tree is byte-identical after rebasing to current develop. Normal install and root verify passed at final head `0ea64e0e16370782d8546e5c69628aac8dda4730`, based on `b408d7c19a0541fcd02592d2a24888a0f51c9058`: all 373 tasks and subsequent repository audits passed. Hosted checks must pass before merge. Screenshots/native capture: N/A for this action/data contract. The actual tool outputs, persistence and final model reply are the relevant evidence. The larger eight-operation workflow remains a separate acceptance item.
