### PR TITLE
test(agent): run Bun-runtime script tests inside the batch runner so bun run test:server can go green (#31149)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -50,7 +50,7 @@
     "format:check": "bunx @biomejs/biome format src",
     "pack:dry-run": "cd dist && npm pack --dry-run",
     "smoke:isolated": "node scripts/isolated-package-smoke.mjs",
-    "test": "bun run test:mobile-workspace-entry && node scripts/run-vitest-batches.mjs",
+    "test": "node scripts/run-vitest-batches.mjs",
     "test:mobile-workspace-entry": "bun test scripts/mobile-workspace-entry.test.mjs",
     "test:e2e": "RUN_CRASH_RESTART_E2E=1 vitest run --config vitest.config.ts test/crash-restart-supervisor.test.ts",
     "test:integration": "cd ../.. && bunx vitest run --config packages/scripts/vitest/integration.config.ts --coverage.enabled=false packages/agent/",

--- a/packages/agent/scripts/run-vitest-batches.mjs
+++ b/packages/agent/scripts/run-vitest-batches.mjs
@@ -1,9 +1,13 @@
 /**
- * Runs the agent Vitest suite in bounded parallel, process-isolated batches.
- * The file selection mirrors vitest.config.ts while one-file batches prevent
- * leaked module state and open handles from crossing test boundaries.
- * Positional arguments select exact eligible files; interruption stops queued work.
- * Requested JUnit evidence includes every batch and is reconciled before publication.
+ * Runs the agent test suite in bounded parallel, process-isolated batches.
+ * Vitest files are selected as vitest.config.ts does, one file per batch so
+ * leaked module state and open handles cannot cross test boundaries; the
+ * Bun-runtime `scripts/*.test.mjs` regressions need `Bun.build`, so each runs
+ * alone through `bun test`. Positional arguments select exact eligible files
+ * of either kind; interruption stops queued work.
+ * Requested JUnit evidence includes every batch of both kinds and is reconciled
+ * before publication, which is what lets the package `test` script stay a
+ * single wrapper command the orchestrator's evidence guard can classify.
  */
 import { spawn } from "node:child_process";
 import {
@@ -26,6 +30,18 @@ const packageRoot = path.resolve(
   "..",
 );
 const roots = ["src", "test", "scripts"];
+
+// Bun-runtime tests sit beside the scripts they exercise and need `Bun.build`,
+// which a Vitest worker does not provide, so they never join a Vitest batch.
+const BUN_TEST_PATTERN = /\.test\.mjs$/;
+const BUN_TEST_ROOT = "scripts/";
+
+export function isBunRuntimeTest(relativePath) {
+  return (
+    relativePath.startsWith(BUN_TEST_ROOT) &&
+    BUN_TEST_PATTERN.test(relativePath)
+  );
+}
 
 const excludedPatterns = [
   /\.e2e\.test\.[cm]?tsx?$/,
@@ -54,7 +70,9 @@ function walk(relativeDir, out) {
       continue;
     }
     if (!stat.isFile()) continue;
-    if (!/\.test\.[cm]?tsx?$/.test(entry)) continue;
+    if (!/\.test\.[cm]?tsx?$/.test(entry) && !isBunRuntimeTest(relativePath)) {
+      continue;
+    }
     if (excludedPatterns.some((pattern) => pattern.test(relativePath))) {
       continue;
     }
@@ -101,6 +119,22 @@ export function createBatches(files, batchSize) {
     batches.push(files.slice(start, start + batchSize));
   }
   return batches;
+}
+
+/**
+ * Vitest files fill batches of `batchSize`; every Bun-runtime test is its own
+ * batch because it runs under a different executable and reporter.
+ */
+export function createRunnerBatches(files, batchSize) {
+  const vitestFiles = files.filter((file) => !isBunRuntimeTest(file));
+  const bunFiles = files.filter((file) => isBunRuntimeTest(file));
+  return [
+    ...createBatches(vitestFiles, batchSize).map((batch) => ({
+      runner: "vitest",
+      files: batch,
+    })),
+    ...bunFiles.map((file) => ({ runner: "bun", files: [file] })),
+  ];
 }
 
 function isFile(filePath) {
@@ -235,6 +269,19 @@ export function createVitestInvocation(bunExecutable, batch, fragmentPath) {
   };
 }
 
+export function createBunTestInvocation(bunExecutable, batch, fragmentPath) {
+  return {
+    command: bunExecutable,
+    args: [
+      "test",
+      ...(fragmentPath
+        ? ["--reporter=junit", `--reporter-outfile=${fragmentPath}`]
+        : []),
+      ...batch,
+    ],
+  };
+}
+
 function terminate(child, signal = "SIGTERM") {
   if (!child.pid) return;
   if (process.platform === "win32") {
@@ -252,11 +299,10 @@ function terminate(child, signal = "SIGTERM") {
 function runBatch(batch, nodeOptions, active, bunExecutable, fragmentPath) {
   return new Promise((resolve) => {
     const startedAt = performance.now();
-    const invocation = createVitestInvocation(
-      bunExecutable,
-      batch,
-      fragmentPath,
-    );
+    const invocation =
+      batch.runner === "bun"
+        ? createBunTestInvocation(bunExecutable, batch.files, fragmentPath)
+        : createVitestInvocation(bunExecutable, batch.files, fragmentPath);
     const child = spawn(invocation.command, invocation.args, {
       cwd: packageRoot,
       detached: process.platform !== "win32",
@@ -327,7 +373,7 @@ async function main() {
   const nodeOptions = inheritedNodeOptions.includes("--max-old-space-size")
     ? inheritedNodeOptions
     : `${inheritedNodeOptions} --max-old-space-size=8192`.trim();
-  const batches = createBatches(files, batchSize);
+  const batches = createRunnerBatches(files, batchSize);
   const fragmentDirectory = reporterOutfile
     ? mkdtempSync(path.join(tmpdir(), "eliza-agent-junit-"))
     : undefined;
@@ -370,7 +416,7 @@ async function main() {
         );
         completed += 1;
         if (verbose || result.status !== 0) {
-          const label = `[agent-test] batch ${index + 1}/${batches.length}: ${batch.join(", ")}`;
+          const label = `[agent-test] batch ${index + 1}/${batches.length}: ${batch.files.join(", ")}`;
           process.stdout.write(`${label}\n${result.stdout}`);
           process.stderr.write(result.stderr);
         } else if (completed % 25 === 0 || completed === batches.length) {
@@ -395,7 +441,7 @@ async function main() {
       for (const failure of failures) {
         if (failure.error) {
           console.error(
-            `[agent-test] ${failure.batch.join(", ")}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
+            `[agent-test] ${failure.batch.files.join(", ")}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
           );
         }
       }

--- a/packages/agent/scripts/run-vitest-batches.test.ts
+++ b/packages/agent/scripts/run-vitest-batches.test.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -13,7 +14,10 @@ import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, test } from "vitest";
 import {
   createBatches,
+  createBunTestInvocation,
+  createRunnerBatches,
   createVitestInvocation,
+  isBunRuntimeTest,
   mergeAgentJunit,
   parseAgentTestArgs,
   positiveInteger,
@@ -47,7 +51,7 @@ function runFakeBatches(
     const inventory = new Map([
       [path.join(root, "src"), ["a.test.ts", "b.test.ts", "c.test.ts", "excluded.live.test.ts", "not-a-test.ts"]],
       [path.join(root, "test"), ["crash-restart-supervisor.test.ts"]],
-      [path.join(root, "scripts"), []],
+      [path.join(root, "scripts"), ["mobile-workspace-entry.test.mjs", "mobile-workspace-entry.mjs"]],
     ]);
     const readDirectory = fs.readdirSync;
     const stat = fs.statSync;
@@ -57,6 +61,7 @@ function runFakeBatches(
       : stat(file, ...rest);
     const children = new Map();
     const spawned = [];
+    const runners = [];
     const killed = [];
     childProcess.spawn = (command, childArgs) => {
       const child = new EventEmitter();
@@ -76,7 +81,11 @@ function runFakeBatches(
         return true;
       };
       children.set(child.pid, child);
-      spawned.push(childArgs.slice(5).map((file) => file.split(path.sep).join("/")));
+      const isBunTest = childArgs[0] === "test";
+      runners.push(isBunTest ? "bun test" : childArgs.slice(0, 3).join(" "));
+      spawned.push((isBunTest ? childArgs.slice(1) : childArgs.slice(5))
+        .filter((arg) => !arg.startsWith("--"))
+        .map((file) => file.split(path.sep).join("/")));
       if (options.signal && spawned.length === 2) {
         queueMicrotask(() => {
           process.emit(options.signal);
@@ -95,7 +104,7 @@ function runFakeBatches(
       return true;
     };
     process.on("exit", () => console.log("FAKE_BATCH_RECEIPT=" + JSON.stringify({
-      spawned, killed, active: children.size,
+      spawned, runners, killed, active: children.size,
       listeners: [process.listenerCount("SIGINT"), process.listenerCount("SIGTERM")],
     })));
     syncBuiltinESMExports();
@@ -133,6 +142,7 @@ function runFakeBatches(
     receiptLine.slice("FAKE_BATCH_RECEIPT=".length),
   ) as {
     spawned: string[][];
+    runners: string[];
     killed: { pid: number; signal: string }[];
     active: number;
     listeners: number[];
@@ -192,6 +202,7 @@ describe("agent Vitest batch orchestration", () => {
     "src/*.test.ts",
     "src/excluded.live.test.ts",
     "src/not-a-test.ts",
+    "scripts/mobile-workspace-entry.mjs",
     "test/crash-restart-supervisor.test.ts",
     "../ui/src/a.test.ts",
     path.join(path.dirname(packageRoot), "ui/src/a.test.ts"),
@@ -212,6 +223,13 @@ describe("agent Vitest batch orchestration", () => {
       ["src/a.test.ts"],
       ["src/b.test.ts"],
       ["src/c.test.ts"],
+      ["scripts/mobile-workspace-entry.test.mjs"],
+    ]);
+    expect(result.receipt.runners).toEqual([
+      "x vitest run",
+      "x vitest run",
+      "x vitest run",
+      "bun test",
     ]);
   });
 
@@ -265,6 +283,24 @@ describe("agent Vitest batch orchestration", () => {
     },
   );
 
+  test("runs a Bun-runtime script test as its own bun test batch beside Vitest batches", () => {
+    // batchSize 2 would pair the files if the .mjs test were a Vitest file;
+    // it must stay alone under `bun test`, which the orchestrator's evidence
+    // guard then sees through the single wrapper command (#31149).
+    const result = runFakeBatches(
+      ["scripts/mobile-workspace-entry.test.mjs", "src/a.test.ts"],
+      { batchSize: 2 },
+    );
+    expect(result.status).toBe(0);
+    expect(result.receipt.spawned).toEqual([
+      ["src/a.test.ts"],
+      ["scripts/mobile-workspace-entry.test.mjs"],
+    ]);
+    expect(result.receipt.runners).toEqual(["x vitest run", "bun test"]);
+    expect(result.receipt.active).toBe(0);
+    expect(result.receipt.listeners).toEqual([0, 0]);
+  });
+
   test("ordinary test failure does not cancel queued siblings", () => {
     const result = runFakeBatches([], { failFirst: true });
     expect(result.status).toBe(1);
@@ -272,6 +308,7 @@ describe("agent Vitest batch orchestration", () => {
       ["src/a.test.ts"],
       ["src/b.test.ts"],
       ["src/c.test.ts"],
+      ["scripts/mobile-workspace-entry.test.mjs"],
     ]);
     expect(result.receipt.killed).toEqual([]);
     expect(result.receipt.listeners).toEqual([0, 0]);
@@ -316,6 +353,91 @@ describe("agent Vitest batch orchestration", () => {
       expect(existsSync(destination)).toBe(false);
     }
     expect(() => mergeAgentJunit([], destination)).toThrow();
+  });
+
+  test("classifies only scripts/*.test.mjs as Bun-runtime tests and isolates each one", () => {
+    expect(isBunRuntimeTest("scripts/mobile-workspace-entry.test.mjs")).toBe(
+      true,
+    );
+    for (const file of [
+      "scripts/mobile-workspace-entry.mjs",
+      "scripts/run-vitest-batches.test.ts",
+      "src/entry.test.mjs",
+      "test/entry.test.mjs",
+    ]) {
+      expect(isBunRuntimeTest(file)).toBe(false);
+    }
+    expect(
+      createRunnerBatches(
+        [
+          "scripts/z.test.mjs",
+          "src/a.test.ts",
+          "src/b.test.ts",
+          "src/c.test.ts",
+        ],
+        2,
+      ),
+    ).toEqual([
+      { runner: "vitest", files: ["src/a.test.ts", "src/b.test.ts"] },
+      { runner: "vitest", files: ["src/c.test.ts"] },
+      { runner: "bun", files: ["scripts/z.test.mjs"] },
+    ]);
+  });
+
+  test("builds a shell-free bun test invocation that emits JUnit only when asked", () => {
+    expect(
+      createBunTestInvocation(
+        "C:/Bun/bun.exe",
+        ["scripts/mobile-workspace-entry.test.mjs"],
+        "C:/tmp/0.xml",
+      ),
+    ).toEqual({
+      command: "C:/Bun/bun.exe",
+      args: [
+        "test",
+        "--reporter=junit",
+        "--reporter-outfile=C:/tmp/0.xml",
+        "scripts/mobile-workspace-entry.test.mjs",
+      ],
+    });
+    expect(
+      createBunTestInvocation("/usr/bin/bun", ["scripts/x.test.mjs"], undefined)
+        .args,
+    ).toEqual(["test", "scripts/x.test.mjs"]);
+  });
+
+  test("merges a Bun fragment, which omits the errors count, with Vitest fragments", () => {
+    const bunFragment = path.join(fixtureRoot, "bun-fragment.xml");
+    writeFileSync(
+      bunFragment,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="2" assertions="0" failures="0" skipped="0" time="0.2">
+  <testsuite name="scripts/mobile-workspace-entry.test.mjs" file="scripts/mobile-workspace-entry.test.mjs" tests="2" assertions="0" failures="0" skipped="0" time="0.1">
+    <testcase name="one" classname="" time="0.05" file="scripts/mobile-workspace-entry.test.mjs" line="13" assertions="0" />
+    <testcase name="two" classname="" time="0.05" file="scripts/mobile-workspace-entry.test.mjs" line="20" assertions="0" />
+  </testsuite>
+</testsuites>
+`,
+    );
+    const vitestFragment = path.join(fixtureRoot, "vitest-fragment.xml");
+    writeFileSync(
+      vitestFragment,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="vitest tests" tests="1" failures="0" errors="0" time="0.1">
+  <testsuite name="src/a.test.ts" timestamp="2026-09-12T00:00:00.000Z" hostname="ci" tests="1" failures="0" errors="0" skipped="0" time="0.1">
+    <testcase classname="src/a.test.ts" name="a" time="0.1" />
+  </testsuite>
+</testsuites>
+`,
+    );
+    const merged = path.join(fixtureRoot, "merged", "report.xml");
+    mergeAgentJunit([vitestFragment, bunFragment], merged);
+    const report = readFileSync(merged, "utf8");
+    expect(report).toMatch(
+      /<testsuites tests="3" failures="0" errors="0" skipped="0">/,
+    );
+    expect(report).toContain('name="scripts/mobile-workspace-entry.test.mjs"');
+    expect(report).toContain('name="src/a.test.ts"');
   });
 
   test("keeps sorted file membership isolated and complete", () => {


### PR DESCRIPTION
# Relates to

Fixes #31149

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` and the exact CI command `bun run test:server` are being run at this head; both results will be posted here.
- [x] A reviewer can confirm the change from the runner evidence and the lane output below without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

Low. `packages/agent` test orchestration only: no runtime source changes. The Bun-runtime packaging regression keeps running on every `bun run --cwd packages/agent test`, now inside the runner instead of chained in front of it. If Bun's JUnit reporter ever changed shape, `mergeAgentJunit` rejects the fragment and the package fails loudly rather than publishing partial evidence.

# Background

## What does this PR do?

`packages/agent`'s `test` script was `bun run test:mobile-workspace-entry && node scripts/run-vitest-batches.mjs`. `packages/scripts/run-all-tests.mjs` attaches JUnit evidence only to a `test` script it can classify as a single `bun test`, `vitest run`, or the batch wrapper (`structuredEvidenceKind`). The `&&` chain classified as nothing, so under `--require-work` the task was tallied `unobserved`, no reporter arguments were forwarded, and because `packages/agent` is the only task in the server lane the aggregate executed count was 0: the vacuous-green guard exited 3 on every develop run, with the suite itself passing.

The batch runner now discovers `scripts/*.test.mjs` (they need `Bun.build`, so a Vitest worker cannot host them), runs each as its own `bun test` batch with `--reporter=junit --reporter-outfile=<fragment>` when evidence is requested, and merges those fragments with the Vitest fragments into the one reconciled report. The `test` script is the bare wrapper again, so the orchestrator classifies it as `vitest` and forwards the reporter arguments; the packaging regression is counted as executed work. `test:mobile-workspace-entry` stays as the focused alias.

Runner changes: `isBunRuntimeTest`, `createRunnerBatches` (Vitest files fill batches of `AGENT_TEST_BATCH_SIZE`; every Bun test is its own batch), `createBunTestInvocation`, and `runBatch` picking the invocation by batch kind. Selection, interruption, and failure handling are unchanged and still covered by the fake-spawn harness, which now records the runner of each spawn.

## What kind of change is this?

Test infrastructure repair for a lane that cannot go green on `develop`.

# Testing

## Where should a reviewer start?

`packages/agent/scripts/run-vitest-batches.mjs` (`walk`, `createRunnerBatches`, `createBunTestInvocation`, `runBatch`) and the four new cases in `run-vitest-batches.test.ts`.

## Detailed testing steps

```text
cd packages/agent
bunx vitest run scripts/run-vitest-batches.test.ts
 Tests  35 passed (35)      # 31 on develop + 4 new

# Real runner, evidence requested, one Bun-runtime file and one Vitest file:
node scripts/run-vitest-batches.mjs --reporter=default --reporter=junit --outputFile.junit=/tmp/agent-evidence.xml \
  scripts/mobile-workspace-entry.test.mjs src/build-config.test.ts
[agent-test] 2 file(s), 2 isolated batch(es), concurrency 2
[agent-test] passed 2 file(s) in 2.2s
# merged report root: <testsuites tests="10" failures="0" errors="0" skipped="0">
# suites present: scripts/mobile-workspace-entry.test.mjs (9 cases, bun) and src/build-config.test.ts (1 case, vitest)
# packages/scripts/lib/junit-summary.mjs parseJunitSummary → {"tests":10,"failures":0,"errors":0,"skipped":0,"executedTests":10}

bunx biome check scripts/run-vitest-batches.mjs scripts/run-vitest-batches.test.ts
Checked 2 files. No fixes applied.
```

Before (develop `ce68dbc`, run 34694307489 job 103555308152):

```text
[eliza-test] PASS @elizaos/agent (packages/agent)#test (2990271ms)
[eliza-test] RESULTS tasks=1 pass=1 fail=0 skip=0 not-run=0 excluded=2 unobserved=1
[eliza-test] EVIDENCE reports=0 tests=0 executed=0 skipped=0 unobserved-tasks=1
[eliza-test] VACUOUS-GREEN GUARD 1 runnable task(s) completed without reconciled evidence that a testcase executed.
error: script "test:server" exited with code 3
```

After: `bun run test:server` at this head is running locally; its `RESULTS` / `EVIDENCE` lines will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
