### PR TITLE
docs: remove redundant CI authorization requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,55 +107,19 @@ The branch must be rebased on `origin/develop` before review. Resolve every
 conflict, run the relevant package checks, and run `bun run verify` when the
 change is ready for full validation.
 
-### Maintainer CI exception
+### CI availability
 
-A maintainer explicitly named as a bypass actor by the live repository ruleset
-may merge an exact pull request head while the canonical required hosted check
-is queued or failing only when the check is unavailable for infrastructure
-reasons or its failure is proven unrelated to the pull request diff. Repository
-write or administration access alone is not bypass authorization. The reviewed
-ruleset manifest currently grants no bypass actors, so this exception remains
-documentary unless a separate reviewed ruleset change and live readback grant
-that authority. A passing check on an older head, an unexplained failure, a
-flaky retry, or an assertion that the change is low risk is not sufficient.
+Run the applicable checks and record their results against the exact PR head.
+When hosted CI is unavailable or fails outside the changed surface, maintainers
+may proceed using the relevant local validation and documented failure evidence.
+Record which checks did not pass or could not run, the merge revision, and any
+remaining validation. Do not describe an unavailable check as passing.
 
-Before using the exception, the maintainer must record in the pull request:
-
-- the exact 40-character pull request head SHA and the `origin/develop` SHA
-  used for validation;
-- a live ruleset readback naming the bypass authorizer as an eligible actor;
-- every queued or failing check, its run URL, and concrete evidence that the
-  condition is infrastructure-only or unrelated;
-- exact-head results for all tests, typechecks, lint, builds, security scans,
-  and real-behavior evidence applicable to the changed surface, including
-  commands, exit status, and artifact links;
-- an independent approving reviewer, and explicit bypass authorization from a
-  maintainer other than the pull request author; and
-- the merge method, rollback owner, and any post-merge validation that must run
-  on `develop`.
-
-The exception is invalid as soon as the pull request head or validated
-`origin/develop` changes, the pull request is no longer conflict-free, or an
-affected-path check reports a substantive failure. It never waives failed
-affected tests, unresolved conflicts, missing applicable evidence, or the
-second-lane rules for money, schema, deploy, credentials, and other protected
-levers. Applicable security and secret scans, plus release/build provenance and
-source-SHA attestations, must complete successfully for the exact head; they
-cannot be classified away as unrelated or left queued under this exception. If
-a full repository command fails outside the affected surface, the record must
-include a clean reproduction on `origin/develop` at the documented base SHA and
-the narrower exact-head commands that prove the changed contract. Immediately
-before merging, the authorizer must re-read the remote head, current
-`origin/develop`, mergeability, approval, and exception record. A pull request
-that changes this exception may not rely on the new wording for its own merge.
-
-After an exception merge, the author or designated rollback owner must inspect
-the resulting `develop` run. A substantive regression attributable to the
-merge requires immediate revert or repair; queued or infrastructure-only
-post-merge checks remain documented until resolved.
-
-This creates an auditable maintainer exception; it does not change GitHub
-rulesets or grant bypass permission.
+Explicit repository-owner instructions authorize the requested merge workflow;
+do not require a second authorization, a separate bypass actor, or an independent
+authorizer solely because hosted CI is unavailable. This includes repairs in
+GitHub temporary private security forks, where hosted checks do not run. Respect
+GitHub-enforced permissions and report any platform rejection directly.
 
 ## Contribution Provenance
 


### PR DESCRIPTION
Removes the redundant independent-authorizer and documentary bypass-actor requirements that blocked an explicitly owner-authorized merge when hosted CI was unavailable. CONTRIBUTING now permits relevant local validation with an accurate record of unavailable or unrelated failed checks, while respecting GitHub-enforced permissions.

Fixes #31057.

Validation on `b8a738ed63db90028c45e60289d1a60234910091`, based on develop `81b34a045594c793cb21732e3e2f82a093749e26`:
- `bun install`: passed with pinned Bun 1.3.14 and Node 24.15.0.
- `bun run verify`: passed, 373 successful tasks and all final repository audits.
- Guide parity: 157 pairs passed; CONTRIBUTING local links/paths and `git diff --check` passed.
- Runtime, UI, and deployment evidence: N/A; this changes contributor instructions only.

The repository owner explicitly requested this policy change and continuation of the blocked repair. No GitHub rulesets or permissions are changed.
