### PR TITLE
fix(app): restore calendar controls and Connections loading

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -406,6 +406,17 @@ for (const width of [1280, 390]) {
         await route.fulfill({ json: { accounts: [] } });
       },
     );
+    await page.route("**/api/permissions/calendar", async (route) => {
+      await route.fulfill({
+        json: {
+          id: "calendar",
+          status: "denied",
+          lastChecked: Date.now(),
+          canRequest: false,
+          platform: "darwin",
+        },
+      });
+    });
     await openAppPath(page, "/lifeops/connections");
     const refresh = page.getByRole("button", {
       name: "Retry all connection checks and synchronization",

--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -56,10 +56,31 @@ test("calendar decomposed view: responsive modes and event creation", async ({
 }) => {
   await openPopulatedCalendar(page);
 
+  if ((await page.evaluate(() => window.innerWidth)) >= 768) {
+    const todayBounds = await page
+      .getByRole("button", { name: "Today", exact: true })
+      .boundingBox();
+    const createBounds = await page
+      .getByTestId("lifeops-calendar-new-event")
+      .boundingBox();
+    if (!todayBounds || !createBounds)
+      throw new Error("Calendar toolbar controls are missing");
+    expect(
+      Math.abs(
+        todayBounds.y +
+          todayBounds.height / 2 -
+          createBounds.y -
+          createBounds.height / 2,
+      ),
+      "Desktop calendar navigation and creation should share one compact toolbar row",
+    ).toBeLessThan(4);
+  }
+
   const monthMode = page.getByRole("button", { name: "Month", exact: true });
   await expectTopmostAtCenter(monthMode, "Calendar Month mode");
   await monthMode.click();
   await expect(monthMode).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByTestId("calendar-month-grid")).toBeVisible();
 
   const newEvent = page.getByTestId("lifeops-calendar-new-event");
   await expectTopmostAtCenter(newEvent, "Calendar New event");
@@ -82,6 +103,7 @@ test("calendar mobile layout keeps navigation and editor inside 390px viewport",
   await expectTopmostAtCenter(dayMode, "Calendar Day mode");
   await dayMode.click();
   await expect(dayMode).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByTestId("calendar-time-grid")).toBeVisible();
 
   const newEvent = page.getByTestId("lifeops-calendar-new-event");
   await expectTopmostAtCenter(newEvent, "Calendar New event");
@@ -110,6 +132,50 @@ test("calendar mobile layout keeps navigation and editor inside 390px viewport",
     page.getByRole("button", { name: "Create event" }),
   ).toBeVisible();
 });
+
+for (const width of [1280, 390]) {
+  test(`empty calendar preserves selected projections and creation at ${width}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.route("**/api/lifeops/calendar/feed**", async (route) => {
+      const url = new URL(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          calendarId: "primary",
+          events: [],
+          source: "cache",
+          state: "complete",
+          sources: [],
+          timeMin: url.searchParams.get("timeMin"),
+          timeMax: url.searchParams.get("timeMax"),
+          syncedAt: new Date().toISOString(),
+        }),
+      });
+    });
+    await openAppPath(page, "/calendar");
+    for (const mode of ["Day", "Week", "Month"]) {
+      const control = page.getByRole("button", { name: mode, exact: true });
+      await control.click();
+      await expect(control).toHaveAttribute("aria-pressed", "true");
+      await expect(
+        page.getByTestId(
+          mode === "Month" ? "calendar-month-grid" : "calendar-time-grid",
+        ),
+      ).toBeVisible();
+      expect(
+        await page.evaluate(() => document.documentElement.scrollWidth),
+      ).toBe(width);
+    }
+    await page.getByTestId("lifeops-calendar-new-event").click();
+    await expect(page.getByLabel("Event title")).toBeInViewport();
+    await expect(
+      page.getByRole("button", { name: "Create event" }),
+    ).toBeVisible();
+  });
+}
 
 test("inbox decomposed view: channel filters toggle", async ({ page }) => {
   // /inbox renders the populated triage list from the inbox mock: an Email

--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -392,3 +392,41 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     timeout: 15_000,
   });
 });
+
+for (const width of [1280, 390]) {
+  test(`connections calendar recovery loads through the built host at ${width}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 900 });
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    await page.route(
+      "**/api/lifeops/connectors/google/status**",
+      async (route) => {
+        await route.fulfill({ json: { accounts: [] } });
+      },
+    );
+    await openAppPath(page, "/lifeops/connections");
+    const refresh = page.getByRole("button", {
+      name: "Retry all connection checks and synchronization",
+    });
+    await expect(refresh).toBeEnabled({ timeout: 60_000 });
+    await page
+      .getByRole("button", { name: "Replace an account", exact: true })
+      .click();
+    await expect(
+      page.getByLabel("Test account to disconnect", { exact: true }),
+    ).toBeVisible();
+    const synchronized = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        url.pathname === "/api/lifeops/calendar/feed" &&
+        url.searchParams.get("forceSync") === "true"
+      );
+    });
+    await refresh.click();
+    await synchronized;
+    await expect(refresh).toBeEnabled();
+    expect(pageErrors).toEqual([]);
+  });
+}

