### PR TITLE
fix(ci): resolve protected secrets in Cloud release handoff

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1027,10 +1027,10 @@ jobs:
       cancel-in-progress: false
       queue: max
     uses: ./.github/workflows/cloud-cf-release.yml
-    # Telegram credentials have empty caller bindings so GitHub exposes their
-    # names to the reusable job's selected Environment without forwarding a
-    # repository or organization value. Omitting the names makes even existing
-    # Environment secrets resolve blank. The authority receipt stays here.
+    # Use explicit secret expressions for the reusable workflow. Empty literal
+    # bindings resolve blank in the called job even when its Environment has
+    # the secret. The called job's protected Environment supplies its values;
+    # identity attestation and the authority receipt remain required.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CARTESIA_API_KEY: ${{ secrets.CARTESIA_API_KEY }}
@@ -1049,8 +1049,8 @@ jobs:
       ELIZA_APP_BLOOIO_API_KEY: ${{ secrets.ELIZA_APP_BLOOIO_API_KEY }}
       ELIZA_APP_BLOOIO_PHONE_NUMBER: ${{ secrets.ELIZA_APP_BLOOIO_PHONE_NUMBER }}
       ELIZA_APP_BLOOIO_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_BLOOIO_WEBHOOK_SECRET }}
-      ELIZA_APP_TELEGRAM_BOT_TOKEN: ""
-      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ""
+      ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
+      ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
       ELIZA_APP_WEBHOOK_GATEWAY_SECRET: ${{ secrets.ELIZA_APP_WEBHOOK_GATEWAY_SECRET }}
       ELIZA_MOBILE_APP_AUTH_APP_ID: ${{ secrets.ELIZA_MOBILE_APP_AUTH_APP_ID }}
       ELIZA_SERVICE_JWT_SECRET: ${{ secrets.ELIZA_SERVICE_JWT_SECRET }}

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -52,11 +52,9 @@ on:
         required: false
         type: string
         default: ""
-    # Keep caller-scope secrets explicit. Telegram's live credentials are
-    # declared so the workflow can reference their fixed names, but the caller
-    # deliberately does not forward them. The entry workflow proves the
-    # environment-specific runtime authority; deploy-api resolves the values
-    # from its own protected Environment for atomic Worker publication.
+    # Keep caller-scope secrets explicit. The entry workflow proves the
+    # environment-specific runtime authority; deploy-api's protected
+    # Environment supplies the credentials for atomic Worker publication.
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -1404,8 +1402,8 @@ jobs:
           # The edge Telegram route needs both values in the Worker. They are
           # required and replaced atomically with the exact attested source;
           # activation is still a separate protected, live-proven rollout.
-          # These fixed names are resolved directly in this job's protected
-          # Environment and are never forwarded through workflow_call. A
+          # These fixed names are resolved in this job's protected Environment
+          # through explicit caller secret expressions. A
           # computed secrets[] key is evaluated without these Environment
           # values in a reusable workflow and silently becomes blank.
           ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}

--- a/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/homepage-deploy-workflow.test.ts
@@ -534,9 +534,11 @@ describe("homepage deployment workflow", () => {
       "TELEGRAM_IDENTITY_AUTHORITY_SHA256",
     );
     for (const name of reusableEnvironmentSecrets) {
-      // GitHub requires the caller binding to expose the selected Environment
-      // secret in the called job. An empty literal cannot forward repo values.
-      expect(callerSecretMap[name], name).toBe("");
+      // Explicit expressions let the called job resolve its protected
+      // Environment secrets; empty literals produced blank deploy credentials.
+      expect(callerSecretMap[name], name).toBe(
+        githubExpression(`secrets.${name}`),
+      );
       expect(
         parsedReleaseWorkflow.on?.workflow_call?.secrets?.[name],
         name,


### PR DESCRIPTION
Production Cloud release 34684027907 passed its protected Telegram identity check but then stopped before API deployment because the reusable workflow received empty Telegram credentials. The caller explicitly bound both secret names to empty strings, despite the production Environment containing valid values.

Use the same explicit secret expressions as the other release credentials so the called job can resolve its selected Environment. Keep the explicit allowlist, protected environments, identity checks, migration gates, atomic secret publication, and post-deploy readiness checks. No credentials are rotated and no product routing is changed.

Validation: 31 focused workflow checks pass; actionlint passes for both edited workflows. Full repository `bun run verify` passed. The actual GitHub production release must still prove the repaired handoff; local YAML checks cannot prove hosted secret resolution.

Evidence: https://github.com/elizaOS/eliza/actions/runs/34684027907 (authorization succeeds, secret preparation fails). UI/model evidence is N/A for this workflow-only repair; the Dedicated production UI walkthrough remains part of the ongoing release acceptance.
