### PR TITLE
fix(app-test): supply native bridge in desktop renderer fixtures

### DIFF
--- a/packages/app/test/dev-smoke/runtime-chooser-default.spec.ts
+++ b/packages/app/test/dev-smoke/runtime-chooser-default.spec.ts
@@ -11,6 +11,7 @@ import {
   installRenderTelemetryGuard,
   seedAppStorage,
 } from "../ui-smoke/helpers";
+import { installDesktopBridgeFixture } from "../ui-smoke/helpers/desktop-bridge";
 
 test.skip(
   process.env.ELIZA_DEV_SMOKE_OFFLINE !== "1",
@@ -54,11 +55,11 @@ test("explicit local development offers cloud, local, and remote", async ({
   await installRenderTelemetryGuard(page);
   await installDefaultAppRoutes(page);
   await routeFreshFirstRun(page);
+  await installDesktopBridgeFixture(page);
   await page.addInitScript(() => {
     const win = window as unknown as Record<string, unknown>;
     win.__ELIZA_APP_API_BASE__ = window.location.origin;
     win.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: window.location.origin };
-    win.__electrobunWindowId = 1;
   });
   await seedAppStorage(page, {
     "eliza:first-run-complete": "",

--- a/packages/app/test/ui-smoke/helpers/desktop-bridge.ts
+++ b/packages/app/test/ui-smoke/helpers/desktop-bridge.ts
@@ -1,0 +1,38 @@
+/** Supplies the native host boundary for browser-only desktop renderer tests; storage is synthetic and local to each page load. */
+import type { Page } from "@playwright/test";
+
+export async function installDesktopBridgeFixture(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const secureStore = new Map<string, string>();
+    Object.assign(window, {
+      __electrobunWindowId: 1,
+      __ELIZA_ELECTROBUN_RPC__: {
+        request: {
+          desktopGetVersion: async () => ({ runtime: "playwright-smoke" }),
+          desktopRegisterShortcut: async () => ({ success: true }),
+          desktopSetTrayMenu: async () => undefined,
+          secureStoreGet: async ({ kind }: { kind: string }) =>
+            secureStore.has(kind)
+              ? { ok: true, value: secureStore.get(kind) }
+              : { ok: false, reason: "not_found" },
+          secureStoreSet: async ({
+            kind,
+            value,
+          }: {
+            kind: string;
+            value: string;
+          }) => {
+            secureStore.set(kind, value);
+            return { ok: true };
+          },
+          secureStoreDelete: async ({ kind }: { kind: string }) => ({
+            ok: true,
+            deleted: secureStore.delete(kind),
+          }),
+        },
+        onMessage: () => undefined,
+        offMessage: () => undefined,
+      },
+    });
+  });
+}

--- a/packages/app/test/ui-smoke/voice-desktop-selftest.spec.ts
+++ b/packages/app/test/ui-smoke/voice-desktop-selftest.spec.ts
@@ -1,20 +1,12 @@
 /**
- * DESKTOP voice self-test (Electrobun renderer path), headless.
- *
- * The desktop voice surface is the SAME renderer bundle as web — the Electrobun
- * pill loads it with a ?shellMode= param over a Chromium-engine webview. We
- * inject the Electrobun runtime marker (window.__electrobunWindowId) so the
- * self-test screen detects platform=desktop and routes TTS through the desktop
- * local-inference TTS route, then drive the real round-trip harness. This proves
- * the desktop CONFIG path of the voice self-test green in CI without a packaged
- * Electrobun build. (The native Electrobun shell integration — talkmodeSpeak
- * main-process bridge, views:// mic grant — is exercised by the packaged
- * electrobun-packaged lane.)
- *
- *   bun run --cwd packages/app test:e2e test/ui-smoke/voice-desktop-selftest.spec.ts
+ * Exercises the desktop voice self-test renderer with a synthetic native bridge
+ * and controlled ASR, conversation, and TTS responses. The browser drives the
+ * real self-test UI and verifies desktop TTS routing; native shell and physical
+ * audio-device behavior belong to the packaged Electrobun lane.
  */
 import { expect, type Page, test } from "@playwright/test";
 import { installDefaultAppRoutes, seedAppStorage } from "./helpers";
+import { installDesktopBridgeFixture } from "./helpers/desktop-bridge";
 
 const EXPECTED_PHRASE = "what time is it";
 
@@ -97,12 +89,7 @@ async function installVoiceBackendMocks(page: Page): Promise<void> {
 }
 
 test.beforeEach(async ({ page }) => {
-  // Make the renderer detect the Electrobun (desktop) runtime BEFORE boot.
-  await page.addInitScript(() => {
-    (
-      window as unknown as { __electrobunWindowId?: number }
-    ).__electrobunWindowId = 1;
-  });
+  await installDesktopBridgeFixture(page);
   await seedAppStorage(page);
   await installDefaultAppRoutes(page);
   await installVoiceBackendMocks(page);


### PR DESCRIPTION
The desktop voice self-test and explicit-local runtime chooser marked Chromium as an Electrobun renderer without providing its required native bridge. Both could stop at the boot-failure screen before exercising their intended behavior. A shared browser fixture now supplies the synthetic host and protected-storage boundary before boot, preserving the production readiness checks and the existing flow assertions.

Fixes #31042. Supports Bettina release validation in #30130.

The existing browser tests now exercise desktop TTS routing and the desktop/mobile runtime chooser. These are controlled browser fixtures, not native-device or live-model proof. The voice header now states that boundary explicitly.

Validation: Node 24.15.0 / Bun 1.3.14; normal installation; root verification (373 tasks and final audits); app typecheck and lint; 950 script tests plus 1,630 component tests passed, with two existing script skips. The chooser passed; its companion live-chat test was skipped because no provider key is configured. The full app audit passed all 222 checks with zero broken or needs-work findings; OCR found zero broken views. Exact-head hosted checks remain required before merge.

The first visual run had one inventory bundle HTTP 424 while dependency builds were replacing generated output. That run is retained; the isolated rerun passed after the builds finished. No production module, API, model behavior or deployment changes.

<!-- evidence-head:977fcc2b8b02a5bf8db48cef34988de717f58bc5 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-before-ci-onboarding-boot-failure.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-test-finished-1.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-voice-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [31043-bettina-31042-voice-record.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-bettina-31042-voice-record.log)

<!-- evidence-row:frontend-logs -->
- [x] [31043-bettina-31042-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-bettina-31042-frontend.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - controlled browser fixtures; no model behavior changed or live-model proof claimed

<!-- evidence-row:domain-artifacts -->
- [x] [31043-source-provenance.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-source-provenance.json)

<!-- evidence-row:ocr-review -->
- [x] [31043-visual-review.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-visual-review.md)



## Review artifacts

[Complete source-bound evidence archive](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-bettina-31042-977fcc-evidence.zip) includes verification and package logs, the original and isolated audit results, screenshots, the complete controlled voice recording, trace, OCR result, and SHA-256 manifest. Archive SHA-256: `07a3612a61792ed7045920c269f54172de08a4e148a83ac2259ffd69bfe465e7`.

Desktop runtime chooser:

![Desktop runtime chooser](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-runtime-chooser-vite-development-desktop-rest.png)

Mobile runtime chooser:

![Mobile runtime chooser](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31043-runtime-chooser-vite-development-mobile-rest.png)
