### PR TITLE
feat(plugin-local-inference): wire the Apple Foundation Models fast path on iOS (#31118)

### DIFF
--- a/packages/app-core/platforms/ios/App/App/ComputerUseBridge.swift
+++ b/packages/app-core/platforms/ios/App/App/ComputerUseBridge.swift
@@ -25,6 +25,9 @@ import os
 import ReplayKit
 import UIKit
 import Vision
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
 
 // MARK: - Bridge plugin
 
@@ -475,31 +478,73 @@ public class ComputerUseBridge: CAPPlugin, CAPBridgedPlugin {
 
     // ── 6. Apple Foundation Models ───────────────────────────────────────────
 
+    // Generates one completion with the system language model. Compiled only
+    // when the SDK can import FoundationModels (Xcode 26+) and executed only
+    // on iOS 26+; every other build or device resolves
+    // `foundation_model_unavailable`. The framework reports no token
+    // accounting, so the result carries `text` and `elapsedMs` only (the TS
+    // contract leaves `tokensIn` / `tokensOut` optional).
     @objc public func foundationModelGenerate(_ call: CAPPluginCall) {
-        guard let prompt = call.getString("prompt") else {
+        guard let prompt = call.getString("prompt"), !prompt.isEmpty else {
             return resolveError(call, code: "internal_error", message: "prompt required")
         }
         guard isFoundationModelAvailable() else {
             return resolveError(call, code: "foundation_model_unavailable",
                                 message: "Apple Foundation Models requires iOS 26+ with Apple Intelligence enabled.")
         }
-        // Real implementation will load the system LanguageModel via the
-        // FoundationModels framework. We surface a clear unavailable error
-        // until the on-device target is validated. The shape below matches
-        // the TS contract so the JS side can already integrate.
-        let _ = prompt
-        let _ = call.getObject("options")
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            let options = call.getObject("options") ?? [:]
+            let temperature = options["temperature"] as? Double
+            let maxTokens = options["maxTokens"] as? Int
+            let instruction = options["instruction"] as? String
+            let started = Date()
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let session: LanguageModelSession
+                    if let instruction, !instruction.isEmpty {
+                        session = LanguageModelSession(instructions: instruction)
+                    } else {
+                        session = LanguageModelSession()
+                    }
+                    var generation = GenerationOptions()
+                    if let temperature { generation.temperature = temperature }
+                    if let maxTokens { generation.maximumResponseTokens = maxTokens }
+                    let response = try await session.respond(to: prompt, options: generation)
+                    let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
+                    call.resolve([
+                        "ok": true,
+                        "data": [
+                            "text": response.content,
+                            "elapsedMs": elapsedMs,
+                        ] as [String: Any],
+                    ])
+                } catch {
+                    // Guardrail refusals, context-window overflow and unsupported
+                    // locales all surface here; the JS side treats any of them as
+                    // "the OS model did not answer" and leaves llama.cpp in charge.
+                    Self.log.error("foundationModelGenerate failed: \(error.localizedDescription, privacy: .public)")
+                    self.resolveError(call, code: "foundation_model_error", message: error.localizedDescription)
+                }
+            }
+            return
+        }
+        #endif
         resolveError(call, code: "foundation_model_unavailable",
-                     message: "Foundation Models adapter is unavailable pending on-device validation.")
+                     message: "This build was compiled without the FoundationModels framework.")
     }
 
     private func isFoundationModelAvailable() -> Bool {
+        #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
-            // The actual API check lives in `FoundationModels.LanguageModel.isAvailable`.
-            // Keep the runtime probe behind that gate; default to false until
-            // the framework is linked.
-            return false
+            // `.unavailable` covers Apple Intelligence off, unsupported device or
+            // region, and the model still downloading.
+            if case .available = SystemLanguageModel.default.availability {
+                return true
+            }
         }
+        #endif
         return false
     }
 

--- a/plugins/plugin-computeruse/docs/IOS_CONSTRAINTS.md
+++ b/plugins/plugin-computeruse/docs/IOS_CONSTRAINTS.md
@@ -101,6 +101,13 @@ Apple Intelligence is enabled. We expose this as an *opportunistic*
 fast-path. If unavailable, the existing llama-cpp-capacitor local Eliza-1
 vision path stays as the default.
 
+The bridge probes `SystemLanguageModel.default.availability` and generates
+through `LanguageModelSession.respond(to:options:)`, compiled only when the
+SDK can import `FoundationModels` (Xcode 26+) and executed only on iOS 26+;
+older SDKs and devices report `foundation_model_unavailable`. The framework
+exposes no token accounting, so `FoundationModelResult.tokensIn/tokensOut`
+are omitted. Not yet validated on a device (see the checklist below).
+
 Entitlement and Info.plist updates are listed below.
 
 ## What does NOT work

--- a/plugins/plugin-computeruse/src/mobile/ios-bridge.ts
+++ b/plugins/plugin-computeruse/src/mobile/ios-bridge.ts
@@ -52,6 +52,7 @@ export type IosBridgeErrorCode =
   | "intent_invocation_failed"
   | "vision_no_text" // OCR ran but found nothing
   | "foundation_model_unavailable" // Apple Intelligence disabled / OS too old
+  | "foundation_model_error" // the system model refused or failed the request (guardrail, context window, locale)
   | "internal_error";
 
 // ── 1. ReplayKit foreground (own-app) capture ────────────────────────────────
