### PR TITLE
fix(core): correlate preserved targets after rejected record wrappers

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -1243,3 +1243,113 @@ it.each([
 		expect(outcomes).toContain(true);
 	},
 );
+
+it.each([
+	["retained raw target", "evt-copper", "eventId", true],
+	["different target", "evt-other", "eventId", false],
+	["redacted target", "***", "eventId", false],
+	["target prefix", "evt-copp", "eventId", false],
+	["unknown field", "evt-copper", "unrecognized", false],
+	["duplicate key", "evt-copper", "eventId", false],
+	["extra entry field", "evt-copper", "eventId", false],
+	["missing original target", "evt-copper", "eventId", false],
+	["missing corrected target", "evt-copper", "eventId", false],
+	["changed bounds", "evt-copper", "eventId", false],
+	["swapped bounds", "evt-copper", "eventId", false],
+	["added conflicting target", "evt-copper", "eventId", false],
+	["conflicting sibling", "evt-copper", "eventId", false],
+] as const)(
+	"correlates a rejected record target only with preserved semantics: %s",
+	async (label, encodedTarget, key, recovered) => {
+		const corrected = {
+			...(label === "added conflicting target" ? { eventId: "evt-other" } : {}),
+			action: "feed",
+			intent: "Read the calendar and verify event evt-copper.",
+			details: {
+				timeMin: "2026-09-10T00:00:00",
+				timeMax: "2026-09-11T00:00:00",
+				timeZone: "America/New_York",
+			},
+		};
+		const failed = {
+			...corrected,
+			details: {
+				...corrected.details,
+				__eliza_record_entries: [
+					{
+						key,
+						value: encodedTarget,
+						...(label === "extra entry field"
+							? { other: "hidden-target" }
+							: {}),
+					},
+					...(label === "duplicate key" ? [{ key, value: encodedTarget }] : []),
+				],
+				...(label === "conflicting sibling" ? { eventId: "evt-other" } : {}),
+			},
+		};
+		if (label === "added conflicting target") delete failed.eventId;
+		if (label === "swapped bounds")
+			[corrected.details.timeMin, corrected.details.timeMax] = [
+				corrected.details.timeMax,
+				corrected.details.timeMin,
+			];
+		if (label === "missing original target")
+			failed.intent = "Read the calendar.";
+		if (label === "missing corrected target")
+			corrected.intent = "Read the calendar.";
+		if (label === "changed bounds")
+			corrected.details.timeMin = "2026-09-12T00:00:00";
+		const failure = {
+			success: false,
+			error: "Unexpected argument 'details.__eliza_record_entries'",
+		};
+		const reply = "Verified event evt-copper from the corrected calendar read.";
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValue({
+					text: "The read remains unresolved.",
+					toolCalls: [],
+				})
+				.mockResolvedValueOnce(plannerToolCall("invalid", "CALENDAR", failed))
+				.mockResolvedValueOnce(
+					plannerToolCall("corrected", "CALENDAR", corrected),
+				),
+		};
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "record-target" },
+			executeToolCall: vi
+				.fn()
+				.mockResolvedValueOnce(failure)
+				.mockResolvedValueOnce({
+					success: true,
+					data: { events: [{ id: "evt-copper" }] },
+				}),
+			evaluate: vi
+				.fn()
+				.mockResolvedValueOnce({
+					success: false,
+					decision: "CONTINUE",
+					thought: "Correct the rejected argument representation.",
+				})
+				.mockResolvedValueOnce({
+					success: true,
+					decision: "FINISH",
+					thought: "The corrected read verified the exact event.",
+					messageToUser: reply,
+				}),
+		});
+		if (recovered) {
+			expect(result.finalMessage).toBe(reply);
+			expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		} else {
+			expect(result.finalMessage).not.toBe(reply);
+		}
+		const steps = result.trajectory.steps.filter((step) => step.result);
+		expect(steps[0].result).toEqual(failure);
+		expect(steps[0].toolCall?.params).toEqual(failed);
+		expect(steps[1].result?.success).toBe(true);
+	},
+);

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -5433,6 +5433,81 @@ function withoutRedundantRejectedRecordEncoding(
 	return projected;
 }
 
