### PR TITLE
fix(core): render shared references in settings debug snapshots instead of "[circular]"

### DIFF
--- a/packages/core/src/settings-debug.test.ts
+++ b/packages/core/src/settings-debug.test.ts
@@ -74,4 +74,33 @@ describe("sanitizeForSettingsDebug reference handling", () => {
 			child: { parent: "[circular]", tag: "t" },
 		});
 	});
+
+	it("bounds a shared-reference chain instead of expanding it exponentially", () => {
+		// 13 distinct objects inside the depth cap, each holding the same next
+		// level under four keys: 4^12 paths. The snapshot must stop at the node
+		// ceiling (20 000 emitted values), not at the heap.
+		let level: Record<string, unknown> = { leaf: true };
+		for (let i = 0; i < 12; i++) {
+			level = { a: level, b: level, c: level, d: level };
+		}
+		const started = performance.now();
+		const out = sanitizeForSettingsDebug(level);
+		const elapsedMs = performance.now() - started;
+		let budgeted = 0;
+		let markers = 0;
+		const walk = (value: unknown): void => {
+			if (value === "[max-size]") {
+				markers += 1;
+				return;
+			}
+			budgeted += 1;
+			if (Array.isArray(value)) for (const item of value) walk(item);
+			else if (value && typeof value === "object")
+				for (const item of Object.values(value)) walk(item);
+		};
+		walk(out);
+		expect(markers).toBeGreaterThan(0);
+		expect(budgeted).toBeLessThanOrEqual(20_000);
+		expect(elapsedMs).toBeLessThan(2_000);
+	});
 });

--- a/packages/core/src/settings-debug.test.ts
+++ b/packages/core/src/settings-debug.test.ts
@@ -3,6 +3,7 @@ import {
 	isElizaSettingsDebugEnabled,
 	MAX_STRING,
 	sanitizeDebugString,
+	sanitizeForSettingsDebug,
 } from "./settings-debug.js";
 
 describe("settings-debug", () => {
@@ -44,5 +45,33 @@ describe("settings-debug", () => {
 		const masked = sanitizeDebugString(long);
 		expect(masked).toContain("chars)");
 		expect(masked).not.toBe(long);
+	});
+});
+
+describe("sanitizeForSettingsDebug reference handling", () => {
+	it("renders a shared (non-cyclic) reference in full at every site", () => {
+		// The same object reached from two keys and twice inside an array is a
+		// DAG, not a cycle; every reference must sanitize to the same snapshot.
+		const shared = { model: "gpt", region: "eu" };
+		const out = sanitizeForSettingsDebug({
+			a: shared,
+			b: shared,
+			list: [shared, shared],
+		}) as Record<string, unknown>;
+		const expected = { model: "gpt", region: "eu" };
+		expect(out.a).toEqual(expected);
+		expect(out.b).toEqual(expected);
+		expect(out.list).toEqual([expected, expected]);
+	});
+
+	it("still collapses a true cycle to [circular] and sanitizes its siblings", () => {
+		const root: Record<string, unknown> = { name: "root" };
+		root.self = root;
+		root.child = { parent: root, tag: "t" };
+		expect(sanitizeForSettingsDebug(root)).toEqual({
+			name: "root",
+			self: "[circular]",
+			child: { parent: "[circular]", tag: "t" },
+		});
 	});
 });

--- a/packages/core/src/settings-debug.ts
+++ b/packages/core/src/settings-debug.ts
@@ -16,6 +16,20 @@ const SENSITIVE_KEY_RE =
 	/(?:^|\.|_)(?:secret|password|token|apikey|api_key|privatekey|private_key|mnemonic|credential|authorization|bearer|cookie|sessionkey|session_id)(?:\.|_|$)|^apikey$|_api_key$|_key$/i;
 
 const MAX_DEPTH = 14;
+/**
+ * Ceiling on the nodes one snapshot may emit. A settings graph that reuses
+ * one object from several keys is rendered once per path (the snapshot carries
+ * no reference identity), which is exponential in the sharing depth even for a
+ * handful of objects; past this many nodes every further value collapses to
+ * "[max-size]" so a debug snapshot can never exhaust the process it is
+ * diagnosing.
+ */
+const MAX_NODES = 20_000;
+
+/** Per-walk emission counter threaded alongside `depth`. */
+interface SnapshotBudget {
+	remaining: number;
+}
 const MAX_ARRAY = 40;
 export const MAX_STRING = 120;
 
