### PR TITLE
fix(cloud): release retired placement before Dedicated resume

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -6,6 +6,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { pushSchema } from "drizzle-kit/api";
 import { eq, sql } from "drizzle-orm";
+import { countAllocatedWorkloadsOnNodeWithDatabase } from "../../../lib/services/docker-node-workload-queries";
 import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import { agentSandboxes, WARM_POOL_ORG_ID, WARM_POOL_USER_ID } from "../../schemas/agent-sandboxes";
 import { apiKeys } from "../../schemas/api-keys";
@@ -65,6 +66,13 @@ beforeAll(async () => {
   await apply();
   const { getPgliteClientForTests } = await import("../../client");
   await installOrganizationPolicyTestSchema((query) => getPgliteClientForTests().exec(query));
+  await dbWrite.execute(sql`
+    CREATE TABLE IF NOT EXISTS containers (
+      id uuid PRIMARY KEY,
+      node_id text,
+      status text NOT NULL
+    )
+  `);
   await repository.countAllPoolEntries({ image: IMAGE });
 
   // Replenish reads the tenant-starvation guard inputs (queued tenant jobs +
@@ -715,12 +723,64 @@ test(
 );
 
 test(
+  "stopped resume leaves its released one-slot node available and preserves recovery data",
+  async () => {
+    const id = await seedUserAgent();
+    const lastBackupAt = new Date("2026-09-12T10:07:33.122Z");
+    await dbWrite.update(dockerNodes).set({ capacity: 1 }).where(eq(dockerNodes.node_id, "node-1"));
+    try {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          status: "stopped",
+          sandbox_id: "retired-sandbox",
+          container_name: "retired-container",
+          node_id: "node-1",
+          bridge_port: 18791,
+          web_ui_port: 20001,
+          database_status: "ready",
+          database_uri: "postgresql://retained.invalid/agent",
+          snapshot_id: "retained-snapshot",
+          last_backup_at: lastBackupAt,
+        })
+        .where(eq(agentSandboxes.id, id));
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, "node-1")).toBe(0);
+
+      const admitted = await repository.trySetProvisioning(id);
+
+      expect(admitted?.status).toBe("provisioning");
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, "node-1")).toBe(0);
+      expect(admitted?.node_id).toBeNull();
+      expect(admitted?.sandbox_id).toBeNull();
+      expect(admitted?.container_name).toBeNull();
+      expect(admitted?.bridge_port).toBeNull();
+      expect(admitted?.web_ui_port).toBeNull();
+      expect(admitted?.database_status).toBe("ready");
+      expect(admitted?.database_uri).toBe("postgresql://retained.invalid/agent");
+      expect(admitted?.snapshot_id).toBe("retained-snapshot");
+      expect(admitted?.last_backup_at?.toISOString()).toBe(lastBackupAt.toISOString());
+    } finally {
+      await dbWrite
+        .update(dockerNodes)
+        .set({ capacity: 16 })
+        .where(eq(dockerNodes.node_id, "node-1"));
+    }
+  },
+  PGLITE_TIMEOUT,
+);
+
+test(
   "restore admission rejects foreign and stale capture before accepting exact authority",
   async () => {
     const id = await seedUserAgent();
     await dbWrite
       .update(agentSandboxes)
-      .set({ status: "stopped" })
+      .set({
+        status: "stopped",
+        sandbox_id: "retired-restore-sandbox",
+        container_name: "retired-restore-container",
+        node_id: "node-1",
+      })
       .where(eq(agentSandboxes.id, id));
     const capture = await persistedAgent(id);
     expect(
@@ -736,9 +796,10 @@ test(
       }),
     ).toBeUndefined();
     expect((await persistedAgent(id)).status).toBe("stopped");
-    expect((await repository.trySetProvisioningFromRestoreCapture(capture))?.status).toBe(
-      "provisioning",
-    );
+    const admitted = await repository.trySetProvisioningFromRestoreCapture(capture);
+    expect(admitted?.status).toBe("provisioning");
+    expect(admitted?.node_id).toBeNull();
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, "node-1")).toBe(0);
   },
   PGLITE_TIMEOUT,
 );

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -391,18 +391,24 @@ function warmPoolGenerationConditions(expected: WarmPoolRuntimeGeneration): SQL[
 /** Keep generic and restore-fenced provisioning transitions byte-equivalent. */
 function provisioningAdmissionUpdatePayload() {
   const permanentProvisionFailure = sql`${agentSandboxes.status} = 'error' AND ${agentSandboxes.error_message} LIKE 'Provisioning permanently failed%'`;
+  // Stop retains the retired locator while the agent is off. Once explicit
+  // provisioning is admitted, keeping that node would count the new
+  // `provisioning` row against its own freed slot before placement can run.
+  // Recovery data stays on the row; unresolved and sleeping generations keep
+  // their existing handle semantics.
+  const retiredPlacement = sql`${agentSandboxes.status} = 'stopped' OR (${permanentProvisionFailure})`;
   return {
     status: "provisioning" as const,
     updated_at: new Date(),
     error_message: null,
-    sandbox_id: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.sandbox_id} END`,
-    bridge_url: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.bridge_url} END`,
-    health_url: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.health_url} END`,
-    node_id: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.node_id} END`,
-    container_name: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.container_name} END`,
-    bridge_port: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.bridge_port} END`,
-    web_ui_port: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.web_ui_port} END`,
-    headscale_ip: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.headscale_ip} END`,
+    sandbox_id: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.sandbox_id} END`,
+    bridge_url: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.bridge_url} END`,
+    health_url: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.health_url} END`,
+    node_id: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.node_id} END`,
+    container_name: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.container_name} END`,
+    bridge_port: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.bridge_port} END`,
+    web_ui_port: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.web_ui_port} END`,
+    headscale_ip: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.headscale_ip} END`,
   };
 }
 


