### PR TITLE
chore(release): promote Dedicated resume slot fix to staging

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -6,6 +6,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { pushSchema } from "drizzle-kit/api";
 import { eq, sql } from "drizzle-orm";
+import { countAllocatedWorkloadsOnNodeWithDatabase } from "../../../lib/services/docker-node-workload-queries";
 import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import { agentSandboxes, WARM_POOL_ORG_ID, WARM_POOL_USER_ID } from "../../schemas/agent-sandboxes";
 import { apiKeys } from "../../schemas/api-keys";
@@ -65,6 +66,13 @@ beforeAll(async () => {
   await apply();
   const { getPgliteClientForTests } = await import("../../client");
   await installOrganizationPolicyTestSchema((query) => getPgliteClientForTests().exec(query));
+  await dbWrite.execute(sql`
+    CREATE TABLE IF NOT EXISTS containers (
+      id uuid PRIMARY KEY,
+      node_id text,
+      status text NOT NULL
+    )
+  `);
   await repository.countAllPoolEntries({ image: IMAGE });
 
   // Replenish reads the tenant-starvation guard inputs (queued tenant jobs +
@@ -715,12 +723,64 @@ test(
 );
 
 test(
+  "stopped resume leaves its released one-slot node available and preserves recovery data",
+  async () => {
+    const id = await seedUserAgent();
+    const lastBackupAt = new Date("2026-09-12T10:07:33.122Z");
+    await dbWrite.update(dockerNodes).set({ capacity: 1 }).where(eq(dockerNodes.node_id, "node-1"));
+    try {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          status: "stopped",
+          sandbox_id: "retired-sandbox",
+          container_name: "retired-container",
+          node_id: "node-1",
+          bridge_port: 18791,
+          web_ui_port: 20001,
+          database_status: "ready",
+          database_uri: "postgresql://retained.invalid/agent",
+          snapshot_id: "retained-snapshot",
+          last_backup_at: lastBackupAt,
+        })
+        .where(eq(agentSandboxes.id, id));
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, "node-1")).toBe(0);
+
+      const admitted = await repository.trySetProvisioning(id);
+
+      expect(admitted?.status).toBe("provisioning");
+      expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, "node-1")).toBe(0);
+      expect(admitted?.node_id).toBeNull();
+      expect(admitted?.sandbox_id).toBeNull();
+      expect(admitted?.container_name).toBeNull();
+      expect(admitted?.bridge_port).toBeNull();
+      expect(admitted?.web_ui_port).toBeNull();
+      expect(admitted?.database_status).toBe("ready");
+      expect(admitted?.database_uri).toBe("postgresql://retained.invalid/agent");
+      expect(admitted?.snapshot_id).toBe("retained-snapshot");
+      expect(admitted?.last_backup_at?.toISOString()).toBe(lastBackupAt.toISOString());
+    } finally {
+      await dbWrite
+        .update(dockerNodes)
+        .set({ capacity: 16 })
+        .where(eq(dockerNodes.node_id, "node-1"));
+    }
+  },
+  PGLITE_TIMEOUT,
+);
+
+test(
   "restore admission rejects foreign and stale capture before accepting exact authority",
   async () => {
     const id = await seedUserAgent();
     await dbWrite
       .update(agentSandboxes)
-      .set({ status: "stopped" })
+      .set({
+        status: "stopped",
+        sandbox_id: "retired-restore-sandbox",
+        container_name: "retired-restore-container",
+        node_id: "node-1",
+      })
       .where(eq(agentSandboxes.id, id));
     const capture = await persistedAgent(id);
     expect(
@@ -736,9 +796,10 @@ test(
       }),
     ).toBeUndefined();
     expect((await persistedAgent(id)).status).toBe("stopped");
-    expect((await repository.trySetProvisioningFromRestoreCapture(capture))?.status).toBe(
-      "provisioning",
-    );
+    const admitted = await repository.trySetProvisioningFromRestoreCapture(capture);
+    expect(admitted?.status).toBe("provisioning");
+    expect(admitted?.node_id).toBeNull();
+    expect(await countAllocatedWorkloadsOnNodeWithDatabase(dbWrite, "node-1")).toBe(0);
   },
   PGLITE_TIMEOUT,
 );

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -391,18 +391,24 @@ function warmPoolGenerationConditions(expected: WarmPoolRuntimeGeneration): SQL[
 /** Keep generic and restore-fenced provisioning transitions byte-equivalent. */
 function provisioningAdmissionUpdatePayload() {
   const permanentProvisionFailure = sql`${agentSandboxes.status} = 'error' AND ${agentSandboxes.error_message} LIKE 'Provisioning permanently failed%'`;
+  // Stop retains the retired locator while the agent is off. Once explicit
+  // provisioning is admitted, keeping that node would count the new
+  // `provisioning` row against its own freed slot before placement can run.
+  // Recovery data stays on the row; unresolved and sleeping generations keep
+  // their existing handle semantics.
+  const retiredPlacement = sql`${agentSandboxes.status} = 'stopped' OR (${permanentProvisionFailure})`;
   return {
     status: "provisioning" as const,
     updated_at: new Date(),
     error_message: null,
-    sandbox_id: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.sandbox_id} END`,
-    bridge_url: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.bridge_url} END`,
-    health_url: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.health_url} END`,
-    node_id: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.node_id} END`,
-    container_name: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.container_name} END`,
-    bridge_port: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.bridge_port} END`,
-    web_ui_port: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.web_ui_port} END`,
-    headscale_ip: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.headscale_ip} END`,
+    sandbox_id: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.sandbox_id} END`,
+    bridge_url: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.bridge_url} END`,
+    health_url: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.health_url} END`,
+    node_id: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.node_id} END`,
+    container_name: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.container_name} END`,
+    bridge_port: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.bridge_port} END`,
+    web_ui_port: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.web_ui_port} END`,
+    headscale_ip: sql`CASE WHEN ${retiredPlacement} THEN NULL ELSE ${agentSandboxes.headscale_ip} END`,
   };
 }
 


### PR DESCRIPTION
Promote the Dedicated resume fix from #31132 to staging. Starting an agent on a one-slot node must not count its retired stopped placement against the released slot; database and backup state remain intact.

Source: develop `cf632311338fb366e69bb0a09ba37c19400675c7`, tree `cbcfb9f8dbd57f760d8841a9a7b85b0495341090`. This is the same tree as tested fix `fcfc89afaebbae0ce622a4f5ceec6537c3631658`; the merge into current staging is conflict-free and changes only the two intended repository/test files.

Validation: 81 real PGlite readiness/capacity/restore tests and full `bun run verify` passed. Detailed inline evidence and the still-running hosted checks are in #31132. Canonical staging worker [34688490624](https://github.com/elizaOS/eliza/actions/runs/34688490624) is deploying this exact source for live Stop → Start/history acceptance. Production activation waits for that result.

No frontend, schema, agent-image, capacity or secret changes. No additional Cloud API/Pages build is requested for this worker-only fix.
