### PR TITLE
fix(plugin-vision): honour boolean values for the object and pose detection toggles

### DIFF
--- a/plugins/plugin-vision/src/detection-flags.test.ts
+++ b/plugins/plugin-vision/src/detection-flags.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pins how VisionService reads its detection toggles from runtime settings.
+ * `getSetting` returns character settings untouched, so a boolean stored in
+ * character JSON must count the same as the string spelling an env file
+ * holds; the face-recognition flag already does, and object/pose detection
+ * must not diverge from it. Real service construction, no mocks of the config
+ * loader.
+ */
+
+import { describe, expect, it } from "vitest";
+import { VisionService } from "./service";
+
+type SettingValue = string | boolean | number | undefined;
+
+function serviceWith(settings: Record<string, SettingValue>) {
+  const runtime = {
+    getSetting: (key: string) => settings[key],
+    character: { name: "test", settings: {} },
+    getService: () => null,
+  } as unknown as ConstructorParameters<typeof VisionService>[0];
+  return new VisionService(runtime) as unknown as {
+    visionConfig: {
+      enableObjectDetection: boolean;
+      enablePoseDetection: boolean;
+      enableFaceRecognition: boolean;
+    };
+  };
+}
+
+describe("VisionService detection flags", () => {
+  it("defaults every detector off", () => {
+    const { visionConfig } = serviceWith({});
+    expect(visionConfig.enableObjectDetection).toBe(false);
+    expect(visionConfig.enablePoseDetection).toBe(false);
+    expect(visionConfig.enableFaceRecognition).toBe(false);
+  });
+
+  it.each([
+    ["string true", "true"],
+    ["boolean true", true],
+  ])("ENABLE_OBJECT_DETECTION=%s enables object detection", (_label, value) => {
+    expect(
+      serviceWith({ ENABLE_OBJECT_DETECTION: value }).visionConfig
+        .enableObjectDetection,
+    ).toBe(true);
+  });
+
+  it.each([
+    ["string true", "true"],
+    ["boolean true", true],
+  ])(
+    "VISION_ENABLE_POSE_DETECTION=%s (the legacy alias) enables pose detection",
+    (_label, value) => {
+      expect(
+        serviceWith({ VISION_ENABLE_POSE_DETECTION: value }).visionConfig
+          .enablePoseDetection,
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    ["string true", "true"],
+    ["boolean true", true],
+  ])(
+    "ENABLE_FACE_RECOGNITION=%s enables face recognition (the existing contract)",
+    (_label, value) => {
+      expect(
+        serviceWith({ ENABLE_FACE_RECOGNITION: value }).visionConfig
+          .enableFaceRecognition,
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    ["string false", "false"],
+    ["boolean false", false],
+  ])(
+    "ENABLE_OBJECT_DETECTION=%s keeps object detection off",
+    (_label, value) => {
+      expect(
+        serviceWith({ ENABLE_OBJECT_DETECTION: value }).visionConfig
+          .enableObjectDetection,
+      ).toBe(false);
+    },
+  );
+});

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -425,12 +425,18 @@ export class VisionService extends Service {
           runtime.getSetting("PIXEL_CHANGE_THRESHOLD") ||
             runtime.getSetting("VISION_PIXEL_CHANGE_THRESHOLD"),
         ) || this.DEFAULT_CONFIG.pixelChangeThreshold,
-      enableObjectDetection:
-        runtime.getSetting("ENABLE_OBJECT_DETECTION") === "true" ||
-        runtime.getSetting("VISION_ENABLE_OBJECT_DETECTION") === "true",
-      enablePoseDetection:
-        runtime.getSetting("ENABLE_POSE_DETECTION") === "true" ||
-        runtime.getSetting("VISION_ENABLE_POSE_DETECTION") === "true",
+      // Read through the same helper as face recognition so a boolean stored
+      // in character settings counts the same as the env-file string.
+      enableObjectDetection: getBooleanSetting(
+        "ENABLE_OBJECT_DETECTION",
+        "VISION_ENABLE_OBJECT_DETECTION",
+        false,
+      ),
+      enablePoseDetection: getBooleanSetting(
+        "ENABLE_POSE_DETECTION",
+        "VISION_ENABLE_POSE_DETECTION",
+        false,
+      ),
       enableFaceRecognition: getBooleanSetting(
         "ENABLE_FACE_RECOGNITION",
         "VISION_ENABLE_FACE_RECOGNITION",


### PR DESCRIPTION
# Relates to

Closes #31000. Same class as #30996 / #30997 (plugin-agent-skills), found by rerunning that scan with a pathspec that includes top-level `src/*.ts` files.

- [x] Targets `develop`, branched from `origin/develop` `822aba345b67`; two files, +12/−6 in the service plus a new regression suite.

# Risks

Low. `enableObjectDetection` and `enablePoseDetection` are now read through the plugin's existing `getBooleanSetting(primary, alias, default)` helper, the same path `enableFaceRecognition` already uses. The string spelling `"true"` behaves as before; a boolean `true` now enables the detector; anything else keeps the default `false`.

# Background

## What does this PR do?

`getSetting` returns `string | boolean | number | null` and hands character settings back untouched. The vision config loader compared the raw value for the object and pose toggles to `"true"`, so a boolean `true` in character JSON left both detectors off with no diagnostic, while the face-recognition toggle in the same block already handled the boolean. All three now agree.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

None. The flag names and defaults are unchanged.

# Testing

## Where should a reviewer start?

`plugins/plugin-vision/src/service.ts` (config loader, the `enableObjectDetection` / `enablePoseDetection` entries), then `detection-flags.test.ts`, which constructs the real `VisionService` with a settings map (the harness `capture-interval.test.ts` already uses) and reads the resulting config.

## Detailed testing steps

RED on develop `822aba345b67` with the new suite and the unchanged loader:

```text
✓ defaults every detector off
✓ ENABLE_OBJECT_DETECTION=string true enables object detection
× ENABLE_OBJECT_DETECTION=boolean true enables object detection
✓ VISION_ENABLE_POSE_DETECTION=string true (the legacy alias) enables pose detection
× VISION_ENABLE_POSE_DETECTION=boolean true (the legacy alias) enables pose detection
✓ ENABLE_FACE_RECOGNITION=string true enables face recognition (the existing contract)
✓ ENABLE_FACE_RECOGNITION=boolean true enables face recognition (the existing contract)
✓ ENABLE_OBJECT_DETECTION=string false keeps object detection off
✓ ENABLE_OBJECT_DETECTION=boolean false keeps object detection off
Tests  2 failed | 7 passed (9)
```

With the fix: 9 passed.

- `plugins/plugin-vision`: full `vitest run` — 46 files, 307 passed, 4 skipped.
- `plugins/plugin-vision`: `tsc --noEmit` — 0 errors.
- Biome on both files — clean.
- Root `bun run verify` — result posted as a comment at this head.

# Evidence Gate

<!-- evidence-head:86fd83cdb13693db721688c68f8ac51044263473 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - service configuration parsing, no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - service configuration parsing, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow
<!-- evidence-row:backend-logs -->
- [x] RED/GREEN suite output above; root verify in a comment
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent reasoning change
<!-- evidence-row:domain-artifacts -->
- [x] resolved `visionConfig` toggles before and after, asserted in the suite above
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X8GVjoFetN9GsjAfUCBTh