### PR DESCRIPTION
Fixes #31131.

Starting a stopped Dedicated agent on a one-slot node fails because provisioning counts its retained node locator against the slot it just released. Clear retired compute placement when admitting a stopped agent to provisioning, preserving its database, snapshot and backup state. Generic and restore-fenced admission share the same transition; sleeping and unresolved generations retain their existing behavior.

Risk: medium, because this changes placement during restart. No schema, capacity, provider policy, frontend, runtime image or secret changes. Rollback is the prior provisioning-worker revision.

Validation at `fcfc89afaebbae0ce622a4f5ceec6537c3631658`, based on current develop `509e1c034c04a1cd5bcb213a15b675edf3a29afb`, with no conflicts:

- Real PGlite reproduction failed before the change: workload count became 1 immediately after admission on the released one-slot node; expected 0. It passes after the change.
- Readiness/admission: 25 passed; workload reconciliation: 6 passed; restore authority: 50 passed. Total: 81 tests, 441 assertions, no failures.
- `bun run verify` exited 0, including workspace typecheck/lint and repository audits. Focused Biome and `git diff --check` passed.
- Existing installation and unchanged dependency lockfile were retained. No dependency update or reinstall was needed for this two-file fix.

Run each focused file separately with `DATABASE_URL=pglite://memory NODE_ENV=test bun --config=packages/scripts/bunfig.script-tests.toml test <file> --timeout 60000`:

```
packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
packages/cloud/shared/src/lib/services/docker-node-workload-reconciliation.pglite.test.ts
packages/cloud/shared/src/lib/services/eliza-sandbox-restore-authority.pglite.test.ts
```

<!-- evidence-head:fcfc89afaebbae0ce622a4f5ceec6537c3631658 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes; the observed production failure and DB transition are documented below.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend admission change; live lifecycle acceptance is tracked separately from source validation.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interaction implementation changes.
<!-- evidence-row:backend-logs -->
- [x] Production before-fix observation: suspend completed, backup created, allocation released; explicit resume ended in `Sandbox creation failed: Exact-success Docker replacement requires a durably pinned database node`. The real PGlite regression reproduces the erroneous count without replacing the repository or workload query.

<details><summary>Observed production lifecycle result before the fix</summary>

```text
Suspend job: completed at 2026-09-12 10:07:41 UTC; backup persisted before stop.
QA node: healthy, enabled, capacity 1, allocated_count 0 after suspension.
Resume job: failed at 2026-09-12 10:13:49 UTC; agent status error.
Error: Sandbox creation failed: Exact-success Docker replacement requires a durably pinned database node
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Normal UI suspend POST returned 202. Reload stayed stopped; connection retry submitted no resume. Explicit Start submitted one resume, which failed as above.

<details><summary>Observed UI and request metadata before the fix</summary>

```text
Settings → Shut down Eliza: POST /api/v1/eliza/agents/[owned-agent]/suspend returned 202.
Full reload: "Your agent is shut down. Start your Dedicated agent to continue."
Retry connection: two session-refresh POSTs; no compute mutation and no resume job.
Explicit Start: one resume job admitted, then the startup-failure alert above.
```

</details>

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, inference provider or runtime change.
<!-- evidence-row:domain-artifacts -->
- [x] Real DB regression: stopped node allocation 0 → admitted provisioning allocation 0; retired sandbox/node/container/ports cleared; managed DB URI/status, snapshot ID and backup timestamp retained. Exact restore capture admits the same transition; foreign and stale capture still reject.

<details><summary>Real PGlite admission and recovery assertions</summary>

```text
Regression: stopped resume leaves its released one-slot node available and preserves recovery data.
Before fix: allocated workload count 0 while stopped, 1 immediately after provisioning admission (FAIL; expected 0).
After fix: allocated workload count 0 while stopped, 0 immediately after provisioning admission (PASS).
Managed DB status/URI, snapshot ID and backup timestamp retain their seeded values.
Readiness/admission: 25 PASS; workload reconciliation: 6 PASS; restore authority: 50 PASS.
Total: 81 PASS, 0 FAIL, 441 assertions. Root bun run verify: exit 0.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

Known gaps: staging and production worker deployment and post-deploy UI Stop → Start/history acceptance are pending. Local tests are not a claim of deployed repair. The existing failed production test agent retains its verified backup. Shared/Telegram and first-ever Google signup are outside this fix.

Hosted CI status at source merge preparation: [run 34688481222](https://github.com/elizaOS/eliza/actions/runs/34688481222) is still running its four checks (dependency installation/core build), not failed or passed. The owner-authorized normal merge relies on completed local root verification and the 81 focused tests; hosted results will still be followed. Staging worker [34688490624](https://github.com/elizaOS/eliza/actions/runs/34688490624) is deploying the exact reviewed source. Merge previews into current staging and main both produce the same source tree `cbcfb9f8dbd57f760d8841a9a7b85b0495341090`, with only the two intended files changed. Production activation remains pending staging acceptance.
