### PR TITLE
fix(plugin-wallet): report an unreachable EVM chain as unavailable instead of absent (#31111)

### DIFF
--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/evm-service-cache.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/evm-service-cache.test.ts
@@ -47,16 +47,17 @@ describe("EVMService cache reads", () => {
   it("coalesces concurrent refreshes and writes one forced network snapshot", async () => {
     const runtime = new AgentRuntime({ logLevel: "fatal" });
     const setCache = vi.spyOn(runtime, "setCache").mockResolvedValue(true);
-    let releaseBalances: ((balances: { mainnet: string }) => void) | undefined;
-    const getWalletBalances = vi.fn(
+    type States = Record<string, { status: "ok"; balance: string }>;
+    let releaseBalances: ((balances: States) => void) | undefined;
+    const getChainBalanceStates = vi.fn(
       () =>
-        new Promise<{ mainnet: string }>((resolve) => {
+        new Promise<States>((resolve) => {
           releaseBalances = resolve;
         })
     );
     const wallet = {
       getAddress: vi.fn(() => "0x1234"),
-      getWalletBalances,
+      getChainBalanceStates,
       getChainConfigs: vi.fn(() => ({
         id: 1,
         name: "Ethereum",
@@ -70,10 +71,10 @@ describe("EVMService cache reads", () => {
     const second = service.refreshWalletData();
     await Promise.resolve();
     expect(initWalletProviderMock).toHaveBeenCalledOnce();
-    expect(getWalletBalances).toHaveBeenCalledOnce();
-    expect(getWalletBalances).toHaveBeenCalledWith(true);
+    expect(getChainBalanceStates).toHaveBeenCalledOnce();
+    expect(getChainBalanceStates).toHaveBeenCalledWith(true);
 
-    releaseBalances?.({ mainnet: "1.5" });
+    releaseBalances?.({ mainnet: { status: "ok", balance: "1.5" } });
     await Promise.all([first, second]);
 
     expect(setCache).toHaveBeenCalledOnce();
@@ -90,9 +91,39 @@ describe("EVMService cache reads", () => {
             name: "Ethereum",
           },
         ],
+        unavailableChains: [],
       })
     );
     expect(service.getWalletProvider()).toBe(wallet);
+  });
+
+  it("records an unreachable chain as unavailable instead of dropping it (#31111)", async () => {
+    const runtime = new AgentRuntime({ logLevel: "fatal" });
+    const setCache = vi.spyOn(runtime, "setCache").mockResolvedValue(true);
+    const wallet = {
+      getAddress: vi.fn(() => "0x1234"),
+      getChainBalanceStates: vi.fn(async () => ({
+        mainnet: { status: "ok", balance: "1.5" },
+        optimism: { status: "unavailable", error: "HTTP request failed: 503" },
+      })),
+      getChainConfigs: vi.fn(() => ({
+        id: 1,
+        name: "Ethereum",
+        nativeCurrency: { symbol: "ETH" },
+      })),
+    };
+    initWalletProviderMock.mockResolvedValue(wallet);
+    const service = new EVMService(runtime);
+
+    await service.refreshWalletData();
+
+    expect(setCache).toHaveBeenCalledWith(
+      EVM_WALLET_DATA_CACHE_KEY,
+      expect.objectContaining({
+        chains: [expect.objectContaining({ chainName: "mainnet", balance: "1.5" })],
+        unavailableChains: [{ chainName: "optimism", error: "HTTP request failed: 503" }],
+      })
+    );
   });
 
   it("throws an explicit uninitialized error before the first refresh", () => {

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
@@ -20,17 +20,21 @@ vi.mock("../../../../utils/intent-trajectory", () => ({
 const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 
-// base mainnet native balance, as a decimal string (the shape getWalletBalances returns)
+// base mainnet native balance, as a decimal string (the balance a chain's ok state carries)
 const BASE_BALANCE = "2"; // 2.0 ETH
 
 function createWalletProvider(
   balances: Record<string, string> = { base: BASE_BALANCE }
 ): WalletProvider {
+  const states = Object.fromEntries(
+    Object.entries(balances).map(([chain, balance]) => [chain, { status: "ok", balance }])
+  );
   return {
     chains: { base },
     getSupportedChains: () => ["base"],
     getChainConfigs: () => base,
     getWalletBalances: async () => balances,
+    getChainBalanceStates: async () => states,
   } as unknown as WalletProvider;
 }
 

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-behavior.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-behavior.test.ts
@@ -81,7 +81,7 @@ describe("WalletProvider local chain and cache behavior", () => {
     expect(setCache).not.toHaveBeenCalled();
   });
 
-  it("force-refreshes every chain in parallel and caches only successful balances", async () => {
+  it("force-refreshes every chain in parallel and caches a complete snapshot", async () => {
     const rt = runtime();
     const getCache = vi.spyOn(rt, "getCache");
     const setCache = vi.spyOn(rt, "setCache").mockResolvedValue(true);
@@ -91,14 +91,57 @@ describe("WalletProvider local chain and cache behavior", () => {
     });
     const getBalance = vi
       .spyOn(provider, "getWalletBalanceForChain")
-      .mockImplementation(async (chain) => (chain === "mainnet" ? "1.25" : null));
+      .mockImplementation(async (chain) => (chain === "mainnet" ? "1.25" : "0.5"));
 
     await expect(provider.getWalletBalances(true)).resolves.toEqual({
       mainnet: "1.25",
+      optimism: "0.5",
     });
     expect(getCache).not.toHaveBeenCalled();
     expect(getBalance).toHaveBeenCalledTimes(2);
-    expect(setCache).toHaveBeenCalledWith("evm/wallet/walletBalances", { mainnet: "1.25" });
+    expect(setCache).toHaveBeenCalledWith("evm/wallet/walletBalances", {
+      mainnet: "1.25",
+      optimism: "0.5",
+    });
+  });
+
+  it("reports an unreachable chain as unavailable and never caches the partial snapshot (#31111)", async () => {
+    const rt = runtime();
+    const setCache = vi.spyOn(rt, "setCache").mockResolvedValue(true);
+    vi.spyOn(rt, "getCache").mockResolvedValue(undefined);
+    const provider = new WalletProvider(generatePrivateKey(), rt, {
+      mainnet,
+      optimism,
+    });
+    let optimismDown = true;
+    vi.spyOn(provider, "getWalletBalanceForChain").mockImplementation(async (chain) => {
+      if (chain === "optimism" && optimismDown) {
+        throw new Error("HTTP request failed: 503 Service Unavailable");
+      }
+      return chain === "mainnet" ? "5" : "0.5";
+    });
+
+    await expect(provider.getChainBalanceStates()).resolves.toEqual({
+      mainnet: { status: "ok", balance: "5" },
+      optimism: {
+        status: "unavailable",
+        error: "HTTP request failed: 503 Service Unavailable",
+      },
+    });
+    // The balances view omits the chain but a partial map is never cached.
+    await expect(provider.getWalletBalances()).resolves.toEqual({ mainnet: "5" });
+    expect(setCache).not.toHaveBeenCalled();
+
+    // Once the RPC answers again the next read sees it (no stale "absent").
+    optimismDown = false;
+    await expect(provider.getWalletBalances()).resolves.toEqual({
+      mainnet: "5",
+      optimism: "0.5",
+    });
+    expect(setCache).toHaveBeenCalledWith("evm/wallet/walletBalances", {
+      mainnet: "5",
+      optimism: "0.5",
+    });
   });
 
   it("creates a configured local provider from runtime settings", async () => {

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-behavior.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-behavior.test.ts
@@ -105,10 +105,58 @@ describe("WalletProvider local chain and cache behavior", () => {
     });
   });
 
+  it("refuses a cached map that is missing a configured chain and refreshes from RPC (#31111)", async () => {
+    const rt = runtime();
+    // The poisoned map from #31111: written while optimism's RPC was down.
+    vi.spyOn(rt, "getCache").mockResolvedValue({ mainnet: "5" });
+    const deleteCache = vi.spyOn(rt, "deleteCache").mockResolvedValue(true);
+    const setCache = vi.spyOn(rt, "setCache").mockResolvedValue(true);
+    const provider = new WalletProvider(generatePrivateKey(), rt, {
+      mainnet,
+      optimism,
+    });
+    const getBalance = vi
+      .spyOn(provider, "getWalletBalanceForChain")
+      .mockImplementation(async (chain) => (chain === "mainnet" ? "5" : "0.5"));
+
+    // Default (non-forced) read: the truncated entry must not be served.
+    await expect(provider.getChainBalanceStates()).resolves.toEqual({
+      mainnet: { status: "ok", balance: "5" },
+      optimism: { status: "ok", balance: "0.5" },
+    });
+    expect(deleteCache).toHaveBeenCalledWith("evm/wallet/walletBalances");
+    expect(getBalance).toHaveBeenCalledTimes(2);
+    expect(setCache).toHaveBeenCalledWith("evm/wallet/walletBalances", {
+      mainnet: "5",
+      optimism: "0.5",
+    });
+  });
+
+  it("clears an older snapshot when a live refresh has an unavailable chain", async () => {
+    const rt = runtime();
+    vi.spyOn(rt, "getCache").mockResolvedValue({ mainnet: "4", optimism: "0.4" });
+    const deleteCache = vi.spyOn(rt, "deleteCache").mockResolvedValue(true);
+    const setCache = vi.spyOn(rt, "setCache").mockResolvedValue(true);
+    const provider = new WalletProvider(generatePrivateKey(), rt, {
+      mainnet,
+      optimism,
+    });
+    vi.spyOn(provider, "getWalletBalanceForChain").mockImplementation(async (chain) => {
+      if (chain === "optimism") throw new Error("503 Service Unavailable");
+      return "5";
+    });
+
+    const states = await provider.getChainBalanceStates(true);
+    expect(states.optimism).toEqual({ status: "unavailable", error: "503 Service Unavailable" });
+    expect(deleteCache).toHaveBeenCalledWith("evm/wallet/walletBalances");
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
   it("reports an unreachable chain as unavailable and never caches the partial snapshot (#31111)", async () => {
     const rt = runtime();
     const setCache = vi.spyOn(rt, "setCache").mockResolvedValue(true);
     vi.spyOn(rt, "getCache").mockResolvedValue(undefined);
+    vi.spyOn(rt, "deleteCache").mockResolvedValue(true);
     const provider = new WalletProvider(generatePrivateKey(), rt, {
       mainnet,
       optimism,

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-timeout.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/wallet-provider-timeout.test.ts
@@ -20,7 +20,7 @@ describe("WalletProvider RPC balance reads", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns null when the cancellation-aware transport rejects", async () => {
+  it("rejects with a NETWORK_ERROR when the cancellation-aware transport rejects", async () => {
     const provider = new WalletProvider(generatePrivateKey(), makeRuntime(), {
       mainnet,
     });
@@ -31,7 +31,10 @@ describe("WalletProvider RPC balance reads", () => {
       },
     } as never);
 
-    await expect(provider.getWalletBalanceForChain("mainnet" as never)).resolves.toBeNull();
+    await expect(provider.getWalletBalanceForChain("mainnet" as never)).rejects.toMatchObject({
+      name: "EVMError",
+      code: "NETWORK_ERROR",
+    });
   });
 
   it("returns the formatted balance when the RPC responds in time", async () => {

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -43,7 +43,11 @@ import {
   NATIVE_TOKEN_ADDRESS,
   TX_CONFIRMATION_TIMEOUT_MS,
 } from "../constants";
-import { initWalletProvider, type WalletProvider } from "../providers/wallet";
+import {
+  type ChainBalanceState,
+  initWalletProvider,
+  type WalletProvider,
+} from "../providers/wallet";
 import { swapTemplate } from "../templates";
 import {
   type BebopRoute,
@@ -769,14 +773,18 @@ export async function buildSwapDetails(
   wp: WalletProvider
 ): Promise<SwapParams> {
   const chains = wp.getSupportedChains();
-  const balances = await wp.getWalletBalances();
+  const balances = await wp.getChainBalanceStates();
 
   state = await runtime.composeState(message, ["RECENT_MESSAGES"], true);
   state.supportedChains = chains.join(" | ");
   state.chainBalances = Object.entries(balances)
     .map(([chain, balance]) => {
       const chainConfig = wp.getChainConfigs(chain as SupportedChain);
-      return `${chain}: ${balance} ${chainConfig.nativeCurrency.symbol}`;
+      // Name an unreachable chain so the intent model does not read its
+      // absence as an empty balance (#31111).
+      return balance.status === "ok"
+        ? `${chain}: ${balance.balance} ${chainConfig.nativeCurrency.symbol}`
+        : `${chain}: balance unavailable (RPC error)`;
     })
     .join(", ");
 
@@ -807,7 +815,9 @@ export async function buildSwapDetails(
   // `chain` is an arbitrary lowercased string from the model, so the balance
   // lookup is honestly `string | undefined` (resolveRelativeAmount throws when
   // it is undefined). Validation of the chain itself happens via parseSwapParams.
-  const chainBalance: string | undefined = (balances as Record<string, string | undefined>)[chain];
+  const chainState = (balances as Record<string, ChainBalanceState | undefined>)[chain];
+  const chainBalance: string | undefined =
+    chainState?.status === "ok" ? chainState.balance : undefined;
 
   const amount =
     amountMode === "absolute"

--- a/plugins/plugin-wallet/src/chains/evm/actions/transfer.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/transfer.ts
@@ -71,13 +71,17 @@ export async function buildTransferDetails(
   wp: WalletProvider
 ): Promise<TransferParams> {
   const chains = wp.getSupportedChains();
-  const balances = await wp.getWalletBalances();
+  const balances = await wp.getChainBalanceStates();
   state = await runtime.composeState(message, ["RECENT_MESSAGES"], true);
 
   state.chainBalances = Object.entries(balances)
     .map(([chain, balance]) => {
       const chainConfig = wp.getChainConfigs(chain as SupportedChain);
-      return `${chain}: ${balance} ${chainConfig.nativeCurrency.symbol}`;
+      // Name an unreachable chain so the intent model does not read its
+      // absence as an empty balance (#31111).
+      return balance.status === "ok"
+        ? `${chain}: ${balance.balance} ${chainConfig.nativeCurrency.symbol}`
+        : `${chain}: balance unavailable (RPC error)`;
     })
     .join(", ");
   state.supportedChains = chains.join(" | ");

--- a/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
@@ -217,22 +217,33 @@ export class WalletProvider {
     forceRefresh = false
   ): Promise<Record<SupportedChain, ChainBalanceState>> {
     const cacheKey = path.join(this.cacheKey, "walletBalances");
+    const chainNames = this.getSupportedChains();
     const cachedData = forceRefresh
       ? undefined
       : await this._runtime.getCache<Record<SupportedChain, string>>(cacheKey);
 
     if (cachedData) {
-      logger.log(`Returning cached wallet balances`);
-      const states = {} as Record<SupportedChain, ChainBalanceState>;
-      for (const [chainName, balance] of Object.entries(cachedData)) {
-        states[chainName as SupportedChain] = { status: "ok", balance };
+      // A cached map is only trusted when it covers every configured chain.
+      // Maps written before this check existed could be missing a chain whose
+      // RPC failed at write time (#31111); the cache has no TTL, so such an
+      // entry would otherwise be served as complete indefinitely.
+      const missing = chainNames.filter((chainName) => cachedData[chainName] === undefined);
+      if (missing.length === 0) {
+        logger.log(`Returning cached wallet balances`);
+        const states = {} as Record<SupportedChain, ChainBalanceState>;
+        for (const chainName of chainNames) {
+          states[chainName] = { status: "ok", balance: cachedData[chainName] };
+        }
+        return states;
       }
-      return states;
+      logger.warn(
+        `Cached wallet balances discarded: missing ${missing.join(", ")}; refreshing from RPC`
+      );
+      await this._runtime.deleteCache(cacheKey);
     }
 
     const states = {} as Record<SupportedChain, ChainBalanceState>;
     const balances = {} as Record<SupportedChain, string>;
-    const chainNames = this.getSupportedChains();
 
     const results = await Promise.allSettled(
       chainNames.map(async (chainName) => {
@@ -259,6 +270,10 @@ export class WalletProvider {
       await this._runtime.setCache(cacheKey, balances);
       logger.log("Wallet balances cached");
     } else {
+      // Never leave an older complete snapshot behind either: a reader that
+      // skips the RPC would otherwise serve balances from before the outage as
+      // current.
+      await this._runtime.deleteCache(cacheKey);
       logger.warn(
         `Wallet balances not cached: ${unavailable} of ${chainNames.length} chains unavailable`
       );

--- a/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
@@ -118,6 +118,11 @@ async function getManagedRpcFallbackReason(response: Response): Promise<string |
   return null;
 }
 
+/** Per-chain outcome of a balance read; `unavailable` carries the RPC failure. */
+export type ChainBalanceState =
+  | { readonly status: "ok"; readonly balance: string }
+  | { readonly status: "unavailable"; readonly error: string };
+
 export class WalletProvider {
   private readonly cacheKey = "evm/wallet";
   private _chains: Record<string, Chain>;
@@ -200,7 +205,17 @@ export class WalletProvider {
     return Object.keys(this._chains) as SupportedChain[];
   }
 
-  async getWalletBalances(forceRefresh = false): Promise<Record<SupportedChain, string>> {
+  /**
+   * Read every configured chain's native balance, reporting each chain as
+   * either `ok` or `unavailable`. A chain whose RPC failed is never dropped
+   * from the result and a snapshot with any unavailable chain is never cached:
+   * a cached partial map would tell later readers (the transfer and swap
+   * intent prompts, the wallet provider) that the wallet holds nothing on that
+   * chain until the next forced refresh (#31111).
+   */
+  async getChainBalanceStates(
+    forceRefresh = false
+  ): Promise<Record<SupportedChain, ChainBalanceState>> {
     const cacheKey = path.join(this.cacheKey, "walletBalances");
     const cachedData = forceRefresh
       ? undefined
@@ -208,9 +223,14 @@ export class WalletProvider {
 
     if (cachedData) {
       logger.log(`Returning cached wallet balances`);
-      return cachedData;
+      const states = {} as Record<SupportedChain, ChainBalanceState>;
+      for (const [chainName, balance] of Object.entries(cachedData)) {
+        states[chainName as SupportedChain] = { status: "ok", balance };
+      }
+      return states;
     }
 
+    const states = {} as Record<SupportedChain, ChainBalanceState>;
     const balances = {} as Record<SupportedChain, string>;
     const chainNames = this.getSupportedChains();
 
@@ -221,30 +241,61 @@ export class WalletProvider {
       })
     );
 
-    for (const result of results) {
-      if (result.status === "fulfilled" && result.value.balance !== null) {
-        balances[result.value.chainName] = result.value.balance;
-      } else if (result.status === "rejected") {
-        logger.error(`Error getting balance:`, result.reason);
+    let unavailable = 0;
+    results.forEach((result, index) => {
+      const chainName = chainNames[index];
+      if (result.status === "fulfilled") {
+        states[chainName] = { status: "ok", balance: result.value.balance };
+        balances[chainName] = result.value.balance;
+        return;
+      }
+      unavailable += 1;
+      const error = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      logger.error(`Error getting balance for ${chainName}:`, error);
+      states[chainName] = { status: "unavailable", error };
+    });
+
+    if (unavailable === 0) {
+      await this._runtime.setCache(cacheKey, balances);
+      logger.log("Wallet balances cached");
+    } else {
+      logger.warn(
+        `Wallet balances not cached: ${unavailable} of ${chainNames.length} chains unavailable`
+      );
+    }
+    return states;
+  }
+
+  /**
+   * Native balances for the chains that answered. An unavailable chain is
+   * omitted here; callers that present balances to a model or a person should
+   * use {@link getChainBalanceStates} so the outage is visible rather than
+   * read as an empty wallet. A partial result is never cached.
+   */
+  async getWalletBalances(forceRefresh = false): Promise<Record<SupportedChain, string>> {
+    const states = await this.getChainBalanceStates(forceRefresh);
+    const balances = {} as Record<SupportedChain, string>;
+    for (const [chainName, state] of Object.entries(states)) {
+      if (state.status === "ok") {
+        balances[chainName as SupportedChain] = state.balance;
       }
     }
-
-    await this._runtime.setCache(cacheKey, balances);
-    logger.log("Wallet balances cached");
     return balances;
   }
 
-  async getWalletBalanceForChain(chainName: SupportedChain): Promise<string | null> {
+  /** Native balance for one chain; throws `EVMError(NETWORK_ERROR)` when the RPC fails. */
+  async getWalletBalanceForChain(chainName: SupportedChain): Promise<string> {
+    const client = this.getPublicClient(chainName);
     try {
-      const client = this.getPublicClient(chainName);
       const balance = await client.getBalance({ address: this._account.address });
       return formatUnits(balance, 18);
     } catch (error) {
-      logger.error(
-        `Error getting wallet balance for ${chainName}:`,
-        error instanceof Error ? error.message : String(error)
+      // error-policy:J2 context-adding rethrow; the aggregator reports the chain as unavailable
+      throw new EVMError(
+        EVMErrorCode.NETWORK_ERROR,
+        `Balance read failed for ${chainName}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error : undefined
       );
-      return null;
     }
   }
 
@@ -612,13 +663,21 @@ class LazyTeeWalletProvider extends WalletProvider {
     return this.teeWallet.getWalletClient(chainName);
   }
 
+  override async getChainBalanceStates(
+    forceRefresh = false
+  ): Promise<Record<SupportedChain, ChainBalanceState>> {
+    await this.ensureInitialized();
+    assertDefined(this.teeWallet, "TEE wallet failed to initialize");
+    return this.teeWallet.getChainBalanceStates(forceRefresh);
+  }
+
   override async getWalletBalances(forceRefresh = false): Promise<Record<SupportedChain, string>> {
     await this.ensureInitialized();
     assertDefined(this.teeWallet, "TEE wallet failed to initialize");
     return this.teeWallet.getWalletBalances(forceRefresh);
   }
 
-  override async getWalletBalanceForChain(chainName: SupportedChain): Promise<string | null> {
+  override async getWalletBalanceForChain(chainName: SupportedChain): Promise<string> {
     await this.ensureInitialized();
     assertDefined(this.teeWallet, "TEE wallet failed to initialize");
     return this.teeWallet.getWalletBalanceForChain(chainName);
@@ -654,6 +713,7 @@ export const evmWalletProvider: Provider = {
                 balance: string;
                 symbol: string;
               }>;
+              unavailableChains?: ReadonlyArray<{ chainName: string; error: string }>;
             }
           | undefined
         >;
@@ -680,15 +740,20 @@ export const evmWalletProvider: Provider = {
 
       const agentName = state?.agentName ?? "The agent";
       const chains = walletData.chains;
-      const balanceText = chains
-        .map((chain) => `${chain.name}: ${chain.balance} ${chain.symbol}`)
-        .join("\n");
+      const unavailableChains = walletData.unavailableChains ?? [];
+      // An unreachable chain is named as such: omitting it would read as an
+      // empty balance on that chain.
+      const balanceText = [
+        ...chains.map((chain) => `${chain.name}: ${chain.balance} ${chain.symbol}`),
+        ...unavailableChains.map((chain) => `${chain.chainName}: balance unavailable (RPC error)`),
+      ].join("\n");
 
       return {
         text: `${agentName}'s EVM Wallet Address: ${walletData.address}\n\nBalances:\n${balanceText}`,
         data: {
           address: walletData.address,
           chains,
+          unavailableChains,
           chainCount: walletData.chains.length,
           displayedChainCount: chains.length,
         },

--- a/plugins/plugin-wallet/src/chains/evm/service.ts
+++ b/plugins/plugin-wallet/src/chains/evm/service.ts
@@ -23,6 +23,11 @@ export interface EVMWalletData {
     readonly symbol: string;
     readonly chainId: number;
   }>;
+  /** Chains whose RPC did not answer on this refresh; never folded into `chains`. */
+  readonly unavailableChains: ReadonlyArray<{
+    readonly chainName: string;
+    readonly error: string;
+  }>;
   readonly timestamp: number;
 }
 
@@ -97,7 +102,16 @@ export class EVMService extends Service {
     }
 
     const address = this.walletProvider.getAddress();
-    const balances = await this.walletProvider.getWalletBalances(true);
+    const balanceStates = await this.walletProvider.getChainBalanceStates(true);
+    const balances: Record<string, string> = {};
+    const unavailableChains: Array<{ chainName: string; error: string }> = [];
+    for (const [chainName, state] of Object.entries(balanceStates)) {
+      if (state.status === "ok") {
+        balances[chainName] = state.balance;
+      } else {
+        unavailableChains.push({ chainName, error: state.error });
+      }
+    }
 
     const chainDetails: Array<{
       chainName: string;
@@ -128,6 +142,7 @@ export class EVMService extends Service {
     const walletData: EVMWalletData = {
       address,
       chains: chainDetails,
+      unavailableChains,
       timestamp: Date.now(),
     };
 


### PR DESCRIPTION
## Summary

`getWalletBalanceForChain` returned `null` from its catch, `getWalletBalances` dropped every `null` and cached the truncated map, and `buildTransferDetails` / `buildSwapDetails` read that cache without `forceRefresh`. One flaky RPC call therefore told the intent model that the wallet held nothing on that chain until the next periodic forced refresh.

Changes in `plugins/plugin-wallet/src/chains/evm`:

- `WalletProvider.getChainBalanceStates(forceRefresh)` (new) returns `Record<chain, { status: "ok", balance } | { status: "unavailable", error }>`. A snapshot with any unavailable chain is never written to the cache; a complete one is cached under the same key and shape as before.
- `getWalletBalances` keeps its return type and now derives from the states (ok chains only), so `EVMService` callers and the TEE wrapper are unchanged in shape. Its doc says unavailable chains are omitted and a partial result is never cached.
- `getWalletBalanceForChain` throws `EVMError(NETWORK_ERROR, message, cause)` instead of returning `null` (`error-policy:J2`); the TEE override signature follows.
- `transfer.ts` and `swap.ts` build `state.chainBalances` from the states and render `base: balance unavailable (RPC error)` for a failed chain. The swap relative-amount lookup reads the ok balance from the state (an unavailable chain still yields "unknown balance" for `half`/`max`/`percent`).
- `EVMWalletData` gains `unavailableChains`, filled by the service refresh, and the EVM wallet provider text lists those chains as unavailable instead of omitting them.

Closes #31111

## Evidence

Before (develop `cbf357b0bd8a`, real provider, `base` RPC 503 on the first call, healthy on the second):

```
call 1 (base RPC down): {"mainnet":"5"}
call 2 (base RPC healthy again): {"mainnet":"5"} <- served from cache
what the transfer action puts in the LLM prompt (state.chainBalances):
  mainnet: 5 ETH
cache entry written by call 1: [["evm/wallet/walletBalances",{"mainnet":"5"}]]
```

After: the new provider test pins `{ mainnet: ok 5, optimism: unavailable "HTTP request failed: 503 Service Unavailable" }`, no `setCache` call for the partial snapshot, and the next read seeing `optimism` once its RPC answers. The service test pins `unavailableChains: [{ chainName: "optimism", error }]` in the cached wallet data. The existing "caches only successful balances" test, which had codified partial caching, is replaced by a complete-snapshot case.

- `bunx vitest run src/chains/evm/__tests__/unit`: 52/52 (8 files).
- `bun run test` in `plugins/plugin-wallet`: 420 passed, 1 skipped (70 files).
- `bun run typecheck` and `bun run lint:check` in `plugins/plugin-wallet`: clean.
- Root `bun run verify`: running on a stack branch holding today's fix PRs; result will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8gwNCWN4PDyeXY6fHhhgy
