### PR TITLE
fix(cloud): retain consent scope in repository updates

### DIFF
--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -431,7 +431,13 @@ export class AppsRepository {
             ...(input.ipAddress != null ? { ip_address: input.ipAddress } : {}),
             ...(input.userAgent != null ? { user_agent: input.userAgent } : {}),
           })
-          .where(eq(appUsers.id, existing.id));
+          .where(
+            and(
+              eq(appUsers.id, existing.id),
+              eq(appUsers.app_id, input.appId),
+              eq(appUsers.user_id, input.userId),
+            ),
+          );
       } else {
         await tx.insert(appUsers).values({
           app_id: input.appId,
@@ -443,7 +449,9 @@ export class AppsRepository {
         await tx
           .update(apps)
           .set({ total_users: sql`COALESCE(${apps.total_users}, 0) + 1` })
-          .where(eq(apps.id, input.appId));
+          .where(
+            and(eq(apps.id, input.appId), eq(apps.is_active, true), eq(apps.is_approved, true)),
+          );
       }
       await materializeAppBillingAccounts(tx, input.appId);
       return existing ? "updated" : "created";


### PR DESCRIPTION
The consent transaction now retains the selected app/user predicates when updating membership and repeats the active/approved-app conditions when updating its counter. This clears the Cloud tenant-scope gate without an exemption and preserves the existing transaction and row lock.

# Relates to

Fixes #31040. Supports Cloud release validation for #30130.

# Sync with develop

Candidate `467954ee5e79f0ea13f661f3e7d740cac71c26ae`, based on `7b0099eab340734e78a418ad8baa38ce6e4c795c`. Normal installation passed with Node 24.15.0 and Bun 1.3.14. Repository verification passed all 373 tasks and final audits. The complete shared-package suite passed. Exact-head hosted checks must finish successfully before merge.

# Risks

Low. The additional predicates repeat conditions already established in the same locked transaction. Consent updates, registration materialization and counters remain in that transaction.

# Background

## What does this PR do?

Makes the consent mutation scope explicit to the repository checker. The real consent behavior is covered by existing database tests.

## What kind of change is this?

Non-breaking repository validation fix.

# Documentation changes needed?

None; no API or operational contract changes.

# Testing

The tenant-scope checker passes across 173 repository files. The existing apps and billing-consent PGlite suites pass 59 tests. The receipt capture reruns the unchanged consent assertions and passes 11 tests, recording synthetic app, membership and billing-account rows before teardown. Complete shared-package validation passed: 1,231 files across 388 batches, 12,637 passing tests and 243 existing skips; process exit 0. [Full suite log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31041-bettina-31040-shared.log), [exact-head result](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31041-bettina-31041-full-suite-result.json).

## Where should a reviewer start?

[Evidence archive](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31041-bettina-31040-467954e-evidence.zip) includes root verification, installation, checker output, database logs, synthetic rows, the reproducible receipt preload and a verified SHA-256 manifest. The archive was captured before the full package run; its pending-suite note is superseded by the full-suite result below. Hosted checks remain pending.

Compare the failed tenant-scope step in Develop Full run 34530365498 with the passing checker log and inspect the captured database rows alongside the consent test log.

## Detailed testing steps

Run `bun run --cwd packages/cloud/shared check:tenant-scope`. From that package, run the existing `src/db/repositories/app-billing-accounts.pglite.test.ts` and `src/db/repositories/__tests__/apps.test.ts` database suites. The evidence includes the external receipt preload; it adds read-only queries before test teardown without modifying repository source or assertions.

# Evidence Gate

<!-- evidence-head:467954ee5e79f0ea13f661f3e7d740cac71c26ae -->
<!-- evidence-row:before-screenshots -->
N/A - no rendered surface changes; the defect is a repository validation failure.
<!-- evidence-row:after-screenshots -->
N/A - no rendered surface changes; consent behavior remains the same.
<!-- evidence-row:walkthrough-video -->
N/A - no changed UI flow; real SQL and checker results are the acceptance boundary.
<!-- evidence-row:backend-logs -->
- [x] [31041-bettina-31040-focused.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31041-bettina-31040-focused.log)
<!-- evidence-row:frontend-logs -->
N/A - no frontend or transport changes.
<!-- evidence-row:llm-trajectory -->
N/A - no agent, prompt or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [31041-bettina-31040-consent-rows.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31041-bettina-31040-consent-rows.json)
<!-- evidence-row:ocr-review -->
N/A - no rendered text or visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no model call is involved.

## Backend + frontend logs

Database tests exercise real Drizzle/PGlite repository operations, registration and HTTP readback. The captured records are synthetic. Frontend logs are N/A because no frontend code or transport behavior changes.

## Screenshots (before / after) + video walkthrough

N/A - repository predicates only, with no changed visual state.

## Audio / voice walkthrough

N/A - no audio or voice changes.

## Known gaps / failures

The current develop Cloud tenant-scope step fails before this change. This PR clears that gate; it does not claim to repair every unrelated Develop Full failure. Repository and full-package gates pass. Hosted checks remain required before merge. No deployment is included.

## Maintainer CI exception record

N/A - no exception requested.



