### PR TITLE
fix(cloud): route Dedicated cutover through the trusted origin

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -29,6 +29,8 @@ process.env.MOCK_REDIS = "1";
 import { eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import * as realAuth from "@/lib/auth";
+import { runWithCloudBindings } from "@/lib/runtime/cloud-bindings";
+import { SandboxTransport } from "@/lib/services/eliza-sandbox/bridge/transport";
 import {
   personalSharedAgent,
   personalSharedAgentId,
@@ -187,6 +189,7 @@ const ENV = {
   SHARED_RUNTIME_CONVERSATIONS: cutoverNamespace,
   PERSONAL_DELIVERY_PROJECTIONS: personalDeliveryProjectionNamespace,
   ELIZA_CLOUD_AGENT_BASE_DOMAIN: "dedicated-cutover.test",
+  AGENT_ROUTER_ORIGIN_HOST: "router-cutover.test",
 } as unknown as AppEnv["Bindings"];
 
 let pgliteReady = true;
@@ -365,17 +368,19 @@ function quote(agentId: string) {
 }
 
 function cutover(agentId: string, dedicatedAgentId: string) {
-  return app.request(
-    `/api/v1/eliza/agents/${encodeURIComponent(agentId)}/upgrade-tier/cutover`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: "Bearer steward-test",
-        "Content-Type": "application/json",
+  return runWithCloudBindings(ENV, () =>
+    app.request(
+      `/api/v1/eliza/agents/${encodeURIComponent(agentId)}/upgrade-tier/cutover`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer steward-test",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ dedicatedAgentId }),
       },
-      body: JSON.stringify({ dedicatedAgentId }),
-    },
-    ENV,
+      ENV,
+    ),
   );
 }
 
@@ -1299,6 +1304,10 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
     });
 
     const originalFetch = globalThis.fetch;
+    const workerRuntime = spyOn(
+      SandboxTransport.prototype,
+      "isCloudflareWorkerRuntime",
+    ).mockReturnValue(true);
     const importFetch = mock(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         Response.json({ error: "not ready" }, { status: 503 }),
@@ -1622,12 +1631,15 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
         },
       });
       expect(importFetch).toHaveBeenLastCalledWith(
-        `https://${CUTOVER_TARGET}.dedicated-cutover.test/api/conversations/${encodeURIComponent(PERSONAL_C)}/import`,
+        `https://router-cutover.test/api/conversations/${encodeURIComponent(PERSONAL_C)}/import`,
         expect.objectContaining({
           method: "POST",
+          redirect: "manual",
           headers: expect.objectContaining({
             Authorization: "Bearer agent_cutover_transport",
             "X-API-Key": "agent_cutover_transport",
+            "X-Forwarded-Host": `${CUTOVER_TARGET}.dedicated-cutover.test`,
+            "X-Forwarded-Proto": "https",
           }),
         }),
       );
@@ -1816,6 +1828,15 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       cutoverCoordinatorOperations.length = 0;
       const recoveredAfterCommit = await cutover(PERSONAL_C, CUTOVER_TARGET);
       expect(recoveredAfterCommit.status).toBe(200);
+      // Initial import, activation, and committed retry must all use the
+      // origin. A public UUID-host fetch from a Worker bypasses its own proxy.
+      for (const [url, init] of importFetch.mock.calls) {
+        expect(new URL(String(url)).hostname).toBe("router-cutover.test");
+        expect(new Headers(init?.headers).get("X-Forwarded-Host")).toBe(
+          `${CUTOVER_TARGET}.dedicated-cutover.test`,
+        );
+        expect(init?.redirect).toBe("manual");
+      }
       expect(cutoverCoordinatorOperations).toEqual(["cutover-commit"]);
       const [afterCommittedRecovery] = await dbWrite
         .select()
@@ -1868,6 +1889,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
         .delete(personalAccountConvergences)
         .where(eq(personalAccountConvergences.token, convergenceToken));
       globalThis.fetch = originalFetch;
