### PR TITLE
release: promote verified login callback transport fix to staging

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/heartbeat-generation-us-fence.test.ts
@@ -30,7 +30,11 @@ process.env.MOCK_REDIS = "1";
 import { pushSchema } from "drizzle-kit/api";
 import { sql } from "drizzle-orm";
 import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { apiKeys } from "../../schemas/api-keys";
+import { generations } from "../../schemas/generations";
+import { jobs } from "../../schemas/jobs";
 import { organizations } from "../../schemas/organizations";
+import { usageRecords } from "../../schemas/usage-records";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
 
@@ -56,7 +60,16 @@ beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
     ({ agentSandboxesRepository: repo } = await import("../agent-sandboxes"));
-    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const schema = {
+      organizations,
+      users,
+      userCharacters,
+      agentSandboxes,
+      apiKeys,
+      usageRecords,
+      generations,
+      jobs,
+    };
     const { apply } = await pushSchema(schema as never, dbWrite as never);
     await apply();
     // Install the lifecycle_revision trigger BEFORE any raw writer runs —

--- a/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/typed-lifecycle-read.test.ts
@@ -485,6 +485,8 @@ describe("typed lifecycle reads and exact sandbox generations", () => {
           await dbWrite
             .update(agentSandboxes)
             .set({
+              sandbox_id: "sleep-generation-test",
+              container_name: "sleep-generation-test",
               bridge_url: `http://127.0.0.1:${port}`,
               health_url: `http://127.0.0.1:${port}`,
               node_id: "test-node",

--- a/packages/login/src/server/__tests__/login-callback-transport.integration.test.ts
+++ b/packages/login/src/server/__tests__/login-callback-transport.integration.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Exercises the real login listener and PGlite challenge store with delayed
+ * callback work. The original HTTP redirect must survive beyond Bun's default
+ * idle window, while a later replay still fails after one-time consumption.
+ */
+import { expect, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { request } from "node:http";
+
+test("delayed one-time callback returns its redirect without a socket retry", async () => {
+  const environment = {
+    NODE_ENV: "test",
+    STEWARD_RUNTIME: "bun",
+    STEWARD_PGLITE_MEMORY: "true",
+    STEWARD_MASTER_PASSWORD: randomBytes(32).toString("hex"),
+    STEWARD_JWT_SECRET: randomBytes(32).toString("hex"),
+    STEWARD_KDF_SALT: randomBytes(32).toString("hex"),
+    STEWARD_AUDIT_HMAC_KEY: randomBytes(32).toString("hex"),
+    REDIS_URL: "",
+    UPSTASH_REDIS_REST_URL: "",
+    UPSTASH_REDIS_REST_TOKEN: "",
+  };
+  const previous = new Map(
+    [...Object.keys(environment), "STEWARD_DB_MODE", "STEWARD_EMBEDDED"].map(
+      (key) => [key, process.env[key]],
+    ),
+  );
+  Object.assign(process.env, environment);
+  const { authRoutes, getAuthChallengeStore } = await import(
+    "../api/src/routes/auth"
+  );
+  const { startEmbeddedLogin } = await import("../runtime");
+  const callbackPath = `/transport-callback-${randomBytes(8).toString("hex")}`;
+  const stateKey = `callback-transport:${randomBytes(16).toString("hex")}`;
+  let calls = 0;
+  let callbackFinished: Promise<void> | undefined;
+  authRoutes.get(callbackPath, async (c) => {
+    calls += 1;
+    if (!(await getAuthChallengeStore().consume(stateKey))) {
+      return c.json({ error: "state_consumed" }, 401);
+    }
+    callbackFinished = Bun.sleep(22_000);
+    await callbackFinished;
+    return c.redirect("/completed-callback", 302);
+  });
+  let server: Awaited<ReturnType<typeof startEmbeddedLogin>> | undefined;
+  try {
+    server = await startEmbeddedLogin({ port: 0 });
+    await getAuthChallengeStore().set(stateKey, "one-time-test-state");
+    const url = `http://127.0.0.1:${server.port}/auth${callbackPath}`;
+    // Node's HTTP client sends exactly once; automatic proxy/fetch retries
+    // would conceal a dropped first response with the replay's 401.
+    const response = await new Promise<{
+      status: number | undefined;
+      location: string | undefined;
+    }>((resolve, reject) => {
+      const req = request(url, { agent: false }, (res) => {
+        res.resume();
+        res.on("end", () =>
+          resolve({ status: res.statusCode, location: res.headers.location }),
+        );
+        res.on("error", reject);
+      });
+      req.on("error", reject);
+      req.end();
+    });
+    expect(response).toEqual({ status: 302, location: "/completed-callback" });
+    expect(calls).toBe(1);
+    const replay = await fetch(url, { redirect: "manual" });
+    expect(replay.status).toBe(401);
+    expect(await replay.json()).toEqual({ error: "state_consumed" });
+    expect(calls).toBe(2);
+  } finally {
+    await callbackFinished;
+    await server?.stop();
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}, 40_000);

--- a/packages/login/src/server/runtime.ts
+++ b/packages/login/src/server/runtime.ts
@@ -166,6 +166,10 @@ async function startOwnedLogin(options: {
     const server = Bun.serve({
       hostname: options.hostname,
       port,
+      // OAuth can consume its one-time state before account provisioning
+      // finishes. Keep the response socket alive beyond the Cloud proxy's
+      // 25-second deadline so a dropped connection cannot provoke a replay.
+      idleTimeout: 30,
       fetch(request, listener) {
         return app.fetch(request, {
           [SOCKET_PEER_ENV_KEY]: listener.requestIP(request)?.address ?? null,


### PR DESCRIPTION
Promote the verified Google callback transport fix and two Dedicated lifecycle fixture corrections from develop to staging.

Develop `cbf357b0bd8a7052b077d75c582974e633e5bd25` and the merge preview both produce tree `8c979bb5837bde91a3ff263946ad9523068c63b8`. Relative to staging, only four files change: the finite login listener timeout, its real HTTP regression, and the two lifecycle fixture repairs already merged in #31105.

The new login source passed the full repository verification, package build, typecheck and lint, plus 614 package tests (one PostgreSQL-only test explicitly skipped). The staging login service already deployed this develop revision; a fresh real Google sign-in reached the app directly, followed by a real Dedicated reply and intact conversation history. This promotion aligns the canonical staging release source; production is unchanged.

Full canonical staging deployment and certification remain required after this merge. Existing agent image and data are preserved.
