### PR TITLE
fix(finances): classify bill due dates on the owner's calendar day (#31062)

### DIFF
--- a/plugins/plugin-finances/src/calendar-date.test.ts
+++ b/plugins/plugin-finances/src/calendar-date.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Pins `calendarDateKeyInZone`: the same instant maps to different calendar
+ * days on either side of the date line, and an unknown zone is rejected by
+ * Intl rather than silently falling back. Deterministic, no I/O.
+ */
+import { describe, expect, it } from "vitest";
+import { calendarDateKeyInZone } from "./calendar-date.ts";
+
+describe("calendarDateKeyInZone", () => {
+  const instant = new Date("2026-03-03T03:30:00.000Z");
+
+  it.each([
+    ["UTC", "2026-03-03"],
+    ["America/Los_Angeles", "2026-03-02"],
+    ["America/New_York", "2026-03-02"],
+    ["Asia/Tokyo", "2026-03-03"],
+    ["Pacific/Kiritimati", "2026-03-03"],
+    ["Pacific/Honolulu", "2026-03-02"],
+  ])("maps 03:30Z on March 3 to the local day in %s", (zone, expected) => {
+    expect(calendarDateKeyInZone(instant, zone)).toBe(expected);
+  });
+
+  it("keeps the calendar day across a DST transition", () => {
+    // 2026-03-08 02:30 local does not exist in New York; 06:30Z is 01:30 EST.
+    expect(
+      calendarDateKeyInZone(
+        new Date("2026-03-08T06:30:00.000Z"),
+        "America/New_York",
+      ),
+    ).toBe("2026-03-08");
+    expect(
+      calendarDateKeyInZone(
+        new Date("2026-03-08T04:59:00.000Z"),
+        "America/New_York",
+      ),
+    ).toBe("2026-03-07");
+  });
+
+  it("rejects an unknown zone instead of guessing", () => {
+    expect(() => calendarDateKeyInZone(instant, "Mars/Olympus")).toThrow(
+      RangeError,
+    );
+  });
+});

