### PR TITLE
fix(cloud): unblock Dedicated recovery and staging onboarding

### DIFF
--- a/packages/agent/src/services/agent-backup-v2-capture.test.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.test.ts
@@ -856,6 +856,17 @@ describe("streamAgentBackupV2Capture", () => {
     try {
       await fs.promises.mkdir(pglite, { recursive: true });
       await fs.promises.mkdir(path.join(root, "a"), { recursive: true });
+      await fs.promises.mkdir(path.join(root, "skills", ".cache"), {
+        recursive: true,
+      });
+      await fs.promises.writeFile(
+        path.join(root, "skills", ".cache", "catalog.json"),
+        "downloadable catalog",
+      );
+      await fs.promises.writeFile(
+        path.join(root, "skills", ".cache", "lock.json"),
+        '{"installed":"pinned"}',
+      );
       for (const [relativePath, value] of [
         ["a-plain", "hyphen"],
         ["a/nested", "nested"],
@@ -935,7 +946,16 @@ describe("streamAgentBackupV2Capture", () => {
         records
           .filter((record) => record.kind === "data")
           .map((record) => record.entry?.path),
-      ).toEqual(["B", "a-plain", "a/nested", "file-2", "file_1", "z", "ä"]);
+      ).toEqual([
+        "B",
+        "a-plain",
+        "a/nested",
+        "file-2",
+        "file_1",
+        "skills/.cache/lock.json",
+        "z",
+        "ä",
+      ]);
     } finally {
       if (previousStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
       else process.env.ELIZA_STATE_DIR = previousStateDir;

--- a/packages/agent/src/services/agent-backup-v2-capture.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.ts
@@ -1053,6 +1053,8 @@ function baseStateFileInclude(
   relativePath: string,
   pgliteRelativePath: string | null,
 ): boolean {
+  // Preserve installed-skill state while excluding the downloadable catalog.
+  if (relativePath === "skills/.cache/catalog.json") return false;
   if (
     pgliteRelativePath !== null &&
     (relativePath === pgliteRelativePath ||

--- a/packages/agent/src/services/agent-backup.test.ts
+++ b/packages/agent/src/services/agent-backup.test.ts
@@ -103,6 +103,15 @@ async function writeFixtureState(
     path.join(root, "skills", "active.json"),
     '{"skills":[]}\n',
   );
+  await fs.mkdir(path.join(root, "skills", ".cache"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "skills", ".cache", "catalog.json"),
+    "downloadable catalog",
+  );
+  await fs.writeFile(
+    path.join(root, "skills", ".cache", "lock.json"),
+    '{"installed":"pinned"}',
+  );
   // Re-downloadable model weights / caches must never enter stateFiles (#17920).
   await fs.mkdir(path.join(root, "models"), { recursive: true });
   await fs.writeFile(
@@ -198,6 +207,8 @@ describe("agent backup manifest", () => {
     expect(pgliteFilePaths).not.toContain("eliza-pglite.lock");
     expect(pgliteFilePaths).not.toContain("pg_stat_tmp/stats.tmp");
     expect(stateFilePaths).toContain("skills/active.json");
+    expect(stateFilePaths).toContain("skills/.cache/lock.json");
+    expect(stateFilePaths).not.toContain("skills/.cache/catalog.json");
     expect(stateFilePaths).not.toContain("pglite/pgdata.bin");
     // #17920: models + cache trees are excluded from the stateFiles manifest.
     expect(stateFilePaths).not.toContain("models/openai.json");

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -564,6 +564,8 @@ function withFileSetHash(fileSet: AgentBackupFileSet): AgentBackupFileSet {
 }
 
 function baseStateFileInclude(relativePath: string): boolean {
+  // The catalog is downloadable; its neighboring lock.json records installed skills.
+  if (relativePath === "skills/.cache/catalog.json") return false;
   const first = relativePath.split("/")[0];
   if (
     first === MEDIA_DIR_NAME ||

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -5,8 +5,9 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { eq, type SQL } from "drizzle-orm";
+import { eq, type SQL, sql } from "drizzle-orm";
 import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../../../lib/storage/r2-runtime-binding";
+import { sqlRows } from "../../execute-helpers";
 import { apps } from "../../schemas/apps";
 import { jobExecutionLeases } from "../../schemas/job-execution-leases";
 import { type Job, jobs } from "../../schemas/jobs";
@@ -268,6 +269,66 @@ describe("jobsRepository.recoverStaleJobs", () => {
     await dbWrite.execute("DELETE FROM jobs;");
     await dbWrite.execute("DELETE FROM containers;");
     await dbWrite.execute("DELETE FROM apps;");
+  });
+
+  test("offloads an owned failure from a raw SQL timestamp without changing its UTC day", async () => {
+    const jobId = "00000000-0000-4000-8000-000000031089";
+    const ownerId = "00000000-0000-4000-8000-000000031090";
+    const createdAt = new Date("2020-01-01T23:55:00.000Z");
+    await dbWrite.insert(jobs).values({
+      id: jobId,
+      type: "agent_message",
+      data: { agentId: AGENT_ID },
+      organization_id: ORG_ID,
+      scheduled_for: createdAt,
+      created_at: createdAt,
+    });
+    await repo.claimPendingJobs({
+      type: "agent_message",
+      limit: 1,
+      executionOwnerId: ownerId,
+      executionLeaseMs: 60_000,
+    });
+    // Raw Node/Postgres claim results bypass Drizzle's timestamp decoder.
+    // Cast in SQL to exercise that real driver representation with PGlite.
+    const [rawClaim] = await sqlRows<Job>(
+      dbWrite,
+      sql`
+      SELECT *, created_at::text AS created_at FROM ${jobs} WHERE id = ${jobId}
+    `,
+    );
+    if (!rawClaim) throw new Error("expected the job to be claimed");
+    expect(typeof rawClaim.created_at).toBe("string");
+    const objects = new Map<string, string>();
+    const originalEnv = HEAVY_PAYLOAD_ENV.map((key) => [key, process.env[key]] as const);
+    const failure = "Complete migration failure details. ".repeat(100);
+    setRuntimeR2Bucket(memoryBucket(objects));
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "r2";
+    process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES = "1";
+    process.env.SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES = "0";
+    try {
+      await expect(
+        repo.updateForExecution(
+          { ...rawClaim, created_at: new Date(Number.NaN) },
+          { error: failure },
+          ownerId,
+        ),
+      ).rejects.toMatchObject({ code: "INVALID_JOB_CREATED_AT" });
+      expect(objects.size).toBe(0);
+      const updated = await repo.updateForExecution(rawClaim, { error: failure }, ownerId);
+      expect(updated.error).toBe(failure);
+      expect(updated.error_storage).toBe("r2");
+      expect(updated.error_key).toContain(`/2020-01-01/${jobId}/`);
+      expect(await repo.findByIdForWrite(jobId)).toMatchObject({ error: failure });
+      expect(await repo.rejectClaimedExecution(rawClaim, failure, ownerId)).toBe("rejected");
+      expect(await repo.renewExecutionLease(rawClaim, ownerId, 60_000)).toBe("settled");
+    } finally {
+      setRuntimeR2Bucket(null);
+      for (const [key, value] of originalEnv) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 
   test("reconstructs one deterministic APP_DEPLOY job across enqueue replay", async () => {

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -3,6 +3,7 @@
  * through the primary and read-intent cloud database boundaries.
  */
 import { randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
 import { and, desc, eq, inArray, lt, type SQL, sql } from "drizzle-orm";
 import {
   assertAdminCanaryImageJobData,
@@ -409,7 +410,19 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
     };
   }
 
-  const createdAt = data.created_at ?? context.created_at ?? new Date();
+  // Raw claim queries bypass Drizzle's timestamp decoder. Decode using the
+  // column's UTC semantics before deriving immutable object-storage keys.
+  const rawCreatedAt = data.created_at ?? context.created_at ?? new Date();
+  const createdAt =
+    typeof rawCreatedAt === "string"
+      ? jobs.created_at.mapFromDriverValue(rawCreatedAt)
+      : rawCreatedAt;
+  if (!(createdAt instanceof Date) || !Number.isFinite(createdAt.getTime())) {
+    throw new ElizaError("Job creation timestamp is invalid", {
+      code: "INVALID_JOB_CREATED_AT",
+      context: { jobId: context.id },
+    });
+  }
   const forceInlineData = data.data_storage === "inline";
   const forceInlineResult = data.result_storage === "inline";
   const forceInlineError = data.error_storage === "inline";

--- a/packages/ui/src/api/client-cloud-agent-base.test.ts
+++ b/packages/ui/src/api/client-cloud-agent-base.test.ts
@@ -308,13 +308,20 @@ describe("cloud-agent-base helpers", () => {
         true,
       ),
     ).toBe(true);
+    expect(
+      isTrustedHostedCloudOnboardingBase(
+        "https://staging.eliza-app.pages.dev",
+        true,
+      ),
+    ).toBe(true);
   });
 
   it("rejects unbranded, insecure, self-hosted, and lookalike Pages bases", () => {
     for (const [base, cloudOnlyBranding] of [
+      ["https://staging.eliza-app.pages.dev", false],
       ["https://develop.eliza-app.pages.dev", false],
-      ["http://develop.eliza-app.pages.dev", true],
-      ["https://develop.eliza-app.pages.dev:8443", true],
+      ["http://staging.eliza-app.pages.dev", true],
+      ["https://staging.eliza-app.pages.dev:8443", true],
       ["https://eliza-app.pages.dev", true],
       ["https://preview.eliza-app.pages.dev", true],
       ["https://pr-30375.preview.eliza-app.pages.dev", true],
@@ -322,7 +329,7 @@ describe("cloud-agent-base helpers", () => {
       ["https://other-project.pages.dev", true],
       ["https://evil-eliza-app.pages.dev", true],
       ["https://eliza-app.pages.dev.evil.example", true],
-      ["https://develop.eliza-app.pages.dev/api/v1/eliza/agents/agent", true],
+      ["https://staging.eliza-app.pages.dev/api/v1/eliza/agents/agent", true],
     ] as const) {
       expect(isTrustedHostedCloudOnboardingBase(base, cloudOnlyBranding)).toBe(
         false,

--- a/packages/ui/src/state/first-run-bootstrap.test.ts
+++ b/packages/ui/src/state/first-run-bootstrap.test.ts
@@ -300,7 +300,7 @@ describe("shouldProbeExistingLocalInstall (#16242, #30375)", () => {
     );
     expect(
       shouldProbeExistingLocalInstall(
-        "https://develop.eliza-app.pages.dev",
+        "https://staging.eliza-app.pages.dev",
         true,
       ),
     ).toBe(false);
@@ -309,7 +309,7 @@ describe("shouldProbeExistingLocalInstall (#16242, #30375)", () => {
   it("continues probing unbranded Pages and arbitrary Cloud-only hosts", () => {
     expect(
       shouldProbeExistingLocalInstall(
-        "https://develop.eliza-app.pages.dev",
+        "https://staging.eliza-app.pages.dev",
         false,
       ),
     ).toBe(true);
@@ -351,7 +351,7 @@ describe("detectExistingFirstRunConnection — Cloud-origin gate (#16242)", () =
   });
 
   it("skips the probe on an authoritative branded Pages alias (#30375)", async () => {
-    setOrigin("https://develop.eliza-app.pages.dev/");
+    setOrigin("https://staging.eliza-app.pages.dev/");
     const client = makeClient();
     const result = await detectExistingFirstRunConnection({
       client,
@@ -365,7 +365,7 @@ describe("detectExistingFirstRunConnection — Cloud-origin gate (#16242)", () =
 
   it("still probes an unbranded Pages alias and arbitrary Cloud-only host", async () => {
     for (const [origin, cloudOnlyBranding] of [
-      ["https://develop.eliza-app.pages.dev/", false],
+      ["https://staging.eliza-app.pages.dev/", false],
       ["https://agent.example.com/", true],
     ] as const) {
       setOrigin(origin);

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -254,13 +254,16 @@ export function isElizaCloudControlPlaneAgentlessBase(
   return isCloudAgentsCollectionBase(value);
 }
 
-const DEVELOP_ELIZA_APP_PAGES_ORIGIN = "https://develop.eliza-app.pages.dev";
+const TRUSTED_ELIZA_APP_PAGES_ORIGINS = new Set([
+  "https://develop.eliza-app.pages.dev",
+  "https://staging.eliza-app.pages.dev",
+]);
 
 /**
  * True when an agentless browser host is trusted to own hosted Cloud
  * onboarding. Canonical and legacy control-plane origins are always trusted.
- * The deployed Cloudflare Pages staging alias is trusted only for an
- * authoritative Cloud-only build and only on its exact HTTPS origin.
+ * The deployed Cloudflare Pages branch aliases are trusted only for an
+ * authoritative Cloud-only build and only on their exact HTTPS origins.
  * Other Pages project/preview hosts and self-hosted `cloudOnly` branding must
  * never suppress the local-install/auth gates because they are outside the
  * credentialed API's server-authoritative origin set.
@@ -277,7 +280,7 @@ export function isTrustedHostedCloudOnboardingBase(
     return false;
   }
 
-  return url.origin.toLowerCase() === DEVELOP_ELIZA_APP_PAGES_ORIGIN;
+  return TRUSTED_ELIZA_APP_PAGES_ORIGINS.has(url.origin.toLowerCase());
 }
 
 /**

--- a/plugins/plugin-sql/src/__tests__/migration/legacy-session-summaries.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/legacy-session-summaries.real.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Exercises legacy schema upgrades against real PGlite while preserving stored
+ * rows and enforcing foreign keys with destructive migrations disabled.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite/vector";
+import { sql } from "drizzle-orm";
+import { foreignKey, pgTable, unique, uuid } from "drizzle-orm/pg-core";
+import { drizzle } from "drizzle-orm/pglite";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { RuntimeMigrator } from "../../runtime-migrator/runtime-migrator";
+import * as currentSchema from "../../schema";
+import { sessionSummaries as legacySessionSummaries } from "../../schema/sessionSummaries";
+
+let client: PGlite;
+
+beforeEach(() => {
+  vi.stubEnv("POSTGRES_URL", "");
+  vi.stubEnv("DATABASE_URL", "");
+  vi.stubEnv("ELIZA_ALLOW_DESTRUCTIVE_MIGRATIONS", "false");
+  client = new PGlite({ extensions: { vector } });
+});
+
+afterEach(async () => {
+  await client.close();
+  vi.unstubAllEnvs();
+});
+
+it("boots the current SQL schema over legacy summary rows without dropping or rewriting them", async () => {
+  const db = drizzle(client);
+  const migrator = new RuntimeMigrator(db);
+  const plugin = "@elizaos/plugin-sql";
+  await migrator.migrate(plugin, {
+    ...currentSchema,
+    sessionSummaries: legacySessionSummaries,
+  });
+  await db.execute(sql`
+    INSERT INTO session_summaries
+      (id, agent_id, room_id, summary, message_count, last_message_offset,
+       start_time, end_time, topics, metadata, embedding)
+    VALUES
+      ('00000000-0000-4000-8000-000000000001',
+       '00000000-0000-4000-8000-000000000002',
+       '00000000-0000-4000-8000-000000000003',
+       'Preserve the original project history.', 7, 11,
+       '2026-08-01 12:00:00', '2026-08-01 13:00:00',
+       '["project"]'::jsonb, '{"source":"legacy"}'::jsonb,
+       ARRAY[0.25,0.5]::real[])
+  `);
+  const before = await db.execute(sql`SELECT row_to_json(s) AS data FROM session_summaries s`);
+
+  await migrator.migrate(plugin, currentSchema);
+  await migrator.migrate(plugin, currentSchema);
+
+  const after = await db.execute(sql`SELECT row_to_json(s) AS data FROM session_summaries s`);
+  expect(after.rows).toEqual(before.rows);
+  expect(after.rows).toHaveLength(1);
+});
+
+it("adds the referenced composite unique constraint before a new table's foreign key", async () => {
+  const db = drizzle(client);
+  const migrator = new RuntimeMigrator(db);
+  const oldAccounts = pgTable("legacy_accounts", {
+    id: uuid("id").primaryKey(),
+    agentId: uuid("agent_id").notNull(),
+  });
+  await migrator.migrate("upgrade-fixture", { accounts: oldAccounts });
+  await client.query(`INSERT INTO legacy_accounts VALUES
+    ('00000000-0000-4000-8000-000000000001', '00000000-0000-4000-8000-000000000002')`);
+  const accounts = pgTable(
+    "legacy_accounts",
+    {
+      id: uuid("id").primaryKey(),
+      agentId: uuid("agent_id").notNull(),
+    },
+    (table) => [unique("legacy_accounts_id_agent_unique").on(table.id, table.agentId)]
+  );
+  const memberships = pgTable(
+    "new_memberships",
+    {
+      id: uuid("id").primaryKey(),
+      accountId: uuid("account_id").notNull(),
+      agentId: uuid("agent_id").notNull(),
+    },
+    (table) => [
+      foreignKey({
+        name: "new_membership_account_fk",
+        columns: [table.accountId, table.agentId],
+        foreignColumns: [accounts.id, accounts.agentId],
+      }),
+    ]
+  );
+
+  await migrator.migrate("upgrade-fixture", { accounts, memberships });
+  await client.query(`INSERT INTO new_memberships VALUES
+    ('00000000-0000-4000-8000-000000000003', '00000000-0000-4000-8000-000000000001',
+     '00000000-0000-4000-8000-000000000002')`);
+  await expect(
+    client.query(`INSERT INTO new_memberships VALUES
+    ('00000000-0000-4000-8000-000000000004', '00000000-0000-4000-8000-000000000001',
+     '00000000-0000-4000-8000-000000000005')`)
+  ).rejects.toMatchObject({ code: "23503" });
+  expect((await client.query("SELECT id FROM legacy_accounts")).rows).toHaveLength(1);
+});

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
@@ -1,8 +1,8 @@
 /**
  * Turns a `SchemaDiff` (from diff-calculator) into an ordered list of raw SQL
- * migration statements — schemas and tables first, foreign keys after all
- * tables exist, then column/index/constraint alterations, mirroring
- * drizzle-kit's own statement ordering. Also runs a pre-flight data-loss
+ * migration statements — schemas and tables first, then column/index/constraint
+ * alterations, and foreign keys after their referenced keys exist.
+ * Also runs a pre-flight data-loss
  * check (`checkForDataLoss`) that flags destructive type changes, dropped
  * tables/columns, and new NOT NULL columns without defaults. `ADD COLUMN` /
  * `DROP COLUMN` statements are emitted with `IF NOT EXISTS` / `IF EXISTS` so
@@ -283,7 +283,7 @@ export async function generateMigrationSQL(
 
   statements.push(...createTableStatements);
 
-  // Phase 3: add foreign keys after all tables exist, deduplicated by
+  // Phase 3: collect foreign keys for the final phase, deduplicated by
   // constraint name to avoid re-adding the same constraint twice.
   const uniqueFKs = new Set<string>();
   const dedupedFKStatements: string[] = [];
@@ -300,8 +300,6 @@ export async function generateMigrationSQL(
       dedupedFKStatements.push(fkSQL);
     }
   }
-
-  statements.push(...dedupedFKStatements);
 
   // Phase 4: table modifications — drops, then column/index/constraint/FK changes.
   for (const tableName of diff.tables.deleted) {
@@ -397,8 +395,12 @@ export async function generateMigrationSQL(
     statements.push(generateDropForeignKeySQL(alteredFK.old));
   }
 
+  // New tables may reference a unique key added to an existing table in this
+  // migration. Install those columns and keys before any new foreign key.
+  statements.push(...dedupedFKStatements);
+
   for (const fk of diff.foreignKeys.created) {
-    // Skip FKs on tables just created above (Phase 3 already added them).
+    // Skip FKs on tables just created above (the collected statements cover them).
     const tableFrom = fk.tableFrom || "";
     const schemaFrom = fk.schemaFrom || "public";
 

--- a/plugins/plugin-sql/src/schema/index.ts
+++ b/plugins/plugin-sql/src/schema/index.ts
@@ -60,6 +60,7 @@ export { participantTable } from "./participant";
 export { relationshipTable } from "./relationship";
 export { roomTable } from "./room";
 export { serverTable } from "./server";
+export { sessionSummaries } from "./sessionSummaries";
 export { taskTable } from "./tasks";
 export { worldTable } from "./world";
 export { worldRoleAuditTable } from "./worldRoleAudit";

--- a/plugins/plugin-sql/src/schema/sessionSummaries.ts
+++ b/plugins/plugin-sql/src/schema/sessionSummaries.ts
@@ -1,0 +1,33 @@
+/**
+ * Retained schema for legacy session summaries. Existing agent databases own
+ * this table in their plugin-sql migration history. Keep its shape registered
+ * so ordinary startup preserves those rows without a destructive migration.
+ * This does not enable summary generation or substitute summaries for history.
+ */
+import { sql } from "drizzle-orm";
+import { index, integer, jsonb, pgTable, real, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const sessionSummaries = pgTable(
+  "session_summaries",
+  {
+    id: uuid("id").primaryKey().notNull(),
+    agentId: uuid("agent_id").notNull(),
+    roomId: uuid("room_id").notNull(),
+    entityId: uuid("entity_id"),
+    summary: text("summary").notNull(),
+    messageCount: integer("message_count").notNull(),
+    lastMessageOffset: integer("last_message_offset").default(0).notNull(),
+    startTime: timestamp("start_time").notNull(),
+    endTime: timestamp("end_time").notNull(),
+    topics: jsonb("topics").$type<string[]>(),
+    metadata: jsonb("metadata"),
+    embedding: real("embedding").array(),
+    createdAt: timestamp("created_at").default(sql`now()`).notNull(),
+    updatedAt: timestamp("updated_at").default(sql`now()`).notNull(),
+  },
+  (table) => [
+    index("session_summaries_agent_room_idx").on(table.agentId, table.roomId),
+    index("session_summaries_entity_idx").on(table.entityId),
+    index("session_summaries_start_time_idx").on(table.startTime),
+  ]
+);


### PR DESCRIPTION
Dedicated recovery could fail before chat opened: legacy SQL upgrades attempted to drop retained state or create foreign keys before their referenced keys; recording the resulting failure could then leave the job stuck because raw SQL timestamps bypassed Drizzle decoding.

- Preserve the legacy summary table without enabling summary generation, and order foreign keys after referenced constraints.
- Decode and validate job creation timestamps before offloading complete payloads to object storage.
- Exclude only the downloadable skills catalog from both snapshot formats, preserving installed-skill locks and other state.
- Recognize the exact staging Pages onboarding origin alongside the existing develop origin, retaining HTTPS, Cloud-build, and host checks.

Validation: SQL and snapshot regressions, raw-timestamp failure, and staging-host tests all reproduced before their fixes. Afterward: 9 real PGlite migration/data tests, 49 snapshot tests (one existing tracked skip), 31 job recovery/storage tests, and 60 onboarding/auth tests passed. SQL build/typecheck, Cloud shared typecheck, and scoped Biome checks passed. Full `bun run verify` passed on final source `323fc6e113a1d40e9b2d5dca84bf8d73ecfa717d`. Image build 34665845922 contains the SQL and snapshot fixes; hosted Gmail-account recovery acceptance is pending.
