### PR TITLE
fix(lifeops): fit populated family controls on phones

### DIFF
--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
@@ -462,7 +462,8 @@ function AgreementPanel({
         <div
           style={{
             display: "grid",
-            gridTemplateColumns: "minmax(110px, 0.4fr) minmax(180px, 1fr) auto",
+            gridTemplateColumns:
+              "repeat(auto-fit, minmax(min(100%, 180px), 1fr))",
             gap: 8,
           }}
         >
@@ -1253,7 +1254,13 @@ export function FamilyOperationsView({
       }}
     >
       <div
-        style={{ maxWidth: 1040, margin: "0 auto", display: "grid", gap: 18 }}
+        style={{
+          maxWidth: 1040,
+          margin: "0 auto",
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr)",
+          gap: 18,
+        }}
       >
         <header>
           <p

--- a/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
+++ b/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
@@ -1,4 +1,4 @@
-/** Synthetic browser state for editing monthly email; no method can call a live provider. */
+/** Synthetic agreement and monthly-email browser state; no method can call a live provider. */
 import type {
   FamilyOperationsAdapter,
   FamilyOperationsSnapshot,
@@ -32,7 +32,33 @@ export function createFamilyPacketFixture(
   return {
     async load(): Promise<FamilyOperationsSnapshot> {
       return {
-        agreements: { status: "ready", data: [] },
+        agreements: {
+          status: "ready",
+          data: [
+            {
+              artifact: {
+                id: "fixture-agreement",
+                agentId: "fixture-agent",
+                householdId: "default",
+                agreementKey: "synthetic-plan",
+                version: 1,
+                supersedesArtifactId: null,
+                title: "Synthetic parenting plan",
+                originalFilename: "synthetic-plan.pdf",
+                documentId: "fixture-document",
+                mediaUrl: "/api/media/fixture.pdf",
+                mediaFileName: "fixture.pdf",
+                contentSha256: "a".repeat(64),
+                mimeType: "application/pdf",
+                byteSize: 2048,
+                pageCount: 3,
+                uploadedByEntityId: "self",
+                createdAt: "2026-09-20T12:00:00Z",
+              },
+              obligations: [],
+            },
+          ],
+        },
         calendarLinks: { status: "ready", data: [] },
         school: {
           status: "unavailable",
@@ -84,7 +110,9 @@ export function createFamilyPacketFixture(
     },
     uploadAgreement: unsupported,
     decideObligation: unsupported,
-    listPins: unsupported,
+    async listPins() {
+      return [];
+    },
     pin: unsupported,
     unpin: unsupported,
     previewGrant: unsupported,

--- a/plugins/plugin-personal-assistant/test/browser-e2e/run-lifeops-connections-e2e.mjs
+++ b/plugins/plugin-personal-assistant/test/browser-e2e/run-lifeops-connections-e2e.mjs
@@ -597,6 +597,36 @@ try {
     const familyErrors = [];
     family.on("pageerror", (error) => familyErrors.push(String(error)));
     await family.goto(`${baseURL}?scenario=family-packet`);
+    const pinTarget = family.getByRole("textbox", { name: "Pin target ID" });
+    await pinTarget.fill("fixture-acceptance-chat");
+    await pinTarget.scrollIntoViewIfNeeded();
+    const clipped = await family.evaluate(() =>
+      [...document.querySelectorAll("main section, main button, main input")]
+        .filter((element) => {
+          const rect = element.getBoundingClientRect();
+          return (
+            rect.width > 0 &&
+            (rect.left < -1 || rect.right > window.innerWidth + 1)
+          );
+        })
+        .map(
+          (element) => element.getAttribute("aria-label") || element.tagName,
+        ),
+    );
+    assert(
+      clipped.length === 0,
+      `${width}px populated agreement keeps cards and controls within the viewport: ${clipped.join(", ")}`,
+    );
+    assert(
+      await family
+        .getByRole("button", { name: "Pin", exact: true })
+        .isEnabled(),
+      `${width}px pin form accepts a target without requiring horizontal scrolling`,
+    );
+    await family.screenshot({
+      path: join(outputDir, `family-agreement-${width}.png`),
+      animations: "disabled",
+    });
     await family
       .getByRole("button", { name: "Monthly packet", exact: true })
       .click();


### PR DESCRIPTION
Opening an uploaded agreement on a 390px phone made the fixed-width Pins row expand every card and clip navigation controls at 407px. Make the pin controls wrap to the available width and keep the parent grid's track within the page.

The browser fixture now includes an agreement, so the pin row is exercised. The regression measures real card/control geometry and fills the pin target. It fails on the old layout at 390px and passes at 390px and1180px with this change. Desktop and phone captures were inspected; the page has no uncaught JavaScript errors.

Fixes #31073. Supports #30123.

Validation on `fd2c78db7a90dc32a70f7d1d3d1ab9261007e00e`:

- Pinned install and root verification:373/373 tasks passed.
- Full real-browser connections/family harness passed after the fix; the prior layout fails only the populated390px boundary check.
- Complete personal-assistant suite:303 files,2648 tests passed, six existing skips.
- Full app audit:226 passed; all four affected Family Operations captures inspected. Standalone populated desktop/phone captures were also inspected.
- All five hosted checks passed for this head. Deployed populated-phone verification remains pending because VPS SSH is timing out before authentication. The running pilot has not been replaced.

This is a responsive layout correction. Synthetic fixtures stand in for provider data; the actual view and shared controls render in Chromium.

[Before/after captures and browser regression logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/bettina-mobile-evidence-fd2c78d.zip). The after captures use the production component with synthetic provider data; public deployment is still pending.
