### PR TITLE
fix(personal-assistant): validate calendar card requests at the route boundary (#31053)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-card.request.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-card.request.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Pins the calendar-card request parser: every field of the untrusted owner
+ * body is validated once, so a malformed date, time zone, event, lifetime, or
+ * privacy mode is an explicit 400-shaped result instead of a throw from the
+ * composer, Intl, or the approval queue. Deterministic, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { parseCalendarCardRequest } from "./calendar-card.js";
+
+const event = {
+  id: "evt-1",
+  title: "Standup",
+  startAt: "2026-03-02T09:00:00.000Z",
+  endAt: "2026-03-02T09:30:00.000Z",
+  location: "Room 4",
+};
+
+const valid = {
+  date: "2026-03-02",
+  timeZone: "America/New_York",
+  privacyMode: "full",
+  recipient: "Sam",
+  events: [event],
+};
+
+describe("parseCalendarCardRequest", () => {
+  it("accepts a complete request and normalizes optional fields", () => {
+    const parsed = parseCalendarCardRequest({
+      ...valid,
+      recipient: "  Sam  ",
+      recipientEntityId: "entity-9",
+      ttlMs: 60_000,
+      events: [{ ...event, location: undefined }],
+    });
+    expect(parsed).toEqual({
+      ok: true,
+      request: {
+        date: "2026-03-02",
+        timeZone: "America/New_York",
+        privacyMode: "full",
+        recipient: "Sam",
+        recipientEntityId: "entity-9",
+        events: [{ ...event, location: null }],
+        ttlMs: 60_000,
+      },
+    });
+  });
+
+  it("defaults the recipient entity and lifetime to null when omitted", () => {
+    const parsed = parseCalendarCardRequest(valid);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.request.recipientEntityId).toBeNull();
+    expect(parsed.request.ttlMs).toBeNull();
+    expect(parsed.request.events).toEqual([event]);
+  });
+
+  it.each([
+    [null, "Calendar card request must be an object"],
+    [[], "Calendar card request must be an object"],
+    [
+      { ...valid, date: "tomorrow" },
+      "date must be a valid YYYY-MM-DD calendar date",
+    ],
+    [
+      { ...valid, date: "2026-02-30" },
+      "date must be a valid YYYY-MM-DD calendar date",
+    ],
+    [
+      { ...valid, date: 20260302 },
+      "date must be a valid YYYY-MM-DD calendar date",
+    ],
+    [
+      { ...valid, timeZone: "Mars/Olympus" },
+      "timeZone must be a valid IANA time zone",
+    ],
+    [{ ...valid, timeZone: "" }, "timeZone must be a valid IANA time zone"],
+    [
+      { ...valid, privacyMode: "everything" },
+      "privacyMode must be one of full, times_only, busy_only",
+    ],
+    [{ ...valid, recipient: "   " }, "recipient must be a non-empty string"],
+    [
+      { ...valid, recipientEntityId: "" },
+      "recipientEntityId must be a non-empty string when present",
+    ],
+    [{ ...valid, events: "none" }, "events must be an array"],
+    [{ ...valid, events: [null] }, "events[0] must be an object"],
+    [
+      { ...valid, events: [{ ...event, id: "" }] },
+      "events[0].id must be a non-empty string",
+    ],
+    [
+      { ...valid, events: [event, { ...event, title: 3 }] },
+      "events[1].title must be a string",
+    ],
+    [
+      { ...valid, events: [{ ...event, startAt: "soon" }] },
+      "events[0].startAt must be a parseable timestamp",
+    ],
+    [
+      { ...valid, events: [{ ...event, endAt: undefined }] },
+      "events[0].endAt must be a parseable timestamp",
+    ],
+    [
+      { ...valid, events: [{ ...event, endAt: "2026-03-02T08:00:00.000Z" }] },
+      "events[0].endAt must not be before startAt",
+    ],
+    [
+      { ...valid, events: [{ ...event, location: 7 }] },
+      "events[0].location must be a string when present",
+    ],
+    [
+      { ...valid, ttlMs: 0 },
+      "ttlMs must be a positive integer number of milliseconds",
+    ],
+    [
+      { ...valid, ttlMs: 1.5 },
+      "ttlMs must be a positive integer number of milliseconds",
+    ],
+    [
+      { ...valid, ttlMs: "1h" },
+      "ttlMs must be a positive integer number of milliseconds",
+    ],
+  ])("rejects %j", (body, error) => {
+    expect(parseCalendarCardRequest(body)).toEqual({ ok: false, error });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-card.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-card.ts
@@ -16,6 +16,7 @@ import {
   ServiceType,
   stableStringify,
 } from "@elizaos/core";
+import { isValidTimeZone } from "@elizaos/shared";
 import type {
   ApprovalPayload,
   CalendarCardApprovalCorrelation,
@@ -23,6 +24,173 @@ import type {
 import { executeRawSql, sqlQuote, toText } from "./sql.js";
 
 export type CalendarCardPrivacyMode = "full" | "times_only" | "busy_only";
+
+const CALENDAR_CARD_PRIVACY_MODES: ReadonlySet<string> = new Set([
+  "full",
+  "times_only",
+  "busy_only",
+]);
+
+/** Owner request to issue a private daily calendar card, after validation. */
+export interface CalendarCardRequest {
+  readonly date: string;
+  readonly timeZone: string;
+  readonly privacyMode: CalendarCardPrivacyMode;
+  readonly recipient: string;
+  readonly recipientEntityId: string | null;
+  readonly events: readonly CalendarCardEvent[];
+  readonly ttlMs: number | null;
+}
+
+export type CalendarCardRequestParse =
+  | { readonly ok: true; readonly request: CalendarCardRequest }
+  | { readonly ok: false; readonly error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isCalendarDay(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  // Date.UTC rolls an out-of-range day such as 02-30 into the next month, so
+  // the parts must survive the round trip unchanged.
+  const roundTrip = new Date(Date.UTC(year, month - 1, day, 12));
+  return (
+    roundTrip.getUTCFullYear() === year &&
+    roundTrip.getUTCMonth() === month - 1 &&
+    roundTrip.getUTCDate() === day
+  );
+}
+
+function parseCalendarCardEvent(
+  value: unknown,
+  index: number,
+): CalendarCardEvent | string {
+  if (!isRecord(value)) return `events[${index}] must be an object`;
+  const id = nonEmptyText(value.id);
+  if (!id) return `events[${index}].id must be a non-empty string`;
+  const title = typeof value.title === "string" ? value.title : null;
+  if (title === null) return `events[${index}].title must be a string`;
+  const startAt = typeof value.startAt === "string" ? value.startAt : null;
+  const endAt = typeof value.endAt === "string" ? value.endAt : null;
+  const startMs = startAt === null ? Number.NaN : Date.parse(startAt);
+  const endMs = endAt === null ? Number.NaN : Date.parse(endAt);
+  if (!Number.isFinite(startMs))
+    return `events[${index}].startAt must be a parseable timestamp`;
+  if (!Number.isFinite(endMs))
+    return `events[${index}].endAt must be a parseable timestamp`;
+  if (endMs < startMs)
+    return `events[${index}].endAt must not be before startAt`;
+  const location = value.location;
+  if (
+    location !== undefined &&
+    location !== null &&
+    typeof location !== "string"
+  ) {
+    return `events[${index}].location must be a string when present`;
+  }
+  return {
+    id,
+    title,
+    startAt: startAt as string,
+    endAt: endAt as string,
+    location: typeof location === "string" ? location : null,
+  };
+}
+
+/**
+ * Validate an untrusted calendar-card request body once, so the route can
+ * answer a 400 instead of letting the composer, Intl, or the approval queue
+ * throw on a malformed date, time zone, event, or lifetime.
+ */
+export function parseCalendarCardRequest(
+  body: unknown,
+): CalendarCardRequestParse {
+  if (!isRecord(body)) {
+    return { ok: false, error: "Calendar card request must be an object" };
+  }
+  const date = typeof body.date === "string" ? body.date.trim() : "";
+  if (!isCalendarDay(date)) {
+    return {
+      ok: false,
+      error: "date must be a valid YYYY-MM-DD calendar date",
+    };
+  }
+  const timeZone = nonEmptyText(body.timeZone);
+  if (!timeZone || !isValidTimeZone(timeZone)) {
+    return { ok: false, error: "timeZone must be a valid IANA time zone" };
+  }
+  const privacyMode =
+    typeof body.privacyMode === "string" &&
+    CALENDAR_CARD_PRIVACY_MODES.has(body.privacyMode)
+      ? (body.privacyMode as CalendarCardPrivacyMode)
+      : null;
+  if (!privacyMode) {
+    return {
+      ok: false,
+      error: "privacyMode must be one of full, times_only, busy_only",
+    };
+  }
+  const recipient = nonEmptyText(body.recipient);
+  if (!recipient) {
+    return { ok: false, error: "recipient must be a non-empty string" };
+  }
+  let recipientEntityId: string | null = null;
+  if (body.recipientEntityId !== undefined && body.recipientEntityId !== null) {
+    recipientEntityId = nonEmptyText(body.recipientEntityId);
+    if (!recipientEntityId) {
+      return {
+        ok: false,
+        error: "recipientEntityId must be a non-empty string when present",
+      };
+    }
+  }
+  if (!Array.isArray(body.events)) {
+    return { ok: false, error: "events must be an array" };
+  }
+  const events: CalendarCardEvent[] = [];
+  for (const [index, candidate] of body.events.entries()) {
+    const parsed = parseCalendarCardEvent(candidate, index);
+    if (typeof parsed === "string") return { ok: false, error: parsed };
+    events.push(parsed);
+  }
+  let ttlMs: number | null = null;
+  if (body.ttlMs !== undefined && body.ttlMs !== null) {
+    if (
+      typeof body.ttlMs !== "number" ||
+      !Number.isInteger(body.ttlMs) ||
+      body.ttlMs <= 0
+    ) {
+      return {
+        ok: false,
+        error: "ttlMs must be a positive integer number of milliseconds",
+      };
+    }
+    ttlMs = body.ttlMs;
+  }
+  return {
+    ok: true,
+    request: {
+      date,
+      timeZone,
+      privacyMode,
+      recipient,
+      recipientEntityId,
+      events,
+      ttlMs,
+    },
+  };
+}
 
 export interface CalendarCardEvent {
   readonly id: string;

--- a/plugins/plugin-personal-assistant/src/lifeops/calendar-card.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/calendar-card.ts
@@ -168,12 +168,18 @@ export function parseCalendarCardRequest(
   if (body.ttlMs !== undefined && body.ttlMs !== null) {
     if (
       typeof body.ttlMs !== "number" ||
-      !Number.isInteger(body.ttlMs) ||
+      !Number.isSafeInteger(body.ttlMs) ||
       body.ttlMs <= 0
     ) {
       return {
         ok: false,
         error: "ttlMs must be a positive integer number of milliseconds",
+      };
+    }
+    if (!Number.isFinite(new Date(Date.now() + body.ttlMs).getTime())) {
+      return {
+        ok: false,
+        error: "ttlMs must produce a representable expiry date",
       };
     }
     ttlMs = body.ttlMs;

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-calendar-card-request.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-calendar-card-request.pglite.integration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Proves the owner calendar-card route validates its body at the HTTP
+ * boundary. Requests travel a real HTTP server → the agent's plugin route
+ * dispatcher → the normally registered personal-assistant routes → the
+ * composer, card access store, and approval queue on a PGlite runtime with
+ * the production file store. A malformed date, time zone, event, or lifetime
+ * is a 400 with a field-specific message, never a dispatcher-translated 500,
+ * and a well-formed body still issues the card and queues its approval (202).
+ */
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { Plugin } from "@elizaos/core";
+import { expect, it } from "vitest";
+import { tryHandleRuntimePluginRoute } from "../../../../packages/agent/src/api/runtime-plugin-routes.ts";
+import { LocalFileStorageService } from "../../../../packages/agent/src/services/file-storage.js";
+import { createLifeOpsTestRuntime } from "../../test/helpers/runtime.js";
+
+const fileStoragePlugin: Plugin = {
+  name: "calendar-card-request-test-file-storage",
+  description: "Production content-addressed file storage for card tests.",
+  services: [LocalFileStorageService],
+};
+
+const event = {
+  id: "evt-1",
+  title: "Standup",
+  startAt: "2026-03-02T09:00:00.000Z",
+  endAt: "2026-03-02T09:30:00.000Z",
+  location: "Room 4",
+};
+
+const valid = {
+  date: "2026-03-02",
+  timeZone: "UTC",
+  privacyMode: "full",
+  recipient: "Sam",
+  events: [event],
+};
+
+it("answers malformed card bodies with a 400 and issues a well-formed card", async () => {
+  const host = await createLifeOpsTestRuntime({ plugins: [fileStoragePlugin] });
+  const runtime = host.runtime;
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const handled = await tryHandleRuntimePluginRoute({
+      req,
+      res,
+      url,
+      pathname: url.pathname,
+      method: req.method ?? "GET",
+      runtime,
+      isAuthorized: () => true,
+    });
+    if (!handled && !res.headersSent) {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string")
+      throw new Error("HTTP server omitted bound TCP address");
+    const base = `http://127.0.0.1:${address.port}`;
+    const post = (body: unknown) =>
+      fetch(`${base}/api/lifeops/calendar/cards`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+    const rejected: Array<[unknown, string]> = [
+      [
+        { ...valid, date: "tomorrow" },
+        "date must be a valid YYYY-MM-DD calendar date",
+      ],
+      [
+        { ...valid, date: "2026-02-30" },
+        "date must be a valid YYYY-MM-DD calendar date",
+      ],
+      [
+        { ...valid, timeZone: "Mars/Olympus" },
+        "timeZone must be a valid IANA time zone",
+      ],
+      [
+        { ...valid, events: [{ ...event, startAt: "soon" }] },
+        "events[0].startAt must be a parseable timestamp",
+      ],
+      [{ ...valid, events: [null] }, "events[0] must be an object"],
+      [
+        { ...valid, ttlMs: -5 },
+        "ttlMs must be a positive integer number of milliseconds",
+      ],
+    ];
+    for (const [body, error] of rejected) {
+      const response = await post(body);
+      expect([JSON.stringify(body), response.status]).toEqual([
+        JSON.stringify(body),
+        400,
+      ]);
+      expect(await response.json()).toEqual({ error });
+    }
+
+    const issued = await post({ ...valid, ttlMs: 60_000 });
+    expect(issued.status).toBe(202);
+    const payload = (await issued.json()) as {
+      approvalId: string;
+      cardId: string;
+      state: string;
+    };
+    expect(payload.approvalId).toEqual(expect.any(String));
+    expect(payload.cardId).toEqual(expect.any(String));
+    expect(runtime.getRecentReportedErrors()).toEqual([]);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+    await host.cleanup();
+  }
+}, 180000);

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-calendar-card-request.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-calendar-card-request.pglite.integration.test.ts
@@ -92,6 +92,14 @@ it("answers malformed card bodies with a 400 and issues a well-formed card", asy
         { ...valid, ttlMs: -5 },
         "ttlMs must be a positive integer number of milliseconds",
       ],
+      [
+        { ...valid, ttlMs: 1e20 },
+        "ttlMs must be a positive integer number of milliseconds",
+      ],
+      [
+        { ...valid, ttlMs: Number.MAX_SAFE_INTEGER },
+        "ttlMs must produce a representable expiry date",
+      ],
     ];
     for (const [body, error] of rejected) {
       const response = await post(body);

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -116,10 +116,9 @@ import { createApprovalQueue } from "../lifeops/approval-queue.js";
 import {
   CalendarCardAccessError,
   CalendarCardAccessStore,
-  type CalendarCardEvent,
-  type CalendarCardPrivacyMode,
   calendarCardApprovalPayload,
   composeDailyCalendarCard,
+  parseCalendarCardRequest,
 } from "../lifeops/calendar-card.js";
 import { probeFullDiskAccess } from "../lifeops/fda-probe.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
@@ -1248,53 +1247,46 @@ export async function handleLifeOpsRoutes(
     const runtime = ctx.state.runtime;
     if (!runtime) return true;
     if (rateLimitRequest(ctx, "calendar_card")) return true;
-    const body = await readJsonBody<{
-      date: string;
-      timeZone: string;
-      privacyMode: CalendarCardPrivacyMode;
-      recipient: string;
-      recipientEntityId?: string;
-      events: CalendarCardEvent[];
-      ttlMs?: number;
-    }>(req, res);
+    const body = await readJsonBody<Record<string, unknown>>(req, res);
     if (!body) return true;
+    const parsedRequest = parseCalendarCardRequest(body);
+    if (!parsedRequest.ok) {
+      json(res, { error: parsedRequest.error }, 400);
+      return true;
+    }
+    const cardRequest = parsedRequest.request;
     const authenticatedEntityId = String(
       ctx.state.requestEntityId ?? ctx.state.adminEntityId ?? SELF_ENTITY_ID,
     );
-    const recipientEntityId = String(
-      body.recipientEntityId ?? authenticatedEntityId,
-    );
+    const recipientEntityId =
+      cardRequest.recipientEntityId ?? authenticatedEntityId;
     const recipientCanAuthenticate =
       recipientEntityId === authenticatedEntityId ||
       (await entityHasVerifiedMachineAuthBinding(runtime, recipientEntityId));
-    if (
-      !body.recipient?.trim() ||
-      !Array.isArray(body.events) ||
-      !["full", "times_only", "busy_only"].includes(body.privacyMode) ||
-      !recipientCanAuthenticate
-    ) {
+    if (!recipientCanAuthenticate) {
       json(res, { error: "Invalid calendar card request" }, 400);
       return true;
     }
+    const ttlMs = cardRequest.ttlMs ?? 24 * 60 * 60_000;
     const placeholder = composeDailyCalendarCard({
-      date: body.date,
-      timeZone: body.timeZone,
-      privacyMode: body.privacyMode,
-      events: body.events,
+      date: cardRequest.date,
+      timeZone: cardRequest.timeZone,
+      privacyMode: cardRequest.privacyMode,
+      events: cardRequest.events,
       accessUrl: "https://invalid.local/pending",
     });
     const store = new CalendarCardAccessStore(runtime);
     const issued = await store.issue({
       recipientEntityId,
       html: placeholder.html,
-      ttlMs: body.ttlMs ?? 24 * 60 * 60_000,
+      ttlMs,
       baseUrl: url.origin,
     });
     const composition = composeDailyCalendarCard({
-      date: body.date,
-      timeZone: body.timeZone,
-      privacyMode: body.privacyMode,
-      events: body.events,
+      date: cardRequest.date,
+      timeZone: cardRequest.timeZone,
+      privacyMode: cardRequest.privacyMode,
+      events: cardRequest.events,
       accessUrl: issued.accessUrl,
     });
     if (composition.htmlSha256 !== issued.htmlSha256) {
@@ -1304,7 +1296,7 @@ export async function handleLifeOpsRoutes(
       );
     }
     const payload = calendarCardApprovalPayload({
-      recipient: body.recipient.trim(),
+      recipient: cardRequest.recipient,
       recipientEntityId,
       cardId: issued.cardId,
       composition,
@@ -1318,9 +1310,9 @@ export async function handleLifeOpsRoutes(
         action: "send_message",
         payload,
         channel: "imessage",
-        reason: `Send the private ${body.privacyMode} calendar card for ${body.date}.`,
+        reason: `Send the private ${cardRequest.privacyMode} calendar card for ${cardRequest.date}.`,
         idempotencyKey: `calendar-card:v1:${composition.envelopeSha256}`,
-        expiresAt: new Date(Date.now() + (body.ttlMs ?? 24 * 60 * 60_000)),
+        expiresAt: new Date(Date.now() + ttlMs),
       });
       await queue.surfaceEnqueuedApproval(approval);
     } catch (error) {


### PR DESCRIPTION
Malformed daily calendar-card input could reach the composer, private file store or approval queue and return HTTP 500. Validate the request before those operations: impossible dates, invalid time zones, malformed event fields and invalid lifetimes now return field-specific HTTP 400 responses; valid requests still create a private card and queue owner approval.

The lifetime check also rejects unsafe integers and values that cannot produce a representable expiry. A real HTTP regression reproduced `ttlMs: 1e20` as HTTP 500 on the initial PR and now verifies HTTP 400 for that value and `Number.MAX_SAFE_INTEGER`. Recipient authentication and approval-gated delivery remain unchanged. No message is sent by the tests.

Closes #31053. Supports #30123.

Current head: `c3d92ac3a26e1d01a434209025530bfae3a41106`, rebased onto develop `f31b6ac246e0e8b0f706fd094f20a27dcd557c57`.

Validation:

- Pinned Bun 1.3.14 / Node 24.15.0 install passed.
- Root `bun run verify`: 373/373 tasks passed, including package typecheck/lint and repository audits. Native temporary directory and Turbo loose environment propagation isolate the packed-consumer check from an unrelated `/tmp/tsconfig.json`.
- Real HTTP server → registered runtime plugin routes → PGlite runtime and production private file store: eight malformed requests return 400; a valid request returns 202 with card and approval references; no runtime errors are reported.
- Full personal-assistant package suite passed on this head: 303 files, 2,646 tests passed, six existing skips. Hosted run: https://github.com/elizaOS/eliza/actions/runs/34629309781. Keep draft until terminal results are reviewed.

Screenshots/MP4 and live-model rows are N/A: this changes deterministic request validation, with no UI source or model behavior change. Earlier original-author validation remains in the PR history; current-head results above supersede it.
