### PR TITLE
fix(lifeops): authenticate Family Operations requests in paired remote sessions (#31070)

### DIFF
--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
@@ -1,7 +1,11 @@
 /** HTTP contract tests for Family Operations calendar conflict mutations. */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { defaultFamilyOperationsAdapter } from "./adapter.js";
+import {
+  createFamilyOperationsAdapter,
+  defaultFamilyOperationsAdapter,
+  type FamilyOperationsApiClient,
+} from "./adapter.js";
 
 afterEach(() => {
   sessionStorage.clear();
@@ -378,5 +382,198 @@ describe("defaultFamilyOperationsAdapter", () => {
       retainEvents: true,
       expectedUpdatedAt: "2026-08-30T13:00:00.000Z",
     });
+  });
+});
+
+describe("createFamilyOperationsAdapter", () => {
+  it("routes queries, binary chunk uploads, and workflow mutations through the authenticated client transport", async () => {
+    const fetchCalls: Array<{ path: string; init?: RequestInit }> = [];
+    const mockClient: FamilyOperationsApiClient = {
+      fetch: vi.fn(async (path: string, init?: RequestInit) => {
+        fetchCalls.push({ path, init });
+        if (path === "/api/lifeops/agreements") {
+          return { agreements: [] } as any;
+        }
+        if (path === "/api/lifeops/calendar/links") {
+          return { links: [] } as any;
+        }
+        if (path === "/api/lifeops/family-workflows/school/status") {
+          return {
+            sourceId: "concord",
+            config: {
+              landingPageUrl: "https://school.example/calendar",
+              schoolLevel: "elementary",
+              updateMode: "review",
+            },
+            lastRun: {
+              runId: "school-run-1",
+              state: "applied",
+              updatedAt: "2026-09-01T00:00:00Z",
+            },
+          } as any;
+        }
+        if (path === "/api/lifeops/family-workflows/school/runs/school-run-1") {
+          return {
+            plan: { changes: [{ kind: "add", event: { title: "Orientation" } }] },
+            errorMessage: null,
+          } as any;
+        }
+        if (path === "/api/lifeops/family-workflows/packets") {
+          return {
+            packets: [
+              {
+                packetId: "packet-99",
+                period: { key: "2026-09" },
+                version: 1,
+                createdAt: "2026-09-01T00:00:00Z",
+                sections: [{ section: "calendar", state: "complete" }],
+                claims: [
+                  {
+                    claimId: "claim-1",
+                    section: "calendar",
+                    statement: "Schedule aligned",
+                  },
+                ],
+              },
+            ],
+            packetStates: [],
+          } as any;
+        }
+        if (path === "/api/lifeops/family-workflows/email-options") {
+          return { options: { recipients: [] } } as any;
+        }
+        if (path === "/api/lifeops/agreement-uploads") {
+          return {
+            upload: {
+              uploadId: "upload-remote-1",
+              sizeBytes: 8,
+              chunkSizeBytes: 4,
+              chunkCount: 2,
+              receivedChunks: [],
+              receivedBytes: 0,
+              status: "uploading",
+            },
+          } as any;
+        }
+        if (path.includes("/chunks/")) {
+          return { upload: {} } as any;
+        }
+        if (path.endsWith("/commit")) {
+          return { upload: { status: "complete" } } as any;
+        }
+        if (path.includes("/obligations/")) {
+          return { obligation: { id: "ob-1", status: "accepted" } } as any;
+        }
+        if (path.endsWith("/pins")) {
+          if (init?.method === "POST") return { pin: { id: "pin-1" } } as any;
+          return { pins: [] } as any;
+        }
+        if (path.includes("/pins/")) {
+          return { pin: { id: "pin-1" } } as any;
+        }
+        if (path.endsWith("/grants/preview")) {
+          return { preview: { canGrant: true } } as any;
+        }
+        if (path.endsWith("/grants")) {
+          return { grant: { id: "grant-1" } } as any;
+        }
+        if (path.includes("/grants/") && path.endsWith("/revoke")) {
+          return { grant: { id: "grant-1", status: "revoked" } } as any;
+        }
+        return {} as any;
+      }),
+    };
+
+    const adapter = createFamilyOperationsAdapter(mockClient);
+    const snapshot = await adapter.load();
+
+    expect(snapshot.agreements).toEqual({ status: "ready", data: [] });
+    expect(snapshot.school).toMatchObject({
+      status: "ready",
+      data: {
+        sourceId: "concord",
+        state: "applied",
+        changes: [{ kind: "add", label: "Orientation" }],
+      },
+    });
+    expect(snapshot.packets.status).toBe("ready");
+
+    const file = new File(["%PDF-1.7sample"], "test.pdf", {
+      type: "application/pdf",
+    });
+    await adapter.uploadAgreement({
+      agreementKey: "plan-a",
+      title: "Plan A",
+      file,
+    });
+
+    const chunkUploadCalls = fetchCalls.filter((c) =>
+      c.path.includes("/chunks/"),
+    );
+    expect(chunkUploadCalls.length).toBeGreaterThan(0);
+    for (const chunkCall of chunkUploadCalls) {
+      expect(chunkCall.init?.headers).toMatchObject({
+        "Content-Type": "application/octet-stream",
+      });
+      expect(chunkCall.init?.headers).toHaveProperty("x-chunk-sha256");
+    }
+
+    await adapter.decideObligation({ id: "ob-1" } as any, "accept", "aligned");
+    await adapter.listPins("artifact-1");
+    await adapter.pin({
+      artifactId: "artifact-1",
+      target: "parenting_time",
+      label: "Weekend",
+    } as any);
+    await adapter.unpin("pin-1");
+    await adapter.previewGrant({
+      artifactId: "artifact-1",
+      recipient: "partner",
+    } as any);
+    await adapter.issueGrant({
+      artifactId: "artifact-1",
+      recipient: "partner",
+    } as any);
+    await adapter.revokeGrant("grant-1", "outdated");
+    await adapter.resolveCalendarConflict(
+      "link-1",
+      "keep_eliza",
+      "2026-09-01T00:00:00Z",
+    );
+    await adapter.disconnectCalendar("link-1", "2026-09-01T00:00:00Z");
+    await adapter.runSchoolWorkflow();
+    await adapter.configureSchool({
+      landingPageUrl: "https://school.example/calendar",
+    } as any);
+    await adapter.approveSchoolDiff("school-run-1");
+    await adapter.generatePacket("2026-09");
+    await adapter.createPacketDraft({
+      packetId: "packet-99",
+      recipient: "co-parent",
+      calendarPrivacyMode: "times_only",
+    });
+    await adapter.revisePacketDraft({
+      packetId: "packet-99",
+      expectedDraftVersion: 1,
+      body: "Updated",
+      subject: "Plan",
+    });
+    await adapter.requestPacketApproval("packet-99", 2);
+
+    expect(mockClient.fetch).toHaveBeenCalledWith(
+      "/api/lifeops/agreements",
+      undefined,
+    );
+    expect(mockClient.fetch).toHaveBeenCalledWith(
+      "/api/lifeops/calendar/links",
+      undefined,
+    );
+    expect(mockClient.fetch).toHaveBeenCalledWith(
+      "/api/lifeops/family-workflows/school/run",
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+      },
+    );
   });
 });

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
@@ -1,5 +1,6 @@
-/** Production Family Operations adapter over owner-authorized local APIs. */
+/** Production Family Operations adapter over owner-authorized canonical client APIs. Delegates all data queries, agreement uploads, workflow actions, and packet mutations to the authenticated client transport to preserve machine-session bearer tokens and non-default API origins across paired remote sessions. */
 