+/**
+ * A rejected record wrapper can repeat an explicit target outside the wrapper.
+ * This projection proves raw identifier redundancy; it never decodes malformed
+ * JSON or drops unaccounted content. Every remaining parameter binding must
+ * match the corrected call. The recorded call remains complete.
+ */
+function withoutRepeatedRejectedRecordTargets(
+	params: Record<string, unknown>,
+	result: PlannerToolResult | undefined,
+	corrected: Record<string, unknown>,
+): Record<string, unknown> {
+	const error = typeof result?.error === "string" ? result.error : result?.text;
+	if (typeof error !== "string") return params;
+	const path =
+		/Unexpected argument ['"]([^'"]+\.__eliza_record_entries)['"]/.exec(
+			error,
+		)?.[1];
+	if (!path) return params;
+	const segments = path.split(".");
+	let parent = params;
+	const ancestors: Array<{ parent: Record<string, unknown>; key: string }> = [];
+	for (const key of segments.slice(0, -1)) {
+		if (!Object.hasOwn(parent, key) || !isObjectRecord(parent[key]))
+			return params;
+		ancestors.push({ parent, key });
+		parent = parent[key];
+	}
+	const marker = "__eliza_record_entries";
+	const entries = parent[marker];
+	if (!Array.isArray(entries) || entries.length === 0) return params;
+	let projected = Object.fromEntries(
+		Object.entries(parent).filter(([key]) => key !== marker),
+	);
+	for (const ancestor of [...ancestors].reverse())
+		projected = { ...ancestor.parent, [ancestor.key]: projected };
+	const survivingText = normalizeCorrelationText(
+		correlationLeafStrings(projected).join(" "),
+	);
+	const correctedText = normalizeCorrelationText(
+		correlationLeafStrings(corrected).join(" "),
+	);
+	const keys = new Set<string>();
+	for (const entry of entries) {
+		if (
+			!isObjectRecord(entry) ||
+			Object.keys(entry).length !== 2 ||
+			typeof entry.key !== "string" ||
+			typeof entry.value !== "string" ||
+			!TARGET_PARAMETER_KEY_PATTERN.test(entry.key) ||
+			!/^[\p{L}\p{N}][\p{L}\p{N}_.:/@-]*$/u.test(entry.value)
+		)
+			return params;
+		const key = entry.key.toLowerCase();
+		if (
+			keys.has(key) ||
+			Object.keys(parent).some((name) => name.toLowerCase() === key)
+		)
+			return params;
+		keys.add(key);
+		const identifier = normalizeCorrelationText(entry.value);
+		if (
+			!identifierPresentAtTokenBoundary(identifier, survivingText) ||
+			!identifierPresentAtTokenBoundary(identifier, correctedText)
+		)
+			return params;
+	}
+	const withoutScope = (value: Record<string, unknown>) =>
+		Object.fromEntries(
+			Object.entries(value).filter(([key]) => key !== "eliza_turn_scope"),
+		);
+	if (!correlationValuesEqual(withoutScope(projected), withoutScope(corrected)))
+		return params;
+	return projected;
+}
+
 export function malformedCallSupersededBy(
 	failedCall: PlannerToolCall,
 	failedResult: PlannerToolResult | undefined,
@@ -5463,11 +5538,15 @@ export function malformedCallSupersededBy(
 			),
 		),
 	};
