### PR TITLE
fix(core,ui,personal-assistant): render shared references in diagnostic serializers instead of "[Circular]"

### DIFF
--- a/packages/core/src/runtime/json-output.diagnostics.test.ts
+++ b/packages/core/src/runtime/json-output.diagnostics.test.ts
@@ -34,4 +34,27 @@ describe("stringifyForDiagnostics reference handling", () => {
 			child: { parent: "[Circular]", tag: "t" },
 		});
 	});
+
+	it("bounds a diamond-shaped shared graph instead of expanding it exponentially", () => {
+		// 21 distinct objects, each holding the same next level under two keys:
+		// 2^20 paths. The serializer must stop at the node ceiling (50 000
+		// objects) and keep the event readable instead of overflowing.
+		let level: Record<string, unknown> = { leaf: true };
+		for (let i = 0; i < 20; i++) level = { l: level, r: level };
+		const started = performance.now();
+		const text = stringifyForDiagnostics({ event: "probe", payload: level });
+		const elapsedMs = performance.now() - started;
+		expect(text).toContain('"event": "probe"');
+		expect(text).toContain('"[Truncated]"');
+		let objects = 0;
+		const walk = (value: unknown): void => {
+			if (value && typeof value === "object") {
+				objects += 1;
+				for (const item of Object.values(value)) walk(item);
+			}
+		};
+		walk(JSON.parse(text));
+		expect(objects).toBeLessThanOrEqual(50_000);
+		expect(elapsedMs).toBeLessThan(5_000);
+	});
 });

--- a/packages/core/src/runtime/json-output.diagnostics.test.ts
+++ b/packages/core/src/runtime/json-output.diagnostics.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Pins the reference handling of `stringifyForDiagnostics`, the serializer
+ * behind trajectory and evaluator diagnostics: a shared object must render
+ * in full at every site, and only a reference back to an open ancestor may
+ * collapse to "[Circular]". Deterministic; no mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { stringifyForDiagnostics } from "./json-output.js";
+
+describe("stringifyForDiagnostics reference handling", () => {
+	it("renders a shared (non-cyclic) reference in full at every site", () => {
+		const shared = { id: 1, tag: "t" };
+		const out = JSON.parse(
+			stringifyForDiagnostics({ a: shared, b: shared, list: [shared, shared] }),
+		);
+		expect(out).toEqual({
+			a: { id: 1, tag: "t" },
+			b: { id: 1, tag: "t" },
+			list: [
+				{ id: 1, tag: "t" },
+				{ id: 1, tag: "t" },
+			],
+		});
+	});
+
+	it("still collapses a true cycle to [Circular] and serializes its siblings", () => {
+		const root: Record<string, unknown> = { name: "root" };
+		root.self = root;
+		root.child = { parent: root, tag: "t" };
+		expect(JSON.parse(stringifyForDiagnostics(root))).toEqual({
+			name: "root",
+			self: "[Circular]",
+			child: { parent: "[Circular]", tag: "t" },
+		});
+	});
+});

--- a/packages/core/src/runtime/json-output.ts
+++ b/packages/core/src/runtime/json-output.ts
@@ -227,7 +227,17 @@ export function stringifyForModel(value: unknown): string {
 	return serialized;
 }
 
