### PR TITLE
fix(app): recover rejected Dedicated credentials on reload

### DIFF
--- a/packages/ui/src/api/auth-client.test.ts
+++ b/packages/ui/src/api/auth-client.test.ts
@@ -20,7 +20,10 @@ import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import { getBootConfig } from "../config/boot-config";
 import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
-import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
+import {
+  isDedicatedCloudAgentBase,
+  isManagedCloudSharedAgentBase,
+} from "../utils/cloud-agent-base";
 import {
   authChangePassword,
   authListSessions,
@@ -57,6 +60,7 @@ vi.mock("../state/shared-cloud-account-binding", () => ({
   clearSharedCloudAccountBinding: vi.fn(),
 }));
 vi.mock("../utils/cloud-agent-base", () => ({
+  isDedicatedCloudAgentBase: vi.fn(() => false),
   isManagedCloudSharedAgentBase: vi.fn(),
 }));
 vi.mock("./client-cloud", () => ({
@@ -434,6 +438,7 @@ describe("authMe over plain HTTP boundaries", () => {
   beforeEach(() => {
     getBootConfigMock.mockReturnValue({ branding: {} });
     fetchWithCsrfMock.mockReset();
+    vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(false);
     isManagedCloudSharedAgentBaseMock.mockReturnValue(false);
     isDesktopExternalApiBaseUrlMock.mockReturnValue(false);
     invokeDesktopBridgeRequestMock.mockReset();
@@ -612,6 +617,56 @@ describe("authMe over plain HTTP boundaries", () => {
       access,
     });
   });
+
+  it("allows Cloud recovery when the Dedicated edge rejects a saved credential", async () => {
+    getBootConfigMock.mockReturnValue({
+      branding: {},
+      apiBase: "https://c469c32e-aba7-42bd-b834-b64ec0a83727.cloud.eliza.app",
+      apiToken: "expired-cloud-session",
+    });
+    vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(true);
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse(
+        {
+          success: false,
+          code: "cloud_auth_rejected",
+          error: "Cloud authentication failed",
+        },
+        401,
+      ),
+    );
+
+    await expect(authMe()).resolves.toEqual({
+      ok: false,
+      status: 401,
+      reason: "remote_auth_required",
+    });
+    // The proxy has already rejected this bearer. Its protected status route
+    // cannot supply a standalone pairing code; Cloud recovery owns the retry.
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { dedicated: false, code: "cloud_auth_rejected" },
+    { dedicated: true, code: "unknown_auth_error" },
+  ])(
+    "keeps unrelated rejection contracts out of Cloud recovery: %j",
+    async ({ dedicated, code }) => {
+      vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(dedicated);
+      fetchWithCsrfMock
+        .mockResolvedValueOnce(jsonResponse({ code }, 401))
+        .mockResolvedValueOnce(
+          jsonResponse({ required: true, pairingEnabled: false }),
+        );
+
+      await expect(authMe()).resolves.toEqual({
+        ok: false,
+        status: 401,
+        reason: "server_error",
+        access: undefined,
+      });
+    },
+  );
 
   it("prefers pairing when a rich remote 401 reports pairing is enabled", async () => {
     fetchWithCsrfMock

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -22,7 +22,10 @@ import { normalizeCloudApiKeyToken } from "../cloud/lib/cloud-api-key-token";
 import { getBootConfig } from "../config/boot-config";
 import { isNative } from "../platform";
 import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
-import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
+import {
+  isDedicatedCloudAgentBase,
+  isManagedCloudSharedAgentBase,
+} from "../utils/cloud-agent-base";
 import { rememberCsrfTokenForUrl } from "./auth/csrf-cookie";
 import {
   cloudTokenSecsRemaining,
@@ -560,10 +563,22 @@ export async function authMe(): Promise<AuthMeResult> {
 
   if (res.status === 401) {
     const body = (await res.json().catch(() => ({}))) as {
+      code?: string;
       reason?: string;
       access?: AuthAccessInfo;
     };
     if (!requestIsCurrent()) return { ok: false, status: 503 };
+    if (
+      !body.reason &&
+      body.code === "cloud_auth_rejected" &&
+      isDedicatedCloudAgentBase(requestBase)
+    ) {
+      // The Dedicated edge rejected the saved Cloud-shaped bearer before the
+      // runtime could return its auth contract. Keep the gate closed, but let
+      // the existing Cloud-authorized re-pair flow replace that credential.
+      // The same rejected bearer cannot query the edge's protected status route.
+      return { ok: false, status: 401, reason: "remote_auth_required" };
+    }
     const result: AuthMeResult = {
       ok: false,
       status: 401,


### PR DESCRIPTION
Fixes #31140.

A fresh hosted Dedicated tab can load its conversation and then show “Open this agent from Eliza Cloud” on ordinary reload, even while the Cloud account session remains valid. The Dedicated proxy returns `401 cloud_auth_rejected` before the runtime can provide its richer auth response. The client was translating that to `server_error`, which prevented the existing recovery hook from running.

Recognize that exact rejection only for Dedicated Cloud targets and expose the existing `remote_auth_required` result. The app stays unauthenticated while its current Cloud session authorizes re-pairing. Existing explicit runtime reasons, unrelated hosts/error codes, target-switch guards and server authorization remain unchanged. No rendered component, styling, worker, schema, infrastructure or agent-image changes.

Risk: auth recovery routing. The fix does not accept the rejected credential; it enables the existing bounded, server-authorized exchange. Rollback is the prior frontend release.

Validation at `6df2259e6dae9591b2aa3e37c2c58db132246b52`, based on current develop `a4654aa68d64f6ca8405e1dbc7bd4b821af364ea`:

- The exact production response regression fails before the fix, passes afterward. Generic and unrelated rejection contracts remain outside Cloud recovery.
- 172 tests across six auth-client, auth-state, recovery and host-classification suites pass under Node24.15.0/Bun1.3.14. Biome and diff checks pass.
- Frozen dependency verification reported no changes; install scripts were omitted because the dependency graph is unchanged and already built.
- Root `bun run verify` exited0, including workspace typecheck/lint and repository audits. The affected chat/Settings audit passed8/8 across four viewports; OCR verified8/8, zero broken or needs-eyeball captures. All eight images were manually inspected. These are shell/layout fixtures, not a substitute for hosted auth acceptance.
- The initial broad visual run was stopped under the owner-requested focused scope after a first mobile startup timeout (11 passed,1 failed,1 interrupted,213 not run). That exact mobile case and every affected layout passed the focused rerun after the existing Vite child restarted. The initial failure artifacts are preserved; this is not a claim that the broad run passed.
- The ordinary local Bun app with this source displays all33 retained messages and the prior real four-fact reply. The repaired production reload remains a release acceptance gate.

<!-- evidence-head:6df2259e6dae9591b2aa3e37c2c58db132246b52 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered diff. The real mobile failure was visually inspected; the regression receipt records the exact response and visible outcome.
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31141-after-mobile-chat.png)
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - owner-authorized accelerated evidence scope for this auth-client repair; no separate MP4. Real hosted reload verification remains required after deployment.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend source or runtime change. Observed backend contract is recorded under frontend diagnostics.
<!-- evidence-row:frontend-logs -->
- [x] [31141-frontend-logs.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31141-frontend-logs.log)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt or inference change. Prior real production restart recalled Harbor-917/teal; local33-message history includes the four-fact recall.
<!-- evidence-row:domain-artifacts -->
- [x] [31141-domain-artifacts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31141-domain-artifacts.json)
<!-- evidence-row:ocr-review -->
- [x] [31141-ocr-review.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31141-ocr-review.json)

Release through normal develop/staging promotion and the canonical exact-tree staging certificate before production. This frontend-only fix does not require restarting the provisioning worker or Dedicated agent. Shared/Telegram and first-ever signup remain separate acceptance items.



Additional reviewed fixture captures:

![Desktop chat shell](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31141-after-desktop-chat.png)
![Desktop Settings](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31141-after-desktop-settings.png)
![Mobile Settings](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31141-after-mobile-settings.png)

Hosted CI34694198691 remains in progress. Completed local checks above authorize the ordinary owner-approved merge; hosted CI is not represented as passed.


