### PR TITLE
fix(plugin-wallet): propagate Solana RPC failures instead of serving zero balances (#31110)

### DIFF
--- a/plugins/plugin-wallet/src/chains/solana/routes/index.ts
+++ b/plugins/plugin-wallet/src/chains/solana/routes/index.ts
@@ -70,7 +70,12 @@ const getWalletBalanceHandler: LegacyRouteHandler = async (_req, res, runtime) =
 
     const publicKeyStr = publicKey.toBase58();
     const balances = await solanaService.getBalancesByAddrs([publicKeyStr]);
-    const balance = balances[publicKeyStr] ?? 0;
+    const balance = balances[publicKeyStr];
+    if (balance === undefined) {
+      // The service reports every requested address or throws; a missing
+      // entry is a contract violation, not a zero balance.
+      throw new Error(`Balance read returned no entry for ${publicKeyStr}`);
+    }
 
     sendSuccess(res, {
       publicKey: publicKeyStr,

--- a/plugins/plugin-wallet/src/chains/solana/service.rpc-errors.test.ts
+++ b/plugins/plugin-wallet/src/chains/solana/service.rpc-errors.test.ts
@@ -1,0 +1,218 @@
+/**
+ * RPC-failure contract for SolanaService balance and token-account reads, the
+ * wallet routes built on them, and the portfolio cache. Uses the real service
+ * prototype and real route handlers with only the RPC connection stubbed, so
+ * the assertions cover the code path a down or rate-limited RPC actually takes
+ * (#31110). Deterministic; no network.
+ */
+import { PublicKey } from "@solana/web3.js";
+import { describe, expect, it, vi } from "vitest";
+import { SOLANA_WALLET_DATA_CACHE_KEY } from "./constants";
+import { solanaRoutes } from "./routes/index";
+import { SolanaService } from "./service";
+
+const ADDR = "11111111111111111111111111111112";
+// Public USDC mint on mainnet, used only as a held-token lookup key.
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const RPC_ERROR = new Error(
+  "failed to get info about accounts: Server responded with 500 Internal Server Error"
+);
+const RATE_LIMIT_ERROR = new Error("429 Too Many Requests");
+
+type Stub = {
+  getMultipleAccountsInfo: () => Promise<unknown[]>;
+  getParsedTokenAccountsByOwner: () => Promise<{ value: unknown[] }>;
+};
+
+function serviceWithConnection(connection: Stub) {
+  const cache = new Map<string, unknown>();
+  const svc = Object.create(SolanaService.prototype) as SolanaService & {
+    connection: Stub;
+    decimalsCache: Map<string, number>;
+    runtime: unknown;
+    lastUpdate: number;
+    UPDATE_INTERVAL: number;
+    ensurePublicKey: () => Promise<PublicKey>;
+  };
+  svc.connection = connection;
+  svc.decimalsCache = new Map();
+  svc.lastUpdate = 0;
+  svc.UPDATE_INTERVAL = 0;
+  svc.runtime = {
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+    getCache: async (key: string) => cache.get(key),
+    setCache: async (key: string, value: unknown) => {
+      cache.set(key, value);
+    },
+    getSetting: () => undefined,
+  };
+  svc.getPublicKey = async () => new PublicKey(ADDR);
+  svc.ensurePublicKey = async () => new PublicKey(ADDR);
+  return { svc, cache };
+}
+
+function mkRes() {
+  const res = { statusCode: 200, payload: undefined as unknown } as {
+    statusCode: number;
+    payload: unknown;
+    status: (code: number) => typeof res;
+    json: (body: unknown) => typeof res;
+    send: (body: unknown) => typeof res;
+  };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.payload = body;
+    return res;
+  };
+  res.send = res.json;
+  return res;
+}
+
+const routeByPath = Object.fromEntries(solanaRoutes.map((route) => [route.path, route.handler]));
+
+describe("SolanaService RPC failures", () => {
+  it("throws a typed error from getTokenAccountsByKeypair instead of returning []", async () => {
+    const { svc } = serviceWithConnection({
+      getMultipleAccountsInfo: async () => {
+        throw RPC_ERROR;
+      },
+      getParsedTokenAccountsByOwner: async () => {
+        throw RPC_ERROR;
+      },
+    });
+    await expect(svc.getTokenAccountsByKeypair(new PublicKey(ADDR), {})).rejects.toMatchObject({
+      code: "SOLANA_RPC_UNAVAILABLE",
+      cause: RPC_ERROR,
+    });
+  });
+
+  it("throws a typed error from getBalancesByAddrs instead of returning {}", async () => {
+    const { svc } = serviceWithConnection({
+      getMultipleAccountsInfo: async () => {
+        throw RPC_ERROR;
+      },
+      getParsedTokenAccountsByOwner: async () => ({ value: [] }),
+    });
+    await expect(svc.getBalancesByAddrs([ADDR])).rejects.toMatchObject({
+      code: "SOLANA_RPC_UNAVAILABLE",
+    });
+  });
+
+  it("bounds the 429 retry and surfaces a rate-limit error", async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const { svc } = serviceWithConnection({
+        getMultipleAccountsInfo: async () => {
+          calls += 1;
+          throw RATE_LIMIT_ERROR;
+        },
+        getParsedTokenAccountsByOwner: async () => ({ value: [] }),
+      });
+      const pending = svc.getBalancesByAddrs([ADDR]);
+      const settled = expect(pending).rejects.toMatchObject({
+        code: "SOLANA_RPC_RATE_LIMITED",
+      });
+      await vi.runAllTimersAsync();
+      await settled;
+      expect(calls).toBe(SolanaService.BALANCE_READ_MAX_ATTEMPTS);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recovers when the rate limit clears within the retry budget", async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const { svc } = serviceWithConnection({
+        getMultipleAccountsInfo: async () => {
+          calls += 1;
+          if (calls === 1) throw RATE_LIMIT_ERROR;
+          return [{ lamports: 2_000_000_000 }];
+        },
+        getParsedTokenAccountsByOwner: async () => ({ value: [] }),
+      });
+      const pending = svc.getBalancesByAddrs([ADDR]);
+      await vi.runAllTimersAsync();
+      await expect(pending).resolves.toEqual({ [ADDR]: 2 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not cache an empty portfolio while the RPC is down", async () => {
+    const { svc, cache } = serviceWithConnection({
+      getMultipleAccountsInfo: async () => {
+        throw RPC_ERROR;
+      },
+      getParsedTokenAccountsByOwner: async () => {
+        throw RPC_ERROR;
+      },
+    });
+    await expect(svc.updateWalletData(true)).rejects.toMatchObject({
+      code: "SOLANA_RPC_UNAVAILABLE",
+    });
+    expect(cache.has(SOLANA_WALLET_DATA_CACHE_KEY)).toBe(false);
+  });
+
+  it("still caches a genuinely empty portfolio when the RPC reports no accounts", async () => {
+    const { svc, cache } = serviceWithConnection({
+      getMultipleAccountsInfo: async () => [],
+      getParsedTokenAccountsByOwner: async () => ({ value: [] }),
+    });
+    await expect(svc.updateWalletData(true)).resolves.toMatchObject({
+      totalUsd: "0",
+      items: [],
+    });
+    expect(cache.get(SOLANA_WALLET_DATA_CACHE_KEY)).toMatchObject({
+      totalUsd: "0",
+      items: [],
+    });
+  });
+
+  it("answers the balance and token routes with 500, not 200/0 or 404, while the RPC is down", async () => {
+    const { svc } = serviceWithConnection({
+      getMultipleAccountsInfo: async () => {
+        throw RPC_ERROR;
+      },
+      getParsedTokenAccountsByOwner: async () => {
+        throw RPC_ERROR;
+      },
+    });
+    const runtime = {
+      getService: () => svc,
+      logger: { warn: vi.fn(), error: vi.fn() },
+      getCache: async () => undefined,
+      setCache: async () => undefined,
+    } as never;
+
+    const balance = mkRes();
+    await routeByPath["/wallet/balance"]({ params: {} } as never, balance as never, runtime);
+    expect(balance.statusCode).toBe(500);
+    expect(balance.payload).toMatchObject({
+      success: false,
+      error: { code: "ERROR" },
+    });
+
+    const token = mkRes();
+    await routeByPath["/wallet/balance/:token"](
+      { params: { token: USDC_MINT } } as never,
+      token as never,
+      runtime
+    );
+    expect(token.statusCode).toBe(500);
+    expect(token.payload).not.toMatchObject({
+      error: { code: "TOKEN_NOT_FOUND" },
+    });
+  });
+});

--- a/plugins/plugin-wallet/src/chains/solana/service.ts
+++ b/plugins/plugin-wallet/src/chains/solana/service.ts
@@ -2102,8 +2102,15 @@ export class SolanaService extends Service {
       });
       return haveAllTokens;
     } catch (error) {
-      logger.error(`Error fetching token accounts: ${error}`);
-      return [];
+      // error-policy:J2 context-adding rethrow. Returning [] here was cached by
+      // updateWalletData as an empty portfolio and told the planner "no tokens
+      // found" while the RPC was merely down (#31110).
+      throw new ElizaError("Solana token account read failed", {
+        code: "SOLANA_RPC_UNAVAILABLE",
+        cause: error,
+        context: { walletAddress: walletAddress.toString() },
+        severity: "ephemeral",
+      });
     }
   }
 
