### PR TITLE
test(lifeops): preserve native iMessage status and permission recovery

### DIFF
--- a/plugins/plugin-personal-assistant/src/routes/lifeops-imessage-status-route.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-imessage-status-route.test.ts
@@ -65,6 +65,56 @@ class BlooioIMessageService extends Service {
   }
 }
 
+interface NativeStatusOverrides {
+  connected: boolean;
+  chatDbAvailable: boolean;
+  permissionAction: {
+    type: "full_disk_access";
+    label: string;
+    url: string;
+    instructions: string[];
+  } | null;
+}
+
+class NativeIMessageService extends Service {
+  static override serviceType = "imessage";
+  capabilityDescription = "native iMessage test transport";
+  connected = true;
+  chatDbAvailable = true;
+  permissionAction: NativeStatusOverrides["permissionAction"] = null;
+
+  static override async start(
+    runtime: IAgentRuntime,
+  ): Promise<NativeIMessageService> {
+    return new NativeIMessageService(runtime);
+  }
+
+  override async stop(): Promise<void> {}
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  getStatus() {
+    return {
+      transport: "native" as const,
+      available: true,
+      connected: this.connected,
+      chatDbAvailable: this.chatDbAvailable,
+      sendOnly: this.connected && !this.chatDbAvailable,
+      chatDbPath: "/Users/owner/Library/Messages/chat.db",
+      reason: null,
+      permissionAction: this.permissionAction,
+      webhookPath: null,
+      channelId: null,
+    };
+  }
+
+  async sendMessage(): Promise<{ success: true; messageId: string }> {
+    return { success: true, messageId: "message-test" };
+  }
+}
+
 function routeContext(runtime: AgentRuntime): {
   context: LifeOpsRouteContext;
   response: CapturedResponse;
@@ -179,6 +229,108 @@ describe("LifeOps iMessage runtime status projection", () => {
       diagnostics: ["blooio_transport_not_connected"],
     });
     expect(response.body).not.toContain("native_bridge_not_connected");
+    expect(response.body).not.toContain("full_disk_access_required");
+  });
+});
+
+describe("LifeOps iMessage native transport projection", () => {
+  let nativeRuntime: AgentRuntime;
+  let nativeService: NativeIMessageService;
+
+  beforeEach(async () => {
+    nativeRuntime = new AgentRuntime({
+      agentId: stringToUuid(`imessage-native-${crypto.randomUUID()}`),
+      character: createCharacter({ name: "iMessage native projection" }),
+      disableBasicCapabilities: true,
+      enableAutonomy: false,
+      logLevel: "fatal",
+    });
+    await nativeRuntime.initialize({
+      allowNoDatabase: true,
+      skipMigrations: true,
+    });
+    Object.defineProperty(nativeRuntime, "adapter", {
+      value: null,
+      configurable: true,
+    });
+    await nativeRuntime.registerService(NativeIMessageService);
+    const loaded = await nativeRuntime.getServiceLoadPromise(
+      NativeIMessageService.serviceType,
+    );
+    if (!(loaded instanceof NativeIMessageService)) {
+      throw new Error("Native iMessage test service did not start.");
+    }
+    nativeService = loaded;
+  });
+
+  afterEach(async () => {
+    await nativeRuntime.stop();
+  });
+
+  it("reports a connected native transport with chat.db details", async () => {
+    const { context, response } = routeContext(nativeRuntime);
+
+    await expect(handleLifeOpsRoutes(context)).resolves.toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      available: true,
+      connected: true,
+      bridgeType: "native",
+      sendMode: "apple-script",
+      diagnostics: [],
+      error: null,
+      chatDbAvailable: true,
+      sendOnly: false,
+      chatDbPath: "/Users/owner/Library/Messages/chat.db",
+      permissionAction: null,
+    });
+    expect(response.body).not.toContain("provider-api");
+    expect(response.body).not.toContain("blooio_transport_not_connected");
+  });
+
+  it("keeps full_disk_access_required diagnostics for a gated native transport", async () => {
+    nativeService.connected = false;
+    nativeService.chatDbAvailable = false;
+    nativeService.permissionAction = {
+      type: "full_disk_access",
+      label: "Grant Full Disk Access",
+      url: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+      instructions: [
+        "Open System Settings > Privacy & Security > Full Disk Access",
+      ],
+    };
+    const { context, response } = routeContext(nativeRuntime);
+
+    await expect(handleLifeOpsRoutes(context)).resolves.toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      connected: false,
+      bridgeType: "native",
+      sendMode: "none",
+      diagnostics: ["full_disk_access_required", "native_bridge_not_connected"],
+      chatDbAvailable: false,
+      sendOnly: false,
+      permissionAction: { type: "full_disk_access" },
+    });
+    expect(response.body).not.toContain("blooio_transport_not_connected");
+  });
+
+  it("falls back to chat_db_unavailable when no permission action is present", async () => {
+    nativeService.connected = true;
+    nativeService.chatDbAvailable = false;
+    nativeService.permissionAction = null;
+    const { context, response } = routeContext(nativeRuntime);
+
+    await expect(handleLifeOpsRoutes(context)).resolves.toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      connected: true,
+      bridgeType: "native",
+      sendMode: "apple-script",
+      diagnostics: ["chat_db_unavailable"],
+      chatDbAvailable: false,
+      sendOnly: true,
+    });
     expect(response.body).not.toContain("full_disk_access_required");
   });
 });


### PR DESCRIPTION
The LifeOps status endpoint now reports Blooio correctly, but its regression suite did not cover native permission recovery. That left a transport-mapping regression able to hide Full Disk Access guidance or report the wrong send mode to the owner.

The added cases exercise the real runtime service registry, domain adapter, route dispatcher and serialized response with an external native-provider fixture. They cover connected native transport, Full Disk Access denial, and missing chat.db with send-only status, alongside the existing Blooio cases. Production transport code is unchanged. Original patch authorship is preserved from HomunculusLabs/eliza@ed136204fe00e5e1a8c79e8a6274ed291a26b20f.

Closes #30247. Related: #30123.

Validation:

- All five focused route tests passed on the final rebased candidate.
- Negative control: routing native permission diagnostics through the Blooio branch caused four test failures, including both new recovery cases. Production source was restored.
- Complete personal-assistant suite passed: 300 files, 2,604 tests, six skipped, at `468ce2fe7c0dd2cc686065eb3961f8f1b8ffb540`. Subsequent base changes affect billing policy and voice tests; this route patch is unchanged. Final candidate `bdeecad7c1f347f806ad04f9ca64878f1f280ca9`, based on develop `1708731834282d31fe6a32a77548eb0f2d04bf70`, passed `bun install` and the complete root verification gate (373 tasks and final audits).

Screenshots, video and model trajectories are N/A: this changes only route regression coverage. The tests prove the owner-visible status contract, not native-device access or real iMessage delivery. Live delivery remains a separate Bettina acceptance gate.


<!-- evidence-head:bdeecad7c1f347f806ad04f9ca64878f1f280ca9 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - Route regression tests only; no UI implementation changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Route regression tests only; no UI implementation changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - Automated serialized status-response contract; no interactive flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - No production backend change. Test and root verification logs are attached separately.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend behavior or source changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No model invocation or agent behavior changes; deterministic route tests.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Tests exercise serialized status responses against an external-provider fixture; no production data mutation.
<!-- evidence-row:ocr-review -->
- [x] N/A - No visual output changed.


[Verification logs and provenance](https://github.com/elizaOS/eliza/releases/download/pr-evidence-4/31036-bettina-30247-evidence.zip) include final install/root/route checks, the complete personal-assistant suite and the native-branch negative control.

