### PR TITLE
test(plugin-local-inference): run the copied-source provenance gate only where the llama.cpp submodule is checked out (#31153)

### DIFF
--- a/plugins/plugin-local-inference/src/services/native-source-provenance.test.ts
+++ b/plugins/plugin-local-inference/src/services/native-source-provenance.test.ts
@@ -23,6 +23,17 @@ interface OwnershipManifest {
 }
 
 const repositoryRoot = resolve(import.meta.dirname, "../../../..");
+// Every mirror root lives inside the llama.cpp submodule. The plugin test
+// lanes check the repository out with submodules disabled (#31153), so an
+// absent tree there is a lane property rather than a provenance failure; the
+// hash gate runs wherever `bun install` initialised the submodule.
+const llamaCppCheckedOut = existsSync(
+	resolve(
+		repositoryRoot,
+		"plugins/plugin-local-inference/native/llama.cpp/CMakeLists.txt",
+	),
+);
+const describeWithSubmodule = llamaCppCheckedOut ? describe : describe.skip;
 const manifestPath = resolve(
 	repositoryRoot,
 	"plugins/plugin-local-inference/native/copied-source-ownership.json",
@@ -80,7 +91,7 @@ function expectFile(path: string, label: string): void {
 	if (existsSync(path)) expect(statSync(path).isFile(), label).toBe(true);
 }
 
-describe("native copied-source ownership", () => {
+describeWithSubmodule("native copied-source ownership", () => {
 	it("uses a complete, non-overlapping classification schema", () => {
 		expect(manifest.version).toBe(1);
 		const familyNames = new Set<string>();


### PR DESCRIPTION
# Relates to

Fixes #31153

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based directly on `origin/develop` `ce68dbca425412131bd2d042b2cc4ffa6c8a61f7` with zero conflicts.
- [x] `bun install --frozen-lockfile` is current for that base (no lockfile drift). Root `bun run verify` is running on a stacked branch with the sibling develop-red repairs; the result will be posted here.
- [x] A reviewer can confirm the change from the two runs below, one on a checkout without the submodule and one with it.

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.

# Risks

Low. Test-only, twelve lines. The provenance hash gate is unchanged where it can run; on a checkout without `plugins/plugin-local-inference/native/llama.cpp` it now reports 25 skipped cases instead of 25 ENOENT failures. The skip is the repository's conditional form (`cond ? describe : describe.skip`), which the anti-larp audit accepts, and the issue number is recorded on the gate.

# Background

## What does this PR do?

Every mirror root the suite hashes (`ggml/src/ggml-cpu`, `tools/omnivoice/src/voice-classifiers/...`) lives inside the llama.cpp submodule. The `Plugin Tests (n/4)` job checks the repository out with `submodules: false` and `install-native-deps: "false"`, so the suite failed on every develop run with `ENOENT: scandir .../native/llama.cpp/ggml/src/ggml-cpu`, which says nothing about provenance. The gate now runs the suite only where the submodule is checked out (`CMakeLists.txt` present at its root), and still fails on drift wherever `bun install` initialised the submodule.

Whether a native lane should run this audit in CI remains the owner decision recorded in #31153; this change stops the plugin shards from being permanently red for a tree they never check out.

## What kind of change is this?

Test repair for a suite that is red at the `develop` tip.

# Testing

## Where should a reviewer start?

The `llamaCppCheckedOut` / `describeWithSubmodule` lines at the top of `native-source-provenance.test.ts`.

## Detailed testing steps

```text
cd plugins/plugin-local-inference

# Worktree without the submodule (what the plugin shards have):
NODE_OPTIONS='--experimental-sqlite' bunx vitest run src/services/native-source-provenance.test.ts
# before: 25 failed — Error: ENOENT: no such file or directory, scandir '.../native/llama.cpp/tools/omnivoice/src/voice-classifiers/wakeword'
# after:   Test Files  1 skipped (1)   Tests  25 skipped (25)

# Worktree with the submodule initialised by bun install:
NODE_OPTIONS='--experimental-sqlite' bunx vitest run src/services/native-source-provenance.test.ts
 Test Files  1 passed (1)   Tests  25 passed (25)

bunx biome check src/services/native-source-provenance.test.ts     # Checked 1 file. No fixes applied.
node packages/scripts/audit-focused-skipped-tests.mjs --dry-run     # [anti-larp] clean — no focused tests, no untracked skips.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCuefLtJHxA7kpLeBfVDGU
