### PR TITLE
chore: promote Dedicated fresh-browser continuity verification

### DIFF
--- a/packages/app/test/cloud-live-optional-action.ts
+++ b/packages/app/test/cloud-live-optional-action.ts
@@ -1,6 +1,10 @@
 /** Bounds optional Cloud onboarding actions without retaining DOM or account data. */
 
 import type { Locator } from "@playwright/test";
+import {
+  type CloudLiveRuntimeBinding,
+  compareCloudLiveRuntimeBindings,
+} from "./cloud-live-continuity-contract";
 
 export type CloudLiveOptionalActionPhase =
   | "pre-identity-runtime-choice"
@@ -193,6 +197,10 @@ interface PrepareCloudLivePersonalIdentityOptions {
   chatOverlay: Locator;
   chatOverlayTimeoutMs: number;
   chooseRuntimeAction: () => Promise<void>;
+  resolvedIdentity?: {
+    reference: CloudLiveRuntimeBinding;
+    readBinding: () => Promise<CloudLiveRuntimeBinding | null>;
+  };
 }
 
 interface WaitForCloudLivePersonalIdentityOptions<T> {
@@ -423,20 +431,62 @@ export async function waitForCloudLivePersonalIdentity<T>({
  * The chat overlay is a pre-choice gate, not a post-choice invariant: a valid
  * Cloud choice may replace the first-run overlay while the account binding is
  * still resolving. Callers that already chose the runtime must proceed directly
- * to the bounded binding-or-retry predicate.
+ * to the bounded binding-or-retry predicate. A fresh browser may also reconnect
+ * an existing Dedicated identity before offering the runtime picker; accepting
+ * that path requires an exact match with the previously verified binding.
  */
 export async function prepareCloudLivePersonalIdentity({
   chooseRuntime,
   chatOverlay,
   chatOverlayTimeoutMs,
   chooseRuntimeAction,
+  resolvedIdentity,
 }: PrepareCloudLivePersonalIdentityOptions): Promise<void> {
   if (!chooseRuntime) return;
+  const hasVerifiedIdentity = async (): Promise<boolean> => {
+    if (resolvedIdentity?.reference.runtime !== "dedicated") {
+      return false;
+    }
+    const binding = await withinCloudLivePersonalIdentityDeadline(
+      resolvedIdentity.readBinding,
+      Date.now() + chatOverlayTimeoutMs,
+    );
+    if (!binding) return false;
+    const reuse = compareCloudLiveRuntimeBindings(
+      resolvedIdentity.reference,
+      binding,
+    );
+    return (
+      reuse.personalIdentityReused &&
+      reuse.runtimeBindingReused &&
+      reuse.apiBaseReused
+    );
+  };
+  if (await hasVerifiedIdentity()) {
+    console.info(
+      "[cloud-live] existing Dedicated identity resolved before runtime choice",
+    );
+    return;
+  }
   await chatOverlay.waitFor({
     state: "visible",
     timeout: chatOverlayTimeoutMs,
   });
-  await chooseRuntimeAction();
+  try {
+    await chooseRuntimeAction();
+  } catch (error) {
+    // error-policy:J1 a missing picker is accepted only with independent proof
+    // of the exact prior Dedicated identity; action and identity failures remain fatal.
+    if (
+      !(error instanceof CloudLiveRequiredActionUnavailableError) ||
+      !(await hasVerifiedIdentity())
+    ) {
+      throw error;
+    }
+    console.info(
+      "[cloud-live] existing Dedicated identity resolved while runtime choice disappeared",
+    );
+  }
 }
 
 /**

--- a/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live-optional-action.spec.ts
@@ -1,6 +1,7 @@
 /** Real-browser regression coverage for bounded optional Cloud actions. */
 
 import { expect, type Locator, test } from "@playwright/test";
+import type { CloudLiveRuntimeBinding } from "../cloud-live-continuity-contract";
 import { installDedicatedAdoptionConsentProof } from "../cloud-live-dedicated-adoption-consent";
 import {
   CloudLiveDedicatedConfirmationRequiredError,
@@ -50,6 +51,93 @@ test.describe("Cloud live optional action boundary", () => {
     });
     expect(String(result.error)).not.toMatch(/data-testid|locator|selector/);
   });
+
+  const referenceBinding: CloudLiveRuntimeBinding = {
+    personalIdentity: "personal-test-account",
+    runtimeBinding: "dedicated-test-agent",
+    runtime: "dedicated",
+    apiBase: "https://api.test/agents/dedicated-test-agent",
+  };
+
+  for (const resolvesDuringChoice of [false, true]) {
+    test(`accepts the verified existing identity ${resolvesDuringChoice ? "while the runtime choice disappears" : "before the overlay opens"}`, async ({
+      page,
+    }) => {
+      await page.setContent(
+        resolvesDuringChoice
+          ? '<main data-testid="chat-overlay">Connecting</main>'
+          : "<main>Connected</main>",
+      );
+      let binding: CloudLiveRuntimeBinding | null = resolvesDuringChoice
+        ? null
+        : referenceBinding;
+      let choiceAttempted = false;
+
+      await prepareCloudLivePersonalIdentity({
+        chooseRuntime: true,
+        chatOverlay: page.getByTestId("chat-overlay"),
+        chatOverlayTimeoutMs: 100,
+        resolvedIdentity: {
+          reference: referenceBinding,
+          readBinding: async () => binding,
+        },
+        chooseRuntimeAction: async () => {
+          choiceAttempted = true;
+          binding = referenceBinding;
+          await clickCloudLiveOptionalAction(
+            page.getByTestId("runtime-cloud"),
+            {
+              phase: "pre-identity-runtime-choice",
+              action: "runtime-cloud",
+              offerTimeoutMs: 100,
+              actionTimeoutMs: 100,
+              required: true,
+            },
+          );
+        },
+      });
+      expect(choiceAttempted).toBe(resolvesDuringChoice);
+    });
+  }
+
+  for (const [label, binding] of [
+    ["missing", null],
+    ["different account", { ...referenceBinding, personalIdentity: "other" }],
+    ["different agent", { ...referenceBinding, runtimeBinding: "other" }],
+    ["shared runtime", { ...referenceBinding, runtime: "shared" }],
+    ["different API", { ...referenceBinding, apiBase: "https://other.test" }],
+  ] as const) {
+    test(`rejects a missing choice with ${label} identity`, async ({
+      page,
+    }) => {
+      await page.setContent(
+        '<main data-testid="chat-overlay">Connecting</main>',
+      );
+      await expect(
+        prepareCloudLivePersonalIdentity({
+          chooseRuntime: true,
+          chatOverlay: page.getByTestId("chat-overlay"),
+          chatOverlayTimeoutMs: 100,
+          resolvedIdentity: {
+            reference: referenceBinding,
+            readBinding: async () => binding,
+          },
+          chooseRuntimeAction: async () => {
+            await clickCloudLiveOptionalAction(
+              page.getByTestId("runtime-cloud"),
+              {
+                phase: "pre-identity-runtime-choice",
+                action: "runtime-cloud",
+                offerTimeoutMs: 100,
+                actionTimeoutMs: 100,
+                required: true,
+              },
+            );
+          },
+        }),
+      ).rejects.toBeInstanceOf(CloudLiveRequiredActionUnavailableError);
+    });
+  }
 
   test("keeps Dedicated activation and adoption confirmation fail-closed by default", async ({
     page,

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -142,6 +142,23 @@ async function chooseCloudRuntime(
       await onRuntimeChoiceState?.("timeout");
     } else if (error instanceof CloudLiveRequiredActionUnavailableError) {
       await onRuntimeChoiceState?.("unavailable");
+      return await rethrowCloudLiveFailureAfterDiagnostic(error, async () => {
+        console.warn(
+          "[cloud-live] runtime choice unavailable",
+          JSON.stringify({
+            bindingPresent: (await readActiveBinding(page)) !== null,
+            chatOverlayVisible: await page
+              .getByTestId("chat-overlay")
+              .isVisible(),
+            retryVisible: await page
+              .getByTestId("choice-__first_run__:error:retry")
+              .isVisible(),
+            googleSignInVisible: await page
+              .getByRole("button", { name: "Google", exact: true })
+              .isVisible(),
+          }),
+        );
+      });
     }
     throw error;
   }
@@ -583,6 +600,7 @@ async function resolvePersonalIdentity(
   chooseRuntime = true,
   onRecovery?: (recovery: CloudLivePersonalIdentityRecovery) => Promise<void>,
   existingDedicatedAdoptionProof?: DedicatedAdoptionConsentProof,
+  existingReferenceBinding?: CloudLiveRuntimeBinding,
 ): Promise<CloudLiveRuntimeBinding> {
   const dedicatedAdoptionProof =
     existingDedicatedAdoptionProof ??
@@ -593,6 +611,12 @@ async function resolvePersonalIdentity(
       chatOverlay: page.getByTestId("chat-overlay"),
       chatOverlayTimeoutMs: 60_000,
       chooseRuntimeAction: () => chooseCloudRuntime(page),
+      resolvedIdentity: existingReferenceBinding
+        ? {
+            reference: existingReferenceBinding,
+            readBinding: () => readActiveBinding(page),
+          }
+        : undefined,
     });
     const confirmationChoices = page.locator(
       '[data-testid="dedicated-adoption-confirm"], [data-testid="choice-__first_run__:dedicated-adoption:confirm"], [data-testid^="choice-__first_run__:dedicated-adoption:confirm:"], [data-testid="choice-__first_run__:dedicated-activation:confirm"], [data-testid^="choice-__first_run__:dedicated-activation:confirm:"]',
@@ -1356,6 +1380,10 @@ test.describe("real cloud login + personal identity + chat", () => {
           dedicatedConsentGate,
           freshAudit,
           CLOUD_LIVE_CONTINUITY_IDENTITY_TIMEOUT_MS,
+          true,
+          undefined,
+          undefined,
+          referenceBinding,
         ).catch((cause: unknown) =>
           rethrowCloudLiveFailureAfterDiagnostic(cause, async () => {
             await enterTrajectoryPhase(


### PR DESCRIPTION
Promote #31102 from develop to staging. The only new changes are the deployed-browser test and its helper/contract tests: accept an already resolved Dedicated connection only when its account, agent, runtime, and endpoint exactly match the primary verified context; retain required initial choice, confirmation, real reply, server-history, and mutation gates. Payload-free entry diagnostics preserve evidence if the fresh-context failure remains.

Local validation: 33 Chromium contract tests, full root `bun run verify`, Biome, and diff checks passed at 84619baf0a4ff7b8ebd5f6b0a91afa7673be2f9f. Develop merge 8ee8fd4415070cd2799189e940672bf2826c9618 and the staging merge preview both have tree af499d9ac560f9b866f6446d1c75f3ec2c3148fa. Hosted source/billing/Windows checks were still running at merge; subscription authority passed. The exact-tree canonical staging release must still prove the clean-context flow. No production release or infrastructure cleanup is included.
