### PR TITLE
registry: add @northschema/plugin-xrpl (read-only XRPL ledger state)

### DIFF
--- a/packages/registry/entries/third-party/northschema__plugin-xrpl.json
+++ b/packages/registry/entries/third-party/northschema__plugin-xrpl.json
@@ -1,0 +1,9 @@
+{
+  "package": "@northschema/plugin-xrpl",
+  "repository": "github:nctrnlsoul/plugin-ns-xrpl",
+  "kind": "plugin",
+  "description": "Reads public XRPL ledger state for elizaOS agents. Read-only: no signing, no key material, no transaction submission.",
+  "homepage": "https://github.com/nctrnlsoul/plugin-ns-xrpl#readme",
+  "version": "0.3.0",
+  "tags": ["xrpl", "xrp", "ledger", "read-only"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -369,6 +369,50 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@northschema/plugin-xrpl": {
+      "git": {
+        "repo": "nctrnlsoul/plugin-ns-xrpl",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@northschema/plugin-xrpl",
+        "v0": null,
+        "v1": null,
+        "v2": "0.3.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Reads public XRPL ledger state for elizaOS agents. Read-only: no signing, no key material, no transaction submission.",
+      "homepage": "https://github.com/nctrnlsoul/plugin-ns-xrpl#readme",
+      "topics": [
+        "xrpl",
+        "xrp",
+        "ledger",
+        "read-only"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@ophis/plugin-elizaos": {
       "git": {
         "repo": "ophis-fi/ophis",


### PR DESCRIPTION
Adds one third-party registry entry, per `packages/registry/README.md`.
Both files are included as step 5 requires: the source entry, and the
regenerated `generated-registry.json`.

The generated file was produced by `bun run --cwd packages/registry generate`
on this branch, not hand-edited. `validate` passes at 50 entries. The diff to
`generated-registry.json` is additive only, 44 insertions and no deletions.

Discussion and full disclosures: #30360, opened 2 September. That issue
carries the security surface, the measured runtime behaviour, and the defect
writeups from testing the published package against a live model. Summarising
here rather than repeating it.

**What it does.** Reads public XRPL account state, an address's XRP balance
and trust lines, and renders it as provider text. Read-only by construction:
no signing, no key material, no transaction submission, no wallet surface.

The entry names 0.3.0. 0.1.1 and 0.2.0 were superseded, and #30360 records
why: I ran the published package against a live model after submitting, found
it let a model invent a balance for an address the report had only counted,
and fixed it by naming every unlooked-up address instead of counting them.
The version in this entry is the one that behaves.

**Verification for 0.3.0**

| Claim | Result |
|---|---|
| npm | `@northschema/plugin-xrpl@0.3.0`, current `latest` |
| provenance | SLSA v1 plus the npm publish attestation, keyless Sigstore, GitHub-hosted runner, `refs/tags/v0.3.0`, workflow `.github/workflows/publish.yml`, commit `f9db5ae` |
| publishing | npm trusted publishing over OIDC. No long-lived npm token exists |
| runtime dependencies | none. No `dependencies` key. The published bundle's only import is `node:crypto` |
| egress primitives | exactly one: a single lazily read `globalThis.fetch`. Zero `XMLHttpRequest`, `WebSocket`, `http.request`, `net.connect`, `dns.*` |
| gates | 559 tests; 223 defects reintroduced and 223 caught; fail-open lint, typecheck and lint clean; `bun audit` clean across 164 packages. A pre-commit hook runs all of it on every commit |
| tarball | 17 files, no build metadata, no secret-shaped content |

**Network egress.** Outbound HTTPS to public XRPL nodes only. Pins
`https://xrplcluster.com/` and enforces a host allowlist of `xrplcluster.com`,
`s1.ripple.com`, `s2.ripple.com`. Those three are the only hostnames present
anywhere in the published bundle. IP literals rejected. No credentials sent.
The only variable on the wire is a public ledger address already present in
the conversation.

**No startup network call.** Zero fetches after `import`, and zero after
constructing and initializing a real `AgentRuntime` with the plugin
registered. `node:http`, `node:net`, `tls` and `dns.lookup` were instrumented
and stayed at zero. A positive control confirms the counter fires on the
first real lookup.

**Known limits, stated rather than left to be found.** Live-model testing is
one model at 3B and a small turn set. Asked to list all trust lines, the model
presented a partial list as complete despite the report saying it is
incomplete; documented, not solved. Homoglyphs and combining marks make an
address fail to match entirely; measured and deliberately open. The package
has not been reviewed by anyone outside my own build process.

Happy to revise the entry or the description to whatever shape reviewers prefer.