### PR TITLE
fix(cloud): return agent identity for Dedicated session recovery

### DIFF
--- a/packages/cloud/api/auth/pair/route.test.ts
+++ b/packages/cloud/api/auth/pair/route.test.ts
@@ -1,5 +1,6 @@
 /** Exercises loopback browser and authenticated native Cloud pairing exchanges. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { parseCloudPairRelaySession } from "@elizaos/shared/contracts";
 import { Hono } from "hono";
 import { AuthenticationError } from "@/lib/api/errors";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -295,10 +296,10 @@ describe("Cloud pairing route", () => {
       agentId: AGENT_ID,
       expectedOrigin: EXPECTED_ORIGIN,
     });
-    await expect(response.json()).resolves.toEqual({
-      message: "Paired successfully",
+    expect(parseCloudPairRelaySession(await response.json())).toEqual({
       apiKey: "agent-api-token",
       agentName: "Native agent",
+      agentId: AGENT_ID,
     });
   });
 

--- a/packages/cloud/api/auth/pair/route.ts
+++ b/packages/cloud/api/auth/pair/route.ts
@@ -253,15 +253,15 @@ app.post("/native", async (c) => {
       );
     }
 
-    return c.json(
-      {
-        message: "Paired successfully",
-        apiKey: claim.apiKey,
-        agentName: claim.agentName ?? "Agent",
-      },
-      200,
-      { "Cache-Control": "no-store, no-cache, must-revalidate" },
-    );
+    const response: CloudPairExchangeResponse = {
+      message: "Paired successfully",
+      apiKey: claim.apiKey,
+      agentName: claim.agentName ?? "Agent",
+      agentId: claim.pairingToken.agentId,
+    };
+    return c.json(response, 200, {
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+    });
   } catch (err) {
     // error-policy:J1 route boundary — translate authentication and dependency
     // failures into structured HTTP errors without exposing token context.


### PR DESCRIPTION
Fixes #31140 together with PR #31141.

A returning Dedicated user can reach authenticated session recovery but still see “Open this agent from Eliza Cloud.” Live staging returned HTTP 200 from `/api/auth/pair/native` with a credential and name but no agent ID. The app's shared session parser therefore rejected the response.

Return the agent ID from the atomically claimed pairing-token record and type the response with the existing shared contract. The regression now passes the real Hono response through the same parser used by the app; it failed before the change. This also covers native consumers of the same endpoint. Existing Cloud authorization, ownership, origin binding, single-use consumption, and no-store headers remain in force.

Validation of fix `3f333f53a1f01e5d3e5784647049ca130b3c3f34` and synced head `2e06f65287f598151074be0b76dbad1b9283cb8a`:

- 171 tests pass in isolated processes: 16 pairing-route, 136 auth-middleware, 12 public-path, and 7 real PGlite native-claim integration tests. Wrong-identity, expiry, retry, and concurrent-claim cases pass.
- The initial combined-process invocation had 8 failures from module-mock contamination; every affected file passed its required isolated rerun. This did not require a source change outside the two-file fix.
- `bun run verify` passed under Node 24.15.0 / Bun 1.3.14, including API types, route contract, Worker dry-run bundle, lint and repository audits. Frozen install reported no dependency changes; install scripts were omitted for the already-built unchanged graph.
- The final head preserves the newly merged develop agreement-pins change (#31099) through an ordinary merge. Both fix files are byte-identical to the tested fix commit, and full `bun run verify` passed again on the combined tree. Hosted PR CI is still running and is not claimed as passed.
- Live staging before evidence and the regression result are attached. Hosted recovery after this server correction is pending deployment. The prior client fix is already live in staging; production has not received either reload fix.

Risk is confined to the pairing response contract. This is an additive identity field taken from the authorized claim, with no auth bypass, database migration, agent restart, or infrastructure change. Release staging first; verify real desktop/mobile reload and full conversation continuity before production promotion.

<!-- evidence-head:2e06f65287f598151074be0b76dbad1b9283cb8a -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend response-only correction; no rendered source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend response-only correction; actual hosted reload remains a deployment acceptance gate.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered or native implementation changes in this response contract fix.
<!-- evidence-row:backend-logs -->
- [x] [31161-pair-response-public-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31161-pair-response-public-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] [31161-pair-response-public-frontend-records.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31161-pair-response-public-frontend-records.json)
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or action change.
<!-- evidence-row:domain-artifacts -->
- [x] [31161-pair-response-public-synced-regression.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31161-pair-response-public-synced-regression.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered component or layout change.


