### PR TITLE
fix(staging): promote Dedicated confirmation and continuity reporting

### DIFF
--- a/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
+++ b/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
@@ -3,6 +3,11 @@
  * contracts with deterministic provider records and public HTTP responses.
  */
 import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCloudLiveContinuityEvidence } from "../../../app/test/cloud-live-continuity-contract";
 import {
   createDeployedRendererProof,
   DEPLOYED_BROWSER_SMOKE_SCHEMA,
@@ -161,21 +166,41 @@ function latency() {
 }
 
 function continuity() {
-  return {
-    schemaVersion: 1,
-    lane: "app-live-e2e-cloud-staging",
+  return createCloudLiveContinuityEvidence({
     challengeTurnCount: 1,
     noAdditionalChatSendAfterChallenge: true,
     personalIdentityEndpointPassed: true,
-    reloadHistoryPassed: true,
-    freshContextHistoryPassed: true,
-    personalIdentityReused: true,
-    runtimeBindingReused: true,
-    apiBaseReused: true,
-    forbiddenAgentMutationCount: 0,
+    reload: {
+      historyGetSucceeded: true,
+      challengeUserLinePresent: true,
+      challengeAssistantLinePresent: true,
+    },
+    freshContext: {
+      historyGetSucceeded: true,
+      challengeUserLinePresent: true,
+      challengeAssistantLinePresent: true,
+      createdWithoutStorageState: true,
+      serviceWorkersBlocked: true,
+    },
+    bindingReuse: {
+      personalIdentityReused: true,
+      runtimeBindingReused: true,
+      apiBaseReused: true,
+    },
+    dedicatedMutationProof: {
+      approvalGrantedCount: 1,
+      confirmationClickCount: 0,
+      confirmationKind: "none",
+      adoptionConfirmationPostCount: 0,
+      activationPostCount: 0,
+      cutoverPostCount: 0,
+      forbiddenAgentMutationCount: 0,
+      approvalBindingPresent: false,
+      lifecycleBindingMismatchCount: 0,
+    },
     cleanupDisposition: "no-test-owned-agent",
     conversationHistoryDisposition: "preserved",
-  };
+  });
 }
 
 describe("Pages deployment authority", () => {
@@ -365,6 +390,59 @@ describe("deployed renderer proof", () => {
       remoteSmoke().chatCorrelation,
     );
     expect(proof.continuity.forbiddenAgentMutationCount).toBe(0);
+  });
+
+  test("combines the browser producer's current evidence through the Node release CLI", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "eliza-pages-proof-"));
+    try {
+      const inputs = {
+        authority: authority(),
+        preflight: await publicCheck("preflight"),
+        "remote-smoke": remoteSmoke(),
+        latency: latency(),
+        continuity: continuity(),
+        postflight: await publicCheck("postflight"),
+      };
+      const args = [
+        new URL("../pages-deployment-authority.mjs", import.meta.url).pathname,
+        "combine",
+      ];
+      for (const [name, value] of Object.entries(inputs)) {
+        const path = join(directory, `${name}.json`);
+        await writeFile(path, JSON.stringify(value));
+        args.push(`--${name}`, path);
+      }
+      const output = join(directory, "proof.json");
+      args.push("--output", output);
+      execFileSync("node", args, { timeout: 10_000, stdio: "pipe" });
+      const proof = parseDeployedRendererProof(
+        JSON.parse(await readFile(output, "utf8")),
+      );
+      expect(proof.continuity).toEqual(inputs.continuity);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps continuity validation closed and enforces lifecycle approval binding", async () => {
+    const inputs = {
+      authority: authority(),
+      preflight: await publicCheck("preflight"),
+      remoteSmoke: remoteSmoke(),
+      latency: latency(),
+      postflight: await publicCheck("postflight"),
+    };
+    for (const invalid of [
+      { ...continuity(), schemaVersion: 1 },
+      { ...continuity(), credential: "must-not-be-published" },
+      { ...continuity(), reloadHistoryPassed: false },
+      { ...continuity(), dedicatedLifecycleBindingMismatchCount: 1 },
+      { ...continuity(), dedicatedCutoverPostCount: 1 },
+    ]) {
+      expect(() =>
+        createDeployedRendererProof({ ...inputs, continuity: invalid }),
+      ).toThrow();
+    }
   });
 
   test("rejects unsafe or unvalidated browser correlation fields", async () => {

--- a/packages/cloud/scripts/pages-deployment-authority.mjs
+++ b/packages/cloud/scripts/pages-deployment-authority.mjs
@@ -12,6 +12,7 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { parseCloudLiveContinuityEvidence } from "../../app/test/cloud-live-continuity-contract.ts";
 
 export const PAGES_AUTHORITY_SCHEMA =
   "elizaos.cloudflare.pages-deployment-authority/v1";
@@ -112,21 +113,6 @@ const LATENCY_KEYS = [
   "firstTurnLatencyMs",
   "lane",
   "metric",
-  "schemaVersion",
-];
-const CONTINUITY_KEYS = [
-  "apiBaseReused",
-  "challengeTurnCount",
-  "cleanupDisposition",
-  "conversationHistoryDisposition",
-  "forbiddenAgentMutationCount",
-  "freshContextHistoryPassed",
-  "lane",
-  "noAdditionalChatSendAfterChallenge",
-  "personalIdentityEndpointPassed",
-  "personalIdentityReused",
-  "reloadHistoryPassed",
-  "runtimeBindingReused",
   "schemaVersion",
 ];
 const PROOF_KEYS = [
@@ -835,31 +821,6 @@ function parseLatency(value) {
   };
 }
 
-function parseContinuity(value) {
-  const continuity = requireExactKeys(value, CONTINUITY_KEYS, "continuity");
-  const expected = {
-    schemaVersion: 1,
-    lane: RECEIPT_LANE,
-    challengeTurnCount: 1,
-    noAdditionalChatSendAfterChallenge: true,
-    personalIdentityEndpointPassed: true,
-    reloadHistoryPassed: true,
-    freshContextHistoryPassed: true,
-    personalIdentityReused: true,
-    runtimeBindingReused: true,
-    apiBaseReused: true,
-    forbiddenAgentMutationCount: 0,
-    cleanupDisposition: "no-test-owned-agent",
-    conversationHistoryDisposition: "preserved",
-  };
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    if (continuity[key] !== expectedValue) {
-      fail(`continuity.${key} is invalid`);
-    }
-  }
-  return expected;
-}
-
 export function createDeployedRendererProof({
   authority: authorityValue,
   preflight: preflightValue,
@@ -872,7 +833,7 @@ export function createDeployedRendererProof({
   const preflight = parsePagesPublicCheck(preflightValue, "preflight");
   const remoteSmoke = parseDeployedBrowserSmoke(remoteSmokeValue);
   const latency = parseLatency(latencyValue);
-  const continuity = parseContinuity(continuityValue);
+  const continuity = parseCloudLiveContinuityEvidence(continuityValue);
   const postflight = parsePagesPublicCheck(postflightValue, "postflight");
 
   for (const [label, observed] of [

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -2028,12 +2028,13 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
       turn,
       "first-run:dedicated-adoption",
     );
-    expect(confirmationTurn.text).toContain("$0.01/hour ($0.24/day)");
-    expect(confirmationTurn.text).toContain("Current status: error");
+    expect(confirmationTurn.text).toContain("$0.24/day ($0.01/hour)");
     expect(confirmationTurn.text).toContain("Balance: $115.54");
-    expect(confirmationTurn.text).toContain("3 days of runway");
-    expect(confirmationTurn.text).toContain("starts Dedicated compute");
-    expect(confirmationTurn.text).toContain("restore its reviewed backup");
+    expect(confirmationTurn.text).toContain("$0.72 required");
+    expect(confirmationTurn.text).toContain("confirm=Start Dedicated");
+    expect(confirmationTurn.text).toContain(
+      "Your verified backup will be restored",
+    );
     expect(confirmationTurn.text).not.toContain(quoteId);
     expect(confirmationTurn.text).not.toContain(dedicatedAgentId);
     expect(spies.completeFirstRun).not.toHaveBeenCalled();

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -392,24 +392,26 @@ function dedicatedAdoptionConfirmationText(
   }
   const disposition =
     quote.stateDisposition === "verified_backup_present"
-      ? "restore its reviewed backup"
+      ? "Your verified backup will be restored."
       : quote.stateDisposition === "fresh_boot_no_verified_backup"
-        ? "start fresh because no verified backup is available"
-        : "keep its current state without a reviewed restore";
+        ? "This starts fresh; no verified backup is available."
+        : "Your current data stays. No verified Cloud backup is available.";
   const changed =
     reason === "quote_changed"
-      ? "The agent or hosting quote changed while you were reviewing it. Please review the updated terms.\n\n"
+      ? "The hosting details changed. Please review them again.\n\n"
       : "";
   return [
     `${changed}Use your existing Dedicated agent?`,
     "",
-    `Current status: ${quote.status}.`,
-    `Hosting: $${quote.hourlyRateUsd.toFixed(2)}/hour ($${quote.dailyRateUsd.toFixed(2)}/day).`,
-    `Balance: $${quote.balanceUsd.toFixed(2)}; minimum required: $${quote.minimumBalanceUsd.toFixed(2)} (${quote.minimumRunwayDays} days of runway); deficit: $${quote.deficitUsd.toFixed(2)}.`,
-    `This action ${quote.startsCompute ? "starts Dedicated compute" : "does not start new compute"} and will ${disposition}.`,
+    `$${quote.dailyRateUsd.toFixed(2)}/day ($${quote.hourlyRateUsd.toFixed(2)}/hour).`,
+    `Balance: $${quote.balanceUsd.toFixed(2)}; $${quote.minimumBalanceUsd.toFixed(2)} required.`,
+    ...(quote.deficitUsd > 0
+      ? [`Add $${quote.deficitUsd.toFixed(2)} to start.`]
+      : []),
+    disposition,
     "",
     "[CHOICE:first-run id=dedicated-adoption]",
-    `${FIRST_RUN_ACTION_PREFIX}dedicated-adoption:confirm=Confirm and continue`,
+    `${FIRST_RUN_ACTION_PREFIX}dedicated-adoption:confirm=${quote.startsCompute ? "Start Dedicated" : "Connect"}`,
     `${FIRST_RUN_ACTION_PREFIX}dedicated-adoption:cancel=Not now`,
     "[/CHOICE]",
   ].join("\n");


### PR DESCRIPTION
Promote #31092 to staging so Dedicated hosting choices remain visible on mobile and the deployed browser report accepts the current strict continuity contract.

The four-file change is cherry-picked from the verified develop change. The resulting Git tree is byte-identical to 7e9e3f946a0e3e2648ccbe8f495cbb451af052e1, which passed full bun run verify plus 82 conductor, 12 deployment authority, 34 continuity and 34 release certification tests. The deployed browser scenario passed in run34666407695; this fixes its subsequent v1/v2 report mismatch. A fresh full staging release will rerun the deployment-bound browser proof.
