### PR TITLE
fix(plugin-finances): classify bill dueness by owner calendar day, not UTC day (#31062)

### DIFF
--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -122,10 +122,65 @@ const plaidJwkCache = new Map<
   }
 >();
 
+/**
+ * Resolves the owner's effective IANA time zone for a given instant. The host
+ * (e.g. the personal-assistant route factory) injects this so bill dueness is
+ * judged against the owner's calendar day, not the container's UTC day. A
+ * resolver may return `null`/`undefined` (or throw) to signal "no owner zone";
+ * the service then falls through to the agent `TIMEZONE` setting and the host
+ * zone.
+ */
+export type OwnerTimeZoneResolver = (
+  now: Date,
+) => Promise<string | null | undefined> | string | null | undefined;
+
 /** Optional construction options (mirrors the LifeOps service shape). */
 export type FinancesServiceOptions = {
   ownerEntityId?: string | null;
+  resolveTimeZone?: OwnerTimeZoneResolver;
 };
+
+/**
+ * True when `timeZone` is a usable IANA identifier accepted by `Intl`. Used to
+ * guard every zone candidate so a malformed stored fact or setting falls
+ * through to the next source instead of throwing during classification.
+ */
+export function isValidTimeZone(timeZone: string): boolean {
+  if (timeZone.trim().length === 0) return false;
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone });
+    return true;
+  } catch {
+    // error-policy:J3 — an unknown IANA zone id makes the Intl constructor
+    // throw RangeError; that is a validation result, not a recoverable state.
+    return false;
+  }
+}
+
+/**
+ * The `YYYY-MM-DD` calendar-day key for `now` as observed in `timeZone`. Bare
+ * `dueDate` strings are the day the owner reads on their own calendar, so
+ * dueness must be compared against this key rather than `now.toISOString()`,
+ * which is the UTC day. Throws (via `Intl`) on an invalid/unknown zone so the
+ * caller can fall through to the next zone source.
+ */
+export function calendarDateKeyInZone(now: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(now);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (!year || !month || !day) {
+    throw new Error(
+      `Unable to derive calendar date key for time zone "${timeZone}"`,
+    );
+  }
+  return `${year}-${month}-${day}`;
+}
 
 export function resolveFinancesCloudManagedClientConfig(): ElizaCloudManagedClientConfig {
   if (resolveDevCloudEnvAuthority()) {
@@ -509,6 +564,7 @@ function computeSpendingSummary(args: {
 export class FinancesService {
   public readonly repository: FinancesRepository;
   public readonly ownerEntityId: string | null;
+  private readonly resolveTimeZoneOption: OwnerTimeZoneResolver | null;
   public plaidManagedClientCache: PlaidManagedClient | null = null;
   public paypalManagedClientCache: PaypalManagedClient | null = null;
 
@@ -518,6 +574,49 @@ export class FinancesService {
   ) {
     this.repository = new FinancesRepository(runtime);
     this.ownerEntityId = normalizeOptionalString(options.ownerEntityId) ?? null;
+    this.resolveTimeZoneOption = options.resolveTimeZone ?? null;
+  }
+
+  /**
+   * Resolve the owner's effective IANA zone for `now` in precedence order:
+   * explicit argument, injected owner resolver, agent `TIMEZONE` setting, then
+   * the process/host zone. Every candidate is validated; an invalid or failing
+   * source falls through to the next so classification never throws. Returns
+   * `"UTC"` only when no candidate yields a usable zone.
+   */
+  private async resolveCalendarTimeZone(
+    now: Date,
+    explicitTimeZone?: string | null,
+  ): Promise<string> {
+    const candidates: Array<
+      () => Promise<string | null | undefined> | string | null | undefined
+    > = [
+      () => explicitTimeZone,
+      () => this.resolveTimeZoneOption?.(now),
+      () => this.runtime.getSetting("TIMEZONE") as string | null | undefined,
+      () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+    ];
+    for (const candidate of candidates) {
+      try {
+        const value = await candidate();
+        if (typeof value === "string") {
+          const trimmed = value.trim();
+          if (trimmed.length > 0 && isValidTimeZone(trimmed)) {
+            return trimmed;
+          }
+        }
+      } catch (error) {
+        // error-policy:J4 — an unavailable or throwing zone source (fact-store
+        // read failure, malformed value) must not break bill classification;
+        // fall through to the next candidate and ultimately the host zone.
+        this.logFinancesWarn(
+          "resolveCalendarTimeZone",
+          "Time zone candidate failed to resolve; falling through to next source.",
+          { error: error instanceof Error ? error.message : String(error) },
+        );
+      }
+    }
+    return "UTC";
   }
 
   agentId(): string {
@@ -991,7 +1090,7 @@ export class FinancesService {
    * so extraction misses do not disappear from the user's review queue.
    */
   async getUpcomingBills(
-    args: { now?: Date } = {},
+    args: { now?: Date; timeZone?: string } = {},
   ): Promise<LifeOpsUpcomingBill[]> {
     const sources = await this.listPaymentSources();
     const emailSource = sources.find((source) => source.kind === "email");
@@ -1003,7 +1102,12 @@ export class FinancesService {
       },
     );
     const now = args.now ?? new Date();
-    const todayIso = now.toISOString().slice(0, 10);
+    // Bare `dueDate` strings are the owner's calendar day. Compare against the
+    // owner-zone calendar day (not the UTC day) so a bill due today does not
+    // flip to "overdue" in the owner's afternoon west of Greenwich, and a bill
+    // due yesterday does not linger as "upcoming" until UTC midnight east of it.
+    const timeZone = await this.resolveCalendarTimeZone(now, args.timeZone);
+    const todayIso = calendarDateKeyInZone(now, timeZone);
     const bills: LifeOpsUpcomingBill[] = [];
     for (const transaction of transactions) {
       const metadata = transaction.metadata;

--- a/plugins/plugin-finances/src/index.ts
+++ b/plugins/plugin-finances/src/index.ts
@@ -83,9 +83,12 @@ export {
   financeErrorMessage,
 } from "./finance-normalize.ts";
 export {
+  calendarDateKeyInZone,
   encryptPaymentMetadataToken,
   FinancesService,
   type FinancesServiceOptions,
+  isValidTimeZone,
+  type OwnerTimeZoneResolver,
   readPaymentMetadataToken,
   sanitizePaymentSourceForClient,
 } from "./finances-service.ts";

--- a/plugins/plugin-finances/src/upcoming-bills-timezone.test.ts
+++ b/plugins/plugin-finances/src/upcoming-bills-timezone.test.ts
@@ -154,6 +154,18 @@ describe("getUpcomingBills owner-zone dueness (#31062)", () => {
     expect(status).toBe("upcoming");
   });
 
+  it("falls through to the TIMEZONE setting when the injected resolver reports no owner zone (null)", async () => {
+    // The HTTP route injects the owner-fact-only resolver, which returns `null`
+    // when no owner timezone fact is stored (#31062). A `null` miss must not be
+    // treated as a resolved zone: the service continues to the agent TIMEZONE
+    // setting (here Honolulu -> same owner day -> upcoming), not the UTC host
+    // day (which would misclassify as overdue).
+    const status = await statusFor("Pacific/Honolulu", {
+      resolveTimeZone: () => null,
+    });
+    expect(status).toBe("upcoming");
+  });
+
   it("falls through to the next source when the resolver throws", async () => {
     const status = await statusFor("America/Los_Angeles", {
       resolveTimeZone: () => {

--- a/plugins/plugin-finances/src/upcoming-bills-timezone.test.ts
+++ b/plugins/plugin-finances/src/upcoming-bills-timezone.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression coverage for #31062: `FinancesService.getUpcomingBills` must judge
+ * bill dueness against the owner's calendar day, not the container's UTC day.
+ *
+ * The harness is deterministic — it pins `now`, seeds one email bill through a
+ * stubbed `FinancesRepository` (no database), and asserts the resulting status
+ * across the documented zone-resolution precedence (explicit arg, injected
+ * owner resolver, agent `TIMEZONE` setting, host zone) including fall-through on
+ * an invalid zone value. It also exercises the `calendarDateKeyInZone` helper
+ * directly so the UTC-vs-owner-day boundary is proven, not implied.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  calendarDateKeyInZone,
+  FinancesService,
+  type FinancesServiceOptions,
+} from "./finances-service.ts";
+import type {
+  LifeOpsPaymentSource,
+  LifeOpsPaymentTransaction,
+} from "./payment-types.ts";
+
+const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+
+// 2026-03-03T03:30:00Z is still 2026-03-02 (evening) in the Americas but is
+// already 2026-03-03 (afternoon) in Tokyo — exactly the window where a UTC-day
+// comparison misclassifies a "2026-03-02" bill.
+const NOW = new Date("2026-03-03T03:30:00.000Z");
+const DUE_DATE = "2026-03-02";
+
+function emailSource(): LifeOpsPaymentSource {
+  return {
+    id: "source-email",
+    agentId: AGENT_ID,
+    kind: "email",
+    label: "Email bills",
+    institution: null,
+    accountMask: null,
+    status: "active",
+    lastSyncedAt: null,
+    transactionCount: 1,
+    metadata: {},
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function billTransaction(): LifeOpsPaymentTransaction {
+  return {
+    id: "txn-bill",
+    agentId: AGENT_ID,
+    sourceId: "source-email",
+    externalId: null,
+    postedAt: "2026-02-25T00:00:00.000Z",
+    amountUsd: 42.5,
+    direction: "debit",
+    merchantRaw: "Water Utility",
+    merchantNormalized: "water utility",
+    description: null,
+    category: null,
+    currency: "USD",
+    metadata: {
+      kind: "bill",
+      dueDate: DUE_DATE,
+      sourceMessageId: "gmail-1",
+      confidence: 0.9,
+    },
+    createdAt: "2026-02-25T00:00:00.000Z",
+  };
+}
+
+function makeService(
+  settingTimeZone: string | null,
+  options: FinancesServiceOptions = {},
+): FinancesService {
+  const runtime = {
+    agentId: AGENT_ID,
+    getSetting: (key: string) =>
+      key === "TIMEZONE" ? settingTimeZone : undefined,
+  } as unknown as IAgentRuntime;
+  const service = new FinancesService(runtime, options);
+  vi.spyOn(service.repository, "listPaymentSources").mockResolvedValue([
+    emailSource(),
+  ]);
+  vi.spyOn(service.repository, "listPaymentTransactions").mockResolvedValue([
+    billTransaction(),
+  ]);
+  return service;
+}
+
+async function statusFor(
+  settingTimeZone: string | null,
+  options: FinancesServiceOptions = {},
+  args: { timeZone?: string } = {},
+): Promise<string> {
+  const service = makeService(settingTimeZone, options);
+  const bills = await service.getUpcomingBills({ now: NOW, ...args });
+  expect(bills).toHaveLength(1);
+  return bills[0].status;
+}
+
+describe("calendarDateKeyInZone (#31062)", () => {
+  it("returns the owner-zone calendar day, not the UTC day", () => {
+    expect(calendarDateKeyInZone(NOW, "UTC")).toBe("2026-03-03");
+    expect(calendarDateKeyInZone(NOW, "America/Los_Angeles")).toBe(
+      "2026-03-02",
+    );
+    expect(calendarDateKeyInZone(NOW, "Pacific/Honolulu")).toBe("2026-03-02");
+    expect(calendarDateKeyInZone(NOW, "Asia/Tokyo")).toBe("2026-03-03");
+  });
+
+  it("zero-pads month and day", () => {
+    const jan = new Date("2026-01-05T12:00:00.000Z");
+    expect(calendarDateKeyInZone(jan, "UTC")).toBe("2026-01-05");
+  });
+
+  it("throws on an unknown IANA zone so the caller can fall through", () => {
+    expect(() => calendarDateKeyInZone(NOW, "Not/AZone")).toThrow();
+  });
+});
+
+describe("getUpcomingBills owner-zone dueness (#31062)", () => {
+  it("classifies a same-owner-day bill as upcoming via the injected owner resolver (America/Los_Angeles)", async () => {
+    const status = await statusFor(null, {
+      resolveTimeZone: () => "America/Los_Angeles",
+    });
+    expect(status).toBe("upcoming");
+  });
+
+  it("classifies as upcoming from the TIMEZONE setting when no resolver is injected (Pacific/Honolulu)", async () => {
+    const status = await statusFor("Pacific/Honolulu");
+    expect(status).toBe("upcoming");
+  });
+
+  it("classifies as overdue when the owner is east of Greenwich (Asia/Tokyo)", async () => {
+    const status = await statusFor("Asia/Tokyo");
+    expect(status).toBe("overdue");
+  });
+
+  it("prefers the injected owner resolver over the TIMEZONE setting", async () => {
+    // Setting says Tokyo (would be overdue) but the owner fact says LA.
+    const status = await statusFor("Asia/Tokyo", {
+      resolveTimeZone: () => "America/Los_Angeles",
+    });
+    expect(status).toBe("upcoming");
+  });
+
+  it("falls through to the TIMEZONE setting when the injected resolver yields an invalid zone", async () => {
+    const status = await statusFor("America/Los_Angeles", {
+      resolveTimeZone: () => "Not/AZone",
+    });
+    expect(status).toBe("upcoming");
+  });
+
+  it("falls through to the next source when the resolver throws", async () => {
+    const status = await statusFor("America/Los_Angeles", {
+      resolveTimeZone: () => {
+        throw new Error("fact store unavailable");
+      },
+    });
+    expect(status).toBe("upcoming");
+  });
+
+  it("honors an explicit timeZone argument above every other source", async () => {
+    const upcoming = await statusFor(
+      "Asia/Tokyo",
+      { resolveTimeZone: () => "Asia/Tokyo" },
+      { timeZone: "America/Los_Angeles" },
+    );
+    expect(upcoming).toBe("upcoming");
+    const overdue = await statusFor(
+      "America/Los_Angeles",
+      { resolveTimeZone: () => "America/Los_Angeles" },
+      { timeZone: "Asia/Tokyo" },
+    );
+    expect(overdue).toBe("overdue");
+  });
+
+  it("falls through an invalid explicit argument to the injected resolver", async () => {
+    const status = await statusFor(
+      "Asia/Tokyo",
+      { resolveTimeZone: () => "America/Los_Angeles" },
+      { timeZone: "Not/AZone" },
+    );
+    expect(status).toBe("upcoming");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
@@ -1053,6 +1053,30 @@ export async function resolveOwnerTimeZone(
   runtime: IAgentRuntime,
   now: Date,
 ): Promise<string> {
+  return (
+    (await resolveOwnerTimeZoneFact(runtime, now)) ?? resolveDefaultTimeZone()
+  );
+}
+
+/**
+ * Resolve the owner's effective IANA zone from the fact store alone, returning
+ * `null` when no usable owner fact exists instead of substituting the host
+ * zone. This is the "owner zone or nothing" variant: callers that layer their
+ * own fallback chain (e.g. the finances service, whose precedence is owner fact
+ * → agent `TIMEZONE` setting → host zone) must be able to distinguish a real
+ * owner fact from the host default, which {@link resolveOwnerTimeZone}'s baked
+ * fallback hides. Injecting this directly as a `resolveTimeZone` resolver keeps
+ * the `null` = "no owner zone" contract those chains rely on.
+ *
+ * Honors the same active-travel override and validation as
+ * {@link resolveOwnerTimeZone}: an invalid stored zone is warned and treated as
+ * absent (`null`), and a fact-store read failure degrades to `null` so the
+ * caller's own fallback — not a silent host-zone substitution — takes over.
+ */
+export async function resolveOwnerTimeZoneFact(
+  runtime: IAgentRuntime,
+  now: Date,
+): Promise<string | null> {
   try {
     const facts = await resolveOwnerFactStore(runtime).read();
     const view = ownerFactsToView(facts, now);
@@ -1062,20 +1086,20 @@ export async function resolveOwnerTimeZone(
     if (view.timezone) {
       logger.warn(
         { src: "lifeops:owner:resolve-timezone", storedZone: view.timezone },
-        "Owner timezone fact is not a valid IANA zone; falling back to host zone for time resolution.",
+        "Owner timezone fact is not a valid IANA zone; ignoring it for time resolution.",
       );
     }
-    return resolveDefaultTimeZone();
+    return null;
   } catch (error) {
     // error-policy:J4 — a fact-store read failure (missing/unavailable cache
-    // backend) must not break time resolution. Degrade to the host zone, the
-    // same honest best-effort default used when no owner fact exists, and
+    // backend) must not break time resolution. Report the miss as `null` so the
+    // caller's own fallback chain decides the honest best-effort default, and
     // surface the failure so the operator can see the store is unreachable
     // rather than silently anchoring to the wrong zone with no signal.
     logger.warn(
       { src: "lifeops:owner:resolve-timezone", error },
-      "Failed to read owner timezone fact; falling back to host zone for time resolution.",
+      "Failed to read owner timezone fact; treating owner zone as unavailable for time resolution.",
     );
-    return resolveDefaultTimeZone();
+    return null;
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/resolve-owner-timezone.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/resolve-owner-timezone.test.ts
@@ -10,6 +10,11 @@
  * owner-fact timezone is consulted, that it falls back to the host zone only
  * when no fact is stored (never fabricated), and that an active-travel
  * destination zone overrides the home zone while travel is live.
+ *
+ * Also covers the fact-only variant `resolveOwnerTimeZoneFact` (#31062), which
+ * the finances HTTP route injects: it reports a miss as `null` rather than
+ * substituting the host zone, so a caller's own precedence chain (owner fact ->
+ * agent TIMEZONE setting -> host zone) is honored instead of short-circuited.
  */
 
 import type { IAgentRuntime, UUID } from "@elizaos/core";
@@ -21,6 +26,7 @@ import {
   registerOwnerFactStore,
   resolveOwnerFactStore,
   resolveOwnerTimeZone,
+  resolveOwnerTimeZoneFact,
 } from "./fact-store.js";
 
 function makeCacheRuntime(): IAgentRuntime {
@@ -129,5 +135,46 @@ describe("resolveOwnerTimeZone (#13509)", () => {
     // NOW (2026-07-04) is AFTER the travel window ended: home zone wins.
     const tz = await resolveOwnerTimeZone(runtime, NOW);
     expect(tz).toBe("America/Chicago");
+  });
+});
+
+describe("resolveOwnerTimeZoneFact (#31062)", () => {
+  // The fact-only variant is what the finances HTTP route injects as its
+  // `resolveTimeZone` resolver. It must report a miss as `null` (never the host
+  // zone) so the service's own precedence chain (owner fact -> agent TIMEZONE
+  // setting -> host zone) is reached; `resolveOwnerTimeZone`'s baked host-zone
+  // fallback would otherwise short-circuit that chain.
+  it("returns null when no owner timezone fact is stored (the service decides the fallback)", async () => {
+    const runtime = makeRuntimeWithStore();
+    const tz = await resolveOwnerTimeZoneFact(runtime, NOW);
+    expect(tz).toBeNull();
+  });
+
+  it("returns the owner's stored timezone fact when present", async () => {
+    const runtime = makeRuntimeWithStore();
+    await resolveOwnerFactStore(runtime).update(
+      { timezone: "America/Chicago" },
+      provenance,
+    );
+    const tz = await resolveOwnerTimeZoneFact(runtime, NOW);
+    expect(tz).toBe("America/Chicago");
+  });
+
+  it("returns null when the stored timezone fact is not a valid IANA zone", async () => {
+    const runtime = makeRuntimeWithStore();
+    await resolveOwnerFactStore(runtime).update(
+      { timezone: "Central Time (definitely not IANA)" },
+      provenance,
+    );
+    const tz = await resolveOwnerTimeZoneFact(runtime, NOW);
+    expect(tz).toBeNull();
+  });
+
+  it("returns null when the fact-store read throws (no cache backend), never crashing", async () => {
+    const runtimeNoCache = {
+      agentId: "66666666-6666-6666-6666-666666666666" as UUID,
+    } as unknown as IAgentRuntime;
+    const tz = await resolveOwnerTimeZoneFact(runtimeNoCache, NOW);
+    expect(tz).toBeNull();
   });
 });

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -122,7 +122,7 @@ import {
   composeDailyCalendarCard,
 } from "../lifeops/calendar-card.js";
 import { probeFullDiskAccess } from "../lifeops/fda-probe.js";
-import { resolveOwnerTimeZone } from "../lifeops/owner/fact-store.js";
+import { resolveOwnerTimeZoneFact } from "../lifeops/owner/fact-store.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 import { entityHasVerifiedMachineAuthBinding } from "./authenticated-entity-principal.js";
@@ -216,10 +216,13 @@ function getFinancesService(ctx: LifeOpsRouteContext): FinancesService | null {
   return new FinancesService(runtime, {
     ownerEntityId: ctx.state.adminEntityId,
     // Judge bill dueness against the owner's calendar day (#31062). The owner
-    // fact store is the same source reminders/scheduled tasks resolve; when no
-    // fact is stored the service falls through to the agent TIMEZONE setting
-    // and then the host zone.
-    resolveTimeZone: (now: Date) => resolveOwnerTimeZone(runtime, now),
+    // fact store is the same source reminders/scheduled tasks resolve. We inject
+    // the fact-only resolver (returns `null` on a miss) rather than
+    // `resolveOwnerTimeZone`, whose baked host-zone fallback would mask the miss
+    // and short-circuit the service's own chain; with `null` the service falls
+    // through to the agent TIMEZONE setting and then the host zone, matching the
+    // documented precedence.
+    resolveTimeZone: (now: Date) => resolveOwnerTimeZoneFact(runtime, now),
   });
 }
 

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -122,6 +122,7 @@ import {
   composeDailyCalendarCard,
 } from "../lifeops/calendar-card.js";
 import { probeFullDiskAccess } from "../lifeops/fda-probe.js";
+import { resolveOwnerTimeZone } from "../lifeops/owner/fact-store.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 import { entityHasVerifiedMachineAuthBinding } from "./authenticated-entity-principal.js";
@@ -214,6 +215,11 @@ function getFinancesService(ctx: LifeOpsRouteContext): FinancesService | null {
   }
   return new FinancesService(runtime, {
     ownerEntityId: ctx.state.adminEntityId,
+    // Judge bill dueness against the owner's calendar day (#31062). The owner
+    // fact store is the same source reminders/scheduled tasks resolve; when no
+    // fact is stored the service falls through to the agent TIMEZONE setting
+    // and then the host zone.
+    resolveTimeZone: (now: Date) => resolveOwnerTimeZone(runtime, now),
   });
 }
 


### PR DESCRIPTION
# Relates to

Closes #31062

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package gates were run (see Known gaps for the repo-wide `verify` note).
- [x] A reviewer can confirm the change works from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts (`git rev-list --count HEAD..origin/develop` = 0).
- [ ] `bun run verify` passes post-sync — not run in full; see **Known gaps / failures** for the exact scope run and why.

# Risks

Low. The change is confined to how the `overdue`/`upcoming` bill status is computed in `FinancesService.getUpcomingBills` and to one route-factory injection. Payment-source, transaction, spending, and recurring logic are untouched, and the bills-list sort/`statusRank` ordering is preserved aside from the corrected classification. Fall-through on any invalid zone value keeps the path fail-safe (never throws during classification; defaults to the host zone, then UTC).

# Background

## What does this PR do?

`FinancesService.getUpcomingBills` classified an email-extracted bill as `overdue` when its bare `YYYY-MM-DD` `dueDate` was less than `now.toISOString().slice(0, 10)` — the **UTC** calendar day. `dueDate` values are the day the owner reads on their own calendar, so the comparison was off by the owner's UTC offset:

- **West of Greenwich**, a bill due *today* wrongly flipped to `overdue` in the owner's afternoon/evening (e.g. 16:00 in Los Angeles, 19:00 in New York).
- **East of Greenwich**, a bill due *yesterday* wrongly stayed `upcoming` until UTC midnight (09:00 local in Tokyo).

This status feeds the `FINANCES` action `dashboard` payload the agent reasons over, `GET /api/lifeops/money/dashboard`, `GET /api/lifeops/money/bills`, and the bills-list `statusRank` sort order.

The fix compares `dueDate` against **today's calendar day in the owner's zone**, resolved in this precedence with fall-through on any invalid/failing value:

1. an explicit `timeZone` argument on `getUpcomingBills` (for callers/tests),
2. a host-supplied owner timezone resolver injected via the new `resolveTimeZone` option,
3. the agent's `TIMEZONE` setting (`runtime.getSetting("TIMEZONE")`, the same access the core current-time provider uses),
4. the process/host zone (`Intl.DateTimeFormat().resolvedOptions().timeZone`), then `"UTC"` as a last resort.

The personal-assistant route factory (`getFinancesService` in `lifeops-routes.ts`) injects `resolveOwnerTimeZone` — the same owner-fact source reminders and scheduled tasks resolve — so the HTTP endpoints honour the owner's stored zone. The `FINANCES` action (`actions/finances.ts`) still constructs `new FinancesService(runtime)` without a resolver, because `plugin-finances` cannot import `plugin-personal-assistant` (dependency direction); its `dashboard` payload therefore resolves through the `TIMEZONE` setting / host zone rather than the owner timezone fact — still a strict improvement over the old UTC day. Two small pure helpers are added and exported: `calendarDateKeyInZone(now, timeZone)` (derives the zero-padded `YYYY-MM-DD` key for a zone via `Intl.DateTimeFormat("en-CA").formatToParts`, throwing on an unknown zone) and `isValidTimeZone(timeZone)`.

### Before / after status

For `now = 2026-03-03T03:30:00.000Z` and a bill with `dueDate: "2026-03-02"`:

| Configured zone | Before (UTC-day bug) | After (owner-day) |
| --- | --- | --- |
| owner fact `America/Los_Angeles` | `overdue` ❌ | `upcoming` ✅ |
| `TIMEZONE=Pacific/Honolulu` | `overdue` ❌ | `upcoming` ✅ |
| `TIMEZONE=Asia/Tokyo` | `overdue` ✅ | `overdue` ✅ |

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue). The `resolveTimeZone` option and the `timeZone` arg are additive; existing callers keep working and now fall through to the `TIMEZONE` setting / host zone.

# Documentation changes needed?

My changes do not require a documentation change. Behaviour is corrected to the documented intent (owner-local dueness); the public option/arg additions are documented via exported-symbol JSDoc.

# Testing

## Where should a reviewer start?

`plugins/plugin-finances/src/upcoming-bills-timezone.test.ts` — a deterministic regression test that pins `now`, seeds one email bill through a stubbed repository (no DB), and asserts status across the full zone-resolution precedence, plus `calendarDateKeyInZone` directly. Then read the `getUpcomingBills` diff in `finances-service.ts` and the one-line injection in `lifeops-routes.ts`.

## Detailed testing steps

None beyond automated tests. Reachability of the route path is proven by wiring `resolveTimeZone` into the existing `getFinancesService` factory that already backs `GET /api/lifeops/money/bills` and `GET /api/lifeops/money/dashboard` (unchanged URLs/response shapes).

# Evidence Gate

<!-- evidence-head:bf2f804d382fb7e0b48c6498d3b52ad1084e7569 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed; this is a backend classification fix in `@elizaos/plugin-finances`.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI flow; the change is a server-side status computation.
<!-- evidence-row:backend-logs -->
- [x] Focused backend proof of the real `FinancesService.getUpcomingBills` classification path, captured at PR head `bf2f804` with `TZ=UTC`. Fork contributors cannot push assets to the upstream `pr-evidence` release (verified this session: `HTTP 404` from `uploads.github.com/.../releases/386633166/assets`) and the gate's trusted-host allowlist excludes gists and fork releases, so per [CONTRIBUTING.md § Evidence](../CONTRIBUTING.md) the full transcripts are pasted inline below. The complete run logs are also in the **Backend + frontend logs** section.
<details><summary>backend test output — red arm (reverted UTC-day compare) then green arm at head bf2f804</summary>

```
# RED ARM — revert only the owner-zone line to now.toISOString().slice(0, 10)
$ TZ=UTC npx vitest run src/upcoming-bills-timezone.test.ts   # plugins/plugin-finances
 Warn  Time zone candidate failed to resolve; falling through to next source. (boundary=finances, operation=resolveCalendarTimeZone, error=fact store unavailable)
 × classifies a same-owner-day bill as upcoming via the injected owner resolver (America/Los_Angeles)
   -> expected 'overdue' to be 'upcoming'
 × classifies as upcoming from the TIMEZONE setting when no resolver is injected (Pacific/Honolulu)
   -> expected 'overdue' to be 'upcoming'
 × falls through to the TIMEZONE setting when the injected resolver reports no owner zone (null)
   -> expected 'overdue' to be 'upcoming'
 Test Files  1 failed (1)
      Tests  8 failed | 4 passed (12)

# GREEN ARM — head bf2f804 unmodified
$ TZ=UTC npx vitest run src/upcoming-bills-timezone.test.ts   # plugins/plugin-finances
 ✓ calendarDateKeyInZone returns the owner-zone calendar day, not the UTC day
 ✓ classifies a same-owner-day bill as upcoming via the injected owner resolver (America/Los_Angeles)
 ✓ classifies as upcoming from the TIMEZONE setting when no resolver is injected (Pacific/Honolulu)
 ✓ falls through to the TIMEZONE setting when the injected resolver reports no owner zone (null)
 Test Files  1 passed (1)
      Tests  12 passed (12)

# OWNER-FACT RESOLVER SUITE — head bf2f804
$ TZ=UTC npx vitest run src/lifeops/owner/resolve-owner-timezone.test.ts   # plugins/plugin-personal-assistant
 ✓ resolveOwnerTimeZoneFact returns null when no owner timezone fact is stored (the service decides the fallback)
 ✓ resolveOwnerTimeZoneFact returns null when the stored timezone fact is not a valid IANA zone
 ✓ resolveOwnerTimeZoneFact returns null when the fact-store read throws (no cache backend), never crashing
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response change; response shape of `/api/lifeops/money/bills` is unchanged (only the `status` value is corrected).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/prompt/model change; the `FINANCES` action payload data is corrected but no prompt or model call was modified.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - there is no separate hostable file artifact for this fix; the domain output is the `overdue`/`upcoming` bill `status` field itself, whose corrected values are proven directly by the focused backend transcripts in the Backend logs row above and by the before/after status matrix under Background.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: the regression test exercises the real `FinancesService.getUpcomingBills` classification path. Frontend: N/A.

**Failing on the unpatched code** (reverting only the owner-zone calendar-day line back to `now.toISOString().slice(0, 10)` at head `bf2f804` — 8 of 12 fail; the 4 that pass are the three `calendarDateKeyInZone` helper cases and the `Asia/Tokyo` case that coincidentally matches the UTC day):

<details><summary>test-fail-on-buggy.txt</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-31064/plugins/plugin-finances

 ❯ src/upcoming-bills-timezone.test.ts (12 tests | 8 failed) 65ms
     × classifies a same-owner-day bill as upcoming via the injected owner resolver (America/Los_Angeles) 12ms
     × classifies as upcoming from the TIMEZONE setting when no resolver is injected (Pacific/Honolulu) 2ms
     × prefers the injected owner resolver over the TIMEZONE setting 2ms
     × falls through to the TIMEZONE setting when the injected resolver yields an invalid zone 3ms
     × falls through to the TIMEZONE setting when the injected resolver reports no owner zone (null) 2ms
     × falls through to the next source when the resolver throws 6ms
     × honors an explicit timeZone argument above every other source 2ms
     × falls through an invalid explicit argument to the injected resolver 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 8 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > classifies a same-owner-day bill as upcoming via the injected owner resolver (America/Los_Angeles)
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:129:20
    127|       resolveTimeZone: () => "America/Los_Angeles",
    128|     });
    129|     expect(status).toBe("upcoming");
       |                    ^
    130|   });
    131|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/8]⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > classifies as upcoming from the TIMEZONE setting when no resolver is injected (Pacific/Honolulu)
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:134:20
    132|   it("classifies as upcoming from the TIMEZONE setting when no resolve…
    133|     const status = await statusFor("Pacific/Honolulu");
    134|     expect(status).toBe("upcoming");
       |                    ^
    135|   });
    136|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/8]⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > prefers the injected owner resolver over the TIMEZONE setting
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:147:20
    145|       resolveTimeZone: () => "America/Los_Angeles",
    146|     });
    147|     expect(status).toBe("upcoming");
       |                    ^
    148|   });
    149|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/8]⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > falls through to the TIMEZONE setting when the injected resolver yields an invalid zone
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:154:20
    152|       resolveTimeZone: () => "Not/AZone",
    153|     });
    154|     expect(status).toBe("upcoming");
       |                    ^
    155|   });
    156|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/8]⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > falls through to the TIMEZONE setting when the injected resolver reports no owner zone (null)
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:166:20
    164|       resolveTimeZone: () => null,
    165|     });
    166|     expect(status).toBe("upcoming");
       |                    ^
    167|   });
    168|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/8]⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > falls through to the next source when the resolver throws
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:175:20
    173|       },
    174|     });
    175|     expect(status).toBe("upcoming");
       |                    ^
    176|   });
    177|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/8]⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > honors an explicit timeZone argument above every other source
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:184:22
    182|       { timeZone: "America/Los_Angeles" },
    183|     );
    184|     expect(upcoming).toBe("upcoming");
       |                      ^
    185|     const overdue = await statusFor(
    186|       "America/Los_Angeles",

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/8]⎯

 FAIL  src/upcoming-bills-timezone.test.ts > getUpcomingBills owner-zone dueness (#31062) > falls through an invalid explicit argument to the injected resolver
AssertionError: expected 'overdue' to be 'upcoming' // Object.is equality

Expected: "upcoming"
Received: "overdue"

 ❯ src/upcoming-bills-timezone.test.ts:199:20
    197|       { timeZone: "Not/AZone" },
    198|     );
    199|     expect(status).toBe("upcoming");
       |                    ^
    200|   });
    201| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/8]⎯


 Test Files  1 failed (1)
      Tests  8 failed | 4 passed (12)
   Start at  20:42:12
   Duration  19.45s (transform 15.05s, setup 12.28s, import 6.84s, tests 65ms, environment 0ms)
```

</details>

**Passing with the fix** (12/12 after the follow-up below added one fall-through case):

<details><summary>test-pass.txt</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-31064/plugins/plugin-finances


 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  17:55:58
   Duration  26.21s (transform 20.59s, setup 16.52s, import 9.26s, tests 55ms, environment 0ms)
```

</details>

### Follow-up (#31064 review by @ss251): TIMEZONE fallthrough on an owner-fact miss

The route previously injected `resolveOwnerTimeZone`, which never returns `null` — on an owner-fact miss it substitutes the host zone itself, so the service's `owner fact → TIMEZONE setting → host zone` chain never reached `TIMEZONE`. The fix injects a new fact-only `resolveOwnerTimeZoneFact` (returns `null` on a miss) and delegates `resolveOwnerTimeZone` to it so its other callers are unchanged.

End-to-end proof of the exact reviewer scenario (host UTC, `TIMEZONE=Pacific/Honolulu`, no owner fact, `now=2026-03-03T03:30:00.000Z`, bill due `2026-03-02`) through the real owner-fact resolver and the real `FinancesService`, run from `plugin-personal-assistant` (the package that may depend on `plugin-finances`) with `TZ=UTC`:

<details><summary>route-timezone-proof.txt (throwaway test, not committed)</summary>

```
 ✓ #31064 route timezone proof (host UTC, TIMEZONE=Pacific/Honolulu, no owner fact) > OLD wiring resolveOwnerTimeZone masks the miss as host UTC => overdue (the defect) 58ms
 ✓ #31064 route timezone proof (host UTC, TIMEZONE=Pacific/Honolulu, no owner fact) > NEW wiring resolveOwnerTimeZoneFact returns null => TIMEZONE fallthrough => upcoming (the fix) 2ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

</details>

Committed regression coverage: `plugin-finances` `upcoming-bills-timezone.test.ts` gains a case proving a resolver returning `null` falls through to `TIMEZONE` (12/12 above); `plugin-personal-assistant` `resolve-owner-timezone.test.ts` gains four cases pinning `resolveOwnerTimeZoneFact` returns `null` on miss / invalid zone / read failure and the stored zone otherwise (10/10):

<details><summary>resolve-owner-timezone.test.txt</summary>

```
RUN  v4.1.10 /home/home/Developer/eliza-swarm/state/worktrees/pr-31064


 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  17:55:59
   Duration  25.09s (transform 20.05s, setup 16.78s, import 7.94s, tests 87ms, environment 0ms)
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

### Before

N/A - no UI change.

### After

N/A - no UI change.

### Walkthrough video

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- **`bun run verify` (repo-wide) was not run in full.** Instead the owning package's gates were run and are attached: `plugin-finances` `tsc --noEmit` (exit 0) and Biome check on the changed files (exit 0); the new regression test passes 11/11 and fails 7/11 on the unpatched code. The repo-wide `verify` gate builds/typechecks the entire workspace, which is not feasible to complete on this constrained host in-session; the change is isolated to two files plus one test.
- **Pre-existing, unrelated `plugin-finances` test failures:** `src/components/finances/format-minor.test.ts` (3) and `src/components/finances/FinancesView.test.tsx` (1) fail on this machine due to an ICU/locale currency-symbol difference (e.g. `JP¥1,500` vs `¥1,500`, `US$` vs `$`). Verified these fail identically on the unmodified base (`git stash` + run) — they are environmental and independent of this change.

<details><summary>typecheck-lint.txt (plugin-finances)</summary>

```
=== plugin-finances typecheck (tsc --noEmit) ===
$ tsc --noEmit -p tsconfig.json
EXIT: 0

=== plugin-finances lint (biome check) ===
Checked 3 files in 103ms. No fixes applied.
EXIT: 0
```

</details>

## Maintainer CI exception record

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@bf2f804d382fb7e0b48c6498d3b52ad1084e7569:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@bf2f804d382fb7e0b48c6498d3b52ad1084e7569:packages/skills/skills/contribute-to-eliza"} -->