@@ -2125,32 +2132,65 @@ export class SolanaService extends Service {
     return out;
   }
 
-  public async getBalancesByAddrs(walletAddressArr: string[]): Promise<Record<string, number>> {
-    try {
-      const publicKeyObjs = walletAddressArr.map((k) => new PublicKey(k));
-      const accounts = await this.batchGetMultipleAccountsInfo(publicKeyObjs, "getBalancesByAddrs");
+  /** Attempts made for one balance read while the RPC answers 429; the last failure is thrown. */
+  static readonly BALANCE_READ_MAX_ATTEMPTS = 3;
+  static readonly BALANCE_READ_RETRY_DELAY_MS = 1000;
 
-      const out: Record<string, number> = {};
-      for (let i = 0; i < accounts.length; i++) {
-        const a = accounts[i];
-        const pk = walletAddressArr[i];
-        if (pk === undefined) continue;
-        if (a?.lamports) {
-          out[pk] = a.lamports * SolanaService.LAMPORTS2SOL;
-        } else {
-          out[pk] = 0;
+  /**
+   * SOL balance per address. A missing address is a genuine zero (the account
+   * does not exist on chain); an RPC failure throws `ElizaError` with code
+   * `SOLANA_RPC_RATE_LIMITED` or `SOLANA_RPC_UNAVAILABLE` so callers do not
+   * serve a fabricated 0 (#31110). A 429 is retried a bounded number of times.
+   */
+  public async getBalancesByAddrs(walletAddressArr: string[]): Promise<Record<string, number>> {
+    const publicKeyObjs = walletAddressArr.map((k) => new PublicKey(k));
+    const accounts = await this.readAccountsWithRateLimitRetry(publicKeyObjs);
+
+    const out: Record<string, number> = {};
+    for (let i = 0; i < accounts.length; i++) {
+      const a = accounts[i];
+      const pk = walletAddressArr[i];
+      if (pk === undefined) continue;
+      if (a?.lamports) {
+        out[pk] = a.lamports * SolanaService.LAMPORTS2SOL;
+      } else {
+        out[pk] = 0;
+      }
+    }
+    return out;
+  }
+
+  private async readAccountsWithRateLimitRetry(
+    publicKeyObjs: PublicKey[]
+  ): Promise<Awaited<ReturnType<SolanaService["batchGetMultipleAccountsInfo"]>>> {
+    for (let attempt = 1; ; attempt += 1) {
+      try {
+        return await this.batchGetMultipleAccountsInfo(publicKeyObjs, "getBalancesByAddrs");
+      } catch (error) {
+        // error-policy:J2 context-adding rethrow after a bounded 429 retry.
+        const msg = error instanceof Error ? error.message : String(error);
+        const rateLimited = msg.includes("429");
+        if (rateLimited && attempt < SolanaService.BALANCE_READ_MAX_ATTEMPTS) {
+          this.runtime.logger.warn(
+            `SolanaService: RPC rate limit hit, retrying balance read (${attempt}/${SolanaService.BALANCE_READ_MAX_ATTEMPTS})`
+          );
+          await new Promise((waitResolve) =>
+            setTimeout(waitResolve, SolanaService.BALANCE_READ_RETRY_DELAY_MS * attempt)
+          );
+          continue;
         }
+        throw new ElizaError(
+          rateLimited
+            ? `Solana RPC rate limit persisted across ${attempt} balance read attempts`
+            : "Solana balance read failed",
+          {
+            code: rateLimited ? "SOLANA_RPC_RATE_LIMITED" : "SOLANA_RPC_UNAVAILABLE",
+            cause: error,
+            context: { addresses: publicKeyObjs.length, attempt },
+            severity: "ephemeral",
+          }
+        );
       }
-      return out;
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes("429")) {
-        this.runtime.logger.warn("RPC rate limit hit, pausing before retry");
-        await new Promise((waitResolve) => setTimeout(waitResolve, 1000));
-        return this.getBalancesByAddrs(walletAddressArr);
-      }
-      this.runtime.logger.error(`solSrv:getBalancesByAddrs - unexpected error: ${error}`);
-      return {};
     }
   }
 


### PR DESCRIPTION
## Summary

Two catch blocks in `plugins/plugin-wallet/src/chains/solana/service.ts` turned an RPC failure into a healthy-looking zero that three consumers persisted or served as fact.

- `getTokenAccountsByKeypair` now throws `ElizaError("SOLANA_RPC_UNAVAILABLE")` with the RPC error as `cause` instead of returning `[]`. `updateWalletData` therefore rejects during an outage and never writes the `{ totalUsd: "0", items: [] }` portfolio to `SOLANA_WALLET_DATA_CACHE_KEY`; the wallet provider, which reads only the cache, keeps returning its existing "not ready" empty result rather than `Total Value: $0.00 / No tokens found`. A wallet the RPC reports as genuinely empty is still cached as an empty portfolio.
- `getBalancesByAddrs` no longer returns `{}` from a catch. The 429 branch, which recursed with no bound, is replaced by `readAccountsWithRateLimitRetry`: up to three attempts with linear backoff, then `ElizaError("SOLANA_RPC_RATE_LIMITED")`; any other failure is `ElizaError("SOLANA_RPC_UNAVAILABLE")`.
- `GET /wallet/balance` drops `balances[publicKeyStr] ?? 0`; a missing entry is treated as a contract violation and the handler's existing catch returns the 500 it was written for. `GET /wallet/balance/:token` now reaches its catch (500) instead of answering `404 TOKEN_NOT_FOUND` for a held token.

Closes #31110

## Evidence

Before (develop `cbf357b0bd8a`, real service and routes, RPC stub answering 500):

```
getBalancesByAddrs  -> {}
getTokenAccountsByKeypair -> []
GET /wallet/balance -> HTTP 200 {"success":true,"data":{...,"balance":0,"symbol":"SOL"}}
GET /wallet/balance/:token (USDC) -> HTTP 404 {"success":false,"error":{"code":"TOKEN_NOT_FOUND",...}}
updateWalletData() -> {"totalUsd":"0","totalSol":"0","items":[]}
cached under SOLANA_WALLET_DATA_CACHE_KEY: [["solana/walletData",{"totalUsd":"0","totalSol":"0","items":[]}]]
provider text: Total Value: $0.00 (0 SOL) / No tokens found with non-zero balance
```

After: `service.rpc-errors.test.ts` uses the real `SolanaService` prototype and the real route handlers with only the connection stubbed, and pins the typed rejections, the bounded 429 retry (exactly `BALANCE_READ_MAX_ATTEMPTS` calls, then `SOLANA_RPC_RATE_LIMITED`), recovery when the limit clears within the budget, no cache write during an outage, the genuine-empty cache write, and both routes answering 500.

- `bunx vitest run src/chains/solana/service.rpc-errors.test.ts`: 7/7.
- `bun run test` in `plugins/plugin-wallet`: 425 passed, 1 skipped (71 files).
- `bun run typecheck` and `bun run lint:check` in `plugins/plugin-wallet`: clean.
- Root `bun run verify`: running on a stack branch holding today's fix PRs; result will be posted as a comment.

The EVM sibling is #31126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8gwNCWN4PDyeXY6fHhhgy
