### PR TITLE
test(cloud): keep integration harness port leases below the ephemeral source-port floor (#31154)

### DIFF
--- a/packages/cloud/scripts/admin/integration-harness-lifecycle.mjs
+++ b/packages/cloud/scripts/admin/integration-harness-lifecycle.mjs
@@ -24,6 +24,59 @@ import { DatabaseSync } from "node:sqlite";
 
 const DEFAULT_PORT_MIN = 20_000;
 const DEFAULT_PORT_MAX = 60_999;
+// A lease proves that nothing listens on a port, not that the kernel will not
+// hand it to an outbound socket as its source port before the server binds.
+// Linux draws those from net.ipv4.ip_local_port_range (32768-60999 by default),
+// so random candidates must stay below that floor or workerd fails its bind
+// with EADDRINUSE after the harness opened its migration connections.
+const IANA_EPHEMERAL_PORT_MIN = 49_152;
+const LOCAL_PORT_RANGE_PATH = "/proc/sys/net/ipv4/ip_local_port_range";
+
+function readLocalPortRange() {
+  let text;
+  try {
+    text = readFileSync(LOCAL_PORT_RANGE_PATH, "utf8");
+  } catch {
+    // error-policy:J3 hosts without procfs (macOS, Windows) report no range
+    // and the caller applies the IANA default instead of a fake value.
+    return null;
+  }
+  const parts = text.trim().split(/\s+/);
+  if (parts.length !== 2) return null;
+  const [min, max] = parts.map((value) =>
+    /^\d+$/.test(value) ? Number(value) : Number.NaN,
+  );
+  if (
+    !Number.isInteger(min) ||
+    !Number.isInteger(max) ||
+    min < 1 ||
+    max < min
+  ) {
+    return null;
+  }
+  return { min, max };
+}
+
+/** Lowest port the kernel may assign to an outbound socket on this host. */
+export function ephemeralPortFloor(readRange = readLocalPortRange) {
+  const range = readRange();
+  return range ? range.min : IANA_EPHEMERAL_PORT_MIN;
+}
+
+/** Random-lease candidates: the configured range clipped below the ephemeral floor. */
+export function candidatePortRange({
+  min = DEFAULT_PORT_MIN,
+  max = DEFAULT_PORT_MAX,
+  ephemeralMin = ephemeralPortFloor(),
+} = {}) {
+  const upper = Math.min(max, ephemeralMin - 1);
+  if (upper < min) {
+    throw new Error(
+      `[cloud-integration] no lease-able ports: ${min}-${max} lies entirely at or above the ephemeral floor ${ephemeralMin}`,
+    );
+  }
+  return { min, max: upper };
+}
 const DEFAULT_STARTUP_TIMEOUT_MS = 90_000;
 const DEFAULT_STOP_TIMEOUT_MS = 10_000;
 const OWNER_FILE = ".cloud-integration-owner.json";
@@ -264,8 +317,9 @@ export async function acquirePortLease({
     return lease;
   }
 
+  const candidates = candidatePortRange();
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    const port = randomInt(DEFAULT_PORT_MIN, DEFAULT_PORT_MAX + 1);
+    const port = randomInt(candidates.min, candidates.max + 1);
     const lease = await tryAcquirePortLease({
       host,
       port,

--- a/packages/cloud/scripts/admin/run-integration-tests.test.mjs
+++ b/packages/cloud/scripts/admin/run-integration-tests.test.mjs
@@ -22,9 +22,11 @@ import { fileURLToPath } from "node:url";
 import pg from "pg";
 import {
   acquirePortLease,
+  candidatePortRange,
   cleanupRunContext,
   createManagedRunContext,
   createOwnedChildRegistry,
+  ephemeralPortFloor,
   externalApiHealthy,
   installSignalTeardown,
   managedApiHealthy,
@@ -336,6 +338,55 @@ test("refuses a listener that races a lease without stopping it", async () => {
   } finally {
     await closeServer(foreignServer);
     if (existsSync(context.runRoot)) cleanupRunContext(context);
+  }
+});
+
+test("random lease candidates stay below the kernel's ephemeral source-port floor", async () => {
+  // A leased port inside ip_local_port_range can be handed to an outbound
+  // socket between the lease and the server's bind (#31154).
+  assert.deepEqual(
+    candidatePortRange({ min: 20_000, max: 60_999, ephemeralMin: 32_768 }),
+    { min: 20_000, max: 32_767 },
+  );
+  assert.deepEqual(
+    candidatePortRange({ min: 20_000, max: 30_000, ephemeralMin: 49_152 }),
+    { min: 20_000, max: 30_000 },
+  );
+  assert.throws(
+    () =>
+      candidatePortRange({ min: 40_000, max: 60_999, ephemeralMin: 32_768 }),
+    /at or above the ephemeral floor/,
+  );
+  assert.equal(
+    ephemeralPortFloor(() => null),
+    49_152,
+  );
+  assert.equal(
+    ephemeralPortFloor(() => ({ min: 32_768, max: 60_999 })),
+    32_768,
+  );
+
+  const leaseRoot = mkdtempSync(
+    path.join(os.tmpdir(), "cloud-integration-lease-floor-"),
+  );
+  const floor = ephemeralPortFloor();
+  const leases = [];
+  try {
+    for (let index = 0; index < 12; index += 1) {
+      const lease = await acquirePortLease({
+        runId: `floor-${index}`,
+        label: "API",
+        leaseRoot,
+      });
+      leases.push(lease);
+      assert.ok(
+        lease.port >= 20_000 && lease.port < floor,
+        `lease ${lease.port} must sit in 20000..${floor - 1}`,
+      );
+    }
+  } finally {
+    for (const lease of leases) releasePortLease(lease);
+    rmSync(leaseRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
# Relates to

Fixes #31154

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` will be run at this head and the result posted here.
- [x] A reviewer can confirm the change from the range arithmetic in the new test and the lease-draw assertion, without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

Low. Only the random candidate range of the cloud integration harness changes: on Linux it becomes `20000..32767` instead of `20000..60999`; on hosts without procfs it becomes `20000..49151`. That still leaves thousands of candidates for the 256 attempts. An explicitly requested `preferredPort` behaves exactly as before.

# Background

## What does this PR do?

`acquirePortLease` proves that nothing *listens* on a port. It does not stop the kernel from handing that port to an outbound socket as its source port, and Linux draws those from `net.ipv4.ip_local_port_range` (`32768 60999` on the runner image and on ordinary hosts). The harness opens many client connections between the lease and workerd's bind (the whole migration run over the PGlite TCP port), so a lease drawn from the ephemeral pool can be taken by one of them, and `bind()` then fails with `EADDRINUSE`. That is the `cloud / integration-tests` failure on develop `ce68dbca4254` (port 44892, inside the pool; the previous run passed).

The harness now reads `/proc/sys/net/ipv4/ip_local_port_range` when present (IANA floor 49152 otherwise) and clips random candidates below that floor. Two exported helpers, `ephemeralPortFloor` and `candidatePortRange`, carry the logic so the test can pin it.

## What kind of change is this?

Test-infrastructure repair for an intermittent develop lane failure.

# Testing

## Where should a reviewer start?

`candidatePortRange` and `readLocalPortRange` in `integration-harness-lifecycle.mjs`, then the new case in `run-integration-tests.test.mjs`.

## Detailed testing steps

```text
node --test --test-name-pattern='ephemeral source-port floor|stale lease reclamation|refuses a listener that races' packages/cloud/scripts/admin/run-integration-tests.test.mjs
ok 1 - refuses a listener that races a lease without stopping it
ok 2 - random lease candidates stay below the kernel's ephemeral source-port floor
ok 3 - stale lease reclamation compares token and inode before replacement
# pass 3
# fail 0

cat /proc/sys/net/ipv4/ip_local_port_range     # 32768 60999 on this host; 12 random leases all landed in 20000..32767
cd packages/cloud && bunx biome check scripts/admin/integration-harness-lifecycle.mjs scripts/admin/run-integration-tests.test.mjs
# only the pre-existing noUndeclaredEnvVars warnings on BUN / npm_execpath (lines untouched by this PR)
```

Before: develop run 34694307489, job 103555179715, `Address already in use (127.0.0.1:44892)` from workerd, lane exit before readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