@@ -73,11 +87,12 @@ function sanitizeDebugArray(
 	value: unknown[],
 	depth: number,
 	seen: WeakSet<object>,
+	budget: SnapshotBudget,
 ): unknown[] {
 	const out: unknown[] = [];
 	const cap = Math.min(value.length, MAX_ARRAY);
 	for (let i = 0; i < cap; i++) {
-		out.push(sanitizeForSettingsDebug(value[i], depth + 1, seen));
+		out.push(sanitizeForSettingsDebug(value[i], depth + 1, seen, budget));
 	}
 	if (value.length > cap) {
 		out.push(`… +${value.length - cap} more`);
@@ -95,12 +110,13 @@ function sanitizeDebugObject(
 	value: Record<string, unknown>,
 	depth: number,
 	seen: WeakSet<object>,
+	budget: SnapshotBudget,
 ): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
 	for (const [key, item] of Object.entries(value)) {
 		out[key] = SENSITIVE_KEY_RE.test(key)
 			? sanitizeSensitiveDebugValue(item)
-			: sanitizeForSettingsDebug(item, depth + 1, seen);
+			: sanitizeForSettingsDebug(item, depth + 1, seen, budget);
 	}
 	return out;
 }
@@ -112,8 +128,13 @@ export function sanitizeForSettingsDebug(
 	value: unknown,
 	depth = 0,
 	seen: WeakSet<object> = new WeakSet(),
+	budget: SnapshotBudget = { remaining: MAX_NODES },
 ): unknown {
 	if (depth > MAX_DEPTH) return "[max-depth]";
+	// Every emitted node, this marker included, spends budget, so the
+	// snapshot stays bounded however many paths reach the same object.
+	if (budget.remaining <= 0) return "[max-size]";
+	budget.remaining -= 1;
 	if (value === null || value === undefined) return value;
 	if (typeof value === "boolean" || typeof value === "number") return value;
 	if (typeof value === "string") return sanitizeDebugString(value);
@@ -130,9 +151,14 @@ export function sanitizeForSettingsDebug(
 	seen.add(value as object);
 	try {
 		if (Array.isArray(value)) {
-			return sanitizeDebugArray(value, depth, seen);
+			return sanitizeDebugArray(value, depth, seen, budget);
 		}
-		return sanitizeDebugObject(value as Record<string, unknown>, depth, seen);
+		return sanitizeDebugObject(
+			value as Record<string, unknown>,
+			depth,
+			seen,
+			budget,
+		);
 	} finally {
 		seen.delete(value as object);
 	}

--- a/packages/core/src/settings-debug.ts
+++ b/packages/core/src/settings-debug.ts
@@ -121,14 +121,21 @@ export function sanitizeForSettingsDebug(
 	if (typeof value === "function") return `[fn ${value.name || "anonymous"}]`;
 	if (typeof value !== "object") return String(value);
 
+	// `seen` is the ancestor path of the value being sanitized, not every
+	// object visited so far: a reference is circular only while its target is
+	// still open above it. The entry is removed once the subtree is done, so a
+	// settings graph that reuses one object from two places renders both in
+	// full instead of collapsing the second one to "[circular]".
 	if (seen.has(value as object)) return "[circular]";
 	seen.add(value as object);
-
-	if (Array.isArray(value)) {
-		return sanitizeDebugArray(value, depth, seen);
+	try {
+		if (Array.isArray(value)) {
+			return sanitizeDebugArray(value, depth, seen);
+		}
+		return sanitizeDebugObject(value as Record<string, unknown>, depth, seen);
+	} finally {
+		seen.delete(value as object);
 	}
-
-	return sanitizeDebugObject(value as Record<string, unknown>, depth, seen);
 }
 
 /** Compact cloud slice for logs (no raw secrets). */


### PR DESCRIPTION
# Relates to

Closes #30999. Same defect class as #25125 (logger, fixed in #30887) and #30994 (JS runtime bridge, #30995).

- [x] Targets `develop`, branched from `origin/develop` `822aba345b67`; two files, +12/−5 in the sanitizer plus two regression cases.

# Risks

Low. `sanitizeForSettingsDebug` keeps its `seen` set as the ancestor path (add before descending, `delete` in `finally`) instead of a global visited set. True cycles still render as `"[circular]"`; masking, depth and array caps, and sensitive-key handling are untouched. Debug-only consumers: agent config snapshots, the `PUT /api/config` request log, and the UI client's error detail.

# Background

## What does this PR do?

A settings graph that references one object from two places (one `secrets` block under two providers, an array reused by two keys) was logged with the second reference replaced by `"[circular]"`, because the walker marked cycles by "seen anywhere earlier" rather than "on the current ancestor path". The snapshots exist to show what was configured, so that is a misleading diagnostic. Now an object is on the set only while its own children are being sanitized.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

`packages/core/src/settings-debug.ts` (`sanitizeForSettingsDebug`), then the `reference handling` describe in `settings-debug.test.ts`.

## Detailed testing steps

At head `f225b564ecff` (node budget added after review):

- `packages/core`: `settings-debug.test.ts` + `settings-debug.surrogate.test.ts` — 16/16 (adds the node-budget case).

Earlier head:

RED on develop `822aba345b67` with the two new cases and the unchanged sanitizer:

```text
× renders a shared (non-cyclic) reference in full at every site   (b and list[1] are "[circular]")
✓ still collapses a true cycle to [circular] and sanitizes its siblings
Tests  1 failed | 5 passed (6)
```

With the fix: `settings-debug.test.ts` + `settings-debug.surrogate.test.ts` — 2 files, 15 passed.

- `packages/core`: `tsc --noEmit -p tsconfig.json` — 0 errors.
- Biome on both files — clean.
- Root `bun run verify` — result posted as a comment at this head.

# Evidence Gate

<!-- evidence-head:f225b564ecffc3245be032e10d9a3d12e12a1699 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - debug log sanitizer, no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - debug log sanitizer, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow
<!-- evidence-row:backend-logs -->
- [x] RED/GREEN suite output above; root verify in a comment
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent reasoning change
<!-- evidence-row:domain-artifacts -->
- [x] sanitized snapshots before and after, asserted in the suite above
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X8GVjoFetN9GsjAfUCBTh

