### PR TITLE
chore: promote Dedicated authentication recovery to staging

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.test.tsx
@@ -96,10 +96,33 @@ it.each([
     expect(destination.origin).toBe("https://staging.eliza.app");
     const returnTo = new URL(requiredReturnTo(destination));
     expect(returnTo.origin).toBe("http://localhost:21484");
-    expect(returnTo.pathname).toBe("/chat");
+    expect(returnTo.pathname + returnTo.hash).toBe("/settings#cloud-overview");
     expect(returnTo.searchParams.get("elizaCloudLoginSession")).toBe(sessionId);
   },
 );
+
+it.each(["/", "/chat"])(
+  "offers agent selection after account switching instead of returning to %s without an agent",
+  async (path) => {
+    await begin(`/login?switchAccount=1&returnTo=${encodeURIComponent(path)}`);
+    await waitFor(() => expect(mocks.assign).toHaveBeenCalledOnce());
+    const login = new URL(mocks.assign.mock.calls[0][0]);
+    const handoff = new URL(requiredReturnTo(login), login.origin);
+    const returnTo = new URL(requiredReturnTo(handoff));
+    expect(mocks.clearBinding).toHaveBeenCalledOnce();
+    expect(returnTo.pathname + returnTo.hash).toBe("/settings#cloud-overview");
+    expect(returnTo.searchParams.get("elizaCloudLoginSession")).toBe(sessionId);
+  },
+);
+
+it("retains an explicit chat return when the existing agent binding is preserved", async () => {
+  await begin("/login?returnTo=%2Fchat");
+  await waitFor(() => expect(mocks.assign).toHaveBeenCalledOnce());
+  const handoff = new URL(mocks.assign.mock.calls[0][0]);
+  const returnTo = new URL(requiredReturnTo(handoff));
+  expect(mocks.clearBinding).not.toHaveBeenCalled();
+  expect(returnTo.pathname).toBe("/chat");
+});
 
 it("preserves a safe app destination and performs explicit account switching on both origins", async () => {
   await begin("/login?switchAccount=1&returnTo=%2Fsettings%23cloud-overview");

--- a/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.tsx
@@ -60,12 +60,20 @@ export default function LoopbackCloudLoginSection() {
         );
       }
       const requested = sanitizeLoginReturnTo(searchParams.get("returnTo"));
-      const returnTo = new URL(requested || "/chat", window.location.origin);
+      const returnTo = new URL(
+        requested || "/settings#cloud-overview",
+        window.location.origin,
+      );
       // Public auth pages cannot consume the app's CLI completion marker.
-      if (/^\/(?:login|join|auth)(?:\/|$)/.test(returnTo.pathname)) {
-        returnTo.pathname = "/chat";
+      // Account switching also removed the selected agent: offer the signed-in
+      // account's agents before returning to a chat with no Cloud target.
+      if (
+        /^\/(?:login|join|auth)(?:\/|$)/.test(returnTo.pathname) ||
+        (switchAccount && ["/", "/chat"].includes(returnTo.pathname))
+      ) {
+        returnTo.pathname = "/settings";
         returnTo.search = "";
-        returnTo.hash = "";
+        returnTo.hash = "cloud-overview";
       }
       returnTo.searchParams.set("elizaCloudLogin", "complete");
       returnTo.searchParams.set("elizaCloudLoginSession", session.sessionId);

--- a/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
@@ -435,15 +435,66 @@ describe("useAgentSessionRecovery", () => {
     expect(mockRunRecovery).not.toHaveBeenCalled();
   });
 
-  it("re-pairs when native SIWE supplies the Cloud token after the initial recovery attempt", async () => {
-    (globalThis as { Capacitor?: unknown }).Capacitor = {
-      isNativePlatform: () => true,
-    };
+  it.each(["native", "cloud-staging.eliza.app"])(
+    "re-pairs on %s when sign-in supplies the Cloud token after the initial recovery attempt",
+    async (host) => {
+      if (host === "native") {
+        (globalThis as { Capacitor?: unknown }).Capacitor = {
+          isNativePlatform: () => true,
+        };
+      } else {
+        setHostname(host);
+      }
+      let cloudToken: string | null = null;
+      mockCloudToken.mockImplementation(() => cloudToken);
+      mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+      mockRunRecovery.mockReturnValue(new Promise(() => {}));
+
+      const statuses: string[] = [];
+      render(
+        <Probe
+          active
+          reason="remote_auth_required"
+          onStatus={(status) => statuses.push(status)}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockEnsureCloudSession).toHaveBeenCalledOnce();
+        expect(statuses.at(-1)).toBe(
+          host === "native" ? "cloud-reauth-required" : "idle",
+        );
+      });
+      expect(mockRunRecovery).not.toHaveBeenCalled();
+
+      cloudToken = "steward.jwt.from-native-siwe";
+      act(() => {
+        window.dispatchEvent(new CustomEvent("steward-token-sync"));
+      });
+
+      await waitFor(() => {
+        expect(mockRunRecovery).toHaveBeenCalledTimes(1);
+      });
+      expect(statuses).toContain("recovering");
+      expect(mockRunRecovery.mock.calls[0][0]).toMatchObject({
+        agentId: "agent-1",
+        cloudToken: "steward.jwt.from-native-siwe",
+      });
+    },
+  );
+
+  it("keeps a hosted cookie repair alive when its session publication arrives before refresh completes", async () => {
+    setHostname("cloud-staging.eliza.app");
     let cloudToken: string | null = null;
+    let completeRefresh!: (token: string) => void;
     mockCloudToken.mockImplementation(() => cloudToken);
     mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockEnsureCloudSession.mockReturnValue(
+      new Promise((resolve) => {
+        completeRefresh = resolve;
+      }),
+    );
     mockRunRecovery.mockReturnValue(new Promise(() => {}));
-
     const statuses: string[] = [];
     render(
       <Probe
@@ -452,25 +503,88 @@ describe("useAgentSessionRecovery", () => {
         onStatus={(status) => statuses.push(status)}
       />,
     );
+    await waitFor(() => expect(mockEnsureCloudSession).toHaveBeenCalledOnce());
 
-    await waitFor(() => {
-      expect(statuses.at(-1)).toBe("cloud-reauth-required");
-    });
-    expect(mockRunRecovery).not.toHaveBeenCalled();
-
-    cloudToken = "steward.jwt.from-native-siwe";
     act(() => {
+      cloudToken = "steward.jwt.from-cookie-refresh";
       window.dispatchEvent(new CustomEvent("steward-token-sync"));
     });
+    await act(async () => completeRefresh("steward.jwt.from-cookie-refresh"));
 
-    await waitFor(() => {
-      expect(mockRunRecovery).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockRunRecovery).toHaveBeenCalledOnce());
+    expect(mockRunRecovery.mock.calls[0][0].signal.aborted).toBe(false);
+    expect(statuses.at(-1)).toBe("recovering");
+  });
+
+  it("uses a refreshed hosted session after rejection without retrying the same rejected credential", async () => {
+    setHostname("cloud-staging.eliza.app");
+    let cloudToken = "steward.jwt.before-refresh";
+    let rejectFirstSession!: (result: {
+      ok: false;
+      reason: "unauthorized";
+      message: string;
+    }) => void;
+    const rejected = {
+      ok: false as const,
+      reason: "unauthorized" as const,
+      message: "Session expired",
+    };
+    mockCloudToken.mockImplementation(() => cloudToken);
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockRunRecovery
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          rejectFirstSession = resolve;
+        }),
+      )
+      .mockResolvedValue(rejected);
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(status) => statuses.push(status)}
+      />,
+    );
+    await waitFor(() => expect(mockRunRecovery).toHaveBeenCalledOnce());
+    const firstSignal = mockRunRecovery.mock.calls[0][0].signal;
+
+    act(() => {
+      cloudToken = "steward.jwt.after-refresh";
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
     });
-    expect(statuses).toContain("recovering");
-    expect(mockRunRecovery.mock.calls[0][0]).toMatchObject({
-      agentId: "agent-1",
-      cloudToken: "steward.jwt.from-native-siwe",
+    expect(firstSignal.aborted).toBe(false);
+    await act(async () => rejectFirstSession(rejected));
+    await waitFor(() => expect(mockRunRecovery).toHaveBeenCalledTimes(2));
+    expect(mockRunRecovery.mock.calls[1][0].cloudToken).toBe(cloudToken);
+    await waitFor(() => expect(statuses.at(-1)).toBe("idle"));
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
     });
+    expect(mockRunRecovery).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels an in-flight hosted repair when its Cloud session is removed", async () => {
+    setHostname("cloud-staging.eliza.app");
+    let cloudToken: string | null = "steward.jwt.before-logout";
+    mockCloudToken.mockImplementation(() => cloudToken);
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockRunRecovery.mockReturnValue(new Promise(() => {}));
+    render(<Probe active reason="remote_auth_required" onStatus={() => {}} />);
+    await waitFor(() => expect(mockRunRecovery).toHaveBeenCalledOnce());
+    const attempt = mockRunRecovery.mock.calls[0][0];
+
+    act(() => {
+      cloudToken = null;
+      window.dispatchEvent(new CustomEvent("steward-token-sync"));
+    });
+    expect(attempt.signal.aborted).toBe(true);
+    await expect(
+      attempt.commitPairedInProcess("late-agent-bearer"),
+    ).rejects.toThrow("target changed");
+    expect(mockPersistCloudPairApiToken).not.toHaveBeenCalled();
+    expect(mockSetAgentToken).not.toHaveBeenCalled();
   });
 
   it("REGRESSION: returning PWA with no app-origin token but a live Eliza Cloud cookie silently re-pairs instead of dead-ending", async () => {

--- a/packages/ui/src/hooks/useAgentSessionRecovery.ts
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.ts
@@ -19,7 +19,7 @@
  */
 
 import { logger } from "@elizaos/logger";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getCloudAuthToken } from "../api/client-cloud";
 import { isAppModeHost } from "../cloud/app-mode/app-mode";
 import { persistCloudPairApiToken } from "../components/auth/CloudPairRelay";
@@ -137,6 +137,7 @@ export function useAgentSessionRecovery(
   // A loading refetch briefly leaves the unauthenticated state, so only a
   // confirmed session (or remount) may rearm recovery for a later genuine 401.
   const attemptedRef = useRef(false);
+  const attemptedCloudTokenRef = useRef<string | null>(null);
   const awaitingCloudTokenRef = useRef(false);
   const attemptedFallbackRef = useRef<ManagedCloudAgentRecoveryStatus>(
     "cloud-retry-required",
@@ -145,24 +146,36 @@ export function useAgentSessionRecovery(
     getCloudAuthToken(),
   );
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const rearmAfterCloudReauth = () => {
-      const cloudToken = getCloudAuthToken();
-      setCloudTokenSnapshot(cloudToken);
-      if (!awaitingCloudTokenRef.current || !cloudToken?.trim()) {
+  const rearmAfterCloudReauth = useCallback(() => {
+    const cloudToken = getCloudAuthToken()?.trim() || null;
+    if (!cloudToken) {
+      // Removing session authority must still cancel an in-flight repair.
+      setCloudTokenSnapshot(null);
+      return;
+    }
+    if (attemptedRef.current) {
+      // A cookie refresh publishes its token before resolving to this hook.
+      // Let that transaction finish instead of aborting it on its own event.
+      // A refused session may retry only after a different session arrives.
+      if (
+        !awaitingCloudTokenRef.current ||
+        cloudToken === attemptedCloudTokenRef.current
+      ) {
         return;
       }
       awaitingCloudTokenRef.current = false;
       attemptedRef.current = false;
-    };
+    }
+    setCloudTokenSnapshot(cloudToken);
+  }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
     window.addEventListener("steward-token-sync", rearmAfterCloudReauth);
     return () => {
       window.removeEventListener("steward-token-sync", rearmAfterCloudReauth);
     };
-  }, []);
+  }, [rearmAfterCloudReauth]);
 
   useEffect(() => {
     const consumeRedirectInProcess = shouldConsumePairRedirectInProcess();
@@ -180,14 +193,20 @@ export function useAgentSessionRecovery(
     ) => {
       attemptedFallbackRef.current = managedStatus;
       awaitingCloudTokenRef.current =
-        isManagedNative && managedStatus === "cloud-reauth-required";
+        consumeRedirectInProcess &&
+        isManagedCloudAgentServer(activeServer) &&
+        managedStatus === "cloud-reauth-required";
       setStatus(fallbackStatus(managedStatus));
+      // Session publication can precede a failed refresh/mint response, so
+      // observe the current session now as well as future sync events.
+      if (awaitingCloudTokenRef.current) rearmAfterCloudReauth();
     };
 
     if (!active) {
       awaitingCloudTokenRef.current = false;
       if (isAuthenticated) {
         attemptedRef.current = false;
+        attemptedCloudTokenRef.current = null;
         attemptedFallbackRef.current = "cloud-retry-required";
       }
       setStatus("idle");
@@ -224,6 +243,7 @@ export function useAgentSessionRecovery(
       cloudToken: string,
     ) => {
       awaitingCloudTokenRef.current = false;
+      attemptedCloudTokenRef.current = cloudToken;
       if (decision.action !== "re-pair") {
         showFallback(
           cloudToken.trim() ? "cloud-manage-required" : "cloud-reauth-required",
@@ -325,6 +345,7 @@ export function useAgentSessionRecovery(
     const initialInput = resolveInput(cloudTokenSnapshot);
     const initialDecision = resolveAgentSessionRecovery(initialInput);
     const initialCloudToken = initialInput.cloudToken?.trim();
+    attemptedCloudTokenRef.current = initialCloudToken || null;
 
     if (initialDecision.action === "re-pair" && initialCloudToken) {
       // Fast path: app-origin cloud token already present, re-pair immediately
@@ -362,16 +383,6 @@ export function useAgentSessionRecovery(
         if (!token) {
           // No cookie / refresh failed / timed out: the notice is honest now.
           showFallback("cloud-reauth-required");
-          // Native SIWE can finish in the narrow window between the cookie
-          // refresh resolving and the fallback being armed. Its sync event has
-          // already fired, so re-check the canonical token once instead of
-          // waiting forever for a second event.
-          const lateCloudToken = getCloudAuthToken();
-          if (awaitingCloudTokenRef.current && lateCloudToken?.trim()) {
-            awaitingCloudTokenRef.current = false;
-            attemptedRef.current = false;
-            setCloudTokenSnapshot(lateCloudToken);
-          }
           return;
         }
         const decision = resolveAgentSessionRecovery(
@@ -397,6 +408,7 @@ export function useAgentSessionRecovery(
     onRecovered,
     isAuthenticated,
     cloudTokenSnapshot,
+    rearmAfterCloudReauth,
   ]);
 
   return status;

--- a/packages/ui/src/state/useCloudState.steward-refresh-electrobun.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-refresh-electrobun.test.tsx
@@ -17,9 +17,21 @@ const clientCloudMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../api/client-cloud", () => ({
+  hasDirectCloudAccountTransport: () => false,
   cloudTokenSecsRemaining: () => 0,
   refreshCloudStewardSession: clientCloudMocks.refreshCloudStewardSession,
   resolveDirectCloudAuthApiBase: () => "https://api.eliza.app",
+}));
+
+vi.mock("../api", () => ({
+  client: {
+    getBaseUrl: () => "",
+    getCloudStatus: async () => ({
+      connected: false,
+      enabled: true,
+      hasApiKey: false,
+    }),
+  },
 }));
 
 vi.mock("../bridge", () => ({

--- a/packages/ui/src/state/useCloudState.steward-refresh-error-boundary.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-refresh-error-boundary.test.tsx
@@ -29,9 +29,21 @@ vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => ({
 }));
 
 vi.mock("../api/client-cloud", () => ({
+  hasDirectCloudAccountTransport: () => false,
   cloudTokenSecsRemaining: () => 0,
   refreshCloudStewardSession: clientCloudMocks.refreshCloudStewardSession,
   resolveDirectCloudAuthApiBase: clientCloudMocks.resolveDirectCloudAuthApiBase,
+}));
+
+vi.mock("../api", () => ({
+  client: {
+    getBaseUrl: () => "",
+    getCloudStatus: async () => ({
+      connected: false,
+      enabled: true,
+      hasApiKey: false,
+    }),
+  },
 }));
 
 vi.mock("../bridge", () => ({

--- a/packages/ui/src/state/useCloudState.steward-refresh.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-refresh.test.tsx
@@ -10,6 +10,7 @@
 
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { client } from "../api";
 import { useCloudState } from "./useCloudState";
 
 const STEWARD_TOKEN_KEY = "steward_session_token";
@@ -78,6 +79,33 @@ describe("useCloudState — Steward refresh arms on stored-token presence", () =
     await waitFor(() =>
       expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(fresh),
     );
+  });
+
+  it("rechecks account authority after refreshing an expired session without a reload", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    const fresh = makeJwt(3600);
+    vi.spyOn(client, "getBaseUrl").mockReturnValue(
+      "https://api-staging.eliza.app",
+    );
+    fetchMock.mockImplementation(async (input: string, init?: RequestInit) => {
+      const path = new URL(input, "https://cloud-staging.eliza.app").pathname;
+      if (path === STEWARD_REFRESH_PATH) return Response.json({ token: fresh });
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        `Bearer ${fresh}`,
+      );
+      if (path === "/api/v1/user")
+        return Response.json({ id: "reconnected-user" });
+      if (path === "/api/v1/credits/balance")
+        return Response.json({ balance: 25 });
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    const { result, unmount } = renderHook(() => useCloudState(makeParams()));
+    await waitFor(() => expect(result.current.elizaCloudConnected).toBe(true));
+    expect(result.current.elizaCloudUserId).toBe("reconnected-user");
+    expect(result.current.elizaCloudCredits).toBe(25);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    unmount();
   });
 
   it("does NOT refresh a comfortably-valid stored JWT (no needless work)", async () => {

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -2044,7 +2044,19 @@ export function useCloudState({
         });
         if (disposed) return;
         if (result?.token) {
-          await replaceStoredStewardTokenIfCurrent(storedToken, result.token);
+          const replaced = await replaceStoredStewardTokenIfCurrent(
+            storedToken,
+            result.token,
+          );
+          // Disconnected accounts have no recurring status poll. Recheck the
+          // server after refresh so a recovered session becomes usable in place.
+          if (
+            replaced &&
+            !disposed &&
+            readStoredStewardToken() === result.token
+          ) {
+            await pollCloudCredits();
+          }
         }
       } catch (err: unknown) {
         // error-policy:J4 a pre-emptive refresh or protected persistence
@@ -2070,7 +2082,7 @@ export function useCloudState({
       disposed = true;
       clearInterval(interval);
     };
-  }, [elizaCloudConnected]);
+  }, [elizaCloudConnected, pollCloudCredits]);
 
   // ── Return ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Promote the Dedicated authentication and local agent-selection fixes from develop to staging.

Source develop 64d6636560ecae2d08b291697f90fbcb74fe96f5 has tree 303a011abcaab4fb5b97090b1082a27bf78897f0. The merge preview produces that identical verified tree. The change covers eight UI/test files: session recovery, account refresh and the local login return destination. The existing Dedicated runtime image and state are retained.

Full bun run verify passed on the final source. Focused validation passed 116 recovery/account tests and 37 local handoff tests; eight affected viewport captures plus packaged OCR passed. Real Google sign-in in the authorized Chrome profile returned to Cloud agent selection; choosing the existing Dedicated agent preserved 18 prior messages and produced a correct new reply, bringing history to 20 messages. Mobile reload and the new hosted rollout are still pending. Hosted source/billing checks remained in progress at owner-authorized merge, subscription authority passed, and the Windows check was cancelled.

After promotion, dispatch the complete canonical staging release with deployed-renderer verification. Production is unchanged, and first-time Google signup remains unverified.

Source PR: #31100.
