### PR TITLE
fix(lifeops): authenticate Family Operations in paired remote sessions

### DIFF
--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
@@ -1,18 +1,114 @@
 /** HTTP contract tests for Family Operations calendar conflict mutations. */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { client } from "@elizaos/ui/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultFamilyOperationsAdapter } from "./adapter.js";
 
+// The package aliases UI imports to an empty client. Exercise the production
+// transport here so bearer, origin and binary-body regressions remain visible.
+vi.mock("@elizaos/ui/api", async () => {
+  const { ElizaClient } = await import(
+    "../../../../../packages/ui/src/api/client-base.ts"
+  );
+  return { client: new ElizaClient() };
+});
+
+const testApiBase = "https://family-api.example";
+
+function requestPath(input: string | URL | Request): string {
+  return new URL(String(input), testApiBase).pathname;
+}
+
+beforeEach(() => {
+  client.setBaseUrl(testApiBase, { persist: false });
+  client.setToken("family-adapter-test-session");
+});
+
 afterEach(() => {
+  vi.useRealTimers();
+  client.setToken(null);
+  client.setBaseUrl(null, { persist: false });
   sessionStorage.clear();
   vi.unstubAllGlobals();
 });
 
 describe("defaultFamilyOperationsAdapter", () => {
+  it("allows provider-backed mutations to complete beyond the ordinary read timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          const timer = setTimeout(
+            () => resolve(new Response("{}", { status: 202 })),
+            11_000,
+          );
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(new DOMException("Request aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        }),
+    );
+    const result = defaultFamilyOperationsAdapter.runSchoolWorkflow().then(
+      () => "accepted",
+      (error) => error,
+    );
+    await vi.advanceTimersByTimeAsync(11_000);
+    expect(await result).toBe("accepted");
+  });
+
+  it("uses the active remote bearer for reads and returns accepted mutations once", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(String(input), "https://renderer.example");
+        if (
+          url.origin !== testApiBase ||
+          new Headers(init?.headers).get("authorization") !==
+            "Bearer family-adapter-test-session"
+        ) {
+          return new Response(JSON.stringify({ error: "Unauthorized" }), {
+            status: 401,
+          });
+        }
+        calls.push(url.pathname);
+        const payload = url.pathname.endsWith("/agreements")
+          ? { agreements: [] }
+          : url.pathname.endsWith("/calendar/links")
+            ? { links: [] }
+            : url.pathname.endsWith("/school/status")
+              ? { sourceId: "concord", config: null, lastRun: null }
+              : url.pathname.endsWith("/packets")
+                ? { packets: [], packetStates: [] }
+                : { accepted: true };
+        return new Response(JSON.stringify(payload), {
+          status: init?.method === "POST" ? 202 : 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    const snapshot = await defaultFamilyOperationsAdapter.load();
+    expect(snapshot.agreements).toEqual({ status: "ready", data: [] });
+    await defaultFamilyOperationsAdapter.runSchoolWorkflow();
+    expect(calls.filter((path) => path.endsWith("/school/run"))).toHaveLength(
+      1,
+    );
+    client.setToken(null);
+    expect((await defaultFamilyOperationsAdapter.load()).agreements).toEqual({
+      status: "unavailable",
+      message: "Unauthorized",
+    });
+  });
+
   it("loads and mutates the mounted family workflow contracts", async () => {
     const calls: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
-      const path = String(input);
+      const path = requestPath(input);
       calls.push(path);
       const payload = path.endsWith("/agreements")
         ? { agreements: [] }
@@ -54,8 +150,8 @@ describe("defaultFamilyOperationsAdapter", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-        calls.push([String(input), init]);
-        const path = String(input);
+        calls.push([requestPath(input), init]);
+        const path = requestPath(input);
         const payload =
           path === "/api/lifeops/agreement-uploads"
             ? {
@@ -109,6 +205,22 @@ describe("defaultFamilyOperationsAdapter", () => {
     });
     expect(calls[1]?.[1]?.body).toBeInstanceOf(ArrayBuffer);
     expect(calls[2]?.[1]?.body).toBeInstanceOf(ArrayBuffer);
+    for (const [, init] of calls.slice(1, 3)) {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe(
+        "Bearer family-adapter-test-session",
+      );
+      expect(headers.get("content-type")).toBe("application/octet-stream");
+      const hash = await crypto.subtle.digest(
+        "SHA-256",
+        init?.body as ArrayBuffer,
+      );
+      expect(headers.get("x-chunk-sha256")).toBe(
+        [...new Uint8Array(hash)]
+          .map((byte) => byte.toString(16).padStart(2, "0"))
+          .join(""),
+      );
+    }
     expect(JSON.parse(calls[3]?.[1]?.body as string)).toEqual({
       contentIdentity: expect.stringMatching(/^[a-f0-9]{64}$/),
     });
@@ -224,7 +336,7 @@ describe("defaultFamilyOperationsAdapter", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-        const path = String(input);
+        const path = requestPath(input);
         calls.push([path, init]);
         const payload =
           path === "/api/lifeops/agreement-uploads/upload-1"
@@ -281,7 +393,7 @@ describe("defaultFamilyOperationsAdapter", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request) => {
-        const path = String(input);
+        const path = requestPath(input);
         const payload = path.endsWith("/agreements")
           ? { agreements: [] }
           : path.endsWith("/calendar/links")
@@ -351,7 +463,9 @@ describe("defaultFamilyOperationsAdapter", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const [path, init] = fetchMock.mock.calls[0];
-    expect(path).toBe("/api/lifeops/calendar/links/link%2F1/resolve");
+    expect(requestPath(path)).toBe(
+      "/api/lifeops/calendar/links/link%2F1/resolve",
+    );
     expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
       strategy: "keep_eliza",
       expectedUpdatedAt: "2026-08-30T12:00:00.000Z",

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
@@ -1,5 +1,6 @@
 /** Production Family Operations adapter over owner-authorized local APIs. */
 
+import { client } from "@elizaos/ui/api";
 import type {
   MonthlyFamilyDraft,
   MonthlyFamilyPacket,
@@ -59,12 +60,24 @@ async function agreementContentIdentity(input: {
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(path, {
-    credentials: "include",
-    ...init,
-    headers: { "content-type": "application/json", ...init?.headers },
-  });
-  const payload = (await response.json().catch(() => null)) as {
+  const response = await client.rawRequest(
+    path,
+    {
+      ...init,
+      headers: { "content-type": "application/json", ...init?.headers },
+    },
+    {
+      allowNonOk: true,
+      // A workflow's accepted mutation is terminal for this request; polling
+      // it as agent startup could repeat the owner-authorized operation.
+      skipResume: true,
+      // PDF extraction and school discovery can include model work. Keep
+      // those mutations on the same ten-minute budget as a model-backed turn.
+      timeoutMs:
+        init?.method && init.method !== "GET" ? 10 * 60_000 : undefined,
+    },
+  );
+  const payload = (await response.json()) as {
     error?: { message?: string } | string;
   } | null;
   if (!response.ok) {


### PR DESCRIPTION
A paired remote browser could load the Family Operations bundle but every section used cookie-only fetches and displayed Unauthorized. Route those JSON and binary requests through the active ElizaClient so the selected API origin, machine-session bearer and CSRF handling apply consistently.

Accepted workflow mutations return once instead of entering the client's startup retry loop. PDF processing and school mutations receive a model-sized request budget; the live three-page PDF ingestion takes longer than the ordinary 10-second read timeout. Binary content type and chunk hashes are preserved, and malformed JSON remains an explicit failure.

Fixes #31070. Supports #30123. This is separate from the protected view-bundle loader fixed by #29953.

Current head: `88f88a2b2240eb4409c97e3f7f79b3c5eb44f671`, based on develop `6580b08cd0feb05fd296bb0886eefd0d84132266`.

Validation:

- The real paired pilot reproduced Agreement inventory HTTP 401 while Calendar, Notes and chat succeeded.
- The production ElizaClient regression reproduces Unauthorized before this change and passes after it. Ten adapter tests cover remote origin/bearer, unauthenticated denial, unchanged binary chunk bytes and hashes, one accepted mutation, resumable uploads and provider work beyond the ordinary read timeout.
- Pinned install and root `bun run verify` passed: 373/373 tasks.
- Complete personal-assistant suite: 303 files, 2,648 passed and six existing skips.
- Full app audit: 226 passed; 220 view findings have zero broken or needs-work verdicts. All four affected Family Operations viewport captures were inspected. OCR flagged 12 unrelated views for human inspection; the affected views are good.
- All five hosted checks passed on this head: source smoke35m34s, Windows8m3s, billing57s, PostgreSQL1m6s and aggregate3s.
- Linux candidate29c5a0d passed install/root verification and PA/Google/app builds. All3577 build hashes and public entry bytes match. Deployment preserved agreement inventory, monthly packet and paused calendar revision14.
- Paired public UI now loads agreement inventory and all Family Operations section APIs return200. A synthetic PDF upload completes through the browser. Approve/reject decisions and chat-pin create/remove persist; final readback has approved/rejected/proposed states and zero pins.
- Populated phone layout clipping is tracked independently in #31073; full family MVP acceptance remains open in #30123.

The existing family pilot remains based on #31032; a separate combined candidate will carry this two-file correction for real UI acceptance without changing the ongoing selected-correspondence intake work. No external message is sent by this change.

[Reviewed evidence bundle: recordings, desktop/mobile captures, deployment and API readback, package logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/bettina-family-auth-evidence-88f88a2.zip). [Live browser upload MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/bettina-auth-88f88a2-public-upload.mp4). The recording proves the upload; review decisions were checked separately through UI and persisted API readback.

Before:

![Paired agreement before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/bettina-auth-88f88a2-before-desktop.png)

After:

![Paired agreement after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/bettina-auth-88f88a2-after-desktop.png)
