### PR TITLE
registry: add @orkid-labs/plugin-orkid

### DIFF
--- a/packages/registry/entries/third-party/orkid-labs__plugin-orkid.json
+++ b/packages/registry/entries/third-party/orkid-labs__plugin-orkid.json
@@ -1,10 +1,10 @@
 {
   "package": "@orkid-labs/plugin-orkid",
-  "repository": "github:jjcav84/plugin-orkid",
+  "repository": "github:orkid-labs/plugin-orkid",
   "kind": "plugin",
   "description": "Orkid gasless swap engine integration — quote, execute, dry-run, confirm, and track swaps via @orkid-labs/sdk",
-  "homepage": "https://github.com/jjcav84/plugin-orkid",
-  "version": "2.0.2",
+  "homepage": "https://github.com/orkid-labs/plugin-orkid",
+  "version": "2.0.3",
   "tags": [
     "orkid",
     "swap",

--- a/packages/registry/entries/third-party/orkid-labs__plugin-orkid.json
+++ b/packages/registry/entries/third-party/orkid-labs__plugin-orkid.json
@@ -4,6 +4,14 @@
   "kind": "plugin",
   "description": "Orkid gasless swap engine integration — quote, execute, dry-run, confirm, and track swaps via @orkid-labs/sdk",
   "homepage": "https://github.com/jjcav84/plugin-orkid",
-  "version": "2.0.1",
-  "tags": ["orkid", "swap", "defi", "base", "ethereum", "arbitrum", "polygon"]
+  "version": "2.0.2",
+  "tags": [
+    "orkid",
+    "swap",
+    "defi",
+    "base",
+    "ethereum",
+    "arbitrum",
+    "polygon"
+  ]
 }

--- a/packages/registry/entries/third-party/orkid-labs__plugin-orkid.json
+++ b/packages/registry/entries/third-party/orkid-labs__plugin-orkid.json
@@ -1,0 +1,9 @@
+{
+  "package": "@orkid-labs/plugin-orkid",
+  "repository": "github:jjcav84/plugin-orkid",
+  "kind": "plugin",
+  "description": "Orkid gasless swap engine integration — quote, execute, dry-run, confirm, and track swaps via @orkid-labs/sdk",
+  "homepage": "https://github.com/jjcav84/plugin-orkid",
+  "version": "2.0.1",
+  "tags": ["orkid", "swap", "defi", "base", "ethereum", "arbitrum", "polygon"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -431,7 +431,7 @@
         "repo": "@orkid-labs/plugin-orkid",
         "v0": null,
         "v1": null,
-        "v2": "2.0.1"
+        "v2": "2.0.2"
       },
       "supports": {
         "v0": false,

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -416,7 +416,7 @@
     },
     "@orkid-labs/plugin-orkid": {
       "git": {
-        "repo": "jjcav84/plugin-orkid",
+        "repo": "orkid-labs/plugin-orkid",
         "v0": {
           "branch": null
         },
@@ -431,7 +431,7 @@
         "repo": "@orkid-labs/plugin-orkid",
         "v0": null,
         "v1": null,
-        "v2": "2.0.2"
+        "v2": "2.0.3"
       },
       "supports": {
         "v0": false,
@@ -439,7 +439,7 @@
         "v2": true
       },
       "description": "Orkid gasless swap engine integration — quote, execute, dry-run, confirm, and track swaps via @orkid-labs/sdk",
-      "homepage": "https://github.com/jjcav84/plugin-orkid",
+      "homepage": "https://github.com/orkid-labs/plugin-orkid",
       "topics": [
         "orkid",
         "swap",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -414,6 +414,53 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@orkid-labs/plugin-orkid": {
+      "git": {
+        "repo": "jjcav84/plugin-orkid",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@orkid-labs/plugin-orkid",
+        "v0": null,
+        "v1": null,
+        "v2": "2.0.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Orkid gasless swap engine integration — quote, execute, dry-run, confirm, and track swaps via @orkid-labs/sdk",
+      "homepage": "https://github.com/jjcav84/plugin-orkid",
+      "topics": [
+        "orkid",
+        "swap",
+        "defi",
+        "base",
+        "ethereum",
+        "arbitrum",
+        "polygon"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@rati-osf/plugin-ruby-high": {
       "git": {
         "repo": "cenetex/plugin-ruby-high",


### PR DESCRIPTION
## Summary

Adds a third-party registry entry for [`@orkid-labs/plugin-orkid`](https://www.npmjs.com/package/@orkid-labs/plugin-orkid) — ElizaOS plugin for the Orkid gasless swap engine.

- **npm:** `@orkid-labs/plugin-orkid@2.0.3` (published)
- **Source:** [orkid-labs/plugin-orkid](https://github.com/orkid-labs/plugin-orkid)
- **Actions:** `ORKID_GET_QUOTE`, `ORKID_EXECUTE_SWAP`, `ORKID_DRY_RUN_SWAP`, `ORKID_CONFIRM_TX`, `ORKID_LIST_TOKENS`, `ORKID_GET_USAGE`
- **Chains:** Base, Ethereum, Arbitrum, Polygon
- Deterministic explicit-command path (`/quote`, `/dryrun`, `/swap`) with action-verified canonical responses

## Files

- `packages/registry/entries/third-party/orkid-labs__plugin-orkid.json` — new entry
- `packages/registry/generated-registry.json` — regenerated via `bun run --cwd packages/registry generate`

## Validation

- `bun run --cwd packages/registry validate` — all entries pass
- `bun run --cwd packages/registry test` — 58/58 tests pass