### PR TITLE
fix(plugin-notes): declare the planner aliases the NOTES handler reads (#31114)

### DIFF
--- a/plugins/plugin-notes/src/action.test.ts
+++ b/plugins/plugin-notes/src/action.test.ts
@@ -109,6 +109,64 @@ function execute(
 }
 
 describe("promoted Notes execution", () => {
+  it("accepts the planner alias spellings the handler documents (#31114)", async () => {
+    // Before the aliases were declared, every one of these calls was rejected
+    // by the core validator with "Unexpected argument" before the handler ran.
+    const runtime = await executorHarness();
+    const created = await execute(runtime, {
+      name: "NOTES_CREATE",
+      params: { text: "Alias check\noriginal body" },
+    });
+    expect(created).toMatchObject({
+      success: true,
+      data: {
+        op: "create",
+        note: { title: "Alias check", body: "original body" },
+      },
+    });
+
+    const listed = await execute(runtime, {
+      name: "NOTES_LIST",
+      params: { query: "alias" },
+    });
+    expect(listed).toMatchObject({
+      success: true,
+      data: { count: 1, filterApplied: true, topic: "alias" },
+    });
+
+    const updated = await execute(runtime, {
+      name: "NOTES_UPDATE",
+      params: { title: "Alias check", newText: "Alias check\nupdated body" },
+    });
+    expect(updated).toMatchObject({
+      success: true,
+      data: {
+        op: "update",
+        note: { title: "Alias check", body: "updated body" },
+      },
+    });
+
+    const umbrella = await execute(runtime, {
+      name: "NOTES",
+      params: { action: "create", note: "Second note" },
+    });
+    expect(umbrella).toMatchObject({
+      success: true,
+      data: { op: "create", note: { title: "Second note" } },
+    });
+
+    // Core never lets an alias clobber an explicit canonical value: when both
+    // arrive, the alias stays undeclared and the call is rejected as before.
+    const conflict = await execute(runtime, {
+      name: "NOTES_LIST",
+      params: { content: "second", query: "alias" },
+    });
+    expect(conflict).toMatchObject({
+      success: false,
+      data: { invalidParameterNames: ["query"] },
+    });
+  });
+
   it("creates, lists, updates, and deletes through the registered children", async () => {
     const runtime = await executorHarness();
     const created = await execute(runtime, {

--- a/plugins/plugin-notes/src/action.ts
+++ b/plugins/plugin-notes/src/action.ts
@@ -301,6 +301,11 @@ export const notesAction: Action = {
         "For create, the complete new note: title on the first line and body on subsequent lines. Copy an explicit user title byte-for-byte, including spaces, capitalization, punctuation, and alphanumeric codes, even when the body is recalled from earlier conversation or generated. Do not reformat the title or substitute the spelling or spacing of a similar prior note. Preserve an explicitly supplied body exactly. Put a newline between title and body; do not join them with a dash into one title. Prefer this single field and omit body. Alternatively, pass only the exact title in content and the requested body in body. For update/delete, this identifies the EXISTING note, not its replacement. On list, pass only a requested topic to filter note text. Omit it for all notes, counts, or recency questions without a topic; use the returned createdAt/updatedAt timestamps to compare recency, not a text filter such as 'most recently updated'.",
       required: false,
       requiredForSubactions: ["create", "update", "delete"],
+      // The handler accepts these spellings as fallbacks for `content`, but
+      // core's validator rejects any undeclared key before the handler runs, so
+      // they must be declared here or a planner that uses them burns a round
+      // on "Unexpected argument" and saves nothing (#31114).
+      aliases: ["text", "note", "title", "query"],
       // Strict providers may serialize an omitted optional string as "". The
       // empty string is never valid note content (minLength is 1), so normalize
       // that provider sentinel back to omission before schema validation. This
@@ -315,6 +320,7 @@ export const notesAction: Action = {
         "For update, COMPLETE replacement note content: first line is the label, remaining lines are the body. To edit only the body, include the unchanged label followed by a newline and the new body. Preserve unedited content; list the matching note first if unknown. For create, OMIT this field when content already holds the full note. If content holds ONLY a title, body may contain ONLY the requested body, never repeat the title.",
       required: false,
       requiredForSubactions: ["update"],
+      aliases: ["newText", "replacement"],
       schema: { type: "string" },
     },
   ],


### PR DESCRIPTION
## Summary

The `NOTES` handler reads `text`, `note`, `title` and `query` as fallbacks for `content`, and `newText` as a fallback for `body`, but the action declared only `action`, `content` and `body`. Core's `validateToolArgs` rejects any undeclared key and `normalizeParamAliases` only renames keys a parameter claims, so every call using those spellings failed with `Unexpected argument` before the handler ran and nothing was saved.

This declares them where core expects them:

- `content.aliases = ["text", "note", "title", "query"]`
- `body.aliases = ["newText", "replacement"]`

The handler's fallbacks are unchanged. An alias sent together with an explicit canonical value is still rejected, per core's alias rule (never clobber a provided canonical value); the new test pins that too.

Closes #31114

## Evidence

Before (develop `cbf357b0bd8a`, real validator against the real action):

```
NOTES {"action":"create","text":"buy milk"} => {"valid":false,"errors":["Unexpected argument 'text'"]}
NOTES {"action":"list","query":"milk"} => {"valid":false,"errors":["Unexpected argument 'query'"]}
NOTES {"action":"update","content":"milk","newText":"oat milk"} => {"valid":false,"errors":["Unexpected argument 'newText'"]}
```

After: the new test drives the real `executePlannedToolCall` through the promoted `NOTES_CREATE` / `NOTES_LIST` / `NOTES_UPDATE` children and the `NOTES` umbrella with `text`, `query`, `title` + `newText`, and `note`; each call succeeds and the created/updated note carries the expected title and body.

- `bunx vitest run` in `plugins/plugin-notes`: 144/144 (10 files).
- `bun run typecheck` and `bun run lint:check` in `plugins/plugin-notes`: clean.
- Root `bun run verify`: running on a stack branch holding today's fix PRs; result will be posted as a comment.

Precedent: `plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts` declares the same kind of aliases for the same observed symptom (#16935).

# Evidence Gate

<!-- evidence-head:2e25431f4f492c27530daa1f2f17d429c04b0a07 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the action calls are asserted by the plugin-notes suite below.
<!-- evidence-row:backend-logs -->
- [x] Test transcripts from the runs described above:
  <details><summary>validator output on develop and vitest output at this head (plugins/plugin-notes)</summary>

  ```text
  BEFORE (develop cbf357b0bd8a, real validator against the real action):
   NOTES {"action":"create","text":"buy milk"} => {"valid":false,"errors":["Unexpected argument 'text'"]}
   NOTES {"action":"list","query":"milk"} => {"valid":false,"errors":["Unexpected argument 'query'"]}
   NOTES {"action":"update","content":"milk","newText":"oat milk"} => {"valid":false,"errors":["Unexpected argument 'newText'"]}
  AFTER (this head): the new test drives the real executePlannedToolCall through NOTES_CREATE / NOTES_LIST / NOTES_UPDATE and the NOTES umbrella with text, query, title + newText and note; every call succeeds
  $ bunx vitest run   (plugins/plugin-notes)
   Test Files  10 passed (10)
        Tests  144 passed (144)
  typecheck + lint:check in plugins/plugin-notes: exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider or model change; no model calls are involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - in-memory note records created through the aliased calls are asserted on title and body inside the new test; no persistent store is touched by the change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8gwNCWN4PDyeXY6fHhhgy
