### PR TITLE
fix(plugin-agent-orchestrator): keep GitLab subgroups and stop matching prose as a repository (#31116)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -48,7 +48,11 @@ import type { TaskThreadDto } from "../services/orchestrator-task-mapper.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import type { OrchestratorTaskStatus } from "../services/orchestrator-task-types.js";
 import { resolveTaskSpawnWorkdir } from "../services/project-binding.js";
-import { normalizeRepositoryInput } from "../services/repo-input.js";
+import {
+  extractGitHubRepositorySlug,
+  extractRepositoryUrl,
+  normalizeRepositoryInput,
+} from "../services/repo-input.js";
 import {
   runDurableTask,
   type SmithersDurableRunLink,
@@ -3628,12 +3632,7 @@ async function runProvisionWorkspace(
 
   let repo = paramRepo ?? content.repo;
   if (!repo && content.text) {
-    const urlMatch = content.text.match(
-      /https?:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[\w.-]+\/[\w.-]+(?:\.git)?/i,
-    );
-    if (urlMatch) {
-      repo = urlMatch[0];
-    }
+    repo = extractRepositoryUrl(content.text);
   }
 
   const useWorktree = paramUseWorktree ?? content.useWorktree === true;
@@ -4361,10 +4360,8 @@ async function runManageIssues(
   const repo = (params.repo as string) ?? (content.repo as string);
 
   if (!repo) {
-    const urlMatch = text.match(
-      /(?:https?:\/\/github\.com\/)?([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/,
-    );
-    if (!urlMatch) {
+    const slug = extractGitHubRepositorySlug(text);
+    if (!slug) {
       if (callback)
         await callback({
           text: "Please specify a repository (e.g., owner/repo or a GitHub URL).",
@@ -4374,7 +4371,7 @@ async function runManageIssues(
     return (
       (await handleIssueAction(
         workspaceService,
-        urlMatch[1],
+        slug,
         action,
         { ...content, ...params },
         text,

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.test.ts
@@ -3,7 +3,11 @@
  * HTTPS clone URL formatting, and SSH preservation.
  */
 import { describe, expect, it } from "vitest";
-import { normalizeRepositoryInput } from "./repo-input.ts";
+import {
+  extractGitHubRepositorySlug,
+  extractRepositoryUrl,
+  normalizeRepositoryInput,
+} from "./repo-input.ts";
 
 describe("repo-input", () => {
   it("returns empty string for empty input", () => {
@@ -29,5 +33,112 @@ describe("repo-input", () => {
   it("normalizes full HTTPS URLs by appending .git if missing", () => {
     const res = normalizeRepositoryInput("https://github.com/elizaOS/eliza");
     expect(res).toBe("https://github.com/elizaOS/eliza.git");
+  });
+
+  it("keeps every GitLab group segment instead of promoting a subgroup to the repo (#31116)", () => {
+    expect(
+      normalizeRepositoryInput(
+        "https://gitlab.com/gitlab-org/security-products/analyzers",
+      ),
+    ).toBe("https://gitlab.com/gitlab-org/security-products/analyzers.git");
+    expect(
+      normalizeRepositoryInput("https://gitlab.com/group/subgroup/repo.git/"),
+    ).toBe("https://gitlab.com/group/subgroup/repo.git");
+    expect(normalizeRepositoryInput("gitlab.com/group/sub/repo")).toBe(
+      "https://gitlab.com/group/sub/repo.git",
+    );
+    expect(normalizeRepositoryInput("https://gitlab.com/group/repo")).toBe(
+      "https://gitlab.com/group/repo.git",
+    );
+  });
+
+  it("drops GitLab sub-resource paths after the `-` separator", () => {
+    expect(
+      normalizeRepositoryInput("https://gitlab.com/group/sub/repo/-/issues/12"),
+    ).toBe("https://gitlab.com/group/sub/repo.git");
+  });
+
+  it("still keeps GitHub and Bitbucket at one owner level", () => {
+    expect(
+      normalizeRepositoryInput("https://github.com/elizaOS/eliza/pull/5"),
+    ).toBe("https://github.com/elizaOS/eliza.git");
+    expect(
+      normalizeRepositoryInput("https://bitbucket.org/team/repo/src/main"),
+    ).toBe("https://bitbucket.org/team/repo.git");
+  });
+
+  it("preserves nested SSH remotes unchanged", () => {
+    const ssh = "git@gitlab.com:group/sub/repo.git";
+    expect(normalizeRepositoryInput(ssh)).toBe(ssh);
+  });
+});
+
+describe("extractRepositoryUrl", () => {
+  it("captures a nested GitLab URL in full so normalization can canonicalize it", () => {
+    const text =
+      "please clone https://gitlab.com/gitlab-org/security-products/analyzers and fix the build";
+    const url = extractRepositoryUrl(text);
+    expect(url).toBe(
+      "https://gitlab.com/gitlab-org/security-products/analyzers",
+    );
+    expect(normalizeRepositoryInput(url ?? "")).toBe(
+      "https://gitlab.com/gitlab-org/security-products/analyzers.git",
+    );
+  });
+
+  it("strips trailing sentence punctuation and ignores unsupported hosts", () => {
+    expect(
+      extractRepositoryUrl("look at https://github.com/acme/widgets."),
+    ).toBe("https://github.com/acme/widgets");
+    expect(extractRepositoryUrl("see https://example.com/acme/widgets")).toBe(
+      undefined,
+    );
+    expect(extractRepositoryUrl("no url here")).toBe(undefined);
+  });
+});
+
+describe("extractGitHubRepositorySlug", () => {
+  it("reads explicit GitHub references in URL, shorthand, and SSH form", () => {
+    expect(
+      extractGitHubRepositorySlug("file it in https://github.com/acme/widgets"),
+    ).toBe("acme/widgets");
+    expect(
+      extractGitHubRepositorySlug("the bug lives in github.com/acme/widgets"),
+    ).toBe("acme/widgets");
+    expect(
+      extractGitHubRepositorySlug("remote is git@github.com:acme/widgets.git"),
+    ).toBe("acme/widgets");
+    expect(
+      extractGitHubRepositorySlug(
+        "open https://github.com/acme/widgets/issues/4",
+      ),
+    ).toBe("acme/widgets");
+  });
+
+  it("accepts a bare slug only when the sentence presents it as a repository", () => {
+    expect(extractGitHubRepositorySlug("close issue 5 in acme/widgets")).toBe(
+      "acme/widgets",
+    );
+    expect(
+      extractGitHubRepositorySlug("repo: acme/widgets, label it bug"),
+    ).toBe("acme/widgets");
+    expect(extractGitHubRepositorySlug("acme/widgets issue 5")).toBe(undefined);
+  });
+
+  it("does not mistake prose for a repository", () => {
+    expect(
+      extractGitHubRepositorySlug(
+        "close the issue about the and/or parsing bug",
+      ),
+    ).toBe(undefined);
+    expect(
+      extractGitHubRepositorySlug("file a bug for the login/logout redirect"),
+    ).toBe(undefined);
+    expect(
+      extractGitHubRepositorySlug("reopen the ticket, it happens 24/7 in prod"),
+    ).toBe(undefined);
+    expect(extractGitHubRepositorySlug("it fails in 24/7 mode")).toBe(
+      undefined,
+    );
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
@@ -5,9 +5,12 @@
  * - owner/repo
  * - github.com/owner/repo
  * - https://github.com/owner/repo
+ * - https://gitlab.com/group/subgroup/repo (nested GitLab groups)
  *
  * Bare owner/repo inputs default to GitHub because the coding workspace
- * flows in this plugin are GitHub-centric.
+ * flows in this plugin are GitHub-centric. GitLab paths keep every group
+ * segment: dropping one rewrites the input into a different, valid-looking
+ * repository that every downstream guard accepts (#31116).
  *
  * @module services/repo-input
  */
@@ -37,13 +40,46 @@ function toHttpsCloneUrl(host: string, owner: string, repo: string): string {
   return `https://${host}/${owner}/${repo}.git`;
 }
 
+/**
+ * Split a known-host path into `[ownerPath, repoName]`, or `null` when the
+ * path does not name a repository. GitHub and Bitbucket nest exactly one
+ * level, so anything after `owner/repo` is a sub-resource (`/pull/5`,
+ * `/issues/12`) and is dropped. GitLab nests groups arbitrarily and separates
+ * sub-resources with a literal `-` segment (`group/sub/repo/-/issues/3`), so
+ * every segment before the first `-` belongs to the repository path.
+ */
+function splitRepositoryPath(
+  host: string,
+  segments: readonly string[],
+): [string, string] | null {
+  const scoped =
+    host === "gitlab.com"
+      ? segments.slice(
+          0,
+          segments.indexOf("-") === -1
+            ? segments.length
+            : segments.indexOf("-"),
+        )
+      : segments.slice(0, 2);
+  if (scoped.length < 2) return null;
+  const repoName = stripGitSuffix(scoped[scoped.length - 1]);
+  if (!repoName) return null;
+  return [scoped.slice(0, -1).join("/"), repoName];
+}
+
+function cloneUrlForKnownHost(host: string, pathname: string): string | null {
+  const split = splitRepositoryPath(host, normalizePathSegments(pathname));
+  return split ? toHttpsCloneUrl(host, split[0], split[1]) : null;
+}
+
 export function normalizeRepositoryInput(repo: string): string {
   const trimmed = repo.trim();
   if (!trimmed) return trimmed;
 
   // Preserve SSH-style clone URLs; they are already explicit and may be
-  // intentionally configured to bypass HTTPS auth.
-  if (/^[^@\s]+@[^:\s]+:[^/\s]+\/[^/\s]+(?:\.git)?$/i.test(trimmed)) {
+  // intentionally configured to bypass HTTPS auth. The path may nest
+  // (GitLab subgroups), so accept one or more `segment/` before the repo.
+  if (/^[^@\s]+@[^:\s]+:(?:[^/\s]+\/)+[^/\s]+(?:\.git)?$/i.test(trimmed)) {
     return trimmed;
   }
 
@@ -57,12 +93,8 @@ export function normalizeRepositoryInput(repo: string): string {
       const parsed = new URL(withoutTrailingSlash);
       const host = parsed.hostname.toLowerCase();
       if (KNOWN_GIT_HOSTS.has(host)) {
-        const segments = normalizePathSegments(parsed.pathname);
-        if (segments.length >= 2) {
-          const owner = segments[0];
-          const repoName = stripGitSuffix(segments[1]);
-          return toHttpsCloneUrl(host, owner, repoName);
-        }
+        const cloneUrl = cloneUrlForKnownHost(host, parsed.pathname);
+        if (cloneUrl) return cloneUrl;
       }
     } catch {
       // error-policy:J3 untrusted repo input; URL parse failure → pass raw through to downstream assertSafeGitRemote validation
@@ -72,14 +104,14 @@ export function normalizeRepositoryInput(repo: string): string {
   }
 
   const hostMatch = withoutTrailingSlash.match(
-    /^(github\.com|gitlab\.com|bitbucket\.org)\/([^/]+)\/([^/]+?)(?:\.git)?$/i,
+    /^(github\.com|gitlab\.com|bitbucket\.org)\/(.+)$/i,
   );
   if (hostMatch) {
-    return toHttpsCloneUrl(
+    const cloneUrl = cloneUrlForKnownHost(
       hostMatch[1].toLowerCase(),
       hostMatch[2],
-      stripGitSuffix(hostMatch[3]),
     );
+    if (cloneUrl) return cloneUrl;
   }
 
   const shorthandMatch = withoutTrailingSlash.match(
@@ -94,6 +126,56 @@ export function normalizeRepositoryInput(repo: string): string {
   }
 
   return withoutTrailingSlash;
+}
+
+const FREE_TEXT_REPOSITORY_URL =
+  /https?:\/\/(?:www\.)?(?:github\.com|gitlab\.com|bitbucket\.org)\/[\w.-]+(?:\/[\w.-]+)+/i;
+
+/**
+ * Find the first supported-host repository URL in free text, keeping every
+ * path segment so {@link normalizeRepositoryInput} can decide which are the
+ * repository and which are a sub-resource. Trailing sentence punctuation is
+ * not part of the URL. Returns `undefined` when no supported URL is present.
+ */
+export function extractRepositoryUrl(text: string): string | undefined {
+  const match = text.match(FREE_TEXT_REPOSITORY_URL);
+  if (!match) return undefined;
+  const url = match[0].replace(/[.,;:!?)]+$/u, "");
+  return url || undefined;
+}
+
+const GITHUB_SLUG = "[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+?";
+// An explicit GitHub reference: a URL, the documented `github.com/owner/repo`
+// shorthand, or an SSH remote. The host anchors it, so prose cannot match.
+const EXPLICIT_GITHUB_REPOSITORY = new RegExp(
+  `(?:https?:\\/\\/)?(?:[\\w.-]+@)?(?:www\\.)?github\\.com[/:](${GITHUB_SLUG})(?:\\.git)?(?![\\w-]|\\.\\w)`,
+  "i",
+);
+// A bare `owner/repo` is only a repository when the sentence presents it as
+// one ("in acme/widgets", "repo acme/widgets"). Without that cue the same
+// shape is ordinary prose ("and/or", "24/7", "login/logout") and must not
+// silence the "which repository?" clarification.
+const CUED_GITHUB_SLUG = new RegExp(
+  `\\b(?:repo(?:sitory)?|project|in|on|for|of|from|at|to)[:\\s]+(${GITHUB_SLUG})(?:\\.git)?(?![\\w-]|\\.\\w)`,
+  "i",
+);
+
+/**
+ * Extract an `owner/repo` GitHub slug from free text for the issue actions.
+ * An explicit GitHub URL, `github.com/` shorthand, or SSH remote always wins;
+ * a bare slug counts only when a repository cue word precedes it. Returns
+ * `undefined` otherwise so the caller asks for the repository.
+ */
+export function extractGitHubRepositorySlug(text: string): string | undefined {
+  const explicit = text.match(EXPLICIT_GITHUB_REPOSITORY);
+  if (explicit) return stripGitSuffix(explicit[1]);
+  const cued = text.match(CUED_GITHUB_SLUG);
+  if (!cued) return undefined;
+  const slug = stripGitSuffix(cued[1]);
+  const [owner, name] = slug.split("/");
+  // Purely numeric pairs ("24/7", "1/2") are never repositories.
+  if (/^\d+$/.test(owner) && /^\d+$/.test(name)) return undefined;
+  return slug;
 }
 
 /** Thrown by {@link assertSafeGitRemote} when a repo string is unsafe to hand


### PR DESCRIPTION
## Summary

Three repository parsers in the orchestrator mishandled paths with more than two segments (GitLab's canonical subgroup layout) and one of them matched ordinary prose.

- `normalizeRepositoryInput` now splits a known-host path with `splitRepositoryPath`: on `gitlab.com` every segment before the literal `-` sub-resource separator is the repository path (`group/sub/repo/-/issues/3` → `group/sub/repo`), while `github.com` and `bitbucket.org` keep one owner level so `owner/repo/pull/5` still resolves to `owner/repo`. The scheme-less `gitlab.com/group/sub/repo` form and nested SSH remotes are handled the same way.
- The free-text URL extractor in `provisionWorkspace` becomes `extractRepositoryUrl`: it captures every path segment and trims trailing sentence punctuation, then `normalizeRepositoryInput` canonicalizes it, so a pasted subgroup URL is no longer truncated before normalization.
- The issue-action extractor becomes `extractGitHubRepositorySlug`: an explicit GitHub reference (URL, `github.com/owner/repo` shorthand, or SSH remote) always wins and `.git` is stripped; a bare `owner/repo` counts only when a repository cue word precedes it (`in`, `on`, `for`, `repo`, ...), and purely numeric pairs never do. `and/or`, `login/logout` and `24/7` now fall through to the "Please specify a repository" clarification instead of firing a GitHub API call for a nonexistent repo.

Closes #31116

## Evidence

Before (develop `cbf357b0bd8a`):

```
https://gitlab.com/gitlab-org/security-products/analyzers -> https://gitlab.com/gitlab-org/security-products.git
"close the issue about the and/or parsing bug" => repo: and/or
"reopen the ticket, it happens 24/7 in prod"    => repo: 24/7
"...in github.com/acme/widgets"                 => repo: github.com/acme
"...git@github.com:acme/widgets.git"            => repo: acme/widgets.git
```

After: `repo-input.test.ts` pins the subgroup round-trip, the `-` cut, GitHub/Bitbucket one-level behaviour, nested SSH preservation, the full-path free-text capture, and the explicit/cued/prose cases above.

- `bunx vitest run src/services/repo-input.test.ts`: 14/14 (5 existing + 9 new).
- `bunx vitest run src/actions`: 21/21.
- `bun run typecheck` (both tsconfigs) and `bun run lint:check` in `plugins/plugin-agent-orchestrator`: clean.
- Root `bun run verify`: running on a stack branch holding today's fix PRs; result will be posted as a comment.

Trade-off worth a reviewer's eye: the bare-slug cue-word rule means `acme/widgets issue 5` (slug first, no cue) now asks which repository instead of guessing. Explicit GitHub URLs and `github.com/` shorthand are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8gwNCWN4PDyeXY6fHhhgy
