### PR TITLE
fix(ui): preserve host configuration during remote onboarding

### DIFF
--- a/packages/agent/src/api/config-routes.test.ts
+++ b/packages/agent/src/api/config-routes.test.ts
@@ -1,7 +1,7 @@
 /**
- * PUT /api/config nest bound. Recursive strip/safeMerge stack limits are
- * runtime-dependent, so structurally excessive patches are rejected by the
- * canonical blocked-object-key walker before those consumers run.
+ * Exercises config patch validation and atomic persistence through the real
+ * route and temporary config files. Remote adoption markers must preserve host
+ * topology and credentials while surviving a config reload.
  */
 
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -150,6 +150,44 @@ describe("config patch persistence", () => {
     }
     resetDevCloudEnvAuthorityForTests();
     rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("persists remote adoption without replacing host topology or credentials", async () => {
+    const config: ConfigRouteContext["config"] = {
+      meta: { firstRunComplete: false },
+      deploymentTarget: { runtime: "local" },
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+          accountId: "elizacloud",
+        },
+        embeddings: { backend: "local-inference", transport: "direct" },
+      },
+      linkedAccounts: { elizacloud: { status: "linked", source: "oauth" } },
+      cloud: { apiKey: "synthetic-host-credential" },
+      ui: { language: "en", assistant: { name: "Family agent" } },
+    };
+    const before = structuredClone(config);
+    const { ctx, error } = makeCtx(
+      { meta: { firstRunComplete: true } },
+      vi.fn(),
+      { config, allowedTopKeys: ["meta"] },
+    );
+    expect(await handleConfigRoutes(ctx)).toBe(true);
+    expect(error).not.toHaveBeenCalled();
+    const expected = {
+      ...before,
+      meta: { ...before.meta, firstRunComplete: true },
+    };
+    expect(config).toEqual(expected);
+    expect(
+      JSON.parse(readFileSync(path.join(tempDir, "eliza.json"), "utf8")),
+    ).toEqual(expected);
+    expect(await handleConfigRoutes(ctx)).toBe(true);
+    expect(
+      JSON.parse(readFileSync(path.join(tempDir, "eliza.json"), "utf8")),
+    ).toEqual(expected);
   });
 
   it("rejects a failed save without changing live config or process.env", async () => {

--- a/packages/agent/src/api/remote-adoption.real-server.test.ts
+++ b/packages/agent/src/api/remote-adoption.real-server.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Exercises device adoption through the real UI client, authenticated HTTP host,
+ * config writer, and server reopen. A registered deterministic model supplies
+ * capability admission only; these cases do not claim live inference evidence.
+ */
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { AgentRuntime, ModelType } from "@elizaos/core";
+import { ElizaClient } from "@elizaos/ui/api/client";
+import { completeRemoteAgentFirstRun } from "@elizaos/ui/first-run/adopt-remote-first-run";
+import { setPendingFirstRunTextReleaseHandler } from "@elizaos/ui/first-run/first-run-pending-text";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { startApiServer } from "./server.ts";
+
+const token = "synthetic-remote-adoption-owner";
+const envKeys = [
+  "ELIZA_STATE_DIR",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZA_API_BIND_HOST",
+  "ELIZA_API_TOKEN",
+  "ELIZA_API_AUTH_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
+  "ELIZA_PLATFORM",
+  "ELIZA_DEVICE_BRIDGE_ENABLED",
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+let directory: string;
+let configPath: string;
+let runtime: AgentRuntime | undefined;
+let api: Awaited<ReturnType<typeof startApiServer>> | undefined;
+const requests: string[] = [];
+const effects: string[] = [];
+
+beforeEach(async () => {
+  for (const key of envKeys) savedEnv.set(key, process.env[key]);
+  directory = await mkdtemp(path.join(tmpdir(), "eliza-remote-adoption-"));
+  configPath = path.join(directory, "eliza.json");
+  process.env.ELIZA_STATE_DIR = directory;
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+  process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
+  process.env.ELIZA_API_TOKEN = token;
+  process.env.ELIZA_REQUIRE_LOCAL_AUTH = "1";
+  for (const key of [
+    "ELIZA_API_AUTH_TOKEN",
+    "ELIZA_CLOUD_PROVISIONED",
+    "ELIZA_PLATFORM",
+    "ELIZA_DEVICE_BRIDGE_ENABLED",
+  ])
+    delete process.env[key];
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      meta: { firstRunComplete: false },
+      logging: { level: "error" },
+      deploymentTarget: { runtime: "local" },
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+          accountId: "elizacloud",
+        },
+      },
+      linkedAccounts: { elizacloud: { status: "linked", source: "oauth" } },
+      cloud: { apiKey: "synthetic-host-credential" },
+      ui: { language: "en", assistant: { name: "Adoption host" } },
+    }),
+  );
+  requests.length = 0;
+  effects.length = 0;
+  setPendingFirstRunTextReleaseHandler(() => {
+    effects.push("release");
+  });
+});
+
+afterEach(async () => {
+  setPendingFirstRunTextReleaseHandler(null);
+  await api?.close();
+  api = undefined;
+  await runtime?.stop({ fast: true });
+  await runtime?.close();
+  runtime = undefined;
+  await rm(directory, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 50,
+  });
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  savedEnv.clear();
+}, 30_000);
+
+async function start(ready: boolean) {
+  if (ready && !runtime) {
+    runtime = new AgentRuntime({ logLevel: "fatal", plugins: [] });
+    await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
+    runtime.registerModel(
+      ModelType.TEXT_LARGE,
+      async () => "deterministic capability fixture",
+      "adoption-test",
+    );
+  }
+  api = await startApiServer({
+    port: 0,
+    runtime,
+    skipDeferredStartupWork: true,
+    requestMiddleware: async (req, _res, next) => {
+      requests.push(`${req.method} ${req.url}`);
+      await next();
+    },
+  });
+  return new ElizaClient(`http://127.0.0.1:${api.port}`, token);
+}
+
+function adopt(client: ElizaClient) {
+  return completeRemoteAgentFirstRun(
+    client,
+    { apiBase: client.getBaseUrl(), token: "synthetic-device-input" },
+    () => {
+      effects.push("complete");
+    },
+  );
+}
+
+it("preserves host configuration across adoption and a fresh server, then replays without writing", async () => {
+  const client = await start(true);
+  expect(await client.getFirstRunStatus()).toEqual({ complete: false });
+  const before = JSON.parse(await readFile(configPath, "utf8"));
+  requests.length = 0;
+  expect(await adopt(client)).toEqual({ alreadyComplete: false });
+  expect(requests).toEqual([
+    "GET /api/first-run/status",
+    "GET /api/status",
+    "PUT /api/config",
+    "GET /api/first-run/status",
+  ]);
+  expect(effects).toEqual(["complete", "release"]);
+  expect(JSON.parse(await readFile(configPath, "utf8"))).toEqual({
+    ...before,
+    meta: { ...before.meta, firstRunComplete: true },
+  });
+  await api?.close();
+  api = undefined;
+  const restarted = await start(true);
+  const persisted = await readFile(configPath, "utf8");
+  requests.length = 0;
+  expect(await adopt(restarted)).toEqual({ alreadyComplete: true });
+  expect(requests).toEqual(["GET /api/first-run/status"]);
+  expect(await readFile(configPath, "utf8")).toBe(persisted);
+}, 60_000);
+
+it("rejects an unauthorized device before mutation or local completion", async () => {
+  const client = await start(true);
+  const before = await readFile(configPath, "utf8");
+  client.setToken("synthetic-invalid-token");
+  await expect(adopt(client)).rejects.toMatchObject({ status: 401 });
+  expect(requests).toEqual(["GET /api/first-run/status"]);
+  expect(effects).toEqual([]);
+  expect(await readFile(configPath, "utf8")).toBe(before);
+}, 60_000);
+
+it("keeps a host without a running runtime in explicit setup", async () => {
+  const client = await start(false);
+  const before = await readFile(configPath, "utf8");
+  await expect(adopt(client)).rejects.toMatchObject({
+    code: "REMOTE_ADOPTION_HOST_NOT_READY",
+  });
+  expect(requests).toEqual(["GET /api/first-run/status", "GET /api/status"]);
+  expect(effects).toEqual([]);
+  expect(await readFile(configPath, "utf8")).toBe(before);
+}, 60_000);

