### PR TITLE
fix(cloud): promote Dedicated reload recovery to staging

### DIFF
--- a/packages/ui/src/api/auth-client.test.ts
+++ b/packages/ui/src/api/auth-client.test.ts
@@ -20,7 +20,10 @@ import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import { getBootConfig } from "../config/boot-config";
 import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
-import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
+import {
+  isDedicatedCloudAgentBase,
+  isManagedCloudSharedAgentBase,
+} from "../utils/cloud-agent-base";
 import {
   authChangePassword,
   authListSessions,
@@ -57,6 +60,7 @@ vi.mock("../state/shared-cloud-account-binding", () => ({
   clearSharedCloudAccountBinding: vi.fn(),
 }));
 vi.mock("../utils/cloud-agent-base", () => ({
+  isDedicatedCloudAgentBase: vi.fn(() => false),
   isManagedCloudSharedAgentBase: vi.fn(),
 }));
 vi.mock("./client-cloud", () => ({
@@ -434,6 +438,7 @@ describe("authMe over plain HTTP boundaries", () => {
   beforeEach(() => {
     getBootConfigMock.mockReturnValue({ branding: {} });
     fetchWithCsrfMock.mockReset();
+    vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(false);
     isManagedCloudSharedAgentBaseMock.mockReturnValue(false);
     isDesktopExternalApiBaseUrlMock.mockReturnValue(false);
     invokeDesktopBridgeRequestMock.mockReset();
@@ -612,6 +617,56 @@ describe("authMe over plain HTTP boundaries", () => {
       access,
     });
   });
+
+  it("allows Cloud recovery when the Dedicated edge rejects a saved credential", async () => {
+    getBootConfigMock.mockReturnValue({
+      branding: {},
+      apiBase: "https://c469c32e-aba7-42bd-b834-b64ec0a83727.cloud.eliza.app",
+      apiToken: "expired-cloud-session",
+    });
+    vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(true);
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse(
+        {
+          success: false,
+          code: "cloud_auth_rejected",
+          error: "Cloud authentication failed",
+        },
+        401,
+      ),
+    );
+
+    await expect(authMe()).resolves.toEqual({
+      ok: false,
+      status: 401,
+      reason: "remote_auth_required",
+    });
+    // The proxy has already rejected this bearer. Its protected status route
+    // cannot supply a standalone pairing code; Cloud recovery owns the retry.
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { dedicated: false, code: "cloud_auth_rejected" },
+    { dedicated: true, code: "unknown_auth_error" },
+  ])(
+    "keeps unrelated rejection contracts out of Cloud recovery: %j",
+    async ({ dedicated, code }) => {
+      vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(dedicated);
+      fetchWithCsrfMock
+        .mockResolvedValueOnce(jsonResponse({ code }, 401))
+        .mockResolvedValueOnce(
+          jsonResponse({ required: true, pairingEnabled: false }),
+        );
+
+      await expect(authMe()).resolves.toEqual({
+        ok: false,
+        status: 401,
+        reason: "server_error",
+        access: undefined,
+      });
+    },
+  );
 
   it("prefers pairing when a rich remote 401 reports pairing is enabled", async () => {
     fetchWithCsrfMock

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -22,7 +22,10 @@ import { normalizeCloudApiKeyToken } from "../cloud/lib/cloud-api-key-token";
 import { getBootConfig } from "../config/boot-config";
 import { isNative } from "../platform";
 import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
-import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
+import {
+  isDedicatedCloudAgentBase,
+  isManagedCloudSharedAgentBase,
+} from "../utils/cloud-agent-base";
 import { rememberCsrfTokenForUrl } from "./auth/csrf-cookie";
 import {
   cloudTokenSecsRemaining,
@@ -560,10 +563,22 @@ export async function authMe(): Promise<AuthMeResult> {
 
   if (res.status === 401) {
     const body = (await res.json().catch(() => ({}))) as {
+      code?: string;
       reason?: string;
       access?: AuthAccessInfo;
     };
     if (!requestIsCurrent()) return { ok: false, status: 503 };
+    if (
+      !body.reason &&
+      body.code === "cloud_auth_rejected" &&
+      isDedicatedCloudAgentBase(requestBase)
+    ) {
+      // The Dedicated edge rejected the saved Cloud-shaped bearer before the
+      // runtime could return its auth contract. Keep the gate closed, but let
+      // the existing Cloud-authorized re-pair flow replace that credential.
+      // The same rejected bearer cannot query the edge's protected status route.
+      return { ok: false, status: 401, reason: "remote_auth_required" };
+    }
     const result: AuthMeResult = {
       ok: false,
       status: 401,


### PR DESCRIPTION
Promote #31141 so a normal Dedicated reload can recover a rejected saved credential through the existing Cloud-authorized re-pair flow. Current develop `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7`; merge preview produces tested tree `51078b9b158c971000368a2370f65058708a2d34`, with only the two reviewed auth-client/test files changing from staging.

The exact production edge401 regression failed before the fix.172 focused auth/recovery tests and full `bun run verify` pass. All8 affected chat/Settings layouts pass capture and OCR and were manually inspected. The first broad-run mobile startup timeout was preserved and passed on the focused rerun. [Reviewed source and inline evidence](https://github.com/elizaOS/eliza/pull/31141).

Normal owner-authorized staging promotion. Run the canonical staging Cloud deployment and verify the exact-tree certificate before production. Hosted repaired-reload acceptance remains pending; no auth bypass, account reset, infrastructure, agent-image or worker-runtime change. Shared/Telegram and first-ever signup remain separate acceptance items.
