### PR TITLE
registry: add @orkid-labs/plugin-mempalace

### DIFF
--- a/packages/registry/entries/third-party/orkid-labs__plugin-mempalace.json
+++ b/packages/registry/entries/third-party/orkid-labs__plugin-mempalace.json
@@ -1,0 +1,15 @@
+{
+  "package": "@orkid-labs/plugin-mempalace",
+  "repository": "github:orkid-labs/plugin-mempalace",
+  "kind": "plugin",
+  "description": "Persistent agent memory via MemPalace MCP — store, search, and recall context across sessions. Supports stdio and HTTP/SSE transports.",
+  "homepage": "https://github.com/orkid-labs/plugin-mempalace",
+  "version": "2.0.0",
+  "tags": [
+    "mempalace",
+    "memory",
+    "mcp",
+    "persistent",
+    "context"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -414,6 +414,51 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@orkid-labs/plugin-mempalace": {
+      "git": {
+        "repo": "orkid-labs/plugin-mempalace",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@orkid-labs/plugin-mempalace",
+        "v0": null,
+        "v1": null,
+        "v2": "2.0.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Persistent agent memory via MemPalace MCP — store, search, and recall context across sessions. Supports stdio and HTTP/SSE transports.",
+      "homepage": "https://github.com/orkid-labs/plugin-mempalace",
+      "topics": [
+        "mempalace",
+        "memory",
+        "mcp",
+        "persistent",
+        "context"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@rati-osf/plugin-ruby-high": {
       "git": {
         "repo": "cenetex/plugin-ruby-high",


### PR DESCRIPTION
## Summary

Adds a third-party registry entry for [`@orkid-labs/plugin-mempalace`](https://www.npmjs.com/package/@orkid-labs/plugin-mempalace) — ElizaOS plugin for persistent agent memory via MemPalace MCP (store/search/recall context across sessions, stdio + HTTP/SSE transports).

- **npm:** `@orkid-labs/plugin-mempalace@2.0.0` (published)
- **Source:** [orkid-labs/plugin-mempalace](https://github.com/orkid-labs/plugin-mempalace)
- **Actions:** `STORE_PALACE_MEMORY`, `RECALL_PALACE_MEMORY`, `CALL_MEMPALACE_TOOL`
- **Provider:** `MEMPALACE_CONTEXT` — auto-injects relevant memories into context

## Files

- `packages/registry/entries/third-party/orkid-labs__plugin-mempalace.json` — new entry
- `packages/registry/generated-registry.json` — regenerated via `bun run --cwd packages/registry generate`

## Validation

- `bun run --cwd packages/registry validate` — all entries pass
- `bun run --cwd packages/registry test` — 58/58 tests pass