### PR TITLE
fix(core): render shared references in redactLogArgs instead of masking them (#31113)

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -669,6 +669,46 @@ describe("redactLogArgs (log-sink redaction, not opt-in)", () => {
 		cyclic.self = cyclic;
 		const [out] = redactLogArgs([cyclic]) as [Record<string, unknown>];
 		expect(out.name).toBe("x");
+		// A genuine cycle is cut with a marker that cannot be read as a
+		// credential mask.
+		expect(out.self).toBe("[circular]");
+	});
+
+	it("renders an object referenced twice in one call at both sites", () => {
+		const shared = { provider: "openai", model: "gpt-4o" };
+		const [, ctx] = redactLogArgs([
+			"model call",
+			{ requested: shared, resolved: shared, list: [shared, shared] },
+		]) as [string, Record<string, unknown>];
+		expect(ctx.requested).toEqual(shared);
+		expect(ctx.resolved).toEqual(shared);
+		expect(ctx.list).toEqual([shared, shared]);
+		expect(JSON.stringify(ctx)).not.toContain("[REDACTED]");
+	});
+
+	it("renders a shared Error at both sites and still scrubs its message", () => {
+		const err = new Error("token sk-abcdefghijklmnop1234 rejected");
+		const [ctx] = redactLogArgs([{ first: err, second: err }]) as [
+			Record<string, Error>,
+		];
+		expect(ctx.first).toBeInstanceOf(Error);
+		expect(ctx.second).toBeInstanceOf(Error);
+		expect(ctx.second.message).toBe(ctx.first.message);
+		expect(ctx.second.message).not.toContain("sk-abcdefghijklmnop1234");
+	});
+
+	it("distinguishes a sibling reference from a cycle inside one walk", () => {
+		// `leaf` appears under two siblings and, separately, inside a true cycle:
+		// the sibling copies are rendered in full, the self-reference is cut.
+		const leaf = { id: "leaf" };
+		const loop: Record<string, unknown> = { leaf };
+		loop.back = loop;
+		const [ctx] = redactLogArgs([{ a: leaf, b: leaf, loop }]) as [
+			Record<string, unknown>,
+		];
+		expect(ctx.a).toEqual(leaf);
+		expect(ctx.b).toEqual(leaf);
+		expect(ctx.loop).toEqual({ leaf, back: "[circular]" });
 	});
 
 	it("drops a hostile own toJSON so serialization cannot reconstitute secrets", () => {

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -569,6 +569,8 @@ export function redactObjectSecrets<T>(
 
 const REDACTED_MASK = "[REDACTED]";
 const MAX_LOG_REDACT_DEPTH = 8;
+/** Marker for a value that is its own ancestor; deliberately not the credential mask. */
+const CIRCULAR_MARKER = "[circular]";
 
 /**
  * Redact one log argument for output at the sink. A string is scrubbed with the
@@ -593,13 +595,15 @@ const MAX_LOG_REDACT_DEPTH = 8;
  * innocent-looking key, and JSON.stringify would emit them as
  * {"type":"Buffer","data":[…]} — either way secret bytes survive in every sink.
  *
- * Depth is bounded and cycles are broken (returning the mask) so a pathological
- * log payload cannot hang or blow the stack — a redactor must never be the thing
- * that takes the process down.
+ * Depth is bounded and true cycles are broken with a distinct circular marker so
+ * a pathological log payload cannot hang or blow the stack — a redactor must
+ * never be the thing that takes the process down. Only ancestors of the current
+ * value count as a cycle: an object referenced from two places in one call is
+ * rendered in full both times, never as the credential mask.
  */
 function redactLogArg(
 	value: unknown,
-	seen: WeakSet<object>,
+	ancestors: WeakSet<object>,
 	depth: number,
 ): unknown {
 	if (typeof value === "string") {
@@ -611,20 +615,15 @@ function redactLogArg(
 	if (value === null || typeof value !== "object") {
 		return value;
 	}
-	if (depth >= MAX_LOG_REDACT_DEPTH || seen.has(value)) {
+	if (depth >= MAX_LOG_REDACT_DEPTH) {
 		return REDACTED_MASK;
 	}
-	seen.add(value);
-	if (Array.isArray(value)) {
-		// Do not call value.map: an Array subclass, custom Symbol.species, or own
-		// map property can return caller-owned data carrying a serializer hook.
-		// Index into the input but construct the output with the intrinsic Array
-		// constructor so no caller-controlled method or result prototype survives.
-		const result: unknown[] = [];
-		for (let index = 0; index < value.length; index += 1) {
-			result.push(redactLogArg(value[index], seen, depth + 1));
-		}
-		return result;
+	// `ancestors` holds only the objects on the current walk path (entries are
+	// removed on the way back out), so this catches a genuine cycle and nothing
+	// else. A shared reference must not be masked: "[REDACTED]" would tell the
+	// reader a credential was present where there was only aliasing.
+	if (ancestors.has(value)) {
+		return CIRCULAR_MARKER;
 	}
 	if (value instanceof Error) {
 		// Preserve the Error shape (name/stack) callers rely on, but scrub the
@@ -641,25 +640,42 @@ function redactLogArg(
 	if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
 		return `[BUFFER REDACTED ${value.byteLength} bytes]`;
 	}
-	// A null-prototype target prevents a __proto__ input key from changing the
-	// clone's prototype and reintroducing inherited serializer behavior.
-	const result = Object.create(null) as Record<string, unknown>;
-	for (const [key, entry] of Object.entries(value)) {
-		if (isSensitiveKeyName(key)) {
-			result[key] = REDACTED_MASK;
-			continue;
+	ancestors.add(value);
+	try {
+		if (Array.isArray(value)) {
+			// Do not call value.map: an Array subclass, custom Symbol.species, or
+			// own map property can return caller-owned data carrying a serializer
+			// hook. Index into the input but construct the output with the
+			// intrinsic Array constructor so no caller-controlled method or result
+			// prototype survives.
+			const result: unknown[] = [];
+			for (let index = 0; index < value.length; index += 1) {
+				result.push(redactLogArg(value[index], ancestors, depth + 1));
+			}
+			return result;
 		}
-		// Function-valued properties are executable serializer hooks
-		// (toJSON/valueOf/toString): a copied hook re-runs when a sink
-		// JSON-stringifies the clone and can reconstitute the very secrets the
-		// walk just masked. JSON.stringify omits function props anyway, so
-		// dropping the key matches serialization semantics.
-		if (typeof entry === "function") {
-			continue;
+		// A null-prototype target prevents a __proto__ input key from changing
+		// the clone's prototype and reintroducing inherited serializer behavior.
+		const result = Object.create(null) as Record<string, unknown>;
+		for (const [key, entry] of Object.entries(value)) {
+			if (isSensitiveKeyName(key)) {
+				result[key] = REDACTED_MASK;
+				continue;
+			}
+			// Function-valued properties are executable serializer hooks
+			// (toJSON/valueOf/toString): a copied hook re-runs when a sink
+			// JSON-stringifies the clone and can reconstitute the very secrets the
+			// walk just masked. JSON.stringify omits function props anyway, so
+			// dropping the key matches serialization semantics.
+			if (typeof entry === "function") {
+				continue;
+			}
+			result[key] = redactLogArg(entry, ancestors, depth + 1);
 		}
-		result[key] = redactLogArg(entry, seen, depth + 1);
+		return result;
+	} finally {
+		ancestors.delete(value);
 	}
-	return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

`redactLogArg` in `packages/core/src/security/redact.ts` kept every visited object in its `WeakSet` for the whole walk, so any object or Error referenced twice in one `logger.*(...)` call rendered as `"[REDACTED]"` on its second occurrence. That string is the credential mask, so a reader concluded a secret was present where there was only a shared reference. The cloud logger runs `redactLogArgs` on every line.

The set now holds only the current ancestor path (each entry is removed in a `finally` after its subtree is walked), so:

- a shared reference is rendered in full at every site;
- a genuine cycle is still cut, but with a distinct `"[circular]"` marker instead of the credential mask;
- the depth bound is unchanged.

Closes #31113

## Evidence

Before (develop `cbf357b0bd8a`):

```
["model call",{"requested":{"provider":"openai","model":"gpt-4o"},"resolved":"[REDACTED]","list":["[REDACTED]","[REDACTED]"]}]
[{"a":"Error(boom)","b":"[REDACTED]"}]
```

After, the same inputs render `resolved`, both `list` entries and `b` in full; the new tests pin that plus sibling-vs-cycle discrimination inside one walk.

- `bunx vitest run src/security/redact.test.ts` in `packages/core`: 66/66 (62 existing + 4 new).
- `bun run --cwd packages/core typecheck`: clean.
- Biome check on both files: clean.
- Root `bun run verify`: running on a stack branch holding today's fix PRs; result will be posted as a comment.

Same defect class as #30887, #31002 and #31005 (logger, settings-debug and JSON-output walkers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8gwNCWN4PDyeXY6fHhhgy