+      workerRuntime.mockRestore();
       currentUser.id = USER_A;
       currentUser.email = "owner-a@test.test";
       currentUser.organization_id = ORG_A;

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { usersRepository } from "@/db/repositories/users";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import {
   finalizePersonalTierUpgradeCutover,
   findActivePersonalDedicatedTarget,
@@ -21,6 +22,8 @@ import {
 } from "@/lib/services/agent-tier-upgrade-target";
 import { readPersonalElizaCutover } from "@/lib/services/eliza-agent-config";
 import { invalidatePersonalDeliveryProjection } from "@/lib/services/eliza-app/personal-delivery-projection-contract";
+import { SandboxTransport } from "@/lib/services/eliza-sandbox/bridge/transport";
+import type { AgentNetworkTarget } from "@/lib/services/eliza-sandbox/bridge/transport-contract";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   coordinateSharedCutoverCommit,
@@ -180,18 +183,38 @@ async function readJsonResponse(response: Response): Promise<unknown> {
 }
 
 async function postDedicatedImport(
+  target: AgentNetworkTarget,
   url: string,
   body: Record<string, unknown>,
   agentToken: string,
 ): Promise<{ response: Response; receipt: Record<string, unknown> | null }> {
-  const response = await fetch(url, {
+  // Same-zone Worker fetches bypass the public Dedicated proxy. Use the
+  // canonical origin transport for both import and post-commit activation.
+  // The explicit local harness sentinel uses the DB-owned loopback base
+  // validated by personalDedicatedAgentApiBase, including its path prefix.
+  const localHarness =
+    getCloudAwareEnv().ELIZA_CLOUD_AGENT_BASE_DOMAIN === "https://";
+  const destination = (localHarness
+    ? null
+    : new SandboxTransport().getWorkerAgentRouterFetchTarget(
+        target,
+        new URL(url).pathname,
+      )) ?? { url };
+  const response = await fetch(destination.url, {
     method: "POST",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
       Authorization: `Bearer ${agentToken}`,
       "X-API-Key": agentToken,
+      ...(destination.forwardedHost
+        ? {
+            "X-Forwarded-Host": destination.forwardedHost,
+            "X-Forwarded-Proto": "https",
+          }
+        : {}),
     },
+    redirect: "manual",
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(20_000),
   });
@@ -412,6 +435,7 @@ app.post("/", async (c) => {
             authoritative: true,
           });
           const activation = await postDedicatedImport(
+            active,
             `${activeBase}/api/conversations/${encodeURIComponent(sourceAgentId)}/import`,
             {
               messages: [],
@@ -635,6 +659,7 @@ app.post("/", async (c) => {
       }));
       for (let attempt = 0; ; attempt += 1) {
         const imported = await postDedicatedImport(
+          target,
           importUrl,
           {
             messages: importedMessages,
@@ -750,6 +775,7 @@ app.post("/", async (c) => {
         { namespace: conversationNamespace },
       );
       const activation = await postDedicatedImport(
+        target,
         importUrl,
         {
           messages: importedMessages,


### PR DESCRIPTION
Healthy Dedicated agents can fail onboarding at the final cutover with HTTP 503 / `dedicated_history_import_failed`: the Cloud Worker fetches the public UUID hostname, bypasses its own Dedicated proxy, and receives upstream TLS 525. This occurred on staging even with an empty conversation and no tasks.

Route initial import, post-commit activation and committed retry through the existing `SandboxTransport` origin resolver. Preserve the explicit local harness's validated, DB-owned loopback URL and path prefix. Keep the container's `ELIZA_API_TOKEN` as the only transport credential and disable redirects so custom auth headers cannot follow a different recipient.

## Relates to

Related to #27096 and #29024. This fixes the cutover transport blocker; it does not close their broader hosted onboarding acceptance criteria.

## Sync with develop

- Based on `dd7f61cb77b390beb48e63aa658da67314f7a3a0`, with only the route and its regression test changed.
- Frozen dependency installation completed with scripts disabled; required prompts/shared/login builds were generated before restarting verification.
- Exact PR head: `2de10e613f0bd31a8a98b3e33c2f6b6c96fe836f`.

## Risks

The destination for the internal import request changes. Tenant/target ownership checks, cutover leases, message and task digests, commit ordering, and the required runtime token remain unchanged. Missing or malformed production routing bindings fail closed. No schema, secret, DNS, deployment-policy, runtime-image, or rendered UI changes are included.

## Testing

- The route regression exercises actual Hono handlers, PGlite rows, failed import, retries, activation and committed recovery; it asserts the configured origin, correct forwarded agent host and manual redirect handling.
- The full local Worker/control-plane/PGlite test exercises one provision job, conversation history, reminder/Todo import and the committed switch. It uses the harness's explicit model substitute and is not evidence of a live LLM reply.
- Exact-head route suite: 19 passing tests, 206 assertions. Cloud API TypeScript, all 716 router mounts and the production Worker bundle dry-run passed. Full repository `bun run verify` passed with exit code 0.
- The first clean-checkout verification attempt stopped at a missing generated `@elizaos/prompts` entry in the unrelated UI design-graph test. Required prompts/shared/login builds were then generated and the complete verification passed. No source workaround or gate change was made.

Exact-head full-stack result:

```text
bun --conditions=eliza-source playwright test tests/shared-to-dedicated-upgrade.spec.ts
PASS: gates on hosting runway, copies identity server-side, and moves the conversation
1 passed (1.7m)
```

## Evidence Gate

<!-- evidence-head:2de10e613f0bd31a8a98b3e33c2f6b6c96fe836f -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend transport only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend transport only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend transport only; the exercised integration boundary is HTTP and persisted cutover state.
<!-- evidence-row:frontend-logs -->
- [x] Browser network reproduction: the authenticated cutover POST returned 503 with code `dedicated_history_import_failed` while its Dedicated target was running.

```text
Observed method: POST /api/v1/eliza/agents/<owned-personal-id>/upgrade-tier/cutover
HTTP status: 503
Response code: dedicated_history_import_failed
Dedicated target status in the staging database: running
```
<!-- evidence-row:backend-logs -->
- [x] Staging Worker tail reproduction: import attempt 1, upstream status 525, messageCount 0, scheduledTaskCount 0, todoCount 0. No credentials or user content are included here.

```text
Operator-filtered staging Worker tail fields:
code=dedicated_history_import_failed
importAttempt=1; upstreamStatus=525
messageCount=0; scheduledTaskCount=0; todoCount=0
```
<!-- evidence-row:llm-trajectory -->
- [x] N/A - HTTP import transport only; no model, provider, prompt or agent action change.
<!-- evidence-row:domain-artifacts -->
- [x] The owning integration assertions inspect the target/active binding, preserved canonical conversation, task import receipts and repeated committed recovery. Exact-head command results follow below.

```text
bun test __tests__/eliza-agents-upgrade-tier.test.ts
19 pass, 0 fail, 206 expect() calls
PASS: a personal cutover activates only after the authoritative history import succeeds
Assertions include the persisted cutover state and post-commit retry, using actual PGlite rows.
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Real LLM-call trajectory

N/A - this patch changes HTTP routing for import/activation, not an agent model, prompt, provider or action. Live Dedicated chat remains a separate staging acceptance check after release.

## Audio / voice walkthrough

N/A - no voice or audio changes.

## Documentation changes

No public documentation changes are required.

## Known gaps / failures

Hosted success is not yet claimed. Staging still serves `e14071f00998f4d10f937015e3060196b991ad4d`. The observed upstream TLS error and local integration results are distinct from a deployed fix.

## Maintainer CI exception record

N/A - no exception requested for this draft.

## Deploy notes

Use the canonical staging release workflow, preserving its source, migration, environment and concurrency guards. No database migration is added by this patch.
