### PR TITLE
test: complete Dedicated lifecycle regression fixtures

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
@@ -30,7 +30,11 @@ process.env.MOCK_REDIS = "1";
 import { pushSchema } from "drizzle-kit/api";
 import { sql } from "drizzle-orm";
 import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { apiKeys } from "../../schemas/api-keys";
+import { generations } from "../../schemas/generations";
+import { jobs } from "../../schemas/jobs";
 import { organizations } from "../../schemas/organizations";
+import { usageRecords } from "../../schemas/usage-records";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
 
@@ -56,7 +60,16 @@ beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
     ({ agentSandboxesRepository: repo } = await import("../agent-sandboxes"));
-    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      apiKeys,
+      usageRecords,
+      generations,
+      jobs,
+    };
     const { apply } = await pushSchema(schema as never, dbWrite as never);
     await apply();
     // Install the lifecycle_revision trigger BEFORE any raw writer runs —

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -485,6 +485,8 @@ describe("typed lifecycle reads and exact sandbox generations", () => {
           await dbWrite
             .update(agentSandboxes)
             .set({
+              sandbox_id: "sleep-generation-test",
+              container_name: "sleep-generation-test",
               bridge_url: `http://127.0.0.1:${port}`,
               health_url: `http://127.0.0.1:${port}`,
               node_id: "test-node",


### PR DESCRIPTION
The full staging run exposed three failing Dedicated lifecycle assertions because their fixtures no longer satisfied the real repository and service prerequisites. The heartbeat revision fixture now creates the canonical jobs table and its foreign-key dependencies. The sleep race fixture now supplies a complete container locator so snapshot I/O reaches the concurrent-write fence it is intended to test.

Production behavior and assertions are unchanged. The two PGlite suites pass all 11 tests / 49 assertions at a7bf49f9e13d9ed8ba5e6b8f7bbfabbfa4041613. Biome, git diff --check, and full root bun run verify pass at this exact source tree. Original failure evidence is in staging run 34678869411, Cloud unit shards 2 and 4. Other full-run failures remain separately recorded and are not represented as passing.
