### PR TITLE
fix(personal-assistant): reject impossible calendar days in the health summary window (#31051)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.status.test.ts
@@ -523,6 +523,31 @@ describe("HealthDomain connector lifecycle and summaries", () => {
     ).rejects.toMatchObject({ status: 400 });
   });
 
+  it("rejects a rolled-over calendar date before any repository query runs", async () => {
+    const listHealthMetricSamples = vi.fn(async () => {
+      throw new Error("repository must not run for an impossible date");
+    });
+    const domain = makeDomain({
+      listConnectorGrants: vi.fn(async () => []),
+      getConnectorGrant: vi.fn(async () => null),
+      getHealthSyncState: vi.fn(),
+      listHealthMetricSamples,
+      listHealthWorkouts: vi.fn(async () => []),
+      listHealthSleepEpisodes: vi.fn(async () => []),
+    });
+    for (const request of [
+      { startDate: "2026-02-30" },
+      { endDate: "2026-04-31" },
+      { startDate: "2026-02-29", endDate: "2026-03-01" },
+    ]) {
+      await expect(domain.getHealthSummary(request)).rejects.toMatchObject({
+        status: 400,
+        message: expect.stringContaining("calendar date"),
+      });
+    }
+    expect(listHealthMetricSamples).not.toHaveBeenCalled();
+  });
+
   it("skips disconnected providers on sync and returns the stored summary", async () => {
     makeOAuthDir();
     const repository = {

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/health-service.ts
@@ -57,6 +57,7 @@ import {
   normalizeOptionalConnectorSide,
 } from "../service-normalize-connector.js";
 import { LifeOpsServiceError } from "../service-types.js";
+import { parseLocalDateKey } from "../time.js";
 import {
   getHealthDataConnectorStatus,
   getHealthDataConnectorStatuses,
@@ -140,13 +141,12 @@ function normalizeDateOnly(value: unknown, field: string): string | null {
   if (value === undefined || value === null || value === "") {
     return null;
   }
-  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value.trim())) {
+  if (typeof value !== "string") {
     fail(400, `${field} must be a YYYY-MM-DD date`);
   }
   const normalized = value.trim();
-  const parsed = Date.parse(`${normalized}T00:00:00.000Z`);
-  if (!Number.isFinite(parsed)) {
-    fail(400, `${field} must be a valid date`);
+  if (parseLocalDateKey(normalized) === null) {
+    fail(400, `${field} must be a valid YYYY-MM-DD calendar date`);
   }
   return normalized;
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/time.calendar-date-key.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.calendar-date-key.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Pins the calendar-day round trip in `parseLocalDateKey`: a `YYYY-MM-DD`
+ * string is accepted only when it names a real day, so impossible dates that
+ * `Date.UTC` would silently roll forward are rejected. Deterministic, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { getLocalDateKey, parseLocalDateKey } from "./time.js";
+
+describe("parseLocalDateKey", () => {
+  it("returns the parts of a real calendar day", () => {
+    expect(parseLocalDateKey("2026-02-28")).toEqual({
+      year: 2026,
+      month: 2,
+      day: 28,
+    });
+    expect(parseLocalDateKey("2024-02-29")).toEqual({
+      year: 2024,
+      month: 2,
+      day: 29,
+    });
+    const parts = parseLocalDateKey("2026-12-31");
+    expect(parts).not.toBeNull();
+    expect(getLocalDateKey(parts ?? { year: 0, month: 0, day: 0 })).toBe(
+      "2026-12-31",
+    );
+  });
+
+  it.each(["2026-02-29", "2026-02-30", "2026-04-31", "2026-06-31"])(
+    "rejects a day that Date.UTC would roll into the next month: %s",
+    (value) => {
+      expect(Number.isFinite(Date.parse(`${value}T00:00:00.000Z`))).toBe(true);
+      expect(parseLocalDateKey(value)).toBeNull();
+    },
+  );
+
+  it.each([
+    "2026-00-10",
+    "2026-13-01",
+    "2026-01-00",
+    "2026-01-32",
+    "2026-1-5",
+    "20260105",
+    "2026-01-05T00:00:00Z",
+    " 2026-01-05",
+    "yesterday",
+    "",
+  ])("rejects a string that is not a YYYY-MM-DD calendar day: %j", (value) => {
+    expect(parseLocalDateKey(value)).toBeNull();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -259,6 +259,33 @@ export function getLocalDateKey(
     .padStart(2, "0")}-${dateOnly.day.toString().padStart(2, "0")}`;
 }
 
+const CALENDAR_DATE_KEY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Parse a `YYYY-MM-DD` key into calendar parts, or return `null` when the
+ * string is not a real calendar day. `Date.parse` and `Date.UTC` roll an
+ * out-of-range day such as `2026-02-30` into the following month, so a shape
+ * check alone lets an impossible date reach SQL literals that Postgres rejects.
+ */
+export function parseLocalDateKey(
+  value: string,
+): Pick<ZonedDateParts, "year" | "month" | "day"> | null {
+  const match = CALENDAR_DATE_KEY_PATTERN.exec(value);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const roundTrip = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  if (
+    roundTrip.getUTCFullYear() !== year ||
+    roundTrip.getUTCMonth() !== month - 1 ||
+    roundTrip.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return { year, month, day };
+}
+
 export function addMinutes(date: Date, minutes: number): Date {
   return new Date(date.getTime() + minutes * 60_000);
 }

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-health-summary-window.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-health-summary-window.test.ts
@@ -1,0 +1,140 @@
+/**
+ * End-to-end proof that the health summary route validates its calendar
+ * window before any SQL runs: an HTTP-shaped GET to
+ * /api/lifeops/health/summary travels the real route dispatcher →
+ * LifeOpsService → HealthDomain → LifeOpsRepository against a real
+ * PGlite-backed AgentRuntime. An impossible day such as 2026-02-30 is a 400
+ * at the boundary, never a 500 from a rejected timestamp literal, and a real
+ * window still reaches the repository and returns 200. No mocks.
+ */
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import { AgentRuntime, type Character, type UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PgliteDatabaseAdapter } from "../../../plugin-sql/src/pglite/adapter.js";
+import { PGliteClientManager } from "../../../plugin-sql/src/pglite/manager.js";
+import {
+  handleLifeOpsRoutes,
+  type LifeOpsRouteContext,
+} from "./lifeops-routes.js";
+
+interface CapturedResponse {
+  statusCode?: number;
+  body?: string;
+}
+
+function buildGet(
+  runtime: AgentRuntime,
+  search: string,
+): { ctx: LifeOpsRouteContext; res: CapturedResponse } {
+  const res: CapturedResponse = {};
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  const httpReq = new IncomingMessage(socket);
+  httpReq.method = "GET";
+  httpReq.headers = {};
+  const httpRes = new ServerResponse(httpReq);
+  httpRes.statusCode = 0;
+  httpRes.end = function end(
+    this: ServerResponse,
+    chunk?: unknown,
+    encodingOrCallback?: BufferEncoding | (() => void),
+    callback?: () => void,
+  ): ServerResponse {
+    res.body = typeof chunk === "string" ? chunk : "";
+    res.statusCode = this.statusCode;
+    const done =
+      typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+    done?.();
+    return this;
+  };
+  const pathname = "/api/lifeops/health/summary";
+  const ctx: LifeOpsRouteContext = {
+    req: httpReq,
+    res: httpRes,
+    method: "GET",
+    pathname,
+    url: new URL(`http://localhost${pathname}${search}`),
+    state: { runtime, adminEntityId: null },
+    json(r, data, status = 200) {
+      r.statusCode = status;
+      r.setHeader?.("content-type", "application/json");
+      r.end?.(JSON.stringify(data));
+    },
+    error(r, message, status = 400) {
+      r.statusCode = status;
+      r.setHeader?.("content-type", "application/json");
+      r.end?.(JSON.stringify({ error: message }));
+    },
+    async readJsonBody<T extends object>(): Promise<T | null> {
+      return null;
+    },
+    decodePathComponent(raw) {
+      return raw;
+    },
+  };
+  return { ctx, res };
+}
+
+describe("health summary window validation e2e (real runtime + PGlite)", () => {
+  let manager: PGliteClientManager;
+  let adapter: PgliteDatabaseAdapter;
+  let runtime: AgentRuntime;
+
+  beforeEach(async () => {
+    const agentId = crypto.randomUUID() as UUID;
+    manager = new PGliteClientManager({});
+    await manager.initialize();
+    adapter = new PgliteDatabaseAdapter(agentId, manager);
+    await adapter.init();
+    runtime = new AgentRuntime({
+      agentId,
+      character: { name: "lifeops-health-window-e2e" } as Character,
+      adapter,
+    });
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+    await manager.close();
+  });
+
+  it.each([
+    "?startDate=2026-02-30",
+    "?endDate=2026-04-31",
+    "?startDate=2026-02-29&endDate=2026-03-01",
+  ])("rejects an impossible calendar day with a 400: %s", async (search) => {
+    const { ctx, res } = buildGet(runtime, search);
+    expect(await handleLifeOpsRoutes(ctx)).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body ?? "{}")).toMatchObject({
+      error: expect.stringContaining("calendar date"),
+    });
+    expect(runtime.getRecentReportedErrors()).toEqual([]);
+  });
+
+  it("serves a real window through the repository", async () => {
+    const { ctx, res } = buildGet(
+      runtime,
+      "?startDate=2026-02-28&endDate=2026-03-01",
+    );
+    expect(await handleLifeOpsRoutes(ctx)).toBe(true);
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body ?? "{}") as {
+      providers: unknown[];
+      summaries: unknown[];
+      samples: unknown[];
+      workouts: unknown[];
+      sleepEpisodes: unknown[];
+    };
+    expect(Array.isArray(payload.providers)).toBe(true);
+    expect(payload.summaries).toEqual([]);
+    expect(payload.samples).toEqual([]);
+    expect(payload.workouts).toEqual([]);
+    expect(payload.sleepEpisodes).toEqual([]);
+    expect(runtime.getRecentReportedErrors()).toEqual([]);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -124,6 +124,7 @@ import {
 import { probeFullDiskAccess } from "../lifeops/fda-probe.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
+import { parseLocalDateKey } from "../lifeops/time.js";
 import { entityHasVerifiedMachineAuthBinding } from "./authenticated-entity-principal.js";
 import { handleFamilyWorkflowRoutes } from "./family-workflows.js";
 
@@ -557,8 +558,11 @@ function parseDateOnlyQuery(
   if (!normalized) {
     return null;
   }
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
-    throw new LifeOpsServiceError(400, `${field} must be a YYYY-MM-DD date`);
+  if (parseLocalDateKey(normalized) === null) {
+    throw new LifeOpsServiceError(
+      400,
+      `${field} must be a valid YYYY-MM-DD calendar date`,
+    );
   }
   return normalized;
 }


### PR DESCRIPTION
## Summary

`GET /api/lifeops/health/summary` accepted `startDate` / `endDate` values that are not real calendar days. Both the route parser (`parseDateOnlyQuery`) and the `HealthDomain` normalizer (`normalizeDateOnly`) only checked the `YYYY-MM-DD` shape; the `Date.parse` guard behind them never fires for a rolled-over day because V8 turns `2026-02-30T00:00:00.000Z` into March 2 instead of `NaN`. The impossible string reached the text-compared repository window (and the connector sync range) while the derived start of the window was computed from the rolled-over instant, so the served window was silently different from the requested one.

Closes #31051.

## Change

- `lifeops/time.ts`: new `parseLocalDateKey(value)` returns the `{ year, month, day }` parts only when a `Date.UTC` round trip leaves them unchanged, otherwise `null`. It sits next to `getLocalDateKey`, its inverse.
- `routes/lifeops-routes.ts` `parseDateOnlyQuery` and `lifeops/domains/health-service.ts` `normalizeDateOnly` both reject a non-calendar day with a 400 (`<field> must be a valid YYYY-MM-DD calendar date`) before any repository or connector call. The redundant `Date.parse` guard is gone.

## Proof

**Develop (5bf3faef78a9), real dispatcher → service → repository on PGlite:** the three impossible-day requests below return 200, and `getHealthSummary({ endDate: "2026-02-30", days: 3 })` asks the repository for `{ startDate: "2026-02-28", endDate: "2026-02-30" }`, which is February 28 only.

**This branch:**

```text
$ bunx vitest run src/routes/lifeops-health-summary-window.test.ts   # real AgentRuntime + PGlite, no mocks
 ✓ rejects an impossible calendar day with a 400: ?startDate=2026-02-30
 ✓ rejects an impossible calendar day with a 400: ?endDate=2026-04-31
 ✓ rejects an impossible calendar day with a 400: ?startDate=2026-02-29&endDate=2026-03-01
 ✓ serves a real window through the repository            # 200, empty summaries, no reported errors
 Tests  4 passed (4)

$ bunx vitest run src/lifeops/time.calendar-date-key.test.ts src/lifeops/domains/health-service.status.test.ts
 Tests  33 passed (33)
```

RED control: with `health-service.ts` and `lifeops-routes.ts` restored to `develop` and the new tests kept, the three route cases fail with `expected 200 to be 400` and the service case fails because the repository mock is reached; every pre-existing case stays green.

Package gates on `plugins/plugin-personal-assistant`: `typecheck` 0 errors, `lint:check` clean, full `test` 303 files / 2639 passed (6 skipped).

Root `bun run verify`: 370 of 371 Turbo tasks green. The one failure, `@elizaos/ui#lint:check`, was the kernel OOM-killing the `design-contract-graph.test.ts` node process at about 5.5 GB resident on this 31 GB host (`dmesg`: `Out of memory: Killed process 527988 (node)`), in a package this branch does not touch. Rerun alone, `bun run --cwd packages/ui lint:check` passes (48/48 and 41/41 node tests, exit 0), and the same step is green in hosted CI at the `develop` tip this branch is based on.

## Evidence checklist

| Row | Status |
| --- | --- |
| Screenshots / MP4 | N/A, no UI surface changes |
| Backend logs | vitest output above; the route test asserts `runtime.getRecentReportedErrors()` is empty |
| Live-model trajectories | N/A, no agent behaviour changes |
| Native targets | N/A |

# Evidence Gate

<!-- evidence-head:8ed704b29fe1922e663c7717d758e8f362ee2a45 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the surface is a GET query parameter; the route responses are asserted in the real-runtime test below.
<!-- evidence-row:backend-logs -->
- [x] Test transcripts from the runs described above:
  <details><summary>vitest output: real AgentRuntime + PGlite route test and unit suites at this head, with the develop control</summary>

  ```text
  $ bunx vitest run src/routes/lifeops-health-summary-window.test.ts   (real AgentRuntime + PGlite)
   PASS rejects an impossible calendar day with a 400: ?startDate=2026-02-30
   PASS rejects an impossible calendar day with a 400: ?endDate=2026-04-31
   PASS rejects an impossible calendar day with a 400: ?startDate=2026-02-29&endDate=2026-03-01
   PASS serves a real window through the repository            # 200, empty summaries, runtime.getRecentReportedErrors() empty
   Tests  4 passed (4)
  $ bunx vitest run src/lifeops/time.calendar-date-key.test.ts src/lifeops/domains/health-service.status.test.ts
   Tests  33 passed (33)
  RED control (health-service.ts and lifeops-routes.ts restored to develop 5bf3faef78a9, new tests kept): the three route cases fail with "expected 200 to be 400"; every pre-existing case stays green
  Package gates: typecheck 0 errors, lint:check clean, full test 303 files / 2639 passed (6 skipped)
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider or model change; no model calls are involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change rejects the request before any repository or connector call, so no rows are written; the repository window requested on develop for endDate=2026-02-30 (startDate 2026-02-28..2026-02-30) is recorded in the Proof section above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CNyebSRMNUZinVaRHTUuN
