### PR TITLE
test(scripts): stop pinning the electrobun red-green control to one importer (#31144)

### DIFF
--- a/packages/scripts/audit-tsconfig-workspace-resolution.test.mjs
+++ b/packages/scripts/audit-tsconfig-workspace-resolution.test.mjs
@@ -321,6 +321,9 @@ test("historic app and Electrobun mappings are real red-green controls", {
   });
   assert.match(
     electrobunBroken.violations.join("\n"),
-    /platforms\/electrobun\/tsconfig\.json: unresolved @elizaos\/capacitor-bun-runtime imported by packages\/app-core\/src\/platform\/ios-runtime-bridge\.ts/,
+    // The control proves that dropping the path mapping is detected; which
+    // workspace file happens to be the first importer is not part of the
+    // contract and has already moved twice (#30709, ios-local-agent-transport).
+    /platforms\/electrobun\/tsconfig\.json: unresolved @elizaos\/capacitor-bun-runtime imported by packages\/\S+\.tsx?$/m,
   );
 });


### PR DESCRIPTION
# Relates to

Fixes #31144

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` is running on a stacked branch holding this and the two sibling develop-red repairs; the result will be posted here.
- [x] A reviewer can confirm the change from the focused test run below without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

None to runtime behavior: test-only, one file. The risk surface is the test's own fidelity, addressed in **Background**.

# Background

## What does this PR do?

The Electrobun red-green control removes the `@elizaos/capacitor-bun-runtime` path mapping and expects the audit to report it unresolved, but it also pinned the reported *importer* to `packages/app-core/src/platform/ios-runtime-bridge.ts`. The audit reports the first importer it meets, which is now `packages/ui/src/api/ios-local-agent-transport.ts`; the same pin was already re-pointed once in #30709. The assertion now matches any workspace importer, because the contract the control proves is that the missing mapping is detected, not which file imports the package first.

## What kind of change is this?

Test repair for a suite that is red at the `develop` tip (see the issue for the failing lanes in develop validation run 34694307489).

# Testing

## Where should a reviewer start?

`packages/scripts/audit-tsconfig-workspace-resolution.test.mjs`, the final `assert.match` in "historic app and Electrobun mappings are real red-green controls".

## Detailed testing steps

```text
node --test packages/scripts/audit-tsconfig-workspace-resolution.test.mjs && bunx biome check packages/scripts/audit-tsconfig-workspace-resolution.test.mjs
```

Before (develop `ce68dbc`):

```text
not ok 6 - historic app and Electrobun mappings are real red-green controls
  The input did not match the regular expression /platforms\/electrobun\/tsconfig\.json: unresolved @elizaos\/capacitor-bun-runtime imported by packages\/app-core\/src\/platform\/ios-runtime-bridge\.ts/. Input:
  '@elizaos/electrobun typecheck -> packages/app-core/platforms/electrobun/tsconfig.json: unresolved @elizaos/capacitor-bun-runtime imported by packages/ui/src/api/ios-local-agent-transport.ts'
# pass 5
# fail 1
```

After (this head):

```text
# pass 6
# fail 0
Checked 1 file in 19ms. No fixes applied.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