--- a/packages/app-core/platforms/electrobun/src/__tests__/renderer-destination-routing.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/renderer-destination-routing.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Exercises renderer destination authority through real TCP servers and the
+ * native first-run, status, and config composers. Server records represent the
+ * two external hosts; client selection, RPC routing, and HTTP serialization are
+ * real. Native binding changes must never redirect a remote write locally.
+ */
+// @vitest-environment jsdom
+
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import { afterEach, expect, it } from "vitest";
+import { authMe } from "../../../../../ui/src/api/auth-client";
+import { ElizaClient } from "../../../../../ui/src/api/client-base";
+import { client } from "../../../../../ui/src/api/index";
+import { completeRemoteAgentFirstRun } from "../../../../../ui/src/first-run/adopt-remote-first-run";
+import { setPendingFirstRunTextReleaseHandler } from "../../../../../ui/src/first-run/first-run-pending-text";
+import { applyLaunchConnection } from "../../../../../ui/src/platform/browser-launch";
+import {
+  composeAgentStatusSnapshot,
+  readAgentStatusViaHttp,
+} from "../agent-status-rpc";
+import {
+  composeAuthMeSnapshot,
+  readAuthMeViaHttp,
+} from "../config-and-auth-rpc";
+import {
+  composeConversationsListSnapshot,
+  readConversationsListViaHttp,
+} from "../conversations-and-character-rpc";
+import {
+  composeFirstRunStatusSnapshot,
+  readFirstRunStatusViaHttp,
+} from "../first-run-rpc";
+import { isRecord } from "../rpc-parse-utils";
+import {
+  composeConfigUpdate,
+  updateConfigViaHttp,
+} from "../settings-mutations-rpc";
+
+const servers: Server[] = [];
+const rpcCalls: string[] = [];
+const desktopWindow = window as typeof window & {
+  __ELIZA_DESKTOP_LOCAL_API_BASE__?: string;
+  __ELIZA_ELECTROBUN_RPC__?: {
+    request: Record<
+      string,
+      (params?: Record<string, unknown>) => Promise<unknown>
+    >;
+    onMessage(): void;
+    offMessage(): void;
+  };
+};
+
+async function host(name: string, prefix = "") {
+  const state = {
+    complete: false,
+    writes: 0,
+    rejectAuth: false,
+    paths: [] as string[],
+  };
+  const server = createServer(async (req, res) => {
+    state.paths.push(`${req.method} ${req.url}`);
+    const route = req.url?.slice(prefix.length);
+    if (route === "/api/auth/me" && state.rejectAuth) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          reason: "remote_auth_required",
+          access: {
+            mode: "remote",
+            passwordConfigured: true,
+            ownerConfigured: true,
+          },
+        }),
+      );
+      return;
+    }
+    let body: Record<string, unknown>;
+    if (route === "/api/first-run/status") body = { complete: state.complete };
+    else if (route === "/api/status")
+      body = {
+        state: "running",
+        agentName: name,
+        model: "synthetic/model",
+        canRespond: true,
+      };
+    else if (route === "/api/conversations")
+      body = {
+        conversations: [
+          {
+            id: name,
+            title: name,
+            roomId: name,
+            createdAt: "2026-09-10T00:00:00.000Z",
+            updatedAt: "2026-09-10T00:00:00.000Z",
+          },
+        ],
+      };
+    else if (route === "/api/auth/me")
+      body = {
+        identity: { id: name, displayName: name, kind: "machine" },
+        session: { id: name, kind: "machine", expiresAt: null },
+        access: {
+          mode: "bearer",
+          passwordConfigured: true,
+          ownerConfigured: true,
+        },
+      };
+    else if (route === "/api/config" && req.method === "PUT") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      const patch = JSON.parse(Buffer.concat(chunks).toString());
+      state.complete = patch.meta.firstRunComplete;
+      state.writes++;
+      body = { meta: { firstRunComplete: state.complete } };
+    } else {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  servers.push(server);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing listener");
+  return {
+    state,
+    port: address.port,
+    base: `http://127.0.0.1:${address.port}${prefix}`,
+  };
+}
+
+function bindLocal(port: number, base: string) {
+  desktopWindow.__ELIZA_DESKTOP_LOCAL_API_BASE__ = base;
+  desktopWindow.__ELIZA_ELECTROBUN_RPC__ = {
+    request: {
+      listConversations: async () => {
+        rpcCalls.push("conversations");
+        return composeConversationsListSnapshot(
+          port,
+          readConversationsListViaHttp,
+        );
+      },
+      getAuthMe: async () => {
+        rpcCalls.push("auth");
+        return composeAuthMeSnapshot(port, readAuthMeViaHttp);
+      },
+      getFirstRunStatus: async () => {
+        rpcCalls.push("firstRun");
+        return composeFirstRunStatusSnapshot(port, readFirstRunStatusViaHttp);
+      },
+      getAgentStatus: async () => {
+        rpcCalls.push("status");
+        return composeAgentStatusSnapshot(port, readAgentStatusViaHttp);
+      },
+      updateConfig: async (patch) => {
+        rpcCalls.push("config");
+        if (!isRecord(patch)) throw new Error("Missing config patch");
+        return composeConfigUpdate(port, patch, updateConfigViaHttp);
+      },
+    },
+    onMessage() {},
+    offMessage() {},
+  };
+}
+
+afterEach(async () => {
+  setPendingFirstRunTextReleaseHandler(null);
+  delete desktopWindow.__ELIZA_DESKTOP_LOCAL_API_BASE__;
+  delete desktopWindow.__ELIZA_ELECTROBUN_RPC__;
+  client.setToken(null);
+  localStorage.clear();
+  sessionStorage.clear();
+  rpcCalls.length = 0;
+  for (const server of servers.splice(0)) {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
+it("adopts the selected prefixed remote, preserves local config, and restores explicit local RPC", async () => {
+  const local = await host("local");
+  const remote = await host("remote", "/deployment");
+  bindLocal(local.port, local.base);
+  const effects: string[] = [];
+  setPendingFirstRunTextReleaseHandler(() => effects.push("release"));
+  applyLaunchConnection({ apiBase: remote.base, token: "synthetic-owner" });
+  expect((await client.getStatus()).agentName).toBe("remote");
+  await completeRemoteAgentFirstRun(client, { apiBase: remote.base }, () =>
+    effects.push("complete"),
+  );
+  expect(effects).toEqual(["complete", "release"]);
+  const identity = await authMe();
+  expect(identity.ok && identity.identity.id).toBe("remote");
+  expect((await client.listConversations()).conversations[0]?.id).toBe(
+    "remote",
+  );
+  expect(remote.state.complete).toBe(true);
+  expect(remote.state.writes).toBe(1);
+  expect(local.state.writes).toBe(0);
+  expect(local.state.paths).toEqual([]);
+  expect(rpcCalls).toEqual([]);
+  const explicitLocal = new ElizaClient(local.base);
+  expect((await explicitLocal.getStatus()).agentName).toBe("local");
+  await explicitLocal.updateConfig({ meta: { firstRunComplete: true } });
+  expect(await explicitLocal.getFirstRunStatus()).toEqual({ complete: true });
+  expect(rpcCalls).toEqual(["status", "config", "firstRun"]);
+  expect(local.state.writes).toBe(1);
+  expect(remote.state.writes).toBe(1);
+  applyLaunchConnection({ apiBase: local.base });
+  const localIdentity = await authMe();
+  expect(localIdentity.ok && localIdentity.identity.id).toBe("local");
+  expect((await client.listConversations()).conversations[0]?.id).toBe("local");
+  expect(rpcCalls).toEqual([
+    "status",
+    "config",
+    "firstRun",
+    "auth",
+    "conversations",
+  ]);
+});
+
+it("does not use local RPC for an explicit different target or missing binding", async () => {
+  const local = await host("local");
+  const remote = await host("remote");
+  bindLocal(local.port, local.base);
+  const explicit = new ElizaClient(remote.base);
+  expect((await explicit.getStatus()).agentName).toBe("remote");
+  await explicit.updateConfig({ meta: { firstRunComplete: true } });
+  expect(local.state.paths).toEqual([]);
+  delete desktopWindow.__ELIZA_DESKTOP_LOCAL_API_BASE__;
+  const unbound = new ElizaClient(local.base);
+  await unbound.updateConfig({ meta: { firstRunComplete: true } });
+  expect(rpcCalls).toEqual([]);
+  expect(local.state.writes).toBe(1);
+});
+
+it("keeps a different prefix on the same origin outside local RPC authority", async () => {
+  const local = await host("prefixed", "/deployment");
+  bindLocal(local.port, `http://127.0.0.1:${local.port}`);
+  const explicit = new ElizaClient(local.base);
+  expect((await explicit.getStatus()).agentName).toBe("prefixed");
+  await explicit.updateConfig({ meta: { firstRunComplete: true } });
+  expect(rpcCalls).toEqual([]);
+  expect(local.state.paths).toContain("PUT /deployment/api/config");
+});
+
+it("preserves remote unauthorized state instead of accepting the local session, including missing binding", async () => {
+  const local = await host("local");
+  const remote = await host("remote");
+  remote.state.rejectAuth = true;
+  bindLocal(local.port, local.base);
+  applyLaunchConnection({
+    apiBase: remote.base,
+    token: "synthetic-invalid-owner",
+  });
+  expect(await authMe()).toMatchObject({
+    ok: false,
+    status: 401,
+    reason: "remote_auth_required",
+  });
+  delete desktopWindow.__ELIZA_DESKTOP_LOCAL_API_BASE__;
+  expect(await authMe()).toMatchObject({
+    ok: false,
+    status: 401,
+    reason: "remote_auth_required",
+  });
+  expect(rpcCalls).toEqual([]);
+  expect(local.state.paths).toEqual([]);
+});

--- a/packages/app-core/platforms/electrobun/src/__tests__/renderer-destination-routing.test.ts
+++ b/packages/app-core/platforms/electrobun/src/__tests__/renderer-destination-routing.test.ts
@@ -8,7 +8,8 @@
 
 import { once } from "node:events";
 import { createServer, type Server } from "node:http";
-import { afterEach, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, expect, it, vi } from "vitest";
+import { WebSocket as TcpWebSocket, WebSocketServer } from "ws";
 import { authMe } from "../../../../../ui/src/api/auth-client";
 import { ElizaClient } from "../../../../../ui/src/api/client-base";
 import { client } from "../../../../../ui/src/api/index";
@@ -19,6 +20,7 @@ import {
   composeAgentStatusSnapshot,
   readAgentStatusViaHttp,
 } from "../agent-status-rpc";
+import { applyElectrobunApiBaseUpdate } from "../bridge/electrobun-boot-config";
 import {
   composeAuthMeSnapshot,
   readAuthMeViaHttp,
@@ -37,7 +39,12 @@ import {
   updateConfigViaHttp,
 } from "../settings-mutations-rpc";
 
+// Use the real TCP WebSocket client without Node EventTarget/jsdom realm mixing.
+beforeAll(() => vi.stubGlobal("WebSocket", TcpWebSocket));
+afterAll(() => vi.unstubAllGlobals());
+
 const servers: Server[] = [];
+const webSockets: WebSocketServer[] = [];
 const rpcCalls: string[] = [];
 const desktopWindow = window as typeof window & {
   __ELIZA_DESKTOP_LOCAL_API_BASE__?: string;
@@ -57,9 +64,12 @@ async function host(name: string, prefix = "") {
     writes: 0,
     rejectAuth: false,
     paths: [] as string[],
+    bearers: [] as (string | undefined)[],
+    upgrades: [] as string[],
   };
   const server = createServer(async (req, res) => {
     state.paths.push(`${req.method} ${req.url}`);
+    state.bearers.push(req.headers.authorization);
     const route = req.url?.slice(prefix.length);
     if (route === "/api/auth/me" && state.rejectAuth) {
       res.writeHead(401, { "Content-Type": "application/json" });
@@ -122,6 +132,12 @@ async function host(name: string, prefix = "") {
     res.end(JSON.stringify(body));
   });
   servers.push(server);
+  const wsServer = new WebSocketServer({ noServer: true });
+  webSockets.push(wsServer);
+  server.on("upgrade", (req, socket, head) => {
+    state.upgrades.push(req.url ?? "");
+    wsServer.handleUpgrade(req, socket, head, () => {});
+  });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
   const address = server.address();
@@ -169,6 +185,7 @@ function bindLocal(port: number, base: string) {
 }
 
 afterEach(async () => {
+  client.disconnectWs();
   setPendingFirstRunTextReleaseHandler(null);
   delete desktopWindow.__ELIZA_DESKTOP_LOCAL_API_BASE__;
   delete desktopWindow.__ELIZA_ELECTROBUN_RPC__;
@@ -176,6 +193,10 @@ afterEach(async () => {
   localStorage.clear();
   sessionStorage.clear();
   rpcCalls.length = 0;
+  for (const wsServer of webSockets.splice(0)) {
+    for (const socket of wsServer.clients) socket.terminate();
+    wsServer.close();
+  }
   for (const server of servers.splice(0)) {
     server.closeAllConnections();
     await new Promise<void>((resolve, reject) =>
@@ -273,4 +294,114 @@ it("preserves remote unauthorized state instead of accepting the local session, 
   });
   expect(rpcCalls).toEqual([]);
   expect(local.state.paths).toEqual([]);
+});
+
+it("retains selected remote auth and writes when the native host publishes a port update", async () => {
+  const local = await host("local");
+  const remote = await host("remote", "/deployment");
+  bindLocal(local.port, local.base);
+  applyLaunchConnection({ apiBase: remote.base, token: "synthetic-remote" });
+  expect(await authMe()).toMatchObject({
+    ok: true,
+    identity: { id: "remote" },
+  });
+  applyElectrobunApiBaseUpdate(window, {
+    base: local.base,
+    token: "synthetic-local",
+    localApiBase: local.base,
+  });
+  expect(await authMe()).toMatchObject({
+    ok: true,
+    identity: { id: "remote" },
+  });
+  await client.updateConfig({ meta: { firstRunComplete: true } });
+  expect(local.state.paths).toEqual([]);
+  expect(remote.state.writes).toBe(1);
+});
+
+it("rotates explicit local selection and its bearer after returning from a remote host", async () => {
+  const oldLocal = await host("old-local");
+  const remote = await host("remote");
+  const nextLocal = await host("next-local");
+  bindLocal(oldLocal.port, oldLocal.base);
+  applyLaunchConnection({ apiBase: remote.base, token: "synthetic-remote" });
+  client.setBaseUrl(oldLocal.base);
+  client.setToken("synthetic-old-local");
+  applyElectrobunApiBaseUpdate(window, {
+    base: nextLocal.base,
+    token: "synthetic-next-local",
+    localApiBase: nextLocal.base,
+  });
+  // Remove RPC only to observe the real client's serialized HTTP destination and bearer.
+  delete desktopWindow.__ELIZA_ELECTROBUN_RPC__;
+  expect((await client.getStatus()).agentName).toBe("next-local");
+  expect(await authMe()).toMatchObject({
+    ok: true,
+    identity: { id: "next-local" },
+  });
+  expect(
+    nextLocal.state.bearers.every(
+      (value) => value === "Bearer synthetic-next-local",
+    ),
+  ).toBe(true);
+  expect(oldLocal.state.paths).toEqual([]);
+  expect(remote.state.paths).toEqual([]);
+  let authorityChanges = 0;
+  const unsubscribe = client.onAuthorityChange(() => {
+    authorityChanges += 1;
+  });
+  applyElectrobunApiBaseUpdate(window, {
+    base: nextLocal.base,
+    token: "synthetic-next-local",
+    localApiBase: nextLocal.base,
+  });
+  expect(authorityChanges).toBe(0);
+  unsubscribe();
+});
+
+it("rotates an unselected local boot and preserves a selected different prefix", async () => {
+  const local = await host("local");
+  const nextLocal = await host("next-local");
+  bindLocal(local.port, local.base);
+  client.setBaseUrl(local.base);
+  client.setToken(null);
+  client.setBaseUrl(null, { persist: false });
+  client.connectWs();
+  await expect.poll(() => local.state.upgrades.length).toBe(1);
+  await expect.poll(() => client.getConnectionState().state).toBe("connected");
+  let changes = 0;
+  const stopObserving = client.onAuthorityChange(() => {
+    changes += 1;
+  });
+  applyElectrobunApiBaseUpdate(window, {
+    base: nextLocal.base,
+    token: "synthetic-next",
+    localApiBase: nextLocal.base,
+  });
+  delete desktopWindow.__ELIZA_ELECTROBUN_RPC__;
+  expect((await client.getStatus()).agentName).toBe("next-local");
+  expect(nextLocal.state.bearers.at(-1)).toBe("Bearer synthetic-next");
+  await expect.poll(() => nextLocal.state.upgrades.length).toBe(1);
+  await expect.poll(() => client.getConnectionState().state).toBe("connected");
+  expect(changes).toBe(1);
+  stopObserving();
+  client.disconnectWs();
+  const prefixed = await host("prefixed", "/deployment");
+  bindLocal(prefixed.port, `http://127.0.0.1:${prefixed.port}`);
+  applyLaunchConnection({ apiBase: prefixed.base, token: "synthetic-prefix" });
+  applyElectrobunApiBaseUpdate(window, {
+    base: local.base,
+    token: "synthetic-local",
+    localApiBase: local.base,
+  });
+  expect(await authMe()).toMatchObject({
+    ok: true,
+    identity: { id: "prefixed" },
+  });
+  expect((await client.getStatus()).agentName).toBe("prefixed");
+  expect(
+    prefixed.state.bearers.every(
+      (value) => value === "Bearer synthetic-prefix",
+    ),
+  ).toBe(true);
 });

--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -315,6 +315,7 @@ type ApiBaseUpdateRpc = {
       base: string;
       token?: string;
       externalApiBase?: string | null;
+      localApiBase?: string | null;
     }) => void;
   };
 };
@@ -324,12 +325,14 @@ export function pushApiBaseToRenderer(
   base: string,
   apiToken?: string,
   externalApiBase?: string | null,
+  localApiBase?: string | null,
 ): void {
   const trimmedToken = apiToken?.trim();
   const payload = {
     base,
     token: trimmedToken || undefined,
     externalApiBase: externalApiBase ?? null,
+    localApiBase: localApiBase ?? null,
   };
   try {
     const rpcSend = (win.webview.rpc as ApiBaseUpdateRpc | undefined)?.send;

--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-direct-rpc.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-direct-rpc.test.ts
@@ -446,7 +446,7 @@ describe("electrobun-direct-rpc preload", () => {
       token: "secret",
       externalApiBase: "  https://ext.example/  ",
     });
-    expect(w.__ELIZA_DESKTOP_EXTERNAL_API_BASE__).toBe("https://ext.example/");
+    expect(w.__ELIZA_DESKTOP_EXTERNAL_API_BASE__).toBe("https://ext.example");
     expect(w.__ELIZAOS_APP_BOOT_CONFIG__).toEqual({
       apiBase: "http://127.0.0.1:31337",
       apiToken: "secret",
@@ -457,7 +457,7 @@ describe("electrobun-direct-rpc preload", () => {
     });
   });
 
-  it("clears a blank or non-string external API base and omits a falsy token", () => {
+  it("rotates a bound local base and clears its absent credential", () => {
     const w = (globalThis as unknown as { window?: TestWindow }).window;
     if (!w) {
       throw new Error("test window missing");
@@ -467,20 +467,22 @@ describe("electrobun-direct-rpc preload", () => {
       base: "http://127.0.0.1:8",
       token: "keep-me",
       externalApiBase: "https://seed.example",
+      localApiBase: "http://127.0.0.1:8",
     });
     harness.wildcardMessage?.("apiBaseUpdate", {
       base: "http://127.0.0.1:9",
       token: "",
       externalApiBase: "   ",
+      localApiBase: "http://127.0.0.1:9",
     });
     expect(w.__ELIZA_DESKTOP_EXTERNAL_API_BASE__).toBeUndefined();
     expect(w.__ELIZAOS_APP_BOOT_CONFIG__).toEqual({
       apiBase: "http://127.0.0.1:9",
-      apiToken: "keep-me",
     });
 
     harness.wildcardMessage?.("apiBaseUpdate", {
       base: "http://127.0.0.1:10",
+      localApiBase: "http://127.0.0.1:10",
       externalApiBase: null,
     });
     expect(w.__ELIZA_DESKTOP_EXTERNAL_API_BASE__).toBeUndefined();

--- a/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-direct-rpc.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/__tests__/electrobun-direct-rpc.test.ts
@@ -14,6 +14,7 @@ import {
   it,
   vi,
 } from "vitest";
+import { isDesktopLocalApiBaseUrl } from "../../../../../../ui/src/api/desktop-local-api-base";
 import { setBrowserTabsRendererImpl } from "../browser-tabs-renderer-registry.ts";
 import {
   ELECTROBUN_BOOT_CONFIG_STORE_KEY,
@@ -705,4 +706,32 @@ describe("electrobun-direct-rpc preload", () => {
     expect(consoleReports).toHaveLength(1);
     expect(asDiagnostic(consoleReports[0]).message).toBe("once");
   });
+});
+
+it("rotates native local RPC authority and clears it on external or old-host updates", () => {
+  harness.wildcardMessage?.("apiBaseUpdate", {
+    base: "http://127.0.0.1:31337/runtime",
+    localApiBase: "http://127.0.0.1:31337/runtime/",
+  });
+  expect(isDesktopLocalApiBaseUrl("http://127.0.0.1:31337/runtime")).toBe(true);
+  harness.wildcardMessage?.("apiBaseUpdate", {
+    base: "http://127.0.0.1:31338/runtime",
+    localApiBase: "http://127.0.0.1:31338/runtime",
+  });
+  expect(isDesktopLocalApiBaseUrl("http://127.0.0.1:31337/runtime")).toBe(
+    false,
+  );
+  expect(isDesktopLocalApiBaseUrl("http://127.0.0.1:31338/runtime")).toBe(true);
+  harness.wildcardMessage?.("apiBaseUpdate", {
+    base: "https://remote.example/runtime",
+    externalApiBase: "https://remote.example/runtime",
+    localApiBase: null,
+  });
+  expect(isDesktopLocalApiBaseUrl("http://127.0.0.1:31338/runtime")).toBe(
+    false,
+  );
+  harness.wildcardMessage?.("apiBaseUpdate", {
+    base: "http://127.0.0.1:31339",
+  });
+  expect(isDesktopLocalApiBaseUrl("http://127.0.0.1:31339")).toBe(false);
 });

--- a/packages/app-core/platforms/electrobun/src/bridge/electrobun-boot-config.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/electrobun-boot-config.ts
@@ -1,4 +1,4 @@
-/** Implements Electrobun desktop electrobun boot config ts behavior for app-core shell integration. */
+/** Keeps native endpoint updates separate from the renderer-selected connection. */
 export const ELECTROBUN_BOOT_CONFIG_STORE_KEY = Symbol.for(
   "elizaos.app.boot-config",
 );
@@ -44,8 +44,87 @@ export function updateElectrobunBootConfig(
     ...updates,
   };
 
+  if (Object.hasOwn(updates, "apiToken") && updates.apiToken === undefined) {
+    delete nextConfig.apiToken;
+  }
   globalObject[BOOT_CONFIG_WINDOW_KEY] = nextConfig;
   globalObject[LEGACY_BOOT_CONFIG_WINDOW_KEY] = nextConfig;
   globalObject[BOOT_CONFIG_STORE_KEY] = { current: nextConfig };
   return nextConfig;
+}
+
+/** Native messages may rotate their own endpoint, never a selected foreign host. */
+export function applyElectrobunApiBaseUpdate(
+  globalObject: ElectrobunBootConfigWindow & {
+    __ELIZA_DESKTOP_LOCAL_API_BASE__?: string;
+    __ELIZA_DESKTOP_EXTERNAL_API_BASE__?: string;
+    dispatchEvent?: (event: Event) => boolean;
+  },
+  update: {
+    base: string;
+    token?: string;
+    localApiBase?: string | null;
+    externalApiBase?: string | null;
+  },
+): void {
+  const previousBase = normalizeNativeApiBase(
+    globalObject.__ELIZA_DESKTOP_LOCAL_API_BASE__ ??
+      globalObject.__ELIZA_DESKTOP_EXTERNAL_API_BASE__,
+  );
+  const currentConfig =
+    globalObject[BOOT_CONFIG_STORE_KEY]?.current ??
+    globalObject[BOOT_CONFIG_WINDOW_KEY] ??
+    globalObject[LEGACY_BOOT_CONFIG_WINDOW_KEY];
+  const selectedBase = normalizeNativeApiBase(currentConfig?.apiBase);
+  const nextBase = normalizeNativeApiBase(update.base);
+  for (const [key, value] of [
+    ["__ELIZA_DESKTOP_LOCAL_API_BASE__", update.localApiBase],
+    ["__ELIZA_DESKTOP_EXTERNAL_API_BASE__", update.externalApiBase],
+  ] as const) {
+    const normalized = normalizeNativeApiBase(value);
+    if (normalized) globalObject[key] = normalized;
+    else Reflect.deleteProperty(globalObject, key);
+  }
+  if (
+    !nextBase ||
+    (currentConfig?.apiBase &&
+      (previousBase === null || selectedBase !== previousBase))
+  )
+    return;
+  if (
+    selectedBase === nextBase &&
+    (currentConfig?.apiToken?.trim() || undefined) ===
+      (update.token?.trim() || undefined)
+  )
+    return;
+  updateElectrobunBootConfig(globalObject, {
+    apiBase: nextBase,
+    apiToken: update.token?.trim() || undefined,
+  });
+  globalObject.dispatchEvent?.(
+    new CustomEvent("eliza:desktop-api-base-updated", {
+      detail: { previousBase, base: nextBase },
+    }),
+  );
+}
+
+function normalizeNativeApiBase(
+  value: string | null | undefined,
+): string | null {
+  if (!value?.trim()) return null;
+  try {
+    const url = new URL(value);
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    )
+      return null;
+    return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    // error-policy:J3 invalid native bindings cannot authorize a selected-host update.
+    return null;
+  }
 }

--- a/packages/app-core/platforms/electrobun/src/bridge/electrobun-direct-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/electrobun-direct-rpc.ts
@@ -15,7 +15,7 @@ import { Electroview } from "electrobun/view";
 import { httpErrorDiagnosticLevel } from "../diagnostic-format.js";
 import type { RpcMessageListener } from "../types.js";
 import { getBrowserTabsRendererImpl } from "./browser-tabs-renderer-registry.js";
-import { updateElectrobunBootConfig } from "./electrobun-boot-config.js";
+import { applyElectrobunApiBaseUpdate } from "./electrobun-boot-config.js";
 import { ensureElectrobunGlobal } from "./electrobun-stub.js";
 
 type RendererRequestHandler = (params: unknown) => Promise<unknown>;
@@ -69,31 +69,7 @@ function dispatchMessage(messageName: string, payload: unknown): void {
       externalApiBase?: string | null;
       localApiBase?: string | null;
     };
-    if (
-      typeof apiBaseUpdate.externalApiBase === "string" &&
-      apiBaseUpdate.externalApiBase.trim()
-    ) {
-      window.__ELIZA_DESKTOP_EXTERNAL_API_BASE__ =
-        apiBaseUpdate.externalApiBase.trim();
-    } else {
-      Reflect.deleteProperty(window, "__ELIZA_DESKTOP_EXTERNAL_API_BASE__");
-    }
-    if (
-      typeof apiBaseUpdate.localApiBase === "string" &&
-      apiBaseUpdate.localApiBase.trim()
-    ) {
-      window.__ELIZA_DESKTOP_LOCAL_API_BASE__ =
-        apiBaseUpdate.localApiBase.trim();
-    } else {
-      Reflect.deleteProperty(window, "__ELIZA_DESKTOP_LOCAL_API_BASE__");
-    }
-    // Propagate to boot config so the appClient picks up port changes.
-    // We modify it directly instead of importing @elizaos/app-core
-    // to prevent bundling React and the entire UI layer into the preload script.
-    updateElectrobunBootConfig(window, {
-      apiBase: apiBaseUpdate.base,
-      ...(apiBaseUpdate.token ? { apiToken: apiBaseUpdate.token } : {}),
-    });
+    applyElectrobunApiBaseUpdate(window, apiBaseUpdate);
   }
 
   const listeners = listenersByRpcMessage[messageName];

--- a/packages/app-core/platforms/electrobun/src/bridge/electrobun-direct-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/electrobun-direct-rpc.ts
@@ -67,6 +67,7 @@ function dispatchMessage(messageName: string, payload: unknown): void {
       base: string;
       token?: string;
       externalApiBase?: string | null;
+      localApiBase?: string | null;
     };
     if (
       typeof apiBaseUpdate.externalApiBase === "string" &&
@@ -76,6 +77,15 @@ function dispatchMessage(messageName: string, payload: unknown): void {
         apiBaseUpdate.externalApiBase.trim();
     } else {
       Reflect.deleteProperty(window, "__ELIZA_DESKTOP_EXTERNAL_API_BASE__");
+    }
+    if (
+      typeof apiBaseUpdate.localApiBase === "string" &&
+      apiBaseUpdate.localApiBase.trim()
+    ) {
+      window.__ELIZA_DESKTOP_LOCAL_API_BASE__ =
+        apiBaseUpdate.localApiBase.trim();
+    } else {
+      Reflect.deleteProperty(window, "__ELIZA_DESKTOP_LOCAL_API_BASE__");
     }
     // Propagate to boot config so the appClient picks up port changes.
     // We modify it directly instead of importing @elizaos/app-core
@@ -200,6 +210,7 @@ declare global {
   interface Window {
     __ELIZA_API_TOKEN__: string;
     __ELIZA_DESKTOP_EXTERNAL_API_BASE__?: string;
+    __ELIZA_DESKTOP_LOCAL_API_BASE__?: string;
     __ELIZA_ELECTROBUN_RPC__?: typeof electrobunRpc;
   }
 }

--- a/packages/app-core/platforms/electrobun/src/bridge/electrobun-preload.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/electrobun-preload.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   ELECTROBUN_BOOT_CONFIG_STORE_KEY,
   type ElectrobunBootConfig,
+  updateElectrobunBootConfig,
 } from "./electrobun-boot-config.ts";
 
 type RpcMessageListener = (payload: unknown) => void;
@@ -332,13 +333,22 @@ describe("electrobun-preload", () => {
   });
 
   it("apiBaseUpdate omits apiToken when the token is absent or empty", () => {
-    host.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: "http://old" };
+    updateElectrobunBootConfig(host, {
+      apiBase: "http://old",
+      apiToken: "old-local",
+    });
+    host.__ELIZA_DESKTOP_LOCAL_API_BASE__ = "http://old";
     dispatchIncoming({
       type: "message",
       id: "apiBaseUpdate",
-      payload: { base: "http://127.0.0.1:3", token: "" },
+      payload: {
+        base: "http://127.0.0.1:3",
+        token: "",
+        localApiBase: "http://127.0.0.1:3",
+      },
     });
     expect(host.__ELIZAOS_APP_BOOT_CONFIG__).toEqual({
+      branding: { name: "Eliza" },
       apiBase: "http://127.0.0.1:3",
     });
     expect(host.__ELIZAOS_APP_BOOT_CONFIG__).not.toHaveProperty("apiToken");

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.test.ts
@@ -2,7 +2,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { runInNewContext } from "node:vm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isDesktopLocalApiBaseUrl } from "../../../../../ui/src/api/desktop-local-api-base";
 import {
   getCurrent,
   injectIntoHtml,
@@ -157,6 +159,7 @@ describe("api-base-owner", () => {
       base: "https://agent.example.com",
       token: "cloud-token",
       externalApiBase: "https://agent.example.com",
+      localApiBase: null,
     });
   });
 
@@ -176,6 +179,7 @@ describe("api-base-owner", () => {
       base: "http://127.0.0.1:31337",
       token: "dev-token",
       externalApiBase: null,
+      localApiBase: "http://127.0.0.1:31337",
     });
   });
 
@@ -224,4 +228,35 @@ describe("api-base-owner", () => {
       `http://127.0.0.1:31337/${ls}p`,
     );
   });
+});
+
+it("executes native bootstrap binding so remote selection and other ports cannot acquire local RPC", () => {
+  setCurrent("http://127.0.0.1:31337/runtime/");
+  const html = injectIntoHtml("<html><head></head><body></body></html>");
+  const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+  if (!script) throw new Error("Missing native bootstrap");
+  const nativeWindow = {};
+  runInNewContext(script, { window: nativeWindow });
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "window");
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: nativeWindow,
+  });
+  try {
+    expect(isDesktopLocalApiBaseUrl("http://127.0.0.1:31337/runtime")).toBe(
+      true,
+    );
+    expect(isDesktopLocalApiBaseUrl("http://127.0.0.1:31338/runtime")).toBe(
+      false,
+    );
+    expect(
+      isDesktopLocalApiBaseUrl("http://127.0.0.1:31337/runtime/other"),
+    ).toBe(false);
+    expect(isDesktopLocalApiBaseUrl("https://remote.example/runtime")).toBe(
+      false,
+    );
+  } finally {
+    if (previous) Object.defineProperty(globalThis, "window", previous);
+    else Reflect.deleteProperty(globalThis, "window");
+  }
 });

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
@@ -174,10 +174,11 @@ export function injectIntoHtml(html: string): string {
     // injected when explicitly cloud, so the default desktop/web behavior is
     // unchanged.
     const externalApiBase = resolveCurrentExternalApiBase();
+    const localApiBaseInject = `window.__ELIZA_DESKTOP_LOCAL_API_BASE__=${safeJsonForHtml(externalApiBase ? null : current.base)};`;
     const externalApiBaseInject = externalApiBase
       ? `window.__ELIZA_DESKTOP_EXTERNAL_API_BASE__=${safeJsonForHtml(externalApiBase)};`
       : "";
-    apiBaseInject = `${externalApiBaseInject}${bootConfigInject}`;
+    apiBaseInject = `${externalApiBaseInject}${localApiBaseInject}${bootConfigInject}`;
   }
 
   const script = `<script>${startupTraceInject}${runtimeChooserTestInject}${desktopTestBridgeInject}${runtimeModeInject}${apiBaseInject}</script>`;
@@ -203,6 +204,7 @@ export function pushToWindow(win: { webview: { rpc?: unknown } }): void {
     current.base,
     current.token || undefined,
     resolveCurrentExternalApiBase(),
+    resolveCurrentExternalApiBase() ? null : current.base,
   );
 }
 

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -2708,6 +2708,7 @@ export type ElizaDesktopRPCSchema = {
         base: string;
         token?: string;
         externalApiBase?: string | null;
+        localApiBase?: string | null;
       };
 
       // Local-agent IPC streaming push events (#12180 / #12355): a

--- a/packages/app/src/main.ios-interactive-entrypoint.test.ts
+++ b/packages/app/src/main.ios-interactive-entrypoint.test.ts
@@ -158,7 +158,9 @@ describe("renderer interactive iOS composition", () => {
 
     const handleDeepLink = iosBoot.lifecycleDependencies?.handleDeepLink;
     expect(handleDeepLink).toBeTypeOf("function");
-    const connectRequest = vi.fn();
+    const connectRequest = vi.fn((_detail: { gatewayUrl: string }) => ({
+      status: "connected" as const,
+    }));
     const removeConnectListener = listenForConnectRequests(connectRequest);
     const notificationCenterRequest = vi.fn();
     window.addEventListener(
@@ -199,6 +201,10 @@ describe("renderer interactive iOS composition", () => {
     );
 
     expect(window.location.hash).toContain("aec-loop");
+    await vi.waitFor(() => expect(connectRequest).toHaveBeenCalledTimes(2));
+    expect(
+      connectRequest.mock.calls.map(([detail]) => detail.gatewayUrl),
+    ).toEqual(["http://localhost:2138", "http://127.0.0.1:31337"]);
     expect(connectRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         gatewayUrl: "http://127.0.0.1:31337",

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -706,6 +706,155 @@ describe("App navigate-view event wiring", () => {
     }
   });
 
+  async function mountedRemoteNavigation() {
+    mockAvailableViews[0] = {
+      ...remoteLedgerView,
+      surface: { capabilities: ["navigate"] },
+    };
+    appState.tab = "views";
+    window.history.replaceState(null, "", remoteLedgerView.path);
+    const rendered = render(<App />);
+    await waitFor(() =>
+      expect(getActiveSurfaceRealmScope()?.viewId).toBe(remoteLedgerView.id),
+    );
+    const actual = await vi.importActual<
+      typeof import("./components/views/DynamicViewLoader")
+    >("./components/views/DynamicViewLoader");
+    const external = await actual.hostImport("@elizaos/ui/app-navigate-view");
+    const navigate = external.navigateBrowserPath;
+    if (typeof navigate !== "function")
+      throw new Error("Host navigation external is unavailable");
+    return { rendered, navigate };
+  }
+
+  it("keeps a mounted remote view's real navigation handle through an equivalent registry refresh", async () => {
+    const { rendered, navigate } = await mountedRemoteNavigation();
+    await act(async () => {
+      mockAvailableViews[0] = {
+        ...mockAvailableViews[0],
+        surface: { capabilities: ["navigate"] },
+      };
+      registerAppShellPage({
+        id: "unrelated-refresh",
+        pluginId: "@test/refresh",
+        label: "Refresh",
+        path: "/refresh",
+        Component: () => null,
+      });
+    });
+    rendered.rerender(<App />);
+    act(() => navigate("/settings"));
+    expect(window.location.pathname).toBe("/settings");
+  });
+
+  it.each(["view", "policy", "bundle", "plugin"] as const)(
+    "revokes a mounted remote handle after actual %s replacement",
+    async (change) => {
+      const { rendered, navigate } = await mountedRemoteNavigation();
+      await act(async () => {
+        if (change === "view") {
+          appState.tab = "settings";
+          shellHistory.replaceState(null, "", "/settings");
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        } else {
+          mockAvailableViews[0] = {
+            ...mockAvailableViews[0],
+            ...(change === "policy" ? { surface: { capabilities: [] } } : {}),
+            ...(change === "bundle"
+              ? { bundleUrl: "/api/views/replacement/bundle.js" }
+              : {}),
+            ...(change === "plugin" ? { pluginName: "@test/replacement" } : {}),
+          };
+        }
+        registerAppShellPage({
+          id: "replacement-refresh",
+          pluginId: "@test/refresh",
+          label: "Refresh",
+          path: "/refresh",
+          Component: () => null,
+        });
+      });
+      rendered.rerender(<App />);
+      expect(() => navigate("/inventory")).toThrow(SurfaceRealmDeniedError);
+      expect(window.location.pathname).not.toBe("/inventory");
+      if (change === "view") {
+        appState.tab = "views";
+        shellHistory.replaceState(null, "", remoteLedgerView.path);
+        window.dispatchEvent(new PopStateEvent("popstate"));
+        rendered.rerender(<App />);
+        expect(() => navigate("/inventory")).toThrow(SurfaceRealmDeniedError);
+      }
+    },
+  );
+
+  it.each(["component", "loader"] as const)(
+    "revokes old host navigation after registered %s replacement",
+    async (change) => {
+      const First = () => <div>Original owned page</div>;
+      const Second = () => <div>Replacement owned page</div>;
+      const registration = {
+        id: "owned-host",
+        pluginId: "@test/owned-host",
+        label: "Owned host",
+        path: "/apps/owned-host",
+        surface: { capabilities: ["navigate"] as const },
+        ...(change === "component"
+          ? { Component: First }
+          : { loader: async () => ({ default: First }) }),
+      };
+      registerAppShellPage(registration);
+      appState.tab = "views";
+      window.history.replaceState(null, "", "/apps/owned-host");
+      const rendered = render(<AppWithRealNavigation />);
+      await waitFor(() =>
+        expect(getActiveSurfaceRealmScope()?.viewId).toBe("owned-host"),
+      );
+      const actual = await vi.importActual<
+        typeof import("./components/views/DynamicViewLoader")
+      >("./components/views/DynamicViewLoader");
+      const external = await actual.hostImport("@elizaos/ui/app-navigate-view");
+      const navigate = external.navigateBrowserPath;
+      if (typeof navigate !== "function")
+        throw new Error("Host navigation external is unavailable");
+      await act(async () => {
+        registerAppShellPage({
+          ...registration,
+          ...(change === "component"
+            ? { Component: Second }
+            : { loader: async () => ({ default: Second }) }),
+        });
+      });
+      rendered.rerender(<AppWithRealNavigation />);
+      expect(() => navigate("/inventory")).toThrow(SurfaceRealmDeniedError);
+      expect(window.location.pathname).toBe("/apps/owned-host");
+    },
+  );
+
+  it.each(["base", "credential"] as const)(
+    "revokes a remote handle on actual client %s authority replacement",
+    async (change) => {
+      const { client: actualClient } = await import("./api/client");
+      const previousBase = actualClient.getBaseUrl();
+      const previousToken = actualClient.getRestAuthToken();
+      actualClient.setBaseUrl("http://127.0.0.1:49181");
+      actualClient.setToken("synthetic-scope-owner-a");
+      const { navigate } = await mountedRemoteNavigation();
+      try {
+        await act(async () => {
+          if (change === "base")
+            actualClient.setBaseUrl("http://127.0.0.1:49182");
+          else actualClient.setToken("synthetic-scope-owner-b");
+        });
+        expect(() => navigate("/inventory")).toThrow(SurfaceRealmDeniedError);
+        expect(window.location.pathname).not.toBe("/inventory");
+      } finally {
+        cleanup();
+        actualClient.setBaseUrl(previousBase);
+        actualClient.setToken(previousToken);
+      }
+    },
+  );
+
   it("keeps the exact branded staging Pages alias inside first-run onboarding", () => {
     window.history.replaceState(null, "", "/?shellMode=full");
     setWindowLocation("https://develop.eliza-app.pages.dev/?shellMode=full");

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -288,6 +288,7 @@ import {
 import { ViewHeader } from "./components/shared/ViewHeader";
 import { DynamicViewLoader } from "./components/views/DynamicViewLoader";
 import { registerSandboxProbeView } from "./components/views/sandbox-probe-view";
+import { useActiveAgentAuthority } from "./hooks/useActiveAgentAuthority";
 import {
   useAvailableViews,
   useRoutableViews,
@@ -881,6 +882,56 @@ function useActiveScreenBackgroundPolicy({
 interface ActiveViewSurface {
   manifest: ResolvedSurfaceManifest;
   viewId: string;
+  sourceKey: string;
+  memberViewIds?: readonly string[];
+  sourceComponent?: AppShellPageRegistration["Component"];
+  sourceLoader?: AppShellPageRegistration["loader"];
+}
+
+function shellSurfaceOwner(page: AppShellPageRegistration) {
+  return {
+    sourceKey: JSON.stringify(["shell", page.pluginId, page.id]),
+    sourceComponent: page.Component,
+    sourceLoader: page.loader,
+  };
+}
+
+function remoteSurfaceOwner(view: ViewRegistryEntry) {
+  return {
+    sourceKey: JSON.stringify([
+      "remote",
+      view.pluginName,
+      view.id,
+      view.bundleUrl,
+      view.frameUrl,
+      view.componentExport,
+    ]),
+  };
+}
+
+function surfacePolicyKey({
+  manifest,
+  viewId,
+  sourceKey,
+  memberViewIds,
+}: ActiveViewSurface): string {
+  const { background, header, isolation, lifecycle, layout, capabilities } =
+    manifest;
+  return JSON.stringify([
+    viewId,
+    sourceKey,
+    memberViewIds,
+    background,
+    header,
+    isolation,
+    lifecycle,
+    layout.kind,
+    layout.topology,
+    layout.width,
+    layout.scroll,
+    layout.gutter,
+    [...capabilities].sort(),
+  ]);
 }
 
 function resolveActiveViewSurface({
@@ -906,6 +957,8 @@ function resolveActiveViewSurface({
   // it resolves to the safe default (no grants) — the default-deny baseline.
   if (viewLayout) {
     return {
+      sourceKey: "layout",
+      memberViewIds: viewLayout.viewIds,
       manifest: resolveRoutedSurfaceManifest(null),
       viewId: `layout:${viewLayout.viewIds.join("+") || tab}`,
     };
@@ -928,6 +981,7 @@ function resolveActiveViewSurface({
     )
   ) {
     return {
+      ...shellSurfaceOwner(visibleAppShellPage),
       manifest: resolveRoutedSurfaceManifest(visibleAppShellPage),
       viewId: visibleAppShellPage.id,
     };
@@ -937,6 +991,7 @@ function resolveActiveViewSurface({
   // their intentional remote-bundle precedence below.
   if (visibleAppShellPage && !isDynamicViewLoadingAllowed()) {
     return {
+      ...shellSurfaceOwner(visibleAppShellPage),
       manifest: resolveRoutedSurfaceManifest(visibleAppShellPage),
       viewId: visibleAppShellPage.id,
     };
@@ -954,6 +1009,7 @@ function resolveActiveViewSurface({
   );
   if (remoteView) {
     return {
+      ...remoteSurfaceOwner(remoteView),
       manifest: resolveRoutedSurfaceManifest(remoteView),
       viewId: remoteView.id,
     };
@@ -961,6 +1017,7 @@ function resolveActiveViewSurface({
 
   if (visibleAppShellPage) {
     return {
+      ...shellSurfaceOwner(visibleAppShellPage),
       manifest: resolveRoutedSurfaceManifest(visibleAppShellPage),
       viewId: visibleAppShellPage.id,
     };
@@ -976,6 +1033,7 @@ function resolveActiveViewSurface({
   );
   if (appShellPageForTab) {
     return {
+      ...shellSurfaceOwner(appShellPageForTab),
       manifest: resolveRoutedSurfaceManifest(appShellPageForTab),
       viewId: appShellPageForTab.agentViewId ?? appShellPageForTab.id,
     };
@@ -983,6 +1041,16 @@ function resolveActiveViewSurface({
 
   if (dynamicPage) {
     return {
+      ...(dynamicPage.registration
+        ? shellSurfaceOwner(dynamicPage.registration)
+        : {
+            sourceKey: JSON.stringify([
+              "dynamic",
+              dynamicPage.pluginId,
+              dynamicPage.id,
+              dynamicPage.componentExport,
+            ]),
+          }),
       manifest: resolveRoutedSurfaceManifest(
         dynamicPage.registration ?? dynamicPage,
       ),
@@ -999,6 +1067,7 @@ function resolveActiveViewSurface({
   );
   if (registeredView) {
     return {
+      ...remoteSurfaceOwner(registeredView),
       manifest: resolveRoutedSurfaceManifest(registeredView),
       viewId: registeredView.id,
     };
@@ -1013,6 +1082,7 @@ function resolveActiveViewSurface({
   const builtinManifest = resolveBuiltinRoutedViewManifest(tab);
   if (builtinManifest) {
     return {
+      sourceKey: "builtin",
       manifest: builtinManifest,
       viewId: tab === "tasks" ? "projects" : resolveBuiltinTabId(tab),
     };
@@ -1021,6 +1091,7 @@ function resolveActiveViewSurface({
   const builtinDescriptor = resolveBuiltinRouteDescriptor(tab);
   if (builtinDescriptor) {
     return {
+      sourceKey: "builtin",
       manifest: {
         ...resolveSurfaceManifest({
           surface: { layout: builtinDescriptor.layout },
@@ -1031,7 +1102,11 @@ function resolveActiveViewSurface({
     };
   }
 
-  return { manifest: resolveRoutedSurfaceManifest(null), viewId: tab };
+  return {
+    sourceKey: "unregistered",
+    manifest: resolveRoutedSurfaceManifest(null),
+    viewId: tab,
+  };
 }
 
 function useActiveViewSurface({
@@ -1054,7 +1129,7 @@ function useActiveViewSurface({
   cloudAuthenticated: boolean;
 }): ActiveViewSurface {
   const registryVersion = useAppShellPageRegistryVersion();
-  return useMemo(() => {
+  const resolved = useMemo(() => {
     void registryVersion;
     return resolveActiveViewSurface({
       tab,
@@ -1077,6 +1152,19 @@ function useActiveViewSurface({
     tab,
     viewLayout,
   ]);
+  // Registry and auth refreshes can replace DTO identities without replacing
+  // the mounted owner. Keep its imported broker handles alive until its actual
+  // policy/source changes; render-phase state adjustment remains render-local.
+  const [stable, setStable] = useState(resolved);
+  if (
+    surfacePolicyKey(stable) !== surfacePolicyKey(resolved) ||
+    stable.sourceComponent !== resolved.sourceComponent ||
+    stable.sourceLoader !== resolved.sourceLoader
+  ) {
+    setStable(resolved);
+    return resolved;
+  }
+  return stable;
 }
 
 function trimmedNavigationPath(navigationPath: string): string {
@@ -2993,6 +3081,7 @@ function AppContent() {
   // and the view's global root/body-class + `:root`-var mutations reset on
   // teardown so nothing a view injected into the host realm survives into the
   // next view. `resolveSurfaceManifest` stays the single policy source.
+  const activeSurfaceAuthority = useActiveAgentAuthority();
   const activeViewSurface = useActiveViewSurface({
     tab,
     navigationPath,
@@ -3029,18 +3118,20 @@ function AppContent() {
   ]);
   useEffect(() => {
     if (typeof window === "undefined") return;
+    void activeSurfaceAuthority;
     const scope = new SurfaceRealmScope(
       activeViewSurface.manifest,
       activeViewSurface.viewId,
       window.localStorage,
       navigateBrowserPath,
+      activeViewSurface.memberViewIds,
     );
     setActiveSurfaceRealmScope(scope);
     return () => {
       scope.resetHostRealm();
       setActiveSurfaceRealmScope(null);
     };
-  }, [activeViewSurface]);
+  }, [activeViewSurface, activeSurfaceAuthority]);
 
   const [editingAction, setEditingAction] = useState<
     import("./api").CustomActionDef | null

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2459,6 +2459,7 @@ function ChatOverlayMount({
       initialMode={initialMode}
       fillHostAtHalf={fillHostAtHalf}
       firstRunOpen={firstRunOpen}
+      acceptPendingFirstRunText={firstRunComplete}
       releaseFirstRunToFull={releaseFirstRunToFull}
       onFirstRunReleaseHandled={onFirstRunReleaseHandled}
       onPilledChange={onPilledChange}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -139,6 +139,7 @@ import { useBootConfig } from "./config/boot-config-react.hooks";
 import { useBranding } from "./config/branding";
 import {
   CHAT_OPEN_EVENT,
+  type ConnectRequestResult,
   dispatchNavigateViewEvent,
   FOCUS_CONNECTOR_EVENT,
   type FocusConnectorEventDetail,
@@ -2627,7 +2628,7 @@ function AppContent() {
       token?: string;
       completeFirstRun?: boolean;
       skipConfirm?: boolean;
-    }): Promise<void> => {
+    }): Promise<ConnectRequestResult> => {
       const shouldCompleteFirstRun = payload.completeFirstRun === true;
       const skipConfirm = payload.skipConfirm === true;
       if (!skipConfirm && !isLoopbackGatewayHost(payload.gatewayUrl)) {
@@ -2642,7 +2643,7 @@ function AppContent() {
         });
         if (!approved) {
           setActionNotice("Connection request cancelled.", "info", 4200);
-          return;
+          return { status: "cancelled" };
         }
       }
 
@@ -2656,7 +2657,6 @@ function AppContent() {
         setState("firstRunRuntimeTarget", "remote");
         setState("firstRunRemoteApiBase", connection.apiBase);
         setState("firstRunRemoteToken", connection.token ?? "");
-        setState("firstRunRemoteConnected", true);
         setState("firstRunRemoteError", null);
         if (shouldCompleteFirstRun) {
           await completeRemoteAgentFirstRun(
@@ -2669,16 +2669,20 @@ function AppContent() {
             completeFirstRun,
           );
         }
+        setState("firstRunRemoteConnected", true);
         setActionNotice("Connected to remote backend.", "success", 4200);
         retryStartup();
+        return { status: "connected" };
       } catch (err) {
-        setActionNotice(
+        // error-policy:J1 expose failed adoption to both the initiating form and shell notice.
+        const message =
           err instanceof Error
             ? err.message
-            : "Failed to connect remote backend.",
-          "error",
-          8000,
-        );
+            : "Failed to connect remote backend.";
+        setState("firstRunRemoteConnected", false);
+        setState("firstRunRemoteError", message);
+        setActionNotice(message, "error", 8000);
+        return { status: "failed", message };
       }
     };
 

--- a/packages/ui/src/api/auth-client.test.ts
+++ b/packages/ui/src/api/auth-client.test.ts
@@ -63,6 +63,9 @@ vi.mock("./client-cloud", () => ({
   cloudTokenSecsRemaining: vi.fn(),
   refreshCloudStewardSession: vi.fn(),
 }));
+vi.mock("./desktop-local-api-base", () => ({
+  isDesktopLocalApiBaseUrl: vi.fn(() => true),
+}));
 vi.mock("./desktop-external-api-base", () => ({
   isDesktopExternalApiBaseUrl: vi.fn(),
 }));
@@ -429,6 +432,7 @@ describe("authLogout", () => {
 
 describe("authMe over plain HTTP boundaries", () => {
   beforeEach(() => {
+    getBootConfigMock.mockReturnValue({ branding: {} });
     fetchWithCsrfMock.mockReset();
     isManagedCloudSharedAgentBaseMock.mockReturnValue(false);
     isDesktopExternalApiBaseUrlMock.mockReturnValue(false);

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -30,6 +30,7 @@ import {
 } from "./client-cloud";
 import { fetchWithCsrf } from "./csrf-client";
 import { isDesktopExternalApiBaseUrl } from "./desktop-external-api-base";
+import { isDesktopLocalApiBaseUrl } from "./desktop-local-api-base";
 import { isPasswordAuthTransportConfidential } from "./password-auth-transport-policy";
 
 // ── Shared response shapes ────────────────────────────────────────────────────
@@ -474,14 +475,16 @@ export async function authMe(): Promise<AuthMeResult> {
   // LoginView). When the agent does return an authoritative 401,
   // its body lands in `unauthorized` and we map to AuthMeResult.
   try {
-    const viaRpc = isDesktopExternalApiBaseUrl(authBase())
-      ? null
-      : await invokeDesktopBridgeRequest<{
-          identity?: AuthIdentity;
-          session?: AuthSessionInfo;
-          access?: AuthAccessInfo;
-          unauthorized?: { reason: string; access: AuthAccessInfo };
-        }>({ rpcMethod: "getAuthMe", ipcChannel: "agent" });
+    const viaRpc =
+      !isDesktopLocalApiBaseUrl(authBase()) ||
+      isDesktopExternalApiBaseUrl(authBase())
+        ? null
+        : await invokeDesktopBridgeRequest<{
+            identity?: AuthIdentity;
+            session?: AuthSessionInfo;
+            access?: AuthAccessInfo;
+            unauthorized?: { reason: string; access: AuthAccessInfo };
+          }>({ rpcMethod: "getAuthMe", ipcChannel: "agent" });
     if (viaRpc) {
       if (viaRpc.identity && viaRpc.session) {
         return {

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -392,6 +392,10 @@ export async function authLogout(): Promise<AuthLogoutResult> {
  * show a backend failure instead of a misleading credential prompt.
  */
 export async function authMe(): Promise<AuthMeResult> {
+  const requestBase = authBase();
+  const requestToken = getBootConfig().apiToken;
+  const requestIsCurrent = () =>
+    authBase() === requestBase && getBootConfig().apiToken === requestToken;
   // A serverless shared-runtime agent has no independent password/session
   // service, so this gate reflects the canonical Steward account credential.
   // It must not report synthetic success merely because the selected base has
@@ -411,6 +415,7 @@ export async function authMe(): Promise<AuthMeResult> {
         const refreshed = await refreshCloudStewardSession({
           throwOnTransientHttpFailure: true,
         });
+        if (!requestIsCurrent()) return { ok: false, status: 503 };
         token = refreshed?.token?.trim() || undefined;
         if (token) await writeStoredStewardToken(token);
       } catch {
@@ -422,6 +427,7 @@ export async function authMe(): Promise<AuthMeResult> {
         return { ok: false, status: 503, reason: "cloud_unavailable" };
       }
     }
+    if (!requestIsCurrent()) return { ok: false, status: 503 };
     const secondsRemaining = token ? cloudTokenSecsRemaining(token) : null;
     if (
       token &&
@@ -431,6 +437,7 @@ export async function authMe(): Promise<AuthMeResult> {
     ) {
       try {
         const refreshed = await refreshCloudStewardSession();
+        if (!requestIsCurrent()) return { ok: false, status: 503 };
         token = refreshed?.token?.trim() || undefined;
         if (token) await writeStoredStewardToken(token);
       } catch {
@@ -438,8 +445,10 @@ export async function authMe(): Promise<AuthMeResult> {
         // refresh into the same explicit signed-out state as a rejected one.
         token = undefined;
       }
+      if (!requestIsCurrent()) return { ok: false, status: 503 };
       if (!token) {
         await clearStoredStewardToken();
+        if (!requestIsCurrent()) return { ok: false, status: 503 };
         clearSharedCloudAccountBinding();
       }
     }
@@ -476,8 +485,8 @@ export async function authMe(): Promise<AuthMeResult> {
   // its body lands in `unauthorized` and we map to AuthMeResult.
   try {
     const viaRpc =
-      !isDesktopLocalApiBaseUrl(authBase()) ||
-      isDesktopExternalApiBaseUrl(authBase())
+      !isDesktopLocalApiBaseUrl(requestBase) ||
+      isDesktopExternalApiBaseUrl(requestBase)
         ? null
         : await invokeDesktopBridgeRequest<{
             identity?: AuthIdentity;
@@ -485,6 +494,7 @@ export async function authMe(): Promise<AuthMeResult> {
             access?: AuthAccessInfo;
             unauthorized?: { reason: string; access: AuthAccessInfo };
           }>({ rpcMethod: "getAuthMe", ipcChannel: "agent" });
+    if (!requestIsCurrent()) return { ok: false, status: 503 };
     if (viaRpc) {
       if (viaRpc.identity && viaRpc.session) {
         return {
@@ -519,19 +529,23 @@ export async function authMe(): Promise<AuthMeResult> {
     /* AgentNotReadyError or any RPC failure → fall through to HTTP */
   }
 
+  // A native response or HTTP failure cannot continue under a new selection.
+  if (!requestIsCurrent()) return { ok: false, status: 503 };
   let res: Response;
   try {
-    res = await fetchWithCsrf(`${authBase()}/api/auth/me`);
+    res = await fetchWithCsrf(`${requestBase}/api/auth/me`);
   } catch {
     return { ok: false, status: 503 };
   }
 
+  if (!requestIsCurrent()) return { ok: false, status: 503 };
   if (res.ok) {
     const body = (await res.json()) as {
       identity: AuthIdentity;
       session: AuthSessionInfo;
       access?: AuthAccessInfo;
     };
+    if (!requestIsCurrent()) return { ok: false, status: 503 };
     return {
       ok: true,
       identity: body.identity,
@@ -549,6 +563,7 @@ export async function authMe(): Promise<AuthMeResult> {
       reason?: string;
       access?: AuthAccessInfo;
     };
+    if (!requestIsCurrent()) return { ok: false, status: 503 };
     const result: AuthMeResult = {
       ok: false,
       status: 401,
@@ -564,14 +579,20 @@ export async function authMe(): Promise<AuthMeResult> {
       result.reason === "remote_auth_required" &&
       result.access?.mode === "remote"
     ) {
-      return (await resolvePairingFallback(authBase())) ?? result;
+      const pairing = await resolvePairingFallback(requestBase);
+      return requestIsCurrent()
+        ? (pairing ?? result)
+        : { ok: false, status: 503 };
     }
     if (result.reason !== "server_error" || result.access) return result;
 
     // Some standalone deployments enforce auth in outer middleware before the
     // agent route can return its richer 401 body. The public status contract is
     // authoritative for the supported one-time pairing flow in that case.
-    return (await resolvePairingFallback(authBase())) ?? result;
+    const pairing = await resolvePairingFallback(requestBase);
+    return requestIsCurrent()
+      ? (pairing ?? result)
+      : { ok: false, status: 503 };
   }
 
   if (res.status === 429) {

--- a/packages/ui/src/api/client-agent-desktop-status.test.ts
+++ b/packages/ui/src/api/client-agent-desktop-status.test.ts
@@ -32,6 +32,7 @@ function installDesktopRpc(
   Object.defineProperty(globalThis, "window", {
     configurable: true,
     value: {
+      __ELIZA_DESKTOP_LOCAL_API_BASE__: "http://agent.example:31337",
       ...globals,
       __ELIZA_ELECTROBUN_RPC__: {
         request,

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -145,6 +145,7 @@ import {
 } from "./client-types";
 import { isApiError } from "./client-types-core";
 import { isDesktopExternalApiBaseUrl } from "./desktop-external-api-base";
+import { isDesktopLocalApiBaseUrl } from "./desktop-local-api-base";
 import { workflowSurfaceClient } from "./workflow-surface-routing";
 
 export {
@@ -275,6 +276,7 @@ async function getDesktopStatusRpc<T>(
   params?: unknown,
 ): Promise<T | null> {
   if (
+    !isDesktopLocalApiBaseUrl(baseUrl) ||
     isDesktopExternalApiBaseUrl(baseUrl) ||
     isRemoteRelayRestAdapterBase(baseUrl)
   ) {
@@ -294,6 +296,7 @@ async function invokeLocalDesktopAgentRpc<T>(
   options: { rpcMethod: string; ipcChannel: string; params?: unknown },
 ): Promise<T | null> {
   if (
+    !isDesktopLocalApiBaseUrl(baseUrl) ||
     isDesktopExternalApiBaseUrl(baseUrl) ||
     isRemoteRelayRestAdapterBase(baseUrl)
   ) {

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -83,6 +83,7 @@ import type {
   WorkbenchVfsSnapshot,
 } from "./client-types";
 import { isDesktopExternalApiBaseUrl } from "./desktop-external-api-base";
+import { isDesktopLocalApiBaseUrl } from "./desktop-local-api-base";
 
 type DocumentListOptions = {
   limit?: number;
@@ -1000,6 +1001,7 @@ async function invokeLocalDesktopChatRpc<T>(
   options: { rpcMethod: string; ipcChannel: string; params?: unknown },
 ): Promise<T | null> {
   if (
+    !isDesktopLocalApiBaseUrl(baseUrl) ||
     isDesktopExternalApiBaseUrl(baseUrl) ||
     isRemoteRelayRestAdapterBase(baseUrl)
   ) {

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -79,6 +79,7 @@ import {
   normalizeWalletRpcSelections,
   WALLET_RPC_PROVIDER_OPTIONS,
 } from "@elizaos/shared";
+import { getBootConfig as getBootConfigForNativeUpdate } from "../config/boot-config-store";
 import type {
   BrowserWorkspaceSnapshot,
   BrowserWorkspaceTab,
@@ -282,3 +283,32 @@ import { ElizaClient as _ElizaClient } from "./client-base";
 // @elizaos/ui export) makes augmented methods visible to callers. The
 // prototype has all methods at runtime via the augmenting side-effect imports.
 export const client: ElizaClient = new _ElizaClient();
+
+if (typeof window !== "undefined") {
+  window.addEventListener("eliza:desktop-api-base-updated", (event: Event) => {
+    const detail = (
+      event as CustomEvent<{ previousBase: string | null; base: string }>
+    ).detail;
+    if (!detail || typeof detail.base !== "string") return;
+    const current = client.getBaseUrl().replace(/\/+$/, "");
+    if (
+      current !== detail.previousBase &&
+      current !== detail.base &&
+      current !== ""
+    )
+      return;
+    const config = getBootConfigForNativeUpdate();
+    const nativeWindow = window as typeof window & {
+      __ELIZA_DESKTOP_LOCAL_API_BASE__?: string;
+      __ELIZA_DESKTOP_EXTERNAL_API_BASE__?: string;
+    };
+    const binding =
+      nativeWindow.__ELIZA_DESKTOP_LOCAL_API_BASE__ ??
+      nativeWindow.__ELIZA_DESKTOP_EXTERNAL_API_BASE__;
+    if (binding !== detail.base || config.apiBase !== detail.base) return;
+    const token = config.apiToken?.trim() || null;
+    // Native publication already excludes unchanged base/token pairs. Lazy
+    // getters can show the new config while the old WebSocket is still open.
+    client.repointBaseUrl(detail.base, token);
+  });
+}

--- a/packages/ui/src/api/desktop-local-api-base.ts
+++ b/packages/ui/src/api/desktop-local-api-base.ts
@@ -1,0 +1,33 @@
+/**
+ * Admits desktop agent RPC only for the backend bound by the native host.
+ * Renderer connection changes do not update this binding; explicit clients and
+ * selected remote profiles must use their own transport, even on another local
+ * port or deployment prefix. A missing native binding falls back to HTTP.
+ */
+function normalizedHttpBase(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const url = new URL(value);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    )
+      return null;
+    return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    // error-policy:J3 invalid destinations never acquire local RPC authority.
+    return null;
+  }
+}
+
+export function isDesktopLocalApiBaseUrl(baseUrl: string): boolean {
+  if (typeof window === "undefined") return false;
+  const binding = normalizedHttpBase(
+    (window as { __ELIZA_DESKTOP_LOCAL_API_BASE__?: unknown })
+      .__ELIZA_DESKTOP_LOCAL_API_BASE__,
+  );
+  return binding !== null && normalizedHttpBase(baseUrl) === binding;
+}

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -11,6 +11,7 @@
 
 import type { PermissionState } from "@elizaos/shared";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -20,7 +21,11 @@ import {
 import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConversationMessage } from "../../api/client-types-chat";
-import { CONNECT_EVENT } from "../../events";
+import {
+  CONNECT_EVENT,
+  type ConnectRequestResult,
+  listenForConnectRequests,
+} from "../../events";
 import { __setAppValueForTests } from "../../state/app-store";
 import { AppContext } from "../../state/useApp";
 
@@ -52,7 +57,9 @@ vi.mock("../../api/client", () => ({
   client: clientMock,
 }));
 
-import { MessageContent } from "./MessageContent";
+import { MessageContent, SensitiveRequestBlock } from "./MessageContent";
+
+const connectionCleanups: Array<() => void> = [];
 
 function baseMessage(
   overrides: Partial<ConversationMessage>,
@@ -270,6 +277,7 @@ function pendingRemoteConnectRequest(): ConversationMessage["secretRequest"] {
 describe("MessageContent sensitive requests", () => {
   afterEach(() => {
     cleanup();
+    for (const stop of connectionCleanups.splice(0)) stop();
     __setAppValueForTests(null);
   });
 
@@ -623,6 +631,9 @@ describe("MessageContent sensitive requests", () => {
   it.each(["https://agent.example.com:31337/", "agent.example.com:31337/"])(
     "remote_connect submits %s without writing the secret store",
     async (address) => {
+      connectionCleanups.push(
+        listenForConnectRequests(() => ({ status: "connected" })),
+      );
       const connectEvents: unknown[] = [];
       const onConnect = (event: Event) => {
         connectEvents.push((event as CustomEvent).detail);
@@ -677,6 +688,9 @@ describe("MessageContent sensitive requests", () => {
   );
 
   it("remote_connect omits an empty token from the CONNECT_EVENT detail", async () => {
+    connectionCleanups.push(
+      listenForConnectRequests(() => ({ status: "connected" })),
+    );
     const connectEvents: unknown[] = [];
     const onConnect = (event: Event) => {
       connectEvents.push((event as CustomEvent).detail);
@@ -712,6 +726,114 @@ describe("MessageContent sensitive requests", () => {
     expect(updateSecretsMock).not.toHaveBeenCalled();
 
     document.removeEventListener(CONNECT_EVENT, onConnect);
+  });
+
+  it("keeps remote credentials editable until adoption succeeds and permits retry after failure", async () => {
+    let finish!: (result: ConnectRequestResult) => void;
+    const attempts: string[] = [];
+    connectionCleanups.push(
+      listenForConnectRequests((detail) => {
+        attempts.push(detail.gatewayUrl);
+        return new Promise<ConnectRequestResult>((resolve) => {
+          finish = resolve;
+        });
+      }),
+    );
+    render(
+      <MessageContent
+        message={baseMessage({ secretRequest: pendingRemoteConnectRequest() })}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Remote agent URL"), {
+      target: { value: "https://paused.example" },
+    });
+    fireEvent.change(screen.getByLabelText("Access token (optional)"), {
+      target: { value: "synthetic-owner" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
+      "Pending",
+    );
+    await act(async () => {
+      finish({
+        status: "failed",
+        message: "Start the remote agent, then try again.",
+      });
+    });
+    expect(
+      screen.getByText("Start the remote agent, then try again."),
+    ).toBeTruthy();
+    expect(
+      (screen.getByLabelText("Remote agent URL") as HTMLInputElement).value,
+    ).toBe("https://paused.example");
+    expect(
+      (screen.getByLabelText("Access token (optional)") as HTMLInputElement)
+        .value,
+    ).toBe("synthetic-owner");
+    expect(
+      (screen.getByRole("button", { name: "Connect" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    await act(async () => {
+      finish({ status: "connected" });
+    });
+    expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
+      "Saved",
+    );
+    expect(screen.queryByLabelText("Remote agent URL")).toBeNull();
+    expect(attempts).toEqual([
+      "https://paused.example",
+      "https://paused.example",
+    ]);
+    expect(updateSecretsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not apply an old completion or finally to a replaced form request", async () => {
+    const completions: Array<(result: ConnectRequestResult) => void> = [];
+    connectionCleanups.push(
+      listenForConnectRequests(
+        () =>
+          new Promise<ConnectRequestResult>((resolve) => {
+            completions.push(resolve);
+          }),
+      ),
+    );
+    const first = pendingRemoteConnectRequest();
+    const second = pendingRemoteConnectRequest();
+    if (!first || !second) throw new Error("Remote form fixture required");
+    const { rerender } = render(<SensitiveRequestBlock request={first} />);
+    fireEvent.change(screen.getByLabelText("Remote agent URL"), {
+      target: { value: "https://a.example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    rerender(<SensitiveRequestBlock request={second} />);
+    fireEvent.change(screen.getByLabelText("Remote agent URL"), {
+      target: { value: "https://b.example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    await act(async () => {
+      completions[0]({ status: "connected" });
+    });
+    expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
+      "Pending",
+    );
+    expect(
+      (screen.getByLabelText("Remote agent URL") as HTMLInputElement).value,
+    ).toBe("https://b.example");
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /Connecting|Saving/,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    await act(async () => {
+      completions[1]({ status: "connected" });
+    });
+    expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
+      "Saved",
+    );
   });
 
   it.each([

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -620,56 +620,61 @@ describe("MessageContent sensitive requests", () => {
     window.open = originalOpen;
   });
 
-  it("remote_connect submit dispatches CONNECT_EVENT with the normalized URL and never touches the secret store", async () => {
-    const connectEvents: unknown[] = [];
-    const onConnect = (event: Event) => {
-      connectEvents.push((event as CustomEvent).detail);
-    };
-    document.addEventListener(CONNECT_EVENT, onConnect);
+  it.each(["https://agent.example.com:31337/", "agent.example.com:31337/"])(
+    "remote_connect submits %s without writing the secret store",
+    async (address) => {
+      const connectEvents: unknown[] = [];
+      const onConnect = (event: Event) => {
+        connectEvents.push((event as CustomEvent).detail);
+      };
+      document.addEventListener(CONNECT_EVENT, onConnect);
 
-    render(
-      <MessageContent
-        message={baseMessage({ secretRequest: pendingRemoteConnectRequest() })}
-      />,
-    );
-
-    const urlInput = screen.getByLabelText(
-      "Remote agent URL",
-    ) as HTMLInputElement;
-    expect(urlInput.type).toBe("text");
-    const tokenInput = screen.getByLabelText(
-      "Access token (optional)",
-    ) as HTMLInputElement;
-    expect(tokenInput.type).toBe("password");
-
-    // Trailing slash proves normalizeRemoteAgentUrl ran before dispatch.
-    fireEvent.change(urlInput, {
-      target: { value: "https://agent.example.com:31337/" },
-    });
-    fireEvent.change(tokenInput, { target: { value: "tok-123" } });
-    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
-        "Saved",
+      render(
+        <MessageContent
+          message={baseMessage({
+            secretRequest: pendingRemoteConnectRequest(),
+          })}
+        />,
       );
-    });
 
-    expect(connectEvents).toEqual([
-      {
-        gatewayUrl: "https://agent.example.com:31337",
-        token: "tok-123",
-        completeFirstRun: true,
-        skipConfirm: true,
-      },
-    ]);
-    // The URL + token point the app at a remote runtime — they must NEVER be
-    // written to the agent secret store or tunneled.
-    expect(updateSecretsMock).not.toHaveBeenCalled();
-    expect(tunnelCredentialMock).not.toHaveBeenCalled();
+      const urlInput = screen.getByLabelText(
+        "Remote agent URL",
+      ) as HTMLInputElement;
+      expect(urlInput.type).toBe("text");
+      const tokenInput = screen.getByLabelText(
+        "Access token (optional)",
+      ) as HTMLInputElement;
+      expect(tokenInput.type).toBe("password");
 
-    document.removeEventListener(CONNECT_EVENT, onConnect);
-  });
+      // Trailing slash proves normalizeRemoteAgentUrl ran before dispatch.
+      fireEvent.change(urlInput, {
+        target: { value: address },
+      });
+      fireEvent.change(tokenInput, { target: { value: "tok-123" } });
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
+          "Saved",
+        );
+      });
+
+      expect(connectEvents).toEqual([
+        {
+          gatewayUrl: "https://agent.example.com:31337",
+          token: "tok-123",
+          completeFirstRun: true,
+          skipConfirm: true,
+        },
+      ]);
+      // The URL + token point the app at a remote runtime — they must NEVER be
+      // written to the agent secret store or tunneled.
+      expect(updateSecretsMock).not.toHaveBeenCalled();
+      expect(tunnelCredentialMock).not.toHaveBeenCalled();
+
+      document.removeEventListener(CONNECT_EVENT, onConnect);
+    },
+  );
 
   it("remote_connect omits an empty token from the CONNECT_EVENT detail", async () => {
     const connectEvents: unknown[] = [];
@@ -709,41 +714,50 @@ describe("MessageContent sensitive requests", () => {
     document.removeEventListener(CONNECT_EVENT, onConnect);
   });
 
-  it("remote_connect surfaces an invalid-URL error, keeps the form editable, and does not dispatch", async () => {
-    const connectEvents: unknown[] = [];
-    const onConnect = (event: Event) => {
-      connectEvents.push((event as CustomEvent).detail);
-    };
-    document.addEventListener(CONNECT_EVENT, onConnect);
+  it.each([
+    ["ftp://agent.example.com", "Remote agents must use HTTP or HTTPS."],
+    [
+      "https://synthetic-user:synthetic-password@agent.example.com",
+      "Use the access token field instead of credentials in the remote URL.",
+    ],
+  ])(
+    "remote_connect rejects invalid URL %s and keeps the form editable",
+    async (address, message) => {
+      const connectEvents: unknown[] = [];
+      const onConnect = (event: Event) => {
+        connectEvents.push((event as CustomEvent).detail);
+      };
+      document.addEventListener(CONNECT_EVENT, onConnect);
 
-    const { container } = render(
-      <MessageContent
-        message={baseMessage({ secretRequest: pendingRemoteConnectRequest() })}
-      />,
-    );
-
-    fireEvent.change(screen.getByLabelText("Remote agent URL"), {
-      target: { value: "ftp://agent.example.com" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
-
-    await waitFor(() => {
-      expect(container.textContent).toContain(
-        "Remote agents must use HTTP or HTTPS.",
+      const { container } = render(
+        <MessageContent
+          message={baseMessage({
+            secretRequest: pendingRemoteConnectRequest(),
+          })}
+        />,
       );
-    });
 
-    // No dispatch, no secret-store write, and the form is still pending +
-    // editable so the user can correct the typo.
-    expect(connectEvents).toEqual([]);
-    expect(updateSecretsMock).not.toHaveBeenCalled();
-    expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
-      "Pending",
-    );
-    expect(screen.getByLabelText("Remote agent URL")).toBeTruthy();
+      fireEvent.change(screen.getByLabelText("Remote agent URL"), {
+        target: { value: address },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
 
-    document.removeEventListener(CONNECT_EVENT, onConnect);
-  });
+      await waitFor(() => {
+        expect(container.textContent).toContain(message);
+      });
+
+      // No dispatch, no secret-store write, and the form is still pending +
+      // editable so the user can correct the typo.
+      expect(connectEvents).toEqual([]);
+      expect(updateSecretsMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId("sensitive-request-status").textContent).toBe(
+        "Pending",
+      );
+      expect(screen.getByLabelText("Remote agent URL")).toBeTruthy();
+
+      document.removeEventListener(CONNECT_EVENT, onConnect);
+    },
+  );
 
   it("degrades a blocked OAuth popup to same-tab navigation on plain web (#15143)", () => {
     const openMock = vi.fn().mockReturnValue(null);

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -931,6 +931,9 @@ export function SensitiveRequestBlock({
   const [authorizing, setAuthorizing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const currentRequest = useRef(request);
+  currentRequest.current = request;
+
   useEffect(() => {
     setStatus(request.status);
     setValues({});
@@ -965,6 +968,7 @@ export function SensitiveRequestBlock({
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       if (!canCollectSecret || !canSubmit) return;
+      const submittedRequest = request;
       setSaving(true);
       setError(null);
       try {
@@ -988,12 +992,23 @@ export function SensitiveRequestBlock({
             );
             return;
           }
-          dispatchConnectRequest({
+          const result = await dispatchConnectRequest({
             gatewayUrl: normalized,
             token: values.token?.trim() || undefined,
             completeFirstRun: true,
             skipConfirm: true,
           });
+          if (currentRequest.current !== submittedRequest) return;
+          if (result.status !== "connected") {
+            setError(
+              result.status === "failed"
+                ? result.message
+                : result.status === "cancelled"
+                  ? "Connection request cancelled. You can edit the details and try again."
+                  : "A newer connection request replaced this attempt. Try connecting again.",
+            );
+            return;
+          }
           setValues({});
           setStatus("saved");
           return;
@@ -1027,6 +1042,7 @@ export function SensitiveRequestBlock({
         setValues({});
         setStatus("saved");
       } catch (caught) {
+        if (currentRequest.current !== submittedRequest) return;
         // error-policy:J4 submit failure renders the form's error state
         setError(
           caught instanceof Error
@@ -1037,10 +1053,18 @@ export function SensitiveRequestBlock({
         );
         setStatus("failed");
       } finally {
-        setSaving(false);
+        if (currentRequest.current === submittedRequest) setSaving(false);
       }
     },
-    [canCollectSecret, canSubmit, fields, isRemoteConnect, tunnel, values],
+    [
+      canCollectSecret,
+      canSubmit,
+      fields,
+      isRemoteConnect,
+      request,
+      tunnel,
+      values,
+    ],
   );
 
   return (

--- a/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.firstrun.test.tsx
@@ -14,6 +14,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -38,6 +39,11 @@ import {
   FIRST_RUN_GREETING,
   FIRST_RUN_SIGN_IN_PROMPT,
 } from "../../first-run/first-run-greeting";
+import {
+  clearPendingFirstRunText,
+  handoffPendingFirstRunText,
+  readPendingFirstRunText,
+} from "../../first-run/first-run-pending-text";
 import { __setAppValueForTests } from "../../state/app-store";
 import type { AppContextValue } from "../../state/internal";
 import { resetShellSurfaceForTests } from "../../state/shell-surface-store";
@@ -51,6 +57,7 @@ beforeAll(() => {
 
 afterEach(() => {
   cleanup();
+  clearPendingFirstRunText();
   resetShellSurfaceForTests();
   setViewChatBinding(null);
   __setAppValueForTests(null);
@@ -1025,4 +1032,86 @@ describe("ChatOverlay first-run gating", () => {
     expect(sheet.getAttribute("data-variant")).toBe("open");
     expect(onHandled).toHaveBeenCalledTimes(1);
   });
+});
+
+it("retains the complete queue until onboarding closes and the actual composer commits it", async () => {
+  const controller = makeController();
+  const requests = [
+    "First complete request with its final sentence.",
+    "Second request.\nKeep the paragraph intact.",
+  ];
+  const view = render(
+    <ChatOverlay
+      controller={controller}
+      firstRunOpen
+      acceptPendingFirstRunText={false}
+    />,
+  );
+  act(() => handoffPendingFirstRunText(requests));
+  expect((screen.getByLabelText("message") as HTMLTextAreaElement).value).toBe(
+    "",
+  );
+  expect(readPendingFirstRunText()).toEqual(requests);
+  view.rerender(
+    <ChatOverlay
+      controller={controller}
+      firstRunOpen={false}
+      acceptPendingFirstRunText
+    />,
+  );
+  await waitFor(() =>
+    expect(
+      (screen.getByLabelText("message") as HTMLTextAreaElement).value,
+    ).toBe(requests.join("\n\n")),
+  );
+  expect(readPendingFirstRunText()).toEqual([]);
+  expect(controller.send).not.toHaveBeenCalled();
+});
+
+it("recovers a cold-start queue only after the host authorizes a ready composer", async () => {
+  const requests = [
+    "Cold startup request",
+    "Retain the second request exactly.",
+  ];
+  handoffPendingFirstRunText(requests);
+  const controller = makeController();
+  const view = render(
+    <ChatOverlay controller={controller} acceptPendingFirstRunText={false} />,
+  );
+  expect(readPendingFirstRunText()).toEqual(requests);
+  expect((screen.getByLabelText("message") as HTMLTextAreaElement).value).toBe(
+    "",
+  );
+  view.rerender(
+    <ChatOverlay controller={controller} acceptPendingFirstRunText />,
+  );
+  await waitFor(() =>
+    expect(
+      (screen.getByLabelText("message") as HTMLTextAreaElement).value,
+    ).toBe(requests.join("\n\n")),
+  );
+  expect(readPendingFirstRunText()).toEqual([]);
+});
+
+it("acknowledges an already committed equal draft when setup authority arrives", async () => {
+  const controller = makeController();
+  const requests = [
+    "Full Unicode request: 渡船 🚢\nKeep every paragraph.\n".repeat(400),
+    "Final request: café, mañana, and the complete ending. 🧡",
+  ];
+  const text = requests.join("\n\n");
+  const view = render(
+    <ChatOverlay controller={controller} acceptPendingFirstRunText={false} />,
+  );
+  const input = screen.getByLabelText("message") as HTMLTextAreaElement;
+  fireEvent.change(input, { target: { value: text } });
+  expect(input.value).toBe(text);
+  handoffPendingFirstRunText(requests);
+  expect(readPendingFirstRunText()).toEqual(requests);
+  view.rerender(
+    <ChatOverlay controller={controller} acceptPendingFirstRunText />,
+  );
+  await waitFor(() => expect(readPendingFirstRunText()).toEqual([]));
+  expect(input.value).toBe(text);
+  expect(controller.send).not.toHaveBeenCalled();
 });

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -4297,6 +4297,7 @@ export function ChatOverlay({
   ]);
 
   React.useEffect(() => {
+    if (!acceptPendingFirstRunText || firstRunOpen) return;
     const pending = pendingFirstRunAcknowledgementRef.current;
     if (!pending || pending.text !== draft) return;
     // A committed composer render acknowledges the complete draft; a remount

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -34,6 +34,7 @@ import {
 } from "motion/react";
 import * as React from "react";
 import { type OrbState, ThinkingOrb } from "thinking-orbs";
+import { registerPendingFirstRunTextConsumer } from "../../first-run/first-run-pending-text";
 import { ChatVoiceStatusBar } from "../composites/chat/ChatVoiceStatusBar";
 import {
   highlightSearchMatches,
@@ -1322,6 +1323,7 @@ export function ChatOverlay({
   agentName = "Eliza",
   slash: slashProp,
   firstRunOpen = false,
+  acceptPendingFirstRunText = false,
   initialMode = "input",
   releaseFirstRunToFull = false,
   fillHostAtHalf = false,
@@ -1344,6 +1346,8 @@ export function ChatOverlay({
    * There is never a separate desktop web chat.
    */
   firstRunOpen?: boolean;
+  /** The host confirms setup completion before this composer may consume queued intent. */
+  acceptPendingFirstRunText?: boolean;
   /** Initial resting detent when a host opens this shared chat surface. */
   initialMode?: "input" | "half";
   /**
@@ -4241,11 +4245,14 @@ export function ChatOverlay({
     expand();
   }, [hasRevealableThread, expand]);
 
+  const pendingFirstRunAcknowledgementRef = React.useRef<{
+    text: string;
+    acknowledge: () => void;
+  } | null>(null);
   React.useEffect(() => {
     if (typeof window === "undefined") return undefined;
-    const onPrefill = (event: Event) => {
+    const applyPrefill = (detail: ChatPrefillEventDetail) => {
       if (firstRunOpen) return;
-      const detail = (event as CustomEvent<ChatPrefillEventDetail>).detail;
       const text = typeof detail?.text === "string" ? detail.text : "";
       if (!text.trim()) return;
       setMode((m) => (m === "pill" ? "input" : m));
@@ -4267,9 +4274,36 @@ export function ChatOverlay({
         prefillFocusTimerRef.current = window.setTimeout(focusComposer, 0);
       }
     };
+    const onPrefill = (event: Event) =>
+      applyPrefill((event as CustomEvent<ChatPrefillEventDetail>).detail);
     window.addEventListener(CHAT_PREFILL_EVENT, onPrefill);
-    return () => window.removeEventListener(CHAT_PREFILL_EVENT, onPrefill);
-  }, [clearPrefillFocusSchedule, firstRunOpen, setDraft]);
+    const unregister =
+      !firstRunOpen && acceptPendingFirstRunText
+        ? registerPendingFirstRunTextConsumer((text, acknowledge) => {
+            pendingFirstRunAcknowledgementRef.current = { text, acknowledge };
+            applyPrefill({ text, select: true });
+          })
+        : undefined;
+    return () => {
+      window.removeEventListener(CHAT_PREFILL_EVENT, onPrefill);
+      unregister?.();
+      pendingFirstRunAcknowledgementRef.current = null;
+    };
+  }, [
+    acceptPendingFirstRunText,
+    clearPrefillFocusSchedule,
+    firstRunOpen,
+    setDraft,
+  ]);
+
+  React.useEffect(() => {
+    const pending = pendingFirstRunAcknowledgementRef.current;
+    if (!pending || pending.text !== draft) return;
+    // A committed composer render acknowledges the complete draft; a remount
+    // before this point leaves the durable onboarding intent available.
+    pending.acknowledge();
+    pendingFirstRunAcknowledgementRef.current = null;
+  }, [acceptPendingFirstRunText, draft, firstRunOpen]);
 
   // "Open chat" intent (the launcher's Messages tile). Land the user IN an open
   // conversation instead of the wordless home with a collapsed pill: un-pill to

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
@@ -36,6 +36,7 @@ vi.mock("../../api/client", () => ({
       unreadCount: 0,
     })),
     onWsEvent: vi.fn(),
+    onAuthorityChange: vi.fn(() => () => {}),
     markNotificationRead: vi.fn(async () => ({})),
     markAllNotificationsRead: vi.fn(async () => ({})),
     removeNotification: vi.fn(async () => ({})),

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../../api/client", () => ({
     })),
     listPendingActions: vi.fn(async () => ({ pending: [] })),
     onWsEvent: vi.fn(),
+    onAuthorityChange: vi.fn(() => () => {}),
     // notificationProbesEnabled reads the configured base URL before every
     // hydration request; empty string = same-origin (probes enabled).
     getBaseUrl: vi.fn(() => ""),

--- a/packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.root-ui-broker.test.tsx
@@ -70,6 +70,23 @@ describe("root @elizaos/ui import is broker-scoped, not an escape hatch (#14237)
     window.localStorage.clear();
   });
 
+  it("does not adopt a replacement scope while an external import is awaiting", async () => {
+    const pending = hostImport("@elizaos/ui/app-navigate-view");
+    setActiveSurfaceRealmScope(
+      new SurfaceRealmScope(
+        resolveSurfaceManifest({ surface: { capabilities: ["navigate"] } }),
+        "replacement",
+        backing,
+        () => {
+          throw new Error("Replacement owner was borrowed");
+        },
+      ),
+    );
+    const external = await pending;
+    const navigate = external.navigateBrowserPath as (path: string) => void;
+    expect(() => navigate("/borrowed")).toThrow(SurfaceRealmDeniedError);
+  });
+
   it("root navigateBrowserPath is the scope-brokered wrapper (denied without the grant), like the subpath", async () => {
     const rootMod = await hostImport("@elizaos/ui");
     const navigate = rootMod.navigateBrowserPath as (path: string) => void;

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -7,8 +7,15 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { ElizaError } from "@elizaos/core";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { ElizaError, resolveSurfaceManifest } from "@elizaos/core";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { type ReactElement, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -17,6 +24,11 @@ import {
 } from "../../cache-telemetry";
 import { APP_PAUSE_EVENT } from "../../events";
 import { Field } from "../../spatial/primitives";
+import {
+  SurfaceRealmDeniedError,
+  SurfaceRealmScope,
+  setActiveSurfaceRealmScope,
+} from "../../surface-realm-broker";
 import {
   __resetDynamicViewLoaderCacheForTests,
   DynamicViewLoader,
@@ -457,6 +469,172 @@ describe("DynamicViewLoader", () => {
     vi.clearAllTimers();
     vi.useRealTimers();
   });
+
+  it("keeps a retained inactive module from acquiring the foreground owner's handles", async () => {
+    const navigations: string[] = [];
+    const makeScope = (id: string) =>
+      new SurfaceRealmScope(
+        resolveSurfaceManifest({ surface: { capabilities: ["navigate"] } }),
+        id,
+        window.localStorage,
+        (path) => navigations.push(`${id}:${path}`),
+      );
+    const loads: Record<string, number> = {};
+    const handles: Record<string, (path: string) => void> = {};
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = async (url) => {
+      loads[url] = (loads[url] ?? 0) + 1;
+      const external = await hostImport("@elizaos/ui/app-navigate-view");
+      const navigate = external.navigateBrowserPath as (path: string) => void;
+      handles[url] = navigate;
+      return {
+        default: () => (
+          <button type="button" onClick={() => navigate("/settings")}>
+            {url}
+          </button>
+        ),
+      };
+    };
+    const firstUrl = "/api/views/retained-a/bundle.js";
+    const secondUrl = "/api/views/foreground-b/bundle.js";
+    setActiveSurfaceRealmScope(makeScope("retained-a"));
+    try {
+      const rendered = render(
+        <div>
+          <DynamicViewLoader bundleUrl={firstUrl} viewId="retained-a" />
+        </div>,
+      );
+      await screen.findByRole("button", { name: firstUrl });
+      act(() => setActiveSurfaceRealmScope(makeScope("foreground-b")));
+      rendered.rerender(
+        <div>
+          <DynamicViewLoader bundleUrl={firstUrl} viewId="retained-a" />
+          <DynamicViewLoader bundleUrl={secondUrl} viewId="foreground-b" />
+        </div>,
+      );
+      fireEvent.click(await screen.findByRole("button", { name: secondUrl }));
+      expect(() => handles[firstUrl]("/borrowed")).toThrow(
+        SurfaceRealmDeniedError,
+      );
+      expect(loads[firstUrl]).toBe(1);
+      expect(navigations).toEqual(["foreground-b:/settings"]);
+    } finally {
+      cleanup();
+      setActiveSurfaceRealmScope(null);
+    }
+  }, 120_000);
+
+  it("loads both admitted split-layout members with default-deny handles", async () => {
+    const navigations: Array<(path: string) => void> = [];
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = async (url) => {
+      const external = await hostImport("@elizaos/ui/app-navigate-view");
+      navigations.push(external.navigateBrowserPath as (path: string) => void);
+      return { default: () => <div>{url}</div> };
+    };
+    const scope = new SurfaceRealmScope(
+      resolveSurfaceManifest(null),
+      "layout:a+b",
+      window.localStorage,
+      () => {
+        throw new Error("Layout unexpectedly navigated");
+      },
+      ["a", "b"],
+    );
+    setActiveSurfaceRealmScope(scope);
+    try {
+      render(
+        <>
+          <DynamicViewLoader bundleUrl="/api/views/a/bundle.js" viewId="a" />
+          <DynamicViewLoader bundleUrl="/api/views/b/bundle.js" viewId="b" />
+        </>,
+      );
+      await screen.findByText("/api/views/a/bundle.js");
+      await screen.findByText("/api/views/b/bundle.js");
+      for (const navigate of navigations)
+        expect(() => navigate("/settings")).toThrow(SurfaceRealmDeniedError);
+    } finally {
+      cleanup();
+      setActiveSurfaceRealmScope(null);
+    }
+  }, 120_000);
+
+  it("re-evaluates mounted namespace handles when the same URL gets a new scope", async () => {
+    const navigations: string[] = [];
+    const manifest = resolveSurfaceManifest({
+      surface: { capabilities: ["navigate", "storage"] },
+    });
+    const first = new SurfaceRealmScope(
+      manifest,
+      "scope-panel",
+      window.localStorage,
+      (path) => navigations.push(`first:${path}`),
+    );
+    const second = new SurfaceRealmScope(
+      manifest,
+      "scope-panel",
+      window.localStorage,
+      (path) => navigations.push(`second:${path}`),
+    );
+    const handles: Array<{
+      navigate: (path: string) => void;
+      write: (key: string, value: string) => Promise<void>;
+    }> = [];
+    window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__ = async () => {
+      const navigation = await hostImport("@elizaos/ui/app-navigate-view");
+      const bridge = await hostImport("@elizaos/ui/bridge");
+      if (
+        typeof navigation.navigateBrowserPath !== "function" ||
+        typeof bridge.setStorageValue !== "function"
+      )
+        throw new Error("Missing broker handles");
+      const handle = {
+        navigate: navigation.navigateBrowserPath as (path: string) => void,
+        write: bridge.setStorageValue as (
+          key: string,
+          value: string,
+        ) => Promise<void>,
+      };
+      handles.push(handle);
+      const label = `Owned module ${handles.length}`;
+      return {
+        default: () => (
+          <button type="button" onClick={() => handle.navigate("/settings")}>
+            {label}
+          </button>
+        ),
+      };
+    };
+    setActiveSurfaceRealmScope(first);
+    try {
+      render(
+        <DynamicViewLoader
+          bundleUrl="/api/views/scope-panel/bundle.js"
+          viewId="scope-panel"
+        />,
+      );
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Owned module 1" }),
+      );
+      await handles[0].write("scope-probe", "first");
+      expect(window.localStorage.getItem("scope-probe")).toBe("first");
+      act(() => setActiveSurfaceRealmScope(second));
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Owned module 2" }),
+      );
+      expect(() => handles[0].navigate("/old")).toThrow(
+        SurfaceRealmDeniedError,
+      );
+      await expect(handles[0].write("scope-probe", "stale")).rejects.toThrow(
+        SurfaceRealmDeniedError,
+      );
+      await handles[1].write("scope-probe", "second");
+      expect(window.localStorage.getItem("scope-probe")).toBe("second");
+      expect(navigations).toEqual(["first:/settings", "second:/settings"]);
+    } finally {
+      cleanup();
+      setActiveSurfaceRealmScope(null);
+      window.localStorage.removeItem("scope-probe");
+    }
+  }, 120_000);
 
   it("imports absolute remote bundleUrl directly", async () => {
     const bundleUrl = "https://capability.example.test/assets/remote-panel.js";

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -424,8 +424,20 @@ function resolveSurfaceRealmScopeForHostExternal(
   );
 }
 
-async function importUiRootCompat(
-  boundScope: SurfaceRealmScope | null = getActiveSurfaceRealmScope(),
+function importUiRootCompat(): Promise<Record<string, unknown>> {
+  return importUiRootCompatForScope(getActiveSurfaceRealmScope());
+}
+
+function importUiAppNavigateViewCompat(): Promise<Record<string, unknown>> {
+  return importUiAppNavigateViewCompatForScope(getActiveSurfaceRealmScope());
+}
+
+function importUiBridgeCompat(): Promise<Record<string, unknown>> {
+  return importUiBridgeCompatForScope(getActiveSurfaceRealmScope());
+}
+
+async function importUiRootCompatForScope(
+  boundScope: SurfaceRealmScope | null,
 ): Promise<Record<string, unknown>> {
   // The root package is deliberately limited to design-system primitives. The
   // brokered navigation and bridge adapters are overlaid for older view bundles
@@ -433,14 +445,14 @@ async function importUiRootCompat(
   // channels are not part of the root namespace and therefore cannot leak here.
   const [rootModule, appNavigateView, bridge] = await Promise.all([
     import("../../index.ts"),
-    importUiAppNavigateViewCompat(boundScope),
-    importUiBridgeCompat(boundScope),
+    importUiAppNavigateViewCompatForScope(boundScope),
+    importUiBridgeCompatForScope(boundScope),
   ]);
   return { ...rootModule, ...appNavigateView, ...bridge };
 }
 
-async function importUiAppNavigateViewCompat(
-  boundScope: SurfaceRealmScope | null = getActiveSurfaceRealmScope(),
+async function importUiAppNavigateViewCompatForScope(
+  boundScope: SurfaceRealmScope | null,
 ): Promise<Record<string, unknown>> {
   const appNavigateView = await import("../../app-navigate-view.ts");
   return {
@@ -460,8 +472,8 @@ async function importUiAppNavigateViewCompat(
   };
 }
 
-async function importUiBridgeCompat(
-  boundScope: SurfaceRealmScope | null = getActiveSurfaceRealmScope(),
+async function importUiBridgeCompatForScope(
+  boundScope: SurfaceRealmScope | null,
 ): Promise<Record<string, unknown>> {
   const bridge = await import("../../bridge/index.ts");
   // The bridge barrel carries the shell-privileged raw-global channel for shell
@@ -784,10 +796,11 @@ async function importHostForScope(
   specifier: string,
   scope: SurfaceRealmScope | null,
 ): Promise<Record<string, unknown>> {
-  if (specifier === "@elizaos/ui") return importUiRootCompat(scope);
+  if (specifier === "@elizaos/ui") return importUiRootCompatForScope(scope);
   if (specifier === "@elizaos/ui/app-navigate-view")
-    return importUiAppNavigateViewCompat(scope);
-  if (specifier === "@elizaos/ui/bridge") return importUiBridgeCompat(scope);
+    return importUiAppNavigateViewCompatForScope(scope);
+  if (specifier === "@elizaos/ui/bridge")
+    return importUiBridgeCompatForScope(scope);
   const importer = resolveHostExternalImporter(specifier);
   if (!importer) {
     throw new Error(

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -41,6 +41,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import * as AgentSurfaceHost from "../../agent-surface";
 import {
@@ -83,6 +84,7 @@ import {
   getActiveSurfaceRealmScope,
   SurfaceRealmDeniedError,
   type SurfaceRealmScope,
+  subscribeActiveSurfaceRealmScope,
 } from "../../surface-realm-broker";
 import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
 import { registerDetailExtension } from "../apps/extensions/registry.ts";
@@ -414,33 +416,33 @@ function resolveSurfaceRealmScopeForHostExternal(
   detail: string,
 ): SurfaceRealmScope | null {
   const activeScope = getActiveSurfaceRealmScope();
-  if (!boundScope) return activeScope;
   if (activeScope === boundScope) return boundScope;
   throw new SurfaceRealmDeniedError(
-    boundScope.viewId,
+    boundScope?.viewId ?? "unbound",
     vector,
     `stale host external call after surface deactivation: ${detail}`,
   );
 }
 
-async function importUiRootCompat(): Promise<Record<string, unknown>> {
+async function importUiRootCompat(
+  boundScope: SurfaceRealmScope | null = getActiveSurfaceRealmScope(),
+): Promise<Record<string, unknown>> {
   // The root package is deliberately limited to design-system primitives. The
   // brokered navigation and bridge adapters are overlaid for older view bundles
   // that still request those names from the root specifier; raw shell-global
   // channels are not part of the root namespace and therefore cannot leak here.
   const [rootModule, appNavigateView, bridge] = await Promise.all([
     import("../../index.ts"),
-    importUiAppNavigateViewCompat(),
-    importUiBridgeCompat(),
+    importUiAppNavigateViewCompat(boundScope),
+    importUiBridgeCompat(boundScope),
   ]);
   return { ...rootModule, ...appNavigateView, ...bridge };
 }
 
-async function importUiAppNavigateViewCompat(): Promise<
-  Record<string, unknown>
-> {
+async function importUiAppNavigateViewCompat(
+  boundScope: SurfaceRealmScope | null = getActiveSurfaceRealmScope(),
+): Promise<Record<string, unknown>> {
   const appNavigateView = await import("../../app-navigate-view.ts");
-  const boundScope = getActiveSurfaceRealmScope();
   return {
     ...appNavigateView,
     navigateBrowserPath(path: string): void {
@@ -458,9 +460,10 @@ async function importUiAppNavigateViewCompat(): Promise<
   };
 }
 
-async function importUiBridgeCompat(): Promise<Record<string, unknown>> {
+async function importUiBridgeCompat(
+  boundScope: SurfaceRealmScope | null = getActiveSurfaceRealmScope(),
+): Promise<Record<string, unknown>> {
   const bridge = await import("../../bridge/index.ts");
-  const boundScope = getActiveSurfaceRealmScope();
   // The bridge barrel carries the shell-privileged raw-global channel for shell
   // code outside packages/ui; handing it to a view bundle would let the view
   // disarm the raw-global guards on itself. Views get the scoped storage
@@ -774,7 +777,17 @@ export async function importAuthenticatedViewBundle(
  * HostModuleImporter} it resolves its externals through — no `globalThis` bridge.
  * Exported so tests can exercise the resolver the factory receives.
  */
-export const hostImport: HostModuleImporter = async (specifier) => {
+export const hostImport: HostModuleImporter = (specifier) =>
+  importHostForScope(specifier, getActiveSurfaceRealmScope());
+
+async function importHostForScope(
+  specifier: string,
+  scope: SurfaceRealmScope | null,
+): Promise<Record<string, unknown>> {
+  if (specifier === "@elizaos/ui") return importUiRootCompat(scope);
+  if (specifier === "@elizaos/ui/app-navigate-view")
+    return importUiAppNavigateViewCompat(scope);
+  if (specifier === "@elizaos/ui/bridge") return importUiBridgeCompat(scope);
   const importer = resolveHostExternalImporter(specifier);
   if (!importer) {
     throw new Error(
@@ -782,7 +795,7 @@ export const hostImport: HostModuleImporter = async (specifier) => {
     );
   }
   return importer();
-};
+}
 
 /**
  * A served view bundle's default export is a `HostExternalBundleFactory`: call
@@ -792,10 +805,20 @@ export const hostImport: HostModuleImporter = async (specifier) => {
  */
 async function resolveBundleNamespace(
   mod: Record<string, unknown>,
+  scope: SurfaceRealmScope | null,
 ): Promise<Record<string, unknown>> {
+  if (scope !== getActiveSurfaceRealmScope()) {
+    throw new SurfaceRealmDeniedError(
+      scope?.viewId ?? "unbound",
+      "navigate",
+      "view bundle authority changed before evaluation",
+    );
+  }
   const factory = mod.default;
   if (typeof factory !== "function") return mod;
-  return (factory as HostExternalBundleFactory)(hostImport);
+  return (factory as HostExternalBundleFactory)((specifier) =>
+    importHostForScope(specifier, scope),
+  );
 }
 
 /** Dev-mode polling interval in ms. Not used in production builds. */
@@ -825,6 +848,7 @@ export function isSameOriginBundleUrl(bundleUrl: string): boolean {
 
 async function importViewBundle(
   bundleUrl: string,
+  scope: SurfaceRealmScope | null,
 ): Promise<Record<string, unknown>> {
   if (
     (import.meta.env.DEV ||
@@ -846,6 +870,7 @@ async function importViewBundle(
   if (hostExternalUrl) {
     return resolveBundleNamespace(
       await importAuthenticatedViewBundle(hostExternalUrl),
+      scope,
     );
   }
 
@@ -866,6 +891,7 @@ async function importViewBundle(
   }
   return resolveBundleNamespace(
     await importAuthenticatedViewBundle(rewrittenUrl),
+    scope,
   );
 }
 
@@ -882,11 +908,31 @@ function buildHostExternalBundleUrl(bundleUrl: string): string | null {
   return rewrittenUrl.href;
 }
 
+// Evaluated namespaces capture broker handles. Reuse is valid only within the
+// scope that evaluated them, even when another backend serves the same URL.
+const bundleScopeIds = new WeakMap<SurfaceRealmScope, number>();
+let nextBundleScopeId = 0;
+function bundleCacheKey(
+  bundleUrl: string,
+  componentExport: string,
+  scope: SurfaceRealmScope | null,
+): string {
+  const base = `${bundleUrl}::${componentExport}`;
+  if (!scope) return base;
+  let id = bundleScopeIds.get(scope);
+  if (id === undefined) {
+    id = ++nextBundleScopeId;
+    bundleScopeIds.set(scope, id);
+  }
+  return `${base}::scope:${id}`;
+}
+
 function ensureBundleModuleEntry(
   bundleUrl: string,
   componentExport: string,
+  scope: SurfaceRealmScope | null,
 ): ViewBundleCacheEntry {
-  const cacheKey = `${bundleUrl}::${componentExport}`;
+  const cacheKey = bundleCacheKey(bundleUrl, componentExport, scope);
   const cached = bundleModuleCache.get(cacheKey);
   if (cached) {
     cached.lastUsedAt = Date.now();
@@ -894,7 +940,7 @@ function ensureBundleModuleEntry(
   }
 
   let entry: ViewBundleCacheEntry;
-  const promise = importViewBundle(bundleUrl).then(
+  const promise = importViewBundle(bundleUrl, scope).then(
     (mod: Record<string, unknown>) => {
       const exported = mod[componentExport] ?? mod.default;
       if (!isReactComponentExport(exported)) {
@@ -957,13 +1003,14 @@ function ensureBundleModuleEntry(
 function acquireBundleModule(
   bundleUrl: string,
   componentExport: string,
+  scope: SurfaceRealmScope | null,
 ): {
   cacheKey: string;
   promise: Promise<ViewBundleModule>;
   release: () => void;
 } {
   installBundleCacheLifecycle();
-  const entry = ensureBundleModuleEntry(bundleUrl, componentExport);
+  const entry = ensureBundleModuleEntry(bundleUrl, componentExport, scope);
   entry.refCount += 1;
   entry.lastUsedAt = Date.now();
   if (entry.retentionTimer) {
@@ -1390,6 +1437,45 @@ interface DynamicViewLoaderProps {
   surface?: SurfaceManifest;
 }
 
+interface ViewRealmBinding {
+  viewId: string;
+  scope: SurfaceRealmScope | null;
+  admitted: boolean;
+}
+
+function useViewRealmBinding(viewId: string): ViewRealmBinding {
+  const published = useSyncExternalStore(
+    subscribeActiveSurfaceRealmScope,
+    getActiveSurfaceRealmScope,
+    getActiveSurfaceRealmScope,
+  );
+  const initialBinding = (): ViewRealmBinding => ({
+    viewId,
+    scope: published?.ownsView(viewId) ? published : null,
+    admitted: published === null || published.ownsView(viewId),
+  });
+  const [binding, setBinding] = useState(initialBinding);
+  // Retained background views keep their old lease and denied handles. They
+  // must never re-evaluate under the foreground owner's grants. A composed
+  // layout admits its explicit members under the shared default-deny scope.
+  if (binding.viewId !== viewId) {
+    const next = initialBinding();
+    setBinding(next);
+    return next;
+  }
+  if (published?.ownsView(viewId) && binding.scope !== published) {
+    const next = { viewId, scope: published, admitted: true };
+    setBinding(next);
+    return next;
+  }
+  if (published && binding.scope === null && binding.admitted) {
+    const next = { viewId, scope: null, admitted: false };
+    setBinding(next);
+    return next;
+  }
+  return binding;
+}
+
 /**
  * Loads and mounts a view component from a remote bundle URL.
  *
@@ -1425,6 +1511,8 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   // and talks to the shell only through the postMessage broker, so the in-realm
   // bundle-load / interact-registry path below is skipped for it.
   const isSandboxed = resolvedManifest.isolation === "sandboxed-iframe";
+  const { scope: activeScope, admitted: scopeAdmitted } =
+    useViewRealmBinding(viewId);
   const [bundle, setBundle] = useState<ViewBundleModule | null>(null);
   const [loadError, setLoadError] = useState<Error | null>(null);
   // Incrementing this key invalidates the module cache entry and forces a
@@ -1446,10 +1534,15 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   // re-run this effect to invalidate the module cache.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is a manual cache-bust trigger
   useEffect(() => {
+    if (!scopeAdmitted) {
+      setBundle(null);
+      setLoadError(null);
+      return;
+    }
     if (!dynamicLoadingAllowed || isSandboxed || !bundleUrl) return;
 
     let cancelled = false;
-    const lease = acquireBundleModule(bundleUrl, componentExport);
+    const lease = acquireBundleModule(bundleUrl, componentExport, activeScope);
 
     setBundle(null);
     setLoadError(null);
@@ -1475,6 +1568,8 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
       lease.release();
     };
   }, [
+    activeScope,
+    scopeAdmitted,
     bundleUrl,
     componentExport,
     dynamicLoadingAllowed,
@@ -1526,7 +1621,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
               params,
               containerRef.current,
               setReloadKey,
-              `${bundleUrl}::${componentExport}`,
+              bundleCacheKey(bundleUrl, componentExport, activeScope),
               registry,
             );
           }
@@ -1542,7 +1637,15 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
     );
 
     return unregister;
-  }, [bundle, bundleUrl, componentExport, resolvedManifest, viewId, viewType]);
+  }, [
+    activeScope,
+    bundle,
+    bundleUrl,
+    componentExport,
+    resolvedManifest,
+    viewId,
+    viewType,
+  ]);
 
   // Dev-mode only: poll the bundle URL with HEAD requests every 2s. When the
   // ETag changes the bundle has been rebuilt — evict the cache entry and bump
@@ -1551,7 +1654,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   useEffect(() => {
     if (!import.meta.env.DEV || !bundleUrl || !dynamicLoadingAllowed) return;
 
-    const cacheKey = `${bundleUrl}::${componentExport}`;
+    const cacheKey = bundleCacheKey(bundleUrl, componentExport, activeScope);
     let requestPath: string;
     try {
       requestPath = trustedBundleRequestPath(bundleUrl);
@@ -1580,7 +1683,7 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
     }, DEV_POLL_INTERVAL_MS);
 
     return () => clearInterval(id);
-  }, [bundleUrl, componentExport, dynamicLoadingAllowed]);
+  }, [activeScope, bundleUrl, componentExport, dynamicLoadingAllowed]);
 
   // Recover from a load failure or render crash: evict the cached module so the
   // next import re-fetches a fresh copy, clear the latched error, and bump
@@ -1589,10 +1692,12 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   // crashed at render is genuinely retried, not stuck behind a latched boundary.
   const recoverView = useCallback(() => {
     if (!bundleUrl) return;
-    invalidateBundleModule(`${bundleUrl}::${componentExport}`);
+    invalidateBundleModule(
+      bundleCacheKey(bundleUrl, componentExport, activeScope),
+    );
     setLoadError(null);
     setReloadKey((k) => k + 1);
-  }, [bundleUrl, componentExport]);
+  }, [activeScope, bundleUrl, componentExport]);
 
   // iOS App Store and Google Play builds cannot load remote JS or HTML frame
   // documents at runtime; both execute plugin-provided code.

--- a/packages/ui/src/events/connect-request.test.ts
+++ b/packages/ui/src/events/connect-request.test.ts
@@ -1,59 +1,140 @@
-/** Verifies connect request handoff through the package's configured test harness. */
+/** Exercises real DOM connection handoff, owner completion, and serialized singleton adoption. */
 // @vitest-environment jsdom
 
-/**
- * Connection-event handoff coverage for native deep links that can arrive
- * before React mounts a startup or live-shell consumer.
- */
-
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { dispatchConnectRequest, listenForConnectRequests } from "./index";
+import {
+  CONNECT_EVENT,
+  type ConnectRequestResult,
+  dispatchConnectRequest,
+  listenForConnectRequests,
+} from "./index";
 
 const cleanups: Array<() => void> = [];
+const connected = (): ConnectRequestResult => ({ status: "connected" });
+function deferred() {
+  let resolve!: (result: ConnectRequestResult) => void;
+  const promise = new Promise<ConnectRequestResult>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
 
 afterEach(() => {
   for (const cleanup of cleanups.splice(0)) cleanup();
 });
 
 describe("connect request handoff", () => {
-  it("replays a request dispatched before the consumer mounts", async () => {
-    const listener = vi.fn();
-
-    dispatchConnectRequest({
+  it("replays before mount and resolves only after the real owner completes", async () => {
+    const completion = deferred();
+    const listener = vi.fn(() => completion.promise);
+    const result = dispatchConnectRequest({
       gatewayUrl: "http://127.0.0.1:31337",
       completeFirstRun: true,
     });
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+    });
     cleanups.push(listenForConnectRequests(listener));
     await Promise.resolve();
-
     expect(listener).toHaveBeenCalledOnce();
-    expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({
-        gatewayUrl: "http://127.0.0.1:31337",
-        completeFirstRun: true,
+    expect(listener.mock.calls[0]).toEqual([
+      { gatewayUrl: "http://127.0.0.1:31337", completeFirstRun: true },
+    ]);
+    expect(settled).toBe(false);
+    completion.resolve(connected());
+    await expect(result).resolves.toEqual(connected());
+  });
+
+  it("lets only one startup/shell owner claim a request", async () => {
+    const startup = vi.fn(connected);
+    const shell = vi.fn(connected);
+    cleanups.push(
+      listenForConnectRequests(startup),
+      listenForConnectRequests(shell),
+    );
+    await expect(
+      dispatchConnectRequest({ gatewayUrl: "https://agent.example.com" }),
+    ).resolves.toEqual(connected());
+    expect(startup).toHaveBeenCalledOnce();
+    expect(shell).not.toHaveBeenCalled();
+  });
+
+  it("serializes A then latest C, settles replaced B, and survives owner remount", async () => {
+    const a = deferred();
+    const calls: string[] = [];
+    const stopStartup = listenForConnectRequests((detail) => {
+      calls.push(detail.gatewayUrl);
+      return a.promise;
+    });
+    cleanups.push(stopStartup);
+    const resultA = dispatchConnectRequest({ gatewayUrl: "https://a.example" });
+    const resultB = dispatchConnectRequest({ gatewayUrl: "https://b.example" });
+    const resultC = dispatchConnectRequest({ gatewayUrl: "https://c.example" });
+    await expect(resultB).resolves.toEqual({ status: "superseded" });
+    expect(calls).toEqual(["https://a.example"]);
+    stopStartup();
+    a.resolve({ status: "failed", message: "A is paused" });
+    await expect(resultA).resolves.toEqual({
+      status: "failed",
+      message: "A is paused",
+    });
+    await Promise.resolve();
+    expect(calls).toEqual(["https://a.example"]);
+    cleanups.push(
+      listenForConnectRequests((detail) => {
+        calls.push(detail.gatewayUrl);
+        return connected();
       }),
     );
+    const duplicateOwner = vi.fn(connected);
+    cleanups.push(listenForConnectRequests(duplicateOwner));
+    await expect(resultC).resolves.toEqual(connected());
+    expect(calls).toEqual(["https://a.example", "https://c.example"]);
+    expect(duplicateOwner).not.toHaveBeenCalled();
   });
 
-  it("lets only one startup/shell consumer claim a queued request", async () => {
-    const startupListener = vi.fn();
-    const shellListener = vi.fn();
+  it.each(["sync", "async", "cancel", "unconfirmed"] as const)(
+    "releases the active slot after %s owner outcome",
+    async (mode) => {
+      let calls = 0;
+      cleanups.push(
+        listenForConnectRequests(() => {
+          calls++;
+          if (calls > 1) return connected();
+          if (mode === "sync") throw new Error("Host unavailable");
+          if (mode === "async")
+            return Promise.reject(new Error("Host unavailable"));
+          if (mode === "cancel") return { status: "cancelled" };
+          return undefined;
+        }),
+      );
+      const first = dispatchConnectRequest({ gatewayUrl: "https://a.example" });
+      const second = dispatchConnectRequest({
+        gatewayUrl: "https://b.example",
+      });
+      expect((await first).status).toBe(
+        mode === "cancel" ? "cancelled" : "failed",
+      );
+      await expect(second).resolves.toEqual(connected());
+      expect(calls).toBe(2);
+    },
+  );
 
-    dispatchConnectRequest({ gatewayUrl: "http://127.0.0.1:31337" });
-    cleanups.push(listenForConnectRequests(startupListener));
-    cleanups.push(listenForConnectRequests(shellListener));
-    await Promise.resolve();
-
-    expect(startupListener).toHaveBeenCalledOnce();
-    expect(shellListener).not.toHaveBeenCalled();
-  });
-
-  it("delivers requests immediately after a consumer mounts", () => {
-    const listener = vi.fn();
+  it("deduplicates a legacy DOM request while retaining a following dispatch", async () => {
+    const completion = deferred();
+    const listener = vi
+      .fn()
+      .mockReturnValueOnce(completion.promise)
+      .mockImplementation(connected);
     cleanups.push(listenForConnectRequests(listener));
-
-    dispatchConnectRequest({ gatewayUrl: "https://agent.example.com" });
-
+    const detail = { gatewayUrl: "https://legacy.example" };
+    document.dispatchEvent(new CustomEvent(CONNECT_EVENT, { detail }));
+    document.dispatchEvent(new CustomEvent(CONNECT_EVENT, { detail }));
+    const next = dispatchConnectRequest({ gatewayUrl: "https://next.example" });
     expect(listener).toHaveBeenCalledOnce();
+    completion.resolve(connected());
+    await expect(next).resolves.toEqual(connected());
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -283,13 +283,11 @@ export type ConnectRequestResult =
   | { status: "superseded" }
   | { status: "failed"; message: string };
 
-type ConnectRequestListener = (
-  detail: ConnectRequestDetail,
-) =>
+type ConnectRequestListener = (detail: ConnectRequestDetail) =>
   | ConnectRequestResult
   | void
-  | Promise<ConnectRequestResult | undefined>
-  | Promise<void>;
+  // biome-ignore lint/suspicious/noConfusingVoidType: legacy async owners return void; absent completion is an explicit failed result.
+  | Promise<ConnectRequestResult | void>;
 
 type ConnectRequestState = {
   claimed: boolean;

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -395,7 +395,7 @@ export function listenForConnectRequests(
     };
     const failed = (error: unknown): void => {
       // error-policy:J1 event-owner failures become a typed completion result.
-      logger.warn("[connect-request] connection owner failed", { error });
+      logger.warn({ error }, "[connect-request] connection owner failed");
       complete({
         status: "failed",
         message:

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -277,44 +277,93 @@ export interface ConnectRequestDetail {
   skipConfirm?: boolean;
 }
 
+export type ConnectRequestResult =
+  | { status: "connected" }
+  | { status: "cancelled" }
+  | { status: "superseded" }
+  | { status: "failed"; message: string };
+
 type ConnectRequestListener = (
   detail: ConnectRequestDetail,
-) => void | Promise<void>;
+) =>
+  | ConnectRequestResult
+  | void
+  | Promise<ConnectRequestResult | undefined>
+  | Promise<void>;
 
-const connectRequestClaims = new WeakMap<object, () => boolean>();
+type ConnectRequestState = {
+  claimed: boolean;
+  settled: boolean;
+  result: Promise<ConnectRequestResult>;
+  complete: (result: ConnectRequestResult) => void;
+};
+
+const connectRequestStates = new WeakMap<object, ConnectRequestState>();
 let pendingConnectRequest: ConnectRequestDetail | null = null;
+let activeConnectRequest: ConnectRequestDetail | null = null;
+
+function connectRequestState(
+  request: ConnectRequestDetail,
+): ConnectRequestState {
+  const existing = connectRequestStates.get(request);
+  if (existing) return existing;
+  let resolve!: (outcome: ConnectRequestResult) => void;
+  const promise = new Promise<ConnectRequestResult>((complete) => {
+    resolve = complete;
+  });
+  const state: ConnectRequestState = {
+    claimed: false,
+    settled: false,
+    result: promise,
+    complete(outcome) {
+      if (state.settled) return;
+      state.settled = true;
+      resolve(outcome);
+    },
+  };
+  connectRequestStates.set(request, state);
+  return state;
+}
 
 function emitConnectRequest(detail: ConnectRequestDetail): void {
   document.dispatchEvent(new CustomEvent(CONNECT_EVENT, { detail }));
 }
 
-/**
- * Dispatches a connection request without losing native deep links that arrive
- * while React is replacing the startup screen with the live shell. The latest
- * unclaimed request is replayed when a consumer mounts; a synchronous claim
- * guarantees that the startup and shell listeners cannot both adopt it.
- */
-export function dispatchConnectRequest(detail: ConnectRequestDetail): void {
-  let claimed = false;
-  const request: ConnectRequestDetail = {
-    ...detail,
-  };
-  connectRequestClaims.set(request, () => {
-    if (claimed) return false;
-    claimed = true;
-    if (pendingConnectRequest === request) {
-      pendingConnectRequest = null;
-    }
-    return true;
-  });
+function queueConnectRequest(request: ConnectRequestDetail): void {
+  if (pendingConnectRequest && pendingConnectRequest !== request) {
+    connectRequestState(pendingConnectRequest).complete({
+      status: "superseded",
+    });
+  }
   pendingConnectRequest = request;
-  emitConnectRequest(request);
+}
+
+function replayPendingConnectRequest(): void {
+  if (!activeConnectRequest && pendingConnectRequest) {
+    emitConnectRequest(pendingConnectRequest);
+  }
 }
 
 /**
- * Subscribes to connection requests and immediately replays one that arrived
- * before this listener mounted. Legacy CustomEvents outside this helper remain
- * supported for browser tests and third-party in-app producers.
+ * Retains native requests across startup/shell remounts and serializes adoption
+ * against the singleton client. The latest unclaimed request replaces an older
+ * pending request. Results always resolve, so legacy fire-and-forget callers
+ * remain safe while forms can wait for actual owner completion.
+ */
+export function dispatchConnectRequest(
+  detail: ConnectRequestDetail,
+): Promise<ConnectRequestResult> {
+  const request = { ...detail };
+  const state = connectRequestState(request);
+  queueConnectRequest(request);
+  emitConnectRequest(request);
+  return state.result;
+}
+
+/**
+ * Claims one request for the mounted startup or live-shell owner. An active
+ * adoption finishes before another owner can repoint the singleton client.
+ * Legacy CustomEvents use the same claim and pending-request queue.
  */
 export function listenForConnectRequests(
   listener: ConnectRequestListener,
@@ -329,19 +378,51 @@ export function listenForConnectRequests(
     ) {
       return;
     }
-
     const request = detail as ConnectRequestDetail;
-    const claim = connectRequestClaims.get(request);
-    if (claim && !claim()) return;
-    void listener(request);
+    const state = connectRequestState(request);
+    if (state.claimed || state.settled) return;
+    if (activeConnectRequest) {
+      queueConnectRequest(request);
+      return;
+    }
+    state.claimed = true;
+    activeConnectRequest = request;
+    if (pendingConnectRequest === request) pendingConnectRequest = null;
+    const complete = (outcome: ConnectRequestResult): void => {
+      state.complete(outcome);
+      activeConnectRequest = null;
+      queueMicrotask(replayPendingConnectRequest);
+    };
+    const failed = (error: unknown): void => {
+      // error-policy:J1 event-owner failures become a typed completion result.
+      logger.warn("[connect-request] connection owner failed", { error });
+      complete({
+        status: "failed",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Failed to connect remote backend.",
+      });
+    };
+    try {
+      const result = listener(request);
+      void Promise.resolve(result).then((outcome) => {
+        complete(
+          outcome ?? {
+            status: "failed",
+            message:
+              "The connection handler did not confirm completion. Try connecting again.",
+          },
+        );
+      }, failed);
+    } catch (error) {
+      // error-policy:J1 synchronous owner failures release the same active slot.
+      failed(error);
+    }
   };
 
   document.addEventListener(CONNECT_EVENT, handle);
-  queueMicrotask(() => {
-    if (pendingConnectRequest) {
-      emitConnectRequest(pendingConnectRequest);
-    }
-  });
+  queueMicrotask(replayPendingConnectRequest);
   return () => document.removeEventListener(CONNECT_EVENT, handle);
 }
 

--- a/packages/ui/src/first-run/adopt-remote-first-run.test.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.test.ts
@@ -56,6 +56,7 @@ function makeClient(overrides: Partial<RemoteFirstRunClient> = {}): {
   const updateConfig = vi.fn(async () => ({}));
   const client: RemoteFirstRunClient = {
     getFirstRunStatus,
+    getStatus: async () => ({ state: "running", canRespond: true }),
     updateConfig,
     ...overrides,
   };
@@ -63,6 +64,32 @@ function makeClient(overrides: Partial<RemoteFirstRunClient> = {}): {
 }
 
 describe("adoptRemoteAgentFirstRun", () => {
+  it.each([
+    { state: "stopped", canRespond: false },
+    { state: "starting", canRespond: false },
+    { state: "running", canRespond: false },
+    { state: "running" },
+  ])("leaves an unready host in setup (%j)", async (status) => {
+    const { client, updateConfig } = makeClient({
+      getStatus: async () => status,
+    });
+    const complete = vi.fn();
+    const release = vi.fn();
+    setPendingFirstRunTextReleaseHandler(release);
+    await expect(
+      completeRemoteAgentFirstRun(
+        client,
+        {
+          apiBase: "https://agent.example.com",
+        },
+        complete,
+      ),
+    ).rejects.toMatchObject({ code: "REMOTE_ADOPTION_HOST_NOT_READY" });
+    expect(updateConfig).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
+  });
+
   it("confirms remote completion after writing only the completion marker", async () => {
     const { client, updateConfig, getFirstRunStatus } = makeClient();
     const result = await adoptRemoteAgentFirstRun(client, {

--- a/packages/ui/src/first-run/adopt-remote-first-run.test.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.test.ts
@@ -48,41 +48,37 @@ describe("normalizeRemoteAgentUrl", () => {
 function makeClient(overrides: Partial<RemoteFirstRunClient> = {}): {
   client: RemoteFirstRunClient;
   getFirstRunStatus: ReturnType<typeof vi.fn>;
-  submitFirstRun: ReturnType<typeof vi.fn>;
+  updateConfig: ReturnType<typeof vi.fn>;
 } {
-  const getFirstRunStatus = vi.fn(async () => ({ complete: false }));
-  const submitFirstRun = vi.fn(async () => undefined);
+  const getFirstRunStatus = vi
+    .fn(async () => ({ complete: true }))
+    .mockResolvedValueOnce({ complete: false });
+  const updateConfig = vi.fn(async () => ({}));
   const client: RemoteFirstRunClient = {
     getFirstRunStatus,
-    submitFirstRun,
+    updateConfig,
     ...overrides,
   };
-  return { client, getFirstRunStatus, submitFirstRun };
+  return { client, getFirstRunStatus, updateConfig };
 }
 
 describe("adoptRemoteAgentFirstRun", () => {
-  it("adopts a fresh remote: probes then POSTs the remote deployment target", async () => {
-    const { client, submitFirstRun } = makeClient({
-      getFirstRunStatus: vi.fn(async () => ({ complete: false })),
-    });
-
+  it("confirms remote completion after writing only the completion marker", async () => {
+    const { client, updateConfig, getFirstRunStatus } = makeClient();
     const result = await adoptRemoteAgentFirstRun(client, {
-      apiBase: "http://127.0.0.1:31337",
+      apiBase: "https://agent.example.com",
+      token: "synthetic-device-token",
+      uiLanguage: "en",
     });
-
     expect(result).toEqual({ alreadyComplete: false });
-    expect(submitFirstRun).toHaveBeenCalledTimes(1);
-    const payload = submitFirstRun.mock.calls[0][0] as {
-      deploymentTarget?: { runtime?: string; remoteApiBase?: string };
-    };
-    expect(payload.deploymentTarget?.runtime).toBe("remote");
-    expect(payload.deploymentTarget?.remoteApiBase).toBe(
-      "http://127.0.0.1:31337",
-    );
+    expect(updateConfig).toHaveBeenCalledWith({
+      meta: { firstRunComplete: true },
+    });
+    expect(getFirstRunStatus).toHaveBeenCalledTimes(2);
   });
 
   it("does NOT clobber a host that already finished first-run", async () => {
-    const { client, submitFirstRun } = makeClient({
+    const { client, updateConfig } = makeClient({
       getFirstRunStatus: vi.fn(async () => ({ complete: true })),
     });
 
@@ -91,7 +87,7 @@ describe("adoptRemoteAgentFirstRun", () => {
     });
 
     expect(result).toEqual({ alreadyComplete: true });
-    expect(submitFirstRun).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
   });
 
   it("preserves the host and pending intent when its status cannot be read", async () => {
@@ -99,7 +95,7 @@ describe("adoptRemoteAgentFirstRun", () => {
     const release = vi.fn();
     setPendingFirstRunTextReleaseHandler(release);
     const failure = new Error("network down");
-    const { client, submitFirstRun } = makeClient({
+    const { client, updateConfig } = makeClient({
       getFirstRunStatus: vi.fn(async () => {
         throw failure;
       }),
@@ -112,7 +108,7 @@ describe("adoptRemoteAgentFirstRun", () => {
         complete,
       ),
     ).rejects.toBe(failure);
-    expect(submitFirstRun).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
     expect(complete).not.toHaveBeenCalled();
     expect(release).not.toHaveBeenCalled();
   });
@@ -120,7 +116,7 @@ describe("adoptRemoteAgentFirstRun", () => {
   it("propagates a completion-write failure instead of faking success", async () => {
     const { client } = makeClient({
       getFirstRunStatus: vi.fn(async () => ({ complete: false })),
-      submitFirstRun: vi.fn(async () => {
+      updateConfig: vi.fn(async () => {
         throw new Error("remote unreachable");
       }),
     });
@@ -130,18 +126,24 @@ describe("adoptRemoteAgentFirstRun", () => {
     ).rejects.toThrow(/remote unreachable/);
   });
 
-  it("forwards an access token in the submitted plan", async () => {
-    const { client, submitFirstRun } = makeClient();
-
-    await adoptRemoteAgentFirstRun(client, {
-      apiBase: "https://agent.example.com",
-      token: "secret-key",
+  it("does not complete or release if a host ignores the completion marker", async () => {
+    const { client } = makeClient({
+      getFirstRunStatus: vi.fn(async () => ({ complete: false })),
     });
-
-    const payload = submitFirstRun.mock.calls[0][0] as {
-      deploymentTarget?: { remoteAccessToken?: string };
-    };
-    expect(payload.deploymentTarget?.remoteAccessToken).toBe("secret-key");
+    const complete = vi.fn();
+    const release = vi.fn();
+    setPendingFirstRunTextReleaseHandler(release);
+    await expect(
+      completeRemoteAgentFirstRun(
+        client,
+        {
+          apiBase: "https://agent.example.com",
+        },
+        complete,
+      ),
+    ).rejects.toMatchObject({ code: "REMOTE_ADOPTION_NOT_CONFIRMED" });
+    expect(complete).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
   });
 });
 
@@ -149,7 +151,10 @@ describe("completeRemoteAgentFirstRun", () => {
   it("releases typed onboarding intent only after successful remote adoption", async () => {
     const order: string[] = [];
     const { client } = makeClient({
-      submitFirstRun: vi.fn(async () => void order.push("adopt")),
+      updateConfig: vi.fn(async () => {
+        order.push("adopt");
+        return {};
+      }),
     });
     setPendingFirstRunTextReleaseHandler(() => void order.push("release"));
 
@@ -166,7 +171,7 @@ describe("completeRemoteAgentFirstRun", () => {
     const complete = vi.fn();
     const release = vi.fn();
     const { client } = makeClient({
-      submitFirstRun: vi.fn(async () => {
+      updateConfig: vi.fn(async () => {
         throw new Error("remote unreachable");
       }),
     });

--- a/packages/ui/src/first-run/adopt-remote-first-run.test.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.test.ts
@@ -94,18 +94,27 @@ describe("adoptRemoteAgentFirstRun", () => {
     expect(submitFirstRun).not.toHaveBeenCalled();
   });
 
-  it("treats an unreachable status probe as 'needs adoption' and still POSTs", async () => {
+  it("preserves the host and pending intent when its status cannot be read", async () => {
+    const complete = vi.fn();
+    const release = vi.fn();
+    setPendingFirstRunTextReleaseHandler(release);
+    const failure = new Error("network down");
     const { client, submitFirstRun } = makeClient({
       getFirstRunStatus: vi.fn(async () => {
-        throw new Error("network down");
+        throw failure;
       }),
     });
 
-    await adoptRemoteAgentFirstRun(client, {
-      apiBase: "http://127.0.0.1:31337",
-    });
-
-    expect(submitFirstRun).toHaveBeenCalledTimes(1);
+    await expect(
+      completeRemoteAgentFirstRun(
+        client,
+        { apiBase: "http://127.0.0.1:31337" },
+        complete,
+      ),
+    ).rejects.toBe(failure);
+    expect(submitFirstRun).not.toHaveBeenCalled();
+    expect(complete).not.toHaveBeenCalled();
+    expect(release).not.toHaveBeenCalled();
   });
 
   it("propagates a completion-write failure instead of faking success", async () => {

--- a/packages/ui/src/first-run/adopt-remote-first-run.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.ts
@@ -43,6 +43,7 @@ export function normalizeRemoteAgentUrl(value: string): string {
 /** The minimal client surface this use case needs (a subset of `ElizaClient`). */
 export interface RemoteFirstRunClient {
   getFirstRunStatus(): Promise<{ complete: boolean }>;
+  getStatus(): Promise<{ state: string; canRespond?: boolean }>;
   updateConfig(
     patch: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
@@ -78,6 +79,17 @@ export async function adoptRemoteAgentFirstRun(
 
   if (alreadyComplete) {
     return { alreadyComplete: true };
+  }
+
+  const status = await client.getStatus();
+  if (status.state !== "running" || status.canRespond !== true) {
+    throw new ElizaError(
+      "Start and configure the remote agent on its host before connecting, then try again.",
+      {
+        code: "REMOTE_ADOPTION_HOST_NOT_READY",
+        context: { state: status.state, canRespond: status.canRespond },
+      },
+    );
   }
 
   await client.updateConfig({ meta: { firstRunComplete: true } });

--- a/packages/ui/src/first-run/adopt-remote-first-run.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.ts
@@ -1,22 +1,9 @@
 /**
- * Headless "adopt a remote agent during first-run" use case.
- *
- * Device + desktop remote-connect-at-URL onboarding (deep link and the Settings
- * "Connect a remote agent" entry) funnels through here AFTER the client base has
- * been pointed at the remote (`applyLaunchConnection({ kind: "remote" })`). It
- * makes the connected remote the device's completed first-run target so the
- * startup poll lands on home instead of re-showing onboarding on the next launch.
- *
- * This is the headless equivalent of the legacy `finishRemote` step that used to
- * live in the full-screen onboarding controller, with one deliberate
- * improvement: it PROBES the remote's first-run status first and only writes
- * when the host has not finished its own first-run. Connecting to an
- * already-configured host therefore adopts it as-is instead of clobbering its
- * deployment target — the destructive overwrite the unconditional legacy POST
- * could cause.
- *
- * It is intentionally dependency-injected (the client surface is the only
- * dependency) so it can be unit-tested without the React shell or a live server.
+ * Coordinates device first-run completion after its client connects to a remote
+ * agent. Deep links and the Settings connection flow share this use case.
+ * A successful status probe gates setup writes; transport or authorization
+ * failures must preserve both host state and pending local onboarding intent.
+ * Completed hosts are adopted without another setup write.
  */
 
 import type { UiLanguage } from "../i18n";
@@ -76,23 +63,14 @@ export interface AdoptRemoteAgentFirstRunResult {
  * target. Returns whether the remote was already complete (so callers can skip
  * a redundant "configured" notice).
  *
- * Throws if the remote cannot be reached for the completion write — surfacing a
- * real connection failure rather than silently landing the user on a dead shell.
+ * Status and completion-write failures propagate to the connection UI before
+ * local completion or pending text release.
  */
 export async function adoptRemoteAgentFirstRun(
   client: RemoteFirstRunClient,
   input: AdoptRemoteAgentFirstRunInput,
 ): Promise<AdoptRemoteAgentFirstRunResult> {
-  let alreadyComplete = false;
-  try {
-    alreadyComplete = (await client.getFirstRunStatus()).complete === true;
-  } catch {
-    // error-policy:J4 a fresh host with no persisted first-run state, or one
-    // whose build predates the status route, is the expected "needs adoption"
-    // shape — fall through to the completion write below. A genuinely
-    // unreachable remote re-fails there, so the failure still surfaces.
-    alreadyComplete = false;
-  }
+  const alreadyComplete = (await client.getFirstRunStatus()).complete === true;
 
   if (alreadyComplete) {
     return { alreadyComplete: true };

--- a/packages/ui/src/first-run/adopt-remote-first-run.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.ts
@@ -14,16 +14,18 @@ import { releasePendingFirstRunText } from "./first-run-pending-text";
 
 /**
  * Normalizes a user- or link-supplied remote agent address into a canonical
- * `http(s)://host[:port]` URL, throwing a friendly message on anything invalid.
- * A bare `host:port` is upgraded to `https://`. Trailing slashes, query, and
- * hash are stripped so the same host always yields one identity.
+ * HTTP(S) base URL, preserving deployment path prefixes. A bare `host:port`
+ * is upgraded to HTTPS. Credentials belong in the separate token field;
+ * trailing slashes, query, and hash are removed from the connection identity.
  */
 export function normalizeRemoteAgentUrl(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error("Enter a remote agent URL.");
-  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)
-    ? trimmed
-    : `https://${trimmed}`;
+  const bareHostPort = /^[^\s:/?#]+:\d+(?:[/?#]|$)/.test(trimmed);
+  const candidate =
+    !bareHostPort && /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)
+      ? trimmed
+      : `https://${trimmed}`;
   let parsed: URL;
   try {
     parsed = new URL(candidate);
@@ -33,6 +35,11 @@ export function normalizeRemoteAgentUrl(value: string): string {
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error("Remote agents must use HTTP or HTTPS.");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error(
+      "Use the access token field instead of credentials in the remote URL.",
+    );
   }
   parsed.pathname = parsed.pathname.replace(/\/+$/, "");
   parsed.search = "";

--- a/packages/ui/src/first-run/adopt-remote-first-run.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.ts
@@ -3,11 +3,13 @@
  * agent. Deep links and the Settings connection flow share this use case.
  * A successful status probe gates setup writes; transport or authorization
  * failures must preserve both host state and pending local onboarding intent.
- * Completed hosts are adopted without another setup write.
+ * Completed hosts are adopted without another write. Incomplete hosts receive
+ * only a completion marker through the config patch API, preserving their
+ * runtime, account, and character configuration.
  */
 
+import { ElizaError } from "@elizaos/core";
 import type { UiLanguage } from "../i18n";
-import { buildFirstRunSubmitPlan } from "./first-run";
 import { releasePendingFirstRunText } from "./first-run-pending-text";
 
 /**
@@ -41,15 +43,17 @@ export function normalizeRemoteAgentUrl(value: string): string {
 /** The minimal client surface this use case needs (a subset of `ElizaClient`). */
 export interface RemoteFirstRunClient {
   getFirstRunStatus(): Promise<{ complete: boolean }>;
-  submitFirstRun(data: Record<string, unknown>): Promise<void>;
+  updateConfig(
+    patch: Record<string, unknown>,
+  ): Promise<Record<string, unknown>>;
 }
 
 export interface AdoptRemoteAgentFirstRunInput {
   /** The remote agent URL — already normalized/applied by the caller. */
   apiBase: string;
-  /** Optional pre-shared access token for a pairing-disabled remote. */
+  /** Already applied to the client transport; never written into host config. */
   token?: string | null;
-  /** Drives the default character preset language; defaults to English. */
+  /** Retained for callers; adoption preserves the host's character language. */
   uiLanguage?: UiLanguage;
 }
 
@@ -76,18 +80,16 @@ export async function adoptRemoteAgentFirstRun(
     return { alreadyComplete: true };
   }
 
-  const plan = buildFirstRunSubmitPlan({
-    draft: {
-      agentName: "",
-      runtime: "remote",
-      localInference: "all-local",
-      remoteApiBase: input.apiBase,
-      remoteToken: input.token ?? "",
-    },
-    uiLanguage: input.uiLanguage ?? "en",
-  });
-
-  await client.submitFirstRun(plan.payload);
+  await client.updateConfig({ meta: { firstRunComplete: true } });
+  if ((await client.getFirstRunStatus()).complete !== true) {
+    throw new ElizaError(
+      "The remote agent did not confirm setup completion. Finish setup on the host, then reconnect.",
+      {
+        code: "REMOTE_ADOPTION_NOT_CONFIRMED",
+        context: { apiBase: input.apiBase },
+      },
+    );
+  }
   return { alreadyComplete: false };
 }
 

--- a/packages/ui/src/first-run/first-run-pending-text.test.ts
+++ b/packages/ui/src/first-run/first-run-pending-text.test.ts
@@ -4,11 +4,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CHAT_PREFILL_EVENT, type ChatPrefillEventDetail } from "../events";
 import {
   __TEST_ONLY__,
   clearPendingFirstRunText,
+  handoffPendingFirstRunText,
   readPendingFirstRunText,
+  registerPendingFirstRunTextConsumer,
   releasePendingFirstRunText,
   setPendingFirstRunTextReleaseHandler,
   takePendingFirstRunText,
@@ -36,6 +37,7 @@ describe("pending first-run text", () => {
   beforeEach(() => stubLocalStorage());
   afterEach(() => {
     setPendingFirstRunTextReleaseHandler(null);
+    clearPendingFirstRunText();
     Object.defineProperty(globalThis, "window", {
       configurable: true,
       value: undefined,
@@ -76,23 +78,43 @@ describe("pending first-run text", () => {
     expect(readPendingFirstRunText()).toEqual([]);
   });
 
-  it("releases the durable requests to the composer exactly once", async () => {
-    const prefill = vi.fn<(event: Event) => void>();
-    window.addEventListener(CHAT_PREFILL_EVENT, prefill);
-    writePendingFirstRunText(["first request", "second\nline"]);
-
+  it("retains requests across absent and unmounted consumers until acknowledgement", () => {
+    const requests = ["first request", "second\nline"];
+    writePendingFirstRunText(requests);
     releasePendingFirstRunText();
-    await Promise.resolve();
+    expect(readPendingFirstRunText()).toEqual(requests);
+    const delivered: string[] = [];
+    const unregister = registerPendingFirstRunTextConsumer((text) =>
+      delivered.push(text),
+    );
+    expect(delivered).toEqual([requests.join("\n\n")]);
+    expect(readPendingFirstRunText()).toEqual(requests);
+    unregister();
+    const unregisterNext = registerPendingFirstRunTextConsumer(
+      (text, acknowledge) => {
+        delivered.push(text);
+        acknowledge();
+      },
+    );
+    expect(delivered).toEqual([requests.join("\n\n"), requests.join("\n\n")]);
+    expect(readPendingFirstRunText()).toEqual([]);
     releasePendingFirstRunText();
-    await Promise.resolve();
+    expect(delivered).toHaveLength(2);
+    unregisterNext();
+  });
 
-    expect(prefill).toHaveBeenCalledTimes(1);
-    expect(
-      (prefill.mock.calls[0][0] as CustomEvent<ChatPrefillEventDetail>).detail,
-    ).toEqual({
-      text: "first request\n\nsecond\nline",
-      select: true,
-    });
+  it("does not let an older acknowledgement clear a newer complete batch", () => {
+    const acknowledgements: Array<() => void> = [];
+    const unregister = registerPendingFirstRunTextConsumer(
+      (_text, acknowledge) => acknowledgements.push(acknowledge),
+    );
+    handoffPendingFirstRunText(["first"]);
+    handoffPendingFirstRunText(["first", "second"]);
+    acknowledgements[0]();
+    expect(readPendingFirstRunText()).toEqual(["first", "second"]);
+    acknowledgements[1]();
+    expect(readPendingFirstRunText()).toEqual([]);
+    unregister();
   });
 
   it("prefers the active conductor's lossless in-memory release seam", () => {

--- a/packages/ui/src/first-run/first-run-pending-text.ts
+++ b/packages/ui/src/first-run/first-run-pending-text.ts
@@ -4,12 +4,45 @@
  * removed atomically when the composer consumes it.
  */
 
-import { dispatchChatPrefill } from "../events";
 import { shellLocalStorage } from "../surface-realm-channel";
 
 const PENDING_FIRST_RUN_TEXT_STORAGE_KEY = "eliza:first-run:pending-text";
 type PendingFirstRunTextReleaseHandler = () => void;
 let releaseHandler: PendingFirstRunTextReleaseHandler | null = null;
+type PendingTextConsumer = (text: string, acknowledge: () => void) => void;
+let consumer: PendingTextConsumer | null = null;
+let releasedRequests: readonly string[] | null = null;
+
+function deliverPendingRequests(): void {
+  if (!consumer) return;
+  const requests = releasedRequests ?? readPendingFirstRunText();
+  if (requests.length === 0) return;
+  releasedRequests = requests;
+  consumer(requests.join("\n\n"), () => {
+    // An older render must not acknowledge a newer producer's request batch.
+    if (releasedRequests !== requests) return;
+    clearPendingFirstRunText();
+  });
+}
+
+/** Retain the authoritative in-memory batch until a mounted composer commits it. */
+export function handoffPendingFirstRunText(requests: readonly string[]): void {
+  if (requests.length === 0) return;
+  releasedRequests = [...requests];
+  writePendingFirstRunText(requests);
+  deliverPendingRequests();
+}
+
+/** Register only after setup completes; remounts retry an unacknowledged batch. */
+export function registerPendingFirstRunTextConsumer(
+  next: PendingTextConsumer,
+): () => void {
+  consumer = next;
+  deliverPendingRequests();
+  return () => {
+    if (consumer === next) consumer = null;
+  };
+}
 
 function parsePendingText(raw: string | null): string[] {
   if (!raw) return [];
@@ -82,13 +115,11 @@ export function releasePendingFirstRunText(): void {
     releaseHandler();
     return;
   }
-  const pending = takePendingFirstRunText();
-  if (pending.length === 0) return;
-  const text = pending.join("\n\n");
-  queueMicrotask(() => dispatchChatPrefill({ text, select: true }));
+  handoffPendingFirstRunText(releasedRequests ?? readPendingFirstRunText());
 }
 
 export function clearPendingFirstRunText(): void {
+  releasedRequests = null;
   if (typeof window === "undefined") return;
   try {
     shellLocalStorage.removeItem(PENDING_FIRST_RUN_TEXT_STORAGE_KEY);

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -156,7 +156,7 @@ vi.mock("../state/cloud-login-launch", async (importOriginal) => {
 import type { ConversationMessage, LocalAgentBackupMetadata } from "../api";
 import { DEFAULT_BRANDING } from "../config/branding-base";
 import { BrandingContext } from "../config/branding-react.hooks";
-import { APP_RESUME_EVENT, CHAT_PREFILL_EVENT } from "../events";
+import { APP_RESUME_EVENT } from "../events";
 import { __setAppValueForTests } from "../state/app-store";
 import {
   ConversationMessagesCtx,

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -14,6 +14,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FIRST_RUN_SIGN_IN_PROMPT } from "./first-run-greeting";
+import { registerPendingFirstRunTextConsumer } from "./first-run-pending-text";
 
 const mocks = vi.hoisted(() => ({
   openDesktopSettingsWindow: vi.fn(async () => undefined),
@@ -912,7 +913,12 @@ describe("useFirstRunConductor", () => {
     first.unmount();
     localStorage.setItem("steward_session_token", "cloud-token");
     const prefill = vi.fn();
-    window.addEventListener(CHAT_PREFILL_EVENT, prefill);
+    const unregisterPrefill = registerPendingFirstRunTextConsumer(
+      (text, acknowledge) => {
+        prefill({ detail: { text, select: true } });
+        acknowledge();
+      },
+    );
     const secondSpies = seedAppStore({ elizaCloudConnected: true });
     const second = renderConductor();
     try {
@@ -942,7 +948,7 @@ describe("useFirstRunConductor", () => {
       expect(prefill).toHaveBeenCalledTimes(1);
       third.unmount();
     } finally {
-      window.removeEventListener(CHAT_PREFILL_EVENT, prefill);
+      unregisterPrefill();
     }
   });
 
@@ -2516,7 +2522,12 @@ describe("useFirstRunConductor — free-text replies (#12178 composer unlock)", 
   it("restores every complete typed request to the real composer after setup", async () => {
     seedAppStore();
     const prefill = vi.fn();
-    window.addEventListener(CHAT_PREFILL_EVENT, prefill);
+    const unregisterPrefill = registerPendingFirstRunTextConsumer(
+      (text, acknowledge) => {
+        prefill({ detail: { text, select: true } });
+        acknowledge();
+      },
+    );
     const { turn, unmount } = renderConductor();
     try {
       await waitForTurn(turn, "first-run:greeting");
@@ -2549,7 +2560,7 @@ describe("useFirstRunConductor — free-text replies (#12178 composer unlock)", 
         ),
       );
     } finally {
-      window.removeEventListener(CHAT_PREFILL_EVENT, prefill);
+      unregisterPrefill();
       unmount();
     }
   });

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -80,7 +80,7 @@ import {
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import { getBootConfig } from "../config/boot-config";
 import { useBranding } from "../config/branding";
-import { APP_RESUME_EVENT, dispatchChatPrefill } from "../events";
+import { APP_RESUME_EVENT } from "../events";
 import {
   ACCENT_PRESETS,
   useAppSelector,
@@ -139,9 +139,9 @@ import {
   FIRST_RUN_SIGN_IN_PROMPT,
 } from "./first-run-greeting";
 import {
+  handoffPendingFirstRunText,
   readPendingFirstRunText,
   setPendingFirstRunTextReleaseHandler,
-  takePendingFirstRunText,
   writePendingFirstRunText,
 } from "./first-run-pending-text";
 import { isRuntimeChooserEnabled } from "./first-run-runtime-flag";
@@ -586,12 +586,11 @@ export function useFirstRunConductor(): void {
     // must not roll it back to an older durable prefix. On a cold mount the ref
     // was initialized from that same durable copy.
     const pending = pendingFirstRunTextRef.current;
-    const durable = takePendingFirstRunText();
+    const durable = readPendingFirstRunText();
     if (pending.length === 0 && durable.length > 0) pending.push(...durable);
     if (pending.length === 0) return;
     pendingFirstRunTextRef.current = [];
-    const text = pending.join("\n\n");
-    queueMicrotask(() => dispatchChatPrefill({ text, select: true }));
+    handoffPendingFirstRunText(pending);
   }, []);
   // Re-offered choice turns have the same collision risk: a user can reject
   // two unavailable options before the wall clock advances.

--- a/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
+++ b/packages/ui/src/hooks/useAuthStatus.prime.test.tsx
@@ -15,6 +15,7 @@ import {
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { authMe } from "../api/auth-client";
+import { client } from "../api/client";
 import { clearStaleStewardSession } from "../cloud/shell/StewardProviderShared";
 import { getBootConfig, setBootConfig } from "../config/boot-config-store";
 import {
@@ -27,6 +28,7 @@ import {
   __setAuthStatusForTests,
   isAuthenticatedNow,
   primeAuthStatusProbe,
+  revalidateAuthStatus,
   subscribeAuthStatus,
   useAuthStatus,
 } from "./useAuthStatus";
@@ -609,6 +611,209 @@ describe("primeAuthStatusProbe + activation reuse", () => {
       expect(result.current.state.phase).toBe("authenticated"),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards a late success without detaching the replacement probe", async () => {
+    client.setBaseUrl("https://first.example.test");
+    const first = Promise.withResolvers<Response>();
+    const second = Promise.withResolvers<Response>();
+    fetchMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    act(() => client.setBaseUrl("https://second.example.test"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await act(async () => first.resolve(jsonResponse(200, AUTH_ME_BODY)));
+    expect(result.current.state.phase).toBe("loading");
+    const joined = revalidateAuthStatus();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      second.resolve(
+        jsonResponse(401, {
+          reason: "remote_password_not_configured",
+          access: {
+            mode: "remote",
+            passwordConfigured: false,
+            ownerConfigured: true,
+          },
+        }),
+      );
+      await joined;
+    });
+    expect(result.current.state.phase).toBe("unauthenticated");
+  });
+
+  it("does not reuse a fresh startup prime from the previous server", async () => {
+    client.setBaseUrl("https://first.example.test");
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, AUTH_ME_BODY));
+    primeAuthStatusProbe();
+    await waitFor(() => expect(isAuthenticatedNow()).toBe(true));
+    client.setBaseUrl("https://second.example.test");
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, {
+        ...AUTH_ME_BODY,
+        identity: { ...AUTH_ME_BODY.identity, id: "second-owner" },
+      }),
+    );
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        phase: "authenticated",
+        identity: { id: "second-owner" },
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not continue an old rejection through the replacement server's pairing route", async () => {
+    client.setBaseUrl("https://first.example.test");
+    const first = Promise.withResolvers<Response>();
+    fetchMock
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValue(jsonResponse(200, { required: false }));
+    const pending = authMe();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    client.setBaseUrl("https://second.example.test");
+    client.setToken("second-token");
+    first.resolve(
+      jsonResponse(401, {
+        reason: "remote_auth_required",
+        access: {
+          mode: "remote",
+          passwordConfigured: true,
+          ownerConfigured: true,
+        },
+      }),
+    );
+    await pending;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getBootConfig().apiToken).toBe("second-token");
+  });
+
+  it("does not return the old identity when selection changes during body parsing", async () => {
+    client.setBaseUrl("https://first.example.test");
+    const body = Promise.withResolvers<typeof AUTH_ME_BODY>();
+    const response = jsonResponse(200, AUTH_ME_BODY);
+    const parse = vi.fn(() => body.promise);
+    response.json = parse;
+    fetchMock.mockResolvedValueOnce(response);
+    const pending = authMe();
+    await waitFor(() => expect(parse).toHaveBeenCalledOnce());
+    client.setBaseUrl("https://second.example.test");
+    body.resolve(AUTH_ME_BODY);
+    expect(await pending).toMatchObject({ ok: false });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clear a replacement Cloud binding after a stale refresh rejection", async () => {
+    const firstBase = "https://api.eliza.app/api/v1/eliza/agents/shared-first";
+    const secondBase =
+      "https://api.eliza.app/api/v1/eliza/agents/shared-second";
+    client.setBaseUrl(firstBase);
+    client.setToken(null);
+    await writeStoredStewardToken(makeJwt(-3600));
+    savePersistedActiveServer({
+      id: "cloud:first",
+      kind: "cloud",
+      label: "First",
+      apiBase: firstBase,
+      accessToken: "first-agent-token",
+    });
+    const refresh = Promise.withResolvers<Response>();
+    fetchMock.mockReturnValueOnce(refresh.promise);
+    const pending = authMe();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    client.setBaseUrl(secondBase);
+    savePersistedActiveServer({
+      id: "cloud:second",
+      kind: "cloud",
+      label: "Second",
+      apiBase: secondBase,
+      accessToken: "second-agent-token",
+    });
+    refresh.resolve(jsonResponse(401, {}));
+    await pending;
+    expect(loadPersistedActiveServer()).toMatchObject({
+      id: "cloud:second",
+      apiBase: secondBase,
+    });
+    expect(getBootConfig().apiBase).toBe(secondBase);
+  });
+
+  it("revalidates a mounted gate against the newly selected server", async () => {
+    client.setBaseUrl("https://first.example.test");
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, AUTH_ME_BODY));
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("authenticated"),
+    );
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(401, {
+        reason: "remote_password_not_configured",
+        access: {
+          mode: "remote",
+          passwordConfigured: true,
+          ownerConfigured: true,
+        },
+      }),
+    );
+    act(() => client.setBaseUrl("https://second.example.test"));
+    expect(result.current.state.phase).toBe("loading");
+    await waitFor(() =>
+      expect(result.current.state.phase).toBe("unauthenticated"),
+    );
+    expect(String(fetchMock.mock.calls.at(-1)?.[0])).toBe(
+      "https://second.example.test/api/auth/me",
+    );
+  });
+
+  it("does not let the previous server's delayed rejection erase the new credential", async () => {
+    client.setBaseUrl("https://first.example.test");
+    client.setToken("first-token");
+    let rejectFirst!: (response: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          rejectFirst = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useAuthStatus({ pollIntervalMs: 0 }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, {
+        ...AUTH_ME_BODY,
+        identity: { ...AUTH_ME_BODY.identity, id: "second-owner" },
+      }),
+    );
+    act(() => {
+      client.setBaseUrl("https://second.example.test");
+      client.setToken("second-token");
+    });
+    await act(async () =>
+      rejectFirst(
+        jsonResponse(401, {
+          reason: "remote_password_not_configured",
+          access: {
+            mode: "remote",
+            passwordConfigured: true,
+            ownerConfigured: true,
+          },
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        phase: "authenticated",
+        identity: { id: "second-owner" },
+      }),
+    );
+    expect(getBootConfig().apiToken).toBe("second-token");
+    expect(
+      fetchMock.mock.calls.filter(([url]) =>
+        String(url).startsWith("https://first.example.test"),
+      ),
+    ).toHaveLength(1);
   });
 });
 

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -27,6 +27,7 @@ import {
   type AuthSessionInfo,
   authMe,
 } from "../api/auth-client";
+import { client } from "../api/client";
 import { getBootConfig, setBootConfig } from "../config/boot-config-store";
 import { scrubRejectedActiveServerCredential } from "../state/active-server-credential";
 import { scrubPersistedAgentProfileTokens } from "../state/agent-profiles";
@@ -90,6 +91,38 @@ let authStatusPrime: Promise<void> | null = null;
 let authStatusPrimeSettledAt = 0;
 let authStatusPrimeRetryAt = 0;
 let authStatusEpoch = 0;
+let authStatusAuthority = currentAuthAuthority();
+
+function currentAuthAuthority(): string {
+  const config = getBootConfig();
+  return `${config.apiBase ?? ""}\u0000${config.apiToken ?? ""}`;
+}
+
+function synchronizeAuthAuthority(): void {
+  const authority = currentAuthAuthority();
+  if (authority === authStatusAuthority) return;
+  const previousBase = authStatusAuthority.split("\u0000", 1)[0];
+  authStatusAuthority = authority;
+  authStatusEpoch += 1;
+  authStatusFetch = null;
+  authStatusPrime = null;
+  authStatusPrimeSettledAt = 0;
+  authStatusPrimeRetryAt = 0;
+  if (
+    isManagedCloudSharedAgentBase(previousBase) &&
+    !getBootConfig().apiBase &&
+    !loadPersistedActiveServer()
+  ) {
+    // Shared-account teardown removes its target; same-origin auth cannot
+    // substitute for the account that was just signed out.
+    publishAuthStatus({
+      phase: "unauthenticated",
+      reason: "remote_auth_required",
+    });
+  } else {
+    publishAuthStatus({ phase: "loading" });
+  }
+}
 // A primed result is only trusted by the activation path for a boot-scale
 // window; a hook that (re)activates later re-probes exactly as before, so a
 // stale prime can never stand in for the session's current auth state.
@@ -107,8 +140,16 @@ function publishAuthStatus(state: AuthStatusState): void {
   }
 }
 
-async function authMeWithRejectedBearerRecovery() {
+async function authMeWithRejectedBearerRecovery(probeEpoch: number) {
+  const requestAuthority = currentAuthAuthority();
   const result = await authMe();
+  // A rejected request owns only the credential it actually dispatched with.
+  if (
+    probeEpoch !== authStatusEpoch ||
+    requestAuthority !== currentAuthAuthority()
+  ) {
+    return result;
+  }
   if (result.ok || result.status !== 401 || result.access?.mode !== "remote") {
     return result;
   }
@@ -123,10 +164,12 @@ async function authMeWithRejectedBearerRecovery() {
   // seeing the same rejected Authorization header twice.
   setBootConfig({ ...getBootConfig(), apiToken: undefined });
   scrubRejectedActiveServerCredential(apiToken);
+  authStatusAuthority = currentAuthAuthority();
   return authMe();
 }
 
 async function fetchAuthStatus(): Promise<void> {
+  synchronizeAuthAuthority();
   if (authStatusFetch) return authStatusFetch;
 
   // The shared snapshot already starts in `loading`, so the cold probe remains
@@ -137,7 +180,7 @@ async function fetchAuthStatus(): Promise<void> {
   const probeEpoch = authStatusEpoch;
   authStatusFetch = (async () => {
     for (let attempt = 0; ; attempt += 1) {
-      const result = await authMeWithRejectedBearerRecovery();
+      const result = await authMeWithRejectedBearerRecovery(probeEpoch);
       if (probeEpoch !== authStatusEpoch) return;
       if (result.ok === true) {
         publishAuthStatus({
@@ -189,6 +232,7 @@ async function fetchAuthStatus(): Promise<void> {
       return;
     }
   })().finally(() => {
+    if (probeEpoch !== authStatusEpoch) return;
     authStatusFetch = null;
   });
 
@@ -213,11 +257,12 @@ async function fetchAuthStatus(): Promise<void> {
  * an already-resolved snapshot make it a no-op.
  */
 export function primeAuthStatusProbe(): void {
+  synchronizeAuthAuthority();
   if (authStatusPrime || authStatusFetch) return;
   if (authStatusSnapshot.phase !== "loading") return;
   const probeEpoch = authStatusEpoch;
   authStatusPrime = (async () => {
-    const result = await authMeWithRejectedBearerRecovery();
+    const result = await authMeWithRejectedBearerRecovery(probeEpoch);
     if (probeEpoch !== authStatusEpoch) return;
     // A real fetch started (or a state was published) while the prime was in
     // flight — that path owns the snapshot; drop the primed result.
@@ -247,6 +292,7 @@ export function primeAuthStatusProbe(): void {
       access: result.access,
     });
   })().finally(() => {
+    if (probeEpoch !== authStatusEpoch) return;
     authStatusPrimeSettledAt = Date.now();
   });
 }
@@ -260,9 +306,12 @@ export function primeAuthStatusProbe(): void {
  * a real probe.
  */
 async function ensureAuthStatusProbe(): Promise<void> {
+  synchronizeAuthAuthority();
+  const activationEpoch = authStatusEpoch;
   if (authStatusFetch) return authStatusFetch;
   if (authStatusPrime) {
     await authStatusPrime;
+    if (activationEpoch !== authStatusEpoch) return;
     if (authStatusPrimeRetryAt > Date.now()) {
       const probeEpoch = authStatusEpoch;
       await new Promise((resolve) =>
@@ -304,7 +353,7 @@ export function useIsAuthenticated(): boolean {
  * (#16242). Mirrors {@link useIsAuthenticated} without subscribing.
  */
 export function isAuthenticatedNow(): boolean {
-  return authStatusSnapshot.phase === "authenticated";
+  return getAuthStatusSnapshot().phase === "authenticated";
 }
 
 /**
@@ -314,7 +363,9 @@ export function isAuthenticatedNow(): boolean {
  * isolating its inbox per user/agent (#18391). Mirrors {@link isAuthenticatedNow}.
  */
 export function getAuthStatusSnapshot(): AuthStatusState {
-  return authStatusSnapshot;
+  return currentAuthAuthority() === authStatusAuthority
+    ? authStatusSnapshot
+    : { phase: "loading" };
 }
 
 /**
@@ -362,6 +413,7 @@ export function __setAuthStatusForTests(state: AuthStatusState): () => void {
  * product code.
  */
 export function __resetAuthStatusForTests(): void {
+  authStatusAuthority = currentAuthAuthority();
   authStatusFetch = null;
   authStatusPrime = null;
   authStatusPrimeSettledAt = 0;
@@ -398,11 +450,27 @@ export function useAuthStatus(options: UseAuthStatusOptions = {}): {
   useEffect(() => {
     mountedRef.current = true;
     authStatusSubscribers.add(setState);
+    synchronizeAuthAuthority();
     setState(authStatusSnapshot);
+    const unsubscribeAuthority = client.onAuthorityChange(() => {
+      synchronizeAuthAuthority();
+      // Connection selection sets base and bearer synchronously. Probe only
+      // after that transaction, while invalidating the old snapshot immediately.
+      queueMicrotask(() => {
+        if (
+          mountedRef.current &&
+          !skip &&
+          !observeOnly &&
+          authStatusSnapshot.phase === "loading"
+        )
+          void activate();
+      });
+    });
     if (!skip && !observeOnly) void activate();
     return () => {
       mountedRef.current = false;
       authStatusSubscribers.delete(setState);
+      unsubscribeAuthority();
     };
   }, [skip, observeOnly, activate]);
 
@@ -504,5 +572,11 @@ export function useAuthStatus(options: UseAuthStatusOptions = {}): {
     };
   }, [skip, observeOnly, pollIntervalMs, fetch]);
 
-  return { state, refetch: fetch };
+  return {
+    state:
+      currentAuthAuthority() === authStatusAuthority
+        ? state
+        : { phase: "loading" },
+    refetch: fetch,
+  };
 }

--- a/packages/ui/src/platform/browser-launch.connection.test.ts
+++ b/packages/ui/src/platform/browser-launch.connection.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Exercises launch admission with the real client, profile persistence, and a
+ * local HTTP receiver. Rejected addresses must leave the previous destination
+ * and its authorization intact, including deployments mounted below a prefix.
+ */
+// @vitest-environment jsdom
+import { once } from "node:events";
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { client } from "../api";
+import { loadAgentProfileRegistry } from "../state/agent-profiles";
+import { loadPersistedActiveServer } from "../state/persistence";
+import { applyLaunchConnection } from "./browser-launch";
+
+let server: Server;
+let base: string;
+const received: Array<{
+  path: string | undefined;
+  authorization: string | undefined;
+}> = [];
+
+beforeEach(async () => {
+  localStorage.clear();
+  sessionStorage.clear();
+  received.length = 0;
+  server = createServer((req, res) => {
+    received.push({ path: req.url, authorization: req.headers.authorization });
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ complete: true }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string")
+    throw new Error("Missing TCP listener");
+  base = `http://127.0.0.1:${address.port}/agent/prefix`;
+  applyLaunchConnection({
+    apiBase: `${base}/`,
+    token: "synthetic-existing-owner",
+  });
+});
+
+afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+  client.setToken(null);
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+it.each([
+  "synthetic-user:synthetic-password",
+  "synthetic-user",
+  ":synthetic-password",
+])(
+  "rejects URL credentials %s before changing the active connection",
+  async (userinfo) => {
+    const active = loadPersistedActiveServer();
+    const registry = loadAgentProfileRegistry();
+    const invalid = new URL(base);
+    const [username, password = ""] = userinfo.split(":");
+    invalid.username = username;
+    invalid.password = password;
+    expect(() =>
+      applyLaunchConnection({
+        apiBase: invalid.toString(),
+        token: "synthetic-replacement",
+      }),
+    ).toThrow("Rejected invalid launch apiBase");
+    expect(client.getBaseUrl()).toBe(base);
+    expect(loadPersistedActiveServer()).toEqual(active);
+    expect(loadAgentProfileRegistry()).toEqual(registry);
+    expect(await client.getFirstRunStatus()).toEqual({ complete: true });
+    expect(received).toEqual([
+      {
+        path: "/agent/prefix/api/first-run/status",
+        authorization: "Bearer synthetic-existing-owner",
+      },
+    ]);
+  },
+);

--- a/packages/ui/src/platform/browser-launch.ts
+++ b/packages/ui/src/platform/browser-launch.ts
@@ -68,6 +68,9 @@ function normalizeLaunchApiBase(
   };
   try {
     const parsed = new URL(trimmed);
+    if (parsed.username || parsed.password) {
+      throw new Error("URL credentials are not supported");
+    }
     if (
       isTrustedRestoreApiBaseUrl(parsed.toString()) ||
       (options.kind === "cloud" &&

--- a/packages/ui/src/state/use-startup-shell-controller.ts
+++ b/packages/ui/src/state/use-startup-shell-controller.ts
@@ -7,7 +7,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../api";
 import type { StartupShellView } from "../components/shell/startup-shell-types";
-import { listenForConnectRequests } from "../events";
+import { type ConnectRequestResult, listenForConnectRequests } from "../events";
 import { completeRemoteAgentFirstRun } from "../first-run/adopt-remote-first-run";
 import { ensureStoreBuildWorkspaceFolder } from "../first-run/ensure-store-build-workspace-folder";
 import { persistMobileRuntimeModeForServerTarget } from "../first-run/mobile-runtime-mode";
@@ -123,7 +123,7 @@ export function useStartupShellController(): StartupShellController {
       token?: string;
       completeFirstRun?: boolean;
       skipConfirm?: boolean;
-    }): Promise<void> => {
+    }): Promise<ConnectRequestResult> => {
       // `completeFirstRun` marks the connected remote as this device's finished
       // first-run target (device/desktop remote-connect-at-URL onboarding), so
       // it lands on home instead of re-showing onboarding on the next launch.
@@ -151,7 +151,7 @@ export function useStartupShellController(): StartupShellController {
         });
         if (!approved) {
           setActionNotice("Connection request cancelled.", "info", 4200);
-          return;
+          return { status: "cancelled" };
         }
       }
 
@@ -165,7 +165,6 @@ export function useStartupShellController(): StartupShellController {
         setState("firstRunRuntimeTarget", "remote");
         setState("firstRunRemoteApiBase", connection.apiBase);
         setState("firstRunRemoteToken", connection.token ?? "");
-        setState("firstRunRemoteConnected", true);
         setState("firstRunRemoteError", null);
         if (shouldCompleteFirstRun) {
           // Adopt the remote as this device's completed first-run target. Probes
@@ -182,16 +181,20 @@ export function useStartupShellController(): StartupShellController {
             completeFirstRun,
           );
         }
+        setState("firstRunRemoteConnected", true);
         setActionNotice("Connected to remote backend.", "success", 4200);
         retryStartup();
+        return { status: "connected" };
       } catch (err) {
-        setActionNotice(
+        // error-policy:J1 expose failed adoption to both the initiating form and shell notice.
+        const message =
           err instanceof Error
             ? err.message
-            : "Failed to connect remote backend.",
-          "error",
-          8000,
-        );
+            : "Failed to connect remote backend.";
+        setState("firstRunRemoteConnected", false);
+        setState("firstRunRemoteError", message);
+        setActionNotice(message, "error", 8000);
+        return { status: "failed", message };
       }
     };
 

--- a/packages/ui/src/surface-realm-broker.ts
+++ b/packages/ui/src/surface-realm-broker.ts
@@ -333,6 +333,7 @@ export interface HostRealmResetResult {
 export class SurfaceRealmScope {
   readonly storage: ScopedStorage;
   readonly navigate: (path: string) => void;
+  private readonly memberViewIds: ReadonlySet<string>;
   private readonly rootClassBaseline: ReadonlySet<string>;
   private readonly bodyClassBaseline: ReadonlySet<string>;
   private readonly rootVarBaseline: ReadonlySet<string>;
@@ -349,7 +350,9 @@ export class SurfaceRealmScope {
     readonly viewId: string,
     backing: Storage,
     navigate: (path: string) => void,
+    memberViewIds: readonly string[] = [viewId],
   ) {
+    this.memberViewIds = new Set(memberViewIds);
     this.storage = brokerSurfaceStorage(manifest, backing, viewId);
     this.navigate = brokerSurfaceNavigate(manifest, viewId, navigate);
     if (typeof document === "undefined") {
@@ -375,6 +378,11 @@ export class SurfaceRealmScope {
           .map((name) => [name, root.style.getPropertyValue(name)]),
       );
     }
+  }
+
+  /** Only the routed owner or explicit layout members may evaluate in this scope. */
+  ownsView(viewId: string): boolean {
+    return this.memberViewIds.has(viewId);
   }
 
   /**
@@ -439,16 +447,29 @@ export class SurfaceRealmScope {
 // active view (and the isolation tests) reach exactly the brokered handles the
 // shell resolved for the current manifest, never the raw globals.
 let activeScope: SurfaceRealmScope | null = null;
+const activeScopeListeners = new Set<() => void>();
+
+/** Observe committed scope replacement so evaluated views renew their handles. */
+export function subscribeActiveSurfaceRealmScope(
+  listener: () => void,
+): () => void {
+  activeScopeListeners.add(listener);
+  return () => {
+    activeScopeListeners.delete(listener);
+  };
+}
 
 /** Publish the scope for the active view. Pass `null` on teardown. */
 export function setActiveSurfaceRealmScope(
   scope: SurfaceRealmScope | null,
 ): void {
+  if (activeScope === scope) return;
   activeScope = scope;
   // Guards install lazily on the first publish (not at module load) so server
   // consumers of the ui barrel never touch window, and so the guards wrap
   // whatever `window.localStorage` the environment (or a test stub) provides.
   if (scope !== null) ensureHostRealmGuards();
+  for (const listener of activeScopeListeners) listener();
 }
 
 /** The scope for the active view, or `null` when no view is mounted. */


### PR DESCRIPTION
Closes #30988.

Remote onboarding adopts an existing agent by sending only its first-run completion marker through the existing configuration writer; that writer's normal configuration normalization still applies. The connection form now waits for adoption to complete, retains its values on failure, and permits retry. Consecutive native and deep-link connection requests are serialized so an older attempt cannot overwrite a newer selection.

Remote selection keeps status, configuration, chat and account state bound to the selected host. Native local endpoint rotation updates the selected local connection atomically. Both connection entry points accept deployment prefixes and reject URL user information before changing the saved connection. Queued onboarding text stays durable until the mounted composer accepts the complete text.

Remote views retain usable navigation through equivalent registry refreshes. Genuine source or selected-host changes replace their module leases while rejecting old handles; inactive retained views cannot acquire the foreground view’s permissions.

Current integration candidate `d35888044509feebc8ea8e9dd3e78ea4475ea993` is rebased onto develop `77041c39df357b97316339faf188f0473d2e67f5` and changes 44 files relative to that base. Root and independent review compared all 28,860 tree entries against qualified `b706137`: only three test files differ, each exactly matching current develop. All production code, configuration and assets are byte-identical, so the installed b706 native and built-browser evidence remains applicable by source equality. New-head normal installation, all 373 repository verification tasks, 38 affected tests (11 notification RPC, 18 real-PGlite outbox and 9 local-HTTP cache), and the 13-commit secret scan passed. All five exact-head hosted checks passed in [run 34548937732](https://github.com/elizaOS/eliza/actions/runs/34548937732). The PostgreSQL conditional gate passed with its contract test steps inapplicable; Windows security, billing replay and source lint/type/build executed successfully. The earlier push-triggered run 34548906889 was superseded by ready-for-review and cancelled; its failed aggregate remains historical, not the acceptance run.

- Current pinned normal installation, full repository `bun run verify`, and 13-commit secret scan passed.
- Current integration replay passed 447 tests: 359 UI contracts, 42 native TCP/WebSocket/preload controls, 29 real HTTP/configuration cases and 17 canonical connector first-run cases.
- Final signed macOS QA build and installation passed. All 8,332 selected payload files match the build by SHA-256. Authenticated native status and first-run status both return 200. Interactive native form replay now passed on the installed build: a visible unauthorized attempt retained setup, native token entry and retry connected to the isolated HTTP agent, and the complete Unicode request appeared unsent in the composer. All 8,332 installed payloads and the served renderer manifest were reverified after interaction.
- Actual served-factory browser replay passed all four cases across host, credential and source changes, including a delayed response rejected before evaluation. The current active module remains usable while old handles are rejected. Production Cloud navigation also passed.
- Final built desktop/mobile/cold adoption and actual paused-host retry passed against a fresh isolated runtime process from this source. Desktop/mobile preserve all 20,972 Unicode codepoints (21,622 UTF-16 units); retry preserves all 20,974 codepoints. Failed adoption preserves the full pending batch and configuration; success changes only the first-run marker through the existing writer. All four complete drafts match exactly.
- Current JPGs and four MP4 walkthroughs were inspected. All 17 current assets were read back from GitHub with matching sizes and SHA-256 digests. All five hosted checks for qualified predecessor b706137 passed in run 34542169614. Native interactive acceptance is complete; newer develop test changes were reconciled without altering production source. The conflict is resolved and new-head local integration validation passed; all five hosted checks for the rebased candidate passed in run 34548937732.

Retained broader validation, with its original scope: full agent 774 files plus 9 mobile controls passed; native 1,501 tests passed; App 950 script tests plus 2 existing skips and 1,630 component tests passed. The earlier full UI run had 13,978 passes, 99 failures in two fixtures and 7 skips; the fixtures were repaired and every failed case passed focused replay. Expanded auth/queue/form/notification contracts passed 390 tests. Final scope integration passed 146 controls, canonical importer replay passed 129, and the remaining App compositions passed 30. These full runs are not relabeled as execution on the new merged base; current integration and packaged replay cover its affected contracts.

The reviewed `ff3c7e3` canonical app audit passed 222 cases: 216 findings, no broken or needs-work verdicts; OCR 203 verified and 13 inspected, no regressions. All 21 visual flags and 13 OCR flags were inspected. Character resting overlaps matched their predecessor exactly and normal scroll/click/editing controls passed. That audit and the merged consolidation's full app matrix qualify unchanged owners; current Cloud, factory and remote-adoption replay cover this merged build.

Reviewed current-head browser evidence (synthetic data only):

| Flow | Before | After | Walkthrough |
| --- | --- | --- | --- |
| Desktop adoption | [JPG](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-desktop-before-adoption.jpg) | [JPG](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-desktop-after-adoption.jpg) | [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-desktop-adoption.mp4) |
| Mobile adoption | [JPG](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-mobile-before-adoption.jpg) | [JPG](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-mobile-after-adoption.jpg) | [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-mobile-adoption.mp4) |
| Failed adoption and retry | [Editable failure](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-retry-failed-editable.jpg) | [Accepted draft](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-retry-after.jpg) | [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-retry-adoption.mp4) |
| Cold-start draft | [Unavailable initial host](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-cold-before.jpg) | [Accepted draft](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-cold-after.jpg) | [MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-cold-adoption.mp4) |

[Exact-text/configuration receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-browser-acceptance.json), [frontend network summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-network.json), and [backend request log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-backend.json). All 17 current attached assets were read back from GitHub with matching byte sizes and SHA-256 digests.

[Current integration and native artifact receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-integration.json). [Native interactive capture](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-native-adoption.png) and [native acceptance receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-b706137-native-adoption.json) are now published; both assets were read back with matching size and SHA-256. This run preserved an existing short QA draft and a keyboard-input fragment, so exact total-draft equality is established by the separate built-browser controls, not inferred from this native capture.

Retained predecessor canonical audit: [summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-ff3c7e3-audit-summary.json), [all captures, reports and manual reviews](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-ff3c7e3-audit-captures.tar.gz), [Cloud desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-ff3c7e3-cloud-desktop.jpg), [Cloud mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-ff3c7e3-cloud-mobile.jpg).

Desktop/mobile/retry captured zero page errors; unavailable initial-host and unsupported fixture-route console diagnostics remain explicit. Cold-start receipt records draft acceptance, not a console-clean claim. Mobile Connect is reached by normal unforced scrolling/hovering; its initial resting position may sit behind the composer fade. Deterministic capability fixtures are not live-model inference evidence, and draft transfer is not configured conversation readiness. Same-URL manual module reload lifetime behavior is unchanged and not claimed repaired. Detailed account-routing diagnostics remain private. The isolated-host tests sent no external messages; native queued text remained unsent.

[Rebased candidate integration and source-equality receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/30989-d358880-integration.json).
