### PR TITLE
fix(timezone): support negative timezone offsets with Unicode minus signs and UTC tokens

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
@@ -125,7 +125,7 @@ function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   if (token === "GMT" || token === "UTC") {
     return 0;
   }
-  const match = token.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
@@ -116,12 +116,15 @@ export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") {
     return 0;
   }
-  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?(?::(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }
   const sign = match[1] === "+" ? 1 : -1;
-  return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? "0");
+  const seconds = Number(match[4] ?? "0");
+  return sign * (hours * 60 + minutes + Math.round(seconds / 60));
 }
 
 export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
@@ -112,16 +112,7 @@ function getZonedDateParts(date: Date, timeZone: string): LocalDateTimeParts {
   };
 }
 
-function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    timeZoneName: "shortOffset",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  }).formatToParts(date);
-  const token = parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") {
     return 0;
   }
@@ -131,6 +122,19 @@ function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   }
   const sign = match[1] === "+" ? 1 : -1;
   return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+}
+
+export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "shortOffset",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const token = parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+  return parseOffsetToken(token);
 }
 
 function localPartsToEpochMs(parts: LocalDateTimeParts): number {

--- a/packages/cloud/shared/src/lib/utils/google-mcp-shared.test.ts
+++ b/packages/cloud/shared/src/lib/utils/google-mcp-shared.test.ts
@@ -94,11 +94,13 @@ describe("mappers", () => {
 });
 
 describe("parseOffsetToken", () => {
-  test("parses offset tokens including Unicode minus signs and UTC formats", () => {
+  test("parses offset tokens including Unicode minus signs, UTC formats, and historical seconds offsets", () => {
     expect(parseOffsetToken("GMT\u22127")).toBe(-420);
     expect(parseOffsetToken("UTC-5")).toBe(-300);
     expect(parseOffsetToken("-07:00")).toBe(-420);
     expect(parseOffsetToken("GMT+02:00")).toBe(120);
     expect(parseOffsetToken("GMT-5")).toBe(-300);
+    expect(parseOffsetToken("GMT-0:44:30")).toBe(-45);
+    expect(parseOffsetToken("GMT-11:19:40")).toBe(-680);
   });
 });

--- a/packages/cloud/shared/src/lib/utils/google-mcp-shared.test.ts
+++ b/packages/cloud/shared/src/lib/utils/google-mcp-shared.test.ts
@@ -6,6 +6,7 @@ import {
   mapCalendarEvent,
   mapContact,
   mapGmailMessage,
+  parseOffsetToken,
   sanitizeHeaderValue,
 } from "./google-mcp-shared";
 
@@ -89,5 +90,15 @@ describe("mappers", () => {
       },
     });
     expect(out).toMatchObject({ name: "Ada", email: "ada@x.com", phone: "+1555" });
+  });
+});
+
+describe("parseOffsetToken", () => {
+  test("parses offset tokens including Unicode minus signs and UTC formats", () => {
+    expect(parseOffsetToken("GMT\u22127")).toBe(-420);
+    expect(parseOffsetToken("UTC-5")).toBe(-300);
+    expect(parseOffsetToken("-07:00")).toBe(-420);
+    expect(parseOffsetToken("GMT+02:00")).toBe(120);
+    expect(parseOffsetToken("GMT-5")).toBe(-300);
   });
 });

--- a/packages/cloud/shared/src/lib/utils/google-mcp-shared.ts
+++ b/packages/cloud/shared/src/lib/utils/google-mcp-shared.ts
@@ -224,7 +224,7 @@ function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   }).formatToParts(date);
   const token = parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }

--- a/packages/cloud/shared/src/lib/utils/google-mcp-shared.ts
+++ b/packages/cloud/shared/src/lib/utils/google-mcp-shared.ts
@@ -215,12 +215,15 @@ function getZonedDateParts(
 
 export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?(?::(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }
   const sign = match[1] === "+" ? 1 : -1;
-  return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? "0");
+  const seconds = Number(match[4] ?? "0");
+  return sign * (hours * 60 + minutes + Math.round(seconds / 60));
 }
 
 export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {

--- a/packages/cloud/shared/src/lib/utils/google-mcp-shared.ts
+++ b/packages/cloud/shared/src/lib/utils/google-mcp-shared.ts
@@ -213,7 +213,17 @@ function getZonedDateParts(
   };
 }
 
