### PR TITLE
test(plugin-goals): anchor the goals-repository leaf to source for the keyless real-db graph (#31158)

### DIFF
--- a/plugins/plugin-goals/vitest.config.ts
+++ b/plugins/plugin-goals/vitest.config.ts
@@ -50,6 +50,12 @@ export default defineConfig({
         replacement: sourceOf("src/db/schema.ts"),
       },
       {
+        // PA's lifeops repository imports this package's own repository leaf;
+        // the plugin lane never builds dist, so it must resolve to source too.
+        find: /^@elizaos\/plugin-goals\/db\/goals-repository$/,
+        replacement: sourceOf("src/db/goals-repository.ts"),
+      },
+      {
         find: /^@elizaos\/plugin-reminders\/db\/schema$/,
         replacement: sourceOf("../plugin-reminders/src/db/schema.ts"),
       },


### PR DESCRIPTION
# Relates to

Fixes #31158

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` will be run at this head and the result posted here.
- [x] A reviewer can confirm the change from the dist-less run below without reading the code.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

None to runtime behavior: one Vitest alias in `plugins/plugin-goals/vitest.config.ts`, following the file's existing pattern for leaf DB subpaths.

# Background

## What does this PR do?

`goals.real-db.test.ts` drives the personal-assistant LifeOps repository, which imports `GoalsRepository` from `@elizaos/plugin-goals/db/goals-repository` since `6b9efdcafc72`. Without the `eliza-source` condition that subpath resolves to `dist`, and the plugin lane never builds `plugin-goals`, so the suite has failed with `Cannot find package` on every develop run while passing on checkouts that carry a built dist. The alias anchors the leaf to `src/db/goals-repository.ts`, next to the existing `db/schema` anchor.

## What kind of change is this?

Test-configuration repair for a suite that is red at the `develop` tip.

# Testing

## Where should a reviewer start?

The new alias entry in `plugins/plugin-goals/vitest.config.ts`.

## Detailed testing steps

Reproduced by pointing the workspace link for `@elizaos/plugin-goals` (root and `plugin-personal-assistant`'s package-local one) at a checkout with no `plugins/plugin-goals/dist`:

```text
cd plugins/plugin-goals && bunx vitest run test/goals.real-db.test.ts
# before: Error: Cannot find package '@elizaos/plugin-goals/db/goals-repository' imported from .../plugin-personal-assistant/src/lifeops/repository.ts
#         Test Files  1 failed (1)   Tests  no tests
# after:  Test Files  1 passed (1)   Tests  5 passed (5)
bunx biome check vitest.config.ts   # Checked 1 file. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:b4f97411f707c6b984cfc49080e369a4d79fbf42 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface is changed by this PR.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - Vitest alias configuration only; there is no user-facing flow.
<!-- evidence-row:backend-logs -->
- [x] Test transcripts from the runs described above:
  <details><summary>vitest output: plugins/plugin-goals test/goals.real-db.test.ts without a plugin-goals dist, before and after the alias</summary>

  ```text
  $ cd plugins/plugin-goals && bunx vitest run test/goals.real-db.test.ts   # workspace link points at a checkout with no plugins/plugin-goals/dist
  BEFORE (develop):
   Error: Cannot find package '@elizaos/plugin-goals/db/goals-repository' imported from .../plugin-personal-assistant/src/lifeops/repository.ts
   Test Files  1 failed (1)
        Tests  no tests
  AFTER (this head):
   Test Files  1 passed (1)
        Tests  5 passed (5)
  $ bunx biome check vitest.config.ts
   Checked 1 file. No fixes applied.
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path is changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider or model change; no model calls are involved.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - Vitest alias configuration only; no runtime data or database rows are produced by the change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
