### PR TITLE
test(ui): mock the steward API override the login page now reads (#31145)

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
@@ -45,6 +45,9 @@ vi.mock("../../../shell/steward-url", () => ({
 
 vi.mock("../../../shell/steward-config", () => ({
   configuredStewardTenantId: () => "elizacloud",
+  // LoginPage reads this through isLoopbackStagingStewardDevelopment at
+  // render; no override means the hosted login section renders.
+  configuredStewardApiUrlOverride: () => undefined,
   DEFAULT_STEWARD_TENANT_ID: "elizacloud",
 }));
 


### PR DESCRIPTION
# Relates to

Fixes #31145

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` is running on a stacked branch holding this and the two sibling develop-red repairs; the result will be posted here.
- [x] A reviewer can confirm the change from the focused test run below without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

None to runtime behavior: test-only, one file. The risk surface is the test's own fidelity, addressed in **Background**.

# Background

## What does this PR do?

`LoginPage` imports `isLoopbackStagingStewardDevelopment` since the local staging login handoff landed (`4b5943ba606a`), and that helper calls `configuredStewardApiUrlOverride()` at render. The accessibility suite mocks `../../../shell/steward-config` with only the tenant exports, so both cases throw `No "configuredStewardApiUrlOverride" export is defined on the mock` before the page renders. The mock now returns `undefined` for the override, which is the hosted-login configuration the suite's assertions describe.

## What kind of change is this?

Test repair for a suite that is red at the `develop` tip (see the issue for the failing lanes in develop validation run 34694307489).

# Testing

## Where should a reviewer start?

`packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx`, the `steward-config` `vi.mock` block.

## Detailed testing steps

```text
cd packages/ui && NODE_OPTIONS="--no-experimental-webstorage" bunx vitest run --config ./vitest.config.ts src/cloud/public-pages/pages/login/login-page.a11y.test.tsx src/cloud/public-pages/pages/login/login-page.same-origin.test.tsx && bunx biome check src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
```

Before (develop `ce68dbc`):

```text
 × owns a dark full-viewport canvas instead of leaking the light document background
 × exposes a main landmark and touch-sized legal links
Error: [vitest] No "configuredStewardApiUrlOverride" export is defined on the "../../../shell/steward-config" mock.
 Tests  2 failed | 5 passed (7)
```

After (this head):

```text
 Test Files  2 passed (2)
      Tests  7 passed (7)
Checked 1 file in 20ms. No fixes applied.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