-	// A rejected native-record wrapper may only disappear when every encoded
-	// value duplicates a surviving sibling. The full arguments remain recorded.
-	const failedParams = withoutRedundantRejectedRecordEncoding(
-		failedCall.params ?? {},
+	// Rejected representation metadata is ignored only with independent proof
+	// that all its content remains represented. The full call stays recorded.
+	const failedParams = withoutRepeatedRejectedRecordTargets(
+		withoutRedundantRejectedRecordEncoding(
+			failedCall.params ?? {},
+			failedResult,
+		),
 		failedResult,
+		params,
 	);
 	for (const [name, value] of Object.entries(failedParams)) {
 		if (name === "eliza_turn_scope") continue;


### PR DESCRIPTION
A calendar read that failed on a redundant record wrapper remained unresolved after a successful correction preserved the same target, intent, time bounds, and timezone. The planner replaced the correct final report because generic argument matching treated the wrapper’s field name as missing content.

Allow this correction only when each rejected raw target is independently present outside the wrapper and in the corrected arguments, and every remaining parameter binding matches. Preserve the complete failed and successful calls/results. The existing JSON-decoding guard stays strict. Changed targets, changed or swapped bounds, conflicting siblings, added targets, duplicate keys, extra entry fields, redactions, and prefix matches remain rejected.

Refs #30965, #24299.

Validation at `7ebdb53a617497ad507f1e047c9e5fd52ecd2994`, based on `b408d7c19a0541fcd02592d2a24888a0f51c9058`:

- Pinned Bun 1.3.14 / Node 24.15.0 normal install passed after rebase.
- Root `bun run verify` passed: 373 workspace tasks plus repository audits, including owning typecheck and lint.
- 116 focused tests passed across complete failure-correlation and pending-scope files. The retained-target consumer regression failed before the repair; the adversarial cases remain unresolved after it.
- Full core suite passed on this exact head: 12,114 passed, 3 skipped across 933 files (one worker, 363.86s).
- Independent source review passed.
- Exact final-head replay of complete recorded live model/tool outputs through the actual planner preserved the evaluator’s full reply. Compact receipt below. This is recorded replay, not a fresh live-model or database run.

```json
{
  "head": "7ebdb53a617497ad507f1e047c9e5fd52ecd2994",
  "recordedRun": "20260910T001835-bc94d9c5df12",
  "wirePrefix": "1789013729067",
  "input": "Four complete recorded tool calls/results and evaluator response 029",
  "baseline": {"modelCalls": 5, "executed": 4, "exactFinalReplyPreserved": false},
  "candidate": {"modelCalls": 4, "executed": 4, "exactFinalReplyPreserved": true},
  "retainedOutcomes": [true, true, false, true],
  "verifiedTodoId": "e6ddceb2-336a-4dfc-90f0-fabf774fa25b",
  "verifiedEventId": "event-83c8dd425f7c08c49406bd67efd74444569ddd9a2143902e961d3c28e1187ba2"
}
```

All five hosted checks passed on the exact PR head. Merge hold: coordinated integration and fresh whole-workflow live acceptance remain incomplete. Subsequent full-workflow attempts exposed separate scope-protocol and partial-reply defects under #30974; those failed attempts are retained. This PR does not claim the eight-step workflow is finished.

UI/native captures: N/A; this change only affects planner failure correlation and leaves the rendering and device paths unchanged.


Current-develop integration preview: `71ff5a7df218b08f859bf74b10c3f651bf1a2165`, parents `7ebdb53a617497ad507f1e047c9e5fd52ecd2994` and `ca2db12495b5c5a6ef734c4aff8e4392e5e973ba`, tree `ebd4b5b517da2ec2487184e03a3f4a079afb96e0`. Normal install and root verify passed (373/373 tasks plus repository audits). Both complete focused message/correlation test files passed: 65 tests. The preview worktree is clean. This supplements the full core suite already passed on the PR head; it is not a fresh full-core run on the preview.

Merge remains held for the coordinated integration sequence. Whole-workflow live acceptance remains incomplete.


Final coordinated-develop merge preview: `f157f7c9fb1d85e05a8a1019043d43fe3f664397`, with parents public head `7ebdb53a617497ad507f1e047c9e5fd52ecd2994` and develop `5ab766e26bc011d6d4085520efc3f28a2539968f`; tree `462381493d489c41412b09b3357920336b41e647`. Normal pinned install and root verify passed. Full core integration passed **12,185 tests, 3 skipped**, across 934 files (437.88 seconds). The complete recorded corrected-read replay on this preview passed with four model calls, four executions, and the exact final reply retained. The worktree is clean. This verifies the scoped read-correlation repair integrated with the coordinated wallet, views, affinity, and Todo changes; it does not claim the whole eight-step workflow is complete.
