### PR TITLE
fix(plugin-form): publish registered control types to the handler registry and keep date answers on the named calendar day

### DIFF
--- a/plugins/plugin-form/src/builtins.ts
+++ b/plugins/plugin-form/src/builtins.ts
@@ -63,6 +63,11 @@
  */
 
 import type { JsonValue } from "@elizaos/core";
+import {
+  calendarDateComponents,
+  formatCalendarDate,
+  parseCalendarDate,
+} from "./calendar-date";
 import { basicEmailValid } from "./email";
 import type { ControlType, FormControl, ValidationResult } from "./types";
 import { testControlPattern } from "./validation";
@@ -381,7 +386,8 @@ const selectType: ControlType = {
  * WHY flexible parsing:
  * - Users say "tomorrow", "next Monday", "12/25/2024"
  * - LLM should normalize to ISO
- * - We accept anything Date() can parse as fallback
+ * - Other formats resolve to the calendar day they name on every host
+ *   timezone; a year-less or unparseable answer is rejected and re-asked
  *
  * WHY locale display:
  * - Agent should speak in user's date format
@@ -403,29 +409,22 @@ const dateType: ControlType = {
       return { valid: false, error: "Must be in YYYY-MM-DD format" };
     }
 
-    // Check if it's a valid date
-    const date = new Date(str);
-    if (Number.isNaN(date.getTime())) {
+    // Check if it's a real calendar day (rejects roll-overs like 2026-02-30)
+    if (!calendarDateComponents(str)) {
       return { valid: false, error: "Invalid date" };
     }
 
     return { valid: true };
   },
 
-  parse: (value: string): string => {
-    // Try to parse and normalize to ISO
-    const date = new Date(value);
-    if (!Number.isNaN(date.getTime())) {
-      return date.toISOString().split("T")[0];
-    }
-    return value.trim();
-  },
+  // Resolve the answer to the calendar day it names; an unparseable or
+  // year-less answer is kept verbatim so validate() rejects it and the form
+  // re-asks instead of storing a fabricated day.
+  parse: (value: string): string => parseCalendarDate(value) ?? value.trim(),
 
   format: (value: JsonValue): string => {
     if (!value) return "";
-    const date = new Date(String(value));
-    if (Number.isNaN(date.getTime())) return String(value);
-    return date.toLocaleDateString();
+    return formatCalendarDate(String(value));
   },
 
   extractionPrompt: "a date (preferably in YYYY-MM-DD format)",

--- a/plugins/plugin-form/src/calendar-date.ts
+++ b/plugins/plugin-form/src/calendar-date.ts
@@ -1,0 +1,68 @@
+/**
+ * Host-timezone-independent calendar-date parsing and display for the `date`
+ * control type. A form answer names a calendar day, not an instant, so the
+ * stored value is always `YYYY-MM-DD` and neither parsing nor display may pass
+ * through a UTC/local conversion that can move the day: `Date.parse` reads
+ * "September 15, 2026" as local midnight and `toISOString` re-renders it in
+ * UTC (the 14th east of UTC), while `new Date("2026-09-15")` is UTC midnight and
+ * `toLocaleDateString` renders it as the 14th west of UTC.
+ */
+
+const ISO_CALENDAR_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const FOUR_DIGIT_YEAR_RE = /\b\d{4}\b/;
+
+/** Calendar components of a `YYYY-MM-DD` string, or null when it is not a real day. */
+export function calendarDateComponents(
+  value: string,
+): { year: number; month: number; day: number } | null {
+  const match = ISO_CALENDAR_DATE_RE.exec(value);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  // Round-trip through UTC to reject roll-overs such as 2026-02-30 → Mar 2.
+  const probe = new Date(Date.UTC(year, month - 1, day));
+  if (
+    probe.getUTCFullYear() !== year ||
+    probe.getUTCMonth() !== month - 1 ||
+    probe.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return { year, month, day };
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+/**
+ * Resolve an extracted answer to the calendar day it names, as `YYYY-MM-DD`.
+ * ISO input is validated and returned as-is. Any other format must carry a
+ * four-digit year (V8 silently defaults a year-less date to 2001) and is read
+ * back through the local calendar components of the parsed instant, which is
+ * the day the user named on every host timezone. Returns null when the input
+ * does not name a real day, so the caller leaves the raw answer for validation
+ * to reject and the form re-asks.
+ */
+export function parseCalendarDate(value: string): string | null {
+  const trimmed = value.trim();
+  if (ISO_CALENDAR_DATE_RE.test(trimmed)) {
+    return calendarDateComponents(trimmed) ? trimmed : null;
+  }
+  if (!FOUR_DIGIT_YEAR_RE.test(trimmed)) return null;
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const candidate = `${parsed.getFullYear()}-${pad2(parsed.getMonth() + 1)}-${pad2(parsed.getDate())}`;
+  return calendarDateComponents(candidate) ? candidate : null;
+}
+
+/**
+ * Locale display of a stored `YYYY-MM-DD` value that names the same day on
+ * every host. Anything that is not a calendar date is echoed unchanged.
+ */
+export function formatCalendarDate(value: string): string {
+  const parts = calendarDateComponents(value.trim());
+  if (!parts) return value;
+  return new Date(parts.year, parts.month - 1, parts.day).toLocaleDateString();
+}

--- a/plugins/plugin-form/src/control-type-registry.test.ts
+++ b/plugins/plugin-form/src/control-type-registry.test.ts
@@ -121,6 +121,45 @@ describe("control type registry bridge (#31049)", () => {
     expect(parseValue("+1 (555) 123-4567", phoneControl)).toBe("+15551234567");
     expect(formatValue("+15551234567", phoneControl)).toBe("tel:+15551234567");
   });
+
+  it("keeps a custom allowOverride contract when another agent's FormService starts", async () => {
+    // The handler registry is process-global while each service's control
+    // map is per instance. A second runtime in the same process boots its own
+    // FormService, whose builtins pass its (empty) instance guard; they must
+    // not overwrite the override the first agent installed.
+    const emailControl: FormControl = {
+      key: "email",
+      label: "Email",
+      type: "email",
+    };
+    service.registerControlType(
+      {
+        id: "email",
+        validate: (value: JsonValue) =>
+          String(value).endsWith("@corp.example")
+            ? { valid: true }
+            : { valid: false, error: "corporate domains only" },
+        extractionPrompt: "a corporate email",
+      },
+      { allowOverride: true },
+    );
+    expect(validateField("x@gmail.com", emailControl)).toEqual({
+      valid: false,
+      error: "corporate domains only",
+    });
+
+    await FormService.start(makeRuntime());
+
+    expect(validateField("x@gmail.com", emailControl)).toEqual({
+      valid: false,
+      error: "corporate domains only",
+    });
+    expect(promptFor([emailControl])).toContain("a corporate email");
+    // A builtin the first agent left alone is still published for the second.
+    expect(getTypeHandler("date")?.extractionPrompt).toBe(
+      "a date (preferably in YYYY-MM-DD format)",
+    );
+  });
 });
 
 describe("date control names the same calendar day on every host (#31049)", () => {

--- a/plugins/plugin-form/src/control-type-registry.test.ts
+++ b/plugins/plugin-form/src/control-type-registry.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression coverage for the control-type registry bridge (#31049): a type
+ * registered through FormService.registerControlType must reach extraction,
+ * parsing, validation, and display for top-level fields, and the builtin
+ * `date` type must name the same calendar day on every host timezone. Runs
+ * the real FormService, extractor prompt builder, and validation module with a
+ * deterministic in-memory runtime; the host timezone is switched per case.
+ */
+import type { Component, IAgentRuntime, JsonValue, UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildFormExtractorPromptSection } from "./extraction";
+import { FormService } from "./service";
+import type { FormControl, FormDefinition } from "./types";
+import {
+  clearTypeHandlers,
+  formatValue,
+  getTypeHandler,
+  parseValue,
+  validateField,
+} from "./validation";
+
+const agentId = "00000000-0000-4000-8000-000000000203" as UUID;
+
+function makeRuntime(): IAgentRuntime {
+  const components = new Map<string, Component>();
+  return {
+    agentId,
+    getRoom: vi.fn(async () => ({ id: agentId, worldId: agentId })),
+    getComponent: vi.fn(async (entity: UUID, type: string) =>
+      components.get(`${entity}:${type}`),
+    ),
+    getComponents: vi.fn(async (entity: UUID) =>
+      Array.from(components.values()).filter((c) => c.entityId === entity),
+    ),
+    createComponent: vi.fn(async (component: Component) => {
+      components.set(`${component.entityId}:${component.type}`, component);
+    }),
+    updateComponent: vi.fn(async (component: Component) => {
+      components.set(`${component.entityId}:${component.type}`, component);
+    }),
+    deleteComponent: vi.fn(async () => undefined),
+    emitEvent: vi.fn(async () => undefined),
+    registerTaskWorker: vi.fn(),
+    logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+  } as unknown as IAgentRuntime;
+}
+
+const dateControl: FormControl = {
+  key: "dueDate",
+  label: "Due date",
+  type: "date",
+};
+const numberControl: FormControl = { key: "age", label: "Age", type: "number" };
+const phoneControl: FormControl = {
+  key: "phone",
+  label: "Phone",
+  type: "phone",
+};
+
+function promptFor(controls: FormControl[]): string {
+  const form: FormDefinition = { id: "f", name: "F", controls };
+  return buildFormExtractorPromptSection({
+    text: "hello",
+    form,
+    controls,
+  });
+}
+
+describe("control type registry bridge (#31049)", () => {
+  let service: FormService;
+
+  beforeEach(async () => {
+    clearTypeHandlers();
+    service = (await FormService.start(makeRuntime())) as FormService;
+  });
+
+  afterEach(() => {
+    clearTypeHandlers();
+  });
+
+  it("publishes builtin extraction prompts to the extractor", () => {
+    expect(getTypeHandler("date")?.extractionPrompt).toBe(
+      "a date (preferably in YYYY-MM-DD format)",
+    );
+    const prompt = promptFor([dateControl]);
+    expect(prompt).toContain("a date (preferably in YYYY-MM-DD format)");
+    expect(prompt).not.toContain('"type": "date"');
+  });
+
+  it("keeps builtin parsing and validation on the hardened switch paths", () => {
+    // The builtin number ControlType parses with a lenient parseFloat; the
+    // switch in parseValue preserves a rejected answer verbatim so it stays
+    // invalid through persistence. Publishing the builtin's parse would
+    // silently reintroduce coercion of garbage-suffixed input.
+    expect(getTypeHandler("number")?.parse).toBeUndefined();
+    expect(getTypeHandler("number")?.validate).toBeUndefined();
+    expect(parseValue("12abc", numberControl)).toBe("12abc");
+    expect(validateField("12abc", numberControl).valid).toBe(false);
+  });
+
+  it("runs a custom simple type's validate, parse, format, and prompt for a top-level field", () => {
+    service.registerControlType({
+      id: "phone",
+      validate: (value: JsonValue) =>
+        /^\+?[\d\s-]{10,}$/.test(String(value))
+          ? { valid: true }
+          : { valid: false, error: "Invalid phone" },
+      parse: (value: string) => value.replace(/[^\d+]/g, ""),
+      format: (value: JsonValue) => `tel:${String(value)}`,
+      extractionPrompt: "a phone number with country code",
+    });
+
+    expect(promptFor([phoneControl])).toContain(
+      "a phone number with country code",
+    );
+    expect(validateField("hello there", phoneControl)).toEqual({
+      valid: false,
+      error: "Invalid phone",
+    });
+    expect(validateField("+1 555 123 4567", phoneControl).valid).toBe(true);
+    expect(parseValue("+1 (555) 123-4567", phoneControl)).toBe("+15551234567");
+    expect(formatValue("+15551234567", phoneControl)).toBe("tel:+15551234567");
+  });
+});
+
+describe("date control names the same calendar day on every host (#31049)", () => {
+  const originalTz = process.env.TZ;
+
+  afterEach(() => {
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+    clearTypeHandlers();
+  });
+
+  it.each([
+    "Asia/Tokyo",
+    "Europe/Berlin",
+    "America/Los_Angeles",
+    "Pacific/Auckland",
+    "UTC",
+  ])("resolves natural-language answers to the named day under TZ=%s", (tz) => {
+    process.env.TZ = tz;
+    for (const input of [
+      "2026-09-15",
+      "September 15, 2026",
+      "9/15/2026",
+      "15 Sep 2026",
+      "  2026-09-15  ",
+    ]) {
+      const parsed = parseValue(input, dateControl);
+      expect(parsed, `${tz}: ${input}`).toBe("2026-09-15");
+      expect(validateField(parsed, dateControl).valid, `${tz}: ${input}`).toBe(
+        true,
+      );
+    }
+  });
+
+  it.each(["Asia/Tokyo", "America/Los_Angeles", "UTC"])(
+    "displays a stored calendar day as that day under TZ=%s",
+    (tz) => {
+      process.env.TZ = tz;
+      const shown = formatValue("2026-09-15", dateControl);
+      expect(shown).toMatch(/15/);
+      expect(shown).toMatch(/2026/);
+      expect(shown).not.toMatch(/14|16/);
+    },
+  );
+
+  it("rejects a year-less answer instead of storing a fabricated year", () => {
+    process.env.TZ = "Asia/Tokyo";
+    const parsed = parseValue("Sept 15", dateControl);
+    expect(parsed).toBe("Sept 15");
+    const result = validateField(parsed, dateControl);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("YYYY-MM-DD");
+  });
+
+  it("rejects a rolled-over day and an instant that is not a calendar date", () => {
+    expect(validateField("2026-02-30", dateControl).valid).toBe(false);
+    expect(validateField("2026-09-14T15:00:00.000Z", dateControl).valid).toBe(
+      false,
+    );
+    expect(validateField("2028-02-29", dateControl).valid).toBe(true);
+  });
+
+  it("honours min/max bounds against the named day", () => {
+    const bounded: FormControl = {
+      ...dateControl,
+      min: Date.UTC(2026, 8, 10),
+      max: Date.UTC(2026, 8, 20),
+    };
+    expect(validateField("2026-09-15", bounded).valid).toBe(true);
+    expect(validateField("2026-09-05", bounded).valid).toBe(false);
+    expect(validateField("2026-09-25", bounded).valid).toBe(false);
+  });
+});

--- a/plugins/plugin-form/src/service.ts
+++ b/plugins/plugin-form/src/service.ts
@@ -134,7 +134,12 @@ import type {
   UncertainFieldSummary,
 } from "./types";
 import { FORM_CONTROL_DEFAULTS, FORM_DEFINITION_DEFAULTS } from "./types";
-import { formatValue, registerTypeHandler, validateField } from "./validation";
+import {
+  formatValue,
+  getTypeHandler,
+  registerTypeHandler,
+  validateField,
+} from "./validation";
 
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
@@ -341,10 +346,19 @@ export class FormService extends Service {
     // validation, and display live on the hardened switch paths in
     // validation.ts (strict number parsing, persistence-safe rejection,
     // calendar-day dates) and the ControlType copies here serve subcontrols.
-    registerTypeHandler(
-      type.id,
-      type.builtin ? { extractionPrompt: type.extractionPrompt } : type,
-    );
+    // The registry is process-global while this map is per instance: every
+    // agent's FormService.start() re-registers the builtins with an empty
+    // instance map, so a builtin must never overwrite a handler another
+    // instance already published (a custom `allowOverride` contract).
+    if (type.builtin) {
+      if (!getTypeHandler(type.id)) {
+        registerTypeHandler(type.id, {
+          extractionPrompt: type.extractionPrompt,
+        });
+      }
+    } else {
+      registerTypeHandler(type.id, type);
+    }
     logger.debug(`[FormService] Registered control type: ${type.id}`);
   }
 

--- a/plugins/plugin-form/src/service.ts
+++ b/plugins/plugin-form/src/service.ts
@@ -134,7 +134,7 @@ import type {
   UncertainFieldSummary,
 } from "./types";
 import { FORM_CONTROL_DEFAULTS, FORM_DEFINITION_DEFAULTS } from "./types";
-import { formatValue, validateField } from "./validation";
+import { formatValue, registerTypeHandler, validateField } from "./validation";
 
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "prototype", "constructor"]);
 
@@ -333,6 +333,18 @@ export class FormService extends Service {
     }
 
     this.controlTypes.set(type.id, type);
+    // Extraction, parsing, validation, and display resolve a control's type
+    // through the handler registry in validation.ts, not through this map, so
+    // a registered type only takes effect for top-level fields once it is
+    // published there as well. A custom type supplies its whole contract; a
+    // builtin publishes only its extraction prompt, because builtin parsing,
+    // validation, and display live on the hardened switch paths in
+    // validation.ts (strict number parsing, persistence-safe rejection,
+    // calendar-day dates) and the ControlType copies here serve subcontrols.
+    registerTypeHandler(
+      type.id,
+      type.builtin ? { extractionPrompt: type.extractionPrompt } : type,
+    );
     logger.debug(`[FormService] Registered control type: ${type.id}`);
   }
 

--- a/plugins/plugin-form/src/validation.ts
+++ b/plugins/plugin-form/src/validation.ts
@@ -52,6 +52,11 @@ import {
   MAX_UNTRUSTED_REGEX_PATTERN_LENGTH,
   matchesSafeUntrustedRegexPattern,
 } from "@elizaos/shared/config/config-catalog";
+import {
+  calendarDateComponents,
+  formatCalendarDate,
+  parseCalendarDate,
+} from "./calendar-date";
 import { strictEmailValid } from "./email";
 import type { FormControl, TypeHandler } from "./types";
 
@@ -441,7 +446,20 @@ function validateDate(
 
   if (value instanceof Date) {
     dateValue = value;
-  } else if (typeof value === "string" || typeof value === "number") {
+  } else if (typeof value === "string") {
+    // A string answer must already be the calendar day parseValue resolved
+    // it to. Accepting anything Date() can read would let a year-less or
+    // free-form answer through as a fabricated instant (V8 reads "Sept 15"
+    // as 2001) instead of re-asking.
+    const parts = calendarDateComponents(value.trim());
+    if (!parts) {
+      return {
+        valid: false,
+        error: `${control.label || control.key} must be a valid date (YYYY-MM-DD)`,
+      };
+    }
+    dateValue = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+  } else if (typeof value === "number") {
     dateValue = new Date(value);
   } else {
     return {
@@ -650,12 +668,11 @@ export function parseValue(value: string, control: FormControl): JsonValue {
       return ["true", "yes", "1", "on"].includes(lower);
     }
 
-    case "date": {
-      const timestamp = Date.parse(value);
-      return Number.isFinite(timestamp)
-        ? new Date(timestamp).toISOString()
-        : value;
-    }
+    case "date":
+      // A date answer names a calendar day; never round-trip it through an
+      // instant, which moves the day by the host's UTC offset. Unparseable
+      // input is kept so validation rejects it and the form re-asks.
+      return parseCalendarDate(value) ?? value.trim();
     default:
       // Keep as string for text-like types
       return value;
@@ -708,8 +725,11 @@ export function formatValue(value: JsonValue, control: FormControl): string {
       return value ? "Yes" : "No";
 
     case "date":
-      // Locale-appropriate date format
-      return value instanceof Date ? value.toLocaleDateString() : String(value);
+      // Locale-appropriate date format that names the stored calendar day on
+      // every host timezone
+      return value instanceof Date
+        ? value.toLocaleDateString()
+        : formatCalendarDate(String(value));
 
     case "select":
       // Show option label instead of value


### PR DESCRIPTION
# Relates to

Closes #31049

# Risks

Low-to-moderate, confined to `@elizaos/plugin-form`. Two behavior changes for top-level fields:

- A **custom** control type registered through `FormService.registerControlType` now has its `validate`, `parse`, `format`, and `extractionPrompt` applied, as the README and CLAUDE.md have documented all along. A consumer whose custom validator was silently never running will now see it enforced.
- The **date** builtin stores `YYYY-MM-DD` instead of a full UTC instant, rejects year-less or free-form answers so the form re-asks, and validates strings as calendar days. A session persisted with the old timestamp shape re-asks that one field at submit-time revalidation.

Builtins other than `date` are unaffected: they publish only their extraction prompt, and their parsing/validation/display stay on the existing hardened switch paths (pinned by a test, because the builtin number `parse` is the lenient `parseFloat` the switch deliberately replaced).

# Background

## What does this PR do?

`FormService.registerControlType()` stored types in `service.controlTypes`, but `parseValue`, `validateField`, `formatValue`, and both extractor prompt builders resolve a control's type through `typeHandlers` in `validation.ts`, which nothing populated (`registerTypeHandler` had no caller). Consequences on `develop` `619545c5357f`:

- `ControlType.validate/parse/format/extractionPrompt` never ran for top-level fields (only `validate`, for subcontrols).
- The planner was told a date field is a `date`, not "a date (preferably in YYYY-MM-DD format)", so it echoes the user's format.
- The switch branch that actually handled dates did `new Date(Date.parse(value)).toISOString()`: host-local midnight re-rendered in UTC. Through the real `parseValue → validateField → formatValue` path:

```text
TZ=Asia/Tokyo    "September 15, 2026" → "2026-09-14T15:00:00.000Z"  valid  displayed verbatim
TZ=Europe/Berlin "9/15/2026"          → "2026-09-14T22:00:00.000Z"  valid  displayed verbatim
any TZ           "Sept 15"            → "2001-09-14T15:00:00.000Z"  valid  (V8 default year)
```

The fix:

- `registerControlType` publishes the type to the handler registry: a custom type in full; a builtin only its `extractionPrompt`.
- New `calendar-date.ts`: `parseCalendarDate` (ISO passes through after a real-day check; any other format must carry a four-digit year and resolves through the local components of the parsed instant, which is the day the user named on every host), `calendarDateComponents`, and `formatCalendarDate` (builds the display from components so `2026-09-15` is not shown as the 14th west of UTC).
- `parseValue`'s date branch and the builtin's `parse`/`format`/`validate` use the helper; `validateDate` requires a calendar-date string (a Date or timestamp number still works for min/max bounds).

## What kind of change is this?

Bug fix.

# Testing

## Where should a reviewer start?

`plugins/plugin-form/src/service.ts` (`registerControlType`), then `src/validation.ts` (`parseValue` date branch, `validateDate`, `formatValue`), then `src/calendar-date.ts`.

## Detailed testing steps

New suite `plugins/plugin-form/src/control-type-registry.test.ts` (14 cases) drives the real `FormService`, the extractor prompt builder, and the validation module, switching `process.env.TZ` per case (Asia/Tokyo, Europe/Berlin, America/Los_Angeles, Pacific/Auckland, UTC).

RED control — develop's `builtins.ts`/`service.ts`/`validation.ts` with this test file:

```text
 × publishes builtin extraction prompts to the extractor
 × runs a custom simple type's validate, parse, format, and prompt for a top-level field
 × resolves natural-language answers to the named day under TZ=Asia/Tokyo
 × resolves natural-language answers to the named day under TZ=Europe/Berlin
 × resolves natural-language answers to the named day under TZ=America/Los_Angeles
 × resolves natural-language answers to the named day under TZ=Pacific/Auckland
 × resolves natural-language answers to the named day under TZ=UTC
 × rejects a year-less answer instead of storing a fabricated year
 × rejects a rolled-over day and an instant that is not a calendar date
 Tests  9 failed | 5 passed (14)
```

(The five that pass on develop pin the hardened number path, the display cases, and min/max bounds.)

GREEN at `36287f191619`:

```text
$ bunx vitest run --config vitest.config.ts        # plugins/plugin-form
 Test Files  12 passed (12)
      Tests  162 passed (162)
$ bun run typecheck                                 # tsc --noEmit, 0 errors
$ bunx @biomejs/biome check <5 changed files>       # clean
```

Root `bun run verify` is running on this exact commit in a fully installed checkout; result follows as a comment.

Not run: a live-model form session. The change is in deterministic parse/validate/format/prompt-assembly code; the new suite exercises the real service and prompt builder rather than a mock, and the model-facing change is only the type hint text now reaching the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnpYyWkEf3naaRGNtRmwNp
