### PR TITLE
fix(login): deliver slow OAuth callback responses before socket timeout

### DIFF
--- a/packages/login/src/server/__tests__/login-callback-transport.integration.test.ts
+++ b/packages/login/src/server/__tests__/login-callback-transport.integration.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Exercises the real login listener and PGlite challenge store with delayed
+ * callback work. The original HTTP redirect must survive beyond Bun's default
+ * idle window, while a later replay still fails after one-time consumption.
+ */
+import { expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { request } from "node:http";
+
+test("delayed one-time callback returns its redirect without a socket retry", async () => {
+  const environment = {
+    NODE_ENV: "test",
+    STEWARD_RUNTIME: "bun",
+    STEWARD_PGLITE_MEMORY: "true",
+    STEWARD_MASTER_PASSWORD: randomBytes(32).toString("hex"),
+    STEWARD_JWT_SECRET: randomBytes(32).toString("hex"),
+    STEWARD_KDF_SALT: randomBytes(32).toString("hex"),
+    STEWARD_AUDIT_HMAC_KEY: randomBytes(32).toString("hex"),
+    REDIS_URL: "",
+    UPSTASH_REDIS_REST_URL: "",
+    UPSTASH_REDIS_REST_TOKEN: "",
+  };
+  const previous = new Map(
+    [...Object.keys(environment), "STEWARD_DB_MODE", "STEWARD_EMBEDDED"].map(
+      (key) => [key, process.env[key]],
+    ),
+  );
+  Object.assign(process.env, environment);
+  const { authRoutes, getAuthChallengeStore } = await import(
+    "../api/src/routes/auth"
+  );
+  const { startEmbeddedLogin } = await import("../runtime");
+  const callbackPath = `/transport-callback-${randomBytes(8).toString("hex")}`;
+  const stateKey = `callback-transport:${randomBytes(16).toString("hex")}`;
+  let calls = 0;
+  let callbackFinished: Promise<void> | undefined;
+  authRoutes.get(callbackPath, async (c) => {
+    calls += 1;
+    if (!(await getAuthChallengeStore().consume(stateKey))) {
+      return c.json({ error: "state_consumed" }, 401);
+    }
+    callbackFinished = Bun.sleep(22_000);
+    await callbackFinished;
+    return c.redirect("/completed-callback", 302);
+  });
+  let server: Awaited<ReturnType<typeof startEmbeddedLogin>> | undefined;
+  try {
+    server = await startEmbeddedLogin({ port: 0 });
+    await getAuthChallengeStore().set(stateKey, "one-time-test-state");
+    const url = `http://127.0.0.1:${server.port}/auth${callbackPath}`;
+    // Node's HTTP client sends exactly once; automatic proxy/fetch retries
+    // would conceal a dropped first response with the replay's 401.
+    const response = await new Promise<{
+      status: number | undefined;
+      location: string | undefined;
+    }>((resolve, reject) => {
+      const req = request(url, { agent: false }, (res) => {
+        res.resume();
+        res.on("end", () =>
+          resolve({ status: res.statusCode, location: res.headers.location }),
+        );
+        res.on("error", reject);
+      });
+      req.on("error", reject);
+      req.end();
+    });
+    expect(response).toEqual({ status: 302, location: "/completed-callback" });
+    expect(calls).toBe(1);
+    const replay = await fetch(url, { redirect: "manual" });
+    expect(replay.status).toBe(401);
+    expect(await replay.json()).toEqual({ error: "state_consumed" });
+    expect(calls).toBe(2);
+  } finally {
+    await callbackFinished;
+    await server?.stop();
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}, 40_000);

--- a/packages/login/src/server/runtime.ts
+++ b/packages/login/src/server/runtime.ts
@@ -166,6 +166,10 @@ async function startOwnedLogin(options: {
     const server = Bun.serve({
       hostname: options.hostname,
       port,
+      // OAuth can consume its one-time state before account provisioning
+      // finishes. Keep the response socket alive beyond the Cloud proxy's
+      // 25-second deadline so a dropped connection cannot provoke a replay.
+      idleTimeout: 30,
       fetch(request, listener) {
         return app.fetch(request, {
           [SOCKET_PEER_ENV_KEY]: listener.requestIP(request)?.address ?? null,


### PR DESCRIPTION
Google sign-in could finish successfully on the login service yet show `oauth_state_expired` in the browser. Bun closed the response socket during account provisioning; Railway retried the callback after its one-time state had already been consumed.

Set the login listener's finite idle timeout to 30 seconds, above the Cloud proxy's existing 25-second request deadline. State expiry, atomic consumption, PKCE and provider verification are unchanged. The shared hosted/embedded listener owns the fix.

Closes #31107.

Validation: a real login listener with PGlite and 22-second callback work failed before the change with Bun's explicit 10-second timeout and ECONNRESET. After the change the original HTTP request receives its 302; a subsequent replay returns 401. This is a transport regression, with delayed fixture work replacing external provider latency, not a claim of full OAuth coverage.

- Login package build and suite: 614 passed, 1 PostgreSQL-only integration test explicitly skipped because its database URL was not configured; 0 failures, 2,262 assertions.
- Login typecheck and lint: passed.
- Full root `bun run verify`: passed.
- Live staging Google verification: passed after Railway deployed develop merge `cbf357b0bd8a7052b077d75c582974e633e5bd25` in deployment `ce95ea46-9025-4e18-a45b-5bf4679c37dc`. A fresh Google sign-in reached the app directly, with one successful callback and no upstream retry. The Dedicated agent returned a real recall response and retained all 24 prior messages. This does not establish first-ever signup or production acceptance.

Merged under repository-owner authorization after the full applicable local checks passed; hosted PR checks were still running at merge. Production remains unchanged. All 26 messages matched exactly after desktop and mobile reloads in both hosted staging and the ordinary local bun run dev app. Both account views confirmed the same authorized user and Ready agent. A new root tab reached the app without a recovery notice.

Live diagnosis: the staging Google callback logged its original successful 302 after Railway had already returned a replay's 401. Railway reported `connection closed unexpectedly` and `Retried single replica`. No credentials or callback codes are included here.
