### PR TITLE
Isolate Codex SDK inference and preserve native tool decisions

### DIFF
--- a/packages/agent/src/runtime/eliza-runtime-settings.test.ts
+++ b/packages/agent/src/runtime/eliza-runtime-settings.test.ts
@@ -29,6 +29,21 @@ afterEach(() => {
 });
 
 describe("buildRuntimeSettingsProjection", () => {
+  it("honors an explicit launch-time brain selection without changing embeddings", () => {
+    const settings = buildRuntimeSettingsProjection({} as ElizaConfig, {
+      env: { ELIZA_BRAIN_PROVIDER: " cli-inference " },
+      brainProviderName: "openai",
+      embeddingProviderName: "local-inference",
+    });
+    expect(settings.ELIZA_BRAIN_PROVIDER).toBe("cli-inference");
+    expect(settings.ELIZA_EMBEDDING_PROVIDER).toBe("local-inference");
+    expect(
+      buildRuntimeSettingsProjection({} as ElizaConfig, {
+        env: { ELIZA_BRAIN_PROVIDER: " " },
+        brainProviderName: "openai",
+      }).ELIZA_BRAIN_PROVIDER,
+    ).toBe("openai");
+  });
   it("cannot restore gateway-owned credentials from legacy or env config", () => {
     const config = {
       channels: {

--- a/packages/agent/src/runtime/runtime-settings.ts
+++ b/packages/agent/src/runtime/runtime-settings.ts
@@ -119,6 +119,8 @@ export function buildRuntimeSettingsProjection(
   options: RuntimeSettingsProjectionOptions = {},
 ): Record<string, string> {
   const env = options.env ?? process.env;
+  const brainProviderName =
+    env.ELIZA_BRAIN_PROVIDER?.trim() || options.brainProviderName;
   const hasCanonicalRouting = Object.hasOwn(config, "serviceRouting");
   const canonicalRouting = hasCanonicalRouting
     ? resolveServiceRoutingInConfig(config as Record<string, unknown>)
@@ -149,9 +151,7 @@ export function buildRuntimeSettingsProjection(
     ...(options.preferredProviderId
       ? { MODEL_PROVIDER: options.preferredProviderId }
       : {}),
-    ...(options.brainProviderName
-      ? { ELIZA_BRAIN_PROVIDER: options.brainProviderName }
-      : {}),
+    ...(brainProviderName ? { ELIZA_BRAIN_PROVIDER: brainProviderName } : {}),
     ...(options.embeddingProviderName
       ? { ELIZA_EMBEDDING_PROVIDER: options.embeddingProviderName }
       : {}),

--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -10,6 +10,22 @@ Node-only (`"platforms": ["node"]`) — exported from `index.node.ts` only.
 
 ## Enable
 
+For an explicit local Codex text-brain override, set `ELIZA_CHAT_VIA_CLI=codex-sdk`
+and `ELIZA_BRAIN_PROVIDER=cli-inference`. The latter selects the existing
+runtime dispatch override; priority alone does not replace an explicitly
+configured provider. Set `ELIZA_CLI_CODEX_MODEL` and
+`ELIZA_CLI_CODEX_PLANNER_MODEL` to the supported model ID; use
+`ELIZA_CLI_CLAUDE_ALL_TIERS=1` to include the small text tiers.
+
+The official SDK manages authentication. Its inference-only exec launcher adds
+`--ignore-user-config --ignore-rules --ephemeral`; the SDK version used here
+does not expose these flags directly. This keeps personal MCP configuration out
+of inference, retains the CLI's own sign-in, and avoids persisted SDK histories.
+The adapter disables shell, apps/plugins, hooks, subagents and Codex memories.
+Use a current installed CLI supporting these flags; unsupported flags fail
+explicitly, never retry with weaker isolation. These are process-local settings,
+not edits to the owner's interactive Codex configuration.
+
 Single env gate: **`ELIZA_CHAT_VIA_CLI=claude`**, **`claude-sdk`**, **`codex`**, or **`codex-sdk`**.
 
 - Unset → the plugin is never added to the resolved set (`auto-enable.ts shouldEnable` is false), and even if force-loaded its models map is empty. INERT; no existing code path changes.
@@ -18,18 +34,18 @@ Single env gate: **`ELIZA_CHAT_VIA_CLI=claude`**, **`claude-sdk`**, **`codex`**,
 
 ## Plugin surface
 
-No actions, providers, evaluators, or routes. Model handlers only, and **only the large tier** so high-frequency should-respond/triage calls fall through to the cheap configured provider (bounding per-turn spawn cost to a few ~3-4s calls):
+No actions, providers, evaluators, or routes. Model handlers only. Large text tiers are registered by default; the existing `ELIZA_CLI_CLAUDE_ALL_TIERS=1` switch also enables small tiers for SDK backends.
 
 | Model type | Backend |
 |---|---|
 | `TEXT_LARGE` | `claude --print` or `codex exec` |
 | `TEXT_MEGA` | "" |
 | `RESPONSE_HANDLER` | "" |
-| `ACTION_PLANNER` | "" — **only when `ELIZA_PLANNER_NATIVE_TOOLS=0`** (text-planner mode) |
+| `ACTION_PLANNER` | Codex SDK: native tool-decision bridge; other backends: text-planner mode only |
 
-`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are intentionally **not** registered (high-frequency triage tiers fall through to the cheap provider).
+`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are opt-in via the shared all-tiers switch.
 
-`ACTION_PLANNER` is **conditional**: in the default native-tools mode
+`ACTION_PLANNER` is **conditional for non-Codex-SDK backends**: in the default native-tools mode
 (`ELIZA_PLANNER_NATIVE_TOOLS=1`) it is **not** registered, because that planner
 needs GBNF / native-tool grammar the free-text CLI cannot honor — so the planner
 stays on a grammar-honoring provider while the CLI still serves the user-facing
@@ -88,31 +104,39 @@ SDK at the Claude Code executable.
 returns a session-limit error); plan a fallback (a key/Cloud tier, or stealth on
 a self-host) for production continuity.
 
-## Warm Codex SDK backend (`ELIZA_CHAT_VIA_CLI=codex-sdk`)
+## Request-isolated Codex SDK backend (`ELIZA_CHAT_VIA_CLI=codex-sdk`)
 
-The codex peer of `claude-sdk` (`src/codex-sdk-session.ts`). Runs the brain on a
-ChatGPT/Codex subscription via `@openai/codex-sdk` (loaded by variable dynamic
-import; reads `~/.codex/auth.json` itself). A `CodexSdkSession` keeps ONE warm
-`Thread` (`codex.startThread()` once, `thread.run()` per turn) instead of the
-`codex exec` cold-spawn-per-call. Two modes:
+Uses the official `@openai/codex-sdk` and CLI authentication. The installed SDK
+spawns a CLI process for each run; it is not a persistent inference process.
+Every request starts a fresh thread in an isolated temporary working directory.
+Eliza supplies the complete authorized conversation and memory context, so no
+second hidden conversation can leak across rooms, actors, or permission changes.
+Adapter configuration/account affinity is keyed by runtime instance and model.
 
 - **TEXT** (`generate`): `thread.run(body)` with `sandboxMode:"read-only"`,
-  `approvalPolicy:"never"`, `networkAccessEnabled:false` → a warm completion
+  `approvalPolicy:"never"`, `networkAccessEnabled:false` → a request-isolated completion
   engine; returns the turn's `finalResponse`.
 - **ROUTE** (`route`): codex NATIVE structured output (`outputSchema`) constrains
   the turn to `{action, params}` (params as a JSON string for OpenAI strict mode),
   reliable at scale. REQUIRES `ELIZA_CLI_CODEX_BIN` pointing at the system codex —
   the SDK bundles an old codex (0.80.0) that rejects current models/structured output.
 
-codex-sdk has no thread-level system prompt, so the system is folded into the
-body and ONE warm thread per `(model, mode)` serves every system prompt. Per-tier
-models: `ELIZA_CLI_CODEX_PLANNER_MODEL` + `ELIZA_CLI_CODEX_MODEL`;
-`ELIZA_CLI_CODEX_REASONING_EFFORT` sets `modelReasoningEffort`.
+In the default native-tool planner mode, supplied tool schemas and toolChoice
+are preserved in the request. Codex structured output is validated and adapted
+to Eliza's `GenerateTextResult.toolCalls`; only Eliza executes those decisions.
+Undeclared tools, malformed argument objects, and missing required calls fail
+explicitly. This also handles Stage-1 HANDLE_RESPONSE. Legacy text routing is
+retained, but malformed route arguments are rejected rather than replaced by {}.
+This Codex backend registers ACTION_PLANNER in either planner mode; the cold
+CLI and Claude paths retain their existing registration policies.
 
-**Status:** LIVE-VERIFIED in the bot on a ChatGPT/Codex sub — btc \$59,527, eth
-\$1,566, weather, identity, knows-user, 8×8=64; live-info routes to WEB_FETCH and
-synthesizes the real fetched value (after the canonical-contentToText fix). Needs
-`ELIZA_CLI_CODEX_BIN`=system codex. 12 fake-SDK unit tests.
+For Astra Light, set `ELIZA_CLI_CODEX_MODEL=gpt-6-astra`,
+`ELIZA_CLI_CODEX_PLANNER_MODEL=gpt-6-astra`, and
+`ELIZA_CLI_CODEX_REASONING_EFFORT=low`; pin `ELIZA_CLI_CODEX_BIN` to an installed
+CLI that supports the model. Availability depends on the signed-in account.
+Use the official SDK/authentication path, not OAuth-token replay against private
+endpoints. Subscription limits still apply. Measure full app latency separately
+from an isolated SDK test; retaining a Thread object does not eliminate startup.
 
 ## Layout
 

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -10,6 +10,22 @@ Node-only (`"platforms": ["node"]`) — exported from `index.node.ts` only.
 
 ## Enable
 
+For an explicit local Codex text-brain override, set `ELIZA_CHAT_VIA_CLI=codex-sdk`
+and `ELIZA_BRAIN_PROVIDER=cli-inference`. The latter selects the existing
+runtime dispatch override; priority alone does not replace an explicitly
+configured provider. Set `ELIZA_CLI_CODEX_MODEL` and
+`ELIZA_CLI_CODEX_PLANNER_MODEL` to the supported model ID; use
+`ELIZA_CLI_CLAUDE_ALL_TIERS=1` to include the small text tiers.
+
+The official SDK manages authentication. Its inference-only exec launcher adds
+`--ignore-user-config --ignore-rules --ephemeral`; the SDK version used here
+does not expose these flags directly. This keeps personal MCP configuration out
+of inference, retains the CLI's own sign-in, and avoids persisted SDK histories.
+The adapter disables shell, apps/plugins, hooks, subagents and Codex memories.
+Use a current installed CLI supporting these flags; unsupported flags fail
+explicitly, never retry with weaker isolation. These are process-local settings,
+not edits to the owner's interactive Codex configuration.
+
 Single env gate: **`ELIZA_CHAT_VIA_CLI=claude`**, **`claude-sdk`**, **`codex`**, or **`codex-sdk`**.
 
 - Unset → the plugin is never added to the resolved set (`auto-enable.ts shouldEnable` is false), and even if force-loaded its models map is empty. INERT; no existing code path changes.
@@ -18,18 +34,18 @@ Single env gate: **`ELIZA_CHAT_VIA_CLI=claude`**, **`claude-sdk`**, **`codex`**,
 
 ## Plugin surface
 
-No actions, providers, evaluators, or routes. Model handlers only, and **only the large tier** so high-frequency should-respond/triage calls fall through to the cheap configured provider (bounding per-turn spawn cost to a few ~3-4s calls):
+No actions, providers, evaluators, or routes. Model handlers only. Large text tiers are registered by default; the existing `ELIZA_CLI_CLAUDE_ALL_TIERS=1` switch also enables small tiers for SDK backends.
 
 | Model type | Backend |
 |---|---|
 | `TEXT_LARGE` | `claude --print` or `codex exec` |
 | `TEXT_MEGA` | "" |
 | `RESPONSE_HANDLER` | "" |
-| `ACTION_PLANNER` | "" — **only when `ELIZA_PLANNER_NATIVE_TOOLS=0`** (text-planner mode) |
+| `ACTION_PLANNER` | Codex SDK: native tool-decision bridge; other backends: text-planner mode only |
 
-`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are intentionally **not** registered (high-frequency triage tiers fall through to the cheap provider).
+`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are opt-in via the shared all-tiers switch.
 
-`ACTION_PLANNER` is **conditional**: in the default native-tools mode
+`ACTION_PLANNER` is **conditional for non-Codex-SDK backends**: in the default native-tools mode
 (`ELIZA_PLANNER_NATIVE_TOOLS=1`) it is **not** registered, because that planner
 needs GBNF / native-tool grammar the free-text CLI cannot honor — so the planner
 stays on a grammar-honoring provider while the CLI still serves the user-facing
@@ -88,31 +104,39 @@ SDK at the Claude Code executable.
 returns a session-limit error); plan a fallback (a key/Cloud tier, or stealth on
 a self-host) for production continuity.
 
-## Warm Codex SDK backend (`ELIZA_CHAT_VIA_CLI=codex-sdk`)
+## Request-isolated Codex SDK backend (`ELIZA_CHAT_VIA_CLI=codex-sdk`)
 
-The codex peer of `claude-sdk` (`src/codex-sdk-session.ts`). Runs the brain on a
-ChatGPT/Codex subscription via `@openai/codex-sdk` (loaded by variable dynamic
-import; reads `~/.codex/auth.json` itself). A `CodexSdkSession` keeps ONE warm
-`Thread` (`codex.startThread()` once, `thread.run()` per turn) instead of the
-`codex exec` cold-spawn-per-call. Two modes:
+Uses the official `@openai/codex-sdk` and CLI authentication. The installed SDK
+spawns a CLI process for each run; it is not a persistent inference process.
+Every request starts a fresh thread in an isolated temporary working directory.
+Eliza supplies the complete authorized conversation and memory context, so no
+second hidden conversation can leak across rooms, actors, or permission changes.
+Adapter configuration/account affinity is keyed by runtime instance and model.
 
 - **TEXT** (`generate`): `thread.run(body)` with `sandboxMode:"read-only"`,
-  `approvalPolicy:"never"`, `networkAccessEnabled:false` → a warm completion
+  `approvalPolicy:"never"`, `networkAccessEnabled:false` → a request-isolated completion
   engine; returns the turn's `finalResponse`.
 - **ROUTE** (`route`): codex NATIVE structured output (`outputSchema`) constrains
   the turn to `{action, params}` (params as a JSON string for OpenAI strict mode),
   reliable at scale. REQUIRES `ELIZA_CLI_CODEX_BIN` pointing at the system codex —
   the SDK bundles an old codex (0.80.0) that rejects current models/structured output.
 
-codex-sdk has no thread-level system prompt, so the system is folded into the
-body and ONE warm thread per `(model, mode)` serves every system prompt. Per-tier
-models: `ELIZA_CLI_CODEX_PLANNER_MODEL` + `ELIZA_CLI_CODEX_MODEL`;
-`ELIZA_CLI_CODEX_REASONING_EFFORT` sets `modelReasoningEffort`.
+In the default native-tool planner mode, supplied tool schemas and toolChoice
+are preserved in the request. Codex structured output is validated and adapted
+to Eliza's `GenerateTextResult.toolCalls`; only Eliza executes those decisions.
+Undeclared tools, malformed argument objects, and missing required calls fail
+explicitly. This also handles Stage-1 HANDLE_RESPONSE. Legacy text routing is
+retained, but malformed route arguments are rejected rather than replaced by {}.
+This Codex backend registers ACTION_PLANNER in either planner mode; the cold
+CLI and Claude paths retain their existing registration policies.
 
-**Status:** LIVE-VERIFIED in the bot on a ChatGPT/Codex sub — btc \$59,527, eth
-\$1,566, weather, identity, knows-user, 8×8=64; live-info routes to WEB_FETCH and
-synthesizes the real fetched value (after the canonical-contentToText fix). Needs
-`ELIZA_CLI_CODEX_BIN`=system codex. 12 fake-SDK unit tests.
+For Astra Light, set `ELIZA_CLI_CODEX_MODEL=gpt-6-astra`,
+`ELIZA_CLI_CODEX_PLANNER_MODEL=gpt-6-astra`, and
+`ELIZA_CLI_CODEX_REASONING_EFFORT=low`; pin `ELIZA_CLI_CODEX_BIN` to an installed
+CLI that supports the model. Availability depends on the signed-in account.
+Use the official SDK/authentication path, not OAuth-token replay against private
+endpoints. Subscription limits still apply. Measure full app latency separately
+from an isolated SDK test; retaining a Thread object does not eliminate startup.
 
 ## Layout
 

--- a/plugins/plugin-cli-inference/__tests__/codex-sdk-session.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/codex-sdk-session.test.ts
@@ -64,6 +64,22 @@ function makeSession(
 }
 
 describe("CodexSdkSession — TEXT mode", () => {
+  it("disables inherited tools and memories in the inference child", async () => {
+    const { session, codexOptions } = makeSession([{ finalResponse: "hello" }]);
+    await session.generate("hi");
+    expect(codexOptions()[0].config).toEqual({
+      features: {
+        apps: false,
+        plugins: false,
+        shell_tool: false,
+        unified_exec: false,
+        multi_agent: false,
+        hooks: false,
+        memories: false,
+        image_generation: false,
+      },
+    });
+  });
   it("returns the turn finalResponse", async () => {
     const { session } = makeSession([{ finalResponse: "hello" }]);
     expect(await session.generate("hi")).toBe("hello");
@@ -76,7 +92,10 @@ describe("CodexSdkSession — TEXT mode", () => {
       subprocessEnv,
     });
     expect(await session.generate("hi")).toBe("hello");
-    expect(codexOptions()[0].env).toBe(subprocessEnv);
+    expect(codexOptions()[0].env).toEqual({
+      ...subprocessEnv,
+      ELIZA_CODEX_INFERENCE_BIN: "codex",
+    });
     session.dispose();
   });
 
@@ -128,7 +147,7 @@ describe("CodexSdkSession — ROUTE mode (native outputSchema)", () => {
     session.dispose();
   });
 
-  it("salvages a JSON object wrapped in prose", async () => {
+  it("rejects structured JSON wrapped in prose instead of guessing a route", async () => {
     const { session } = makeSession(
       [
         {
@@ -138,20 +157,18 @@ describe("CodexSdkSession — ROUTE mode (native outputSchema)", () => {
       ],
       { router: true }
     );
-    const out = JSON.parse(await session.route("2+2?"));
-    expect(out).toEqual({ action: "REPLY", params: { text: "4" } });
+    await expect(session.route("2+2?")).rejects.toThrow(/non-JSON output/);
     session.dispose();
   });
 
-  it("coerces a non-object params to {} but keeps the action", async () => {
+  it("rejects malformed parameters rather than replacing them with an empty object", async () => {
     const { session } = makeSession(
       [{ finalResponse: '{"action":"IGNORE","params":"not valid json"}' }],
       {
         router: true,
       }
     );
-    const out = JSON.parse(await session.route("hi"));
-    expect(out).toEqual({ action: "IGNORE", params: {} });
+    await expect(session.route("hi")).rejects.toThrow();
     session.dispose();
   });
 

--- a/plugins/plugin-cli-inference/__tests__/codex-tool-response.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/codex-tool-response.test.ts
@@ -1,0 +1,120 @@
+/** Tests the real structured-response bridge with a fake SDK transport. */
+
+import type { GenerateTextParams, GenerateTextResult, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { __setCodexSdkSessionFactoryForTests, buildModels, disposeSdkSessions } from "../index";
+import { CodexSdkSession } from "../src/codex-sdk-session";
+import { generateCodexToolResponse } from "../src/codex-tool-response";
+
+const tool = {
+  name: "OPEN_VIEW",
+  description: "Open a view",
+  parameters: {
+    type: "object",
+    properties: { view: { type: "string" } },
+    required: ["view"],
+  },
+};
+
+function fixture(response: string) {
+  const inputs: string[] = [];
+  const schemas: unknown[] = [];
+  let starts = 0;
+  const session = new CodexSdkSession({
+    codexModule: {
+      Codex: class {
+        startThread() {
+          starts++;
+          return {
+            async run(input: string, options?: { outputSchema?: unknown }) {
+              inputs.push(input);
+              schemas.push(options?.outputSchema);
+              return { finalResponse: response };
+            },
+          };
+        }
+      },
+    },
+  });
+  return { session, inputs, schemas, starts: () => starts };
+}
+
+describe("Codex structured tools", () => {
+  it("registers the native planner and isolates two runtime instances", async () => {
+    let adapters = 0;
+    const restore = __setCodexSdkSessionFactoryForTests(() => {
+      adapters++;
+      return fixture(
+        '{"text":"","toolCalls":[{"name":"OPEN_VIEW","arguments":"{\\"view\\":\\"notes\\"}"}]}'
+      ).session;
+    });
+    try {
+      const models = buildModels({ ELIZA_CHAT_VIA_CLI: "codex-sdk" });
+      const handler = models?.ACTION_PLANNER as (
+        runtime: IAgentRuntime,
+        params: GenerateTextParams
+      ) => Promise<GenerateTextResult>;
+      expect(handler).toBeTypeOf("function");
+      const makeRuntime = () =>
+        ({
+          getSetting: (key: string) =>
+            key === "ELIZA_CHAT_VIA_CLI"
+              ? "codex-sdk"
+              : key === "ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION"
+                ? "0"
+                : undefined,
+        }) as IAgentRuntime;
+      const a = makeRuntime();
+      const b = makeRuntime();
+      for (const runtime of [a, a, b]) {
+        const result = await handler(runtime, {
+          prompt: "Open notes",
+          tools: [tool],
+          toolChoice: "required",
+        });
+        expect(result.toolCalls?.[0].name).toBe("OPEN_VIEW");
+      }
+      expect(adapters).toBe(2);
+    } finally {
+      restore();
+      await disposeSdkSessions();
+    }
+  });
+  it("preserves context and schemas and returns an Eliza tool decision", async () => {
+    const f = fixture(
+      JSON.stringify({
+        text: "",
+        toolCalls: [{ name: "OPEN_VIEW", arguments: '{"view":"notes"}' }],
+      })
+    );
+    const result = await generateCodexToolResponse(f.session, {
+      system: "Keep this complete",
+      prompt: "Open Notes",
+      tools: [tool],
+      toolChoice: "required",
+    });
+    expect(result.toolCalls?.[0]).toMatchObject({
+      name: "OPEN_VIEW",
+      arguments: '{"view":"notes"}',
+    });
+    expect(f.inputs[0]).toContain("Keep this complete");
+    expect(f.inputs[0]).toContain(JSON.stringify([tool]));
+    expect(f.schemas[0]).toBeDefined();
+    await generateCodexToolResponse(f.session, { prompt: "Different room", tools: [tool] });
+    expect(f.starts()).toBe(2);
+    expect(f.inputs[1]).not.toContain("Keep this complete");
+  });
+
+  it.each([
+    ['{"text":"done","toolCalls":[]}', "required"],
+    ['{"text":"","toolCalls":[{"name":"DELETE_ALL","arguments":"{}"}]}', "auto"],
+    ['{"text":"","toolCalls":[{"name":"OPEN_VIEW","arguments":"broken"}]}', "auto"],
+    ['{"text":"","toolCalls":[{"name":"OPEN_VIEW","arguments":"[]"}]}', "auto"],
+    ['{"text":"","toolCalls":[{"name":"OPEN_VIEW","arguments":"{}"}]}', "none"],
+  ] as const)("rejects invalid or disallowed output %s", async (response, toolChoice) => {
+    const f = fixture(response);
+    await expect(
+      generateCodexToolResponse(f.session, { prompt: "test", tools: [tool], toolChoice })
+    ).rejects.toThrow();
+  });
+});

--- a/plugins/plugin-cli-inference/codex-inference-exec.mjs
+++ b/plugins/plugin-cli-inference/codex-inference-exec.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// The SDK lacks these exec flags. Keep its protocol intact while preventing an
+// inference request from inheriting the owner's interactive tools or rules.
+import { spawn } from "node:child_process";
+
+const [command, ...args] = process.argv.slice(2);
+if (command !== "exec") throw new Error("Inference launcher only supports codex exec");
+const { ELIZA_CODEX_INFERENCE_BIN: binary, ...env } = process.env;
+if (!binary) throw new Error("Inference Codex binary is not configured");
+const child = spawn(binary, [
+  command, "--ignore-user-config", "--ignore-rules", "--ephemeral", ...args,
+], { env, stdio: "inherit" });
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => child.kill(signal));
+}
+child.on("error", (error) => {
+  console.error(`Could not start Codex inference: ${error.message}`);
+  process.exitCode = 1;
+});
+child.on("exit", (code) => { process.exitCode = code ?? 1; });

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -1,5 +1,11 @@
-import { createHash } from "node:crypto";
-import type { GenerateTextParams, IAgentRuntime, Plugin, ToolDefinition } from "@elizaos/core";
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  GenerateTextParams,
+  GenerateTextResult,
+  IAgentRuntime,
+  Plugin,
+  ToolDefinition,
+} from "@elizaos/core";
 import {
   ElizaError,
   HANDLE_RESPONSE_TOOL_NAME,
@@ -31,21 +37,22 @@ import {
 } from "./src/clean-routing-planner";
 import { CodexCli } from "./src/codex-cli-exec";
 import { CodexSdkSession, type CodexSdkSessionConfig } from "./src/codex-sdk-session";
+import { generateCodexToolResponse } from "./src/codex-tool-response";
 import { flattenPrompt } from "./src/prompt-flatten";
 
 /**
- * @elizaos/plugin-cli-inference — the TOS-clean SAFE/CLOUD inference route.
+ * @elizaos/plugin-cli-inference — opt-in local CLI/SDK inference.
  *
  * Serves chat/planner inference through sanctioned local routes:
  *   - `claude --print`  (reads ~/.claude/.credentials.json itself), or
  *   - a warm Claude Agent SDK session (reads the Claude subscription creds itself), or
- *   - `codex exec`      (reads ~/.codex/auth.json itself).
+ *   - `codex exec` or the official Codex SDK (owns its stored sign-in).
  *
  * eliza never sees/forwards/logs the subscription token — the child env is
  * filtered (allowlist + secret blocklist) and the CLI loads its own creds.
  *
  * The whole models map is INERT unless `ELIZA_CHAT_VIA_CLI` is `claude`,
- * `claude-sdk`, or `codex`. We register TEXT_LARGE / TEXT_MEGA /
+ * `claude-sdk`, `codex`, or `codex-sdk`. By default we register TEXT_LARGE / TEXT_MEGA /
  * RESPONSE_HANDLER only:
  *
  *   - RESPONSE_HANDLER is the whole point — it generates the user-facing reply,
@@ -53,7 +60,7 @@ import { flattenPrompt } from "./src/prompt-flatten";
  *     turn that actually answers (~3-4s).
  *   - TEXT_LARGE / TEXT_MEGA cover other large free-text generations (e.g. the
  *     post-turn evaluator) — also occasional, also tolerant of plain text.
- *   - ACTION_PLANNER is registered ONLY in text-planner mode
+ *   - The free-text backends register ACTION_PLANNER only in text-planner mode
  *     (`ELIZA_PLANNER_NATIVE_TOOLS=0`), where the planner emits an XML
  *     `<response><actions>` block the free-text CLI CAN produce. With native
  *     tools on (the default), the planner needs GBNF / native-tool /
@@ -62,10 +69,12 @@ import { flattenPrompt } from "./src/prompt-flatten";
  *     `NATIVE_TOOLS=0` lets the SAFE route run STANDALONE (chat + planner +
  *     coding all on the subscription CLI) without ever hijacking a hybrid setup.
  *
- * High-frequency should-respond/triage (TEXT_SMALL/NANO/MEDIUM) is never
- * registered, so per-turn CLI spawn cost stays bounded to the user-facing reply
- * via RESPONSE_HANDLER, the planner (text mode only), and possibly the post-turn
- * evaluator — not the cheap triage calls.
+ * Codex SDK also supports the native Eliza planner contract: structured output
+ * returns tool decisions which Eliza validates and executes. It starts a fresh
+ * thread per request, retaining no independent conversation history. The shared
+ * ELIZA_CLI_CLAUDE_ALL_TIERS setting also enables its small text tiers.
+ * Authentication and permitted usage remain subject to each vendor's terms;
+ * this adapter is not a blanket authorization for hosted subscription reuse.
  */
 
 /** Large-tier free-text model types this plugin registers (when enabled). */
@@ -76,9 +85,8 @@ const LARGE_TIER_MODEL_TYPES: readonly string[] = [
 ];
 
 /**
- * The planner. Registered ONLY in text-planner mode so the SAFE/CLI route can
- * run standalone. The free-text CLI can emit the XML `<actions>` block but cannot
- * honor GBNF/native-tool enforcement, so this REQUIRES `ELIZA_PLANNER_NATIVE_TOOLS=0`.
+ * Codex SDK bridges the native tool contract; other backends require the
+ * existing text-planner mode (ELIZA_PLANNER_NATIVE_TOOLS=0).
  */
 const PLANNER_MODEL_TYPES: readonly string[] = [ModelType.ACTION_PLANNER];
 
@@ -235,7 +243,7 @@ type CodexSdkSessionFactory = (config: CodexSdkSessionConfig) => CodexSdkSession
 
 let createCodexSdkSession: CodexSdkSessionFactory = (config) => new CodexSdkSession(config);
 
-/** Replace the warm Codex-session constructor for deterministic boundary tests. */
+/** Replace the Codex adapter constructor for deterministic boundary tests. */
 export function __setCodexSdkSessionFactoryForTests(factory: CodexSdkSessionFactory): () => void {
   const previous = createCodexSdkSession;
   createCodexSdkSession = factory;
@@ -379,15 +387,15 @@ export async function disposeSdkSessions(): Promise<void> {
   for (const s of codex) s.dispose();
 }
 
-// Warm Codex SDK threads use one stable (model, mode) key. The effective restart
-// cadence is stored beside the session so a change disposes/replaces the thread
-// without leaking cache or account-rotation entries.
+// Cache adapter configuration, not conversation history. Codex starts a fresh
+// thread for each request; runtime identity isolates configuration and account affinity.
 interface CachedCodexSdkSession {
   session: CodexSdkSession;
   lifecycleFingerprint: string;
 }
 
 const codexSdkSessions = new Map<string, CachedCodexSdkSession>();
+const codexRuntimeIds = new WeakMap<IAgentRuntime, string>();
 
 /** The codex model for a given tier (planner/small can differ from large). */
 function resolveCodexModel(runtime: IAgentRuntime, modelType: string): string {
@@ -397,8 +405,13 @@ function resolveCodexModel(runtime: IAgentRuntime, modelType: string): string {
   return ((isSmallTier ? small : large) || large || "gpt-5.5").trim();
 }
 
-function codexSessionKey(model: string, router: boolean): string {
-  return `${model}\u001f${router ? "route" : "text"}`;
+function codexSessionKey(runtime: IAgentRuntime, model: string, router: boolean): string {
+  let id = codexRuntimeIds.get(runtime);
+  if (!id) {
+    id = randomUUID();
+    codexRuntimeIds.set(runtime, id);
+  }
+  return `${id}\u001f${model}\u001f${router ? "route" : "text"}`;
 }
 
 function codexLifecycleFingerprint(config: CodexSdkTimeoutConfiguration): string {
@@ -406,7 +419,7 @@ function codexLifecycleFingerprint(config: CodexSdkTimeoutConfiguration): string
 }
 
 /**
- * Evict + dispose a warm Codex SDK thread by its cache key so the next
+ * Evict + dispose a Codex SDK adapter by its cache key so the next
  * `getCodexSdkSession` re-starts it — re-reading the (rotated) per-account
  * `CODEX_HOME`. Used by account rotation after a subscription limit.
  */
@@ -417,7 +430,7 @@ function evictCodexSdkSession(key: string): void {
   existing.session.dispose();
 }
 
-/** Lazily cache a warm Codex SDK thread for a (model, mode, restart cadence). */
+/** Cache adapter configuration per runtime; request threads are never reused. */
 function getCodexSdkSession(
   runtime: IAgentRuntime,
   model: string,
@@ -425,8 +438,12 @@ function getCodexSdkSession(
   timeoutConfiguration: CodexSdkTimeoutConfiguration,
   subprocessEnv?: RotationSubprocessEnv
 ): CodexSdkSession {
-  const key = codexSessionKey(model, router);
-  const lifecycleFingerprint = codexLifecycleFingerprint(timeoutConfiguration);
+  const key = codexSessionKey(runtime, model, router);
+  const lifecycleFingerprint = JSON.stringify([
+    codexLifecycleFingerprint(timeoutConfiguration),
+    getSetting(runtime, "ELIZA_CLI_CODEX_REASONING_EFFORT"),
+    getSetting(runtime, "ELIZA_CLI_CODEX_BIN"),
+  ]);
   const existing = codexSdkSessions.get(key);
   if (existing?.lifecycleFingerprint === lifecycleFingerprint) {
     return existing.session;
@@ -591,7 +608,7 @@ function resolveClaudeSdkTimeoutConfiguration(
   };
 }
 
-/** Resolve the only numeric setting consumed by the warm Codex backend. */
+/** Parse the legacy Codex restart setting for configuration compatibility. */
 function resolveCodexSdkTimeoutConfiguration(runtime: IAgentRuntime): CodexSdkTimeoutConfiguration {
   return {
     sdkRestartAfterTurns:
@@ -638,7 +655,7 @@ async function generateViaCli(
   runtime: IAgentRuntime,
   params: GenerateTextParams,
   modelType: string
-): Promise<string> {
+): Promise<string | GenerateTextResult> {
   const backend = resolveCliBackend({
     ELIZA_CHAT_VIA_CLI: getSetting(runtime, "ELIZA_CHAT_VIA_CLI"),
   });
@@ -734,10 +751,17 @@ async function generateViaCli(
     const model = resolveCodexModel(runtime, modelType);
     const { system, body } = flattenPrompt(generateParams);
     const framedBody = appendTextDirective(`${frameTextSystemPrompt(system)}\n\n${body}`);
-    const key = codexSessionKey(model, false);
-    return withAccountRotation(
+    const key = codexSessionKey(runtime, model, false);
+    return withAccountRotation<string | GenerateTextResult>(
       (env) =>
-        getCodexSdkSession(runtime, model, false, timeoutConfiguration, env).generate(framedBody),
+        params.tools?.length
+          ? generateCodexToolResponse(
+              getCodexSdkSession(runtime, model, false, timeoutConfiguration, env),
+              params
+            )
+          : getCodexSdkSession(runtime, model, false, timeoutConfiguration, env).generate(
+              framedBody
+            ),
       {
         backend,
         getValue: (k) => getSetting(runtime, k),
@@ -775,7 +799,10 @@ async function generateViaCli(
  * (`parseJsonPlannerOutput` → `normalizeBarePlannerAction`) accepts directly, so
  * no core change is needed.
  */
-async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): Promise<string> {
+async function planViaCli(
+  runtime: IAgentRuntime,
+  params: GenerateTextParams
+): Promise<string | GenerateTextResult> {
   const backend = resolveCliBackend({
     ELIZA_CHAT_VIA_CLI: getSetting(runtime, "ELIZA_CHAT_VIA_CLI"),
   });
@@ -803,6 +830,7 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
     );
   }
   if (backend === "codex-sdk") {
+    if (params.tools?.length) return generateViaCli(runtime, params, ModelType.ACTION_PLANNER);
     const timeoutConfiguration = resolveCodexSdkTimeoutConfiguration(runtime);
     // codex routes via NATIVE structured output (outputSchema) for a reliable
     // {action, params} shape. The clean-routing prompt (menu + transcript +
@@ -811,7 +839,7 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
     const model = resolveCodexModel(runtime, ModelType.ACTION_PLANNER);
     const clean = buildCleanRoutingParams(params);
     const routeBody = `${clean.system ?? ""}\n\n${clean.prompt ?? ""}`;
-    const key = codexSessionKey(model, true);
+    const key = codexSessionKey(runtime, model, true);
     return withAccountRotation(
       (env) => getCodexSdkSession(runtime, model, true, timeoutConfiguration, env).route(routeBody),
       {
@@ -836,7 +864,7 @@ export function buildModels(
   if (!resolveCliBackend(source)) return {};
   const models: Record<
     string,
-    (runtime: IAgentRuntime, params: GenerateTextParams) => Promise<string>
+    (runtime: IAgentRuntime, params: GenerateTextParams) => Promise<string | GenerateTextResult>
   > = {};
   const textTiers = allTiersEnabled()
     ? [...LARGE_TIER_MODEL_TYPES, ...SMALL_TIER_MODEL_TYPES]
@@ -844,7 +872,7 @@ export function buildModels(
   for (const modelType of textTiers) {
     models[modelType] = (runtime, params) => generateViaCli(runtime, params, modelType);
   }
-  if (textPlannerEnabled()) {
+  if (textPlannerEnabled() || resolveCliBackend(source) === "codex-sdk") {
     for (const modelType of PLANNER_MODEL_TYPES) {
       models[modelType] = (runtime, params) => planViaCli(runtime, params);
     }
@@ -893,7 +921,7 @@ export function buildModelMetadata(
       metadata[modelType] = declaration(settings);
     }
   }
-  if (textPlannerEnabled()) {
+  if (textPlannerEnabled() || backend === "codex-sdk") {
     for (const modelType of PLANNER_MODEL_TYPES) {
       metadata[modelType] = declaration(isWarm ? [plannerSetting, largeSetting] : [largeSetting]);
     }
@@ -904,7 +932,7 @@ export function buildModelMetadata(
 export const cliInferencePlugin: Plugin = {
   name: "cli-inference",
   description:
-    "TOS-clean SAFE/CLOUD inference: serves large-tier model handlers through sanctioned claude, claude-sdk, or codex routes; each route reads its own creds. Inert unless ELIZA_CHAT_VIA_CLI=claude|claude-sdk|codex.",
+    "Opt-in local CLI/SDK inference via claude, claude-sdk, codex, or codex-sdk. Each backend manages its own authentication; Codex SDK bridges Eliza tool decisions using isolated requests.",
   modelMetadata: buildModelMetadata(),
   // High priority so that, when ELIZA_CHAT_VIA_CLI is set, this plugin
   // deterministically wins the tiers it registers (TEXT_LARGE / TEXT_MEGA /

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -37,6 +37,7 @@
   },
   "files": [
     "dist",
+    "codex-inference-exec.mjs",
     "auto-enable.ts"
   ],
   "elizaos": {

--- a/plugins/plugin-cli-inference/src/account-rotation.ts
+++ b/plugins/plugin-cli-inference/src/account-rotation.ts
@@ -257,11 +257,11 @@ export function resetRotationStateForTests(): void {
  * leakage). At most `maxRotations` swaps are attempted to bound the loop even if
  * the pool mis-reports health.
  */
-export async function withAccountRotation(
-  attempt: (env?: RotationSubprocessEnv) => Promise<string>,
+export async function withAccountRotation<T>(
+  attempt: (env?: RotationSubprocessEnv) => Promise<T>,
   ctx: RotationContext,
   maxRotations = 8
-): Promise<string> {
+): Promise<T> {
   const agentType = rotationAgentTypeForBackend(ctx.backend);
   const bridge = agentType ? getCodingAccountBridge() : null;
   // No rotation possible/desired → single, un-wrapped attempt (behavior

--- a/plugins/plugin-cli-inference/src/codex-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/codex-sdk-session.ts
@@ -1,43 +1,37 @@
 /**
- * Warm Codex SDK inference session — the codex peer of {@link ClaudeSdkSession}.
+ * Request-isolated Codex SDK inference for Eliza text and structured decisions.
  *
  * Runs an Eliza chat brain (chat + planner) on a personal ChatGPT/Codex
  * subscription via `@openai/codex-sdk`, which wraps the bundled `codex` binary
- * and reads its own `~/.codex/auth.json` (eliza never sees the token). Unlike
- * `codex exec` (CodexCli), which cold-spawns a fresh process per call, this keeps
- * ONE warm `Thread` alive (`codex.startThread()` once; `thread.run()` per turn),
- * so the startup cost is paid once.
+ * and manages its own authentication. The installed TypeScript SDK spawns the
+ * CLI for every run. Each request starts a fresh thread: Eliza supplies the
+ * complete authorized context, without a second hidden conversation history.
  *
  * TWO MODES:
  *  - TEXT mode (`generate`): pure completion for the reply / large tiers. The
- *    thread runs read-only, no network, no approvals — a warm completion engine.
+ *    thread runs read-only, no network, no approvals.
  *    Returns the turn's `finalResponse`.
  *  - ROUTE mode (`route`): the ACTION_PLANNER decision via codex NATIVE structured
  *    output (`TurnOptions.outputSchema`). The schema constrains the turn to
  *    `{action, params}` with `params` as a JSON STRING (OpenAI strict mode forbids
  *    open-ended objects), which `normalizeRoute` parses back into the bare
  *    `{action, params}` shape the planner loop's text-mode parser accepts. This
- *    is reliable at scale (the model cannot drift off-shape) — unlike free-text
- *    JSON. REQUIRES the system codex binary (`codexBinPath`): the SDK's bundled
- *    binary is too old and rejects structured output ("requires a newer version").
+ *    is validated before being returned to Eliza. Use a current installed Codex
+ *    binary supporting structured output and the inference isolation flags.
  *
- * codex-sdk has NO thread-level system prompt (ThreadOptions carries none), so
- * the system content is folded into the body per call — which also means ONE warm
- * thread per (model, mode) can serve every system prompt (no per-systemPrompt
- * keying needed, unlike claude). Calls are SERIALIZED; the session self-heals on
- * error and restarts after `restartAfterTurns` to bound the thread's accumulating
- * context.
- *
- * LIVE-VERIFIED on a ChatGPT/Codex subscription: btc/eth/weather route to
- * WEB_FETCH and synthesize the real fetched value; math/chat/identity work. Needs
- * the system codex binary via `codexBinPath` (the SDK's bundled 0.80.0 rejects
- * gpt-5.5). Unit-tested via the injectable `codexModule` seam.
+ * System content is folded into each request body. Calls on an adapter instance
+ * are serialized, but no provider thread survives a completed or failed call.
  *
  * @module plugin-cli-inference/codex-sdk-session
  */
 
+import { mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { logger } from "@elizaos/core";
 import type { RotationSubprocessEnv } from "./account-rotation";
+import { filterEnv } from "./sandbox";
 
 const DEFAULT_MODEL = "gpt-5.5";
 const DEFAULT_RESTART_AFTER_TURNS = 20;
@@ -96,7 +90,7 @@ export interface CodexSdkSessionConfig {
    * gpt-5.5 work.
    */
   codexBinPath?: string | null;
-  /** Restart the warm thread after this many turns (bounds context growth). */
+  /** Legacy compatibility option; requests now always use fresh threads. */
   restartAfterTurns?: number;
   /**
    * Optional subprocess-only env for a pooled account. Passed to the Codex SDK
@@ -140,9 +134,9 @@ function turnToText(turn: CodexTurn): string {
 }
 
 /**
- * A single warm Codex SDK thread for one (model, mode). Lazily starts on first
- * call, serializes calls, and self-heals (restarts) on error or after
- * `restartAfterTurns`.
+ * Serializes requests for one adapter configuration. Every request creates a
+ * fresh thread: Eliza owns the authorized conversation context. The installed
+ * SDK starts a subprocess for each run, not a persistent inference process.
  */
 export class CodexSdkSession {
   private readonly model: string;
@@ -154,6 +148,7 @@ export class CodexSdkSession {
   private readonly codexOverride?: CodexModule;
 
   private thread: CodexThread | null = null;
+  private workingDirectory: string | null = null;
   private turns = 0;
   private chain: Promise<unknown> = Promise.resolve();
 
@@ -171,8 +166,8 @@ export class CodexSdkSession {
   }
 
   /** TEXT mode: generate one completion's text. Serialized. */
-  generate(body: string): Promise<string> {
-    return this.enqueue(() => this.sendOnce(body, "text"));
+  generate(body: string, outputSchema?: unknown): Promise<string> {
+    return this.enqueue(() => this.sendOnce(body, "text", outputSchema));
   }
 
   /**
@@ -193,25 +188,31 @@ export class CodexSdkSession {
     return run;
   }
 
-  private async sendOnce(body: string, mode: "text" | "route"): Promise<string> {
+  private async sendOnce(
+    body: string,
+    mode: "text" | "route",
+    outputSchema?: unknown
+  ): Promise<string> {
     if (!body.trim()) {
       throw new Error("[cli-inference:codex-sdk] empty prompt body");
     }
     if (this.thread && this.turns >= this.restartAfterTurns) {
       this.dispose();
     }
-    if (!this.thread) {
-      await this.start();
-    }
-    this.turns += 1;
     try {
+      if (!this.thread) await this.start();
+      this.turns += 1;
       const thread = this.thread;
       if (!thread) throw new Error("[cli-inference:codex-sdk] thread not started");
       // ROUTE: constrain output to {action, params:json-string} via the codex
       // native output schema (reliable shape; needs the system codex binary).
       const turn = await thread.run(
         body,
-        mode === "route" ? { outputSchema: ROUTE_OUTPUT_SCHEMA } : undefined
+        outputSchema
+          ? { outputSchema }
+          : mode === "route"
+            ? { outputSchema: ROUTE_OUTPUT_SCHEMA }
+            : undefined
       );
       const text = turnToText(turn);
       if (mode === "route") {
@@ -226,6 +227,12 @@ export class CodexSdkSession {
       // must not poison the next turn), then rethrow so the caller sees the failure.
       this.dispose();
       throw err instanceof Error ? err : new Error(`[cli-inference:codex-sdk] ${String(err)}`);
+    } finally {
+      // Eliza owns conversation history and access filtering, not the SDK.
+      this.dispose();
+      const directory = this.workingDirectory;
+      this.workingDirectory = null;
+      if (directory) await rm(directory, { recursive: true, force: true });
     }
   }
 
@@ -237,34 +244,22 @@ export class CodexSdkSession {
     let parsed: unknown;
     try {
       parsed = JSON.parse(text);
-    } catch {
-      // error-policy:J3 untrusted model output — structured output SHOULD be valid
-      // JSON; if wrapped, salvage the first {...} block, else throw a typed
-      // "non-JSON output" (does not fabricate a valid route).
-      const match = text.match(/\{[\s\S]*\}/);
-      if (!match) {
-        throw new Error("[cli-inference:codex-sdk] route: non-JSON output");
-      }
-      parsed = JSON.parse(match[0]);
+    } catch (cause) {
+      // error-policy:J3 reject malformed structured output, never infer a route.
+      throw new Error("[cli-inference:codex-sdk] route: non-JSON output", { cause });
     }
-    const obj = parsed as { action?: unknown; params?: unknown };
+    if (!isRecord(parsed) || Array.isArray(parsed)) {
+      throw new Error("[cli-inference:codex-sdk] route: expected an object");
+    }
+    const obj = parsed;
     if (typeof obj.action !== "string" || !obj.action.trim()) {
       throw new Error("[cli-inference:codex-sdk] route: missing action");
     }
     // `params` arrives as a JSON STRING (ROUTE_OUTPUT_SCHEMA encodes it that way
     // for strict-mode), or already as an object on the free-text fallback path.
-    let params: Record<string, unknown> = {};
-    if (typeof obj.params === "string" && obj.params.trim()) {
-      try {
-        const p = JSON.parse(obj.params);
-        if (p && typeof p === "object") params = p as Record<string, unknown>;
-      } catch {
-        // error-policy:J3 untrusted model output — a malformed `params` JSON
-        // string degrades to {} (a valid "no params" route arg), the action
-        // itself is already validated above; not a swallowed required-data failure.
-      }
-    } else if (obj.params && typeof obj.params === "object") {
-      params = obj.params as Record<string, unknown>;
+    const params: unknown = typeof obj.params === "string" ? JSON.parse(obj.params) : obj.params;
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+      throw new Error("[cli-inference:codex-sdk] route: params must be an object");
     }
     return JSON.stringify({
       action: obj.action.trim(),
@@ -276,12 +271,33 @@ export class CodexSdkSession {
     const { Codex } = this.codexOverride ?? (await loadCodex());
     // Drive the system codex binary (not the SDK's bundled-and-often-stale one)
     // when a path is configured, so current models work.
-    const codexOptions: Record<string, unknown> = {};
-    if (this.codexBinPath) codexOptions.codexPathOverride = this.codexBinPath;
-    if (this.subprocessEnv) codexOptions.env = this.subprocessEnv;
+    // The inference child must not inherit tools or memories from the owner's
+    // interactive Codex setup. Authentication still belongs to the SDK/CLI.
+    const codexOptions: Record<string, unknown> = {
+      config: {
+        features: {
+          apps: false,
+          plugins: false,
+          shell_tool: false,
+          unified_exec: false,
+          multi_agent: false,
+          hooks: false,
+          memories: false,
+          image_generation: false,
+        },
+      },
+    };
+    codexOptions.codexPathOverride = join(
+      dirname(createRequire(import.meta.url).resolve("@elizaos/plugin-cli-inference/package.json")),
+      "codex-inference-exec.mjs"
+    );
+    codexOptions.env = {
+      ...(this.subprocessEnv ?? filterEnv(process.env)),
+      ELIZA_CODEX_INFERENCE_BIN: this.codexBinPath ?? "codex",
+    };
     const codex = new Codex(codexOptions);
-    // Pure inference: read-only, no network, no approvals, no git-repo coupling —
-    // a warm completion engine, not a coding agent.
+    this.workingDirectory = await mkdtemp(join(tmpdir(), "eliza-codex-inference-"));
+    // This SDK run is inference-only; Eliza executes returned action decisions.
     const options: Record<string, unknown> = {
       model: this.model,
       sandboxMode: "read-only",
@@ -289,17 +305,18 @@ export class CodexSdkSession {
       networkAccessEnabled: false,
       webSearchEnabled: false,
       skipGitRepoCheck: true,
+      workingDirectory: this.workingDirectory,
     };
     if (this.reasoningEffort) options.modelReasoningEffort = this.reasoningEffort;
     this.thread = codex.startThread(options);
     this.turns = 0;
     logger.debug(
       { src: "cli-inference:codex-sdk", model: this.model, mode: this.router ? "route" : "text" },
-      "warm Codex SDK thread started"
+      "isolated Codex SDK thread started"
     );
   }
 
-  /** Tear down the warm thread (on restart, error, or dispose). */
+  /** Release the request thread without retaining its conversation history. */
   dispose(): void {
     this.thread = null;
     this.turns = 0;

--- a/plugins/plugin-cli-inference/src/codex-tool-response.ts
+++ b/plugins/plugin-cli-inference/src/codex-tool-response.ts
@@ -1,0 +1,91 @@
+/**
+ * Bridge Codex structured output to Eliza's tool-result contract. The full
+ * request and tool schemas remain model-visible; only Eliza executes actions.
+ */
+import { randomUUID } from "node:crypto";
+import type { GenerateTextParams, GenerateTextResult } from "@elizaos/core";
+import type { CodexSdkSession } from "./codex-sdk-session";
+import { flattenPrompt } from "./prompt-flatten";
+
+export async function generateCodexToolResponse(
+  session: CodexSdkSession,
+  params: GenerateTextParams
+): Promise<GenerateTextResult> {
+  const tools = params.tools ?? [];
+  const choice = params.toolChoice ?? "auto";
+  const forced =
+    typeof choice === "object"
+      ? "function" in choice
+        ? choice.function.name
+        : choice.name
+      : undefined;
+  const names = tools.map((tool) => tool.name);
+  if (forced && !names.includes(forced)) throw new Error("Codex requested tool is not declared");
+  const { system, body } = flattenPrompt(params);
+  const outputSchema = {
+    type: "object",
+    additionalProperties: false,
+    required: ["text", "toolCalls"],
+    properties: {
+      text: { type: "string" },
+      toolCalls: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["name", "arguments"],
+          properties: {
+            name: { type: "string", enum: forced ? [forced] : names },
+            arguments: {
+              type: "string",
+              description: "JSON object matching the selected tool's complete parameter schema",
+            },
+          },
+        },
+      },
+    },
+  };
+  const raw = await session.generate(
+    `${system}\n\n${body}\n\nEliza tool definitions (complete):\n${JSON.stringify(tools)}\nTool choice: ${JSON.stringify(choice)}\nReturn the structured response. Tool calls are decisions for Eliza to execute, not actions you have completed. Do not execute tools yourself. Required means at least one tool call; none means no tool calls.`,
+    outputSchema
+  );
+  const result: unknown = JSON.parse(raw);
+  if (
+    !result ||
+    typeof result !== "object" ||
+    !("text" in result) ||
+    typeof result.text !== "string" ||
+    !("toolCalls" in result) ||
+    !Array.isArray(result.toolCalls)
+  ) {
+    throw new Error("Invalid Codex structured tool response");
+  }
+  const calls = result.toolCalls.map((call: unknown) => {
+    if (
+      !call ||
+      typeof call !== "object" ||
+      !("name" in call) ||
+      typeof call.name !== "string" ||
+      !names.includes(call.name) ||
+      (forced && call.name !== forced) ||
+      !("arguments" in call) ||
+      typeof call.arguments !== "string"
+    ) {
+      throw new Error("Codex returned an undeclared or invalid tool call");
+    }
+    const args: unknown = JSON.parse(call.arguments);
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      throw new Error("Codex tool arguments must be a JSON object");
+    }
+    return { id: randomUUID(), name: call.name, arguments: call.arguments };
+  });
+  if ((choice === "required" || forced) && calls.length === 0)
+    throw new Error("Codex omitted a required tool call");
+  if (choice === "none" && calls.length !== 0)
+    throw new Error("Codex called a tool when toolChoice is none");
+  return {
+    text: result.text,
+    toolCalls: calls,
+    finishReason: calls.length ? "tool_calls" : "stop",
+  };
+}


### PR DESCRIPTION
The optional Codex SDK inference adapter needs to preserve native tool decisions and isolate each inference request from personal project/configuration context. This draft extracts the saved adapter checkpoint from the local Eliza lane so it can be reviewed independently of chat trajectories and memory work.

@lalalune — uncertain compatibility and live acceptance remain open; please keep this draft. Extracted from local commit `25886bf6de5` onto develop `5bf3faef78a9a214431fb3e8a7eaa0f0518767de` without conflicts.

### Changes

- Create an isolated, ephemeral Codex SDK request and preserve complete supplied model/tool context.
- Translate validated structured tool decisions to Eliza tool calls; reject malformed arguments, undeclared tools and missing required decisions. Eliza remains responsible for executing actions.
- Add an inference launcher and package it with the plugin; unsupported isolation flags fail rather than retrying with weaker settings.
- Preserve runtime/model account affinity and honor an explicit process-local brain-provider override.

### Validation and remaining acceptance

- Frozen dependency installation and `git diff --check` passed.
- Unit suite: 219 passed, 2 skipped across 10 files after building the required core/prompt packages. An initial attempt failed because the fresh checkout had no built core bundle; the rerun above passed.
- Current-head full repository verification, package typecheck/build and a real installed-CLI end-to-end trajectory remain open. Unit tests use fake SDK/spawn boundaries and do not establish live behavior.
- Installed CLI flags/version and SDK output behavior must be verified before enabling this path. No live model call or provider switch was performed while preparing this draft.
- The active Eliza demo remains on its configured Cerebras text path. No credentials, personal configuration or raw conversation traces are included.

This PR preserves existing local work for review; it does not request deployment or assert subscription eligibility, provider policy approval or a performance improvement.