-function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
+export function parseOffsetToken(token: string): number {
+  if (token === "GMT" || token === "UTC") return 0;
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
+  if (!match) {
+    throw new Error(`unsupported offset token: ${token}`);
+  }
+  const sign = match[1] === "+" ? 1 : -1;
+  return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+}
+
+export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone,
     timeZoneName: "shortOffset",
@@ -223,13 +233,7 @@ function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
     hour12: false,
   }).formatToParts(date);
   const token = parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
-  if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
-  if (!match) {
-    throw new Error(`unsupported offset token: ${token}`);
-  }
-  const sign = match[1] === "+" ? 1 : -1;
-  return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+  return parseOffsetToken(token);
 }
 
 function formatOffsetToken(offsetMinutes: number): string {

--- a/plugins/plugin-calendar/src/internal/time.test.ts
+++ b/plugins/plugin-calendar/src/internal/time.test.ts
@@ -54,6 +54,23 @@ describe("getTimeZoneOffsetMinutes", () => {
     expect(getTimeZoneOffsetMinutes(NOON_UTC, "America/Los_Angeles")).toBe(-420);
     expect(getTimeZoneOffsetMinutes(NOON_UTC, "America/Chicago")).toBe(-300);
   });
+
+  it("parses tokens with Unicode minus sign, UTC prefix, and bare offsets", () => {
+    const parseToken = (token: string) => {
+      if (token === "GMT" || token === "UTC") return 0;
+      const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
+      if (!match) throw new Error(`unsupported offset token: ${token}`);
+      const sign = match[1] === "+" ? 1 : -1;
+      const hours = Number(match[2]);
+      const minutes = Number(match[3] ?? "0");
+      return sign * (hours * 60 + minutes);
+    };
+
+    expect(parseToken("GMT\u22127")).toBe(-420);
+    expect(parseToken("UTC-5")).toBe(-300);
+    expect(parseToken("-07:00")).toBe(-420);
+    expect(parseToken("GMT+02:00")).toBe(120);
+  });
 });
 
 describe("buildUtcDateFromLocalParts", () => {

--- a/plugins/plugin-calendar/src/internal/time.test.ts
+++ b/plugins/plugin-calendar/src/internal/time.test.ts
@@ -49,6 +49,11 @@ describe("getTimeZoneOffsetMinutes", () => {
     const janNoonUtc = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
     expect(getTimeZoneOffsetMinutes(janNoonUtc, "America/New_York")).toBe(-300);
   });
+
+  it("handles negative timezone offsets for various timezones", () => {
+    expect(getTimeZoneOffsetMinutes(NOON_UTC, "America/Los_Angeles")).toBe(-420);
+    expect(getTimeZoneOffsetMinutes(NOON_UTC, "America/Chicago")).toBe(-300);
+  });
 });
 
 describe("buildUtcDateFromLocalParts", () => {

--- a/plugins/plugin-calendar/src/internal/time.test.ts
+++ b/plugins/plugin-calendar/src/internal/time.test.ts
@@ -11,6 +11,7 @@ import {
   getTimeZoneOffsetMinutes,
   getWeekdayForLocalDate,
   getZonedDateParts,
+  parseOffsetToken,
 } from "./time.js";
 
 /**
@@ -56,20 +57,11 @@ describe("getTimeZoneOffsetMinutes", () => {
   });
 
   it("parses tokens with Unicode minus sign, UTC prefix, and bare offsets", () => {
-    const parseToken = (token: string) => {
-      if (token === "GMT" || token === "UTC") return 0;
-      const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
-      if (!match) throw new Error(`unsupported offset token: ${token}`);
-      const sign = match[1] === "+" ? 1 : -1;
-      const hours = Number(match[2]);
-      const minutes = Number(match[3] ?? "0");
-      return sign * (hours * 60 + minutes);
-    };
-
-    expect(parseToken("GMT\u22127")).toBe(-420);
-    expect(parseToken("UTC-5")).toBe(-300);
-    expect(parseToken("-07:00")).toBe(-420);
-    expect(parseToken("GMT+02:00")).toBe(120);
+    expect(parseOffsetToken("GMT\u22127")).toBe(-420);
+    expect(parseOffsetToken("UTC-5")).toBe(-300);
+    expect(parseOffsetToken("-07:00")).toBe(-420);
+    expect(parseOffsetToken("GMT+02:00")).toBe(120);
+    expect(parseOffsetToken("GMT-5")).toBe(-300);
   });
 });
 

--- a/plugins/plugin-calendar/src/internal/time.test.ts
+++ b/plugins/plugin-calendar/src/internal/time.test.ts
@@ -56,12 +56,14 @@ describe("getTimeZoneOffsetMinutes", () => {
     expect(getTimeZoneOffsetMinutes(NOON_UTC, "America/Chicago")).toBe(-300);
   });
 
-  it("parses tokens with Unicode minus sign, UTC prefix, and bare offsets", () => {
+  it("parses tokens with Unicode minus sign, UTC prefix, bare offsets, and historical seconds offsets", () => {
     expect(parseOffsetToken("GMT\u22127")).toBe(-420);
     expect(parseOffsetToken("UTC-5")).toBe(-300);
     expect(parseOffsetToken("-07:00")).toBe(-420);
     expect(parseOffsetToken("GMT+02:00")).toBe(120);
     expect(parseOffsetToken("GMT-5")).toBe(-300);
+    expect(parseOffsetToken("GMT-0:44:30")).toBe(-45);
+    expect(parseOffsetToken("GMT-11:19:40")).toBe(-680);
   });
 });
 

--- a/plugins/plugin-calendar/src/internal/time.ts
+++ b/plugins/plugin-calendar/src/internal/time.ts
@@ -78,14 +78,15 @@ export function getZonedDateParts(
 
 export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?(?::(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }
   const sign = match[1] === "+" ? 1 : -1;
   const hours = Number(match[2]);
   const minutes = Number(match[3] ?? "0");
-  return sign * (hours * 60 + minutes);
+  const seconds = Number(match[4] ?? "0");
+  return sign * (hours * 60 + minutes + Math.round(seconds / 60));
 }
 
 export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {

--- a/plugins/plugin-calendar/src/internal/time.ts
+++ b/plugins/plugin-calendar/src/internal/time.ts
@@ -81,7 +81,7 @@ export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   const token =
     parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }

--- a/plugins/plugin-calendar/src/internal/time.ts
+++ b/plugins/plugin-calendar/src/internal/time.ts
@@ -76,10 +76,7 @@ export function getZonedDateParts(
   };
 }
 
-export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
-  const parts = getOffsetFormatter(timeZone).formatToParts(date);
-  const token =
-    parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
   const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
@@ -89,6 +86,13 @@ export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   const hours = Number(match[2]);
   const minutes = Number(match[3] ?? "0");
   return sign * (hours * 60 + minutes);
+}
+
+export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
+  const parts = getOffsetFormatter(timeZone).formatToParts(date);
+  const token =
+    parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+  return parseOffsetToken(token);
 }
 
 function localPartsToEpochMs(parts: ZonedDateParts): number {

--- a/plugins/plugin-health/src/util/time.localdate.test.ts
+++ b/plugins/plugin-health/src/util/time.localdate.test.ts
@@ -51,12 +51,15 @@ describe("getTimeZoneOffsetMinutes", () => {
     expect(getTimeZoneOffsetMinutes(noonUtcJan, "Asia/Kolkata")).toBe(330);
   });
 
-  it("parses offset tokens including Unicode minus signs and UTC formats", () => {
+  it("parses offset tokens including Unicode minus signs, UTC formats, and historical seconds offsets", () => {
     expect(parseOffsetToken("GMT\u22127")).toBe(-420);
     expect(parseOffsetToken("UTC-5")).toBe(-300);
     expect(parseOffsetToken("-07:00")).toBe(-420);
     expect(parseOffsetToken("GMT+02:00")).toBe(120);
     expect(parseOffsetToken("GMT-5")).toBe(-300);
+    expect(parseOffsetToken("GMT-0:44:30")).toBe(-45);
+    expect(parseOffsetToken("GMT-11:19:40")).toBe(-680);
+    expect(getTimeZoneOffsetMinutes(new Date("1970-01-01T00:00:00Z"), "Africa/Monrovia")).toBe(-45);
   });
 });
 

--- a/plugins/plugin-health/src/util/time.localdate.test.ts
+++ b/plugins/plugin-health/src/util/time.localdate.test.ts
@@ -10,6 +10,7 @@ import {
   formatInstantAsRfc3339InTimeZone,
   getLocalDateKey,
   getTimeZoneOffsetMinutes,
+  parseOffsetToken,
   getWeekdayForLocalDate,
   getZonedDateParts,
 } from "./time.js";
@@ -48,6 +49,14 @@ describe("getTimeZoneOffsetMinutes", () => {
 
   it("parses half-hour offsets (Asia/Kolkata = +05:30)", () => {
     expect(getTimeZoneOffsetMinutes(noonUtcJan, "Asia/Kolkata")).toBe(330);
+  });
+
+  it("parses offset tokens including Unicode minus signs and UTC formats", () => {
+    expect(parseOffsetToken("GMT\u22127")).toBe(-420);
+    expect(parseOffsetToken("UTC-5")).toBe(-300);
+    expect(parseOffsetToken("-07:00")).toBe(-420);
+    expect(parseOffsetToken("GMT+02:00")).toBe(120);
+    expect(parseOffsetToken("GMT-5")).toBe(-300);
   });
 });
 

--- a/plugins/plugin-health/src/util/time.ts
+++ b/plugins/plugin-health/src/util/time.ts
@@ -75,10 +75,7 @@ export function getZonedDateParts(
   };
 }
 
-export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
-  const parts = getOffsetFormatter(timeZone).formatToParts(date);
-  const token =
-    parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
   const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
@@ -88,6 +85,13 @@ export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   const hours = Number(match[2]);
   const minutes = Number(match[3] ?? "0");
   return sign * (hours * 60 + minutes);
+}
+
+export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
+  const parts = getOffsetFormatter(timeZone).formatToParts(date);
+  const token =
+    parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+  return parseOffsetToken(token);
 }
 
 function formatOffsetToken(offsetMinutes: number): string {

--- a/plugins/plugin-health/src/util/time.ts
+++ b/plugins/plugin-health/src/util/time.ts
@@ -80,7 +80,7 @@ export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   const token =
     parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }

--- a/plugins/plugin-health/src/util/time.ts
+++ b/plugins/plugin-health/src/util/time.ts
@@ -77,14 +77,15 @@ export function getZonedDateParts(
 
 export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?(?::(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }
   const sign = match[1] === "+" ? 1 : -1;
   const hours = Number(match[2]);
   const minutes = Number(match[3] ?? "0");
-  return sign * (hours * 60 + minutes);
+  const seconds = Number(match[4] ?? "0");
+  return sign * (hours * 60 + minutes + Math.round(seconds / 60));
 }
 
 export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {

--- a/plugins/plugin-personal-assistant/src/lifeops/__tests__/service-helpers-misc.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/__tests__/service-helpers-misc.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { sortOverviewOccurrences } from "../service-helpers-misc.js";
+import { parseOffsetToken } from "../time.js";
 import type { LifeOpsOccurrenceView } from "../types.js";
 
 describe("LifeOps service helpers sorting", () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/__tests__/service-helpers-misc.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/__tests__/service-helpers-misc.test.ts
@@ -41,3 +41,13 @@ describe("LifeOps service helpers sorting", () => {
     expect(sorted[2]?.id).toBe("occ-2");
   });
 });
+
+describe("parseOffsetToken", () => {
+  it("parses offset tokens including Unicode minus signs and UTC formats", () => {
+    expect(parseOffsetToken("GMT\u22127")).toBe(-420);
+    expect(parseOffsetToken("UTC-5")).toBe(-300);
+    expect(parseOffsetToken("-07:00")).toBe(-420);
+    expect(parseOffsetToken("GMT+02:00")).toBe(120);
+    expect(parseOffsetToken("GMT-5")).toBe(-300);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/__tests__/service-helpers-misc.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/__tests__/service-helpers-misc.test.ts
@@ -44,11 +44,13 @@ describe("LifeOps service helpers sorting", () => {
 });
 
 describe("parseOffsetToken", () => {
-  it("parses offset tokens including Unicode minus signs and UTC formats", () => {
+  it("parses offset tokens including Unicode minus signs, UTC formats, and historical seconds offsets", () => {
     expect(parseOffsetToken("GMT\u22127")).toBe(-420);
     expect(parseOffsetToken("UTC-5")).toBe(-300);
     expect(parseOffsetToken("-07:00")).toBe(-420);
     expect(parseOffsetToken("GMT+02:00")).toBe(120);
     expect(parseOffsetToken("GMT-5")).toBe(-300);
+    expect(parseOffsetToken("GMT-0:44:30")).toBe(-45);
+    expect(parseOffsetToken("GMT-11:19:40")).toBe(-680);
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatTimezoneOffsetToken } from "./types.js";
+
+describe("formatTimezoneOffsetToken", () => {
+  it("formats offset tokens including Unicode minus signs and UTC formats", () => {
+    expect(formatTimezoneOffsetToken("GMT\u22127")).toBe("-07:00");
+    expect(formatTimezoneOffsetToken("UTC-5")).toBe("-05:00");
+    expect(formatTimezoneOffsetToken("-07:00")).toBe("-07:00");
+    expect(formatTimezoneOffsetToken("GMT+02:00")).toBe("+02:00");
+    expect(formatTimezoneOffsetToken("GMT-5")).toBe("-05:00");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.test.ts
@@ -10,5 +10,6 @@ describe("formatTimezoneOffsetToken", () => {
     expect(formatTimezoneOffsetToken("GMT-5")).toBe("-05:00");
     expect(formatTimezoneOffsetToken("GMT-00:44:30")).toBe("-00:45");
     expect(formatTimezoneOffsetToken("GMT+00:19:32")).toBe("+00:20");
+    expect(formatTimezoneOffsetToken("GMT-09:59:36")).toBe("-10:00");
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import { formatTimezoneOffsetToken } from "./types.js";
 
 describe("formatTimezoneOffsetToken", () => {
-  it("formats offset tokens including Unicode minus signs and UTC formats", () => {
+  it("formats offset tokens including Unicode minus signs, UTC formats, and historical seconds offsets", () => {
     expect(formatTimezoneOffsetToken("GMT\u22127")).toBe("-07:00");
     expect(formatTimezoneOffsetToken("UTC-5")).toBe("-05:00");
     expect(formatTimezoneOffsetToken("-07:00")).toBe("-07:00");
     expect(formatTimezoneOffsetToken("GMT+02:00")).toBe("+02:00");
     expect(formatTimezoneOffsetToken("GMT-5")).toBe("-05:00");
+    expect(formatTimezoneOffsetToken("GMT-00:44:30")).toBe("-00:45");
+    expect(formatTimezoneOffsetToken("GMT+00:19:32")).toBe("+00:20");
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
@@ -440,12 +440,10 @@ export function formatTimezoneOffsetToken(value: string): string {
     );
   }
   const sign = match[1] === "+" ? "+" : "-";
-  const hoursNum = Number(match[2]);
-  let minutesNum = Number(match[3] ?? "0");
-  const secondsNum = Number(match[4] ?? "0");
-  minutesNum += Math.round(secondsNum / 60);
-  const hours = String(hoursNum).padStart(2, "0");
-  const minutes = String(minutesNum).padStart(2, "0");
+  const totalSeconds = Number(match[2]) * 3600 + Number(match[3] ?? "0") * 60 + Number(match[4] ?? "0");
+  const totalMinutes = Math.round(totalSeconds / 60);
+  const hours = String(Math.floor(totalMinutes / 60)).padStart(2, "0");
+  const minutes = String(totalMinutes % 60).padStart(2, "0");
   return `${sign}${hours}:${minutes}`;
 }
 
@@ -467,10 +465,12 @@ function timezoneOffsetAt(instant: Date, timezone: string): string {
   try {
     return formatTimezoneOffsetToken(value);
   } catch (err) {
+    // error-policy:J2
     throw new HouseholdCoordinationError(
       "Could not resolve the IANA time-zone offset at the supplied instant",
       "HOUSEHOLD_INVALID_CONTRACT",
       { timezone, instant: instant.toISOString() },
+      err,
     );
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
@@ -438,7 +438,7 @@ function timezoneOffsetAt(instant: Date, timezone: string): string {
     .formatToParts(instant)
     .find((part) => part.type === "timeZoneName")?.value;
   if (value === "GMT" || value === "UTC") return "+00:00";
-  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{2}:\d{2})$/i.exec(value ?? "");
+  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i.exec(value ?? "");
   if (!match?.[1] || !match?.[2]) {
     throw new HouseholdCoordinationError(
       "Could not resolve the IANA time-zone offset at the supplied instant",
@@ -447,7 +447,9 @@ function timezoneOffsetAt(instant: Date, timezone: string): string {
     );
   }
   const sign = match[1] === "+" ? "+" : "-";
-  return `${sign}${match[2]}`;
+  const hours = match[2].padStart(2, "0");
+  const minutes = match[3] ? match[3].padStart(2, "0") : "00";
+  return `${sign}${hours}:${minutes}`;
 }
 
 function localDateTimeAt(

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
@@ -429,6 +429,22 @@ export function normalizeGrantScopes(
 const RFC3339_INSTANT_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
+export function formatTimezoneOffsetToken(value: string): string {
+  if (value === "GMT" || value === "UTC") return "+00:00";
+  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i.exec(value ?? "");
+  if (!match?.[1] || !match?.[2]) {
+    throw new HouseholdCoordinationError(
+      "Could not resolve the IANA time-zone offset at the supplied instant",
+      "HOUSEHOLD_INVALID_CONTRACT",
+      { value },
+    );
+  }
+  const sign = match[1] === "+" ? "+" : "-";
+  const hours = match[2].padStart(2, "0");
+  const minutes = match[3] ? match[3].padStart(2, "0") : "00";
+  return `${sign}${hours}:${minutes}`;
+}
+
 function timezoneOffsetAt(instant: Date, timezone: string): string {
   const value = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
@@ -437,19 +453,7 @@ function timezoneOffsetAt(instant: Date, timezone: string): string {
   })
     .formatToParts(instant)
     .find((part) => part.type === "timeZoneName")?.value;
-  if (value === "GMT" || value === "UTC") return "+00:00";
-  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i.exec(value ?? "");
-  if (!match?.[1] || !match?.[2]) {
-    throw new HouseholdCoordinationError(
-      "Could not resolve the IANA time-zone offset at the supplied instant",
-      "HOUSEHOLD_INVALID_CONTRACT",
-      { timezone, instant: instant.toISOString() },
-    );
-  }
-  const sign = match[1] === "+" ? "+" : "-";
-  const hours = match[2].padStart(2, "0");
-  const minutes = match[3] ? match[3].padStart(2, "0") : "00";
-  return `${sign}${hours}:${minutes}`;
+  return formatTimezoneOffsetToken(value ?? "");
 }
 
 function localDateTimeAt(

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
@@ -437,16 +437,17 @@ function timezoneOffsetAt(instant: Date, timezone: string): string {
   })
     .formatToParts(instant)
     .find((part) => part.type === "timeZoneName")?.value;
-  if (value === "GMT") return "+00:00";
-  const match = /^GMT([+-]\d{2}:\d{2})$/.exec(value ?? "");
-  if (!match?.[1]) {
+  if (value === "GMT" || value === "UTC") return "+00:00";
+  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{2}:\d{2})$/i.exec(value ?? "");
+  if (!match?.[1] || !match?.[2]) {
     throw new HouseholdCoordinationError(
       "Could not resolve the IANA time-zone offset at the supplied instant",
       "HOUSEHOLD_INVALID_CONTRACT",
       { timezone, instant: instant.toISOString() },
     );
   }
-  return match[1];
+  const sign = match[1] === "+" ? "+" : "-";
+  return `${sign}${match[2]}`;
 }
 
 function localDateTimeAt(

--- a/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/types.ts
@@ -431,7 +431,7 @@ const RFC3339_INSTANT_PATTERN =
 
 export function formatTimezoneOffsetToken(value: string): string {
   if (value === "GMT" || value === "UTC") return "+00:00";
-  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i.exec(value ?? "");
+  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?(?::(\d{2}))?$/i.exec(value ?? "");
   if (!match?.[1] || !match?.[2]) {
     throw new HouseholdCoordinationError(
       "Could not resolve the IANA time-zone offset at the supplied instant",
@@ -440,8 +440,12 @@ export function formatTimezoneOffsetToken(value: string): string {
     );
   }
   const sign = match[1] === "+" ? "+" : "-";
-  const hours = match[2].padStart(2, "0");
-  const minutes = match[3] ? match[3].padStart(2, "0") : "00";
+  const hoursNum = Number(match[2]);
+  let minutesNum = Number(match[3] ?? "0");
+  const secondsNum = Number(match[4] ?? "0");
+  minutesNum += Math.round(secondsNum / 60);
+  const hours = String(hoursNum).padStart(2, "0");
+  const minutes = String(minutesNum).padStart(2, "0");
   return `${sign}${hours}:${minutes}`;
 }
 
@@ -453,7 +457,22 @@ function timezoneOffsetAt(instant: Date, timezone: string): string {
   })
     .formatToParts(instant)
     .find((part) => part.type === "timeZoneName")?.value;
-  return formatTimezoneOffsetToken(value ?? "");
+  if (!value) {
+    throw new HouseholdCoordinationError(
+      "Could not resolve the IANA time-zone offset at the supplied instant",
+      "HOUSEHOLD_INVALID_CONTRACT",
+      { timezone, instant: instant.toISOString() },
+    );
+  }
+  try {
+    return formatTimezoneOffsetToken(value);
+  } catch (err) {
+    throw new HouseholdCoordinationError(
+      "Could not resolve the IANA time-zone offset at the supplied instant",
+      "HOUSEHOLD_INVALID_CONTRACT",
+      { timezone, instant: instant.toISOString() },
+    );
+  }
 }
 
 function localDateTimeAt(

--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -88,7 +88,7 @@ export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   const token =
     parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }

--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -85,14 +85,15 @@ export function getZonedDateParts(
 
 export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
-  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
+  const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?(?::(\d{2}))?$/i);
   if (!match) {
     throw new Error(`unsupported offset token: ${token}`);
   }
   const sign = match[1] === "+" ? 1 : -1;
   const hours = Number(match[2]);
   const minutes = Number(match[3] ?? "0");
-  return sign * (hours * 60 + minutes);
+  const seconds = Number(match[4] ?? "0");
+  return sign * (hours * 60 + minutes + Math.round(seconds / 60));
 }
 
 export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {

--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -83,10 +83,7 @@ export function getZonedDateParts(
   };
 }
 
-export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
-  const parts = getOffsetFormatter(timeZone).formatToParts(date);
-  const token =
-    parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
   const match = token.match(/^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i);
   if (!match) {
@@ -96,6 +93,13 @@ export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
   const hours = Number(match[2]);
   const minutes = Number(match[3] ?? "0");
   return sign * (hours * 60 + minutes);
+}
+
+export function getTimeZoneOffsetMinutes(date: Date, timeZone: string): number {
+  const parts = getOffsetFormatter(timeZone).formatToParts(date);
+  const token =
+    parts.find((part) => part.type === "timeZoneName")?.value?.trim() ?? "GMT";
+  return parseOffsetToken(token);
 }
 
 function formatOffsetToken(offsetMinutes: number): string {

--- a/plugins/plugin-scheduling/src/scheduled-task/local-time.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/local-time.test.ts
@@ -6,12 +6,14 @@ import { describe, expect, it } from "vitest";
 import { parseOffsetToken, resolveLocalHHMMToIso } from "./local-time.js";
 
 describe("parseOffsetToken", () => {
-  it("parses offset tokens including Unicode minus signs and UTC formats", () => {
+  it("parses offset tokens including Unicode minus signs, UTC formats, and historical seconds offsets", () => {
     expect(parseOffsetToken("GMT\u22127")).toBe(-420);
     expect(parseOffsetToken("UTC-5")).toBe(-300);
     expect(parseOffsetToken("-07:00")).toBe(-420);
     expect(parseOffsetToken("GMT+02:00")).toBe(120);
     expect(parseOffsetToken("GMT-5")).toBe(-300);
+    expect(parseOffsetToken("GMT-0:44:30")).toBe(-45);
+    expect(parseOffsetToken("GMT-11:19:40")).toBe(-680);
   });
 });
 

--- a/plugins/plugin-scheduling/src/scheduled-task/local-time.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/local-time.test.ts
@@ -3,7 +3,17 @@
  * clocks, skipped hours, and a skipped calendar date.
  */
 import { describe, expect, it } from "vitest";
-import { resolveLocalHHMMToIso } from "./local-time.js";
+import { parseOffsetToken, resolveLocalHHMMToIso } from "./local-time.js";
+
+describe("parseOffsetToken", () => {
+  it("parses offset tokens including Unicode minus signs and UTC formats", () => {
+    expect(parseOffsetToken("GMT\u22127")).toBe(-420);
+    expect(parseOffsetToken("UTC-5")).toBe(-300);
+    expect(parseOffsetToken("-07:00")).toBe(-420);
+    expect(parseOffsetToken("GMT+02:00")).toBe(120);
+    expect(parseOffsetToken("GMT-5")).toBe(-300);
+  });
+});
 
 describe("resolveLocalHHMMToIso compatible disambiguation", () => {
   it("moves Santiago's skipped midnight forward by the one-hour gap", () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
@@ -97,12 +97,15 @@ function localParts(date: Date, timeZone: string): LocalMinuteParts {
 
 export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
-  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i.exec(token);
+  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?(?::(\d{2}))?$/i.exec(token);
   if (!match) {
     throw new Error(`unsupported timezone offset token: ${token}`);
   }
   const sign = match[1] === "+" ? 1 : -1;
-  return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? "0");
+  const seconds = Number(match[4] ?? "0");
+  return sign * (hours * 60 + minutes + Math.round(seconds / 60));
 }
 
 function offsetMinutes(date: Date, timeZone: string): number {

--- a/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
@@ -102,7 +102,7 @@ function offsetMinutes(date: Date, timeZone: string): number {
       .find((part) => part.type === "timeZoneName")
       ?.value.trim() ?? "GMT";
   if (token === "GMT" || token === "UTC") return 0;
-  const match = /^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/.exec(token);
+  const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i.exec(token);
   if (!match) {
     throw new Error(`unsupported timezone offset token: ${token}`);
   }

--- a/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/local-time.ts
@@ -95,12 +95,7 @@ function localParts(date: Date, timeZone: string): LocalMinuteParts {
   };
 }
 
-function offsetMinutes(date: Date, timeZone: string): number {
-  const token =
-    offsetFormatter(timeZone)
-      .formatToParts(date)
-      .find((part) => part.type === "timeZoneName")
-      ?.value.trim() ?? "GMT";
+export function parseOffsetToken(token: string): number {
   if (token === "GMT" || token === "UTC") return 0;
   const match = /^(?:GMT|UTC)?([+-]|\u2212|\u2013|\u2014)(\d{1,2})(?::?(\d{2}))?$/i.exec(token);
   if (!match) {
@@ -108,6 +103,15 @@ function offsetMinutes(date: Date, timeZone: string): number {
   }
   const sign = match[1] === "+" ? 1 : -1;
   return sign * (Number(match[2]) * 60 + Number(match[3] ?? "0"));
+}
+
+function offsetMinutes(date: Date, timeZone: string): number {
+  const token =
+    offsetFormatter(timeZone)
+      .formatToParts(date)
+      .find((part) => part.type === "timeZoneName")
+      ?.value.trim() ?? "GMT";
+  return parseOffsetToken(token);
 }
 
 function sameLocalMinute(


### PR DESCRIPTION
## Description
This PR normalizes timezone offset parsing across all 7 timezone offset parser functions in the codebase.

### Changes
- Updated regex in all 7 timezone offset parsers to handle optional GMT/UTC prefixes, Unicode minus signs (U+2212), and dash variants.
- Updated 7th parser in `plugins/plugin-personal-assistant/src/lifeops/household/types.ts`.
- Added direct unit test assertions for token parsing (`GMT−7`, `UTC-5`, `-07:00`, `GMT+02:00`).
