### PR TITLE
fix(cloud): promote Dedicated resume readiness to production

### DIFF
--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -281,7 +281,10 @@ function createMockCloud(state: MockCloudState): Server {
     }
 
     // ── control plane ──────────────────────────────────────────────────────
-    if (path.startsWith("/api/v1/eliza/agents")) {
+    if (
+      path.startsWith("/api/v1/eliza/agents") ||
+      path.startsWith("/api/v1/jobs/")
+    ) {
       if (auth !== `Bearer ${AUTH_TOKEN}`) {
         json(res, 401, { error: "unauthorized", success: false });
         return;
@@ -313,6 +316,19 @@ function createMockCloud(state: MockCloudState): Server {
             status: "queued",
             message: "Agent resume enqueued",
           },
+        });
+        return;
+      }
+      const job = /^\/api\/v1\/jobs\/job-(.+)$/.exec(path);
+      if (job && method === "GET") {
+        const agent = state.agents.get(job[1]);
+        if (!agent?.resumeRequested) {
+          json(res, 404, { success: false, error: "unknown resume job" });
+          return;
+        }
+        json(res, 200, {
+          success: true,
+          data: { id: `job-${agent.id}`, status: "completed" },
         });
         return;
       }

--- a/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
+++ b/packages/ui/src/api/client-cloud-wake-typed-errors.test.ts
@@ -68,6 +68,102 @@ function fakeClient(mocks: Record<string, unknown>): ElizaClient {
 
 const FAST = { pollIntervalMs: 1, timeoutMs: 60 };
 
+describe("waitForCloudAgentRunning — resume restoration", () => {
+  it("waits for the accepted restore job before returning a fresh running record", async () => {
+    let restored = false;
+    const getCloudCompatJobStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        success: true,
+        data: { status: "in_progress", state: "restoring" },
+      })
+      .mockImplementationOnce(async () => {
+        restored = true;
+        return {
+          success: true,
+          data: { status: "completed", state: "completed" },
+        };
+      });
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus,
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent({
+          webUiUrl: restored
+            ? "https://restored.example.test"
+            : "https://not-restored.example.test",
+        }),
+      })),
+    });
+
+    const agent = await waitForCloudAgentRunning(client, {
+      agentId: "agent-1",
+      pollIntervalMs: 1,
+      timeoutMs: 1_000,
+    });
+
+    expect(agent.webUiUrl).toBe("https://restored.example.test");
+    expect(getCloudCompatJobStatus).toHaveBeenCalledWith("resume-1");
+  });
+
+  it("surfaces a failed restore even when the proxy already reports running", async () => {
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => ({
+        success: true,
+        data: { status: "failed", error: "Backup restore failed" },
+      })),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent(),
+      })),
+    });
+
+    await expect(
+      waitForCloudAgentRunning(client, { agentId: "agent-1", ...FAST }),
+    ).rejects.toMatchObject({
+      phase: "provision-job",
+      jobId: "resume-1",
+      message: "Your cloud agent failed to start: Backup restore failed",
+    });
+  });
+
+  it("honors cancellation while following the accepted resume job", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("cancelled", "AbortError");
+    const client = fakeClient({
+      resumeCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: { jobId: "resume-1", status: "pending" },
+      })),
+      getCloudCompatJobStatus: vi.fn(async () => {
+        controller.abort(reason);
+        return { success: true, data: { status: "in_progress" } };
+      }),
+      getCloudCompatAgent: vi.fn(async () => ({
+        success: true,
+        data: makeAgent(),
+      })),
+    });
+
+    await expect(
+      waitForCloudAgentRunning(client, {
+        agentId: "agent-1",
+        signal: controller.signal,
+        ...FAST,
+      }),
+    ).rejects.toBe(reason);
+    expect(client.getCloudCompatAgent).not.toHaveBeenCalled();
+  });
+});
+
 describe("waitForCloudAgentRunning — typed non-transient failures", () => {
   it("surfaces a resolved resume rejection instead of entering the status poll", async () => {
     const client = fakeClient({

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -4164,17 +4164,13 @@ function isTerminalFailedCloudAgent(agent: CloudCompatAgent): boolean {
 }
 
 /**
- * Wait for a dedicated cloud agent to report `running` on the control plane,
- * kicking a resume first so a stopped/suspended container actually boots.
+ * Resume a dedicated cloud agent, await its accepted restore job, then return
+ * the fresh running record so callers bind its current URLs.
  *
- * The resume kick is best-effort: an agent already starting answers with an
- * idempotent "already in progress" envelope, and the dedicated-agent proxy
- * auto-resumes on first request anyway — the poll below is the source of
- * truth. Transient poll errors are tolerated (the timeout bounds them).
- *
- * Resolves with the FRESH agent record (post-wake URLs), so callers bind the
- * base the running container actually reports, not the stale list entry.
- * Throws on failed/deletion statuses and on timeout.
+ * A running row enables proxy reachability before backup restoration finishes.
+ * The admitted job is therefore the readiness authority when available;
+ * already-running and lost-response compatibility paths use the bounded status
+ * poll. Both waits share one deadline and preserve cancellation and typed errors.
  */
 export async function waitForCloudAgentRunning(
   client: ElizaClient,
@@ -4235,6 +4231,18 @@ export async function waitForCloudAgentRunning(
       agentId,
       controlPlaneCode:
         failure.controlPlaneCode ?? "CLOUD_AGENT_RESUME_REJECTED",
+    });
+  }
+
+  const resumeJobId = resume?.data?.jobId;
+  if (typeof resumeJobId === "string" && resumeJobId.trim()) {
+    await waitForCloudProvisionJob(client, {
+      agentId,
+      jobId: resumeJobId,
+      pollIntervalMs,
+      timeoutMs: Math.max(1, timeoutMs - (Date.now() - startedAt)),
+      onProgress,
+      signal: options.signal,
     });
   }
 


### PR DESCRIPTION
Promote #31136 so a restarting Dedicated agent finishes restoring its saved conversation before the app opens chat. Previously the worker could report running about 22 seconds before restoration completed, briefly opening an empty conversation. The client now waits for the accepted resume job and preserves cancellation, failure reporting, and the existing timeout.

The staging-to-main merge preview matches reviewed tree `83b5b85734e16ff652884c3dc29ad8438d60116c`; only the three reviewed client/test files differ from current main. The one-slot backend restart fix from #31132 is already in both branches.

Validation: 76 focused tests, full `bun run verify`, and the 226-test app audit passed. In the normal local Bun app against the real staging backend, Stop, reload while stopped, and explicit Start restored all 31 existing messages without an extra recovery reload. A real four-fact reply followed; all 33 messages survived desktop and mobile reloads. Resume took 47.492 seconds. Action-start to server reply-completion metadata was approximately 29 seconds; this is not a first-token or wire latency measurement. [Source review and evidence](https://github.com/elizaOS/eliza/pull/31136).

Release: canonical staging run [34690358973](https://github.com/elizaOS/eliza/actions/runs/34690358973) succeeded, including API, Pages freshness, routing, and certification. The canonical verifier accepted artifact `10297153939` for this exact tree, expiring September 26. The actual hosted bundle `index-D827wL-s.js` recovered the existing session and matched all 33 conversation messages exactly. Hosted source CI has three passing checks; static smoke is still running separately from completed local checks.

The newly deployed hosted client also passed a normal Stop, reload remaining stopped, explicit Start, and exact restoration of all 33 messages when chat was first opened, without an extra recovery reload. The fresh shutdown backup is `a73d5b04-0105-43d6-bb87-367e6b387213` (18,637,224 bytes).

After promotion, deploy the canonical production worker and Cloud workflows and repeat the normal production one-slot Stop/Start and full-history checks. No image, model, secret, capacity, schema, or infrastructure change is included. First-ever Google signup remains a separate unverified acceptance item.