-/** Serialize diagnostic context without allowing hostile or cyclic values to mask the original event. */
+/**
+ * Object nodes one diagnostic serialization may emit before collapsing to
+ * "[Truncated]". Diagnostic payloads are small; the ceiling exists for shared
+ * graphs, which are otherwise re-expanded once per path.
+ */
+const MAX_DIAGNOSTIC_NODES = 50_000;
+
+/**
+ * Serialize diagnostic context without allowing hostile, cyclic, or
+ * exponentially shared values to mask the original event.
+ */
 export function stringifyForDiagnostics(value: unknown): string {
 	if (typeof value === "string") return value;
 	// The replacer sees each value with its holder as `this`, so the open
@@ -236,6 +246,11 @@ export function stringifyForDiagnostics(value: unknown): string {
 	// ancestor circular; an object reached twice through different paths
 	// (a DAG) serializes in full at every site.
 	const ancestors: object[] = [];
+	// A shared object is emitted once per path, which is exponential in the
+	// sharing depth; past the node ceiling every further value collapses to a
+	// marker so the diagnostic can neither exhaust the heap nor overflow the
+	// string limit and mask the event it describes.
+	let remainingNodes = MAX_DIAGNOSTIC_NODES;
 	try {
 		const serialized = JSON.stringify(
 			value,
@@ -249,6 +264,8 @@ export function stringifyForDiagnostics(value: unknown): string {
 						ancestors.pop();
 					}
 					if (ancestors.includes(nestedValue)) return "[Circular]";
+					if (remainingNodes <= 0) return "[Truncated]";
+					remainingNodes -= 1;
 					ancestors.push(nestedValue);
 				}
 				return nestedValue;

--- a/packages/core/src/runtime/json-output.ts
+++ b/packages/core/src/runtime/json-output.ts
@@ -230,15 +230,26 @@ export function stringifyForModel(value: unknown): string {
 /** Serialize diagnostic context without allowing hostile or cyclic values to mask the original event. */
 export function stringifyForDiagnostics(value: unknown): string {
 	if (typeof value === "string") return value;
-	const seen = new WeakSet<object>();
+	// The replacer sees each value with its holder as `this`, so the open
+	// ancestor chain is the stack of holders above the current one. Popping
+	// back to the holder before the check makes only a reference to an open
+	// ancestor circular; an object reached twice through different paths
+	// (a DAG) serializes in full at every site.
+	const ancestors: object[] = [];
 	try {
 		const serialized = JSON.stringify(
 			value,
-			(_key, nestedValue: unknown) => {
+			function replacer(this: unknown, _key, nestedValue: unknown) {
 				if (typeof nestedValue === "bigint") return `${nestedValue}n`;
 				if (nestedValue && typeof nestedValue === "object") {
-					if (seen.has(nestedValue)) return "[Circular]";
-					seen.add(nestedValue);
+					while (
+						ancestors.length > 0 &&
+						ancestors[ancestors.length - 1] !== this
+					) {
+						ancestors.pop();
+					}
+					if (ancestors.includes(nestedValue)) return "[Circular]";
+					ancestors.push(nestedValue);
 				}
 				return nestedValue;
 			},

--- a/packages/ui/src/utils/tts-debug.test.ts
+++ b/packages/ui/src/utils/tts-debug.test.ts
@@ -53,6 +53,20 @@ describe("ttsDebug", () => {
     );
   });
 
+  it("bounds a diamond-shaped shared detail instead of expanding it exponentially", () => {
+    // 17 distinct objects, 2^16 paths: the line must stay bounded and keep
+    // its phase instead of growing past the serializer's limits.
+    let level: Record<string, unknown> = { leaf: true };
+    for (let i = 0; i < 16; i++) level = { l: level, r: level };
+    ttsDebug("play:start", { payload: level });
+
+    expect(info).toHaveBeenCalledTimes(1);
+    const line = info.mock.calls[0][0] as string;
+    expect(line.startsWith("[eliza][tts] play:start {")).toBe(true);
+    expect(line).toContain('"[Truncated]"');
+    expect(line.length).toBeLessThan(2_000_000);
+  });
+
   it("keeps the no-detail log form", () => {
     ttsDebug("play:end");
 

--- a/packages/ui/src/utils/tts-debug.test.ts
+++ b/packages/ui/src/utils/tts-debug.test.ts
@@ -44,6 +44,15 @@ describe("ttsDebug", () => {
     );
   });
 
+  it("renders a shared (non-cyclic) diagnostic value in full at every site", () => {
+    const shared = { voice: "alloy" };
+    ttsDebug("play:start", { a: shared, b: shared, list: [shared, shared] });
+
+    expect(info).toHaveBeenCalledWith(
+      '[eliza][tts] play:start {"a":{"voice":"alloy"},"b":{"voice":"alloy"},"list":[{"voice":"alloy"},{"voice":"alloy"}]}',
+    );
+  });
+
   it("keeps the no-detail log form", () => {
     ttsDebug("play:end");
 

--- a/packages/ui/src/utils/tts-debug.ts
+++ b/packages/ui/src/utils/tts-debug.ts
@@ -68,16 +68,28 @@ export function ttsDebugTextPreview(
 }
 
 function serializeTtsDebugDetail(detail: Record<string, unknown>): string {
-  const seen = new WeakSet<object>();
+  // Track the open ancestor chain through the replacer's holder (`this`) so
+  // only a reference back to an ancestor is circular; a value shared by two
+  // keys serializes in full at both sites.
+  const ancestors: object[] = [];
   try {
-    return JSON.stringify(detail, (_key, value: unknown) => {
-      if (typeof value === "bigint") return value.toString();
-      if (value && typeof value === "object") {
-        if (seen.has(value)) return "[Circular]";
-        seen.add(value);
-      }
-      return value;
-    });
+    return JSON.stringify(
+      detail,
+      function replacer(this: unknown, _key, value: unknown) {
+        if (typeof value === "bigint") return value.toString();
+        if (value && typeof value === "object") {
+          while (
+            ancestors.length > 0 &&
+            ancestors[ancestors.length - 1] !== this
+          ) {
+            ancestors.pop();
+          }
+          if (ancestors.includes(value)) return "[Circular]";
+          ancestors.push(value);
+        }
+        return value;
+      },
+    );
   } catch {
     // error-policy:J4 Debug serialization must not interrupt audio playback.
     return "[Unserializable diagnostic detail]";

--- a/packages/ui/src/utils/tts-debug.ts
+++ b/packages/ui/src/utils/tts-debug.ts
@@ -67,11 +67,17 @@ export function ttsDebugTextPreview(
   return `${truncateWellFormed(wellFormed, maxChars)}…`;
 }
 
+/** Object nodes one debug detail may serialize before collapsing to "[Truncated]". */
+const MAX_DEBUG_DETAIL_NODES = 10_000;
+
 function serializeTtsDebugDetail(detail: Record<string, unknown>): string {
   // Track the open ancestor chain through the replacer's holder (`this`) so
   // only a reference back to an ancestor is circular; a value shared by two
   // keys serializes in full at both sites.
   const ancestors: object[] = [];
+  // Shared objects are emitted once per path; past the node ceiling every
+  // further object collapses to a marker so a debug line stays bounded.
+  let remainingNodes = MAX_DEBUG_DETAIL_NODES;
   try {
     return JSON.stringify(
       detail,
@@ -85,6 +91,8 @@ function serializeTtsDebugDetail(detail: Record<string, unknown>): string {
             ancestors.pop();
           }
           if (ancestors.includes(value)) return "[Circular]";
+          if (remainingNodes <= 0) return "[Truncated]";
+          remainingNodes -= 1;
           ancestors.push(value);
         }
         return value;

--- a/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Pins the reference handling of the lifeops redaction walker: a shared object
+ * must be redacted in full at every site, and only a reference back to an open
+ * ancestor may collapse to "[Circular]". Deterministic; no mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+import { redactSensitiveData } from "./redact-sensitive-data.ts";
+
+describe("redactSensitiveData reference handling", () => {
+  it("redacts a shared (non-cyclic) reference in full at every site", () => {
+    const shared = { note: "plain text" };
+    expect(
+      redactSensitiveData({ a: shared, b: shared, list: [shared, shared] }),
+    ).toEqual({
+      a: { note: "plain text" },
+      b: { note: "plain text" },
+      list: [{ note: "plain text" }, { note: "plain text" }],
+    });
+  });
+
+  it("still collapses a true cycle to [Circular] and redacts its siblings", () => {
+    const root: Record<string, unknown> = { note: "root" };
+    root.self = root;
+    root.child = { parent: root, note: "child" };
+    expect(redactSensitiveData(root)).toEqual({
+      note: "root",
+      self: "[Circular]",
+      child: { parent: "[Circular]", note: "child" },
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.test.ts
@@ -29,4 +29,32 @@ describe("redactSensitiveData reference handling", () => {
       child: { parent: "[Circular]", note: "child" },
     });
   });
+
+  it("bounds a shared-reference chain instead of expanding it exponentially", () => {
+    // 13 distinct objects, each holding the same next level under four keys:
+    // 4^12 paths. The walker returns a structure, so the budget is its only
+    // ceiling.
+    let level: Record<string, unknown> = { note: "leaf" };
+    for (let i = 0; i < 12; i++)
+      level = { a: level, b: level, c: level, d: level };
+    const started = performance.now();
+    const out = redactSensitiveData(level);
+    const elapsedMs = performance.now() - started;
+    let objects = 0;
+    let markers = 0;
+    const walk = (value: unknown): void => {
+      if (value === "[Truncated]") {
+        markers += 1;
+        return;
+      }
+      if (value && typeof value === "object") {
+        objects += 1;
+        for (const item of Object.values(value)) walk(item);
+      }
+    };
+    walk(out);
+    expect(markers).toBeGreaterThan(0);
+    expect(objects).toBeLessThanOrEqual(50_000);
+    expect(elapsedMs).toBeLessThan(5_000);
+  });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
@@ -148,21 +148,32 @@ function redactValue(
   if (typeof value === "string") {
     return redactString(rawKey, value, opts);
   }
+  // `seen` is the ancestor path, not every object visited: an entry is
+  // removed once its subtree is redacted, so a value shared by two keys is
+  // redacted in full at both sites and only a true cycle collapses.
   if (Array.isArray(value)) {
     if (seen.has(value)) return "[Circular]";
     seen.add(value);
-    // Arrays use the parent key for redaction context (e.g. `toList: [...]`).
-    return value.map((entry) => redactValue(rawKey, entry, opts, seen));
+    try {
+      // Arrays use the parent key for redaction context (e.g. `toList: [...]`).
+      return value.map((entry) => redactValue(rawKey, entry, opts, seen));
+    } finally {
+      seen.delete(value);
+    }
   }
   if (typeof value === "object") {
     const obj = value as Record<string, unknown>;
     if (seen.has(obj)) return "[Circular]";
     seen.add(obj);
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(obj)) {
-      out[k] = redactValue(k, v, opts, seen);
+    try {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        out[k] = redactValue(k, v, opts, seen);
+      }
+      return out;
+    } finally {
+      seen.delete(obj);
     }
-    return out;
   }
   // numbers / booleans / bigint / symbol — pass through unchanged.
   return value;

--- a/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts
@@ -138,11 +138,20 @@ function redactString(
   return valueWithoutEmails;
 }
 
+/** Object nodes one redaction may emit before collapsing to "[Truncated]". */
+const MAX_REDACT_NODES = 50_000;
+
+/** Per-walk emission counter; shared objects are emitted once per path. */
+interface RedactBudget {
+  remaining: number;
+}
+
 function redactValue(
   rawKey: string,
   value: unknown,
   opts: RedactOptions,
   seen: WeakSet<object>,
+  budget: RedactBudget,
 ): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "string") {
@@ -153,10 +162,16 @@ function redactValue(
   // redacted in full at both sites and only a true cycle collapses.
   if (Array.isArray(value)) {
     if (seen.has(value)) return "[Circular]";
+    // The walker returns a structure, not a string, so nothing downstream
+    // can catch an oversized result: the budget is the only ceiling.
+    if (budget.remaining <= 0) return "[Truncated]";
+    budget.remaining -= 1;
     seen.add(value);
     try {
       // Arrays use the parent key for redaction context (e.g. `toList: [...]`).
-      return value.map((entry) => redactValue(rawKey, entry, opts, seen));
+      return value.map((entry) =>
+        redactValue(rawKey, entry, opts, seen, budget),
+      );
     } finally {
       seen.delete(value);
     }
@@ -164,11 +179,13 @@ function redactValue(
   if (typeof value === "object") {
     const obj = value as Record<string, unknown>;
     if (seen.has(obj)) return "[Circular]";
+    if (budget.remaining <= 0) return "[Truncated]";
+    budget.remaining -= 1;
     seen.add(obj);
     try {
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(obj)) {
-        out[k] = redactValue(k, v, opts, seen);
+        out[k] = redactValue(k, v, opts, seen, budget);
       }
       return out;
     } finally {
@@ -188,5 +205,7 @@ function redactValue(
  * input value is left intact.
  */
 export function redactSensitiveData<T>(value: T, opts: RedactOptions = {}): T {
-  return redactValue("", value, opts, new WeakSet()) as T;
+  return redactValue("", value, opts, new WeakSet(), {
+    remaining: MAX_REDACT_NODES,
+  }) as T;
 }


### PR DESCRIPTION
# Relates to

Closes #31004. Same class as #25125 (logger, #30887), #30994 (JS runtime bridge, #30995), and #30999 (settings debug, #31002); this PR takes the three remaining sites found by a repo-wide scan for `"[Circular]"` markers written by a visited set that is never emptied.

- [x] Targets `develop`, branched from `origin/develop` `822aba345b67`; three source files (+37/−14) and three regression cases.

# Risks

Low. Each serializer changes only how it decides a value is circular. The two `JSON.stringify` replacers keep an ancestor stack recovered from the replacer's holder (`this`), which is the standard way to get the open path inside a replacer; the recursive walker deletes the entry in `finally`. Masking, bigint handling, the J4/J7 catch boundaries, and the `"[Circular]"` marker for true cycles are unchanged.

# Background

## What does this PR do?

| Site | Consumers |
|---|---|
| `packages/core/src/runtime/json-output.ts` `stringifyForDiagnostics` | `trajectory-recorder.ts`, `trajectory-utils.ts`, `services/evaluator.ts`, experience evaluators, relationships provider |
| `packages/ui/src/utils/tts-debug.ts` `serializeTtsDebugDetail` | TTS debug log lines |
| `plugins/plugin-personal-assistant/src/lifeops/redact-sensitive-data.ts` `redactValue` | lifeops redaction helper (currently test-exercised) |

Before: `stringifyForDiagnostics({ a: shared, b: shared })` → `{"a":{…},"b":"[Circular]"}`. A model response or tool result that reuses one sub-object was therefore recorded into the trajectory with the second reference replaced by a string. After: every reference renders in full; only a reference back to an open ancestor collapses.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

None.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/json-output.ts` (the replacer in `stringifyForDiagnostics`), then `json-output.diagnostics.test.ts`; the other two sites are the same shape.

## Detailed testing steps

At head `1b178b488d48` (node budgets added after review): core json-output.diagnostics 3/3 + __tests__/json-output 22/22, ui tts-debug 13/13, personal-assistant redact-sensitive-data 3/3 + truncate-suffix-reserve 6/6, core tsc 0 errors, Biome clean.

Earlier head:

RED on develop `822aba345b67` with the new cases and the unchanged serializers, one per package:

```text
core  × renders a shared (non-cyclic) reference in full at every site        (1 failed | 1 passed)
ui    × renders a shared (non-cyclic) diagnostic value in full at every site (1 failed | 11 passed)
pa    × redacts a shared (non-cyclic) reference in full at every site        (1 failed | 1 passed)
```

The true-cycle cases pass on both sides, pinning that `"[Circular]"` still appears for a real cycle and that the cycle's siblings still serialize.

With the fix:

- `packages/core`: `json-output.diagnostics.test.ts` 2/2; existing `__tests__/json-output.test.ts` 22/22; `tsc --noEmit -p tsconfig.json` 0 errors.
- `packages/ui`: `tts-debug.test.ts` 12/12 (11 existing + 1).
- `plugins/plugin-personal-assistant`: `redact-sensitive-data.test.ts` 2/2 and `truncate-suffix-reserve.test.ts` 6/6 (the existing consumer).
- Biome on all six files — clean.
- Root `bun run verify` (covers the ui and personal-assistant typechecks on a full install) — result posted as a comment at this head.

# Evidence Gate

<!-- evidence-head:1b178b488d486eeb415cc97737026dd087d2ef80 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - serializer internals, no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - serializer internals, no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow
<!-- evidence-row:backend-logs -->
- [x] RED/GREEN suite output above; root verify in a comment
<!-- evidence-row:frontend-logs -->
- [x] the TTS debug log line before and after is the asserted string in `tts-debug.test.ts`
<!-- evidence-row:llm-trajectory -->
- [x] the trajectory diagnostics serializer's output before and after is asserted in `json-output.diagnostics.test.ts`
<!-- evidence-row:domain-artifacts -->
- [x] serialized snapshots before and after, asserted in the suites above
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X8GVjoFetN9GsjAfUCBTh

