### PR TITLE
Promote fresh-account sign-in completion fixes to staging

### DIFF
--- a/packages/cloud/shared/src/lib/services/steward-tenant-config.ts
+++ b/packages/cloud/shared/src/lib/services/steward-tenant-config.ts
@@ -122,6 +122,7 @@ export async function ensureStewardTenant(
       "X-Steward-Platform-Key": platformKey,
     },
     body: JSON.stringify({ id: tenantId, name: tenantName }),
+    signal: AbortSignal.timeout(10_000),
   });
 
   // A 409 ("already exists") is a recovery path that only needs the STATUS,

--- a/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-eager-tenant.test.ts
@@ -310,6 +310,38 @@ describe("syncUserFromSteward — eager Steward tenant provisioning (#14645)", (
     expect(result).toMatchObject({ id: "user-existing-1" });
   });
 
+  test("Worker sign-in returns while a missing tenant is repaired, and records a late failure", async () => {
+    getByStewardIdImpl = async () => existingUser;
+    const tenant = deferred<void>();
+    ensureStewardTenantImpl = async (organizationId) => {
+      ensureStewardTenantCalls.push(organizationId);
+      await tenant.promise;
+      throw new Error("Steward tenant request timed out");
+    };
+    const background: Promise<unknown>[] = [];
+    const { syncUserFromSteward } = await import("./steward-sync");
+    const signIn = syncUserFromSteward({
+      ...baseParams,
+      executionCtx: { waitUntil: (promise) => background.push(promise) },
+    });
+    try {
+      const result = await Promise.race([
+        signIn,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 100)),
+      ]);
+      expect(result).toMatchObject({ id: "user-existing-1" });
+      expect(ensureStewardTenantCalls).toEqual(["org-existing-1"]);
+      expect(background).toHaveLength(1);
+    } finally {
+      tenant.resolve();
+      await signIn;
+      await Promise.all(background);
+    }
+    expect(
+      loggerWarnCalls.some((call) => call.message.includes("Steward tenant request timed out")),
+    ).toBe(true);
+  });
+
   test("FAIL-OPEN: existing-user sign-in still succeeds when the tenant heal rejects", async () => {
     getByStewardIdImpl = async () => existingUser;
     ensureStewardTenantImpl = async (organizationId) => {

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -890,18 +890,23 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     // #14869's eager new-signup provisioning. `ensureStewardTenant` reads the
     // org first and returns immediately when a tenant already exists, so the
     // healthy-org cost is one indexed read while existing NULL-tenant orgs get
-    // repaired opportunistically without a bulk backfill.
+    // repaired opportunistically without a bulk backfill. On Workers, keep
+    // that repair owned by waitUntil so a stalled tenant endpoint cannot hold
+    // an already-authenticated user's session exchange open.
     if (user.organization_id && !claimedTelegramUser) {
-      try {
-        await ensureStewardTenant(user.organization_id);
-      } catch (error) {
-        // error-policy:J4 tenant provisioning is an opportunistic repair, not
-        // an auth precondition; keep sign-in fail-open and leave an observable
-        // warning so Steward outages do not block returning users.
-        logger.warn(
-          `[StewardSync] Sign-in tenant self-heal failed for org ${user.organization_id}; sign-in proceeds and the next attempt retries: ${describeSyncError(error)}`,
-        );
-      }
+      const organizationId = user.organization_id;
+      await settleOffResponsePath(params.executionCtx, async () => {
+        try {
+          await ensureStewardTenant(organizationId);
+        } catch (error) {
+          // error-policy:J4 tenant provisioning is an opportunistic repair, not
+          // an auth precondition; retain an observable warning and retry on the
+          // next sign-in rather than failing the authenticated session.
+          logger.warn(
+            `[StewardSync] Sign-in tenant self-heal failed for org ${organizationId}; sign-in proceeds and the next attempt retries: ${describeSyncError(error)}`,
+          );
+        }
+      });
     }
 
     return user;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.email-login.test.tsx
@@ -245,6 +245,41 @@ describe("StewardLoginSection email magic-link companion code", () => {
     expect(screen.queryByLabelText("Six-digit code")).toBeNull();
   });
 
+  it("keeps local code verification in control while polling observes a consumed code", async () => {
+    let finishVerify!: (value: { token: string; refreshToken: string }) => void;
+    emailLoginSpies.verify.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishVerify = resolve;
+        }),
+    );
+    emailLoginSpies.poll.mockResolvedValue("consumed");
+    sessionSpies.recoverEmail.mockResolvedValue(null);
+    renderSection("/login?returnTo=%2Fjoin");
+    await startEmailLogin();
+    fireEvent.change(screen.getByLabelText("Six-digit code"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Verify code/i }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(sessionSpies.recoverEmail).not.toHaveBeenCalled();
+    expect(screen.queryByText("Link approved")).toBeNull();
+
+    await act(async () => {
+      finishVerify({ token: "session-token", refreshToken: "refresh-token" });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("location-path").textContent).toBe("/join"),
+    );
+    expect(sessionSpies.sync).toHaveBeenCalledWith(
+      "session-token",
+      "refresh-token",
+    );
+  });
+
   it("aborts an abandoned challenge's recovery and never hands it to a later email", async () => {
     emailLoginSpies.poll.mockResolvedValue("consumed");
     const pendingRecoveries: Array<(value: { ok: true } | null) => void> = [];

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1144,6 +1144,7 @@ export default function StewardLoginSection() {
   useEffect(() => {
     if (
       step !== "email-sent" ||
+      loading === "email" ||
       !emailChallenge?.challengeId ||
       !emailChallenge.pollSecret
     ) {
@@ -1223,6 +1224,7 @@ export default function StewardLoginSection() {
   }, [
     emailChallenge,
     emailCheckState,
+    loading,
     recoverSharedEmailSession,
     searchParams,
     step,
@@ -1230,7 +1232,10 @@ export default function StewardLoginSection() {
   ]);
 
   useEffect(() => {
-    if (step !== "email-sent" || !email.trim()) return;
+    // A code submitted here consumes the same challenge that link polling
+    // observes. Let its verification and cookie sync finish before treating a
+    // consumed challenge as a sign-in completed in another tab.
+    if (step !== "email-sent" || loading === "email" || !email.trim()) return;
     let cancelled = false;
     const unsubscribe = subscribeStewardEmailLoginComplete(email, (message) => {
       void (async () => {
@@ -1271,7 +1276,7 @@ export default function StewardLoginSection() {
       cancelled = true;
       unsubscribe();
     };
-  }, [email, recoverSharedEmailSession, step]);
+  }, [email, loading, recoverSharedEmailSession, step]);
 
   useEffect(() => {
     const tracksEmailExpiry = step === "email-sent" && emailChallenge !== null;


### PR DESCRIPTION
Promote #31086 to fix the fresh-account sign-in failures reproduced during Dedicated onboarding: optional Steward tenant repair no longer blocks Worker session establishment, its upstream request is bounded, and email-link polling cannot override code verification in the current tab.

Both regressions failed before their fixes; 30 backend and 25 login UI tests passed afterward. Scoped formatting passed. Full `bun run verify` passed on the unchanged source. The owner authorized routine CI wait bypass; canonical deployment and migration checks remain in place. This is a staging promotion, with the fresh-account and Dedicated UI recheck still required before production acceptance.
