### PR TITLE
test(plugin-pty): assert the cloud model defaults through the shared constants (#31143)

### DIFF
--- a/plugins/plugin-pty/test/pty-routes.test.ts
+++ b/plugins/plugin-pty/test/pty-routes.test.ts
@@ -8,6 +8,10 @@ import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
 import { resetDevCloudEnvAuthorityForTests } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ELIZA_CLOUD_FAST_MODEL,
+  ELIZA_CLOUD_SMART_MODEL,
+} from "../lib/eliza-code-spec";
 import { ptyRoutes } from "../routes/pty-routes";
 import { PtyService } from "../services/pty-service";
 import { makeFakeSpawn, type SpawnCall } from "./fake-pty";
@@ -207,7 +211,9 @@ describe("POST /api/pty/sessions", () => {
     ]);
     expect(h.calls[0].opts.env?.ELIZA_CODE_CODING_ONLY).toBe("1");
     expect(h.calls[0].opts.env?.OPENAI_API_KEY).toBe("sk-cloud");
-    expect(h.calls[0].opts.env?.OPENAI_SMALL_MODEL).toBe("gemma-4-31b");
+    expect(h.calls[0].opts.env?.OPENAI_SMALL_MODEL).toBe(
+      ELIZA_CLOUD_FAST_MODEL,
+    );
   });
 
   it("403 when interactive spawning is disabled", async () => {
@@ -817,7 +823,7 @@ describe("PTY interactive gate + model fallbacks (regression edges)", () => {
     expect(env?.OPENAI_SMALL_MODEL).toBe("fast-only");
     expect(env?.OPENAI_MEDIUM_MODEL).toBe("fast-only");
     // SMART unset → the cerebras default, not the FAST pin.
-    expect(env?.OPENAI_LARGE_MODEL).toBe("gemma-4-31b");
+    expect(env?.OPENAI_LARGE_MODEL).toBe(ELIZA_CLOUD_SMART_MODEL);
   });
 
   it("applies the SMART tier env fallback without touching the FAST default", async () => {
@@ -833,8 +839,8 @@ describe("PTY interactive gate + model fallbacks (regression edges)", () => {
     expect(res.status).toBe(200);
     const env = h.calls[0].opts.env;
     // FAST unset → the cerebras default, not the SMART pin.
-    expect(env?.OPENAI_SMALL_MODEL).toBe("gemma-4-31b");
-    expect(env?.OPENAI_MEDIUM_MODEL).toBe("gemma-4-31b");
+    expect(env?.OPENAI_SMALL_MODEL).toBe(ELIZA_CLOUD_FAST_MODEL);
+    expect(env?.OPENAI_MEDIUM_MODEL).toBe(ELIZA_CLOUD_FAST_MODEL);
     expect(env?.OPENAI_LARGE_MODEL).toBe("smart-only");
   });
 });


### PR DESCRIPTION
# Relates to

Fixes #31143

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` is running on a stacked branch holding this and the two sibling develop-red repairs; the result will be posted here.
- [x] A reviewer can confirm the change from the focused test run below without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

None to runtime behavior: test-only, one file. The risk surface is the test's own fidelity, addressed in **Background**.

# Background

## What does this PR do?

The pty spawn-route tests pinned the Cerebras default model as the literal `"gemma-4-31b"` in four assertions. Production derives the spawn env from `ELIZA_CLOUD_FAST_MODEL` / `ELIZA_CLOUD_SMART_MODEL` (`lib/eliza-code-spec.ts`), which are `DEFAULT_CEREBRAS_TEXT_MODEL` from `@elizaos/core`, now `qwen-3.8-27b`. The tests import those two constants and assert them, so they keep pinning the contract (a FAST pin must not touch the SMART default and vice versa) instead of a model id that changes with the provider policy.

## What kind of change is this?

Test repair for a suite that is red at the `develop` tip (see the issue for the failing lanes in develop validation run 34694307489).

# Testing

## Where should a reviewer start?

`plugins/plugin-pty/test/pty-routes.test.ts`: the new import and the four assertions at the `OPENAI_SMALL_MODEL` / `OPENAI_MEDIUM_MODEL` / `OPENAI_LARGE_MODEL` reads.

## Detailed testing steps

```text
cd plugins/plugin-pty && bunx vitest run test/pty-routes.test.ts && bunx biome check test/pty-routes.test.ts
```

Before (develop `ce68dbc`):

```text
 × spawns an interactive eliza-code session and returns its id
 × applies the FAST tier env fallback without touching the SMART default
 × applies the SMART tier env fallback without touching the FAST default
AssertionError: expected 'qwen-3.8-27b' to be 'gemma-4-31b'
 Tests  3 failed | 40 passed (43)
```

After (this head):

```text
 Test Files  1 passed (1)
      Tests  43 passed (43)
Checked 1 file. No fixes applied.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