+import { client, type ElizaClient } from "@elizaos/ui/api";
 import type {
   MonthlyFamilyDraft,
   MonthlyFamilyPacket,
@@ -18,6 +19,8 @@ import type {
   Loadable,
   SchoolWorkflowView,
 } from "./types.js";
+
+export type FamilyOperationsApiClient = Pick<ElizaClient, "fetch">;
 
 interface PacketPersistenceState {
   packetId: string;
@@ -58,36 +61,6 @@ async function agreementContentIdentity(input: {
   return sha256Hex(new TextEncoder().encode(canonical).buffer);
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(path, {
-    credentials: "include",
-    ...init,
-    headers: { "content-type": "application/json", ...init?.headers },
-  });
-  const payload = (await response.json().catch(() => null)) as {
-    error?: { message?: string } | string;
-  } | null;
-  if (!response.ok) {
-    const message =
-      typeof payload?.error === "string"
-        ? payload.error
-        : payload?.error?.message;
-    throw new Error(message || `Request failed (${response.status})`);
-  }
-  return payload as T;
-}
-
-async function loadSection<T>(path: string, key: string): Promise<Loadable<T>> {
-  try {
-    const payload = await request<Record<string, T>>(path);
-    return { status: "ready", data: payload[key] as T };
-  } catch (error) {
-    return {
-      status: "unavailable",
-      message: error instanceof Error ? error.message : "Service unavailable",
-    };
-  }
-}
 
 function schoolView(
   status: SchoolCalendarWorkflowStatus,
@@ -158,50 +131,69 @@ function packetView(
   };
 }
 
-async function loadSchool(): Promise<Loadable<SchoolWorkflowView>> {
-  try {
-    const status = await request<SchoolCalendarWorkflowStatus>(
-      "/api/lifeops/family-workflows/school/status",
-    );
-    const review = status.lastRun?.runId
-      ? await request<SchoolCalendarRunReview>(
-          `/api/lifeops/family-workflows/school/runs/${encodeURIComponent(status.lastRun.runId)}`,
-        )
-      : null;
-    return { status: "ready", data: schoolView(status, review) };
-  } catch (error) {
-    return {
-      status: "unavailable",
-      message: error instanceof Error ? error.message : "Service unavailable",
-    };
+export function createFamilyOperationsAdapter(
+  apiClient: FamilyOperationsApiClient = client,
+): FamilyOperationsAdapter {
+  async function request<T>(path: string, init?: RequestInit): Promise<T> {
+    return apiClient.fetch<T>(path, init);
   }
-}
 
-async function loadPackets(): Promise<Loadable<FamilyPacketView[]>> {
-  try {
-    const payload = await request<{
-      packets: MonthlyFamilyPacket[];
-      packetStates?: PacketPersistenceState[];
-    }>("/api/lifeops/family-workflows/packets");
-    const states = new Map(
-      (payload.packetStates ?? []).map((state) => [state.packetId, state]),
-    );
-    return {
-      status: "ready",
-      data: payload.packets.map((packet) =>
-        packetView(packet, states.get(packet.packetId)),
-      ),
-    };
-  } catch (error) {
-    return {
-      status: "unavailable",
-      message: error instanceof Error ? error.message : "Service unavailable",
-    };
+  async function loadSection<T>(path: string, key: string): Promise<Loadable<T>> {
+    try {
+      const payload = await request<Record<string, T>>(path);
+      return { status: "ready", data: payload[key] as T };
+    } catch (error) {
+      return {
+        status: "unavailable",
+        message: error instanceof Error ? error.message : "Service unavailable",
+      };
+    }
   }
-}
 
-export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter = {
-  async load(): Promise<FamilyOperationsSnapshot> {
+  async function loadSchool(): Promise<Loadable<SchoolWorkflowView>> {
+    try {
+      const status = await request<SchoolCalendarWorkflowStatus>(
+        "/api/lifeops/family-workflows/school/status",
+      );
+      const review = status.lastRun?.runId
+        ? await request<SchoolCalendarRunReview>(
+            `/api/lifeops/family-workflows/school/runs/${encodeURIComponent(status.lastRun.runId)}`,
+          )
+        : null;
+      return { status: "ready", data: schoolView(status, review) };
+    } catch (error) {
+      return {
+        status: "unavailable",
+        message: error instanceof Error ? error.message : "Service unavailable",
+      };
+    }
+  }
+
+  async function loadPackets(): Promise<Loadable<FamilyPacketView[]>> {
+    try {
+      const payload = await request<{
+        packets: MonthlyFamilyPacket[];
+        packetStates?: PacketPersistenceState[];
+      }>("/api/lifeops/family-workflows/packets");
+      const states = new Map(
+        (payload.packetStates ?? []).map((state) => [state.packetId, state]),
+      );
+      return {
+        status: "ready",
+        data: payload.packets.map((packet) =>
+          packetView(packet, states.get(packet.packetId)),
+        ),
+      };
+    } catch (error) {
+      return {
+        status: "unavailable",
+        message: error instanceof Error ? error.message : "Service unavailable",
+      };
+    }
+  }
+
+  return {
+    async load(): Promise<FamilyOperationsSnapshot> {
     const [agreements, calendarLinks, school, packets, emailOptions] =
       await Promise.all([
         loadSection<ParentingAgreementView[]>(
@@ -304,7 +296,7 @@ export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter = {
           {
             method: "PUT",
             headers: {
-              "content-type": "application/octet-stream",
+              "Content-Type": "application/octet-stream",
               "x-chunk-sha256": sha256,
             },
             body: bytes,
@@ -471,4 +463,8 @@ export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter = {
       { method: "POST", body: JSON.stringify({}) },
     );
   },
-};
+  };
+}
+
+export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter =
+  createFamilyOperationsAdapter(client);

--- a/plugins/plugin-personal-assistant/test/stubs/ui.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/ui.ts
@@ -38,7 +38,25 @@ function TestAlertDescription({
   return createElement("div", null, children);
 }
 
-export class ElizaClient {}
+export class ElizaClient {
+  async fetch<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(path, {
+      ...init,
+      headers: { "Content-Type": "application/json", ...init?.headers },
+    });
+    const payload = (await response.json().catch(() => null)) as {
+      error?: { message?: string } | string;
+    } | null;
+    if (!response.ok) {
+      const message =
+        typeof payload?.error === "string"
+          ? payload.error
+          : payload?.error?.message;
+      throw new Error(message || `Request failed (${response.status})`);
+    }
+    return payload as T;
+  }
+}
 
 export const client = new ElizaClient();
 


### PR DESCRIPTION
## Summary

Addresses #31070.

In paired remote sessions, bearer tokens and non-default API base URLs are managed by the canonical ElizaClient transport (`client`). Previously, FamilyOperationsAdapter issued raw fetch calls directly to `/api/...`, bypassing `client.fetch`. Consequently:
1. Requests lacked Authorization headers, triggering HTTP 401 Unauthorized errors in paired remote sessions.
2. In non-default host environments, bare path requests failed to route to the bound remote agent URL (`client.baseUrl`).

## Changes

- Defined `FamilyOperationsApiClient = Pick<ElizaClient, "fetch">`.
- Refactored `plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts` to export `createFamilyOperationsAdapter(apiClient: FamilyOperationsApiClient = client)` and bound `defaultFamilyOperationsAdapter = createFamilyOperationsAdapter(client)`.
- Delegated all queries (agreements, calendar links, school status, packets, email options), binary agreement PDF chunk uploads, and workflow mutations through `apiClient.fetch`.
- Updated binary chunk upload headers to explicitly pass `Content-Type: application/octet-stream` alongside `x-chunk-sha256`.
- Updated test stub `ElizaClient` in `plugins/plugin-personal-assistant/test/stubs/ui.ts` to implement `fetch`.
- Added test coverage in `adapter.test.ts` verifying that `createFamilyOperationsAdapter` routes queries, binary chunk uploads, and mutations through the injected `apiClient`.

## Testing

- Added unit tests in `plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts` exercising `createFamilyOperationsAdapter` against a mock client double, validating that all paths, methods, and chunk binary upload headers pass through `apiClient.fetch`.