@@ -256,8 +257,13 @@ export interface FoundationModelOptions {
 
 export interface FoundationModelResult {
   readonly text: string;
-  readonly tokensIn: number;
-  readonly tokensOut: number;
+  /**
+   * Token accounting is absent when the framework does not report it. The
+   * FoundationModels API exposes no token counts, so the Swift bridge omits
+   * both fields rather than estimating them.
+   */
+  readonly tokensIn?: number;
+  readonly tokensOut?: number;
   readonly elapsedMs: number;
 }
 

--- a/plugins/plugin-local-inference/__tests__/apple-foundation.test.ts
+++ b/plugins/plugin-local-inference/__tests__/apple-foundation.test.ts
@@ -214,10 +214,10 @@ describe("apple-foundation adapter", () => {
     const found = getAppleFoundationAdapter();
     expect(found).toBe(adapter);
     expect(found!.name).toBe("apple-foundation");
-    // The runtime side that wires up `registerAppleFoundationAdapter` does
-    // so only when the iOS bridge probe reports `foundationModel:true`. The
-    // adapter exposes a structural `LocalInferenceRuntimeService`-compatible
-    // surface — `generate` is the relevant entry point.
+    // `tryRegisterAppleFoundationAdapter` (src/runtime/apple-foundation-fast-path.ts)
+    // registers here at iOS boot only when the bridge probe reports
+    // `foundationModel:true`; the local text handler then consults
+    // `getAppleFoundationAdapter()` per call. `generate` is the entry point.
     expect(typeof found!.generate).toBe("function");
   });
 });

--- a/plugins/plugin-local-inference/docs/per-platform-backend-strategy.md
+++ b/plugins/plugin-local-inference/docs/per-platform-backend-strategy.md
@@ -39,7 +39,11 @@ efficiency." There is no separate per-platform runtime to add.
 - **Apple Foundation Models** (`src/backends/apple-foundation.ts`): an
   **opportunistic** iOS-26 text adapter, never the owned backend (native/AGENTS.md
   §11). Out-of-process OS model services cannot satisfy the single-runtime
-  contract.
+  contract. `src/runtime/apple-foundation-fast-path.ts` registers it at iOS boot
+  when the `ComputerUse` bridge probe reports `foundationModel:true`, and the
+  local text handler routes only plain short `TEXT_SMALL` / `TEXT_COMPLETION`
+  calls to it (never planner, structured, or streaming calls);
+  `ELIZA_APPLE_FOUNDATION_FAST_PATH=0` disables it.
 
 ### 2a. Every voice/vision model is already on its optimal backend — MEASURED, no ANE win to capture
 

