### PR TITLE
fix(app): keep an unreadable OCR transcript from fabricating a missing-label regression (#31156)

### DIFF
--- a/packages/app/scripts/ocr-real-engine.test.ts
+++ b/packages/app/scripts/ocr-real-engine.test.ts
@@ -140,15 +140,18 @@ describe("real OCR blank-vs-unreadable classification", () => {
   }, 90_000);
 
   it("does not call a populated mobile launcher blank when the first OCR pass is weak", async () => {
+    // The capture is the launcher grid, so it is audited under the launcher
+    // policy (builtin-views). The file is the historical rolodex baseline,
+    // whose own policy has since become the unavailable-view fallback.
     const auditDir = join(dir, "launcher-audit");
     const viewportDir = join(auditDir, "mobile-portrait");
     mkdirSync(viewportDir, { recursive: true });
-    copyFileSync(LAUNCHER_CAPTURE, join(viewportDir, "builtin-rolodex.png"));
+    copyFileSync(LAUNCHER_CAPTURE, join(viewportDir, "builtin-views.png"));
     writeFileSync(
       join(auditDir, "report.json"),
       JSON.stringify([
         {
-          slug: "builtin-rolodex",
+          slug: "builtin-views",
           viewport: "mobile-portrait",
           viewType: "gui",
           verdict: "good",
@@ -181,8 +184,11 @@ describe("real OCR blank-vs-unreadable classification", () => {
       true,
     );
     expect(entry.pixelBlank).toBe(false);
+    // Glyph salad over the icon labels can clear the confidence floor by a
+    // point; it is a manual check, never a fabricated missing-label regression.
     expect(entry.ocrVerdict).toBe("needs-eyeball");
     expect(entry.regression).toBe(false);
+    expect(entry.reasons.join(" ")).toMatch(/OCR inconclusive/);
     expect(entry.reasons.join(" ")).not.toMatch(/pixels are blank/i);
   }, 90_000);
 

--- a/packages/app/test/audit/ocr-content-rules.test.ts
+++ b/packages/app/test/audit/ocr-content-rules.test.ts
@@ -12,6 +12,7 @@ import {
   normalize,
   type OcrResult,
   positiveExpectationMatches,
+  readableTokenShare,
 } from "../ui-smoke/ocr-content-rules";
 import {
   resolveViewOcrPolicy,
@@ -69,6 +70,25 @@ describe("normalize", () => {
   it("lowercases and canonicalizes punctuation and whitespace", () => {
     expect(normalize("  Ask   Eliza\n\n")).toBe("ask eliza");
     expect(normalize("Fine-Tuning")).toBe("fine tuning");
+  });
+});
+
+// The packaged engine's best pass over the populated mobile launcher baseline
+// (icon labels on gradient tiles): 28 "words" at 46% mean confidence, almost
+// none of them words.
+const LAUNCHER_GLYPH_SALAD =
+  "E8CE 0 rao, te vv re NCA EL & AP 09 ca 3°] a NZ DN 4 kh = MA fA Lo LJ + Ask Eliza 9";
+
+describe("readableTokenShare", () => {
+  it("separates glyph salad from rendered labels", () => {
+    expect(readableTokenShare(LAUNCHER_GLYPH_SALAD)).toBeLessThan(0.5);
+    expect(
+      readableTokenShare(
+        "Messages Settings Wallet Tasks Automations Browser Ask Eliza",
+      ),
+    ).toBe(1);
+    expect(readableTokenShare("")).toBe(0);
+    expect(readableTokenShare("$1,650.50 0250000 ETH")).toBeLessThan(0.5);
   });
 });
 
@@ -192,6 +212,37 @@ ph eg`,
       expect(f.verdict).toBe("verified");
     },
   );
+
+  it("routes an unreadable transcript that clears the confidence floor to review, not a fabricated miss", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr(LAUNCHER_GLYPH_SALAD, {
+        meanConfidence: 0.46,
+        pixelBlank: false,
+      }),
+      expectation: {
+        requireAll: ["Settings", "Wallet"],
+        requireAny: ["Projects", "Calendar", "Automations"],
+      },
+    });
+    expect(f.ocrInconclusive).toBe(true);
+    expect(f.missingRequired).toHaveLength(0);
+    expect(f.blankPixels).toBe(false);
+    expect(f.verdict).toBe("needs-eyeball");
+    expect(f.reasons.join(" ")).toMatch(/readable tokens/);
+  });
+
+  it("still breaks a readable transcript that omits a required label at the same confidence", () => {
+    const f = evaluateOcrContent({
+      ocr: ocr("Messages Tasks Automations Browser Character Ask Eliza", {
+        meanConfidence: 0.46,
+        pixelBlank: false,
+      }),
+      expectation: { requireAll: ["Settings", "Wallet"] },
+    });
+    expect(f.ocrInconclusive).toBe(false);
+    expect(f.missingRequired).toEqual(["Settings", "Wallet"]);
+    expect(f.verdict).toBe("broken");
+  });
 
   it("requires token boundaries when short anchors bypass low OCR confidence", () => {
     const exactAnchor = evaluateOcrContent({

--- a/packages/app/test/ui-smoke/ocr-content-rules.ts
+++ b/packages/app/test/ui-smoke/ocr-content-rules.ts
@@ -199,6 +199,26 @@ export function detectPlaceholderLeaks(text: string): string[] {
 export const OCR_RELIABLE_WORD_FLOOR = 2;
 export const OCR_RELIABLE_CONFIDENCE_FLOOR = 0.45;
 
+/**
+ * Minimum share of transcript tokens that read as words (three or more letters
+ * with a vowel) before a transcript with no matched semantic anchor may claim
+ * that a declared label is missing. Tesseract renders icon labels it cannot
+ * resolve as glyph salad ("MCSSUYCS", "JLUSKS", "E8CE") that can still clear
+ * the mean-confidence floor by a point; such a transcript proves nothing about
+ * which labels the view rendered, so it stays a manual check instead of a
+ * fabricated regression. The vowel test is English-only, like the audited UI.
+ */
+export const OCR_READABLE_TOKEN_SHARE_FLOOR = 0.5;
+
+export function readableTokenShare(text: string): number {
+  const tokens = normalize(text).split(" ").filter(Boolean);
+  if (tokens.length === 0) return 0;
+  const readable = tokens.filter(
+    (token) => /^\p{Letter}{3,}$/u.test(token) && /[aeiouy]/.test(token),
+  ).length;
+  return readable / tokens.length;
+}
+
 export interface EvaluateArgs {
   ocr: OcrResult;
   expectation?: OcrExpectation;
@@ -242,12 +262,14 @@ export function evaluateOcrContent({
     positiveSegments,
     expectation,
   );
+  const readableShare = readableTokenShare(ocr.text);
   const ocrInconclusive =
     !exemptFromBlank &&
     !blankPixels &&
     (ocr.words < OCR_RELIABLE_WORD_FLOOR ||
-      (ocr.meanConfidence < OCR_RELIABLE_CONFIDENCE_FLOOR &&
-        !semanticAnchorsMatched));
+      (!semanticAnchorsMatched &&
+        (ocr.meanConfidence < OCR_RELIABLE_CONFIDENCE_FLOOR ||
+          readableShare < OCR_READABLE_TOKEN_SHARE_FLOOR)));
   const errorLeaks = ocrInconclusive ? [] : detectErrorLeaks(ocr.text);
   const placeholderLeaks = ocrInconclusive
     ? []
@@ -278,7 +300,7 @@ export function evaluateOcrContent({
     );
   } else if (ocrInconclusive) {
     reasons.push(
-      `OCR inconclusive — ${ocr.words} word(s), ${(ocr.meanConfidence * 100).toFixed(1)}% mean confidence; pixels were not blank`,
+      `OCR inconclusive — ${ocr.words} word(s), ${(ocr.meanConfidence * 100).toFixed(1)}% mean confidence, ${(readableShare * 100).toFixed(0)}% readable tokens; pixels were not blank`,
     );
   }
   if (errorLeaks.length)


### PR DESCRIPTION
# Relates to

Fixes #31156

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` will be run at this head and the result posted here.
- [x] A reviewer can confirm the change from the real-engine run and the baseline-wide before/after evaluation below without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

Low and measured. The only behavioural change is in `evaluateOcrContent`: a transcript with **no** matched semantic anchor now also has to be lexically readable before its missing labels can make a non-blank capture `broken`; otherwise it is `needs-eyeball` (manual review). Anchor matches, the word floor, blank-pixel verdicts, and blank-exempt surfaces (`exemptFromBlank`) are untouched, so a verified view cannot lose its verification and a blank paint cannot be hidden. Evaluated against the full mobile-portrait baseline set (below): verified count unchanged, two glyph-salad launcher captures move from a fabricated regression to manual review, nothing else moves. The vowel heuristic is English-only, which matches the audited UI locale; it is documented on the constant.

# Background

## What does this PR do?

The packaged Tesseract engine reads the mobile launcher's icon labels (small text on gradient tiles) as glyph salad: 28 "words" at 46% mean confidence, almost none of them words (`E8CE 0 rao, te vv re NCA EL & AP 09 ca 3°] a NZ DN 4 kh = MA fA Lo LJ + Ask Eliza 9`). That clears `OCR_RELIABLE_CONFIDENCE_FLOOR` (0.45) by a point, so the rules treated it as a reliable transcript, reported every declared label as missing, and the triage recorded a populated, DOM-good launcher as a **regression**. The real-engine suite that exists to guard this (`ocr-real-engine.test.ts` > "does not call a populated mobile launcher blank when the first OCR pass is weak") has been red on `develop` for it.

- `test/ui-smoke/ocr-content-rules.ts`: adds `readableTokenShare` and `OCR_READABLE_TOKEN_SHARE_FLOOR` (0.5). `ocrInconclusive` is now true when no anchor matched and either the confidence floor or the readable-share floor is not met; the inconclusive reason reports the readable share.
- `test/audit/ocr-content-rules.test.ts`: pins the share on the real glyph-salad transcript versus rendered labels; the salad at 0.46 routes to review with no fabricated miss; a readable transcript at the same 0.46 that omits `Settings`/`Wallet` still breaks.
- `scripts/ocr-real-engine.test.ts`: the launcher capture is audited under the launcher policy (`builtin-views`) instead of `builtin-rolodex`, whose policy became the unavailable-view fallback in #29982; the case also asserts the inconclusive reason and `regression: false`.

## What kind of change is this?

Bug fix in the visual-audit tooling plus the repair of the red suite that guards it.

# Testing

## Where should a reviewer start?

`readableTokenShare` and the `ocrInconclusive` expression in `ocr-content-rules.ts`, then the three new unit cases, then the real-engine case.

## Detailed testing steps

```text
cd packages/app
bun test scripts/ocr-real-engine.test.ts
# before (develop): (fail) does not call a populated mobile launcher blank … Expected: "needs-eyeball" Received: "broken"
# after:  7 pass, 0 fail

bunx vitest run --config vitest.config.ts test/audit/ocr-content-rules.test.ts test/audit/ocr-view-expectations.test.ts
 Tests  54 passed (54)      # 51 on develop + 3 new
bunx biome check test/ui-smoke/ocr-content-rules.ts test/audit/ocr-content-rules.test.ts scripts/ocr-real-engine.test.ts
Checked 3 files. No fixes applied.
```

Baseline-wide evaluation: the OCR triage run over every `scripts/mvp-visual-verify/baseline/mobile-portrait/*.png` that has a declared policy (46 captures), each with a DOM verdict of `good`, on the packaged engine, before and after this change:

| | verified | broken | needs-eyeball |
| --- | --- | --- | --- |
| develop `ce68dbc` | 31 | 14 | 1 |
| this head | 31 | 12 | 3 |

The two captures that move (`builtin-rolodex`, `plugin-contacts-gui`) are byte-identical copies of the launcher grid read at 46% confidence with 17% readable tokens; their reason is now `OCR inconclusive — 28 word(s), 46.0% mean confidence, 17% readable tokens; pixels were not blank`. The three other copies of the same image (`builtin-camera`, `plugin-messages-gui`, `plugin-phone-gui`) stay `broken` because their slugs are blank-exempt native surfaces, where the inconclusive gate is bypassed by design; that is pre-existing and out of scope here. The remaining 10 `broken` entries are confident transcripts (60–92%) of stale baseline captures that genuinely do not match their current expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
