### PR TITLE
release(production): repair Dedicated session recovery on reload

### DIFF
--- a/packages/cloud/api/auth/pair/route.test.ts
+++ b/packages/cloud/api/auth/pair/route.test.ts
@@ -1,5 +1,6 @@
 /** Exercises loopback browser and authenticated native Cloud pairing exchanges. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { parseCloudPairRelaySession } from "@elizaos/shared/contracts";
 import { Hono } from "hono";
 import { AuthenticationError } from "@/lib/api/errors";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -295,10 +296,10 @@ describe("Cloud pairing route", () => {
       agentId: AGENT_ID,
       expectedOrigin: EXPECTED_ORIGIN,
     });
-    await expect(response.json()).resolves.toEqual({
-      message: "Paired successfully",
+    expect(parseCloudPairRelaySession(await response.json())).toEqual({
       apiKey: "agent-api-token",
       agentName: "Native agent",
+      agentId: AGENT_ID,
     });
   });
 

--- a/packages/cloud/api/auth/pair/route.ts
+++ b/packages/cloud/api/auth/pair/route.ts
@@ -253,15 +253,15 @@ app.post("/native", async (c) => {
       );
     }
 
-    return c.json(
-      {
-        message: "Paired successfully",
-        apiKey: claim.apiKey,
-        agentName: claim.agentName ?? "Agent",
-      },
-      200,
-      { "Cache-Control": "no-store, no-cache, must-revalidate" },
-    );
+    const response: CloudPairExchangeResponse = {
+      message: "Paired successfully",
+      apiKey: claim.apiKey,
+      agentName: claim.agentName ?? "Agent",
+      agentId: claim.pairingToken.agentId,
+    };
+    return c.json(response, 200, {
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+    });
   } catch (err) {
     // error-policy:J1 route boundary — translate authentication and dependency
     // failures into structured HTTP errors without exposing token context.

--- a/packages/ui/src/api/auth-client.test.ts
+++ b/packages/ui/src/api/auth-client.test.ts
@@ -20,7 +20,10 @@ import { invokeDesktopBridgeRequest } from "../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import { getBootConfig } from "../config/boot-config";
 import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
-import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
+import {
+  isDedicatedCloudAgentBase,
+  isManagedCloudSharedAgentBase,
+} from "../utils/cloud-agent-base";
 import {
   authChangePassword,
   authListSessions,
@@ -57,6 +60,7 @@ vi.mock("../state/shared-cloud-account-binding", () => ({
   clearSharedCloudAccountBinding: vi.fn(),
 }));
 vi.mock("../utils/cloud-agent-base", () => ({
+  isDedicatedCloudAgentBase: vi.fn(() => false),
   isManagedCloudSharedAgentBase: vi.fn(),
 }));
 vi.mock("./client-cloud", () => ({
@@ -434,6 +438,7 @@ describe("authMe over plain HTTP boundaries", () => {
   beforeEach(() => {
     getBootConfigMock.mockReturnValue({ branding: {} });
     fetchWithCsrfMock.mockReset();
+    vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(false);
     isManagedCloudSharedAgentBaseMock.mockReturnValue(false);
     isDesktopExternalApiBaseUrlMock.mockReturnValue(false);
     invokeDesktopBridgeRequestMock.mockReset();
@@ -612,6 +617,56 @@ describe("authMe over plain HTTP boundaries", () => {
       access,
     });
   });
+
+  it("allows Cloud recovery when the Dedicated edge rejects a saved credential", async () => {
+    getBootConfigMock.mockReturnValue({
+      branding: {},
+      apiBase: "https://c469c32e-aba7-42bd-b834-b64ec0a83727.cloud.eliza.app",
+      apiToken: "expired-cloud-session",
+    });
+    vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(true);
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse(
+        {
+          success: false,
+          code: "cloud_auth_rejected",
+          error: "Cloud authentication failed",
+        },
+        401,
+      ),
+    );
+
+    await expect(authMe()).resolves.toEqual({
+      ok: false,
+      status: 401,
+      reason: "remote_auth_required",
+    });
+    // The proxy has already rejected this bearer. Its protected status route
+    // cannot supply a standalone pairing code; Cloud recovery owns the retry.
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { dedicated: false, code: "cloud_auth_rejected" },
+    { dedicated: true, code: "unknown_auth_error" },
+  ])(
+    "keeps unrelated rejection contracts out of Cloud recovery: %j",
+    async ({ dedicated, code }) => {
+      vi.mocked(isDedicatedCloudAgentBase).mockReturnValue(dedicated);
+      fetchWithCsrfMock
+        .mockResolvedValueOnce(jsonResponse({ code }, 401))
+        .mockResolvedValueOnce(
+          jsonResponse({ required: true, pairingEnabled: false }),
+        );
+
+      await expect(authMe()).resolves.toEqual({
+        ok: false,
+        status: 401,
+        reason: "server_error",
+        access: undefined,
+      });
+    },
+  );
 
   it("prefers pairing when a rich remote 401 reports pairing is enabled", async () => {
     fetchWithCsrfMock

--- a/packages/ui/src/api/auth-client.ts
+++ b/packages/ui/src/api/auth-client.ts
@@ -22,7 +22,10 @@ import { normalizeCloudApiKeyToken } from "../cloud/lib/cloud-api-key-token";
 import { getBootConfig } from "../config/boot-config";
 import { isNative } from "../platform";
 import { clearSharedCloudAccountBinding } from "../state/shared-cloud-account-binding";
-import { isManagedCloudSharedAgentBase } from "../utils/cloud-agent-base";
+import {
+  isDedicatedCloudAgentBase,
+  isManagedCloudSharedAgentBase,
+} from "../utils/cloud-agent-base";
 import { rememberCsrfTokenForUrl } from "./auth/csrf-cookie";
 import {
   cloudTokenSecsRemaining,
@@ -560,10 +563,22 @@ export async function authMe(): Promise<AuthMeResult> {
 
   if (res.status === 401) {
     const body = (await res.json().catch(() => ({}))) as {
+      code?: string;
       reason?: string;
       access?: AuthAccessInfo;
     };
     if (!requestIsCurrent()) return { ok: false, status: 503 };
+    if (
+      !body.reason &&
+      body.code === "cloud_auth_rejected" &&
+      isDedicatedCloudAgentBase(requestBase)
+    ) {
+      // The Dedicated edge rejected the saved Cloud-shaped bearer before the
+      // runtime could return its auth contract. Keep the gate closed, but let
+      // the existing Cloud-authorized re-pair flow replace that credential.
+      // The same rejected bearer cannot query the edge's protected status route.
+      return { ok: false, status: 401, reason: "remote_auth_required" };
+    }
     const result: AuthMeResult = {
       ok: false,
       status: 401,

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -11,8 +11,11 @@ import path from "node:path";
 import { resolveKnowledgeGraphService } from "@elizaos/agent";
 import {
   type AgentRuntime,
+  attestAuthenticatedApiDeliveryAudience,
+  ChannelType,
   documentsPluginCore,
   type IAgentRuntime,
+  type Memory,
   type Plugin,
   Service,
   ServiceType,
@@ -21,6 +24,7 @@ import {
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { LocalFileStorageService } from "../../../../../packages/agent/src/services/file-storage.js";
+import { composeResponseState } from "../../../../../packages/core/src/services/message/provider-state.js";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
@@ -388,6 +392,103 @@ describe("parenting-agreement knowledge — real PGlite", () => {
     await expect(
       service.listOwnerAgreements({ ownerEntityId: "verified-co-parent" }),
     ).rejects.toMatchObject({ code: "AGREEMENT_ACCESS_DENIED" });
+  });
+
+  it("composes approved pins on ordinary owner turns while preserving room and audience boundaries", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const ownerId = crypto.randomUUID() as UUID;
+    const roomId = crypto.randomUUID() as UUID;
+    const otherRoomId = crypto.randomUUID() as UUID;
+    const previousOwner = runtime.getSetting("ELIZA_ADMIN_ENTITY_ID");
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerId);
+    await runtime.createEntity({
+      id: ownerId,
+      names: ["Pin owner"],
+      agentId: runtime.agentId,
+    });
+    for (const id of [roomId, otherRoomId]) {
+      await runtime.createRoom({
+        id,
+        source: "eliza-client",
+        type: ChannelType.DM,
+        worldId: runtime.agentId,
+      });
+      await runtime.addParticipant(ownerId, id);
+      await runtime.addParticipant(runtime.agentId, id);
+    }
+    const compose = async (targetRoomId: UUID) => {
+      const message: Memory = {
+        id: crypto.randomUUID() as UUID,
+        entityId: ownerId,
+        agentId: runtime.agentId,
+        roomId: targetRoomId,
+        content: {
+          text: "What approved agreement obligation applies here?",
+          source: "eliza-client",
+        },
+      };
+      await attestAuthenticatedApiDeliveryAudience(runtime, message, {
+        kind: "owner_session",
+        principalId: ownerId,
+      });
+      return composeResponseState(runtime, message);
+    };
+    let pin = await service.pin({
+      artifactId: artifact.id,
+      targetType: "chat",
+      targetId: roomId,
+      pinnedByEntityId: SELF_ENTITY_ID,
+    });
+    try {
+      const state = await compose(roomId);
+      expect(state.text).toContain(
+        "Share school notices within twenty-four hours.",
+      );
+      expect(state.text).toContain("source pages 4-5");
+      expect(state.text).not.toContain("An unsupported model interpretation.");
+      expect((await compose(otherRoomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+
+      await service.unpin({
+        pinId: pin.id,
+        unpinnedByEntityId: SELF_ENTITY_ID,
+      });
+      expect((await compose(roomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+      pin = await service.pin({
+        artifactId: artifact.id,
+        targetType: "agent",
+        targetId: runtime.agentId,
+        pinnedByEntityId: SELF_ENTITY_ID,
+      });
+      expect((await compose(otherRoomId)).text).toContain(
+        "Share school notices within twenty-four hours.",
+      );
+
+      const guestId = crypto.randomUUID() as UUID;
+      await runtime.createEntity({
+        id: guestId,
+        names: ["Other participant"],
+        agentId: runtime.agentId,
+      });
+      await runtime.addParticipant(guestId, roomId);
+      expect((await compose(roomId)).text).not.toContain(
+        "Share school notices within twenty-four hours.",
+      );
+    } finally {
+      await service.unpin({
+        pinId: pin.id,
+        unpinnedByEntityId: SELF_ENTITY_ID,
+      });
+      runtime.setSetting(
+        "ELIZA_ADMIN_ENTITY_ID",
+        typeof previousOwner === "string" || typeof previousOwner === "boolean"
+          ? previousOwner
+          : null,
+      );
+    }
   });
 
   it("requires verified identity plus an exact active household grant", async () => {

--- a/plugins/plugin-personal-assistant/src/providers/agreement-pins.ts
+++ b/plugins/plugin-personal-assistant/src/providers/agreement-pins.ts
@@ -16,6 +16,7 @@ export const agreementPinsProvider: Provider = {
   descriptionCompressed:
     "Owner-approved, page-cited parenting-agreement obligations from active pins.",
   dynamic: true,
+  alwaysInResponseState: true,
   position: -8,
   cacheScope: "turn",
 


### PR DESCRIPTION
Promote the two verified Dedicated reload repairs: recognize rejected proxy credentials (#31141), then return the required agent identity from authenticated pairing (#31161). A returning signed-in user now recovers the existing agent session and conversation through the normal app UI. This promotion also preserves the separately reviewed agreement-pins change #31099 already on develop/staging.

Staging source `10dd581e538dd340ce16ca9c0903df9fd8912c2b`; expected merged tree `7b79911b05c2e3f865242db4d87e1bfe7066031d`. Canonical staging release [34710434302](https://github.com/elizaOS/eliza/actions/runs/34710434302) succeeded. The canonical verifier accepted artifact `10302409777`, digest `sha256:325873fc79148372d7c163d2854dd0068463e1110ef49c43a1d29ca0a000eb8f`, expiring 2026-09-26T18:29:39.640Z. Live Pages freshness matched all 434 emitted JavaScript assets and entry `index-BYmY9Xof.js`.

Live staging acceptance: the failed tab recovered on ordinary reload without another sign-in. The corrected pairing response matched the intended agent, and the UI showed the expected account and Ready agent. All 33 existing messages matched exactly at desktop and 390×844 mobile width. A real mobile reply recalled all four saved facts; the final reload preserved all 35 messages exactly, with the reply and composer visible and no horizontal overflow. The reply was first observed complete 102.478 seconds after submission; this is an observation bound, not an exact response-time measurement or an instant-response claim.

The normal local Bun app also retains the full 33-message baseline after fresh browser open and desktop/mobile reload. Source checks and full root verification are documented in the two source PRs, including passing real PGlite ownership/single-use tests for pairing. Hosted source CI remains separate and is not claimed passed here.

After merge, dispatch the canonical production Cloud release once, then verify the actual production app, real reply, and complete desktop/mobile reload history. No new migration, paid capacity, credit grant, provisioning-worker restart, or Dedicated-agent restart is required. The existing production agent and backups remain intact. First-ever Google signup is still unverified because the authorized Google identity already has an account.
