### PR TITLE
fix(dedicated): preserve provisioned credentials after restore and repair hosted recovery

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -842,6 +842,29 @@ describe("unsigned Cloud inference fallback (#20045)", () => {
 });
 
 describe("provisioned cloud container topology (#9887)", () => {
+  it("keeps managed launch credentials when restoring an older Cloud config", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "current-managed-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "revoked-snapshot-key",
+        baseUrl: "https://api-staging.elizacloud.ai/api/v1",
+        agentId: "agent-test",
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(config.cloud?.apiKey).toBe("current-managed-key");
+    expect(config.cloud?.baseUrl).toBe("https://api-staging.eliza.app/api/v1");
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("current-managed-key");
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
+  });
+
   it("repairs a cloud-provisioned config that lost canonical routing fields", () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     process.env.ELIZAOS_CLOUD_SMALL_MODEL = "small-test";

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1213,7 +1213,10 @@ export function ensureProvisionedCloudContainerConfig(
     return false;
   }
 
+  // Managed launch credentials belong to the control plane. A restored config
+  // can contain a key that was revoked when this container was provisioned.
   const apiKey =
+    trimCloudCredential(env.ELIZAOS_CLOUD_API_KEY) ??
     trimCloudCredential(config.cloud?.apiKey) ??
     readEffectiveCloudCredential(config, "ELIZAOS_CLOUD_API_KEY", env);
   if (!apiKey) {
@@ -1223,6 +1226,7 @@ export function ensureProvisionedCloudContainerConfig(
   let changed = false;
   const cloud = config.cloud ?? {};
   const baseUrl =
+    trimEnvString(env.ELIZAOS_CLOUD_BASE_URL) ??
     trimEnvString(config.cloud?.baseUrl) ??
     readEffectiveEnvValue(config, "ELIZAOS_CLOUD_BASE_URL", env);
   const agentId =

--- a/packages/ui/src/components/auth/CloudPairRelay.tsx
+++ b/packages/ui/src/components/auth/CloudPairRelay.tsx
@@ -298,6 +298,14 @@ export function resolveCloudHostedAgentUrl(
   const classified = classifyElizaHostname(hostname);
   const environment = classified.environment ?? "production";
   const base = ELIZA_DOMAIN_CONTRACTS[environment].cloudAppOrigin;
+  // The app's agent-auth gate also covers dashboard URLs. Re-enter the join
+  // flow so an expired agent session can sign in and pair again.
+  if (
+    classified.role === "cloud-app" ||
+    classified.role === "legacy-cloud-app"
+  ) {
+    return `${base}/join`;
+  }
   const agentId = classified.agentId ?? "";
   const agentPath =
     agentId &&

--- a/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
@@ -407,7 +407,13 @@ describe("CloudPairRelay", () => {
       resolveCloudHostedAgentUrl({
         hostname: "app-staging.elizacloud.ai",
       }),
-    ).toBe("https://cloud-staging.eliza.app/cloud/agents");
+    ).toBe("https://cloud-staging.eliza.app/join");
+    expect(
+      resolveCloudHostedAgentUrl({ hostname: "cloud-staging.eliza.app" }),
+    ).toBe("https://cloud-staging.eliza.app/join");
+    expect(resolveCloudHostedAgentUrl({ hostname: "cloud.eliza.app" })).toBe(
+      "https://cloud.eliza.app/join",
+    );
   });
 });
 


### PR DESCRIPTION
Restoring a Dedicated agent could let the snapshot's retired Cloud key and URL override its newly provisioned credentials, leaving chat unable to authenticate. Managed containers now prefer explicitly injected Cloud credentials and URL, while retaining saved-config fallbacks when no values are injected.

The hosted recovery screen also sends Cloud app users to `/join`; its old `/cloud/agents` link passed through the same expired-agent gate and repeated the recovery screen.

Validation: full `bun run verify` passed; 61 runtime Cloud-config tests passed, including a regression that failed before this fix; 20 auth relay/gate tests passed; scoped formatting passed. The existing staging agent was recovered with its history intact and returned a real answer in the ordinary local app. The immutable agent image build is running separately; this PR alone is not a deployment receipt.
