### PR TITLE
release(staging): repair Dedicated pairing response

### DIFF
--- a/packages/cloud/api/auth/pair/route.test.ts
+++ b/packages/cloud/api/auth/pair/route.test.ts
@@ -1,5 +1,6 @@
 /** Exercises loopback browser and authenticated native Cloud pairing exchanges. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { parseCloudPairRelaySession } from "@elizaos/shared/contracts";
 import { Hono } from "hono";
 import { AuthenticationError } from "@/lib/api/errors";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -295,10 +296,10 @@ describe("Cloud pairing route", () => {
       agentId: AGENT_ID,
       expectedOrigin: EXPECTED_ORIGIN,
     });
-    await expect(response.json()).resolves.toEqual({
-      message: "Paired successfully",
+    expect(parseCloudPairRelaySession(await response.json())).toEqual({
       apiKey: "agent-api-token",
       agentName: "Native agent",
+      agentId: AGENT_ID,
     });
   });
 

--- a/packages/cloud/api/auth/pair/route.ts
+++ b/packages/cloud/api/auth/pair/route.ts
@@ -253,15 +253,15 @@ app.post("/native", async (c) => {
       );
     }
 
-    return c.json(
-      {
-        message: "Paired successfully",
-        apiKey: claim.apiKey,
-        agentName: claim.agentName ?? "Agent",
-      },
-      200,
-      { "Cache-Control": "no-store, no-cache, must-revalidate" },
-    );
+    const response: CloudPairExchangeResponse = {
+      message: "Paired successfully",
+      apiKey: claim.apiKey,
+      agentName: claim.agentName ?? "Agent",
+      agentId: claim.pairingToken.agentId,
+    };
+    return c.json(response, 200, {
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+    });
   } catch (err) {
     // error-policy:J1 route boundary — translate authentication and dependency
     // failures into structured HTTP errors without exposing token context.

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -11,8 +11,11 @@ import path from "node:path";
 import { resolveKnowledgeGraphService } from "@elizaos/agent";
 import {
   type AgentRuntime,
+  attestAuthenticatedApiDeliveryAudience,
+  ChannelType,
   documentsPluginCore,
   type IAgentRuntime,
+  type Memory,
   type Plugin,
   Service,
   ServiceType,
@@ -21,6 +24,7 @@ import {
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { LocalFileStorageService } from "../../../../../packages/agent/src/services/file-storage.js";
+import { composeResponseState } from "../../../../../packages/core/src/services/message/provider-state.js";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
@@ -388,6 +392,103 @@ describe("parenting-agreement knowledge — real PGlite", () => {
     await expect(
       service.listOwnerAgreements({ ownerEntityId: "verified-co-parent" }),
     ).rejects.toMatchObject({ code: "AGREEMENT_ACCESS_DENIED" });
+  });
+
+  it("composes approved pins on ordinary owner turns while preserving room and audience boundaries", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const ownerId = crypto.randomUUID() as UUID;
+    const roomId = crypto.randomUUID() as UUID;
+    const otherRoomId = crypto.randomUUID() as UUID;
+    const previousOwner = runtime.getSetting("ELIZA_ADMIN_ENTITY_ID");
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId);
+    await runtime.createEntity({
+      id: ownerId,
+      names: ["Pin owner"],
+      agentId: runtime.agentId,
+    });
+    for (const id of [roomId, otherRoomId]) {
+      await runtime.createRoom({
+        id,
+        source: "eliza-client",
+        type: ChannelType.DM,
+        worldId: runtime.agentId,
+      });
+      await runtime.addParticipant(ownerId, id);
+      await runtime.addParticipant(runtime.agentId, id);
+    }
+    const compose = async (targetRoomId: UUID) => {
+      const message: Memory = {
+        id: crypto.randomUUID() as UUID,
+        entityId: ownerId,
+        agentId: runtime.agentId,
+        roomId: targetRoomId,
+        content: {
+          text: "What approved agreement obligation applies here?",
+          source: "eliza-client",
+        },
+      };
+      await attestAuthenticatedApiDeliveryAudience(runtime, message, {
+        kind: "owner_session",
+        principalId: ownerId,
+      });
+      return composeResponseState(runtime, message);
+    };
+    let pin = await service.pin({
+      artifactId: artifact.id,
+      targetType: "chat",
+      targetId: roomId,
+      pinnedByEntityId: SELF_ENTITY_ID,
+    });
+    try {
+      const state = await compose(roomId);
+      expect(state.text).toContain(
+        "Share school notices within twenty-four hours.",
+      );
+      expect(state.text).toContain("source pages 4-5");
+      expect(state.text).not.toContain("An unsupported model interpretation.");
+      expect((await compose(otherRoomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+
+      await service.unpin({
+        pinId: pin.id,
+        unpinnedByEntityId: SELF_ENTITY_ID,
+      });
+      expect((await compose(roomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+      pin = await service.pin({
+        artifactId: artifact.id,
+        targetType: "agent",
+        targetId: runtime.agentId,
+        pinnedByEntityId: SELF_ENTITY_ID,
+      });
+      expect((await compose(otherRoomId)).text).toContain(
+        "Share school notices within twenty-four hours.",
+      );
+
+      const guestId = crypto.randomUUID() as UUID;
+      await runtime.createEntity({
+        id: guestId,
+        names: ["Other participant"],
+        agentId: runtime.agentId,
+      });
+      await runtime.addParticipant(guestId, roomId);
+      expect((await compose(roomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+    } finally {
+      await service.unpin({
+        pinId: pin.id,
+        unpinnedByEntityId: SELF_ENTITY_ID,
+      });
+      runtime.setSetting(
+        "ELIZA_ADMIN_ENTITY_ID",
+        typeof previousOwner === "string" || typeof previousOwner === "boolean"
+          ? previousOwner
+          : null,
+      );
+    }
   });
 
   it("requires verified identity plus an exact active household grant", async () => {

--- a/plugins/plugin-personal-assistant/src/providers/agreement-pins.ts
+++ b/plugins/plugin-personal-assistant/src/providers/agreement-pins.ts
@@ -16,6 +16,7 @@ export const agreementPinsProvider: Provider = {
   descriptionCompressed:
     "Owner-approved, page-cited parenting-agreement obligations from active pins.",
   dynamic: true,
+  alwaysInResponseState: true,
   position: -8,
   cacheScope: "turn",
 


### PR DESCRIPTION
Promote the Dedicated pairing-response correction from #31161 to staging so the deployed app can recover a rejected session on reload. The authenticated exchange now returns the agent identity required by the shared app parser. The preceding client correction from #31141 is already in staging.

Reviewed develop source: `7021a6414a7d144f3e5235397375bf30999e6c86`; expected merge tree: `7b79911b05c2e3f865242db4d87e1bfe7066031d`. The source PR contains 171 focused passing checks, real PGlite claim coverage, a regression that fails before the response correction, and passing root verification. The combined tree was verified after preserving the separately reviewed agreement-pins change #31099, which is also included in this promotion. Hosted PR CI remains separate and is not claimed passed.

No new database migration, capacity change, provisioning-worker restart, or Dedicated restart is needed. After the canonical staging release, verify the real browser pairing response, desktop/mobile reload, full history and chat before production promotion. First-ever signup remains unverified. Evidence: https://github.com/elizaOS/eliza/pull/31161.