--- a/plugins/plugin-local-inference/src/backends/apple-foundation.ts
+++ b/plugins/plugin-local-inference/src/backends/apple-foundation.ts
@@ -51,8 +51,15 @@ export interface AppleFoundationAdapter {
  */
 export function createAppleFoundationAdapter(
 	getBridge: () => IosComputerUseBridge | null,
+	options: {
+		/**
+		 * Result of a probe the caller has already awaited. Seeds `available()`
+		 * so the first call is deterministic and the device is not probed twice.
+		 */
+		readonly knownAvailable?: boolean;
+	} = {},
 ): AppleFoundationAdapter {
-	let probedAvailable: boolean | null = null;
+	let probedAvailable: boolean | null = options.knownAvailable ?? null;
 	let probing: Promise<boolean> | null = null;
 
 	async function probe(): Promise<boolean> {

--- a/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.test.ts
@@ -334,6 +334,20 @@ describe("generateWithAppleFoundation", () => {
 		expect(truncateAtStopSequence("plain", ["<end_of_turn>"])).toBe("plain");
 	});
 
+	it("accepts a result without token accounting (FoundationModels reports none)", async () => {
+		const { adapter } = await registerAvailableAdapter(
+			makeBridge({
+				foundationModelGenerate: vi.fn(async () => ({
+					ok: true as const,
+					data: { text: "no counts", elapsedMs: 7 },
+				})),
+			} as Partial<IosComputerUseBridge>),
+		);
+		await expect(
+			generateWithAppleFoundation(adapter, { prompt: "Say hi" }),
+		).resolves.toBe("no counts");
+	});
+
 	it("propagates a bridge failure as an error instead of empty text", async () => {
 		const { adapter } = await registerAvailableAdapter(
 			makeBridge({

--- a/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Deterministic unit tests for the Apple Foundation Models fast path: boot
+ * registration against a fake iOS bridge, per-call eligibility, the env kill
+ * switch, and the parameter mapping onto the bridge's generate call.
+ */
+import { ModelType } from "@elizaos/core";
+import type { IosComputerUseBridge } from "@elizaos/plugin-computeruse/mobile/ios-bridge";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	_resetAppleFoundationAdapterForTests,
+	createAppleFoundationAdapter,
+	getAppleFoundationAdapter,
+	registerAppleFoundationAdapter,
+} from "../backends/apple-foundation";
+import {
+	APPLE_FOUNDATION_FAST_PATH_ENV,
+	APPLE_FOUNDATION_MAX_PROMPT_CHARS,
+	generateWithAppleFoundation,
+	resolveAppleFoundationFastPath,
+	resolveIosComputerUseBridge,
+	truncateAtStopSequence,
+	tryRegisterAppleFoundationAdapter,
+} from "./apple-foundation-fast-path";
+
+function makeBridge(
+	overrides: Partial<IosComputerUseBridge> = {},
+): IosComputerUseBridge {
+	return {
+		probe: () =>
+			Promise.resolve({
+				ok: true as const,
+				data: {
+					platform: "ios",
+					osVersion: "26.0",
+					capabilities: {
+						replayKitForeground: false,
+						broadcastExtension: false,
+						visionOcr: false,
+						appIntents: false,
+						accessibilityRead: false,
+						foundationModel: true,
+					},
+				},
+			}),
+		foundationModelGenerate: vi.fn(async () => ({
+			ok: true as const,
+			data: { text: "from apple", tokensIn: 3, tokensOut: 2, elapsedMs: 12 },
+		})),
+		...overrides,
+	} as unknown as IosComputerUseBridge;
+}
+
+async function registerAvailableAdapter(bridge = makeBridge()) {
+	const adapter = createAppleFoundationAdapter(() => bridge);
+	registerAppleFoundationAdapter(adapter);
+	adapter.available();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(adapter.available()).toBe(true);
+	return { adapter, bridge };
+}
+
+describe("resolveIosComputerUseBridge", () => {
+	it("returns the Capacitor ComputerUse handle when present and null otherwise", () => {
+		const handle = makeBridge();
+		expect(
+			resolveIosComputerUseBridge({
+				Capacitor: { Plugins: { ComputerUse: handle } },
+			} as unknown as typeof globalThis),
+		).toBe(handle);
+		expect(resolveIosComputerUseBridge({} as typeof globalThis)).toBeNull();
+		expect(
+			resolveIosComputerUseBridge({
+				Capacitor: { Plugins: {} },
+			} as unknown as typeof globalThis),
+		).toBeNull();
+	});
+});
+
+describe("tryRegisterAppleFoundationAdapter", () => {
+	afterEach(() => {
+		_resetAppleFoundationAdapterForTests();
+	});
+
+	it("registers the adapter on iOS when the bridge probe reports foundationModel:true", async () => {
+		const bridge = makeBridge();
+		const result = await tryRegisterAppleFoundationAdapter({
+			platform: "ios",
+			getBridge: () => bridge,
+		});
+		expect(result).toEqual({ outcome: "registered" });
+		expect(getAppleFoundationAdapter()?.name).toBe("apple-foundation");
+	});
+
+	it("skips off iOS, without a bridge, on a failed probe, and when the model is absent", async () => {
+		expect(
+			await tryRegisterAppleFoundationAdapter({
+				platform: "android",
+				getBridge: () => makeBridge(),
+			}),
+		).toEqual({ outcome: "skipped", reason: "not_ios" });
+		expect(
+			await tryRegisterAppleFoundationAdapter({
+				platform: "ios",
+				getBridge: () => null,
+			}),
+		).toEqual({ outcome: "skipped", reason: "bridge_unavailable" });
+		expect(
+			await tryRegisterAppleFoundationAdapter({
+				platform: "ios",
+				getBridge: () =>
+					makeBridge({
+						probe: () =>
+							Promise.resolve({
+								ok: false as const,
+								code: "internal_error",
+								message: "no",
+							}),
+					} as Partial<IosComputerUseBridge>),
+			}),
+		).toEqual({ outcome: "skipped", reason: "probe_failed" });
+		expect(
+			await tryRegisterAppleFoundationAdapter({
+				platform: "ios",
+				getBridge: () =>
+					makeBridge({
+						probe: () => Promise.reject(new Error("bridge crashed")),
+					} as Partial<IosComputerUseBridge>),
+			}),
+		).toEqual({ outcome: "skipped", reason: "probe_failed" });
+		const noModel = makeBridge();
+		const probe = await noModel.probe();
+		expect(
+			await tryRegisterAppleFoundationAdapter({
+				platform: "ios",
+				getBridge: () =>
+					makeBridge({
+						probe: () =>
+							Promise.resolve(
+								probe.ok
+									? {
+											...probe,
+											data: {
+												...probe.data,
+												capabilities: {
+													...probe.data.capabilities,
+													foundationModel: false,
+												},
+											},
+										}
+									: probe,
+							),
+					} as Partial<IosComputerUseBridge>),
+			}),
+		).toEqual({ outcome: "skipped", reason: "foundation_model_unavailable" });
+		expect(getAppleFoundationAdapter()).toBeNull();
+	});
+});
+
+describe("resolveAppleFoundationFastPath", () => {
+	afterEach(() => {
+		_resetAppleFoundationAdapterForTests();
+	});
+
+	it("returns null when no adapter is registered", () => {
+		expect(
+			resolveAppleFoundationFastPath(
+				ModelType.TEXT_SMALL,
+				{ prompt: "hi" },
+				{},
+			),
+		).toBeNull();
+	});
+
+	it("serves plain short TEXT_SMALL and TEXT_COMPLETION calls only", async () => {
+		const { adapter } = await registerAvailableAdapter();
+		const short = { prompt: "Summarize: the cat sat." };
+		expect(
+			resolveAppleFoundationFastPath(ModelType.TEXT_SMALL, short, {}),
+		).toBe(adapter);
+		expect(
+			resolveAppleFoundationFastPath(ModelType.TEXT_COMPLETION, short, {}),
+		).toBe(adapter);
+		for (const modelType of [
+			ModelType.TEXT_LARGE,
+			ModelType.ACTION_PLANNER,
+			ModelType.RESPONSE_HANDLER,
+		]) {
+			expect(resolveAppleFoundationFastPath(modelType, short, {})).toBeNull();
+		}
+	});
+
+	it("declines long, empty, streaming, and structured-decoding requests", async () => {
+		await registerAvailableAdapter();
+		const decline = (params: Record<string, unknown>) =>
+			expect(
+				resolveAppleFoundationFastPath(
+					ModelType.TEXT_SMALL,
+					params as never,
+					{},
+				),
+			).toBeNull();
+		decline({ prompt: "" });
+		decline({ messages: [{ role: "user", content: "hi" }] });
+		decline({ prompt: "x".repeat(APPLE_FOUNDATION_MAX_PROMPT_CHARS + 1) });
+		decline({ prompt: "hi", stream: true });
+		decline({ prompt: "hi", streamStructured: true });
+		decline({ prompt: "hi", onStreamChunk: () => undefined });
+		decline({ prompt: "hi", grammar: "root ::= 'a'" });
+		decline({ prompt: "hi", responseSkeleton: { kind: "json" } });
+		decline({ prompt: "hi", spanSamplerPlan: {} });
+		decline({ prompt: "hi", prefill: "{" });
+		decline({ prompt: "hi", responseFormat: { type: "json_object" } });
+		decline({ prompt: "hi", responseFormat: "json" });
+		decline({ prompt: "hi", responseSchema: { type: "object" } });
+		decline({
+			prompt: "hi",
+			tools: [{ name: "t", description: "", parameters: {} }],
+		});
+		decline({ prompt: "hi", toolChoice: "auto" });
+		decline({ prompt: "hi", omitMaxTokens: true });
+	});
+
+	it("registration seeds availability so the first call is deterministic", async () => {
+		let probes = 0;
+		const bridge = makeBridge();
+		const probe = bridge.probe;
+		const counting = makeBridge({
+			probe: () => {
+				probes += 1;
+				return probe();
+			},
+		} as Partial<IosComputerUseBridge>);
+		await tryRegisterAppleFoundationAdapter({
+			platform: "ios",
+			getBridge: () => counting,
+		});
+		expect(probes).toBe(1);
+		expect(
+			resolveAppleFoundationFastPath(
+				ModelType.TEXT_SMALL,
+				{ prompt: "hi" },
+				{},
+			),
+		).not.toBeNull();
+		expect(probes).toBe(1);
+	});
+
+	it("honours the env kill switch and a not-yet-available adapter", async () => {
+		const { adapter } = await registerAvailableAdapter();
+		expect(
+			resolveAppleFoundationFastPath(
+				ModelType.TEXT_SMALL,
+				{ prompt: "hi" },
+				{ [APPLE_FOUNDATION_FAST_PATH_ENV]: "0" },
+			),
+		).toBeNull();
+		expect(
+			resolveAppleFoundationFastPath(
+				ModelType.TEXT_SMALL,
+				{ prompt: "hi" },
+				{ [APPLE_FOUNDATION_FAST_PATH_ENV]: "1" },
+			),
+		).toBe(adapter);
+
+		_resetAppleFoundationAdapterForTests();
+		const pending = createAppleFoundationAdapter(() =>
+			makeBridge({
+				probe: () => new Promise(() => undefined),
+			} as Partial<IosComputerUseBridge>),
+		);
+		registerAppleFoundationAdapter(pending);
+		expect(
+			resolveAppleFoundationFastPath(
+				ModelType.TEXT_SMALL,
+				{ prompt: "hi" },
+				{},
+			),
+		).toBeNull();
+	});
+});
+
+describe("generateWithAppleFoundation", () => {
+	afterEach(() => {
+		_resetAppleFoundationAdapterForTests();
+	});
+
+	it("maps prompt, maxTokens, temperature and system onto the bridge and returns the text", async () => {
+		const { adapter, bridge } = await registerAvailableAdapter();
+		const text = await generateWithAppleFoundation(adapter, {
+			prompt: "Say hi",
+			maxTokens: 64,
+			temperature: 0.3,
+			system: "You are terse.",
+			// Stop sequences are deliberately absent from the bridge options:
+			// FoundationModelOptions has no such field, so they are enforced by
+			// trimming the returned text instead (next test).
+			stopSequences: ["\n\n"],
+		});
+		expect(text).toBe("from apple");
+		expect(bridge.foundationModelGenerate).toHaveBeenCalledWith({
+			prompt: "Say hi",
+			options: {
+				maxTokens: 64,
+				temperature: 0.3,
+				instruction: "You are terse.",
+			},
+		});
+	});
+
+	it("cuts the completion at the Eliza turn markers and at caller stop sequences", async () => {
+		const { adapter } = await registerAvailableAdapter(
+			makeBridge({
+				foundationModelGenerate: vi.fn(async () => ({
+					ok: true as const,
+					data: {
+						text: "Hello there.<end_of_turn>\n<start_of_turn>user\nnext turn",
+						tokensIn: 3,
+						tokensOut: 9,
+						elapsedMs: 4,
+					},
+				})),
+			} as Partial<IosComputerUseBridge>),
+		);
+		await expect(
+			generateWithAppleFoundation(adapter, { prompt: "Say hi" }),
+		).resolves.toBe("Hello there.");
+		await expect(
+			generateWithAppleFoundation(adapter, {
+				prompt: "Say hi",
+				stopSequences: [" there"],
+			}),
+		).resolves.toBe("Hello");
+		expect(truncateAtStopSequence("plain", ["<end_of_turn>"])).toBe("plain");
+	});
+
+	it("propagates a bridge failure as an error instead of empty text", async () => {
+		const { adapter } = await registerAvailableAdapter(
+			makeBridge({
+				foundationModelGenerate: vi.fn(async () => ({
+					ok: false as const,
+					code: "model_unavailable",
+					message: "Apple Intelligence is off",
+				})),
+			} as Partial<IosComputerUseBridge>),
+		);
+		await expect(
+			generateWithAppleFoundation(adapter, { prompt: "Say hi" }),
+		).rejects.toThrow(/model_unavailable/);
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.ts
+++ b/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.ts
@@ -1,0 +1,208 @@
+/**
+ * Apple Foundation Models fast path for the local text handler on iOS 26+.
+ *
+ * The adapter in `../backends/apple-foundation` is an opportunistic route,
+ * never the owned backend: it is registered at iOS boot only when the
+ * Capacitor `ComputerUse` bridge probe reports `foundationModel: true`, and
+ * the local text handler consults it only for plain short-prompt calls
+ * (`TEXT_SMALL` / `TEXT_COMPLETION`). Planner and response-handler model types
+ * share the TEXT_SMALL slot but depend on llama.cpp's structured decoding
+ * (grammar, skeletons, span samplers, streaming), which the out-of-process OS
+ * model cannot honour, so they never take this path. `ELIZA_APPLE_FOUNDATION_FAST_PATH=0`
+ * disables it without touching the registration.
+ */
+import { type GenerateTextParams, logger, ModelType } from "@elizaos/core";
+import type { IosComputerUseBridge } from "@elizaos/plugin-computeruse/mobile/ios-bridge";
+
+import {
+	type AppleFoundationAdapter,
+	createAppleFoundationAdapter,
+	getAppleFoundationAdapter,
+	registerAppleFoundationAdapter,
+} from "../backends/apple-foundation";
+import { mergeElizaTurnStopSequences } from "../services/eliza-turn-stops";
+
+type IosBridge = IosComputerUseBridge;
+
+/** Capacitor plugin jsName; kept in sync with `IOS_BRIDGE_JS_NAME` in plugin-computeruse. */
+const IOS_COMPUTER_USE_PLUGIN = "ComputerUse";
+
+/**
+ * The live `Capacitor.Plugins.ComputerUse` handle, or `null` off the
+ * Capacitor iOS shell. Mirrors plugin-computeruse's `getIosBridge`; that
+ * package publishes `mobile/ios-bridge` as declarations only, so the lookup
+ * is local rather than a runtime import.
+ */
+export function resolveIosComputerUseBridge(
+	root: typeof globalThis = globalThis,
+): IosBridge | null {
+	const cap = (root as { Capacitor?: unknown }).Capacitor;
+	if (!cap || typeof cap !== "object") return null;
+	const plugins = (cap as { Plugins?: Record<string, unknown> }).Plugins;
+	if (!plugins || typeof plugins !== "object") return null;
+	const handle = plugins[IOS_COMPUTER_USE_PLUGIN];
+	return handle ? (handle as IosBridge) : null;
+}
+
+export const APPLE_FOUNDATION_FAST_PATH_ENV =
+	"ELIZA_APPLE_FOUNDATION_FAST_PATH";
+
+/** Prompts longer than this stay on llama.cpp; the OS model is a short-turn tool. */
+export const APPLE_FOUNDATION_MAX_PROMPT_CHARS = 4000;
+
+/** Model types that may take the fast path; all others always use llama.cpp. */
+export const APPLE_FOUNDATION_ELIGIBLE_MODEL_TYPES: ReadonlySet<string> =
+	new Set([ModelType.TEXT_SMALL, ModelType.TEXT_COMPLETION]);
+
+export type AppleFoundationRegistration =
+	| { readonly outcome: "registered" }
+	| {
+			readonly outcome: "skipped";
+			readonly reason:
+				| "not_ios"
+				| "bridge_unavailable"
+				| "probe_failed"
+				| "foundation_model_unavailable";
+	  };
+
+export function isAppleFoundationFastPathDisabledByEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	const raw = env[APPLE_FOUNDATION_FAST_PATH_ENV]?.trim().toLowerCase();
+	return raw === "0" || raw === "false" || raw === "off";
+}
+
+/**
+ * Register the adapter on an iOS host whose bridge reports Foundation Models
+ * availability. The probe runs here, once, so the boot log states plainly why
+ * the fast path is or is not active; `available()` on the adapter stays the
+ * per-call guard afterwards.
+ */
+export async function tryRegisterAppleFoundationAdapter(args: {
+	platform: string | undefined;
+	getBridge: () => IosBridge | null;
+	env?: NodeJS.ProcessEnv;
+}): Promise<AppleFoundationRegistration> {
+	if (args.platform !== "ios") return { outcome: "skipped", reason: "not_ios" };
+	const bridge = args.getBridge();
+	if (!bridge) return { outcome: "skipped", reason: "bridge_unavailable" };
+	let probe: Awaited<ReturnType<IosBridge["probe"]>>;
+	try {
+		probe = await bridge.probe();
+	} catch (error) {
+		// error-policy:J4 user-facing degrade: a probe that throws means the
+		// fast path is unavailable; llama.cpp stays the active handler.
+		logger.warn(
+			`[local-inference] Apple Foundation probe threw; fast path stays off: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return { outcome: "skipped", reason: "probe_failed" };
+	}
+	if (!probe.ok) return { outcome: "skipped", reason: "probe_failed" };
+	if (probe.data.capabilities.foundationModel !== true) {
+		return { outcome: "skipped", reason: "foundation_model_unavailable" };
+	}
+	// The probe above already answered; seed the adapter with it so the first
+	// eligible call is deterministic and the device is not probed a second time.
+	registerAppleFoundationAdapter(
+		createAppleFoundationAdapter(args.getBridge, { knownAvailable: true }),
+	);
+	logger.info(
+		"[local-inference] Apple Foundation Models fast path registered (iOS 26 bridge reports foundationModel:true)",
+	);
+	return { outcome: "registered" };
+}
+
+/**
+ * The adapter to use for this call, or `null` when llama.cpp must serve it.
+ * Every structured-decoding or streaming feature the local engine honours is
+ * a reason to decline: the OS model returns one plain completion.
+ */
+export function resolveAppleFoundationFastPath(
+	modelType: string,
+	params: GenerateTextParams,
+	env: NodeJS.ProcessEnv = process.env,
+): AppleFoundationAdapter | null {
+	if (isAppleFoundationFastPathDisabledByEnv(env)) return null;
+	if (!APPLE_FOUNDATION_ELIGIBLE_MODEL_TYPES.has(modelType)) return null;
+	const adapter = getAppleFoundationAdapter();
+	if (!adapter?.available()) return null;
+	const prompt = params.prompt ?? "";
+	if (
+		prompt.length === 0 ||
+		prompt.length > APPLE_FOUNDATION_MAX_PROMPT_CHARS
+	) {
+		return null;
+	}
+	if (params.stream === true || params.streamStructured === true) return null;
+	if (typeof params.onStreamChunk === "function") return null;
+	// Structured decoding, tool calling and schema-shaped output are llama.cpp
+	// features; the OS model returns one plain completion.
+	if (
+		params.grammar !== undefined ||
+		params.responseSkeleton !== undefined ||
+		params.spanSamplerPlan !== undefined ||
+		params.prefill !== undefined ||
+		params.responseSchema !== undefined ||
+		params.toolChoice !== undefined ||
+		(params.tools !== undefined && params.tools.length > 0)
+	) {
+		return null;
+	}
+	// `omitMaxTokens` asks for no output cap; FoundationModelOptions defaults
+	// maxTokens to 256 when unset, so the OS model would apply the tightest
+	// cap in the system to the one call that opted out of caps.
+	if (params.omitMaxTokens === true) return null;
+	if (params.responseFormat !== undefined) {
+		const format =
+			typeof params.responseFormat === "string"
+				? params.responseFormat
+				: params.responseFormat.type;
+		if (format !== "text") return null;
+	}
+	return adapter;
+}
+
+/**
+ * Run one eligible call on the OS model and return its text, cut at the first
+ * stop sequence. Every llama.cpp text route unions `ELIZA_TURN_STOP_SEQUENCES`
+ * into the caller's stops so a completion never runs past the turn boundary;
+ * `FoundationModelOptions` has no stop field, so the same invariant is applied
+ * to the returned text here instead of at decode time.
+ */
+export async function generateWithAppleFoundation(
+	adapter: AppleFoundationAdapter,
+	params: GenerateTextParams,
+): Promise<string> {
+	const result = await adapter.generate({
+		prompt: params.prompt ?? "",
+		options: {
+			...(params.maxTokens !== undefined
+				? { maxTokens: params.maxTokens }
+				: {}),
+			...(params.temperature !== undefined
+				? { temperature: params.temperature }
+				: {}),
+			...(params.system ? { instruction: params.system } : {}),
+		},
+	});
+	logger.info(
+		`[local-inference] apple-foundation served ${result.tokensIn}->${result.tokensOut} tokens in ${result.elapsedMs}ms`,
+	);
+	return truncateAtStopSequence(
+		result.text,
+		mergeElizaTurnStopSequences(params.stopSequences),
+	);
+}
+
+/** The text before the earliest occurrence of any stop sequence (the text itself when none occurs). */
+export function truncateAtStopSequence(
+	text: string,
+	stopSequences: readonly string[],
+): string {
+	let cut = text.length;
+	for (const stop of stopSequences) {
+		const index = text.indexOf(stop);
+		if (index !== -1 && index < cut) cut = index;
+	}
+	return cut === text.length ? text : text.slice(0, cut);
+}

--- a/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.ts
+++ b/plugins/plugin-local-inference/src/runtime/apple-foundation-fast-path.ts
@@ -185,8 +185,12 @@ export async function generateWithAppleFoundation(
 			...(params.system ? { instruction: params.system } : {}),
 		},
 	});
+	const tokens =
+		result.tokensIn !== undefined && result.tokensOut !== undefined
+			? `${result.tokensIn}->${result.tokensOut} tokens`
+			: `${result.text.length} chars (no token accounting)`;
 	logger.info(
-		`[local-inference] apple-foundation served ${result.tokensIn}->${result.tokensOut} tokens in ${result.elapsedMs}ms`,
+		`[local-inference] apple-foundation served ${tokens} in ${result.elapsedMs}ms`,
 	);
 	return truncateAtStopSequence(
 		result.text,

--- a/plugins/plugin-local-inference/src/runtime/boot.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/boot.test.ts
@@ -30,6 +30,22 @@ vi.mock("@elizaos/core", () => ({
 	isMobilePlatform: () => isMobilePlatform(),
 	logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));
+// boot.ts reads ELIZA_PLATFORM through the alias-aware reader; the real
+// shared module pulls in core at load, which the mock above does not provide.
+vi.mock("@elizaos/shared", () => ({
+	readAliasedEnv: (key: string) => process.env[key],
+}));
+const tryRegisterAppleFoundationAdapter = vi.fn(
+	async (_args: { platform: string | undefined }) => ({
+		outcome: "skipped" as const,
+		reason: "not_ios" as const,
+	}),
+);
+vi.mock("./apple-foundation-fast-path", () => ({
+	resolveIosComputerUseBridge: () => null,
+	tryRegisterAppleFoundationAdapter: (args: { platform: string | undefined }) =>
+		tryRegisterAppleFoundationAdapter(args),
+}));
 
 import { registerLocalInferenceBoot } from "./boot";
 
@@ -42,6 +58,35 @@ describe("registerLocalInferenceBoot", () => {
 		vi.clearAllMocks();
 		isMobilePlatform.mockReturnValue(false);
 		shouldEnableMobileLocalInference.mockReturnValue(false);
+	});
+
+	it("attempts the Apple Foundation registration on a mobile platform with the configured platform (#31118)", async () => {
+		isMobilePlatform.mockReturnValue(true);
+		shouldEnableMobileLocalInference.mockReturnValue(true);
+		const previous = process.env.ELIZA_PLATFORM;
+		process.env.ELIZA_PLATFORM = "ios";
+		try {
+			const runtime = makeFakeRuntime();
+			await registerLocalInferenceBoot(runtime);
+			expect(tryRegisterAppleFoundationAdapter).toHaveBeenCalledOnce();
+			expect(tryRegisterAppleFoundationAdapter.mock.calls[0][0]).toMatchObject({
+				platform: "ios",
+			});
+			// Registration precedes the handler install so the first handler
+			// call can already consult the adapter.
+			expect(
+				tryRegisterAppleFoundationAdapter.mock.invocationCallOrder[0],
+			).toBeLessThan(ensureLocalInferenceHandler.mock.invocationCallOrder[0]);
+		} finally {
+			if (previous === undefined) delete process.env.ELIZA_PLATFORM;
+			else process.env.ELIZA_PLATFORM = previous;
+		}
+	});
+
+	it("does not touch the Apple Foundation registration on desktop", async () => {
+		isMobilePlatform.mockReturnValue(false);
+		await registerLocalInferenceBoot(makeFakeRuntime());
+		expect(tryRegisterAppleFoundationAdapter).not.toHaveBeenCalled();
 	});
 
 	it("always emits the mobile-voice-invariant warning (evaluated regardless of platform)", async () => {

--- a/plugins/plugin-local-inference/src/runtime/boot.ts
+++ b/plugins/plugin-local-inference/src/runtime/boot.ts
@@ -26,7 +26,12 @@
  * this hook only owns the local-inference-specific init.
  */
 import { type AgentRuntime, isMobilePlatform, logger } from "@elizaos/core";
+import { readAliasedEnv } from "@elizaos/shared";
 
+import {
+	resolveIosComputerUseBridge,
+	tryRegisterAppleFoundationAdapter,
+} from "./apple-foundation-fast-path";
 import { ensureLocalInferenceHandler } from "./ensure-local-inference-handler";
 import {
 	shouldEnableMobileLocalInference,
@@ -54,6 +59,18 @@ export async function registerLocalInferenceBoot(
 	});
 
 	if (isMobilePlatform()) {
+		// iOS 26 Apple Foundation Models: register the opportunistic adapter
+		// when the Capacitor bridge probe reports it. The local text handler
+		// consults it per call; llama.cpp stays the owned backend.
+		const appleFoundation = await tryRegisterAppleFoundationAdapter({
+			platform: readAliasedEnv("ELIZA_PLATFORM")?.trim().toLowerCase(),
+			getBridge: resolveIosComputerUseBridge,
+		});
+		if (appleFoundation.outcome === "skipped") {
+			logger.debug(
+				`[local-inference] Apple Foundation fast path not registered: ${appleFoundation.reason}`,
+			);
+		}
 		// Mobile bundle wires the local model handler only when a mobile-safe
 		// backend (device-bridge / AOSP FFI / bionic host / riscv64) is enabled;
 		// otherwise the runtime serves from a remote/cloud provider.

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -120,6 +120,10 @@ vi.mock("../services/voice", () => ({
 	})),
 }));
 
+import {
+	_resetAppleFoundationAdapterForTests,
+	registerAppleFoundationAdapter,
+} from "../backends/apple-foundation";
 import { resolveLocalInferenceLoadArgs } from "../services/active-model";
 import { probeHardware } from "../services/hardware";
 import { installRouterHandler } from "../services/router-handler";
@@ -435,6 +439,53 @@ describe("ensureLocalInferenceHandler", () => {
 				topP: 0.9,
 			}),
 		);
+	});
+
+	it("serves an eligible TEXT_SMALL call from a registered Apple Foundation adapter (#31118)", async () => {
+		const { registrations, runtime } = makeRuntime();
+		engineState.hasLoadedModel.mockReturnValue(true);
+		const generate = vi.fn(async () => ({
+			text: "from apple",
+			tokensIn: 2,
+			tokensOut: 2,
+			elapsedMs: 5,
+		}));
+		registerAppleFoundationAdapter({
+			name: "apple-foundation",
+			available: () => true,
+			generate,
+		});
+		try {
+			await ensureLocalInferenceHandler(runtime);
+			const small = findRegisteredHandler(registrations, ModelType.TEXT_SMALL);
+			await expect(
+				small(runtime, { prompt: "Say hi", maxTokens: 16 }),
+			).resolves.toBe("from apple");
+			expect(generate).toHaveBeenCalledWith({
+				prompt: "Say hi",
+				options: { maxTokens: 16 },
+			});
+			expect(engineState.generate).not.toHaveBeenCalled();
+
+			// The planner shares the TEXT_SMALL slot but never takes the fast path.
+			const planner = findRegisteredHandler(
+				registrations,
+				ModelType.ACTION_PLANNER,
+			);
+			await planner(runtime, { prompt: "plan", maxTokens: 16 });
+			expect(engineState.generate).toHaveBeenCalledTimes(1);
+
+			// A streaming request stays on llama.cpp too.
+			await small(runtime, {
+				prompt: "Say hi",
+				stream: true,
+				onStreamChunk: () => undefined,
+			});
+			expect(engineState.generate).toHaveBeenCalledTimes(2);
+			expect(generate).toHaveBeenCalledTimes(1);
+		} finally {
+			_resetAppleFoundationAdapterForTests();
+		}
 	});
 
 	it("uses the complete native tool history when prompt segments are also present", async () => {

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -93,6 +93,10 @@ import {
 	ELIZA_POOLING_MEAN,
 } from "../services/voice/ffi-bindings";
 import { extractRequestedKokoroVoiceId } from "../services/voice/requested-voice.js";
+import {
+	generateWithAppleFoundation,
+	resolveAppleFoundationFastPath,
+} from "./apple-foundation-fast-path";
 import { DEFAULT_MODELS_DIR } from "./embedding-manager-support";
 import {
 	EMBEDDING_PRESETS,
@@ -464,8 +468,20 @@ function engineGenerateArgsFromParams(
 	};
 }
 
-function makeHandler(slot: AgentModelSlot): GenerateTextHandler {
+function makeHandler(
+	slot: AgentModelSlot,
+	modelType: string,
+): GenerateTextHandler {
 	return async (runtime, params) => {
+		// iOS 26 opportunistic fast path: a registered, available Apple
+		// Foundation adapter serves plain short TEXT_SMALL / TEXT_COMPLETION
+		// calls; everything else (planner, structured, streaming, long prompts)
+		// stays on llama.cpp below.
+		const appleFoundation = resolveAppleFoundationFastPath(modelType, params);
+		if (appleFoundation) {
+			return generateWithAppleFoundation(appleFoundation, params);
+		}
+
 		const loader = getLoader(runtime);
 
 		// Lazy-load the assigned model for this slot, if any. Swaps are
@@ -1650,7 +1666,7 @@ export async function ensureLocalInferenceHandler(
 		try {
 			runtimeWithRegistration.registerModel(
 				modelType,
-				makeHandler(slot),
+				makeHandler(slot, modelType),
 				provider,
 				LOCAL_INFERENCE_PRIORITY,
 				{ local: true, streamable: true },


### PR DESCRIPTION
## Summary

`registerAppleFoundationAdapter` / `getAppleFoundationAdapter` in `plugins/plugin-local-inference/src/backends/apple-foundation.ts` had no production writer or reader, so the iOS 26 Apple Foundation Models fast path the module header, `docs/per-platform-backend-strategy.md` and the adapter test all describe never activated. This wires it, keeping llama.cpp as the owned backend.

New `src/runtime/apple-foundation-fast-path.ts`:

- `tryRegisterAppleFoundationAdapter({ platform, getBridge })` runs at mobile boot (`registerLocalInferenceBoot`, before the local handler installs). It registers the adapter only when `ELIZA_PLATFORM=ios`, the bridge handle exists, and `bridge.probe()` reports `capabilities.foundationModel === true`; every other outcome is returned as a typed skip reason and logged at debug.
- `resolveIosComputerUseBridge()` reads `Capacitor.Plugins.ComputerUse` locally (mirroring computeruse's `getIosBridge`). A runtime import of `@elizaos/plugin-computeruse/mobile/ios-bridge` is not possible: that package publishes `dist/mobile/` as declarations only, and the plugin's vitest alias maps the package root to `src/index.ts`. The type import stays.
- `resolveAppleFoundationFastPath(modelType, params)` is consulted at the top of the local text handler (`makeHandler` now receives the model type). It returns the adapter only for `ModelType.TEXT_SMALL` and `TEXT_COMPLETION` with a non-empty prompt of at most 4000 characters, no streaming (`stream`, `streamStructured`, `onStreamChunk`), no structured decoding (`grammar`, `responseSkeleton`, `spanSamplerPlan`, `prefill`), and no non-text `responseFormat`. `ACTION_PLANNER` and `RESPONSE_HANDLER` share the TEXT_SMALL slot but never take it. `ELIZA_APPLE_FOUNDATION_FAST_PATH=0|false|off` disables the route.
- `generateWithAppleFoundation` maps `prompt`, `maxTokens` and `temperature` onto `foundationModelGenerate`, returns the text, and throws on a bridge failure (no empty-string success).

The adapter test's "runtime side wires this up" comment and the backend-strategy doc now describe the real wiring.

Closes #31118

## Evidence

- `apple-foundation-fast-path.test.ts` (new, 9 cases): bridge resolution from a fake `Capacitor` global; registration on iOS with `foundationModel:true`; skips for non-iOS, missing bridge, `probe.ok:false`, a throwing probe, and `foundationModel:false` (registry stays null); eligibility matrix for model types, prompt length, streaming and structured-decoding params; env kill switch; not-yet-available adapter declined; generate mapping and failure propagation.
- `ensure-local-inference-handler.test.ts` (new case): with an adapter registered, the registered TEXT_SMALL handler returns the adapter's text and never calls the engine; the ACTION_PLANNER handler and a streaming TEXT_SMALL call still reach `localInferenceEngine.generate`.
- `boot.test.ts` (2 new cases): on a mobile platform with `ELIZA_PLATFORM=ios` the registration runs with `platform: "ios"` before the handler install; on desktop it is never attempted.
- `bunx vitest run` on the four touched suites: 53/53. `bun run test` in `plugins/plugin-local-inference`: 3005 passed, 2 skipped (285 files). `bun run typecheck` and `bun run lint:check`: clean.
- Root `bun run verify`: running on this branch; result will be posted as a comment.

**Not exercised: a real iOS 26 device.** The bridge contract (`probe`, `foundationModelGenerate`) is the existing `IosComputerUseBridge` interface implemented in `ComputerUseBridge.swift`; the tests drive it through a fake. On a device, the boot log states whether the fast path registered and, per call, `[local-inference] apple-foundation served N->M tokens in Xms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8gwNCWN4PDyeXY6fHhhgy
