### PR TITLE
test(cloud): enable cache explicitly in cache-dependent fixtures

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/affiliate-payout-outbox.test.ts
@@ -6,6 +6,8 @@
 
 import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
 
+const originalCacheEnabled = process.env.CACHE_ENABLED;
+process.env.CACHE_ENABLED = "true";
 process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
@@ -140,7 +142,12 @@ beforeAll(async () => {
 }, PGLITE_TIMEOUT);
 
 afterAll(async () => {
-  await closeDatabaseConnectionsForTests();
+  try {
+    await closeDatabaseConnectionsForTests();
+  } finally {
+    if (originalCacheEnabled === undefined) delete process.env.CACHE_ENABLED;
+    else process.env.CACHE_ENABLED = originalCacheEnabled;
+  }
 });
 
 describe("affiliate payout outbox", () => {

--- a/packages/cloud/shared/src/lib/services/proxy/rpc-cache.transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/rpc-cache.transport.test.ts
@@ -44,10 +44,16 @@ mock.module("../usage", () => ({
 const { createHandler } = await import("./engine");
 const { rpcConfigForChain, rpcHandlerForChain } = await import("./services/rpc");
 const originalFetch = globalThis.fetch;
-const envNames = ["CACHE_BACKEND", "ALCHEMY_API_KEY", "ALCHEMY_MAX_RETRIES"] as const;
+const envNames = [
+  "CACHE_ENABLED",
+  "CACHE_BACKEND",
+  "ALCHEMY_API_KEY",
+  "ALCHEMY_MAX_RETRIES",
+] as const;
 const originalEnv = Object.fromEntries(envNames.map((name) => [name, process.env[name]]));
 
 beforeEach(() => {
+  process.env.CACHE_ENABLED = "true";
   process.env.CACHE_BACKEND = "memory";
   process.env.ALCHEMY_API_KEY = "local-cache-fixture";
   process.env.ALCHEMY_MAX_RETRIES = "1";


### PR DESCRIPTION
Two real-cache fixtures fail in Cloud CI because the workflow sets `CACHE_ENABLED=false`. The RPC transport test then observes two provider executions; the affiliate payout outbox test cannot acquire its balance hint. Each fixture now explicitly enables its in-memory cache and restores the previous setting during teardown.

Fixes #31044. Supports Bettina Cloud validation under #30130.

Candidate `a5cc1eb8df56ea9a245f4438caeb8a7369746325`, based on `c745213d6100bc941e0a78f2c6105462b2e5925e`. Normal install and root verification (373 tasks plus final audits) pass with Bun 1.3.14 and Node 24.15.0. Existing production cache behavior, assertions and workflow settings remain unchanged.

Both original failures reproduced with the hosted cache-disabled environment. After the repair all 27 focused tests pass in normal and CI environments. On the previous base (963d8ef), the complete shared suite under `CACHE_ENABLED=false CACHE_BACKEND=wadis` passes: 1,231 files, 388 batches, 12,637 tests, zero failures and 243 existing skips; exit 0. Tests exercise the real memory cache, loopback HTTP transport and PGlite transactional payout outbox with controlled external-provider boundaries.

# Evidence Gate

<!-- evidence-head:a5cc1eb8df56ea9a245f4438caeb8a7369746325 -->
<!-- evidence-row:before-screenshots -->
N/A - test fixture environment repair; no rendered UI, native, model or production behavior changes.
<!-- evidence-row:after-screenshots -->
N/A - test fixture environment repair; no rendered UI, native, model or production behavior changes.
<!-- evidence-row:walkthrough-video -->
N/A - test fixture environment repair; no rendered UI, native, model or production behavior changes.
<!-- evidence-row:backend-logs -->
- [x] [31047-bettina-31047-c745-focused.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31047-bettina-31047-c745-focused.log)
<!-- evidence-row:frontend-logs -->
N/A - test fixture environment repair; no rendered UI, native, model or production behavior changes.
<!-- evidence-row:llm-trajectory -->
N/A - test fixture environment repair; no rendered UI, native, model or production behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - fixture configuration only; real HTTP and PGlite assertions are recorded in the focused log.
<!-- evidence-row:ocr-review -->
N/A - test fixture environment repair; no rendered UI, native, model or production behavior changes.

## Known gaps / failures

Hosted checks must pass on this exact head before merge. Other Develop Full failures are separate. This repairs test setup and does not deploy or change Cloud resources.




[Reviewed evidence archive](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31047-bettina-31044-1f951-evidence.zip) contains both baseline failures, focused tests in both environments, full shared-package logs, installation, root verification, source provenance and a SHA-256 manifest. [Complete shared suite log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31047-bettina-31044-shared.log).


Current-base qualification: normal installation, all 373 root tasks and final audits, and all 27 cache-dependent tests pass after rebasing over #30229. The complete shared suite also passed on this candidate: 1,232 files across 388 batches, 12,670 passing tests, zero failures and 243 existing skips; exit 0. The previous archive and full-suite log remain historical evidence.



[Current a5cc evidence archive](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31047-bettina-31047-a5cc-evidence.zip) includes fresh installation, repository verification, focused and full shared-suite logs, source provenance and a SHA-256 manifest. Archive SHA-256: `b06a626c7cda451fc669f7a2830584b643c4b822ea3164703432303aaadc4800`. All required local gates pass; hosted checks remain required.
