### PR TITLE
fix(cloud): retain live credentials during provisioning retries

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/provision.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/provision.ts
@@ -305,12 +305,15 @@ export class SandboxProvision {
     const isWarmPoolProvision =
       rec.organization_id === WARM_POOL_ORG_ID && rec.pool_status === "unclaimed";
     const containerLaunch = resolveSandboxContainerLaunchConfig(rec.agent_config);
+    const provisioningRetryHandle =
+      previousStatus === "provisioning" ? this.buildProvisioningRetryHandle(rec) : null;
 
     // Every claimed row carries the exact managed key owned by its durable
     // handoff fence. Generic environment preparation revokes that key before
-    // writing the replacement, so it is reserved for cold-created rows; warm
-    // claims reuse their persisted environment through restart and attestation.
-    if (!rec.claimed_at) {
+    // writing the replacement. A retained provisioning container also needs its
+    // original environment: re-probing it cannot install a replacement key.
+    // Only a new cold container may rotate credentials here.
+    if (!rec.claimed_at && !provisioningRetryHandle) {
       const managedEnvironment = await prepareManagedElizaEnvironment({
         existingEnv: (rec.environment_vars as Record<string, string>) ?? {},
         organizationId: rec.organization_id,
@@ -386,10 +389,7 @@ export class SandboxProvision {
       let healthContext: SandboxHealthContext = { kind: "candidate" };
 
       try {
-        const retryHandle =
-          attempt === 1 && previousStatus === "provisioning"
-            ? this.buildProvisioningRetryHandle(rec)
-            : null;
+        const retryHandle = attempt === 1 ? provisioningRetryHandle : null;
         if (retryHandle) {
           handle = retryHandle;
           healthContext = { kind: "canonical" };

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/provision-retry.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/provision-retry.test.ts
@@ -1678,6 +1678,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       bridge_port: 3333,
       web_ui_port: 4444,
       headscale_ip: "100.64.0.42",
+      environment_vars: {
+        ELIZAOS_CLOUD_API_KEY: "eliza_live_container_key",
+        ELIZA_API_TOKEN: "agent_live_container_token",
+      },
     };
     const finalRow: AgentSandbox = { ...row, status: "running" };
     const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
@@ -1720,6 +1724,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(res.success).toBe(true);
       expect(create).not.toHaveBeenCalled();
       expect(stop).not.toHaveBeenCalled();
+      expect(apiKeySpy).not.toHaveBeenCalled();
+      expect(updateSpy.mock.calls.some(([, data]) => data.environment_vars !== undefined)).toBe(
+        false,
+      );
       expect(healthInputs).toEqual([{ sandboxId: "sandbox-blue-1" }]);
       const runningWrite = updateSpy.mock.calls.find(
         ([, data]) => (data as { status?: string }).status === "running",


### PR DESCRIPTION
A Dedicated provisioning retry can adopt an existing healthy container after an unresolved network probe. The retry previously rotated the inference key first, leaving that container running with a revoked key and every model request failing authentication.

Resolve the retained container handle before environment preparation and preserve its credentials when re-probing it. New cold containers still receive a fresh key. Warm-claim credential handling is unchanged.

Validation: the retained-container regression fails before this change; 42 provisioning tests and 342 assertions pass afterward. The complete `bun run verify` gate passed on the final two-file tree. Live staging reproduced the credential mismatch; the matching narrow fix is applied to the staging provisioner while recovery and app UI acceptance continue.
