### PR TITLE
test(ui): repair cross-realm Blob stub so download-share picker-cancel test proves the pickerOpened gate

### DIFF
--- a/packages/ui/src/utils/download-share.test.ts
+++ b/packages/ui/src/utils/download-share.test.ts
@@ -324,6 +324,38 @@ describe("downloadAttachment — <a download> fallback path", () => {
     expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("saves through the picker and never fires the anchor fallback", async () => {
+    // Supply the blob directly so the picker branch's success path — the only
+    // path none of the other picker tests exercise — runs end to end:
+    // prefetch → open picker → createWritable → write(blob) → close → return.
+    const blob = new Blob(["hello"], { type: "image/png" });
+    const fetchMock = vi.fn(async () => ({ ok: true, blob: async () => blob }));
+    vi.stubGlobal("fetch", fetchMock);
+    const writable = {
+      write: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+    };
+    const handle = { createWritable: vi.fn(async () => writable) };
+    const picker = vi.fn(async () => handle);
+    vi.stubGlobal("window", { showSaveFilePicker: picker });
+
+    await withGlobal("Capacitor", undefined, () =>
+      downloadAttachment("https://example.com/cat.png", "cat.png"),
+    );
+
+    // The chosen-location save runs to completion: picker opens, a writable is
+    // created, the prefetched blob is written, and the stream is closed.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(picker).toHaveBeenCalledWith({ suggestedName: "cat.png" });
+    expect(handle.createWritable).toHaveBeenCalledTimes(1);
+    expect(writable.write).toHaveBeenCalledWith(blob);
+    expect(writable.close).toHaveBeenCalledTimes(1);
+    // A successful save must return before the anchor fallback — guarding the
+    // double-download the picker branch exists to avoid.
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
   it("does not start an anchor download when the user cancels the picker", async () => {
     // Use a string body so the Node-global `Response` constructs its own
     // spec-compliant Blob. A jsdom cross-realm `new Blob([...])` lacks the

--- a/packages/ui/src/utils/download-share.test.ts
+++ b/packages/ui/src/utils/download-share.test.ts
@@ -359,8 +359,9 @@ describe("downloadAttachment — <a download> fallback path", () => {
   it("does not start an anchor download when the user cancels the picker", async () => {
     // Use a string body so the Node-global `Response` constructs its own
     // spec-compliant Blob. A jsdom cross-realm `new Blob([...])` lacks the
-    // `.stream()` undici `Response.blob()` requires, which would make the
-    // prefetch throw before the picker ever opens and silently reroute this
+    // `.stream()` undici's `Response` requires to read a `Blob` body, so
+    // `new Response(new Blob([...]))` throws (`object.stream is not a
+    // function`) before the picker ever opens and silently reroutes this
     // scenario through the anchor path — masking the picker-cancel contract.
     const fetchMock = vi.fn(async () => new Response("hello"));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/ui/src/utils/download-share.test.ts
+++ b/packages/ui/src/utils/download-share.test.ts
@@ -325,21 +325,31 @@ describe("downloadAttachment — <a download> fallback path", () => {
   });
 
   it("does not start an anchor download when the user cancels the picker", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response(new Blob(["hello"]))),
-    );
-    vi.stubGlobal("window", {
-      showSaveFilePicker: vi.fn(async () => {
-        throw new DOMException("The user aborted a request", "AbortError");
-      }),
+    // Use a string body so the Node-global `Response` constructs its own
+    // spec-compliant Blob. A jsdom cross-realm `new Blob([...])` lacks the
+    // `.stream()` undici `Response.blob()` requires, which would make the
+    // prefetch throw before the picker ever opens and silently reroute this
+    // scenario through the anchor path — masking the picker-cancel contract.
+    const fetchMock = vi.fn(async () => new Response("hello"));
+    vi.stubGlobal("fetch", fetchMock);
+    const picker = vi.fn(async () => {
+      throw new DOMException("The user aborted a request", "AbortError");
     });
+    vi.stubGlobal("window", { showSaveFilePicker: picker });
 
     await withGlobal("Capacitor", undefined, () =>
       downloadAttachment("https://example.com/cat.png", "cat.png"),
     );
 
+    // The prefetch must succeed and the picker must actually open before the
+    // user cancels it — this is what distinguishes picker-cancel from a
+    // prefetch failure (the `pickerOpened` gate in download-share.ts).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(picker).toHaveBeenCalledTimes(1);
+    expect(picker).toHaveBeenCalledWith({ suggestedName: "cat.png" });
+    // A cancelled picker must return early, never firing the anchor fallback.
     expect(clickSpy).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
# Relates to

Closes #31035

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync. The full `bun run verify` gate is
      blocked by a pre-existing, unrelated `@elizaos/login` build-order
      typecheck red on `develop`, documented in **Known gaps / failures**; the
      owning package's focused test and Biome lint were run to completion.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after vitest output attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] The exact unrelated blocker to a clean `bun run verify` (a pre-existing
      `@elizaos/login` build-order typecheck red, identical on the unmodified
      develop tip) is documented in **Known gaps / failures** below.

# Risks

Low. Test-only change to a single file
(`packages/ui/src/utils/download-share.test.ts`). No production source is
touched, so runtime behavior is unchanged. The only risk surface is the test's
own fidelity, which this PR increases by making the picker-cancel assertion
genuinely reachable.

# Background

## What does this PR do?

Repairs a permanently-red (shipped-red on `develop`) test in the elizaOS UI
download-share suite:

> `downloadAttachment — <a download> fallback path` ›
> `does not start an anchor download when the user cancels the picker`

The test stubbed `fetch` with a **jsdom cross-realm Blob** body:

```ts
vi.stubGlobal("fetch", vi.fn(async () => new Response(new Blob(["hello"]))));
```

`@vitest-environment jsdom` provides jsdom's `Blob`, but the `Response`
constructor in scope is the Node/undici global — a **different realm**. undici's
`Response.blob()` requires a spec `Blob` exposing `.stream()`, which jsdom's
`Blob` does not. So `fetchDownloadBlob` threw *inside the picker branch* of
`downloadAttachment` **before the picker opened**. The `catch` (correctly)
treated that as a prefetch failure and fell through to the anchor path, firing
the anchor `click` — even though the scenario is "user cancels the picker". The
assertion `expect(clickSpy).not.toHaveBeenCalled()` therefore failed on every
tip, not as a recent regression.

The **production code is correct**: the `pickerOpened` gate at
`packages/ui/src/utils/download-share.ts:345-361` already distinguishes a
picker-cancel (return early, no double-download) from a prefetch failure (fall
through to the anchor). The defect was purely in the test stub.

The fix switches the stub to a **string body** so the Node-global `Response`
constructs its own spec-compliant `Blob`:

```ts
const fetchMock = vi.fn(async () => new Response("hello"));
```

and strengthens the test so it now **proves** the `pickerOpened` gating
contract rather than merely asserting a side effect:

- `expect(fetchMock).toHaveBeenCalledTimes(1)` — the prefetch succeeded;
- `expect(picker).toHaveBeenCalledTimes(1)` and
  `expect(picker).toHaveBeenCalledWith({ suggestedName: "cat.png" })` — the
  picker actually opened (so `pickerOpened === true`);
- `expect(clickSpy).not.toHaveBeenCalled()` and
  `expect(removeSpy).not.toHaveBeenCalled()` — the `AbortError` early-return
  fired and the anchor fallback did **not**.

These added assertions make the test strictly stronger than the minimal
one-line body swap: it now fails both on the original cross-realm-Blob stub
defect (the picker is never reached) **and** on any future regression of the
`pickerOpened` gate.

## What kind of change is this?

Bug fixes (non-breaking change which fixes a shipped-red test). Test-only.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/utils/download-share.test.ts`, the test
`does not start an anchor download when the user cancels the picker`. Compare
against the production gate at `packages/ui/src/utils/download-share.ts:345-361`.

## Detailed testing steps

From `packages/ui`:

```bash
# BEFORE (revert the single test file to develop's version) → RED
npx vitest run src/utils/download-share.test.ts

# AFTER (this PR) → GREEN
npx vitest run src/utils/download-share.test.ts
```

# Evidence Gate

<!-- evidence-head:cd960500f200c92968b84755ad5952dd11927cc0 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - test-only change; no rendered UI surface. The diff touches a single
      `.test.ts` file and zero `.tsx`/`.css`/`.svg` source.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - test-only change; no rendered UI surface (see above).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - test-only change; no user flow to record. The before/after vitest
      output below is the complete proof.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend/server path; this is a frontend unit-test harness fix.
<!-- evidence-row:frontend-logs -->
- [x] Focused vitest test-runner output for the repaired suite. There is no
      browser/console runtime path (test-harness fix), so the runner output is
      the applicable frontend proof. It is pasted inline below and also attached
      as immutable, GitHub-hosted generated artifacts on a fork release
      (agent-cortex lacks push access to the canonical `pr-evidence` release —
      see **Known gaps**):
      [BEFORE develop stub → RED](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-download-share-vitest-before-develop.txt),
      [AFTER this PR → GREEN](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-download-share-vitest-after.txt),
      [pickerOpened mutation → only the cancel case fails](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-download-share-vitest-mutation.txt),
      [jsdom/undici Response(Blob) probe](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-jsdom-undici-response-blob-probe.txt).

  <details><summary>vitest output — repaired suite after this PR (23/23 green)</summary>

  ```
   RUN  v4.1.10 /packages/ui

   Test Files  1 passed (1)
        Tests  23 passed (23)
     Start at  17:11:19
     Duration  1.95s (transform 161ms, setup 144ms, import 107ms, tests 56ms, environment 1.36s)
  ```

  </details>
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model code is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB rows, memories, scheduled tasks, files, or on-chain output;
      the domain artifact is the vitest result attached below.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this test-only diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model code is touched.`

## Backend + frontend logs

Backend: `N/A - no server path`.

Frontend / test runner output:

<details>
<summary>BEFORE — develop's stub (cross-realm Blob) → RED (1 failed / 22)</summary>

```
 RUN  v4.1.10 /packages/ui

 ❯ src/utils/download-share.test.ts (22 tests | 1 failed) 50ms
     × does not start an anchor download when the user cancels the picker 9ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/utils/download-share.test.ts > downloadAttachment — <a download> fallback path > does not start an anchor download when the user cancels the picker
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array []


Number of calls: 1

 ❯ src/utils/download-share.test.ts:342:26
    340|     );
    341|
    342|     expect(clickSpy).not.toHaveBeenCalled();
       |                          ^
    343|   });
    344| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed (1)
      Tests  1 failed | 21 passed (22)
```

</details>

<details>
<summary>AFTER — this PR (string body + strengthened assertions + picker success-path test) → GREEN (23/23)</summary>

```
 RUN  v4.1.10 /packages/ui

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Start at  12:19:29
   Duration  1.72s (transform 233ms, setup 133ms, import 156ms, tests 48ms, environment 1.08s)
```

</details>

<details>
<summary>MUTATION — flip the gate `pickerOpened = true` → `false` at download-share.ts:349 → only the repaired cancel case fails (1 failed / 22)</summary>

```
 RUN  v4.1.10 /packages/ui

 ❏ src/utils/download-share.test.ts (23 tests | 1 failed) 71ms
     × does not start an anchor download when the user cancels the picker 17ms

 FAIL  src/utils/download-share.test.ts > downloadAttachment — <a download> fallback path > does not start an anchor download when the user cancels the picker
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ src/utils/download-share.test.ts:380:23

 Test Files  1 failed (1)
      Tests  1 failed | 22 passed (23)
```

The source was restored immediately after; the mutation is not part of the diff.
This discriminates the picker-cancel contract from the anchor-fallback path:
breaking the gate produces the exact double-download (anchor fires a 2nd time)
the test guards against, and no other case regresses.

</details>

<details>
<summary>PROBE — jsdom/undici Response(Blob) throw that the test's rationale comment names</summary>

```
 RUN  v4.1.10 /packages/ui

PROBE threw: TypeError: object.stream is not a function

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

`Blob.prototype.stream` is `undefined` under jsdom, so undici's `Response`
constructor throws `TypeError: object.stream is not a function` at body
extraction — before the picker opens — confirming the rationale comment at
`download-share.test.ts:360-365` on this repo's pinned toolchain.

</details>

All four runs above are attached verbatim as immutable, GitHub-hosted files:
[before](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-download-share-vitest-before-develop.txt),
[after](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-download-share-vitest-after.txt),
[mutation](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-download-share-vitest-mutation.txt),
[probe](https://github.com/agent-cortex/eliza/releases/download/pr-31138-evidence/31138-jsdom-undici-response-blob-probe.txt).

## Screenshots (before / after) + video walkthrough

### Before

`N/A - test-only change; no rendered UI surface.`

### After

`N/A - test-only change; no rendered UI surface.`

### Walkthrough video

`N/A - test-only change; no user flow to record.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT/omnivoice code is touched.`

## Known gaps / failures

- `bun run typecheck` in `packages/ui` reports **113 pre-existing errors**, all
  `TS2307 Cannot find module '@elizaos/login'` (and dependent `.tsx`/`.ts` in
  `src/login/**` and `src/cloud/**`). This is a monorepo build-order condition
  on `develop` — the `@elizaos/login` workspace is not built in this worktree.
  Verified by stashing my change and re-running: the **identical 113 errors**
  exist on the unmodified develop tip, and **zero** of them reference
  `download-share`. My test-only diff adds no new type errors.
- `bun install` completed successfully. Biome lint is clean on the changed file
  (`biome check packages/ui/src/utils/download-share.test.ts` → "No fixes
  applied"). The focused suite passes 23/23.
- I did **not** run the full repository `bun run verify` to completion because
  it is gated by the same pre-existing `@elizaos/login` typecheck red above. On
  the final rebased head I ran: `bun install` (success), the owning package's
  focused test `npx vitest run src/utils/download-share.test.ts` (23/23 green),
  and `biome check` on the changed file (clean).
- Evidence artifacts are both embedded inline above (the canonical before /
  after / mutation / probe vitest output) **and** attached as immutable,
  GitHub-hosted files on the fork release
  [`pr-31138-evidence`](https://github.com/agent-cortex/eliza/releases/tag/pr-31138-evidence).
  They are on a fork release rather than the canonical `elizaOS/eliza`
  `pr-evidence` release because uploading to that release requires push access
  to the upstream repository, which this fork-based PR's author (agent-cortex)
  does not have — `gh release upload pr-evidence …` returns `HTTP 404`. The
  captured files are the exact generated runner output for head
  `cd960500f200c92968b84755ad5952dd11927cc0` on this repo's pinned toolchain
  (vitest 4.1.10, jsdom, Node v22.22.2).

## Maintainer CI exception record

`N/A - no exception requested`

- PR head SHA: `N/A - no exception requested`
- Validated `origin/develop` SHA: `N/A - no exception requested`
- Live ruleset readback and named bypass eligibility: `N/A - no exception requested`
- Queued or failing checks and run URLs: `N/A - no exception requested`
- Infrastructure-only or unrelated-failure proof: `N/A - no exception requested`
- Exact-head commands, exit status, and artifacts: `N/A - no exception requested`
- Exact-head security, secret-scan, and provenance results: `N/A - no exception requested`
- Conflict-free and affected-path failure attestation: `N/A - no exception requested`
- Independent approving reviewer: `N/A - no exception requested`
- Bypass authorizer: `N/A - no exception requested`
- Merge method: `N/A - no exception requested`
- Rollback owner: `N/A - no exception requested`
- Post-merge `develop` validation: `N/A - no exception requested`

---
AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@cd960500f200c92968b84755ad5952dd11927cc0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@cd960500f200c92968b84755ad5952dd11927cc0:packages/skills/skills/contribute-to-eliza"} -->
