### PR TITLE
fix(cloud): write the AI billing ledger row even when usage analytics fails (#31112)

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -574,6 +574,39 @@ describe("passthrough streaming — qualifying request pipes bytes verbatim and 
     expect(aiBillingRecord).toHaveBeenCalledTimes(1);
   });
 
+  test("writes the billing ledger row even when usage analytics fails (#31112)", async () => {
+    const ledger = makeLedgerReservation(100, 0.9);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    fetchImpl = async () => sseResponse(UPSTREAM_SSE);
+    // The shared mock is declared without parameters; widen it here so the
+    // failure can be handed back through the onError option.
+    (
+      recordUsageAnalytics as unknown as {
+        mockImplementationOnce: (
+          fn: (...args: unknown[]) => Promise<null>,
+        ) => void;
+      }
+    ).mockImplementationOnce(async (...args) => {
+      const options = args[2] as { onError?: (e: unknown) => void };
+      options.onError?.(new Error("usage_records insert failed"));
+      return null;
+    });
+
+    const res = await callStreaming(settle, { effectiveMaxTokens: 4096 });
+    await res.text();
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(aiBillingRecord).toHaveBeenCalledTimes(1);
+    const [recordInput] = (
+      aiBillingRecord.mock.calls as unknown as Array<[Record<string, unknown>]>
+    )[0];
+    expect(recordInput).toMatchObject({
+      usageRecord: null,
+      usageRecordError: "usage_records insert failed",
+    });
+  });
+
   test("usage-bearing passthrough keeps the admitted estimate when local billing fails", async () => {
     const ledger = makeLedgerReservation(100, 0.9);
     const settle = createCreditReservationSettler(ledger.reservation);

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -77,12 +77,13 @@ import {
 import {
   type AIUsage,
   type BillingContext,
+  type BillingResult,
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
-  recordUsageAnalytics,
+  type recordUsageAnalytics,
 } from "@/lib/services/ai-billing";
-import { aiBillingRecordsService } from "@/lib/services/ai-billing-records";
+import { recordSettledInferenceBilling } from "@/lib/services/ai-billing-settled";
 import {
   AiPricingCacheUnavailableError,
   AiPricingCacheWarmingError,
@@ -143,6 +144,44 @@ import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import { settleOffResponsePath } from "@/lib/utils/settle-off-response-path";
+
+/**
+ * Write the durable billing ledger row for one settled inference. Credits are
+ * settled before this runs, so the row must exist even when the usage
+ * analytics insert fails (#31112); `recordSettledInferenceBilling` carries that
+ * failure into the row as an explicit marker. A ledger write failure is logged
+ * as before: the response is already delivered and settlement is not rolled
+ * back.
+ */
+async function recordChatBillingLedgerRow(args: {
+  billingContext: BillingContext;
+  billing: BillingResult;
+  reconciliation: CreditReconciliationResult | null;
+  idempotencyKey: string;
+  analytics: Parameters<typeof recordUsageAnalytics>[2];
+}): Promise<void> {
+  try {
+    await recordSettledInferenceBilling({
+      context: args.billingContext,
+      billing: args.billing,
+      reconciliation: args.reconciliation,
+      idempotencyKey: args.idempotencyKey,
+      analytics: args.analytics,
+    });
+  } catch (auditError) {
+    // error-policy:J7 diagnostics must not kill the loop: the failed ledger
+    // write is logged with the idempotency key so it can be replayed.
+    logger.error("[Chat Completions] audit record failed (non-fatal)", {
+      idempotencyKey: args.idempotencyKey,
+      error:
+        auditError instanceof Error ? auditError.message : String(auditError),
+      cause:
+        auditError instanceof Error && auditError.cause
+          ? String((auditError.cause as Error).message ?? auditError.cause)
+          : undefined,
+    });
+  }
+}
 
 const ROUTE_MAX_DURATION = 800;
 
@@ -2441,37 +2480,21 @@ async function settleStreamingAbortReservation(params: {
       params.billingReservation,
     );
     const reconciliation = await params.settleReservation(billing.totalCost);
-    const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-      type: "chat",
-      isSuccessful: false,
-      errorMessage: "client_aborted_stream",
-      content: params.deliveredText,
-      systemPrompt: params.systemPrompt,
-      prompt: params.prompt,
-      latencyMs: Date.now() - params.startTime,
+    await recordChatBillingLedgerRow({
+      billingContext,
+      billing,
+      reconciliation,
+      idempotencyKey: params.idempotencyKey,
+      analytics: {
+        type: "chat",
+        isSuccessful: false,
+        errorMessage: "client_aborted_stream",
+        content: params.deliveredText,
+        systemPrompt: params.systemPrompt,
+        prompt: params.prompt,
+        latencyMs: Date.now() - params.startTime,
+      },
     });
-    if (usageRecord) {
-      try {
-        await aiBillingRecordsService.record({
-          context: billingContext,
-          billing,
-          usageRecord,
-          idempotencyKey: params.idempotencyKey,
-          reconciliation,
-        });
-      } catch (auditError) {
-        logger.error("[Chat Completions] audit record failed (non-fatal)", {
-          error:
-            auditError instanceof Error
-              ? auditError.message
-              : String(auditError),
-          cause:
-            auditError instanceof Error && auditError.cause
-              ? String((auditError.cause as Error).message ?? auditError.cause)
-              : undefined,
-        });
-      }
-    }
 
     logger.info(
       "[Chat Completions] Stream aborted; reservation partially settled",
@@ -2873,35 +2896,19 @@ async function tryPassthroughStreamingRequest(params: {
           params.billingReservation,
         );
         const reconciliation = await settleReservation(billing.totalCost);
-        const usageRecord = await recordUsageAnalytics(
+        await recordChatBillingLedgerRow({
           billingContext,
           billing,
-          {
+          reconciliation,
+          idempotencyKey: params.idempotencyKey,
+          analytics: {
             type: "chat",
             content: tail.deliveredText,
             systemPrompt: params.systemPrompt,
             prompt: billingPrompt,
             latencyMs: Date.now() - params.startTime,
           },
-        );
-        if (usageRecord) {
-          try {
-            await aiBillingRecordsService.record({
-              context: billingContext,
-              billing,
-              usageRecord,
-              idempotencyKey: params.idempotencyKey,
-              reconciliation,
-            });
-          } catch (auditError) {
-            logger.error("[Chat Completions] audit record failed (non-fatal)", {
-              error:
-                auditError instanceof Error
-                  ? auditError.message
-                  : String(auditError),
-            });
-          }
-        }
+        });
         logger.info("[Chat Completions] Passthrough streaming complete", {
           model,
           durationMs: Date.now() - params.startTime,
@@ -3277,45 +3284,19 @@ async function handleStreamingRequest(
             executionCtx,
           );
 
-          const usageRecord = await recordUsageAnalytics(
+          await recordChatBillingLedgerRow({
             billingContext,
             billing,
-            {
+            reconciliation,
+            idempotencyKey: idempotencyKey,
+            analytics: {
               type: "chat",
               content: text,
               systemPrompt,
               prompt: billingPrompt,
               latencyMs: Date.now() - startTime,
             },
-          );
-          if (usageRecord) {
-            try {
-              await aiBillingRecordsService.record({
-                context: billingContext,
-                billing,
-                usageRecord,
-                idempotencyKey,
-                reconciliation,
-              });
-            } catch (auditError) {
-              logger.error(
-                "[Chat Completions] audit record failed (non-fatal)",
-                {
-                  error:
-                    auditError instanceof Error
-                      ? auditError.message
-                      : String(auditError),
-                  cause:
-                    auditError instanceof Error && auditError.cause
-                      ? String(
-                          (auditError.cause as Error).message ??
-                            auditError.cause,
-                        )
-                      : undefined,
-                },
-              );
-            }
-          }
+          });
 
           logger.info("[Chat Completions] Streaming complete", {
             durationMs: Date.now() - startTime,
@@ -3849,41 +3830,19 @@ async function handleNonStreamingRequest(
           executionCtx,
         );
 
-        const usageRecord = await recordUsageAnalytics(
+        await recordChatBillingLedgerRow({
           billingContext,
           billing,
-          {
+          reconciliation,
+          idempotencyKey: idempotencyKey,
+          analytics: {
             type: "chat",
             content: result.text,
             systemPrompt,
             prompt: billingPrompt,
             latencyMs: responseLatencyMs,
           },
-        );
-        if (usageRecord) {
-          try {
-            await aiBillingRecordsService.record({
-              context: billingContext,
-              billing,
-              usageRecord,
-              idempotencyKey,
-              reconciliation,
-            });
-          } catch (auditError) {
-            logger.error("[Chat Completions] audit record failed (non-fatal)", {
-              error:
-                auditError instanceof Error
-                  ? auditError.message
-                  : String(auditError),
-              cause:
-                auditError instanceof Error && auditError.cause
-                  ? String(
-                      (auditError.cause as Error).message ?? auditError.cause,
-                    )
-                  : undefined,
-            });
-          }
-        }
+        });
 
         logger.info("[Chat Completions] Non-streaming complete", {
           durationMs: Date.now() - startTime,

--- a/packages/cloud/shared/src/db/migrations/0386_ai_billing_records_nullable_usage_record.sql
+++ b/packages/cloud/shared/src/db/migrations/0386_ai_billing_records_nullable_usage_record.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ai_billing_records" ALTER COLUMN "usage_record_id" DROP NOT NULL;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -2584,6 +2584,13 @@
       "when": 1796083200012,
       "tag": "0385_subscription_reconciliation",
       "breakpoints": true
+    },
+    {
+      "idx": 369,
+      "version": "7",
+      "when": 1796083200013,
+      "tag": "0386_ai_billing_records_nullable_usage_record",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/ai-billing-records.ts
+++ b/packages/cloud/shared/src/db/schemas/ai-billing-records.ts
@@ -31,9 +31,12 @@ export const aiBillingRecords = pgTable(
       .notNull()
       .references(() => organizations.id, { onDelete: "cascade" }),
     user_id: uuid("user_id").references(() => users.id, { onDelete: "set null" }),
-    usage_record_id: uuid("usage_record_id")
-      .notNull()
-      .references(() => usageRecords.id, { onDelete: "cascade" }),
+    // Null when the usage-analytics insert failed after credits were already
+    // settled: the ledger row must still exist so the charge is visible and
+    // reconcilable (#31112). `metadata.usageRecordStatus` says why it is null.
+    usage_record_id: uuid("usage_record_id").references(() => usageRecords.id, {
+      onDelete: "cascade",
+    }),
     reservation_transaction_id: uuid("reservation_transaction_id").references(
       () => creditTransactions.id,
       { onDelete: "set null" },

--- a/packages/cloud/shared/src/lib/services/__tests__/ai-billing-records-usage-unavailable.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ai-billing-records-usage-unavailable.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Real-DB contract for the AI billing ledger row when the usage-analytics
+ * insert failed after credits were settled (#31112): the row is still written,
+ * with a null usage link and an explicit unavailable marker, and the normal
+ * linked row is unchanged. Pushes the real Drizzle schema into in-process
+ * PGlite and drives the real repository; nothing on the write path is mocked.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const ORG_ID = "00000000-0000-0000-0000-00000000b112";
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let service: typeof import("../ai-billing-records").aiBillingRecordsService;
+let recordSettledInferenceBilling: typeof import("../ai-billing-settled").recordSettledInferenceBilling;
+
+const billing = {
+  inputTokens: 10,
+  outputTokens: 5,
+  totalTokens: 15,
+  inputCost: 0.001,
+  outputCost: 0.002,
+  totalCost: 0.003,
+  baseInputCost: 0.0005,
+  baseOutputCost: 0.001,
+  baseTotalCost: 0.0015,
+  platformMarkup: 2,
+} as unknown as import("../ai-billing").BillingResult;
+
+function context(requestId: string): import("../ai-billing").BillingContext {
+  return {
+    organizationId: ORG_ID,
+    // No users row is seeded; the ledger keeps user_id nullable (set null on delete).
+    userId: null,
+    apiKeyId: null,
+    model: "gpt-oss-120b",
+    provider: "cerebras",
+    requestId,
+  } as unknown as import("../ai-billing").BillingContext;
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+  const { pushSchemaToTestDb } = await import("../../../db/push-schema-for-tests");
+  // Push the ledger table with its foreign-key closure
+  // (usage_records -> api_keys, and every table -> organizations/users).
+  const { aiBillingRecords } = await import("../../../db/schemas/ai-billing-records");
+  const { organizations } = await import("../../../db/schemas/organizations");
+  const { users } = await import("../../../db/schemas/users");
+  const { apiKeys } = await import("../../../db/schemas/api-keys");
+  const { usageRecords } = await import("../../../db/schemas/usage-records");
+  const { creditTransactions } = await import("../../../db/schemas/credit-transactions");
+  await pushSchemaToTestDb({
+    organizations,
+    users,
+    apiKeys,
+    usageRecords,
+    creditTransactions,
+    aiBillingRecords,
+  });
+  await dbWrite.execute(
+    `INSERT INTO organizations (id, name, slug) VALUES ('${ORG_ID}', 'Acme', 'acme-${ORG_ID}');`,
+  );
+  ({ aiBillingRecordsService: service } = await import("../ai-billing-records"));
+  ({ recordSettledInferenceBilling } = await import("../ai-billing-settled"));
+});
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("aiBillingRecordsService.record without a usage record", () => {
+  test("writes the ledger row with a null usage link and an unavailable marker", async () => {
+    const row = await service.record({
+      context: context("req-no-usage"),
+      billing,
+      usageRecord: null,
+      usageRecordError: "usage_records insert failed: connection reset",
+      idempotencyKey: "idem-no-usage",
+      reconciliation: null,
+    });
+    expect(row.usage_record_id).toBeNull();
+    expect(row.provider).toBe("cerebras");
+    expect(row.status).toBe("recorded");
+    expect(row.usage_total_cost).toBe("0.003000");
+    expect(row.metadata).toMatchObject({
+      usageRecordStatus: "unavailable",
+      usageRecordError: "usage_records insert failed: connection reset",
+    });
+
+    const stored = await dbWrite.execute(
+      `SELECT usage_record_id, idempotency_key FROM ai_billing_records WHERE organization_id = '${ORG_ID}';`,
+    );
+    expect(stored.rows).toEqual([{ usage_record_id: null, idempotency_key: "idem-no-usage" }]);
+  });
+
+  test("still dedupes on the organization idempotency key when the usage link is null", async () => {
+    const again = await service.record({
+      context: context("req-no-usage"),
+      billing,
+      usageRecord: null,
+      idempotencyKey: "idem-no-usage",
+      reconciliation: null,
+    });
+    const rows = await dbWrite.execute(
+      `SELECT count(*)::int AS n FROM ai_billing_records WHERE organization_id = '${ORG_ID}';`,
+    );
+    expect((rows.rows[0] as { n: number }).n).toBe(1);
+    expect(again.metadata).toMatchObject({ usageRecordStatus: "unavailable" });
+  });
+
+  test("a linked row keeps the usage id and reports recorded", async () => {
+    await dbWrite.execute(
+      `INSERT INTO usage_records (id, organization_id, type, model, provider, input_tokens, output_tokens, input_cost, output_cost)
+       VALUES ('00000000-0000-0000-0000-00000000b114', '${ORG_ID}', 'chat', 'gpt-oss-120b', 'cerebras', 10, 5, '0.001', '0.002');`,
+    );
+    const row = await service.record({
+      context: context("req-with-usage"),
+      billing,
+      usageRecord: {
+        id: "00000000-0000-0000-0000-00000000b114",
+        provider: "cerebras",
+      } as unknown as import("../../../db/repositories").UsageRecord,
+      idempotencyKey: "idem-with-usage",
+      reconciliation: null,
+    });
+    expect(row.usage_record_id).toBe("00000000-0000-0000-0000-00000000b114");
+    expect(row.metadata).toMatchObject({ usageRecordStatus: "recorded" });
+    expect(row.metadata).not.toHaveProperty("usageRecordError");
+  });
+
+  test("recordSettledInferenceBilling writes the ledger row when the real usage insert fails", async () => {
+    // usage_records.api_key_id references api_keys; an unknown key makes the
+    // real analytics insert fail while the ledger row (no api_key column)
+    // can still be written.
+    const outcome = await recordSettledInferenceBilling({
+      context: {
+        ...context("req-analytics-down"),
+        apiKeyId: "00000000-0000-0000-0000-00000000dead",
+      } as unknown as import("../ai-billing").BillingContext,
+      billing,
+      reconciliation: null,
+      idempotencyKey: "idem-analytics-down",
+      analytics: { type: "chat", content: "hi", prompt: "hello" },
+    });
+    expect(outcome.usageRecord).toBeNull();
+    expect(outcome.record.usage_record_id).toBeNull();
+    expect(outcome.record.metadata).toMatchObject({ usageRecordStatus: "unavailable" });
+    expect(String((outcome.record.metadata as Record<string, unknown>).usageRecordError)).toMatch(
+      /api_key|foreign key|violates/i,
+    );
+
+    const usageRows = await dbWrite.execute(
+      `SELECT count(*)::int AS n FROM usage_records WHERE request_id = 'req-analytics-down';`,
+    );
+    expect((usageRows.rows[0] as { n: number }).n).toBe(0);
+  });
+
+  test("recordSettledInferenceBilling links the usage row when analytics succeeds", async () => {
+    const outcome = await recordSettledInferenceBilling({
+      context: context("req-analytics-ok"),
+      billing,
+      reconciliation: null,
+      idempotencyKey: "idem-analytics-ok",
+      analytics: { type: "chat", content: "hi", prompt: "hello" },
+    });
+    expect(outcome.usageRecord?.id).toBeTruthy();
+    expect(outcome.record.usage_record_id).toBe(outcome.usageRecord?.id ?? "");
+    expect(outcome.record.metadata).toMatchObject({ usageRecordStatus: "recorded" });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/ai-billing-records.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing-records.ts
@@ -5,13 +5,21 @@ import {
   aiBillingRecordsRepository,
   type NewAiBillingRecord,
 } from "../../db/repositories/ai-billing-records";
+import { getProviderFromModel } from "../pricing";
 import type { BillingContext, BillingResult } from "./ai-billing";
 import type { CreditReconciliationResult } from "./credits";
 
 export interface RecordAiBillingInput {
   context: BillingContext;
   billing: BillingResult;
-  usageRecord: UsageRecord;
+  /**
+   * The usage-analytics row, or `null` when its insert failed. Credits are
+   * settled before analytics runs, so a null here must still produce a ledger
+   * row; otherwise the charge is invisible and unreconcilable (#31112).
+   */
+  usageRecord: UsageRecord | null;
+  /** Why `usageRecord` is null; stored in the row's metadata. */
+  usageRecordError?: string;
   idempotencyKey: string;
   reconciliation: CreditReconciliationResult | null;
 }
@@ -26,9 +34,14 @@ function totalLedgerAmount(
 
 export class AiBillingRecordsService {
   async record(input: RecordAiBillingInput): Promise<AiBillingRecord> {
-    const { context, billing, usageRecord, idempotencyKey, reconciliation } = input;
+    const { context, billing, usageRecord, usageRecordError, idempotencyKey, reconciliation } =
+      input;
     const metadata = {
       ...(context.metadata ?? {}),
+      usageRecordStatus: usageRecord ? "recorded" : "unavailable",
+      ...(usageRecord
+        ? {}
+        : { usageRecordError: usageRecordError ?? "usage analytics insert failed" }),
       baseInputCost: billing.baseInputCost,
       baseOutputCost: billing.baseOutputCost,
       baseTotalCost: billing.baseTotalCost,
@@ -45,12 +58,12 @@ export class AiBillingRecordsService {
     const record: NewAiBillingRecord = {
       organization_id: context.organizationId,
       user_id: context.userId,
-      usage_record_id: usageRecord.id,
+      usage_record_id: usageRecord?.id ?? null,
       reservation_transaction_id: reconciliation?.reservationTransactionId ?? null,
       settlement_transaction_ids: reconciliation?.settlementTransactionIds ?? [],
       idempotency_key: idempotencyKey,
       request_id: context.requestId ?? null,
-      provider: context.provider ?? usageRecord.provider,
+      provider: context.provider ?? usageRecord?.provider ?? getProviderFromModel(context.model),
       model: context.model,
       billing_source: context.billingSource ?? null,
       pricing_snapshot_ids: context.pricingSnapshotId ? [context.pricingSnapshotId] : [],

--- a/packages/cloud/shared/src/lib/services/ai-billing-settled.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing-settled.ts
@@ -1,0 +1,48 @@
+/**
+ * Post-settlement bookkeeping for one billed inference: the usage-analytics
+ * row and the durable AI billing ledger row, in that order, for every caller
+ * that has already settled credits. The ledger row is written even when the
+ * analytics insert fails; otherwise the charge is invisible on the usage page
+ * and unreconcilable in a dispute (#31112). A ledger write failure propagates
+ * so each boundary keeps its own handling (log-and-continue after a delivered
+ * reply, or the billing-failure path before one).
+ */
+import type { UsageRecord } from "../../db/repositories";
+import type { AiBillingRecord } from "../../db/repositories/ai-billing-records";
+import { type BillingContext, type BillingResult, recordUsageAnalytics } from "./ai-billing";
+import { aiBillingRecordsService } from "./ai-billing-records";
+import type { CreditReconciliationResult } from "./credits";
+
+export interface RecordSettledInferenceBillingInput {
+  context: BillingContext;
+  billing: BillingResult;
+  reconciliation: CreditReconciliationResult | null;
+  idempotencyKey: string;
+  analytics: Parameters<typeof recordUsageAnalytics>[2];
+}
+
+export interface SettledInferenceBillingOutcome {
+  usageRecord: UsageRecord | null;
+  record: AiBillingRecord;
+}
+
+export async function recordSettledInferenceBilling(
+  input: RecordSettledInferenceBillingInput,
+): Promise<SettledInferenceBillingOutcome> {
+  let usageRecordError: string | undefined;
+  const usageRecord = await recordUsageAnalytics(input.context, input.billing, {
+    ...input.analytics,
+    onError: (error) => {
+      usageRecordError = error instanceof Error ? error.message : String(error);
+    },
+  });
+  const record = await aiBillingRecordsService.record({
+    context: input.context,
+    billing: input.billing,
+    usageRecord,
+    usageRecordError,
+    idempotencyKey: input.idempotencyKey,
+    reconciliation: input.reconciliation,
+  });
+  return { usageRecord, record };
+}

--- a/packages/cloud/shared/src/lib/services/ai-billing.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing.ts
@@ -716,6 +716,12 @@ export async function recordUsageAnalytics(
     purpose?: string;
     /** Latency in ms for trajectory logging */
     latencyMs?: number;
+    /**
+     * Receives the failure when the usage row cannot be written. Billing
+     * callers use it to record the ledger row with an explicit
+     * "usage record unavailable" marker instead of skipping it (#31112).
+     */
+    onError?: (error: unknown) => void;
   } = {},
 ): Promise<UsageRecord | null> {
   const { type = "chat", isSuccessful = true, errorMessage, content, prompt } = options;
@@ -809,9 +815,13 @@ export async function recordUsageAnalytics(
     }
     return usageRecord;
   } catch (error) {
+    // error-policy:J4 user-facing degrade: analytics is best-effort for the
+    // request, but the failure is handed to the caller so the billing ledger
+    // can still be written with an explicit unavailable marker.
     logger.error("[AI Billing] Failed to record usage analytics", {
       error: error instanceof Error ? error.message : String(error),
     });
+    options.onError?.(error);
     return null;
   }
 }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox/bridge/active.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox/bridge/active.ts
@@ -18,10 +18,9 @@ import {
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
-  recordUsageAnalytics,
   reserveCredits,
 } from "../../ai-billing";
-import { aiBillingRecordsService } from "../../ai-billing-records";
+import { recordSettledInferenceBilling } from "../../ai-billing-settled";
 import { chatSseFrame, normalizeChatSseDonePayload } from "../../chat-sse-frames";
 import type { CreditReconciliationResult, CreditReservation } from "../../credits";
 import {
@@ -370,27 +369,21 @@ export class ActiveSandboxBridge {
                   : undefined,
               );
               const settlement = await settleReservation(billing.totalCost);
-              const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-                type: "chat",
-                content: turn.reply,
-                prompt: text,
+              await recordSettledInferenceBilling({
+                context: billingContext,
+                billing,
+                reconciliation: settlement,
+                idempotencyKey,
+                analytics: { type: "chat", content: turn.reply, prompt: text },
+              }).catch((error) => {
+                // error-policy:J7 the reply is already delivered; the failed ledger
+                // write is logged with the idempotency key so it can be replayed.
+                logger.error("[shared-runtime] AI billing audit record failed", {
+                  error: error instanceof Error ? error.message : String(error),
+                  agentId: rec.id,
+                  idempotencyKey,
+                });
               });
-              if (usageRecord) {
-                await aiBillingRecordsService
-                  .record({
-                    context: billingContext,
-                    billing,
-                    usageRecord,
-                    idempotencyKey,
-                    reconciliation: settlement,
-                  })
-                  .catch((error) => {
-                    logger.error("[shared-runtime] AI billing audit record failed", {
-                      error: error instanceof Error ? error.message : String(error),
-                      agentId: rec.id,
-                    });
-                  });
-              }
             } catch (error) {
               // error-policy:J1 deferred-settlement boundary — the response may
               // already be gone, so the refund is the handling: settle(0) is
@@ -598,27 +591,21 @@ export class ActiveSandboxBridge {
                         : undefined,
                     );
                     const settlement = await settleReservation(billing.totalCost);
-                    const usageRecord = await recordUsageAnalytics(billingContext, billing, {
-                      type: "chat",
-                      content: finalReply,
-                      prompt: text,
+                    await recordSettledInferenceBilling({
+                      context: billingContext,
+                      billing,
+                      reconciliation: settlement,
+                      idempotencyKey,
+                      analytics: { type: "chat", content: finalReply, prompt: text },
+                    }).catch((error) => {
+                      // error-policy:J7 the reply is already delivered; the failed ledger
+                      // write is logged with the idempotency key so it can be replayed.
+                      logger.error("[shared-runtime] AI billing audit record failed", {
+                        error: error instanceof Error ? error.message : String(error),
+                        agentId: rec.id,
+                        idempotencyKey,
+                      });
                     });
-                    if (usageRecord) {
-                      await aiBillingRecordsService
-                        .record({
-                          context: billingContext,
-                          billing,
-                          usageRecord,
-                          idempotencyKey,
-                          reconciliation: settlement,
-                        })
-                        .catch((error) => {
-                          logger.error("[shared-runtime] AI billing audit record failed", {
-                            error: error instanceof Error ? error.message : String(error),
-                            agentId: rec.id,
-                          });
-                        });
-                    }
                   } catch (error) {
                     // error-policy:J1 deferred-settlement boundary — the `done`
                     // frame may already be flushed, so the refund is the

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -40,9 +40,8 @@ import {
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
-  recordUsageAnalytics,
 } from "../ai-billing";
-import { aiBillingRecordsService } from "../ai-billing-records";
+import { recordSettledInferenceBilling } from "../ai-billing-settled";
 import { getSupportedVideoModelDefinition } from "../ai-pricing-definitions";
 import { chatSseFrame } from "../chat-sse-frames";
 import { contentSafetyService } from "../content-safety";
@@ -1137,20 +1136,13 @@ async function finishBilling(
       billing.reservation,
     );
     const reconciliation = await billing.settle(result.totalCost);
-    const record = await recordUsageAnalytics(billing.context, result, {
-      type: "chat",
-      content: reply,
-      prompt,
+    await recordSettledInferenceBilling({
+      context: billing.context,
+      billing: result,
+      reconciliation,
+      idempotencyKey: billing.idempotencyKey,
+      analytics: { type: "chat", content: reply, prompt },
     });
-    if (record) {
-      await aiBillingRecordsService.record({
-        context: billing.context,
-        billing: result,
-        usageRecord: record,
-        idempotencyKey: billing.idempotencyKey,
-        reconciliation,
-      });
-    }
   } catch (error) {
     // error-policy:J1 the reply may already be delivered, so an unavailable
     // meter is not evidence of zero provider work. Preserve the admitted


### PR DESCRIPTION
## Summary

`packages/cloud/api/v1/chat/completions/route.ts` settled the credit reservation, then wrote the `ai_billing_records` row only when `recordUsageAnalytics` returned a record. `recordUsageAnalytics` returns `null` from its catch, so any failure of the `usage_records` insert left a debited charge with no ledger row. The same `if (usageRecord)` gate existed at four sites in the chat route, two in `eliza-sandbox/bridge/active.ts`, and one in `shared-runtime/shared-runtime-chat.ts`.

Changes:

- **Schema and migration.** `ai_billing_records.usage_record_id` becomes nullable (`0386_ai_billing_records_nullable_usage_record.sql`, journal entry added). The FK, the unique index on it, and the org/idempotency unique index are unchanged; a null usage link never collides.
- **`AiBillingRecordsService.record`** accepts `usageRecord: UsageRecord | null` plus `usageRecordError`, writes `usage_record_id: null` when absent, resolves `provider` from the context or the model, and stores `metadata.usageRecordStatus` (`recorded` | `unavailable`) with the failure reason.
- **`recordUsageAnalytics`** gains an `onError` option so the failure reaches the caller; its return type and every other caller are unchanged.
- **`recordSettledInferenceBilling`** (new, `ai-billing-settled.ts`) runs analytics then always writes the ledger row and returns both. All seven post-settlement sites use it. A failed ledger write still propagates to each site's existing handling (non-fatal log after a delivered reply in the chat route and sandbox bridge; the billing-failure path in shared-runtime chat).

Closes #31112

## Evidence

Real-DB (`ai-billing-records-usage-unavailable.test.ts`, PGlite with the Drizzle schema pushed, real repository and services):

- `record()` with a null usage record writes the row with `usage_record_id = NULL`, `provider` from context, `usage_total_cost = 0.003000`, and `metadata.usageRecordStatus = "unavailable"` plus the error; the stored row is read back by SQL.
- A second call with the same idempotency key dedupes to one row.
- A linked row keeps its usage id and reports `recorded`.
- `recordSettledInferenceBilling` with a context whose `apiKeyId` violates the `usage_records` foreign key: the real usage insert fails, zero usage rows exist, and the ledger row is still written with the FK error captured in metadata.
- The success path links the freshly inserted usage row.

Route-level (`chat-completions-passthrough-streaming.test.ts`, new case): with analytics stubbed to fail through `onError`, the reservation is reconciled once and `aiBillingRecordsService.record` is called once with `usageRecord: null` and the error message.

- `bun test src/lib/services/__tests__/ai-billing-records-usage-unavailable.test.ts`: 5/5.
- `bun test` on `eliza-sandbox-shared-stream-deferred-billing`, `eliza-sandbox-shared-turn-deferred-billing`, `inference-pending-charges-migration` (journal well-formed): all green.
- `bun test` in `packages/cloud/api` on `chat-completions-passthrough-streaming` (50/50), `chat-completions-streaming-credit-leak` (20/20), `shared-agent-turn-idempotency` (2/2).
- `bun run typecheck` and `bun run lint:check` in `packages/cloud/shared` and `packages/cloud/api`: clean.
- Root `bun run verify`: running on a stack branch holding today's fix PRs; result will be posted as a comment.

Not exercised: a live Postgres deployment of the migration (only PGlite via schema push). The migration is a single `DROP NOT NULL`.

# Evidence Gate

<!-- evidence-head:6611039cbd7b2eea747f48c2e70fcafae6c08a78 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the ledger write is asserted by the real-DB suite below.
<!-- evidence-row:backend-logs -->
- [x] Test transcripts from the runs described above:
  <details><summary>bun test output: PGlite real-DB suite and the cloud-api route suites at this head</summary>

  ```text
  $ bun test src/lib/services/__tests__/ai-billing-records-usage-unavailable.test.ts   (packages/cloud/shared, PGlite with the Drizzle schema pushed)
   record() with a null usage record writes usage_record_id = NULL, provider from context, usage_total_cost = 0.003000, metadata.usageRecordStatus = "unavailable" + error
   second call with the same idempotency key dedupes to one row
   linked row keeps its usage id and reports "recorded"
   recordSettledInferenceBilling with an apiKeyId violating the usage_records FK: usage insert fails, zero usage rows, ledger row written with the FK error in metadata
   success path links the freshly inserted usage row
   5 pass / 0 fail
  $ bun test (packages/cloud/api) chat-completions-passthrough-streaming 50 pass / 0 fail; chat-completions-streaming-credit-leak 20 pass / 0 fail; shared-agent-turn-idempotency 2 pass / 0 fail
  $ bun test (packages/cloud/shared) eliza-sandbox-shared-stream-deferred-billing, eliza-sandbox-shared-turn-deferred-billing, inference-pending-charges-migration: all pass
  typecheck + lint:check in packages/cloud/shared and packages/cloud/api: exit 0
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider or model change; no model calls are involved.
<!-- evidence-row:domain-artifacts -->
- [x] Database rows read back in the real-DB suite:
  <details><summary>ai_billing_records rows read back by SQL in ai-billing-records-usage-unavailable.test.ts (PGlite)</summary>

  ```text
  usage unavailable case:
    usage_record_id              = NULL
    provider                     = <from context>
    usage_total_cost             = 0.003000
    metadata.usageRecordStatus   = "unavailable"
    metadata.usageRecordError    = <usage_records insert failure message>
  same idempotency key again      => still one row
  linked case:
    usage_record_id              = <fresh usage_records id>
    metadata.usageRecordStatus   = "recorded"
  FK-violation case (bad apiKeyId): usage_records count = 0, ledger row present with the FK error in metadata
  ```
  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8gwNCWN4PDyeXY6fHhhgy
