### PR TITLE
fix(lifeops): include approved agreement pins in initial response context

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -11,8 +11,11 @@ import path from "node:path";
 import { resolveKnowledgeGraphService } from "@elizaos/agent";
 import {
   type AgentRuntime,
+  attestAuthenticatedApiDeliveryAudience,
+  ChannelType,
   documentsPluginCore,
   type IAgentRuntime,
+  type Memory,
   type Plugin,
   Service,
   ServiceType,
@@ -21,6 +24,7 @@ import {
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { LocalFileStorageService } from "../../../../../packages/agent/src/services/file-storage.js";
+import { composeResponseState } from "../../../../../packages/core/src/services/message/provider-state.js";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
@@ -388,6 +392,103 @@ describe("parenting-agreement knowledge — real PGlite", () => {
     await expect(
       service.listOwnerAgreements({ ownerEntityId: "verified-co-parent" }),
     ).rejects.toMatchObject({ code: "AGREEMENT_ACCESS_DENIED" });
+  });
+
+  it("composes approved pins on ordinary owner turns while preserving room and audience boundaries", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const ownerId = crypto.randomUUID() as UUID;
+    const roomId = crypto.randomUUID() as UUID;
+    const otherRoomId = crypto.randomUUID() as UUID;
+    const previousOwner = runtime.getSetting("ELIZA_ADMIN_ENTITY_ID");
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId);
+    await runtime.createEntity({
+      id: ownerId,
+      names: ["Pin owner"],
+      agentId: runtime.agentId,
+    });
+    for (const id of [roomId, otherRoomId]) {
+      await runtime.createRoom({
+        id,
+        source: "eliza-client",
+        type: ChannelType.DM,
+        worldId: runtime.agentId,
+      });
+      await runtime.addParticipant(ownerId, id);
+      await runtime.addParticipant(runtime.agentId, id);
+    }
+    const compose = async (targetRoomId: UUID) => {
+      const message: Memory = {
+        id: crypto.randomUUID() as UUID,
+        entityId: ownerId,
+        agentId: runtime.agentId,
+        roomId: targetRoomId,
+        content: {
+          text: "What approved agreement obligation applies here?",
+          source: "eliza-client",
+        },
+      };
+      await attestAuthenticatedApiDeliveryAudience(runtime, message, {
+        kind: "owner_session",
+        principalId: ownerId,
+      });
+      return composeResponseState(runtime, message);
+    };
+    let pin = await service.pin({
+      artifactId: artifact.id,
+      targetType: "chat",
+      targetId: roomId,
+      pinnedByEntityId: SELF_ENTITY_ID,
+    });
+    try {
+      const state = await compose(roomId);
+      expect(state.text).toContain(
+        "Share school notices within twenty-four hours.",
+      );
+      expect(state.text).toContain("source pages 4-5");
+      expect(state.text).not.toContain("An unsupported model interpretation.");
+      expect((await compose(otherRoomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+
+      await service.unpin({
+        pinId: pin.id,
+        unpinnedByEntityId: SELF_ENTITY_ID,
+      });
+      expect((await compose(roomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+      pin = await service.pin({
+        artifactId: artifact.id,
+        targetType: "agent",
+        targetId: runtime.agentId,
+        pinnedByEntityId: SELF_ENTITY_ID,
+      });
+      expect((await compose(otherRoomId)).text).toContain(
+        "Share school notices within twenty-four hours.",
+      );
+
+      const guestId = crypto.randomUUID() as UUID;
+      await runtime.createEntity({
+        id: guestId,
+        names: ["Other participant"],
+        agentId: runtime.agentId,
+      });
+      await runtime.addParticipant(guestId, roomId);
+      expect((await compose(roomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+    } finally {
+      await service.unpin({
+        pinId: pin.id,
+        unpinnedByEntityId: SELF_ENTITY_ID,
+      });
+      runtime.setSetting(
+        "ELIZA_ADMIN_ENTITY_ID",
+        typeof previousOwner === "string" || typeof previousOwner === "boolean"
+          ? previousOwner
+          : null,
+      );
+    }
   });
 
   it("requires verified identity plus an exact active household grant", async () => {

--- a/plugins/plugin-personal-assistant/src/providers/agreement-pins.ts
+++ b/plugins/plugin-personal-assistant/src/providers/agreement-pins.ts
@@ -16,6 +16,7 @@ export const agreementPinsProvider: Provider = {
   descriptionCompressed:
     "Owner-approved, page-cited parenting-agreement obligations from active pins.",
   dynamic: true,
+  alwaysInResponseState: true,
   position: -8,
   cacheScope: "turn",
 


### PR DESCRIPTION
An owner-approved agreement could be visibly pinned to a chat while an ordinary response still received no agreement context. The live pilot replied `NO_PINNED_OBLIGATION` in both an unpinned chat and a fresh chat with an approved, page-cited obligation pinned to it.

The agreement provider now participates in ordinary response-state composition. Its existing owner-only disclosure gate, per-turn evaluation, and pin-target checks remain in place.

A regression uses the real PGlite agreement store and core response-state composer. It failed before the change and now verifies approved text with page citations, rejection exclusion, chat isolation, removal, agent-wide pins, and shared-room denial. The test harness stubs the package owner-access helper; live owner authentication is verified separately on the pilot.

Fixes #31085.

A second recorded live baseline on the mobile pilot captured seven model calls: the initial two lacked the approved pin, later calls included it, and an unnecessary `VIEWS` action failed because no view client was attached. This narrows the regression to initial response composition rather than absence from every later planner stage. The temporary pin was removed and independently read back.

Validation:

- Pinned `bun install` passed; root `bun run verify` passed all 373 tasks on `e0c72296cf9d040a9d9cfb84ad2e37448445ab0c`.
- Focused real-PGlite integration: 7/7 passed, including initial response context, citations, scope, removal and audience denial.
- Combined pilot `aa65e08acd40d808dad5df6d32e5f19ca2905920`: local and Linux root gates passed; Linux production builds completed and all 3,577 release-file hashes were verified. Deployment and independent public HTTPS entry hashes match; stored agreements/calendar controls/monthly packet were preserved.
- Live fixed-version pinned response: "Parent Example A handles the Monday library pickup at 15:00. (source page 1-1)". The initial model prompt contains the approved obligation and excludes rejected/proposed obligations; no tool actions were taken. The temporary pin was removed and independently read back.
- A fresh unpinned control contains no pinned-agreement block, but the provider hit its model-output limit and returned a retrieval error. This control is not a full live-model pass and remains part of broader MVP acceptance #30123. Full traces remain private because they contain owner context; [sanitized synthetic live evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/bettina-pin-live-evidence.zip) includes the before/after inputs, replies and failed control.
- Full personal-assistant suites passed: source branch 2,648 tests across 303 files; Linux combined candidate 2,708 tests across 308 files. Each has six existing skips. All five hosted checks passed on the exact PR head: Source static smoke, Windows security, billing payment replay, PostgreSQL subscription authority, and the aggregate gate (run 34674569244).

UI evidence: N/A for this provider-composition change. The separate deployed mobile repair is documented in #30123.
