### PR TITLE
fix(release): promote dedicated resume readiness to staging

### DIFF
--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -281,7 +281,10 @@ function createMockCloud(state: MockCloudState): Server {
     }
 
     // ── control plane ──────────────────────────────────────────────────────
-    if (path.startsWith("/api/v1/eliza/agents")) {
+    if (
+      path.startsWith("/api/v1/eliza/agents") ||
+      path.startsWith("/api/v1/jobs/")
+    ) {
       if (auth !== `Bearer ${AUTH_TOKEN}`) {
         json(res, 401, { error: "unauthorized", success: false });
         return;
@@ -313,6 +316,19 @@ function createMockCloud(state: MockCloudState): Server {
             status: "queued",
             message: "Agent resume enqueued",
           },
+        });
+        return;
+      }
+      const job = /^\/api\/v1\/jobs\/job-(.+)$/.exec(path);
+      if (job && method === "GET") {
+        const agent = state.agents.get(job[1]);
+        if (!agent?.resumeRequested) {
+          json(res, 404, { success: false, error: "unknown resume job" });
+          return;
+        }
+        json(res, 200, {
+          success: true,
+          data: { id: `job-${agent.id}`, status: "completed" },
         });
         return;
       }

--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -68,6 +68,102 @@ function fakeClient(mocks: Record<string, unknown>): ElizaClient {
 
 const FAST = { pollIntervalMs: 1, timeoutMs: 60 };
 
+describe("waitForCloudAgentRunning — resume restoration", () => {
+  it("waits for the accepted restore job before returning a fresh running record", async () => {
+    let restored = false;
+    const getCloudCompatJobStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        data: { status: "in_progress", state: "restoring" },
+      })
+      .mockImplementationOnce(async () => {
+        restored = true;
+        return {
+          success: true,
+          data: { status: "completed", state: "completed" },
+        };
+      });
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus,
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent({
+          webUiUrl: restored
+            ? "https://restored.example.test"
+            : "https://not-restored.example.test",
+        }),
+      })),
+    });
+
+    const agent = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      pollIntervalMs: 1,
+      timeoutMs: 1_000,
+    });
+
+    expect(agent.webUiUrl).toBe("https://restored.example.test");
+    expect(getCloudCompatJobStatus).toHaveBeenCalledWith("resume-1");
+  });
+
+  it("surfaces a failed restore even when the proxy already reports running", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => ({
+        success: true,
+        data: { status: "failed", error: "Backup restore failed" },
+      })),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent(),
+      })),
+    });
+
+    await expect(
+      waitForCloudAgentRunning(client, { agentId: "agent-1", ...FAST }),
+    ).rejects.toMatchObject({
+      phase: "provision-job",
+      jobId: "resume-1",
+      message: "Your cloud agent failed to start: Backup restore failed",
+    });
+  });
+
+  it("honors cancellation while following the accepted resume job", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("cancelled", "AbortError");
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => {
+        controller.abort(reason);
+        return { success: true, data: { status: "in_progress" } };
+      }),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent(),
+      })),
+    });
+
+    await expect(
+      waitForCloudAgentRunning(client, {
+        agentId: "agent-1",
+        signal: controller.signal,
+        ...FAST,
+      }),
+    ).rejects.toBe(reason);
+    expect(client.getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+});
+
 describe("waitForCloudAgentRunning — typed non-transient failures", () => {
   it("surfaces a resolved resume rejection instead of entering the status poll", async () => {
     const client = fakeClient({

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -4164,17 +4164,13 @@ function isTerminalFailedCloudAgent(agent: CloudCompatAgent): boolean {
 }
 
 /**
- * Wait for a dedicated cloud agent to report `running` on the control plane,
- * kicking a resume first so a stopped/suspended container actually boots.
+ * Resume a dedicated cloud agent, await its accepted restore job, then return
+ * the fresh running record so callers bind its current URLs.
  *
- * The resume kick is best-effort: an agent already starting answers with an
- * idempotent "already in progress" envelope, and the dedicated-agent proxy
- * auto-resumes on first request anyway — the poll below is the source of
- * truth. Transient poll errors are tolerated (the timeout bounds them).
- *
- * Resolves with the FRESH agent record (post-wake URLs), so callers bind the
- * base the running container actually reports, not the stale list entry.
- * Throws on failed/deletion statuses and on timeout.
+ * A running row enables proxy reachability before backup restoration finishes.
+ * The admitted job is therefore the readiness authority when available;
+ * already-running and lost-response compatibility paths use the bounded status
+ * poll. Both waits share one deadline and preserve cancellation and typed errors.
  */
 export async function waitForCloudAgentRunning(
   client: ElizaClient,
@@ -4235,6 +4231,18 @@ export async function waitForCloudAgentRunning(
       agentId,
       controlPlaneCode:
         failure.controlPlaneCode ?? "CLOUD_AGENT_RESUME_REJECTED",
+    });
+  }
+
+  const resumeJobId = resume?.data?.jobId;
+  if (typeof resumeJobId === "string" && resumeJobId.trim()) {
+    await waitForCloudProvisionJob(client, {
+      agentId,
+      jobId: resumeJobId,
+      pollIntervalMs,
+      timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
+      onProgress,
+      signal: options.signal,
     });
   }
 


### PR DESCRIPTION
Promote #31136 so the Dedicated client waits for backup restoration before opening chat. Source develop `a4654aa68d64f6ca8405e1dbc7bd4b821af364ea`; the merge preview produces tested tree `83b5b85734e16ff652884c3dc29ad8438d60116c`, with only the three reviewed client/test files changing from staging.

Validation: 76 focused tests, full `bun run verify`, and the 226-test app audit passed. OCR found no broken captures or regressions; affected desktop/mobile captures were manually inspected. Real ordinary local Bun UI against the staging Dedicated backend passed Stop, reload stays stopped, explicit Start, exact 31-message restoration without an extra reload, a real four-fact recall, and exact 33-message history after desktop/mobile reloads. Resume job completed in 47.492 seconds; the reply was observed settled at 71.513 seconds, not an exact latency measurement. [Reviewed source and inline evidence](https://github.com/elizaOS/eliza/pull/31136).

This is the normal owner-authorized release promotion. Hosted source CI34689985249 remains in progress separately from completed local validation. After merge, run the canonical staging Cloud deployment for this tree and obtain its actual release certificate before production effects. No agent-image, infrastructure, capacity, secret, schema or provider change. Rollback is the previous frontend release; production remains on its prior release until separately deployed and tested.
