### PR TITLE
fix(app): await dedicated resume restoration before chat

### DIFF
--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -281,7 +281,10 @@ function createMockCloud(state: MockCloudState): Server {
     }
 
     // ── control plane ──────────────────────────────────────────────────────
-    if (path.startsWith("/api/v1/eliza/agents")) {
+    if (
+      path.startsWith("/api/v1/eliza/agents") ||
+      path.startsWith("/api/v1/jobs/")
+    ) {
       if (auth !== `Bearer ${AUTH_TOKEN}`) {
         json(res, 401, { error: "unauthorized", success: false });
         return;
@@ -313,6 +316,19 @@ function createMockCloud(state: MockCloudState): Server {
             status: "queued",
             message: "Agent resume enqueued",
           },
+        });
+        return;
+      }
+      const job = /^\/api\/v1\/jobs\/job-(.+)$/.exec(path);
+      if (job && method === "GET") {
+        const agent = state.agents.get(job[1]);
+        if (!agent?.resumeRequested) {
+          json(res, 404, { success: false, error: "unknown resume job" });
+          return;
+        }
+        json(res, 200, {
+          success: true,
+          data: { id: `job-${agent.id}`, status: "completed" },
         });
         return;
       }

--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -68,6 +68,102 @@ function fakeClient(mocks: Record<string, unknown>): ElizaClient {
 
 const FAST = { pollIntervalMs: 1, timeoutMs: 60 };
 
+describe("waitForCloudAgentRunning — resume restoration", () => {
+  it("waits for the accepted restore job before returning a fresh running record", async () => {
+    let restored = false;
+    const getCloudCompatJobStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        data: { status: "in_progress", state: "restoring" },
+      })
+      .mockImplementationOnce(async () => {
+        restored = true;
+        return {
+          success: true,
+          data: { status: "completed", state: "completed" },
+        };
+      });
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus,
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent({
+          webUiUrl: restored
+            ? "https://restored.example.test"
+            : "https://not-restored.example.test",
+        }),
+      })),
+    });
+
+    const agent = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      pollIntervalMs: 1,
+      timeoutMs: 1_000,
+    });
+
+    expect(agent.webUiUrl).toBe("https://restored.example.test");
+    expect(getCloudCompatJobStatus).toHaveBeenCalledWith("resume-1");
+  });
+
+  it("surfaces a failed restore even when the proxy already reports running", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => ({
+        success: true,
+        data: { status: "failed", error: "Backup restore failed" },
+      })),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent(),
+      })),
+    });
+
+    await expect(
+      waitForCloudAgentRunning(client, { agentId: "agent-1", ...FAST }),
+    ).rejects.toMatchObject({
+      phase: "provision-job",
+      jobId: "resume-1",
+      message: "Your cloud agent failed to start: Backup restore failed",
+    });
+  });
+
+  it("honors cancellation while following the accepted resume job", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("cancelled", "AbortError");
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => {
+        controller.abort(reason);
+        return { success: true, data: { status: "in_progress" } };
+      }),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent(),
+      })),
+    });
+
+    await expect(
+      waitForCloudAgentRunning(client, {
+        agentId: "agent-1",
+        signal: controller.signal,
+        ...FAST,
+      }),
+    ).rejects.toBe(reason);
+    expect(client.getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+});
+
 describe("waitForCloudAgentRunning — typed non-transient failures", () => {
   it("surfaces a resolved resume rejection instead of entering the status poll", async () => {
     const client = fakeClient({

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -4164,17 +4164,13 @@ function isTerminalFailedCloudAgent(agent: CloudCompatAgent): boolean {
 }
 
 /**
- * Wait for a dedicated cloud agent to report `running` on the control plane,
- * kicking a resume first so a stopped/suspended container actually boots.
+ * Resume a dedicated cloud agent, await its accepted restore job, then return
+ * the fresh running record so callers bind its current URLs.
  *
- * The resume kick is best-effort: an agent already starting answers with an
- * idempotent "already in progress" envelope, and the dedicated-agent proxy
- * auto-resumes on first request anyway — the poll below is the source of
- * truth. Transient poll errors are tolerated (the timeout bounds them).
- *
- * Resolves with the FRESH agent record (post-wake URLs), so callers bind the
- * base the running container actually reports, not the stale list entry.
- * Throws on failed/deletion statuses and on timeout.
+ * A running row enables proxy reachability before backup restoration finishes.
+ * The admitted job is therefore the readiness authority when available;
+ * already-running and lost-response compatibility paths use the bounded status
+ * poll. Both waits share one deadline and preserve cancellation and typed errors.
  */
 export async function waitForCloudAgentRunning(
   client: ElizaClient,
@@ -4235,6 +4231,18 @@ export async function waitForCloudAgentRunning(
       agentId,
       controlPlaneCode:
         failure.controlPlaneCode ?? "CLOUD_AGENT_RESUME_REJECTED",
+    });
+  }
+
+  const resumeJobId = resume?.data?.jobId;
+  if (typeof resumeJobId === "string" && resumeJobId.trim()) {
+    await waitForCloudProvisionJob(client, {
+      agentId,
+      jobId: resumeJobId,
+      pollIntervalMs,
+      timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
+      onProgress,
+      signal: options.signal,
     });
   }
 


### PR DESCRIPTION
Fixes #31135.

Starting a stopped Dedicated agent can open an empty chat while its backup is still being restored. The worker publishes `running` early to enable proxy access for restoration, so that status alone cannot establish readiness. Follow the resume response's accepted job to completion before reading and connecting to the fresh running agent record.

The existing job waiter preserves typed failures, cancellation and progress updates. Resume-job polling and the subsequent agent-status poll share the existing overall timeout. Already-running responses without a job ID and lost-response compatibility keep their current behavior. No worker ordering, agent image, schema, capacity, authentication policy or rendered component changes.

Risk: medium, because this changes when the client connects after a restart. A failed restoration now surfaces immediately instead of opening chat prematurely. Rollback is the previous frontend release.

Validation at `191cc7881991b204dc30403c15c765028c232bd2`, based on freshly fetched develop `cf632311338fb366e69bb0a09ba37c19400675c7`, with no conflicts or dependency changes:

- Three regression tests failed before the fix: returning an early running record, ignoring restore failure, and ignoring cancellation during restore. All pass afterward.
- 76 tests passed across the real client/mock HTTP integration, typed wake errors, agent selection/provisioning, progress-copy and startup-failure suites. No failed or skipped tests in those six files.
- Root `bun run verify` exited 0, including workspace typecheck, lint and repository audits. Focused Biome and `git diff --check` passed.
- Existing installation and unchanged dependency lockfile retained under the owner's request for a focused repair.
- `bun run --cwd packages/app audit:app` exited 0: 226 tests passed. OCR evaluated 220 captures: 208 verified, 0 broken, 12 need manual review, 0 regressions. The affected chat-shell and Settings desktop/mobile captures are manually reviewed and OCR-verified.
- Actual ordinary local Bun UI against the staging Dedicated backend passed normal Stop → reload stays stopped → explicit Start → all 31 original messages immediately available without a recovery reload. A real recall returned all four saved details. All 33 messages then matched after desktop 1440×900 and mobile 390×844 reloads. No horizontal page overflow; mobile reply and composer visibly inspected. Reply was observed settled at 71,513 ms, not an exact latency measurement.

<!-- evidence-head:191cc7881991b204dc30403c15c765028c232bd2 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered component or styling changes. Before-fix behavior and timings are recorded below; full UI behavior is being checked separately.
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31136-after-mobile-chat.png)

![Desktop chat shell](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31136-after-desktop-chat.png)
![Mobile chat shell](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31136-after-mobile-chat.png)
![Desktop Settings](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31136-after-desktop-settings.png)
![Mobile Settings](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31136-after-mobile-settings.png)
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - owner-authorized accelerated evidence scope for this API readiness fix; no separate MP4 captured. Real UI lifecycle and history proof are documented under domain artifacts.
<!-- evidence-row:backend-logs -->
- [x] Actual staging lifecycle timing establishes the premature-running interval:

```text
Resume job admitted: 2026-09-12 10:36:53.539 UTC.
Agent running published: 2026-09-12 10:37:36.918 UTC.
Resume job completed: 2026-09-12 10:37:59.082 UTC.
UI opened empty during restoration; a later reload recovered all 26 original messages.
```

<!-- evidence-row:frontend-logs -->
- [x] Real client regression and HTTP integration results:

```text
Before source fix: 3 resume-restoration regressions failed.
After fix: typed wake + HTTP integration, 38 passed.
Selection/provisioning + progress copy + startup recovery, 38 passed.
Root bun run verify: exit 0. Focused Biome: 3 files checked, no errors.
```

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, inference-provider or runtime changes. Real post-restart recall passed: “Project Juniper, kickoff Monday, restart-check code Maple-604, and the color amber.”
<!-- evidence-row:domain-artifacts -->
- [x] Regression verifies fresh post-restoration URL selection, failed restore propagation and abort handling. The real local UI completed shutdown and restart with its verified backup and full history:

```text
Baseline conversation: 31 visible messages, including Maple-604 / amber recall.
Suspend job 208491af-f9d2-41db-9db6-3bb4cb115953 completed 11:00:22.754 UTC.
Backup 0b467d21-8436-4479-b7dd-e26377410434 created 11:00:12.670 UTC; 17,616,324 bytes.
Full reload stayed stopped; explicit Start admitted resume job cdc4c15d-05c1-4742-a59c-8a9feec10bd1.
Resume job completed 11:01:48.129 UTC; elapsed 47.492 seconds.
Chat opened without a recovery reload; exact 31-message equality.
Real recall returned all four details; exact 33-message equality after desktop/mobile reloads.
```

<!-- evidence-row:ocr-review -->
- [x] [OCR and manual review receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31136-ocr-review.json): 220 captures evaluated, 0 broken or new regressions. All four affected chat-shell/Settings desktop/mobile captures are OCR-verified and manually inspected. The 12 remaining needs-eyeball captures are unrelated views unchanged by this fix.

Release plan: local lifecycle acceptance passed; promote normally through develop and staging, run the canonical staging Cloud deployment to obtain the exact-tree certificate, then promote and deploy production. Production worker run 34689350357 stopped before deployment because the previous backend-only tree lacked that certificate. No certification bypass or additional server is part of this fix. Shared/Telegram and first-ever Google signup remain separate acceptance items.

Hosted CI at merge preparation: run34689985249 is in progress; Subscription authority PostgreSQL passed, the other three checks are still running. Local full verification, focused tests and real UI acceptance above are complete. The owner-authorized normal merge uses that completed local evidence; hosted results remain separately tracked. The earlier backend fix PR31132 now has all hosted checks passing.

