### PR TITLE
Promote Dedicated credential and hosted recovery fixes to staging

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -842,6 +842,29 @@ describe("unsigned Cloud inference fallback (#20045)", () => {
 });
 
 describe("provisioned cloud container topology (#9887)", () => {
+  it("keeps managed launch credentials when restoring an older Cloud config", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "current-managed-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api-staging.eliza.app/api/v1";
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "revoked-snapshot-key",
+        baseUrl: "https://api-staging.elizacloud.ai/api/v1",
+        agentId: "agent-test",
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(config.cloud?.apiKey).toBe("current-managed-key");
+    expect(config.cloud?.baseUrl).toBe("https://api-staging.eliza.app/api/v1");
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("current-managed-key");
+    expect(process.env.ELIZAOS_CLOUD_BASE_URL).toBe(
+      "https://api-staging.eliza.app/api/v1",
+    );
+  });
+
   it("repairs a cloud-provisioned config that lost canonical routing fields", () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     process.env.ELIZAOS_CLOUD_SMALL_MODEL = "small-test";

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1213,7 +1213,10 @@ export function ensureProvisionedCloudContainerConfig(
     return false;
   }
 
+  // Managed launch credentials belong to the control plane. A restored config
+  // can contain a key that was revoked when this container was provisioned.
   const apiKey =
+    trimCloudCredential(env.ELIZAOS_CLOUD_API_KEY) ??
     trimCloudCredential(config.cloud?.apiKey) ??
     readEffectiveCloudCredential(config, "ELIZAOS_CLOUD_API_KEY", env);
   if (!apiKey) {
@@ -1223,6 +1226,7 @@ export function ensureProvisionedCloudContainerConfig(
   let changed = false;
   const cloud = config.cloud ?? {};
   const baseUrl =
+    trimEnvString(env.ELIZAOS_CLOUD_BASE_URL) ??
     trimEnvString(config.cloud?.baseUrl) ??
     readEffectiveEnvValue(config, "ELIZAOS_CLOUD_BASE_URL", env);
   const agentId =

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/provision.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/lifecycle/provision.ts
@@ -305,12 +305,15 @@ export class SandboxProvision {
     const isWarmPoolProvision =
       rec.organization_id === WARM_POOL_ORG_ID && rec.pool_status === "unclaimed";
     const containerLaunch = resolveSandboxContainerLaunchConfig(rec.agent_config);
+    const provisioningRetryHandle =
+      previousStatus === "provisioning" ? this.buildProvisioningRetryHandle(rec) : null;
 
     // Every claimed row carries the exact managed key owned by its durable
     // handoff fence. Generic environment preparation revokes that key before
-    // writing the replacement, so it is reserved for cold-created rows; warm
-    // claims reuse their persisted environment through restart and attestation.
-    if (!rec.claimed_at) {
+    // writing the replacement. A retained provisioning container also needs its
+    // original environment: re-probing it cannot install a replacement key.
+    // Only a new cold container may rotate credentials here.
+    if (!rec.claimed_at && !provisioningRetryHandle) {
       const managedEnvironment = await prepareManagedElizaEnvironment({
         existingEnv: (rec.environment_vars as Record<string, string>) ?? {},
         organizationId: rec.organization_id,
@@ -386,10 +389,7 @@ export class SandboxProvision {
       let healthContext: SandboxHealthContext = { kind: "candidate" };
 
       try {
-        const retryHandle =
-          attempt === 1 && previousStatus === "provisioning"
-            ? this.buildProvisioningRetryHandle(rec)
-            : null;
+        const retryHandle = attempt === 1 ? provisioningRetryHandle : null;
         if (retryHandle) {
           handle = retryHandle;
           healthContext = { kind: "canonical" };

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/provision-retry.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/provision-retry.test.ts
@@ -1678,6 +1678,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       bridge_port: 3333,
       web_ui_port: 4444,
       headscale_ip: "100.64.0.42",
+      environment_vars: {
+        ELIZAOS_CLOUD_API_KEY: "eliza_live_container_key",
+        ELIZA_API_TOKEN: "agent_live_container_token",
+      },
     };
     const finalRow: AgentSandbox = { ...row, status: "running" };
     const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
@@ -1720,6 +1724,10 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(res.success).toBe(true);
       expect(create).not.toHaveBeenCalled();
       expect(stop).not.toHaveBeenCalled();
+      expect(apiKeySpy).not.toHaveBeenCalled();
+      expect(updateSpy.mock.calls.some(([, data]) => data.environment_vars !== undefined)).toBe(
+        false,
+      );
       expect(healthInputs).toEqual([{ sandboxId: "sandbox-blue-1" }]);
       const runningWrite = updateSpy.mock.calls.find(
         ([, data]) => (data as { status?: string }).status === "running",

--- a/packages/ui/src/components/auth/CloudPairRelay.tsx
+++ b/packages/ui/src/components/auth/CloudPairRelay.tsx
@@ -298,6 +298,14 @@ export function resolveCloudHostedAgentUrl(
   const classified = classifyElizaHostname(hostname);
   const environment = classified.environment ?? "production";
   const base = ELIZA_DOMAIN_CONTRACTS[environment].cloudAppOrigin;
+  // The app's agent-auth gate also covers dashboard URLs. Re-enter the join
+  // flow so an expired agent session can sign in and pair again.
+  if (
+    classified.role === "cloud-app" ||
+    classified.role === "legacy-cloud-app"
+  ) {
+    return `${base}/join`;
+  }
   const agentId = classified.agentId ?? "";
   const agentPath =
     agentId &&

--- a/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
@@ -407,7 +407,13 @@ describe("CloudPairRelay", () => {
       resolveCloudHostedAgentUrl({
         hostname: "app-staging.elizacloud.ai",
       }),
-    ).toBe("https://cloud-staging.eliza.app/cloud/agents");
+    ).toBe("https://cloud-staging.eliza.app/join");
+    expect(
+      resolveCloudHostedAgentUrl({ hostname: "cloud-staging.eliza.app" }),
+    ).toBe("https://cloud-staging.eliza.app/join");
+    expect(resolveCloudHostedAgentUrl({ hostname: "cloud.eliza.app" })).toBe(
+      "https://cloud.eliza.app/join",
+    );
   });
 });
 

--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
@@ -462,7 +462,8 @@ function AgreementPanel({
         <div
           style={{
             display: "grid",
-            gridTemplateColumns: "minmax(110px, 0.4fr) minmax(180px, 1fr) auto",
+            gridTemplateColumns:
+              "repeat(auto-fit, minmax(min(100%, 180px), 1fr))",
             gap: 8,
           }}
         >
@@ -1253,7 +1254,13 @@ export function FamilyOperationsView({
       }}
     >
       <div
-        style={{ maxWidth: 1040, margin: "0 auto", display: "grid", gap: 18 }}
+        style={{
+          maxWidth: 1040,
+          margin: "0 auto",
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr)",
+          gap: 18,
+        }}
       >
         <header>
           <p

--- a/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
+++ b/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
@@ -1,4 +1,4 @@
-/** Synthetic browser state for editing monthly email; no method can call a live provider. */
+/** Synthetic agreement and monthly-email browser state; no method can call a live provider. */
 import type {
   FamilyOperationsAdapter,
   FamilyOperationsSnapshot,
@@ -32,7 +32,33 @@ export function createFamilyPacketFixture(
   return {
     async load(): Promise<FamilyOperationsSnapshot> {
       return {
-        agreements: { status: "ready", data: [] },
+        agreements: {
+          status: "ready",
+          data: [
+            {
+              artifact: {
+                id: "fixture-agreement",
+                agentId: "fixture-agent",
+                householdId: "default",
+                agreementKey: "synthetic-plan",
+                version: 1,
+                supersedesArtifactId: null,
+                title: "Synthetic parenting plan",
+                originalFilename: "synthetic-plan.pdf",
+                documentId: "fixture-document",
+                mediaUrl: "/api/media/fixture.pdf",
+                mediaFileName: "fixture.pdf",
+                contentSha256: "a".repeat(64),
+                mimeType: "application/pdf",
+                byteSize: 2048,
+                pageCount: 3,
+                uploadedByEntityId: "self",
+                createdAt: "2026-09-20T12:00:00Z",
+              },
+              obligations: [],
+            },
+          ],
+        },
         calendarLinks: { status: "ready", data: [] },
         school: {
           status: "unavailable",
@@ -84,7 +110,9 @@ export function createFamilyPacketFixture(
     },
     uploadAgreement: unsupported,
     decideObligation: unsupported,
-    listPins: unsupported,
+    async listPins() {
+      return [];
+    },
     pin: unsupported,
     unpin: unsupported,
     previewGrant: unsupported,

--- a/plugins/plugin-personal-assistant/test/browser-e2e/run-lifeops-connections-e2e.mjs
+++ b/plugins/plugin-personal-assistant/test/browser-e2e/run-lifeops-connections-e2e.mjs
@@ -597,6 +597,36 @@ try {
     const familyErrors = [];
     family.on("pageerror", (error) => familyErrors.push(String(error)));
     await family.goto(`${baseURL}?scenario=family-packet`);
+    const pinTarget = family.getByRole("textbox", { name: "Pin target ID" });
+    await pinTarget.fill("fixture-acceptance-chat");
+    await pinTarget.scrollIntoViewIfNeeded();
+    const clipped = await family.evaluate(() =>
+      [...document.querySelectorAll("main section, main button, main input")]
+        .filter((element) => {
+          const rect = element.getBoundingClientRect();
+          return (
+            rect.width > 0 &&
+            (rect.left < -1 || rect.right > window.innerWidth + 1)
+          );
+        })
+        .map(
+          (element) => element.getAttribute("aria-label") || element.tagName,
+        ),
+    );
+    assert(
+      clipped.length === 0,
+      `${width}px populated agreement keeps cards and controls within the viewport: ${clipped.join(", ")}`,
+    );
+    assert(
+      await family
+        .getByRole("button", { name: "Pin", exact: true })
+        .isEnabled(),
+      `${width}px pin form accepts a target without requiring horizontal scrolling`,
+    );
+    await family.screenshot({
+      path: join(outputDir, `family-agreement-${width}.png`),
+      animations: "disabled",
+    });
     await family
       .getByRole("button", { name: "Monthly packet", exact: true })
       .click();


### PR DESCRIPTION
Promote the Dedicated recovery fixes to staging so restored agents retain the current provisioned Cloud credentials, provisioning retries keep the existing container's valid key, and hosted recovery can reach sign-in through `/join`.

Includes #31081 and #31082. The runtime and provisioning regressions each failed before their fixes; 42 provisioning tests, 61 runtime configuration tests, and 20 auth relay/gate tests passed. Full verification passed for both source changes. The recovered staging agent has returned real model replies in the ordinary local app with its original history intact.

The owner authorized routine CI wait bypass to complete staging verification. Canonical migration, source, release, and image-boot gates remain intact. Production is not part of this promotion; hosted/mobile acceptance and the new image rollout remain in progress.
