### PR TITLE
fix(core,inbox): batch entity and room lookups instead of one read per item (#31008)

### DIFF
--- a/packages/core/src/entities.preservation.test.ts
+++ b/packages/core/src/entities.preservation.test.ts
@@ -84,6 +84,7 @@ function runtime(
 		],
 		getRelationships: async () => relationships,
 		getEntityById: async () => null,
+		getEntitiesByIds: async () => [],
 		getMemories: async () => [],
 		useModel: async () => modelResult,
 	} as unknown as IAgentRuntime;
@@ -463,6 +464,7 @@ describe("adversarial: contextual binding containment", () => {
 			getEntitiesForRoom: async () => entities,
 			getRelationships: async () => [],
 			getEntityById: async () => null,
+			getEntitiesByIds: async () => [],
 			getMemories: async () => [],
 			useModel: async () => modelResult,
 		} as unknown as IAgentRuntime;

--- a/packages/core/src/entities.resolution-consistency.test.ts
+++ b/packages/core/src/entities.resolution-consistency.test.ts
@@ -99,6 +99,11 @@ function runtime(
 			const found = byId.get(String(id));
 			return found ? structuredClone(found) : null;
 		},
+		getEntitiesByIds: async (ids: UUID[]) =>
+			ids.flatMap((id) => {
+				const found = byId.get(String(id));
+				return found ? [structuredClone(found)] : [];
+			}),
 		getMemories: async () => [],
 		useModel: async () => modelResult,
 		...overrides,

--- a/packages/core/src/entities.resolution.test.ts
+++ b/packages/core/src/entities.resolution.test.ts
@@ -115,6 +115,11 @@ function runtime(
 			const found = byId.get(id);
 			return found ? structuredClone(found) : null;
 		},
+		getEntitiesByIds: async (ids: UUID[]) =>
+			ids.flatMap((id) => {
+				const found = byId.get(id);
+				return found ? [structuredClone(found)] : [];
+			}),
 		getMemories: async () => [],
 		useModel: async (_type: unknown, params: { prompt?: string }) => {
 			if (typeof params?.prompt === "string") prompts.push(params.prompt);
@@ -136,6 +141,55 @@ describe("findEntityByName referent and candidate containment", () => {
 		expect(prompt).toContain("tell Alice Smith to call me");
 		expect(prompt).toContain("00000000-0000-0000-0000-0000000000aa");
 		expect(prompt).toContain("Eliza");
+	});
+
+	it("reads every relationship counterpart through one batched lookup", async () => {
+		const batchCalls: UUID[][] = [];
+		const singleCalls: UUID[] = [];
+		const base = runtime({});
+		const found = await findEntityByName(
+			runtime({
+				getRelationships: async () =>
+					[
+						{
+							id: "00000000-0000-0000-0000-0000000000r1",
+							sourceEntityId: BOB,
+							targetEntityId: ALICE,
+							agentId: AGENT,
+							tags: ["knows"],
+						},
+						{
+							id: "00000000-0000-0000-0000-0000000000r2",
+							sourceEntityId: STRANGER,
+							targetEntityId: BOB,
+							agentId: AGENT,
+							tags: ["knows"],
+						},
+						{
+							id: "00000000-0000-0000-0000-0000000000r3",
+							sourceEntityId: BOB,
+							targetEntityId: ALICE,
+							agentId: AGENT,
+							tags: ["met"],
+						},
+					] as Relationship[],
+				getEntitiesByIds: async (ids: UUID[]) => {
+					batchCalls.push([...ids]);
+					return base.getEntitiesByIds(ids);
+				},
+				getEntityById: async (id: UUID) => {
+					singleCalls.push(id);
+					return base.getEntityById(id);
+				},
+			}),
+			message("Alice Smith"),
+			state,
+		);
+		expect(found?.id).toBe(ALICE);
+		// Three relationships name two distinct counterparts: one read, deduped,
+		// and no per-relationship lookup.
+		expect(batchCalls).toEqual([[ALICE, STRANGER]]);
+		expect(singleCalls).toEqual([]);
 	});
 
 	it("does not return the sole room entity when the referent names a relationship contact", async () => {

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -560,15 +560,22 @@ export async function findEntityByName(
 	const relationships = await runtime.getRelationships({
 		entityIds: [message.entityId],
 	});
-	const relationshipEntities = await Promise.all(
-		relationships.map(async (rel) => {
-			const entityId =
+	// One batched read for every counterpart: a per-relationship
+	// `getEntityById` fan-out admits as many concurrent database reads as the
+	// sender has relationships.
+	const counterpartIds = [
+		...new Set(
+			relationships.map((rel) =>
 				rel.sourceEntityId === message.entityId
 					? rel.targetEntityId
-					: rel.sourceEntityId;
-			return runtime.getEntityById(entityId);
-		}),
-	);
+					: rel.sourceEntityId,
+			),
+		),
+	];
+	const relationshipEntities =
+		counterpartIds.length > 0
+			? await runtime.getEntitiesByIds(counterpartIds)
+			: [];
 
 	const filteredEntities = await Promise.all(
 		entitiesInRoom.map((entity) =>
@@ -576,11 +583,9 @@ export async function findEntityByName(
 		),
 	);
 	const filteredRelationshipEntities = await Promise.all(
-		relationshipEntities
-			.filter((entity): entity is Entity => entity !== null)
-			.map((entity) =>
-				withVisibleComponents(runtime, world, entity, message.entityId),
-			),
+		relationshipEntities.map((entity) =>
+			withVisibleComponents(runtime, world, entity, message.entityId),
+		),
 	);
 
 	const allEntities = uniqueEntitiesById([

--- a/packages/core/src/features/advanced-capabilities/providers/followUps.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/followUps.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the FOLLOW_UPS provider's contact-name resolution. The
+ * runtime and FollowUpService are in-memory doubles; entity lookups are held
+ * at an explicit gate so the admission bound can be measured before any
+ * lookup completes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.js";
+import { followUpsProvider } from "./followUps.js";
+
+describe("followUpsProvider", () => {
+	const dummyMessage = { roomId: "room-1" as UUID } as Memory;
+	const dummyState = {} as State;
+
+	it("bounds concurrent entity lookups while still naming every contact (#30731)", async () => {
+		const contactCount = 64;
+		const followUps = Array.from({ length: contactCount }, (_unused, i) => ({
+			task: {
+				id: `task-${i}` as UUID,
+				metadata: {
+					scheduledAt: new Date(
+						Date.now() + (i + 1) * 86_400_000,
+					).toISOString(),
+					reason: `reason ${i}`,
+				},
+			},
+			contact: { entityId: `entity-${i}` as UUID },
+		}));
+		const followUpService = {
+			getUpcomingFollowUps: vi.fn().mockResolvedValue(followUps),
+			getFollowUpSuggestions: vi.fn().mockResolvedValue([]),
+		};
+
+		let inFlight = 0;
+		let peakInFlight = 0;
+		const releases: Array<() => void> = [];
+		const runtime = {
+			getService: vi.fn().mockReturnValue(followUpService),
+			getEntityById: vi.fn(async (id: string) => {
+				inFlight += 1;
+				peakInFlight = Math.max(peakInFlight, inFlight);
+				await new Promise<void>((resolve) => {
+					releases.push(resolve);
+				});
+				inFlight -= 1;
+				return { names: [`Name ${id}`] };
+			}),
+			logger: { warn: vi.fn(), error: vi.fn() },
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const pending = followUpsProvider.get(runtime, dummyMessage, dummyState);
+
+		// Drain the gate until every lookup has been admitted and released.
+		let released = 0;
+		while (released < contactCount) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			while (releases.length > 0) {
+				releases.shift()?.();
+				released += 1;
+			}
+		}
+		const result = await pending;
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(contactCount);
+		expect(peakInFlight).toBe(8);
+		expect(result.values?.followUpCount).toBe(contactCount);
+		for (let i = 0; i < contactCount; i += 1) {
+			expect(result.text).toContain(`Name entity-${i}`);
+		}
+	});
+
+	it("resolves each unique contact once and labels unknown entities", async () => {
+		const followUps = [
+			{
+				task: {
+					id: "t1" as UUID,
+					metadata: { scheduledAt: new Date(0).toISOString() },
+				},
+				contact: { entityId: "e1" as UUID },
+			},
+			{
+				task: { id: "t2" as UUID, metadata: {} },
+				contact: { entityId: "e1" as UUID },
+			},
+			{
+				task: { id: "t3" as UUID, metadata: {} },
+				contact: { entityId: "e2" as UUID },
+			},
+		];
+		const runtime = {
+			getService: vi.fn().mockReturnValue({
+				getUpcomingFollowUps: vi.fn().mockResolvedValue(followUps),
+				getFollowUpSuggestions: vi.fn().mockResolvedValue([]),
+			}),
+			getEntityById: vi.fn(async (id: string) =>
+				id === "e1" ? { names: ["Alice"] } : null,
+			),
+			logger: { warn: vi.fn(), error: vi.fn() },
+			reportError: vi.fn(),
+		} as unknown as IAgentRuntime;
+
+		const result = await followUpsProvider.get(
+			runtime,
+			dummyMessage,
+			dummyState,
+		);
+
+		expect(runtime.getEntityById).toHaveBeenCalledTimes(2);
+		expect(result.text).toContain("Alice");
+		expect(result.text).toContain("Unknown");
+		expect(result.values?.followUpCount).toBe(3);
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/providers/followUps.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/followUps.ts
@@ -15,9 +15,18 @@ import type {
 	ProviderResult,
 	State,
 } from "../../../types/index.ts";
+import { mapWithConcurrency } from "../../../utils/bounded-map.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("FOLLOW_UPS");
+
+/**
+ * Upper bound on simultaneous entity lookups while resolving follow-up
+ * contact names. The follow-up list is data-driven, so resolving every unique
+ * contact through one `Promise.all` would admit as many concurrent database
+ * reads as there are contacts.
+ */
+const MAX_CONCURRENT_ENTITY_LOOKUPS = 8;
 
 export const followUpsProvider: Provider = {
 	name: spec.name,
@@ -62,8 +71,10 @@ export const followUpsProvider: Provider = {
 			const contactIds = Array.from(
 				new Set(upcomingFollowUps.map((f) => f.contact.entityId)),
 			);
-			const entities = await Promise.all(
-				contactIds.map((id) => runtime.getEntityById(id)),
+			const entities = await mapWithConcurrency(
+				contactIds,
+				MAX_CONCURRENT_ENTITY_LOOKUPS,
+				(id) => runtime.getEntityById(id),
 			);
 			const entityNames = new Map<string, string>();
 			for (let i = 0; i < contactIds.length; i += 1) {

--- a/packages/core/src/features/autonomy/service.entity-names.test.ts
+++ b/packages/core/src/features/autonomy/service.entity-names.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Covers the autonomy service's sender-name lookup: every distinct sender in
+ * the target rooms is resolved through one batched entity read, with an id
+ * fallback for senders that have no entity row. Deterministic mock runtime.
+ */
+import { describe, expect, test } from "vitest";
+import { createMockRuntime } from "../../testing/mock-runtime";
+import type { Entity, IAgentRuntime, UUID } from "../../types";
+import { AutonomyService } from "./service";
+
+const ALICE = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const BOB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" as UUID;
+const GHOST = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+
+type Harness = {
+	buildEntityNameLookup: (ids: Set<UUID>) => Promise<Map<UUID, string>>;
+};
+
+function serviceWith(runtime: IAgentRuntime): Harness {
+	const service = new AutonomyService();
+	(service as unknown as { runtime: IAgentRuntime }).runtime = runtime;
+	return service as unknown as Harness;
+}
+
+describe("AutonomyService sender name lookup", () => {
+	test("resolves every sender through one batched read and falls back to the id", async () => {
+		const batchReads: UUID[][] = [];
+		const runtime = createMockRuntime({
+			getEntitiesByIds: async (ids: UUID[]) => {
+				batchReads.push([...ids]);
+				const rows: Record<string, Entity> = {
+					[ALICE]: { id: ALICE, names: ["Alice"], agentId: ALICE },
+					[BOB]: { id: BOB, names: ["Bob"], agentId: BOB },
+				};
+				return ids.flatMap((id) => (rows[id] ? [rows[id]] : []));
+			},
+		});
+
+		const names = await serviceWith(runtime).buildEntityNameLookup(
+			new Set([ALICE, GHOST, BOB]),
+		);
+
+		expect(batchReads).toEqual([[ALICE, GHOST, BOB]]);
+		expect(names).toEqual(
+			new Map([
+				[ALICE, "Alice"],
+				[GHOST, GHOST],
+				[BOB, "Bob"],
+			]),
+		);
+	});
+
+	test("skips the read entirely when no sender needs a name", async () => {
+		let reads = 0;
+		const runtime = createMockRuntime({
+			getEntitiesByIds: async () => {
+				reads += 1;
+				return [];
+			},
+		});
+
+		const names = await serviceWith(runtime).buildEntityNameLookup(new Set());
+
+		expect(reads).toBe(0);
+		expect(names.size).toBe(0);
+	});
+});

--- a/packages/core/src/features/autonomy/service.ts
+++ b/packages/core/src/features/autonomy/service.ts
@@ -659,16 +659,25 @@ export class AutonomyService extends Service {
 	private async buildEntityNameLookup(
 		entityIds: Set<UUID>,
 	): Promise<Map<UUID, string>> {
-		const entries = await Promise.all(
-			Array.from(entityIds).map(async (entityId) => {
-				if (!this.runtime.getEntityById) {
-					return [entityId, String(entityId)] as const;
-				}
-				const entity = await this.runtime.getEntityById(entityId);
-				return [entityId, this.readEntityName(entity, entityId)] as const;
-			}),
+		const ids = Array.from(entityIds);
+		// One batched read for every distinct sender; a per-sender lookup would
+		// fan out one database read per participant on every loop tick.
+		const entities =
+			typeof this.runtime.getEntitiesByIds === "function" && ids.length > 0
+				? await this.runtime.getEntitiesByIds(ids)
+				: [];
+		const entityById = new Map(
+			entities.map((entity) => [entity.id, entity] as const),
 		);
-		return new Map(entries);
+		return new Map(
+			ids.map(
+				(entityId) =>
+					[
+						entityId,
+						this.readEntityName(entityById.get(entityId) ?? null, entityId),
+					] as const,
+			),
+		);
 	}
 
 	private readEntityName(entity: Entity | null, entityId: UUID): string {

--- a/packages/core/src/services/followUp.test.ts
+++ b/packages/core/src/services/followUp.test.ts
@@ -82,6 +82,8 @@ function makeHarness() {
 	const insights: Array<{ entity: { id: UUID }; daysSinceContact: number }> =
 		[];
 	const analytics = new Map<UUID, { strength: number }>();
+	const batchEntityReads: UUID[][] = [];
+	const singleEntityReads: UUID[] = [];
 	// Forces the storage adapter's atomic pending-task transition to refuse,
 	// mimicking a concurrent claim winning the race before completeFollowUp.
 	const refusedTransitions = new Set<string>();
@@ -134,7 +136,17 @@ function makeHarness() {
 			workers.delete(name);
 		},
 		getServiceLoadPromise: async () => relationshipsService,
-		getEntityById: async (id: UUID) => entities.get(id) ?? null,
+		getEntityById: async (id: UUID) => {
+			singleEntityReads.push(id);
+			return entities.get(id) ?? null;
+		},
+		getEntitiesByIds: async (ids: UUID[]) => {
+			batchEntityReads.push([...ids]);
+			return ids.flatMap((id) => {
+				const entity = entities.get(id);
+				return entity ? [entity] : [];
+			});
+		},
 		createMemory: async (memory: unknown, table?: string) => {
 			memories.push({ memory, table });
 		},
@@ -187,6 +199,9 @@ function makeHarness() {
 		contacts,
 		insights,
 		analytics,
+		batchEntityReads,
+		singleEntityReads,
+		relationshipsService,
 		refusedTransitions,
 		addEntity,
 		addContact,
@@ -683,6 +698,55 @@ describe("getFollowUpSuggestions", () => {
 		expect(suggestions.map((suggestion) => suggestion.entityId)).toEqual([
 			CONTACT_A,
 		]);
+	});
+
+	it("reads candidate entities in one batch and analyzes at most four at a time", async () => {
+		const harness = makeHarness();
+		const candidates: UUID[] = [];
+		for (let i = 0; i < 12; i++) {
+			const id =
+				`${i.toString(16).padStart(8, "0")}-0000-4000-8000-00000000000f` as UUID;
+			candidates.push(id);
+			qualifyCandidate(harness, id, { days: 30, strength: 50 });
+		}
+		let inFlight = 0;
+		let peak = 0;
+		const releases: Array<() => void> = [];
+		const original = harness.relationshipsService.analyzeRelationship;
+		harness.relationshipsService.analyzeRelationship = async (
+			agentId: UUID,
+			id: UUID,
+		) => {
+			inFlight += 1;
+			peak = Math.max(peak, inFlight);
+			await new Promise<void>((resolve) => releases.push(resolve));
+			inFlight -= 1;
+			return original(agentId, id);
+		};
+		const service = await startService(harness);
+
+		const pending = service.getFollowUpSuggestions();
+		for (let i = 0; i < 10 && inFlight < 4; i++) await Promise.resolve();
+		expect(harness.batchEntityReads).toEqual([candidates]);
+		expect(harness.singleEntityReads).toEqual([]);
+		expect(inFlight).toBe(4);
+
+		// Release one analysis at a time; each release admits the next.
+		let released = 0;
+		while (released < 12) {
+			const release = releases.shift();
+			if (release) {
+				release();
+				released += 1;
+			}
+			await vi.advanceTimersByTimeAsync(0);
+		}
+		const suggestions = await pending;
+
+		expect(peak).toBe(4);
+		expect(suggestions.map((s) => s.entityId).sort()).toEqual(
+			[...candidates].sort(),
+		);
 	});
 
 	it("skips candidates whose entity record is gone", async () => {

--- a/packages/core/src/services/followUp.ts
+++ b/packages/core/src/services/followUp.ts
@@ -16,7 +16,15 @@ import type { ServiceTypeName } from "../types/service";
 import { Service } from "../types/service";
 import type { Task, TaskWorker } from "../types/task";
 import { stringToUuid } from "../utils";
+import { mapWithConcurrency } from "../utils/bounded-map.ts";
 import type { ContactInfo, RelationshipsService } from "./relationships.ts";
+
+/**
+ * Upper bound on simultaneous relationship analyses while building follow-up
+ * suggestions; matches the bound the relationships service applies to its own
+ * insight pass, since every candidate analysis loads shared-room history.
+ */
+const MAX_CONCURRENT_RELATIONSHIP_ANALYSES = 4;
 
 const FOLLOW_UP_WORKER_NAME = "follow_up";
 
@@ -384,10 +392,23 @@ export class FollowUpService extends Service {
 			return Boolean(needsAttention && needsAttention.daysSinceContact > 14);
 		});
 
+		// One batched entity read, then a bounded number of relationship
+		// analyses in flight: the candidate list is data-driven, and each
+		// analysis loads the pair's shared-room history.
+		const entityById = new Map(
+			(candidates.length > 0
+				? await this.runtime.getEntitiesByIds(
+						candidates.map((contact) => contact.entityId),
+					)
+				: []
+			).map((entity) => [entity.id, entity] as const),
+		);
 		const suggestionResults: Array<FollowUpSuggestion | null> =
-			await Promise.all(
-				candidates.map(async (contact) => {
-					const entity = await this.runtime.getEntityById(contact.entityId);
+			await mapWithConcurrency(
+				candidates,
+				MAX_CONCURRENT_RELATIONSHIP_ANALYSES,
+				async (contact) => {
+					const entity = entityById.get(contact.entityId);
 					if (!entity) return null;
 
 					const needsAttention = needsAttentionById.get(contact.entityId);
@@ -419,7 +440,7 @@ export class FollowUpService extends Service {
 							needsAttention.daysSinceContact,
 						),
 					};
-				}),
+				},
 			);
 
 		const suggestions = suggestionResults.filter(

--- a/packages/core/src/services/relationships.safe-sort.test.ts
+++ b/packages/core/src/services/relationships.safe-sort.test.ts
@@ -117,6 +117,13 @@ describe("RelationshipsService.getRelationshipInsights ordering", () => {
 			async getEntityById(id: UUID) {
 				return { id, names: [String(id)], agentId: AGENT_ID };
 			},
+			async getEntitiesByIds(ids: UUID[]) {
+				return ids.map((id) => ({
+					id,
+					names: [String(id)],
+					agentId: AGENT_ID,
+				}));
+			},
 			async getRoomsForParticipant() {
 				return [ROOM];
 			},
@@ -160,6 +167,9 @@ describe("RelationshipsService.listOverdueFollowups ordering", () => {
 			},
 			async getEntityById() {
 				return null;
+			},
+			async getEntitiesByIds() {
+				return [];
 			},
 		};
 

--- a/packages/core/src/services/relationships.test.ts
+++ b/packages/core/src/services/relationships.test.ts
@@ -75,6 +75,7 @@ function buildStore() {
 		entities: new Map<string, StubEntity>(),
 		emitted: [] as Array<{ event: string; payload: Record<string, unknown> }>,
 		relationships: [] as RelationshipRow[],
+		batchReads: [] as string[][],
 	};
 }
 
@@ -149,6 +150,13 @@ function buildRuntime(store: Store) {
 		},
 		async getEntityById(id: string) {
 			return store.entities.get(id) ?? null;
+		},
+		async getEntitiesByIds(ids: string[]) {
+			store.batchReads.push([...ids]);
+			return ids.flatMap((id) => {
+				const entity = store.entities.get(id);
+				return entity ? [entity] : [];
+			});
 		},
 		async createEntity(entity: StubEntity) {
 			store.entities.set(entity.id, entity);
@@ -633,6 +641,96 @@ describe("RelationshipsService.searchContacts", () => {
 	it("returns nothing for a searchTerm that matches no candidate", async () => {
 		const { service } = await seed();
 		expect(await service.searchContacts({ searchTerm: "zzz" })).toEqual([]);
+	});
+
+	it("resolves searchTerm candidates through one batched entity read", async () => {
+		const store = buildStore();
+		store.entities.set(ENTITY_A, {
+			id: ENTITY_A,
+			names: ["Ada Lovelace"],
+			agentId: AGENT_ID,
+			components: [],
+		});
+		const service = makeService(store);
+		await service.addContact(ENTITY_A, ["friend"]);
+		await service.addContact(ENTITY_B, ["colleague"]);
+		await service.addContact(ENTITY_C, ["family"]);
+		store.batchReads.length = 0;
+
+		const hits = await service.searchContacts({ searchTerm: "lovelace" });
+
+		expect(hits.map((c) => c.entityId)).toEqual([ENTITY_A]);
+		// Every candidate contact goes into a single read; contacts whose
+		// entity row is missing simply do not match.
+		expect(store.batchReads).toHaveLength(1);
+		expect([...store.batchReads[0]].sort()).toEqual(
+			[ENTITY_A, ENTITY_B, ENTITY_C].sort(),
+		);
+	});
+});
+
+describe("RelationshipsService insight admission", () => {
+	it("reads counterparts in one batch and analyzes at most four relationships at a time", async () => {
+		const store = buildStore();
+		const counterparts: UUID[] = [];
+		for (let i = 0; i < 12; i++) {
+			const id =
+				`${i.toString(16).padStart(8, "0")}-0000-4000-8000-000000000000` as UUID;
+			counterparts.push(id);
+			store.entities.set(id, {
+				id,
+				names: [`Contact ${i}`],
+				agentId: AGENT_ID,
+				components: [],
+			});
+			store.relationships.push(
+				confirmedLink(
+					`rel-${i}`,
+					i % 2 === 0 ? ENTITY_A : id,
+					i % 2 === 0 ? id : ENTITY_A,
+				),
+			);
+		}
+		const service = makeService(store);
+
+		let inFlight = 0;
+		let peak = 0;
+		const releases: Array<() => void> = [];
+		const analyze = vi
+			.spyOn(service, "analyzeRelationship")
+			.mockImplementation(async () => {
+				inFlight += 1;
+				peak = Math.max(peak, inFlight);
+				await new Promise<void>((resolve) => releases.push(resolve));
+				inFlight -= 1;
+				return {
+					strength: 80,
+					lastInteractionAt: new Date(Date.now() - 40 * DAY).toISOString(),
+				} as Awaited<ReturnType<RelationshipsService["analyzeRelationship"]>>;
+			});
+
+		const pending = service.getRelationshipInsights(ENTITY_A);
+		// Let the batched entity read and the first admissions settle.
+		for (let i = 0; i < 10 && inFlight < 4; i++) await Promise.resolve();
+		expect(store.batchReads).toEqual([counterparts]);
+		expect(inFlight).toBe(4);
+
+		// Release one analysis at a time; each release admits the next.
+		let released = 0;
+		while (released < 12) {
+			const release = releases.shift();
+			if (release) {
+				release();
+				released += 1;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		const insights = await pending;
+
+		expect(analyze).toHaveBeenCalledTimes(12);
+		expect(peak).toBe(4);
+		expect(insights.strongestRelationships).toHaveLength(12);
+		expect(insights.needsAttention).toHaveLength(12);
 	});
 });
 

--- a/packages/core/src/services/relationships.ts
+++ b/packages/core/src/services/relationships.ts
@@ -23,6 +23,7 @@ import { asUUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
 import { Service } from "../types/service";
 import { stringToUuid } from "../utils";
+import { mapWithConcurrency } from "../utils/bounded-map.ts";
 import { UnionFind } from "../utils/union-find";
 import {
 	createNativeRelationshipsGraphService,
@@ -32,6 +33,14 @@ import {
 	type RelationshipsGraphSnapshot,
 	type RelationshipsPersonDetail,
 } from "./relationships-graph-builder";
+
+/**
+ * Upper bound on simultaneous relationship analyses. Each analysis re-reads
+ * the pair's relationships, both participants' room lists, and every message
+ * in their shared rooms, so admitting one analysis per relationship would
+ * multiply that load by the size of the contact graph.
+ */
+const MAX_CONCURRENT_RELATIONSHIP_ANALYSES = 4;
 
 /**
  * Handles on these platforms are enrichment (phone/email/website) — they
@@ -1146,12 +1155,18 @@ export class RelationshipsService extends Service {
 		// If searchTerm is provided, further filter by entity names
 		if (criteria.searchTerm) {
 			const searchTermLower = criteria.searchTerm.toLowerCase();
-			const entities = await Promise.all(
-				results.map((contact) => this.runtime.getEntityById(contact.entityId)),
+			// One batched read: the candidate list is every contact, so a
+			// per-contact lookup would fan out one database read per contact.
+			const entityById = new Map(
+				(
+					await this.runtime.getEntitiesByIds(
+						results.map((contact) => contact.entityId),
+					)
+				).map((entity) => [entity.id, entity] as const),
 			);
 			const filteredResults: ContactInfo[] = [];
 			for (let i = 0; i < results.length; i++) {
-				const entity = entities[i];
+				const entity = entityById.get(results[i].entityId);
 				const entityNames = entity?.names ?? [];
 				const displayName = getContactDisplayName(results[i])?.toLowerCase();
 				if (
@@ -1363,17 +1378,25 @@ export class RelationshipsService extends Service {
 		const targets = relationships.map((rel) =>
 			rel.sourceEntityId === entityId ? rel.targetEntityId : rel.sourceEntityId,
 		);
-		const entities = await Promise.all(
-			targets.map((target) => this.runtime.getEntityById(target)),
+		// Entities come from one batched read. Each analysis then loads the pair's
+		// shared-room history, so the analyses are admitted a few at a time
+		// instead of all at once; the relationship list is data-driven and can
+		// be as long as the entity's whole contact graph.
+		const entityById = new Map(
+			(targets.length > 0
+				? await this.runtime.getEntitiesByIds(targets)
+				: []
+			).map((entity) => [entity.id, entity] as const),
 		);
-		const analyticsResults = await Promise.all(
-			targets.map((target, index) =>
-				entities[index] ? this.analyzeRelationship(entityId, target) : null,
-			),
+		const analyzed = targets.filter((target) => entityById.has(target));
+		const analyticsResults = await mapWithConcurrency(
+			analyzed,
+			MAX_CONCURRENT_RELATIONSHIP_ANALYSES,
+			(target) => this.analyzeRelationship(entityId, target),
 		);
 
-		for (let i = 0; i < relationships.length; i++) {
-			const entity = entities[i];
+		for (let i = 0; i < analyzed.length; i++) {
+			const entity = entityById.get(analyzed[i]);
 			const analytics = analyticsResults[i];
 			if (!entity || !analytics) continue;
 

--- a/packages/core/src/utils/bounded-map.test.ts
+++ b/packages/core/src/utils/bounded-map.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Pins mapWithConcurrency's admission bound, ordering, and failure
+ * propagation. Deterministic: in-flight calls are released by explicit
+ * resolvers rather than timers.
+ */
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "./bounded-map.ts";
+
+function gate() {
+	const releases: Array<() => void> = [];
+	return {
+		hold: () =>
+			new Promise<void>((resolve) => {
+				releases.push(resolve);
+			}),
+		releaseAll: async () => {
+			while (releases.length > 0) {
+				releases.shift()?.();
+				await Promise.resolve();
+			}
+		},
+		pending: () => releases.length,
+	};
+}
+
+describe("mapWithConcurrency", () => {
+	it("never admits more than the limit and keeps input order", async () => {
+		const g = gate();
+		let inFlight = 0;
+		let peak = 0;
+		const items = Array.from({ length: 23 }, (_unused, i) => i);
+		const run = mapWithConcurrency(items, 4, async (item) => {
+			inFlight += 1;
+			peak = Math.max(peak, inFlight);
+			await g.hold();
+			inFlight -= 1;
+			return item * 10;
+		});
+		// Let the workers start; only the first `limit` calls may be waiting.
+		await Promise.resolve();
+		expect(g.pending()).toBe(4);
+		while (inFlight > 0 || g.pending() > 0) {
+			await g.releaseAll();
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		const results = await run;
+		expect(peak).toBe(4);
+		expect(results).toEqual(items.map((i) => i * 10));
+	});
+
+	it("returns an empty array for an empty input without calling fn", async () => {
+		let calls = 0;
+		const results = await mapWithConcurrency([], 3, async () => {
+			calls += 1;
+			return 1;
+		});
+		expect(results).toEqual([]);
+		expect(calls).toBe(0);
+	});
+
+	it("uses fewer workers than the limit when the input is shorter", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		const results = await mapWithConcurrency([1, 2], 8, async (item) => {
+			inFlight += 1;
+			peak = Math.max(peak, inFlight);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			inFlight -= 1;
+			return item;
+		});
+		expect(results).toEqual([1, 2]);
+		expect(peak).toBe(2);
+	});
+
+	it("rejects with the first failure and stops admitting new items", async () => {
+		const started: number[] = [];
+		const run = mapWithConcurrency([0, 1, 2, 3, 4, 5], 2, async (item) => {
+			started.push(item);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			if (item === 1) {
+				throw new Error(`item ${item} failed`);
+			}
+			return item;
+		});
+		await expect(run).rejects.toThrow("item 1 failed");
+		// Items 0 and 1 were admitted first; the worker that hit the failure
+		// stops, and the surviving worker drains at most what it had claimed.
+		expect(started).not.toContain(5);
+	});
+
+	it("rejects a non-positive or fractional limit", async () => {
+		await expect(mapWithConcurrency([1], 0, async (x) => x)).rejects.toThrow(
+			RangeError,
+		);
+		await expect(mapWithConcurrency([1], 1.5, async (x) => x)).rejects.toThrow(
+			RangeError,
+		);
+	});
+});

--- a/packages/core/src/utils/bounded-map.test.ts
+++ b/packages/core/src/utils/bounded-map.test.ts
@@ -36,8 +36,8 @@ describe("mapWithConcurrency", () => {
 			inFlight -= 1;
 			return item * 10;
 		});
-		// Let the workers start; only the first `limit` calls may be waiting.
-		await Promise.resolve();
+		// The first `limit` calls are admitted synchronously; no more until one
+		// of them settles.
 		expect(g.pending()).toBe(4);
 		while (inFlight > 0 || g.pending() > 0) {
 			await g.releaseAll();
@@ -72,20 +72,64 @@ describe("mapWithConcurrency", () => {
 		expect(peak).toBe(2);
 	});
 
-	it("rejects with the first failure and stops admitting new items", async () => {
-		const started: number[] = [];
-		const run = mapWithConcurrency([0, 1, 2, 3, 4, 5], 2, async (item) => {
-			started.push(item);
-			await new Promise((resolve) => setTimeout(resolve, 0));
-			if (item === 1) {
+	it("rejects as soon as one item fails, without waiting for a sibling still in flight", async () => {
+		const g = gate();
+		const started: string[] = [];
+		let siblingSettled = false;
+		const run = mapWithConcurrency(
+			["held", "failing", "never-admitted"],
+			2,
+			async (item) => {
+				started.push(item);
+				if (item === "held") {
+					await g.hold();
+					siblingSettled = true;
+					return item;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				throw new Error(`${item} failed`);
+			},
+		);
+
+		// The map must reject while the sibling is still held at the gate.
+		await expect(run).rejects.toThrow("failing failed");
+		expect(siblingSettled).toBe(false);
+		expect(g.pending()).toBe(1);
+		expect(started).toEqual(["held", "failing"]);
+
+		// Releasing the sibling afterwards admits nothing further and surfaces
+		// no second error.
+		await g.releaseAll();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(siblingSettled).toBe(true);
+		expect(started).toEqual(["held", "failing"]);
+	});
+
+	it("drops a later rejection from an item admitted before the first failure", async () => {
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown) => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const run = mapWithConcurrency([1, 2], 2, async (item) => {
+				await new Promise((resolve) => setTimeout(resolve, item));
 				throw new Error(`item ${item} failed`);
-			}
-			return item;
-		});
-		await expect(run).rejects.toThrow("item 1 failed");
-		// Items 0 and 1 were admitted first; the worker that hit the failure
-		// stops, and the surviving worker drains at most what it had claimed.
-		expect(started).not.toContain(5);
+			});
+			await expect(run).rejects.toThrow("item 1 failed");
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
+
+	it("rejects when fn throws synchronously", async () => {
+		await expect(
+			mapWithConcurrency([1], 2, () => {
+				throw new Error("sync boom");
+			}),
+		).rejects.toThrow("sync boom");
 	});
 
 	it("rejects a non-positive or fractional limit", async () => {

--- a/packages/core/src/utils/bounded-map.ts
+++ b/packages/core/src/utils/bounded-map.ts
@@ -3,9 +3,9 @@
  * `Promise.all(items.map(fn))` admits every element at once, so the input
  * length decides how many lookups run simultaneously; callers that resolve one
  * database row per item use this to keep that number fixed. Results keep the
- * input order, and the first rejection rejects the whole map after the
- * workers already in flight settle, matching `Promise.all` semantics closely
- * enough for callers that treat one failure as total.
+ * input order. The first rejection rejects the map immediately and stops
+ * further admission, matching `Promise.all`'s prompt failure; items already in
+ * flight run to completion and their outcomes are dropped.
  */
 
 /**
@@ -13,49 +13,70 @@
  * Returns results in input order. Throws a `RangeError` for a non-positive or
  * non-integer `limit`.
  */
-export async function mapWithConcurrency<T, R>(
+export function mapWithConcurrency<T, R>(
 	items: ReadonlyArray<T>,
 	limit: number,
 	fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
 	if (!Number.isInteger(limit) || limit < 1) {
-		throw new RangeError(
-			`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+		return Promise.reject(
+			new RangeError(
+				`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+			),
 		);
 	}
 	const results: R[] = new Array(items.length);
 	if (items.length === 0) {
-		return results;
+		return Promise.resolve(results);
 	}
-	let nextIndex = 0;
-	const state: { failure: { error: unknown } | null } = { failure: null };
-	const worker = async (): Promise<void> => {
-		while (state.failure === null) {
-			// No await sits between the read and the increment, so each worker
-			// claims a distinct index in the single-threaded loop.
-			const index = nextIndex++;
-			if (index >= items.length) {
+	return new Promise<R[]>((resolve, reject) => {
+		let nextIndex = 0;
+		let inFlight = 0;
+		let settled = false;
+
+		const fail = (error: unknown): void => {
+			if (settled) {
+				// error-policy:J5 the map already rejected with the first failure;
+				// a later rejection from an item admitted before it is observed
+				// here and dropped so it cannot surface as an unhandled rejection.
 				return;
 			}
-			try {
-				results[index] = await fn(items[index], index);
-			} catch (error) {
-				// error-policy:J2 remember the first failure so the map rejects with it once in-flight workers settle
-				if (state.failure === null) {
-					state.failure = { error };
+			settled = true;
+			reject(error);
+		};
+
+		const admit = (): void => {
+			while (!settled && inFlight < limit && nextIndex < items.length) {
+				const index = nextIndex++;
+				inFlight += 1;
+				let pending: Promise<R>;
+				try {
+					pending = fn(items[index], index);
+				} catch (error) {
+					inFlight -= 1;
+					fail(error);
+					return;
 				}
-				return;
+				pending.then(
+					(value) => {
+						inFlight -= 1;
+						if (settled) return;
+						results[index] = value;
+						if (nextIndex >= items.length && inFlight === 0) {
+							settled = true;
+							resolve(results);
+							return;
+						}
+						admit();
+					},
+					(error: unknown) => {
+						inFlight -= 1;
+						fail(error);
+					},
+				);
 			}
-		}
-	};
-	const workers: Array<Promise<void>> = [];
-	const workerCount = Math.min(limit, items.length);
-	for (let i = 0; i < workerCount; i += 1) {
-		workers.push(worker());
-	}
-	await Promise.all(workers);
-	if (state.failure !== null) {
-		throw state.failure.error;
-	}
-	return results;
+		};
+
+		admit();
+	});
 }

--- a/packages/core/src/utils/bounded-map.ts
+++ b/packages/core/src/utils/bounded-map.ts
@@ -1,0 +1,61 @@
+/**
+ * Bounded-concurrency map for fan-out over caller-controlled lists. A plain
+ * `Promise.all(items.map(fn))` admits every element at once, so the input
+ * length decides how many lookups run simultaneously; callers that resolve one
+ * database row per item use this to keep that number fixed. Results keep the
+ * input order, and the first rejection rejects the whole map after the
+ * workers already in flight settle, matching `Promise.all` semantics closely
+ * enough for callers that treat one failure as total.
+ */
+
+/**
+ * Maps `items` through `fn` with at most `limit` calls in flight at once.
+ * Returns results in input order. Throws a `RangeError` for a non-positive or
+ * non-integer `limit`.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: ReadonlyArray<T>,
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	if (!Number.isInteger(limit) || limit < 1) {
+		throw new RangeError(
+			`mapWithConcurrency limit must be a positive integer (got ${String(limit)})`,
+		);
+	}
+	const results: R[] = new Array(items.length);
+	if (items.length === 0) {
+		return results;
+	}
+	let nextIndex = 0;
+	const state: { failure: { error: unknown } | null } = { failure: null };
+	const worker = async (): Promise<void> => {
+		while (state.failure === null) {
+			// No await sits between the read and the increment, so each worker
+			// claims a distinct index in the single-threaded loop.
+			const index = nextIndex++;
+			if (index >= items.length) {
+				return;
+			}
+			try {
+				results[index] = await fn(items[index], index);
+			} catch (error) {
+				// error-policy:J2 remember the first failure so the map rejects with it once in-flight workers settle
+				if (state.failure === null) {
+					state.failure = { error };
+				}
+				return;
+			}
+		}
+	};
+	const workers: Array<Promise<void>> = [];
+	const workerCount = Math.min(limit, items.length);
+	for (let i = 0; i < workerCount; i += 1) {
+		workers.push(worker());
+	}
+	await Promise.all(workers);
+	if (state.failure !== null) {
+		throw state.failure.error;
+	}
+	return results;
+}

--- a/plugins/plugin-inbox/src/inbox/message-fetcher.batched-rooms.test.ts
+++ b/plugins/plugin-inbox/src/inbox/message-fetcher.batched-rooms.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Covers the chat-room scan in the inbox message fetcher: the agent's whole
+ * room list is resolved through one batched room read rather than one read
+ * per room. Deterministic runtime stub; no database.
+ */
+import type { IAgentRuntime, Room, UUID } from "@elizaos/core";
+import { ChannelType } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { fetchChatMessages } from "./message-fetcher.js";
+
+const AGENT = "11111111-1111-4111-8111-111111111111" as UUID;
+const ROOM_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const ROOM_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" as UUID;
+const ROOM_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+
+describe("fetchChatMessages room resolution", () => {
+  it("reads every participant room through one batched lookup", async () => {
+    const batchReads: UUID[][] = [];
+    const singleReads: UUID[] = [];
+    const rooms: Room[] = [ROOM_A, ROOM_B].map((id) => ({
+      id,
+      name: `room-${id.slice(0, 2)}`,
+      source: "discord",
+      type: ChannelType.GROUP,
+      channelId: `chan-${id.slice(0, 2)}`,
+      serverId: "guild",
+    }));
+    const runtime = {
+      agentId: AGENT,
+      getRoomsForParticipant: async () => [ROOM_A, ROOM_B, ROOM_C],
+      getRoomsByIds: async (ids: UUID[]) => {
+        batchReads.push([...ids]);
+        return rooms.filter((room) => ids.includes(room.id));
+      },
+      getRoom: async (id: UUID) => {
+        singleReads.push(id);
+        return rooms.find((room) => room.id === id) ?? null;
+      },
+      getMemoriesByRoomIds: async () => [],
+      getWorld: async () => null,
+    } as unknown as IAgentRuntime;
+
+    // A source filter no room matches ends the scan right after the room
+    // read, which is the only step this pin is about.
+    const messages = await fetchChatMessages(runtime, {
+      sources: ["telegram"],
+      limit: 10,
+    });
+
+    expect(messages).toEqual([]);
+    expect(batchReads).toEqual([[ROOM_A, ROOM_B, ROOM_C]]);
+    expect(singleReads).toEqual([]);
+  });
+});

--- a/plugins/plugin-inbox/src/inbox/message-fetcher.ts
+++ b/plugins/plugin-inbox/src/inbox/message-fetcher.ts
@@ -305,11 +305,11 @@ export async function fetchChatMessages(
   const allRoomIds = await runtime.getRoomsForParticipant(runtime.agentId);
   if (allRoomIds.length === 0) return [];
 
-  const roomIds = allRoomIds as UUID[];
-  const rooms = await Promise.all(roomIds.map((id) => runtime.getRoom(id)));
+  // One batched read: the agent's room list is unbounded, so a per-room
+  // `getRoom` fan-out would admit one database read per room at once.
+  const rooms = await runtime.getRoomsByIds(allRoomIds as UUID[]);
   const sourceRooms: Room[] = [];
   for (const room of rooms) {
-    if (!room) continue;
     const roomSource = extractRoomSource(room);
     if (sourceMatchesFilter(roomSource, sourceTags)) {
       sourceRooms.push(room);


### PR DESCRIPTION
## Summary

Fixes #31008. Five data-driven paths issued one database read per list item through `Promise.all`, so their concurrency equalled the size of the sender's relationship graph, the contact list, or the agent's room list; three of them sit under the follow-ups provider, so the bound #30895 adds there was undone one layer down.

- `findEntityByName` (`packages/core/src/entities.ts`): the relationship counterparts are read with one `getEntitiesByIds` call over the deduplicated id set instead of one `getEntityById` per relationship.
- `RelationshipsService.searchContacts({ searchTerm })`: one batched entity read over the candidate contacts.
- `RelationshipsService.getRelationshipInsights`: one batched entity read, then the per-relationship analyses (each re-reads the pair's relationships, room lists, and shared-room messages) are admitted at most four at a time through `mapWithConcurrency`.
- `FollowUpService.getFollowUpSuggestions`: one batched entity read over the candidates and the same four-wide bound on the analyses.
- `AutonomyService.buildEntityNameLookup`: one batched read for every distinct sender per loop tick.
- `plugin-inbox` `fetchChatMessages`: `getRoomsByIds` over the agent's room list instead of `getRoom` per room.

## Stacked on #30895

The first two commits are #30895's exact commits (`git cherry-pick -x`), which add the `mapWithConcurrency` helper this change reuses for the analyses. When #30895 merges, a rebase drops them as patch-identical; the delta of this PR is the commits after them. If #30895 is superseded, the helper commit here stands on its own.

## Verification

Executed on this branch (develop `d7df7af187f0` + #30895 + this change):

- `packages/core` vitest: `src/features/autonomy`, `src/entities*`, `src/services/relationships*`, `src/services/followUp*` — 22 files, all green, including the new pins:
  - `entities.resolution.test.ts` "reads every relationship counterpart through one batched lookup" — three relationships naming two counterparts produce exactly one `getEntitiesByIds([ALICE, STRANGER])` and no `getEntityById`.
  - `relationships.test.ts` "resolves searchTerm candidates through one batched entity read" and "reads counterparts in one batch and analyzes at most four relationships at a time" — twelve relationships, one batched read, peak of four analyses in flight, all twelve analysed.
  - `followUp.test.ts` "reads candidate entities in one batch and analyzes at most four at a time" — twelve candidates, one batched read, no single reads, peak four.
  - `service.entity-names.test.ts` (autonomy) — batched read with id fallback; no read when there are no senders.
  - `plugin-inbox` `message-fetcher.batched-rooms.test.ts` — three rooms, one `getRoomsByIds`, no `getRoom`.
- RED controls: swapping in develop's `entities.ts`, `relationships.ts`, `followUp.ts`, and `message-fetcher.ts` one at a time fails exactly the new pins (1 / 2 / 1 / 1) and nothing else.
- `packages/core` typecheck: clean. `plugins/plugin-inbox` typecheck: clean. Biome: clean on all 12 changed files.
- Downstream suites against the rebuilt core dist: `packages/agent` contact actions 34/34, `plugin-inbox` 266 passed / 2 skipped, `plugin-personal-assistant` follow-up 9/9.
- Root `bun run verify` is running on this head and will be posted as a comment when it finishes.

# Evidence Gate

<!-- evidence-head:f94fff68061c8f07fb4254f37808e871c38ebc01 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; adapter call counts are asserted in the core suites below.
<!-- evidence-row:backend-logs -->
- [x] Test transcripts from the runs described above:
  <details><summary>vitest output: packages/core and downstream suites at this head, with per-file RED controls</summary>

  ```text
  $ bunx vitest run src/features/autonomy src/entities* src/services/relationships* src/services/followUp*   (packages/core)
   22 files, all green, including:
   PASS entities.resolution.test.ts > reads every relationship counterpart through one batched lookup   (one getEntitiesByIds([ALICE, STRANGER]), no getEntityById)
   PASS relationships.test.ts > resolves searchTerm candidates through one batched entity read
   PASS relationships.test.ts > reads counterparts in one batch and analyzes at most four relationships at a time   (twelve relationships, peak four in flight)
   PASS followUp.test.ts > reads candidate entities in one batch and analyzes at most four at a time
   PASS service.entity-names.test.ts (autonomy) > batched read with id fallback; no read when there are no senders
   PASS plugin-inbox message-fetcher.batched-rooms.test.ts > three rooms, one getRoomsByIds, no getRoom
  RED controls: develop's entities.ts / relationships.ts / followUp.ts / message-fetcher.ts swapped in one at a time fail exactly the new pins (1 / 2 / 1 / 1) and nothing else
  Downstream against the rebuilt core dist: packages/agent contact actions 34/34; plugin-inbox 266 passed / 2 skipped; plugin-personal-assistant follow-up 9/9
  typecheck: packages/core clean, plugins/plugin-inbox clean; Biome clean on all 12 changed files
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider or model change; no model calls are involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - read-path batching only; the asserted artifacts are the recorded adapter calls (one getEntitiesByIds / getRoomsByIds and no per-item reads) shown in the transcript above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198eoZHgXmp6RzdAdegaD3B
