### PR TITLE
test(ui): restore login-page.same-origin collection with storage-bridge mock exports

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx
@@ -57,6 +57,14 @@ vi.mock("@elizaos/shared/steward-session-client", () => ({
   readStoredStewardToken: () => null,
   writeStoredStewardToken: () => undefined,
   StewardSessionError: class extends Error {},
+  // The login import graph now reaches `bridge/storage-bridge.ts`, which reads
+  // these three module-scope members at evaluation time. They are stubbed to
+  // mirror the real client's shapes: the token key is the exact localStorage
+  // constant, and the two registrars return their no-op unregister callbacks so
+  // the bridge's module-init `register*` calls resolve without a native store.
+  STEWARD_TOKEN_KEY: "steward_session_token",
+  registerStewardTokenPersistence: () => () => undefined,
+  registerStewardTokenRemoval: () => () => undefined,
 }));
 
 vi.mock("../../lib/steward-session", () => ({


### PR DESCRIPTION
# Relates to

Closes #30952

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync; focused package checks recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`822aba345b`); zero conflicts.
- [x] Focused `packages/ui` login suites, changed-file lint, and the failing
      suite all run green post-sync. Full `bun run verify` is not required for a
      test-only mock fix; see **Known gaps / failures**.

# Risks

Low. Test-only change confined to one suite's `vi.mock` factory. No production
source, exports, or runtime behavior are touched, so no consumer path changes.

# Background

## What does this PR do?

Restores `packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx`
to a collectable, passing state.

The suite failed during **vitest collection** — all 4 tests failed to run — with:

```
Error: [vitest] No "STEWARD_TOKEN_KEY" export is defined on the
"@elizaos/shared/steward-session-client" mock. Did you forget to return it from "vi.mock"?
 ❯ src/bridge/storage-bridge.ts:79:3
 ❯ src/state/agent-profiles.ts:9:1
```

Root cause: the login surface's import graph grew to include the storage bridge
(`login-page.tsx` → state/API modules → `src/state/agent-profiles.ts` →
`src/bridge/storage-bridge.ts`). `storage-bridge.ts` imports three members from
`@elizaos/shared/steward-session-client` at **module-evaluation** time:

- `STEWARD_TOKEN_KEY` — read into the native-Preferences sync denylist (line 79),
- `registerStewardTokenPersistence` — called at module init (line 752),
- `registerStewardTokenRemoval` — called at module init (line 751).

The suite's `vi.mock("@elizaos/shared/steward-session-client", …)` factory only
returned `hasStewardAuthedCookie`, `readStoredStewardToken`,
`writeStoredStewardToken`, and `StewardSessionError`. With the three imported
members absent, evaluating `storage-bridge.ts` threw and the whole suite failed
to collect. The suite was green when written and broke when the import graph grew.

The fix extends the existing mock factory with faithful stand-ins verified against
`packages/shared/src/steward-session-client/index.ts`:

- `STEWARD_TOKEN_KEY: "steward_session_token"` — the exact localStorage constant
  (index.ts line 22).
- `registerStewardTokenPersistence: () => () => undefined` — the real function
  (index.ts line ~131) returns an unregister callback; the stand-in mirrors that
  `() => () => void` shape with a no-op.
- `registerStewardTokenRemoval: () => () => undefined` — same, mirroring the real
  registrar at index.ts line ~117.

The mock is kept minimal: only the members the import graph actually consumes are
added, and the four existing test bodies are unchanged.

## What kind of change is this?

Bug fix (test-only): repairs a broken test fixture so the suite collects and runs.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx` —
the only changed file (the `vi.mock("@elizaos/shared/steward-session-client", …)`
factory near line 55).

## Detailed testing steps

From `packages/ui`:

```
NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" \
  bunx vitest run --config ./vitest.config.ts \
  src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx
```

- Before this change (parent commit of the changed file): `Test Files 1 failed`,
  `Tests no tests` — collection throws the `No "STEWARD_TOKEN_KEY" export` error.
- After this change: `Test Files 1 passed (1)`, `Tests 4 passed (4)`.

Neighboring suites: the full `src/cloud/public-pages/pages/login/` directory runs
`146/147` in one concurrent pass; the single `phone-login` "override the
locale-derived country" case timed out under concurrent load and passes `15/15`
in isolation — unrelated to this test-only mock change. Changed file is lint-clean
under Biome.

# Evidence Gate

<!-- evidence-head:f6173f6222faaf1b65f7d13aa49520b290597ec1 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only change; no rendered UI surface is added or modified.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only change; no rendered UI surface is added or modified.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - test-only change; there is no user-facing flow to walk through.`
<!-- evidence-row:backend-logs -->
- [x] Focused vitest output — the gate-satisfying proof is the passing run
      pasted inline below; a convenience mirror of the same genuine run lives on
      a fork release at
      [30952-after-4-passed.txt](https://github.com/agent-cortex/eliza/releases/download/pr-30993-evidence/30952-after-4-passed.txt)
      (see **Known gaps** for why it is not on the canonical `pr-evidence`
      release).

  <details><summary>vitest output — same-origin suite after the fix</summary>

  ```
   RUN  v4.1.10 /packages/ui
   Test Files  1 passed (1)
        Tests  4 passed (4)
     Start at  09:45:50
     Duration  23.39s (transform 17.03s, setup 110ms, import 21.04s, tests 898ms, environment 1.12s)
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no browser/runtime code path changes; this repairs a test fixture only.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows, memories, tasks, wallet, or generated files involved.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - test-only change with no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Focused vitest runs for the affected suite, captured at the reviewed head.

<details><summary>BEFORE — parent of the changed file: collection fails, 0 tests run</summary>

```
Error: [vitest] No "STEWARD_TOKEN_KEY" export is defined on the "@elizaos/shared/steward-session-client" mock. Did you forget to return it from "vi.mock"?
 ❯ src/bridge/storage-bridge.ts:79:3
     77|   // set is consulted, so credentials never land in Preferences.
     78|   "eliza.device.auth",
     79|   STEWARD_TOKEN_KEY,
       |   ^
     80|   "elizaos:active-server",
     81|   "eliza:first-run-complete",
 ❯ src/state/agent-profiles.ts:9:1

 Test Files  1 failed (1)
      Tests  no tests
```

</details>

<details><summary>AFTER — with the fix: 4/4 pass, no collection error</summary>

```
 RUN  v4.1.10 packages/ui

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Duration  23.39s
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

N/A - test-only change; no rendered UI surface is added or modified.

### After

N/A - test-only change; no rendered UI surface is added or modified.

### Walkthrough video

N/A - test-only change; there is no user-facing flow to walk through.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- Full `bun run verify` was not run: this is a test-only, one-file `vi.mock`
  extension with no production, export, or type surface change; the owning
  package's focused suite, neighboring login suites, and changed-file Biome lint
  are the proportionate gates and all pass. The lone `phone-login` timeout is a
  pre-existing concurrency flake (passes 15/15 in isolation) and is unrelated to
  this change.
- The downloadable log artifacts are mirrored on a **fork release**
  (`agent-cortex/eliza`, tag `pr-30993-evidence`), not the canonical
  `elizaOS/eliza` `pr-evidence` release. Uploading to the canonical release
  requires push access that fork contributors do not have — a direct
  `gh release upload` to it returns `HTTP 404` — and GitHub's `user-attachments`
  uploader is browser-only and unavailable in this headless environment. The
  substantive, gate-satisfying evidence is therefore the focused vitest output
  pasted inline in the fenced blocks above (both the BEFORE collection failure
  and the AFTER 4/4 pass); the fork-release links are a convenience mirror of
  that same genuine run at head `f6173f62`.

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@822aba345b678f877c56edbb47d6cdfe588ad596:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@822aba345b678f877c56edbb47d6cdfe588ad596:packages/skills/skills/contribute-to-eliza"} -->

