### PR TITLE
test(calendar): validate optional arguments across provider strictness modes

### DIFF
--- a/plugins/plugin-personal-assistant/test/calendar-optional-tool-parameters.test.ts
+++ b/plugins/plugin-personal-assistant/test/calendar-optional-tool-parameters.test.ts
@@ -7,7 +7,10 @@ import type { Action, ActionParameterSchema } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { promoteSubactionsToActions } from "../../../packages/core/src/actions/promote-subactions.js";
 import { buildPlannerToolsFromActions } from "../../../packages/core/src/actions/to-tool.js";
-import { validateToolArgs } from "../../../packages/core/src/actions/validate-tool-args.js";
+import {
+  validateSchema,
+  validateToolArgs,
+} from "../../../packages/core/src/actions/validate-tool-args.js";
 import { createCalendarActionRunner } from "../../plugin-calendar/src/actions/calendar-handler.js";
 import { __INTERNAL_normalizeNativeToolsForCall as normalizeNativeToolsForCall } from "../../plugin-openai/models/text.js";
 import { calendarAction } from "../src/actions/calendar.js";
@@ -24,32 +27,54 @@ describe.each([
   ["domain calendar", domainCalendarAction],
 ] as const)("%s optional native arguments", (_name, parent) => {
   it.each([false, true])(
-    "keeps optional detail fields optional after provider normalization (Cerebras: %s)",
+    "admits sparse calendar creates through the provider schema without weakening travel types (Cerebras: %s)",
     (cerebrasMode) => {
       const family = promoteSubactionsToActions(parent);
-      expect(family.length).toBeGreaterThan(1);
+      const create = family.find(
+        (action) => action.name === "CALENDAR_CREATE_EVENT",
+      );
+      if (!create)
+        throw new Error("calendar create operation was not promoted");
       const normalized = normalizeNativeToolsForCall(
         buildPlannerToolsFromActions(family),
         { cerebrasMode },
       ).tools;
       if (!normalized)
         throw new Error("calendar tool family was not normalized");
-      for (const action of family) {
-        const tool = normalized[action.name] as {
-          strict?: boolean;
-          inputSchema: { jsonSchema: ActionParameterSchema };
-        };
-        expect(tool.strict).toBe(false);
-        const details = tool.inputSchema.jsonSchema.properties?.details;
-        if (
-          action.parameters?.some((parameter) => parameter.name === "details")
-        ) {
-          expect(details?.properties?.travelOriginAddress).toMatchObject({
-            type: "string",
-          });
-          expect(details?.required ?? []).toEqual([]);
-        }
+      const tool = normalized[create.name] as {
+        strict?: boolean;
+        inputSchema: { jsonSchema: ActionParameterSchema };
+      };
+      expect(tool.strict).toBe(cerebrasMode);
+      const args = {
+        title: "Pottery class",
+        details: {
+          startAt: "2026-09-11T16:00:00.000Z",
+          endAt: "2026-09-11T17:00:00.000Z",
+          timeZone: "UTC",
+        },
+      };
+      for (const details of [
+        args.details,
+        { ...args.details, travelOriginAddress: "Studio" },
+      ]) {
+        const input = { ...args, details };
+        const errors: string[] = [];
+        validateSchema(tool.inputSchema.jsonSchema, input, "", errors);
+        expect(errors).toEqual([]);
+        expect(validateToolArgs(create, input)).toMatchObject({
+          valid: true,
+          args: input,
+        });
       }
+      const invalid = {
+        ...args,
+        details: { ...args.details, travelOriginAddress: false },
+      };
+      const errors: string[] = [];
+      validateSchema(tool.inputSchema.jsonSchema, invalid, "", errors);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(validateToolArgs(create, invalid).valid).toBe(false);
     },
   );
 


### PR DESCRIPTION
Closes #31013.

The personal-assistant calendar boundary test rejected the Cerebras strict-tool contract introduced by #30990 even though optional calendar fields remain optional. Replace the stale family-wide schema assertions with actual validation of sparse calendar-create arguments through the normalized provider schema and the original action validator. Both calendar owners and both provider modes accept omitted or explicitly supplied travel origins and reject an incorrectly typed travel origin. Existing title-delete and travel-sentinel regressions remain.

Current-develop control reproduces the two obsolete strictness failures. The updated focused file passes all eight tests; an independent reviewer approved the changed consumer contract. No production code changes, live provider calls, or calendar writes are included.

Published head: `3009bfbc19c6f6f09d4752919ac404b8d68eeeb5`. Its complete personal-assistant suite passed 2,601 tests in 300 files, with six skips; all five hosted checks passed in run34501537816.

Current integration: develop `f7221e0548d723cc714b07a239f2f5ed85105442` plus this published head produces tree `fcccac5cd7d68c7fb9424ad393cbfd4787d97ae1`, identical to locally qualified candidate `587068d8f33501d1385d06839d6a9c03d3acbd74`. Normal installation and all 373 repository tasks plus final audits passed on that tree using Node24.15.0 and Bun1.3.14. The base advance changes only seven standalone LifeOps script/test files; the personal-assistant package and its tested provider/runtime source are unchanged. The full package suite was not repeated for that unrelated script change.

The provider-wire regression covered here is sparse calendar creation, not every calendar operation. Both a delegated reviewer and an external reviewer approved this targeted contract; the external reviewer also demonstrated that disabling optional-field preservation makes the new validator assertions fail.

<!-- evidence-head:3009bfbc19c6f6f09d4752919ac404b8d68eeeb5 -->
<!-- evidence-row:before-screenshots -->
N/A - only a backend test changes; no rendered surface changes.
<!-- evidence-row:after-screenshots -->
N/A - only a backend test changes; no rendered surface changes.
<!-- evidence-row:walkthrough-video -->
N/A - deterministic provider-schema and action-validator behavior is exercised in the test runner.
<!-- evidence-row:backend-logs -->
Current-head repository verification (exit0):
```text
 Tasks:    373 successful, 373 total
  Time:    15m51.471s 
[anti-larp] scanned 11676 test files — 0 focused, 0 orphaned skip(s)
[anti-larp] clean — no focused tests, no untracked skips.
```
<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime is involved.
<!-- evidence-row:llm-trajectory -->
N/A - no planner or production behavior changes; this test calls the real provider schema normalizer and argument validators without model dispatch.
<!-- evidence-row:domain-artifacts -->
The previous source produced6pass/2fail because the two provider-normalization cases expected strict:false for every tool. The replacement8cases pass. For each calendar owner and provider mode, both the normalized JSONschema validator and the original action validator accept sparse create arguments and a supplied string travelOriginAddress, and reject a boolean travelOriginAddress. Existing delete-by-title and travel-sentinel consumer regressions remain covered.
The focused candidate result below predates the current-base rebase; the changed test source is unchanged. The complete package suite at the published head also passed, as shown below.
```text
$ node scripts/lint-default-packs.mjs
[lint-default-packs] clean — 0 findings across default packs.
$ vitest run --config vitest.config.ts test/calendar-optional-tool-parameters.test.ts

 RUN  v4.1.10 /private/tmp/eliza-project19-review/core-worktree


 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  11:26:39
   Duration  42.76s (transform 36.63s, setup 125ms, import 40.86s, tests 43ms, environment 0ms)

```
```text

 RUN  v4.1.10 /private/tmp/eliza-project19-review/core-worktree


 Test Files  300 passed (300)
      Tests  2601 passed | 6 skipped (2607)
   Start at  12:16:47
   Duration  1953.72s (transform 2035.76s, setup 21.14s, import 837.94s, tests 1052.26s, environment 8.37s)

```
<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface changes.