--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -52,6 +52,56 @@ async function openPopulatedCalendar(page: Page): Promise<void> {
   });
 }
 
+test("calendar inherits the host accent for current and selected days after a preference change", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("eliza:ui-accent", "green");
+  });
+  await openPopulatedCalendar(page);
+  await page.getByRole("button", { name: "Month", exact: true }).click();
+  const grid = page.getByTestId("calendar-month-grid");
+  const selected = grid
+    .locator(
+      'button[data-agent-id^="calendar-day-"]:not([aria-current="date"])',
+    )
+    .first();
+  await selected.click();
+  await expect(selected).toHaveAttribute("aria-pressed", "true");
+  await page.mouse.move(0, 0);
+  await page.waitForTimeout(300);
+  const colors = await page.evaluate(() => {
+    const root = getComputedStyle(document.documentElement);
+    const current = document.querySelector(
+      '[data-testid="calendar-month-grid"] button[aria-current="date"]',
+    );
+    const selection = document.querySelector(
+      '[data-testid="calendar-month-grid"] button[aria-pressed="true"]',
+    );
+    if (!current || !selection)
+      throw new Error("Calendar day controls missing");
+    const probe = document.createElement("span");
+    document.body.append(probe);
+    const resolve = (value: string) => {
+      probe.style.backgroundColor = value;
+      return getComputedStyle(probe).backgroundColor;
+    };
+    const result = {
+      current: getComputedStyle(current).backgroundColor,
+      selected: getComputedStyle(selection).backgroundColor,
+      expectedCurrent: resolve(root.getPropertyValue("--accent")),
+      expectedSelected: resolve(root.getPropertyValue("--accent-subtle")),
+      preferenceApplied:
+        document.documentElement.style.getPropertyValue("--accent") !== "",
+    };
+    probe.remove();
+    return result;
+  });
+  expect(colors.preferenceApplied).toBe(true);
+  expect(colors.current).toBe(colors.expectedCurrent);
+  expect(colors.selected).toBe(colors.expectedSelected);
+});
+
 test("calendar decomposed view: responsive modes and event creation", async ({
   page,
 }) => {

--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -11,6 +11,7 @@ import {
   openAppPath,
   seedAppStorage,
 } from "./helpers";
+import { installRemoteConnectionsView } from "./remote-connections-fixture";
 
 test.beforeEach(async ({ page }) => {
   await seedAppStorage(page);
@@ -400,6 +401,7 @@ for (const width of [1280, 390]) {
     await page.setViewportSize({ width, height: 900 });
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));
+    const { bundleRequests } = await installRemoteConnectionsView(page);
     await page.route(
       "**/api/lifeops/connectors/google/status**",
       async (route) => {
@@ -438,6 +440,11 @@ for (const width of [1280, 390]) {
     await refresh.click();
     await synchronized;
     await expect(refresh).toBeEnabled();
+    expect(
+      bundleRequests.some(
+        (url) => new URL(url).searchParams.get("hostExternalRuntime") === "1",
+      ),
+    ).toBe(true);
     expect(pageErrors).toEqual([]);
   });
 }

--- a/packages/app/test/ui-smoke/remote-connections-fixture.ts
+++ b/packages/app/test/ui-smoke/remote-connections-fixture.ts
@@ -1,0 +1,63 @@
+/**
+ * Serves the built Connections bundle through the remote-view registry for
+ * browser tests. Canonical server rewriting preserves the host-module import
+ * boundary, and recorded requests prove the shell used that transport.
+ */
+import { readFileSync } from "node:fs";
+import type { Page } from "@playwright/test";
+import {
+  parseHostExternalSpecifiers,
+  wrapBundleAsHostExternalFactory,
+} from "../../../agent/src/api/dynamic-view-host-external.mjs";
+
+export async function installRemoteConnectionsView(page: Page) {
+  const bundlePath = "/api/views/lifeops-connections/bundle.js";
+  const bundleRequests: string[] = [];
+  const source = readFileSync(
+    new URL(
+      "../../../../plugins/plugin-personal-assistant/dist/views/bundle.js",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  await page.route(
+    (url) => url.pathname === "/api/views",
+    async (route) => {
+      await route.fulfill({
+        json: {
+          views: [
+            {
+              id: "lifeops-connections",
+              label: "Mail & Calendars",
+              pluginName: "@elizaos/plugin-personal-assistant",
+              path: "/lifeops/connections",
+              viewType: "gui",
+              componentExport: "LifeOpsConnectionsView",
+              bundleUrl: bundlePath,
+              available: true,
+              surface: {
+                header: "fullscreen",
+                capabilities: ["agent-surface"],
+              },
+            },
+          ],
+        },
+      });
+    },
+  );
+  await page.context().route(
+    (url) => url.pathname === bundlePath,
+    async (route) => {
+      const url = new URL(route.request().url());
+      bundleRequests.push(url.href);
+      const specifiers = parseHostExternalSpecifiers(url);
+      await route.fulfill({
+        contentType: "application/javascript",
+        body: specifiers.length
+          ? wrapBundleAsHostExternalFactory(source, specifiers)
+          : source,
+      });
+    },
+  );
+  return { bundleRequests };
+}

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -531,7 +531,7 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
     importHostExternal("@elizaos/capacitor-phone"),
   "@elizaos/capacitor-system": () =>
     importHostExternal("@elizaos/capacitor-system"),
-  "@elizaos/shared": () => importHostExternal("@elizaos/shared"),
+  "@elizaos/shared": () => import("@elizaos/shared"),
   "@elizaos/ui": importUiRootCompat,
   "@elizaos/ui/agent-surface": async () => AgentSurfaceHost,
   "@elizaos/ui/app-navigate-view": importUiAppNavigateViewCompat,

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -1,3 +1,4 @@
+/** Provides shared theme styles and utilities for application and dynamic plugin views. */
 @import "@fontsource/poppins/400.css";
 @import "@fontsource/poppins/500.css";
 @import "@fontsource/poppins/600.css";
@@ -49,6 +50,7 @@ electrobun-wgpu {
 @source "..";
 @source "../../../ui/src";
 @source "../../../../plugins/app-lifeops/src";
+@source "../../../../plugins/plugin-calendar/src";
 @source "../../../../plugins/plugin-maps/src";
 
 /* Memories sits beside a persistent filter rail in short landscape, where the

--- a/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
@@ -27,8 +27,6 @@ import type { UseCalendarWeekResult } from "../hooks/useCalendarWeek.js";
 // Mocks: @elizaos/ui primitives, agent-surface, the data hook, and the drawer.
 // ---------------------------------------------------------------------------
 
-const mediaQueryState = vi.hoisted(() => ({ compact: false }));
-
 const calendarSectionAppValue = vi.hoisted(() => ({
   t: (_key: string, opts?: { defaultValue?: string }) =>
     opts?.defaultValue ?? _key,
@@ -85,16 +83,11 @@ vi.mock("@elizaos/ui", () => ({
   useAppSelectorShallow: <T,>(
     selector: (value: typeof calendarSectionAppValue) => T,
   ) => selector(calendarSectionAppValue),
-  useMediaQuery: () => mediaQueryState.compact,
 }));
 
 vi.mock("@elizaos/ui/components", async () => {
   return await vi.importMock<Record<string, unknown>>("@elizaos/ui");
 });
-
-vi.mock("@elizaos/ui/hooks", () => ({
-  useMediaQuery: () => mediaQueryState.compact,
-}));
 
 vi.mock("@elizaos/ui/state", () => ({
   useApp: () => calendarSectionAppValue,
@@ -270,7 +263,6 @@ function ControlledCalendarSection({
 describe("CalendarSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mediaQueryState.compact = false;
     calendarState.current = makeResult();
   });
 
@@ -415,9 +407,9 @@ describe("CalendarSection", () => {
     expect(within(overflow).getByText("Demo")).toBeTruthy();
   });
 
-  it("renders the agenda layout with meta lines on compact (mobile) screens", () => {
-    mediaQueryState.compact = true;
+  it("opens the selected month's day agenda without replacing the calendar grid", () => {
     calendarState.current = makeResult({
+      viewMode: "month",
       events: [
         evt({
           id: "a1",
@@ -432,25 +424,26 @@ describe("CalendarSection", () => {
 
     render(<CalendarSection {...noopProps} />);
 
-    expect(screen.getByText("Dentist")).toBeTruthy();
-    // Agenda meta line concatenates time range, location, and calendar summary.
-    const meta = screen.getByText(/Downtown Clinic/);
+    fireEvent.click(screen.getByRole("button", { name: "Mon, Jun 15" }));
+    const agenda = screen.getByRole("region", { name: "Mon, Jun 15" });
+    expect(within(agenda).getByText("Dentist")).toBeTruthy();
+    expect(screen.getByTestId("calendar-month-grid")).toBeTruthy();
+    const meta = within(agenda).getByText(/Downtown Clinic/);
     expect(meta.textContent).toContain("Personal");
     expect(meta.textContent).toMatch(/9[:.]?0?0?\s*AM/i);
   });
 
-  it("shows the empty status when the agenda feed has no events", () => {
-    mediaQueryState.compact = true;
+  it("keeps the time grid and event creation available on an empty calendar", () => {
     calendarState.current = makeResult({ events: [], status: "empty" });
 
     render(<CalendarSection {...noopProps} />);
 
-    expect(
-      screen.getByRole("status", { name: "No events in this range" }),
-    ).toBeTruthy();
+    expect(screen.getByTestId("calendar-time-grid")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("lifeops-calendar-new-event"));
+    expect(screen.getByTestId("event-editor-drawer-create")).toBeTruthy();
   });
 
-  it("keeps the selected calendar grid visible on an empty desktop feed", () => {
+  it("keeps the selected calendar grid visible on an empty month feed", () => {
     calendarState.current = makeResult({
       events: [],
       status: "empty",
@@ -495,6 +488,8 @@ describe("CalendarSection", () => {
     render(<CalendarSection {...noopProps} />);
 
     expect(screen.getByText("Calendar failed to load.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(calendarState.current.refresh).toHaveBeenCalledOnce();
   });
 
   it("keeps provider diagnostics out of the owner calendar", () => {

--- a/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.test.tsx
@@ -28,6 +28,7 @@ import type { UseCalendarWeekResult } from "../hooks/useCalendarWeek.js";
 // ---------------------------------------------------------------------------
 
 const calendarSectionAppValue = vi.hoisted(() => ({
+  uiAccentId: "default",
   t: (_key: string, opts?: { defaultValue?: string }) =>
     opts?.defaultValue ?? _key,
   setActionNotice: vi.fn(),

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -1087,6 +1087,7 @@ export function CalendarSection({
   getPrimedEvent,
 }: CalendarSectionProps) {
   const t = useAppSelector((s) => s.t);
+  const uiAccentId = useAppSelector((s) => s.uiAccentId);
   const calendar = useCalendarWeek();
   useViewEvent(VIEW_EVENTS.VIEW_REFRESH, () => {
     void calendar.refresh();
@@ -1229,12 +1230,22 @@ export function CalendarSection({
       <section
         className="flex min-h-full flex-col gap-4"
         style={
-          {
-            "--accent": "var(--eliza-brand-orange, #ff5800)",
-            "--accent-foreground": "#111111",
-            "--accent-muted":
-              "color-mix(in srgb, var(--eliza-brand-orange, #ff5800) 75%, #111111)",
-          } as CSSProperties
+          uiAccentId === "default"
+            ? ({
+                "--accent": "var(--eliza-brand-orange, #ff5800)",
+                "--accent-rgb": "255, 88, 0",
+                "--accent-foreground": "#111111",
+                "--accent-hover":
+                  "color-mix(in srgb, var(--accent) 88%, white)",
+                "--accent-muted":
+                  "color-mix(in srgb, var(--accent) 75%, #111111)",
+                "--accent-subtle":
+                  "color-mix(in srgb, var(--accent) 14%, transparent)",
+                "--ring": "var(--accent)",
+                "--border-hover": "var(--accent)",
+                "--primary": "var(--accent)",
+              } as CSSProperties)
+            : undefined
         }
         data-testid="lifeops-calendar-section"
       >

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -263,7 +263,7 @@ function CalendarStatusIcon({
 }) {
   return (
     <div
-      className="flex items-center justify-center py-12 text-muted"
+      className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted"
       role="status"
       aria-label={label}
       title={label}
@@ -273,7 +273,7 @@ function CalendarStatusIcon({
       ) : (
         <CalendarClock className="size-5 opacity-70" aria-hidden />
       )}
-      <span className="sr-only">{label}</span>
+      <span>{label}</span>
     </div>
   );
 }

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -801,7 +801,7 @@ function MonthGrid({
         ))}
       </div>
       <div
-        className="grid gap-px bg-border/8"
+        className="grid gap-px bg-border"
         style={{ gridTemplateColumns: "repeat(7, minmax(0, 1fr))" }}
       >
         {days.map((day) => {
@@ -941,7 +941,7 @@ function MonthDayButton({
   return (
     <Button
       ref={control.ref}
-      variant="selection"
+      variant={today ? "accentDarkHover" : "selection"}
       size="touch"
       type="button"
       className="min-w-0 self-start px-1"

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -944,7 +944,7 @@ function MonthDayButton({
       variant={today ? "accentDarkHover" : "selection"}
       size="touch"
       type="button"
-      className="min-w-0 self-start px-1"
+      className="w-11 min-w-0 max-w-full self-start px-1"
       aria-label={label}
       aria-current={today ? "date" : undefined}
       aria-pressed={selected}

--- a/plugins/plugin-calendar/src/components/CalendarSection.tsx
+++ b/plugins/plugin-calendar/src/components/CalendarSection.tsx
@@ -1,5 +1,5 @@
 /**
- * CalendarSection — Google Calendar-style week/day/month views.
+ * Renders the owner's calendar as selectable day, week, and month grids.
  *
  * Day/week views render an hour-by-hour grid and position events by their
  * actual start/end time. Month view renders a 5-6 row day grid. Events get
@@ -7,10 +7,8 @@
  * the same feed keeps the same colour across renders.
  *
  * Shell concerns (selection state, chat launching, and the primed-event
- * lookup cache) are injected as props so the component stays decoupled from
- * the LifeOps dashboard shell. `@elizaos/plugin-personal-assistant` wraps this with a
- * thin adapter that wires its own selection context, chat launcher, and
- * event prime cache.
+ * lookup cache) are injected as props so route and embedded consumers share
+ * the same event editor and calendar mutation boundary.
  */
 
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
@@ -23,10 +21,16 @@ import {
   SegmentedControl,
   Spinner,
 } from "@elizaos/ui/components";
-import { useMediaQuery } from "@elizaos/ui/hooks";
+import { useViewEvent, VIEW_EVENTS } from "@elizaos/ui/events";
 import { useAppSelector } from "@elizaos/ui/state";
 import { CalendarClock, ChevronLeft, ChevronRight, Plus } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   type CalendarViewMode,
   useCalendarWeek,
@@ -411,7 +415,7 @@ function DayColumnHeader({ day, isFirst }: { day: Date; isFirst: boolean }) {
   const isToday = isSameDayKey(day, new Date());
   return (
     <div
-      className={`flex items-center justify-center gap-1.5 ${isFirst ? "" : "border-l border-border/12"} px-2 text-[11px] font-medium ${
+      className={`flex items-center justify-center gap-1.5 ${isFirst ? "" : "border-l border-border"} px-2 text-[11px] font-medium ${
         isToday ? "bg-accent/8" : ""
       }`}
       style={{ height: `${HEADER_ROW_HEIGHT_REM}rem` }}
@@ -445,7 +449,7 @@ function AllDayBandCell({
 }) {
   return (
     <fieldset
-      className={`m-0 min-w-0 space-y-0.5 border-0 p-1 ${isFirst ? "" : "border-l border-border/12"}`}
+      className={`m-0 min-w-0 space-y-0.5 border-0 p-1 ${isFirst ? "" : "border-l border-border"}`}
       aria-label={`All-day events for ${day.toISOString()}`}
     >
       {events.map((event) => {
@@ -524,7 +528,7 @@ function DayColumnGrid({
 
   return (
     <div
-      className={`relative ${isFirst ? "" : "border-l border-border/12"} ${isToday ? "bg-accent/5" : ""}`}
+      className={`relative ${isFirst ? "" : "border-l border-border"} ${isToday ? "bg-accent/5" : ""}`}
       style={{ height: `${gridHeight}px` }}
     >
       {/* hour lines */}
@@ -532,7 +536,7 @@ function DayColumnGrid({
         (hour) => (
           <div
             key={hour}
-            className="pointer-events-none absolute inset-x-0 border-t border-border/6"
+            className="pointer-events-none absolute inset-x-0 border-t border-border"
             style={{ top: `${(hour - DAY_START_HOUR) * HOUR_HEIGHT_PX}px` }}
           />
         ),
@@ -663,7 +667,7 @@ function TimeGrid({
     <div className="overflow-hidden" data-testid="calendar-time-grid">
       {/* Header row: empty cell above rail, then weekday + date per column */}
       <div
-        className="grid border-b border-border/12"
+        className="grid border-b border-border"
         style={{ gridTemplateColumns }}
       >
         <div aria-hidden style={{ height: `${HEADER_ROW_HEIGHT_REM}rem` }} />
@@ -679,7 +683,7 @@ function TimeGrid({
       {/* All-day band: stays aligned row-wise with the header */}
       {hasAnyAllDay ? (
         <div
-          className="grid border-b border-border/12 bg-bg-muted/15"
+          className="grid border-b border-border bg-bg-muted/15"
           style={{ gridTemplateColumns }}
         >
           <div
@@ -760,11 +764,15 @@ function MonthGrid({
   eventsByDay,
   selectedEventId,
   onSelectEvent,
+  onSelectDay,
+  selectedDay,
 }: {
   baseDate: Date;
   eventsByDay: Map<string, LifeOpsCalendarEvent[]>;
   selectedEventId: string | null;
   onSelectEvent: (event: LifeOpsCalendarEvent) => void;
+  onSelectDay: (day: Date) => void;
+  selectedDay: Date | null;
 }) {
   const start = startOfMonthGrid(baseDate);
   const days = buildDays(start, 42);
@@ -783,7 +791,7 @@ function MonthGrid({
   return (
     <div className="overflow-hidden" data-testid="calendar-month-grid">
       <div
-        className="grid border-b border-border/12 text-[10px] font-medium text-muted"
+        className="grid border-b border-border text-[10px] font-medium text-muted"
         style={{ gridTemplateColumns: "repeat(7, minmax(0, 1fr))" }}
       >
         {weekdayLabels.map((label) => (
@@ -804,21 +812,18 @@ function MonthGrid({
           return (
             <div
               key={key}
-              className={`flex min-h-24 flex-col gap-1 bg-bg p-1.5 text-left ${
+              className={`flex min-h-24 min-w-0 flex-col gap-1 bg-bg p-1 text-left md:p-1.5 ${
                 inMonth ? "" : "opacity-55"
               }`}
             >
-              <div
-                className={`text-[11px] font-medium ${
-                  isToday
-                    ? "inline-flex h-5 w-5 items-center justify-center self-start rounded-full bg-accent text-accent-fg"
-                    : inMonth
-                      ? "text-txt"
-                      : "text-muted"
-                }`}
-              >
-                {formatDayNumber(day)}
-              </div>
+              <MonthDayButton
+                day={day}
+                today={isToday}
+                selected={
+                  selectedDay !== null && isSameDayKey(day, selectedDay)
+                }
+                onSelectDay={onSelectDay}
+              />
               <div className="flex flex-col gap-0.5">
                 {dayEvents.slice(0, 3).map((event) => {
                   const color = paletteFor(event);
@@ -910,6 +915,45 @@ function MonthGrid({
         })}
       </div>
     </div>
+  );
+}
+
+function MonthDayButton({
+  day,
+  today,
+  selected,
+  onSelectDay,
+}: {
+  day: Date;
+  today: boolean;
+  selected: boolean;
+  onSelectDay: (day: Date) => void;
+}) {
+  const label = formatAgendaDayLabel(day);
+  const selectDay = () => onSelectDay(day);
+  const control = useAgentElement<HTMLButtonElement>({
+    id: `calendar-day-${toLocalDayKey(day)}`,
+    role: "button",
+    label,
+    group: "calendar-days",
+    onActivate: selectDay,
+  });
+  return (
+    <Button
+      ref={control.ref}
+      variant="selection"
+      size="touch"
+      type="button"
+      className="min-w-0 self-start px-1"
+      aria-label={label}
+      aria-current={today ? "date" : undefined}
+      aria-pressed={selected}
+      data-state={selected ? "on" : "off"}
+      onClick={selectDay}
+      {...control.agentProps}
+    >
+      {formatDayNumber(day)}
+    </Button>
   );
 }
 
@@ -1044,7 +1088,10 @@ export function CalendarSection({
 }: CalendarSectionProps) {
   const t = useAppSelector((s) => s.t);
   const calendar = useCalendarWeek();
-  const compactLayout = useMediaQuery("(max-width: 767px)");
+  useViewEvent(VIEW_EVENTS.VIEW_REFRESH, () => {
+    void calendar.refresh();
+  }, [calendar.refresh]);
+  const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [drawerEvent, setDrawerEvent] = useState<LifeOpsCalendarEvent | null>(
     null,
   );
@@ -1181,6 +1228,14 @@ export function CalendarSection({
     <>
       <section
         className="flex min-h-full flex-col gap-4"
+        style={
+          {
+            "--accent": "var(--eliza-brand-orange, #ff5800)",
+            "--accent-foreground": "#111111",
+            "--accent-muted":
+              "color-mix(in srgb, var(--eliza-brand-orange, #ff5800) 75%, #111111)",
+          } as CSSProperties
+        }
         data-testid="lifeops-calendar-section"
       >
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1228,7 +1283,7 @@ export function CalendarSection({
             </h2>
           </div>
 
-          <div className="flex w-full items-center gap-2 sm:w-auto">
+          <div className="flex items-center gap-2">
             <SegmentedControl<CalendarViewMode>
               aria-label={t("lifeopsCalendar.viewModeAria", {
                 defaultValue: "Calendar view",
@@ -1236,8 +1291,8 @@ export function CalendarSection({
               value={calendar.viewMode}
               onValueChange={calendar.setViewMode}
               items={VIEW_ITEMS}
-              className="w-full border-0 bg-transparent p-0.5"
-              buttonClassName="min-h-8 flex-1 px-3 py-1 text-xs"
+              className="border-0 bg-transparent p-0.5"
+              buttonClassName="min-h-8 px-3 py-1 text-xs"
               {...viewMode.agentProps}
             />
             <Button
@@ -1277,6 +1332,35 @@ export function CalendarSection({
             {calendar.error}
           </div>
         ) : null}
+        {calendar.status === "empty" ? (
+          <p role="status" className="text-sm text-muted">
+            {t("lifeopsCalendar.noEvents", {
+              defaultValue: "No events in this range",
+            })}
+          </p>
+        ) : null}
+        {calendar.status === "partial" ? (
+          <p role="status" className="text-sm text-muted">
+            {t("lifeopsCalendar.partialFeed", {
+              defaultValue:
+                "Some calendar sources are unavailable. Events may be incomplete.",
+            })}
+          </p>
+        ) : null}
+        {calendar.status === "error" ||
+        calendar.status === "unavailable" ||
+        calendar.status === "partial" ? (
+          <Button
+            type="button"
+            variant="surface"
+            size="touch"
+            className="self-start"
+            disabled={calendar.refreshing}
+            onClick={() => void calendar.refresh()}
+          >
+            {t("common.retry", { defaultValue: "Retry" })}
+          </Button>
+        ) : null}
 
         {calendar.status === "loading" ? (
           <CalendarStatusIcon
@@ -1297,45 +1381,40 @@ export function CalendarSection({
               defaultValue: "Calendar could not load",
             })}
           />
-        ) : compactLayout && calendar.status === "empty" ? (
-          <CalendarStatusIcon
-            label={t("lifeopsCalendar.noEvents", {
-              defaultValue: "No events in this range",
-            })}
-          />
-        ) : compactLayout &&
-          calendar.status === "partial" &&
-          calendar.events.length === 0 ? (
-          <CalendarStatusIcon
-            label={t("lifeopsCalendar.noEventsPartial", {
-              defaultValue: "No events from available sources",
-            })}
-          />
-        ) : compactLayout ? (
-          <AgendaView
-            days={days}
-            eventsByDay={eventsByDay}
-            selectedEventId={selectedEventId}
-            onSelectEvent={handleSelectEvent}
-            emptyLabel={t("lifeopsCalendar.empty", {
-              defaultValue: "Clear",
-            })}
-          />
         ) : calendar.viewMode === "month" ? (
           <MonthGrid
             baseDate={calendar.baseDate}
             eventsByDay={eventsByDay}
             selectedEventId={selectedEventId}
             onSelectEvent={handleSelectEvent}
+            onSelectDay={setSelectedDay}
+            selectedDay={selectedDay}
           />
         ) : (
-          <TimeGrid
-            days={days}
-            eventsByDay={eventsByDay}
-            selectedEventId={selectedEventId}
-            onSelectEvent={handleSelectEvent}
-          />
+          <div className="min-w-0 overflow-x-auto">
+            <div className={days.length > 1 ? "min-w-3xl" : "min-w-0"}>
+              <TimeGrid
+                days={days}
+                eventsByDay={eventsByDay}
+                selectedEventId={selectedEventId}
+                onSelectEvent={handleSelectEvent}
+              />
+            </div>
+          </div>
         )}
+        {calendar.viewMode === "month" &&
+        selectedDay &&
+        days.some((day) => isSameDayKey(day, selectedDay)) ? (
+          <section aria-label={formatAgendaDayLabel(selectedDay)}>
+            <AgendaView
+              days={[selectedDay]}
+              eventsByDay={eventsByDay}
+              selectedEventId={selectedEventId}
+              onSelectEvent={handleSelectEvent}
+              emptyLabel={t("lifeopsCalendar.empty", { defaultValue: "Clear" })}
+            />
+          </section>
+        ) : null}
       </section>
 
       <EventEditorDrawer

--- a/plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarPage.tsx
@@ -5,15 +5,23 @@
  */
 
 import { ViewHeader } from "@elizaos/ui/components";
-import type { JSX } from "react";
-import { SimpleCalendarView } from "./SimpleCalendarView.tsx";
+import { type JSX, useState } from "react";
+import { CalendarSection } from "../CalendarSection.tsx";
+
+// Route-local selections come from the current feed, without an external prime cache.
+const getPrimedEvent = () => null;
 
 export function CalendarPage(): JSX.Element {
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden pt-[var(--safe-area-top,0px)]">
       <ViewHeader title="Calendar" />
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-        <SimpleCalendarView />
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto p-3 md:p-4">
+        <CalendarSection
+          selectedEventId={selectedEventId}
+          onSelectEvent={setSelectedEventId}
+          getPrimedEvent={getPrimedEvent}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
The calendar route rendered a month-only picker, leaving the existing day/week grids and event editor inaccessible. It now uses the shared calendar component on desktop and mobile, keeps empty grids usable, supports selected-day agendas, and shows source failures with Retry. The host scans the calendar’s styles, and the reviewed layout preserves orange controls, readable grid lines and usable date targets.

Connections failed in the production browser because the host imported `@elizaos/shared` through an ignored variable specifier. A literal host import now lets the production bundler resolve that shared module. The isolated repair preserves the original commit authorship from #31003 without including its unfinished Google cutover work.

Calendar defaults use the required orange palette consistently across the accent family. An explicit user preference inherits the host theme instead of being overridden locally. The built-browser regression fails against the original unconditional override and passes with this fix.

Closes #31010. Closes #30222. Closes #31007. Related: #30123, #31003.

Candidate: `0d17f1b1a7d4f17af372306d8911148e7206ff71`, based on develop `1708731834282d31fe6a32a77548eb0f2d04bf70`.

- Complete root verification passed: all 373 tasks and final audits, including 11,679 test files checked for focused tests and untracked skips.
- Production renderer build and chunk-safety checks passed. The host source and recorded renderer hashes are unchanged from that build; the calendar bundle was rebuilt after the accent fix. Eight built-browser acceptance cases passed on this candidate.
- The Connections regression uses the real built personal-assistant bundle and canonical server rewriting through the remote-view registry. Both desktop and mobile fail with the original host importer and pass with the repaired importer; account-review and forced-sync controls work with no browser errors.
- Complete shared UI suite passed at `97fb3b4`: 1,307 files, 14,053 tests, seven skipped. UI production sources are unchanged; develop subsequently added two voice test changes. The current candidate received the fresh root gate and eight browser acceptance cases. Complete calendar suite passed on this candidate: 88 files passed, two skipped; 840 tests passed, four skipped.
- Desktop/mobile rest and hover captures were inspected across day/week/month, empty, partial and unavailable states. Interaction checks proved selected-day details, today hover and mobile week scrolling. Build hashes and console/network reports identify the served artifacts.
- Final candidate app audit: all 222 checks passed; zero broken/needs-work findings. Packaged OCR: 203 verified, zero broken, 13 requiring inspection. The affected calendar captures were inspected at all four audit viewports, alongside the detailed desktop/mobile captures. All 654 artifacts in `20260910-185215-0d17f1b-cpu` passed integrity verification. The generated dashboard reviewed all 654 artifacts; OCR completed on all 216 screenshots with zero engine failures.

The data endpoints in these UI tests use deterministic fixtures. This PR does not claim real Google account replacement, external messaging delivery, or a merged VPS deployment; those remain in #30123/#31003.

| Surface | Before | After |
| --- | --- | --- |
| Calendar desktop | ![Before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-calendar-before-1280-populated-rest.jpg) | ![After](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-calendar-week-1280-populated-rest.jpg) |
| Calendar mobile | ![Before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-calendar-before-390-populated-rest.jpg) | ![After](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-calendar-month-390-populated-rest.jpg) |
| Connections desktop | ![Before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-before-1280.jpg) | ![After](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-after-1280-rest.jpg) |
| Connections mobile | ![Before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-before-390.jpg) | ![After](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-after-390-rest.jpg) |

[Desktop calendar walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-calendar-week-1280-populated.mp4) · [Mobile calendar walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-calendar-week-390-populated.mp4) · [Desktop Connections walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-after-1280.mp4) · [Mobile Connections walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-after-390.mp4)

<!-- evidence-head:0d17f1b1a7d4f17af372306d8911148e7206ff71 -->
<!-- evidence-row:before-screenshots -->
- [x] [Before screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-before-390.jpg) — desktop/mobile calendar and Connections pairs are inline above.
<!-- evidence-row:after-screenshots -->
- [x] [After screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-calendar-month-390-populated-rest.jpg) — all affected rest/hover states were inspected.
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-connections-after-390.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - No backend domain behavior changes. Data endpoints use deterministic fixtures; the browser exercises the real built host and dynamic view-bundle transport.
<!-- evidence-row:frontend-logs -->
- [x] [Console and network evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-frontend-evidence.json) — expected negative-control errors are identified separately from successful current captures.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No model, prompt, provider or action behavior changes. The agent-bridge case exercises existing controls without a model call.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - No production provider or database mutations are exercised by this UI repair.
<!-- evidence-row:ocr-review -->
- [x] [31029-0d17-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-0d17-ocr-triage.json)



[Complete reviewed evidence archive](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-bettina-calendar-0d17-reviewed-evidence.zip) includes all desktop/mobile rest/hover captures, MP4 recordings, browser diagnostics, build provenance, package/root logs, manual review and the full verified canonical bundle.

[Generated OCR review dashboard](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31029-bettina-calendar-0d17-review-dashboard.zip): extract and open `index.html`; all 654 artifacts and 216 OCR text results are included.

