### PR TITLE
test: verify Dedicated reconnect before requiring runtime choice

### DIFF
--- a/packages/app/test/cloud-live-optional-action.ts
+++ b/packages/app/test/cloud-live-optional-action.ts
@@ -1,6 +1,10 @@
 /** Bounds optional Cloud onboarding actions without retaining DOM or account data. */
 
 import type { Locator } from "@playwright/test";
+import {
+  type CloudLiveRuntimeBinding,
+  compareCloudLiveRuntimeBindings,
+} from "./cloud-live-continuity-contract";
 
 export type CloudLiveOptionalActionPhase =
   | "pre-identity-runtime-choice"
@@ -193,6 +197,10 @@ interface PrepareCloudLivePersonalIdentityOptions {
   chatOverlay: Locator;
   chatOverlayTimeoutMs: number;
   chooseRuntimeAction: () => Promise<void>;
+  resolvedIdentity?: {
+    reference: CloudLiveRuntimeBinding;
+    readBinding: () => Promise<CloudLiveRuntimeBinding | null>;
+  };
 }
 
 interface WaitForCloudLivePersonalIdentityOptions<T> {
@@ -423,20 +431,62 @@ export async function waitForCloudLivePersonalIdentity<T>({
  * The chat overlay is a pre-choice gate, not a post-choice invariant: a valid
  * Cloud choice may replace the first-run overlay while the account binding is
  * still resolving. Callers that already chose the runtime must proceed directly
- * to the bounded binding-or-retry predicate.
+ * to the bounded binding-or-retry predicate. A fresh browser may also reconnect
+ * an existing Dedicated identity before offering the runtime picker; accepting
+ * that path requires an exact match with the previously verified binding.
  */
 export async function prepareCloudLivePersonalIdentity({
   chooseRuntime,
   chatOverlay,
   chatOverlayTimeoutMs,
   chooseRuntimeAction,
+  resolvedIdentity,
 }: PrepareCloudLivePersonalIdentityOptions): Promise<void> {
   if (!chooseRuntime) return;
+  const hasVerifiedIdentity = async (): Promise<boolean> => {
+    if (resolvedIdentity?.reference.runtime !== "dedicated") {
+      return false;
+    }
+    const binding = await withinCloudLivePersonalIdentityDeadline(
+      resolvedIdentity.readBinding,
+      Date.now() + chatOverlayTimeoutMs,
+    );
+    if (!binding) return false;
+    const reuse = compareCloudLiveRuntimeBindings(
+      resolvedIdentity.reference,
+      binding,
+    );
+    return (
+      reuse.personalIdentityReused &&
+      reuse.runtimeBindingReused &&
+      reuse.apiBaseReused
+    );
+  };
+  if (await hasVerifiedIdentity()) {
+    console.info(
+      "[cloud-live] existing Dedicated identity resolved before runtime choice",
+    );
+    return;
+  }
   await chatOverlay.waitFor({
     state: "visible",
     timeout: chatOverlayTimeoutMs,
   });
-  await chooseRuntimeAction();
+  try {
+    await chooseRuntimeAction();
+  } catch (error) {
+    // error-policy:J1 a missing picker is accepted only with independent proof
+    // of the exact prior Dedicated identity; action and identity failures remain fatal.
+    if (
+      !(error instanceof CloudLiveRequiredActionUnavailableError) ||
+      !(await hasVerifiedIdentity())
+    ) {
+      throw error;
+    }
+    console.info(
+      "[cloud-live] existing Dedicated identity resolved while runtime choice disappeared",
+    );
+  }
 }
 
 /**

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -1,6 +1,7 @@
 /** Real-browser regression coverage for bounded optional Cloud actions. */
 
 import { expect, type Locator, test } from "@playwright/test";
+import type { CloudLiveRuntimeBinding } from "../cloud-live-continuity-contract";
 import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
 import {
   CloudLiveDedicatedConfirmationRequiredError,
@@ -50,6 +51,93 @@ test.describe("Cloud live optional action boundary", () => {
     });
     expect(String(result.error)).not.toMatch(/data-testid|locator|selector/);
   });
+
+  const referenceBinding: CloudLiveRuntimeBinding = {
+    personalIdentity: "personal-test-account",
+    runtimeBinding: "dedicated-test-agent",
+    runtime: "dedicated",
+    apiBase: "https://api.test/agents/dedicated-test-agent",
+  };
+
+  for (const resolvesDuringChoice of [false, true]) {
+    test(`accepts the verified existing identity ${resolvesDuringChoice ? "while the runtime choice disappears" : "before the overlay opens"}`, async ({
+      page,
+    }) => {
+      await page.setContent(
+        resolvesDuringChoice
+          ? '<main data-testid="chat-overlay">Connecting</main>'
+          : "<main>Connected</main>",
+      );
+      let binding: CloudLiveRuntimeBinding | null = resolvesDuringChoice
+        ? null
+        : referenceBinding;
+      let choiceAttempted = false;
+
+      await prepareCloudLivePersonalIdentity({
+        chooseRuntime: true,
+        chatOverlay: page.getByTestId("chat-overlay"),
+        chatOverlayTimeoutMs: 100,
+        resolvedIdentity: {
+          reference: referenceBinding,
+          readBinding: async () => binding,
+        },
+        chooseRuntimeAction: async () => {
+          choiceAttempted = true;
+          binding = referenceBinding;
+          await clickCloudLiveOptionalAction(
+            page.getByTestId("runtime-cloud"),
+            {
+              phase: "pre-identity-runtime-choice",
+              action: "runtime-cloud",
+              offerTimeoutMs: 100,
+              actionTimeoutMs: 100,
+              required: true,
+            },
+          );
+        },
+      });
+      expect(choiceAttempted).toBe(resolvesDuringChoice);
+    });
+  }
+
+  for (const [label, binding] of [
+    ["missing", null],
+    ["different account", { ...referenceBinding, personalIdentity: "other" }],
+    ["different agent", { ...referenceBinding, runtimeBinding: "other" }],
+    ["shared runtime", { ...referenceBinding, runtime: "shared" }],
+    ["different API", { ...referenceBinding, apiBase: "https://other.test" }],
+  ] as const) {
+    test(`rejects a missing choice with ${label} identity`, async ({
+      page,
+    }) => {
+      await page.setContent(
+        '<main data-testid="chat-overlay">Connecting</main>',
+      );
+      await expect(
+        prepareCloudLivePersonalIdentity({
+          chooseRuntime: true,
+          chatOverlay: page.getByTestId("chat-overlay"),
+          chatOverlayTimeoutMs: 100,
+          resolvedIdentity: {
+            reference: referenceBinding,
+            readBinding: async () => binding,
+          },
+          chooseRuntimeAction: async () => {
+            await clickCloudLiveOptionalAction(
+              page.getByTestId("runtime-cloud"),
+              {
+                phase: "pre-identity-runtime-choice",
+                action: "runtime-cloud",
+                offerTimeoutMs: 100,
+                actionTimeoutMs: 100,
+                required: true,
+              },
+            );
+          },
+        }),
+      ).rejects.toBeInstanceOf(CloudLiveRequiredActionUnavailableError);
+    });
+  }
 
   test("keeps Dedicated activation and adoption confirmation fail-closed by default", async ({
     page,

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -142,6 +142,23 @@ async function chooseCloudRuntime(
       await onRuntimeChoiceState?.("timeout");
     } else if (error instanceof CloudLiveRequiredActionUnavailableError) {
       await onRuntimeChoiceState?.("unavailable");
+      return await rethrowCloudLiveFailureAfterDiagnostic(error, async () => {
+        console.warn(
+          "[cloud-live] runtime choice unavailable",
+          JSON.stringify({
+            bindingPresent: (await readActiveBinding(page)) !== null,
+            chatOverlayVisible: await page
+              .getByTestId("chat-overlay")
+              .isVisible(),
+            retryVisible: await page
+              .getByTestId("choice-__first_run__:error:retry")
+              .isVisible(),
+            googleSignInVisible: await page
+              .getByRole("button", { name: "Google", exact: true })
+              .isVisible(),
+          }),
+        );
+      });
     }
     throw error;
   }
@@ -583,6 +600,7 @@ async function resolvePersonalIdentity(
   chooseRuntime = true,
   onRecovery?: (recovery: CloudLivePersonalIdentityRecovery) => Promise<void>,
   existingDedicatedAdoptionProof?: DedicatedAdoptionConsentProof,
+  existingReferenceBinding?: CloudLiveRuntimeBinding,
 ): Promise<CloudLiveRuntimeBinding> {
   const dedicatedAdoptionProof =
     existingDedicatedAdoptionProof ??
@@ -593,6 +611,12 @@ async function resolvePersonalIdentity(
       chatOverlay: page.getByTestId("chat-overlay"),
       chatOverlayTimeoutMs: 60_000,
       chooseRuntimeAction: () => chooseCloudRuntime(page),
+      resolvedIdentity: existingReferenceBinding
+        ? {
+            reference: existingReferenceBinding,
+            readBinding: () => readActiveBinding(page),
+          }
+        : undefined,
     });
     const confirmationChoices = page.locator(
       '[data-testid="dedicated-adoption-confirm"], [data-testid="choice-__first_run__:dedicated-adoption:confirm"], [data-testid^="choice-__first_run__:dedicated-adoption:confirm:"], [data-testid="choice-__first_run__:dedicated-activation:confirm"], [data-testid^="choice-__first_run__:dedicated-activation:confirm:"]',
@@ -1356,6 +1380,10 @@ test.describe("real cloud login + personal identity + chat", () => {
           dedicatedConsentGate,
           freshAudit,
           CLOUD_LIVE_CONTINUITY_IDENTITY_TIMEOUT_MS,
+          true,
+          undefined,
+          undefined,
+          referenceBinding,
         ).catch((cause: unknown) =>
           rethrowCloudLiveFailureAfterDiagnostic(cause, async () => {
             await enterTrajectoryPhase(


### PR DESCRIPTION
The deployed staging trajectory failed in its fresh-browser identity phase because it required the Cloud runtime picker after the primary chat and reload checks. A returning account can resolve its existing Dedicated binding before that picker is offered or while it disappears. The fresh-context check now accepts that path only when the account-derived Personal identity, Dedicated agent binding, runtime kind, and normalized API endpoint exactly match the already verified primary context. Initial onboarding still requires its visible Cloud choice; missing or mismatched identities and action timeouts remain failures. Hosting confirmation, real reply, server history, and forbidden-mutation checks are unchanged.

Adds payload-free entry diagnostics so an unresolved live failure distinguishes missing binding, retry, sign-in, and chat-overlay states. The subsequent protected deployed run confirmed that the fresh context had already resolved the exact Dedicated binding while the picker disappeared, then passed fresh-context history verification.

Validation: 33 real Chromium contract tests passed, including two new reconnect cases that failed before the change and rejection of missing/different account, agent, runtime, and endpoint. Full root `bun run verify`, focused Biome, and `git diff --check` passed. No product UI or runtime files changed; new visual captures are N/A for this test-only change. Existing latest-source Google sign-in, real Dedicated reply, and exact 22-message desktop/mobile reload evidence remain separate from clean-context certification.

Observed failing run: https://github.com/elizaOS/eliza/actions/runs/34676934969 (renderer job 103510639511, fresh-context-identity). Follow-up to #31100. The protected staging release and its fresh-context proof must pass before production promotion; this PR does not claim that gate has passed.

Final live validation: canonical staging run34678890343 passed at source1b2e3b9/treeaf499, with an actual Dedicated reply, reload/fresh-context history, exact identity/runtime/API reuse, and zero forbidden agent mutations. All hosted checks for this PR completed successfully.
