### PR TITLE
registry: add elizaos-plugin-aiworker (paid x402 data routes as actions)

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-aiworker.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-aiworker.json
@@ -1,0 +1,10 @@
+{
+  "package": "elizaos-plugin-aiworker",
+  "repository": "github:ai-worker227/aiworker-examples",
+  "directory": "elizaos",
+  "kind": "plugin",
+  "description": "aiworker's paid x402 data routes as ElizaOS actions: DeFi yields and protocol snapshots, page-to-Markdown, Base token and wallet checks, Polymarket resolution, odds, history, screener and backtests, fact checks, sourced briefs and headline search. Each call pays its own USDC on Base from the agent's wallet; nothing is settled unless the request succeeds.",
+  "homepage": "https://aiworker.duckdns.org",
+  "version": "0.1.0",
+  "tags": ["data", "x402", "usdc", "base", "defi", "polymarket", "web-scraping", "news"]
+}

--- a/packages/registry/entries/third-party/elizaos-plugin-aiworker.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-aiworker.json
@@ -5,6 +5,6 @@
   "kind": "plugin",
   "description": "aiworker's paid x402 data routes as ElizaOS actions: DeFi yields and protocol snapshots, page-to-Markdown, Base token and wallet checks, Polymarket resolution, odds, history, screener and backtests, fact checks, sourced briefs and headline search. Each call pays its own USDC on Base from the agent's wallet; nothing is settled unless the request succeeds.",
   "homepage": "https://aiworker.duckdns.org",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "tags": ["data", "x402", "usdc", "base", "defi", "polymarket", "web-scraping", "news"]
 }

--- a/packages/registry/entries/third-party/elizaos-plugin-aiworker.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-aiworker.json
@@ -5,6 +5,6 @@
   "kind": "plugin",
   "description": "aiworker's paid x402 data routes as ElizaOS actions: DeFi yields and protocol snapshots, page-to-Markdown, Base token and wallet checks, Polymarket resolution, odds, history, screener and backtests, fact checks, sourced briefs and headline search. Each call pays its own USDC on Base from the agent's wallet; nothing is settled unless the request succeeds.",
   "homepage": "https://aiworker.duckdns.org",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "tags": ["data", "x402", "usdc", "base", "defi", "polymarket", "web-scraping", "news"]
 }

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1374,6 +1374,54 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-aiworker": {
+      "git": {
+        "repo": "ai-worker227/aiworker-examples",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-aiworker",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "aiworker's paid x402 data routes as ElizaOS actions: DeFi yields and protocol snapshots, page-to-Markdown, Base token and wallet checks, Polymarket resolution, odds, history, screener and backtests, fact checks, sourced briefs and headline search. Each call pays its own USDC on Base from the agent's wallet; nothing is settled unless the request succeeds.",
+      "homepage": "https://aiworker.duckdns.org",
+      "topics": [
+        "data",
+        "x402",
+        "usdc",
+        "base",
+        "defi",
+        "polymarket",
+        "web-scraping",
+        "news"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": "elizaos"
+    },
     "elizaos-plugin-coinrailz": {
       "git": {
         "repo": "tdnupe3/elizaos-plugin-coinrailz",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1391,7 +1391,7 @@
         "repo": "elizaos-plugin-aiworker",
         "v0": null,
         "v1": null,
-        "v2": "0.1.1"
+        "v2": "0.1.2"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1391,7 +1391,7 @@
         "repo": "elizaos-plugin-aiworker",
         "v0": null,
         "v1": null,
-        "v2": "0.1.0"
+        "v2": "0.1.1"
       },
       "supports": {
         "v0": false,


### PR DESCRIPTION
## Add `elizaos-plugin-aiworker` to the third-party registry

One entry file under `packages/registry/entries/third-party/` plus the regenerated `generated-registry.json`
(`bun run validate` → 50 entries validated; `bun run generate`).

**What the plugin is.** [aiworker](https://aiworker.duckdns.org) sells seventeen small data routes to agents, paid per
call in USDC over the x402 protocol (no account, no API key). The plugin builds one action per route from the live
OpenAPI catalogue; each action pays its own call from the agent's wallet through `@x402/fetch`. Routes: DeFi yields and
protocol snapshots, page-to-Markdown, Base token safety cards and wallet checks, Polymarket resolution, odds, history,
screener and rule backtests, fact checks, sourced briefs, headline search.

- npm: https://www.npmjs.com/package/elizaos-plugin-aiworker (`keywords` include `elizaos`)
- source: https://github.com/ai-worker227/aiworker-examples/tree/main/elizaos (MIT; tests run on fakes, no network)
- configuration: `AIWORKER_BUYER_KEY` (a Base wallet holding USDC), optional `AIWORKER_BASE_URL`, `AIWORKER_CHAIN`,
  `AIWORKER_MAX_PRICE_USD` (default 0.05). Without a key the plugin stays empty and the agent still starts.
- security notes: arguments come only from `options.args` or a JSON message, never from the runtime's options bag;
  invalid arguments make no request (nothing paid); a non-2xx answer is returned, never thrown; the key is used
  only to sign the x402 payment header and is never logged.