--- a/plugins/plugin-finances/src/calendar-date.ts
+++ b/plugins/plugin-finances/src/calendar-date.ts
@@ -1,0 +1,38 @@
+/**
+ * Calendar-day keys in a named IANA zone. Due dates are stored as bare
+ * `YYYY-MM-DD` strings the owner reads on their own calendar, so "is this bill
+ * overdue" must compare against today's date in the owner's zone rather than
+ * the UTC date, which is already tomorrow every evening west of Greenwich.
+ */
+
+const DAY_KEY_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
+
+function dayKeyFormatter(timeZone: string): Intl.DateTimeFormat {
+  let formatter = DAY_KEY_FORMATTERS.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    DAY_KEY_FORMATTERS.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+/**
+ * Return the `YYYY-MM-DD` calendar day that `instant` falls on in `timeZone`.
+ * Throws the Intl `RangeError` for an unknown zone; callers validate first.
+ */
+export function calendarDateKeyInZone(instant: Date, timeZone: string): string {
+  const parts = dayKeyFormatter(timeZone).formatToParts(instant);
+  const read = (type: "year" | "month" | "day"): string => {
+    const part = parts.find((candidate) => candidate.type === type);
+    if (!part) {
+      throw new Error(`Calendar ${type} unavailable for zone ${timeZone}`);
+    }
+    return part.value;
+  };
+  return `${read("year").padStart(4, "0")}-${read("month")}-${read("day")}`;
+}

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -36,9 +36,12 @@ import {
   resolveCloudApiBaseUrl,
 } from "@elizaos/plugin-elizacloud/cloud/managed-payment-clients";
 import {
+  isValidTimeZone,
+  resolveDefaultTimeZone,
   resolveDevCloudAuthorityEnvValue,
   resolveDevCloudEnvAuthority,
 } from "@elizaos/shared";
+import { calendarDateKeyInZone } from "./calendar-date.ts";
 import {
   FinancesRepository,
   PlaidSyncCursorConflictError,
@@ -125,6 +128,13 @@ const plaidJwkCache = new Map<
 /** Optional construction options (mirrors the LifeOps service shape). */
 export type FinancesServiceOptions = {
   ownerEntityId?: string | null;
+  /**
+   * Resolve the owner's IANA zone for calendar-day comparisons such as bill
+   * due dates. Hosts that know the owner (the personal-assistant routes) pass
+   * the owner-fact resolver; otherwise the agent's `TIMEZONE` setting and then
+   * the host zone apply.
+   */
+  resolveTimeZone?: (now: Date) => Promise<string> | string;
 };
 
 export function resolveFinancesCloudManagedClientConfig(): ElizaCloudManagedClientConfig {
@@ -509,6 +519,9 @@ function computeSpendingSummary(args: {
 export class FinancesService {
   public readonly repository: FinancesRepository;
   public readonly ownerEntityId: string | null;
+  private readonly resolveConfiguredTimeZone:
+    | ((now: Date) => Promise<string> | string)
+    | null;
   public plaidManagedClientCache: PlaidManagedClient | null = null;
   public paypalManagedClientCache: PaypalManagedClient | null = null;
 
@@ -518,6 +531,27 @@ export class FinancesService {
   ) {
     this.repository = new FinancesRepository(runtime);
     this.ownerEntityId = normalizeOptionalString(options.ownerEntityId) ?? null;
+    this.resolveConfiguredTimeZone = options.resolveTimeZone ?? null;
+  }
+
+  /**
+   * Owner calendar zone for due-date status: the host-supplied resolver, then
+   * the agent's `TIMEZONE` setting, then the process zone. An invalid value at
+   * any step falls through to the next so a stale setting cannot pin the
+   * comparison to a zone Intl cannot format.
+   */
+  async resolveCalendarTimeZone(now: Date): Promise<string> {
+    if (this.resolveConfiguredTimeZone) {
+      const resolved = normalizeOptionalString(
+        await this.resolveConfiguredTimeZone(now),
+      );
+      if (resolved && isValidTimeZone(resolved)) return resolved;
+    }
+    const setting = this.runtime.getSetting("TIMEZONE");
+    const configured =
+      typeof setting === "string" ? normalizeOptionalString(setting) : null;
+    if (configured && isValidTimeZone(configured)) return configured;
+    return resolveDefaultTimeZone();
   }
 
   agentId(): string {
@@ -991,7 +1025,7 @@ export class FinancesService {
    * so extraction misses do not disappear from the user's review queue.
    */
   async getUpcomingBills(
-    args: { now?: Date } = {},
+    args: { now?: Date; timeZone?: string | null } = {},
   ): Promise<LifeOpsUpcomingBill[]> {
     const sources = await this.listPaymentSources();
     const emailSource = sources.find((source) => source.kind === "email");
@@ -1003,7 +1037,14 @@ export class FinancesService {
       },
     );
     const now = args.now ?? new Date();
-    const todayIso = now.toISOString().slice(0, 10);
+    const explicitZone = normalizeOptionalString(args.timeZone);
+    if (explicitZone && !isValidTimeZone(explicitZone)) {
+      fail(400, "timeZone must be a valid IANA time zone");
+    }
+    const todayIso = calendarDateKeyInZone(
+      now,
+      explicitZone ?? (await this.resolveCalendarTimeZone(now)),
+    );
     const bills: LifeOpsUpcomingBill[] = [];
     for (const transaction of transactions) {
       const metadata = transaction.metadata;

--- a/plugins/plugin-finances/test/finances-bills-owner-day.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances-bills-owner-day.real-db.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Proves bill due-date status is classified on the owner's calendar day, not
+ * the UTC day, against a real AgentRuntime with the finances schema on PGlite.
+ * A bill due "today" for an owner west of Greenwich stays `upcoming` through
+ * the evening even though UTC has already rolled to the next date, and the
+ * same instant is `overdue` for an owner east of the date line. Covers the
+ * resolver chain: explicit argument, host-supplied resolver, the agent's
+ * `TIMEZONE` setting, and the process zone. Real runtime and repository, no
+ * mocks.
+ */
+import crypto from "node:crypto";
+import type { AgentRuntime } from "@elizaos/core";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  createRealTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../packages/app-core/test/helpers/real-runtime.ts";
+import { FinancesRepository } from "../src/db/finances-repository.ts";
+import { FinancesService } from "../src/finances-service.ts";
+import financesPlugin from "../src/plugin.ts";
+
+// 03:30Z on March 3 is still the evening of March 2 in Los Angeles and
+// Honolulu, and already March 3 in Tokyo and on UTC.
+const NOW = new Date("2026-03-03T03:30:00.000Z");
+const DUE_TODAY_IN_LA = "2026-03-02";
+
+describe("upcoming bills classify due dates on the owner's calendar day", () => {
+  let runtime: AgentRuntime;
+  let testResult: RealTestRuntimeResult;
+  let repository: FinancesRepository;
+  let billId: string;
+  const originalTz = process.env.TZ;
+
+  beforeAll(async () => {
+    testResult = await createRealTestRuntime({
+      characterName: "finances-bills-owner-day",
+      plugins: [financesPlugin],
+    });
+    runtime = testResult.runtime;
+    repository = new FinancesRepository(runtime);
+    const createdAt = "2026-02-20T12:00:00.000Z";
+    const sourceId = crypto.randomUUID();
+    await repository.upsertPaymentSource({
+      id: sourceId,
+      agentId: runtime.agentId,
+      kind: "email",
+      label: "Gmail bills",
+      institution: null,
+      accountMask: null,
+      status: "active",
+      lastSyncedAt: null,
+      transactionCount: 0,
+      metadata: {},
+      createdAt,
+      updatedAt: createdAt,
+    });
+    billId = crypto.randomUUID();
+    await repository.insertPaymentTransaction({
+      id: billId,
+      agentId: runtime.agentId,
+      sourceId,
+      externalId: null,
+      postedAt: createdAt,
+      amountUsd: 84.5,
+      direction: "debit",
+      merchantRaw: "City Water",
+      merchantNormalized: "city water",
+      description: "March water bill",
+      category: null,
+      currency: "USD",
+      metadata: {
+        kind: "bill",
+        dueDate: DUE_TODAY_IN_LA,
+        confidence: 0.9,
+        sourceMessageId: "msg-1",
+      },
+      createdAt,
+    });
+  }, 180_000);
+
+  afterEach(() => {
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+    runtime.setSetting("TIMEZONE", null);
+  });
+
+  afterAll(async () => {
+    await testResult?.cleanup();
+  });
+
+  async function statusFor(
+    service: FinancesService,
+    args: { timeZone?: string } = {},
+  ): Promise<string> {
+    const bills = await service.getUpcomingBills({ now: NOW, ...args });
+    const bill = bills.find((candidate) => candidate.id === billId);
+    if (!bill) throw new Error("seeded bill missing from upcoming bills");
+    return bill.status;
+  }
+
+  it("uses the host-supplied owner zone before the agent setting", async () => {
+    runtime.setSetting("TIMEZONE", "Asia/Tokyo");
+    const service = new FinancesService(runtime, {
+      resolveTimeZone: async () => "America/Los_Angeles",
+    });
+    expect(await statusFor(service)).toBe("upcoming");
+    expect(await service.resolveCalendarTimeZone(NOW)).toBe(
+      "America/Los_Angeles",
+    );
+  });
+
+  it("falls back to the agent's TIMEZONE setting", async () => {
+    runtime.setSetting("TIMEZONE", "Pacific/Honolulu");
+    expect(await statusFor(new FinancesService(runtime))).toBe("upcoming");
+    runtime.setSetting("TIMEZONE", "Asia/Tokyo");
+    expect(await statusFor(new FinancesService(runtime))).toBe("overdue");
+  });
+
+  it("skips an invalid resolver result and an invalid setting", async () => {
+    runtime.setSetting("TIMEZONE", "Mars/Olympus");
+    process.env.TZ = "America/Los_Angeles";
+    const service = new FinancesService(runtime, {
+      resolveTimeZone: () => "Not/AZone",
+    });
+    expect(await service.resolveCalendarTimeZone(NOW)).toBe(
+      "America/Los_Angeles",
+    );
+    expect(await statusFor(service)).toBe("upcoming");
+  });
+
+  it("honours an explicit zone argument and rejects an invalid one", async () => {
+    const service = new FinancesService(runtime, {
+      resolveTimeZone: () => "America/Los_Angeles",
+    });
+    expect(await statusFor(service, { timeZone: "Asia/Tokyo" })).toBe(
+      "overdue",
+    );
+    await expect(
+      service.getUpcomingBills({ now: NOW, timeZone: "Mars/Olympus" }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-money-bills-owner-day.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-money-bills-owner-day.pglite.integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Proves the owner bills route classifies due dates on the owner's stored
+ * calendar zone. A GET travels a real HTTP server → the agent's plugin route
+ * dispatcher → the registered personal-assistant routes → FinancesService →
+ * FinancesRepository on a PGlite runtime. The owner's timezone fact
+ * (America/Los_Angeles) must win over the agent's `TIMEZONE` setting
+ * (Asia/Tokyo) at an instant where the two zones sit on different calendar
+ * days. Only `Date` is faked so the clock is deterministic; no mocks
+ * otherwise.
+ */
+import crypto from "node:crypto";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import financesPlugin from "@elizaos/plugin-finances";
+import { FinancesRepository } from "@elizaos/plugin-finances/db/finances-repository";
+import { afterAll, beforeAll, expect, it, vi } from "vitest";
+import { tryHandleRuntimePluginRoute } from "../../../../packages/agent/src/api/runtime-plugin-routes.ts";
+import { createLifeOpsTestRuntime } from "../../test/helpers/runtime.js";
+import {
+  createOwnerFactStore,
+  registerOwnerFactStore,
+  resolveOwnerFactStore,
+} from "../lifeops/owner/fact-store.js";
+
+// 03:30Z on March 3: still March 2 in Los Angeles, already March 3 in Tokyo.
+const NOW = new Date("2026-03-03T03:30:00.000Z");
+const DUE_TODAY_IN_LA = "2026-03-02";
+
+let host: Awaited<ReturnType<typeof createLifeOpsTestRuntime>>;
+
+beforeAll(async () => {
+  host = await createLifeOpsTestRuntime({ plugins: [financesPlugin] });
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(NOW);
+}, 180_000);
+
+afterAll(async () => {
+  vi.useRealTimers();
+  await host?.cleanup();
+});
+
+it("classifies a bill due today for the owner as upcoming, not overdue", async () => {
+  const runtime = host.runtime;
+  runtime.setSetting("TIMEZONE", "Asia/Tokyo");
+  registerOwnerFactStore(runtime, createOwnerFactStore(runtime));
+  await resolveOwnerFactStore(runtime).update(
+    { timezone: "America/Los_Angeles" },
+    { source: "profile_save", recordedAt: "2026-02-01T00:00:00.000Z" },
+  );
+  const repository = new FinancesRepository(runtime);
+  const createdAt = "2026-02-20T12:00:00.000Z";
+  const sourceId = crypto.randomUUID();
+  await repository.upsertPaymentSource({
+    id: sourceId,
+    agentId: runtime.agentId,
+    kind: "email",
+    label: "Gmail bills",
+    institution: null,
+    accountMask: null,
+    status: "active",
+    lastSyncedAt: null,
+    transactionCount: 0,
+    metadata: {},
+    createdAt,
+    updatedAt: createdAt,
+  });
+  const billId = crypto.randomUUID();
+  await repository.insertPaymentTransaction({
+    id: billId,
+    agentId: runtime.agentId,
+    sourceId,
+    externalId: null,
+    postedAt: createdAt,
+    amountUsd: 84.5,
+    direction: "debit",
+    merchantRaw: "City Water",
+    merchantNormalized: "city water",
+    description: "March water bill",
+    category: null,
+    currency: "USD",
+    metadata: { kind: "bill", dueDate: DUE_TODAY_IN_LA, confidence: 0.9 },
+    createdAt,
+  });
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const handled = await tryHandleRuntimePluginRoute({
+      req,
+      res,
+      url,
+      pathname: url.pathname,
+      method: req.method ?? "GET",
+      runtime,
+      isAuthorized: () => true,
+    });
+    if (!handled && !res.headersSent) {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string")
+      throw new Error("HTTP server omitted bound TCP address");
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/api/lifeops/money/bills`,
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      bills: Array<{ id: string; dueDate: string | null; status: string }>;
+    };
+    expect(payload.bills.find((bill) => bill.id === billId)).toMatchObject({
+      dueDate: DUE_TODAY_IN_LA,
+      status: "upcoming",
+    });
+    expect(runtime.getRecentReportedErrors()).toEqual([]);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}, 180_000);

--- a/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts
@@ -122,6 +122,7 @@ import {
   composeDailyCalendarCard,
 } from "../lifeops/calendar-card.js";
 import { probeFullDiskAccess } from "../lifeops/fda-probe.js";
+import { resolveOwnerTimeZone } from "../lifeops/owner/fact-store.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 import { entityHasVerifiedMachineAuthBinding } from "./authenticated-entity-principal.js";
@@ -214,6 +215,9 @@ function getFinancesService(ctx: LifeOpsRouteContext): FinancesService | null {
   }
   return new FinancesService(runtime, {
     ownerEntityId: ctx.state.adminEntityId,
+    // Bill due dates are owner calendar days; classify them in the owner's
+    // stored zone rather than the agent host's.
+    resolveTimeZone: (now) => resolveOwnerTimeZone(runtime, now),
   });
 }
 


### PR DESCRIPTION
## Summary

`FinancesService.getUpcomingBills` compared each bill's bare `YYYY-MM-DD` due date against the UTC calendar date, so a bill due today was reported `overdue` from 16:00 local in Los Angeles (19:00 in New York), and a bill due yesterday stayed `upcoming` until 09:00 local in Tokyo. The status feeds the `FINANCES` action's `dashboard` payload, `GET /api/lifeops/money/dashboard`, `GET /api/lifeops/money/bills`, and the bills sort order.

Closes #31062.

## Change

- `plugins/plugin-finances/src/calendar-date.ts`: `calendarDateKeyInZone(instant, timeZone)` returns the `YYYY-MM-DD` day in a named IANA zone via `Intl.DateTimeFormat.formatToParts`; an unknown zone raises Intl's `RangeError`.
- `FinancesService`: new `resolveTimeZone` option and `resolveCalendarTimeZone(now)`, which takes the host-supplied resolver, then the agent's `TIMEZONE` setting, then the process zone, skipping any value `isValidTimeZone` rejects. `getUpcomingBills` accepts an explicit `timeZone` (400 when invalid) and computes today's key in the resolved zone.
- `plugins/plugin-personal-assistant/src/routes/lifeops-routes.ts`: the finances service factory injects `resolveOwnerTimeZone`, so the owner's stored timezone fact wins on every finances route.

## Proof

**Develop (5415f6424c91):** at `2026-03-03T03:30Z` (19:30 March 2 in Los Angeles) a bill due `2026-03-02` is `overdue` for an owner in Los Angeles or Honolulu, both through the service and through `GET /api/lifeops/money/bills` with the owner fact set.

**This branch:**

```text
$ bunx vitest run test/finances-bills-owner-day.real-db.test.ts        # real AgentRuntime + finances schema on PGlite
 ✓ uses the host-supplied owner zone before the agent setting           # LA resolver beats TIMEZONE=Asia/Tokyo → upcoming
 ✓ falls back to the agent's TIMEZONE setting                           # Honolulu → upcoming, Tokyo → overdue
 ✓ skips an invalid resolver result and an invalid setting              # Not/AZone, Mars/Olympus → process zone
 ✓ honours an explicit zone argument and rejects an invalid one         # Tokyo arg → overdue; Mars/Olympus → 400
 Tests  4 passed (4)

$ bunx vitest run --config vitest.src-integration.config.ts src/routes/lifeops-money-bills-owner-day.pglite.integration.test.ts
 ✓ classifies a bill due today for the owner as upcoming, not overdue   # real HTTP server → plugin route dispatcher → registered routes; owner fact LA, TIMEZONE Tokyo, Date faked
 Tests  1 passed (1)

$ bunx vitest run src/calendar-date.test.ts
 Tests  8 passed (8)
```

RED controls: with `finances-service.ts` restored to `develop`, all four finances cases fail with `expected 'overdue' to be 'upcoming'`; with only `lifeops-routes.ts` restored (service fixed, no owner injection), the route case fails the same way because the Tokyo setting wins.

Package gates: plugin-finances `typecheck` 0 errors and `lint:check` clean; plugin-personal-assistant `typecheck` 0 errors (after rebuilding plugin-finances so its declarations carry the new option) and `lint:check` clean; full package tests plugin-finances 17 files / 211 passed and plugin-personal-assistant 302 files / 2623 passed (6 skipped).

Root `bun run verify`: 373 of 373 Turbo tasks green (run with `RUN_TURBO_CONCURRENCY=4` on this 31 GB host).

## Evidence checklist

| Row | Status |
| --- | --- |
| Screenshots / MP4 | N/A, the finances view does not render bill status; the change is in the DTO |
| Backend logs | vitest output above; both real-runtime suites assert `runtime.getRecentReportedErrors()` is empty |
| Live-model trajectories | N/A, no prompt or planner changes; the action payload's `status` field is corrected |
| Native targets | N/A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CNyebSRMNUZinVaRHTUuN
