### PR TITLE
feat(lifeops): export verified agreement provenance and audit history

### DIFF
--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -232,7 +232,7 @@ for every page with native text plus rendered-page vision transcription for
 images or text-empty pages. One failed page fails ingestion; partial content is
 never published as a complete owner-private `DocumentService` record. LifeOps
 persists the media SHA-256, handle, document id, byte size, MIME type, filename,
-parser-derived page count, complete extracted text, and version chain; it does
+parser-derived page count, complete extracted text and page map, and version chain; it does
 not create another permanent file store.
 
 Owner- or agent-extracted obligations begin as `proposed` and must carry an
@@ -252,6 +252,21 @@ authenticated `/api/lifeops/agreements/*` routes. Grant previews enumerate the
 exact read effects and exclusions before issuance. Active agent/chat pins feed
 only approved, page-cited obligations into owner planner context; uploading a
 PDF remains on the document/API surface so chat actions never invent bytes.
+
+Owners can download the original PDF or export one agreement version from the
+Agreement view. `POST /api/lifeops/agreements/:id/export` returns a ZIP containing
+`original.pdf`, `manifest.json`, and `SHA256SUMS`. Verify both files independently
+with `sha256sum -c SHA256SUMS`. The versioned manifest includes all obligation
+states and citations, current and inactive pin/grant records, linked household
+grant expiry/revocation records, and the canonical agreement audit history from
+one database snapshot. Original byte length and SHA-256 must match before export.
+
+Agreement ingestion, review, pin, and grant transitions commit atomically with
+`life_audit_events`. Export preparation records the manifest and archive hashes;
+it does not assert that the browser received or saved the download. Legacy
+versions explicitly identify missing extraction page maps and partial audit
+history. Export never reconstructs unrecorded past activity. This agreement
+archive does not replace workspace-wide export or deletion workflows.
 
 ## Default packs
 

--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -255,8 +255,10 @@ PDF remains on the document/API surface so chat actions never invent bytes.
 
 Owners can download the original PDF or export one agreement version from the
 Agreement view. `POST /api/lifeops/agreements/:id/export` returns a ZIP containing
-`original.pdf`, `manifest.json`, and `SHA256SUMS`. Verify both files independently
-with `sha256sum -c SHA256SUMS`. The versioned manifest includes all obligation
+`original.pdf`, `manifest.json`, `SHA256SUMS`, and the exact saved
+`extraction.json` when available. Verify the files independently with
+`sha256sum -c SHA256SUMS`; the extraction hash also matches its ingestion audit
+event. The versioned manifest includes all obligation
 states and citations, current and inactive pin/grant records, linked household
 grant expiry/revocation records, and the canonical agreement audit history from
 one database snapshot. Original byte length and SHA-256 must match before export.

--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.test.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.test.tsx
@@ -131,6 +131,7 @@ function adapter(data = snapshot()): FamilyOperationsAdapter {
     approveSchoolDiff: vi.fn(async () => undefined),
     generatePacket: vi.fn(async () => undefined),
     uploadAgreement: vi.fn(async () => undefined),
+    downloadAgreement: vi.fn(async () => new Blob()),
     createPacketDraft: vi.fn(async () => undefined),
     revisePacketDraft: vi.fn(async () => undefined),
     requestPacketApproval: vi.fn(async () => undefined),
@@ -175,6 +176,39 @@ describe("FamilyOperationsView", () => {
     );
     expect(local.runSchoolWorkflow).not.toHaveBeenCalled();
   });
+  it("shows export preparation and recovers visibly when the original cannot be verified", async () => {
+    const local = adapter();
+    let fail: (reason: Error) => void = () => {
+      throw new Error("Download has not started");
+    };
+    local.downloadAgreement = () =>
+      new Promise<Blob>((_resolve, reject) => {
+        fail = reject;
+      });
+    render(<FamilyOperationsView adapter={local} />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Export agreement" }),
+    );
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Preparing export…",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    fail(new Error("Original failed integrity verification"));
+    expect(
+      await screen.findByText("Original failed integrity verification"),
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Export agreement",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+  });
+
   it("requires a review reason and delegates approval to the canonical adapter", async () => {
     const local = adapter();
     render(<FamilyOperationsView adapter={local} />);

--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
@@ -398,6 +398,7 @@ function AgreementPanel({
           style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 16 }}
         >
           <Button
+            variant="accentDarkHover"
             disabled={downloading !== null}
             onClick={() => void download("original")}
           >
@@ -406,6 +407,7 @@ function AgreementPanel({
               : "Download original PDF"}
           </Button>
           <Button
+            variant="accentDarkHover"
             disabled={downloading !== null}
             onClick={() => void download("export")}
           >

--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
@@ -249,6 +249,9 @@ function AgreementPanel({
   refresh: () => Promise<void>;
 }) {
   const [selectedId, setSelectedId] = useState("");
+  const [downloading, setDownloading] = useState<"original" | "export" | null>(
+    null,
+  );
   const [reason, setReason] = useState("");
   const [targetType, setTargetType] = useState<"agent" | "chat">("agent");
   const [targetId, setTargetId] = useState("");
@@ -291,6 +294,41 @@ function AgreementPanel({
       await refresh();
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "The request failed");
+    }
+  };
+
+  const download = async (format: "original" | "export") => {
+    if (!selected || downloading) return;
+    setDownloading(format);
+    setError(null);
+    setNotice(null);
+    try {
+      const blob = await adapter.downloadAgreement(
+        selected.artifact.id,
+        format,
+      );
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download =
+        format === "original"
+          ? selected.artifact.originalFilename
+          : `agreement-${selected.artifact.id}-v${selected.artifact.version}.zip`;
+      document.body.append(link);
+      link.click();
+      link.remove();
+      // Allow the browser to consume the object URL before releasing it.
+      window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+      setNotice(
+        format === "original"
+          ? "Original PDF download started."
+          : "Agreement export download started. The archive includes the original, provenance, and checksums.",
+      );
+    } catch (cause) {
+      // error-policy:J1 Download failures remain visible in the owner workspace.
+      setError(cause instanceof Error ? cause.message : "Download failed");
+    } finally {
+      setDownloading(null);
     }
   };
 
@@ -356,6 +394,26 @@ function AgreementPanel({
             </dd>
           </div>
         </dl>
+        <div
+          style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 16 }}
+        >
+          <Button
+            disabled={downloading !== null}
+            onClick={() => void download("original")}
+          >
+            {downloading === "original"
+              ? "Preparing PDF…"
+              : "Download original PDF"}
+          </Button>
+          <Button
+            disabled={downloading !== null}
+            onClick={() => void download("export")}
+          >
+            {downloading === "export"
+              ? "Preparing export…"
+              : "Export agreement"}
+          </Button>
+        </div>
       </Card>
 
       <Card

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
@@ -69,6 +69,30 @@ describe("defaultFamilyOperationsAdapter", () => {
     ).rejects.toThrow("Original failed integrity verification");
   });
 
+  it.each([
+    ["text/html", "<html>Bad gateway</html>", 502],
+    ["text/plain", "Payload too large", 413],
+    ["application/json", "{invalid", 502],
+  ])(
+    "preserves HTTP failures for %s error responses",
+    async (contentType, body, status) => {
+      vi.stubGlobal(
+        "fetch",
+        async () =>
+          new Response(body, {
+            status,
+            headers: { "content-type": contentType },
+          }),
+      );
+      await expect(
+        defaultFamilyOperationsAdapter.downloadAgreement(
+          "artifact-one",
+          "export",
+        ),
+      ).rejects.toThrow(`Download failed (${status})`);
+    },
+  );
+
   it("allows provider-backed mutations to complete beyond the ordinary read timeout", async () => {
     vi.useFakeTimers();
     vi.stubGlobal(

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
@@ -33,6 +33,42 @@ afterEach(() => {
 });
 
 describe("defaultFamilyOperationsAdapter", () => {
+  it("downloads binary exports through authenticated transport and surfaces integrity failures", async () => {
+    const bytes = new Uint8Array([80, 75, 3, 4, 0, 255]);
+    vi.stubGlobal(
+      "fetch",
+      async (input: string | URL | Request, init?: RequestInit) => {
+        if (
+          new URL(String(input)).origin !== testApiBase ||
+          new Headers(init?.headers).get("authorization") !==
+            "Bearer family-adapter-test-session"
+        )
+          return new Response("Unauthorized", { status: 401 });
+        if (requestPath(input).endsWith("/export") && init?.method === "POST")
+          return new Response(bytes, {
+            headers: { "content-type": "application/zip" },
+          });
+        return new Response(
+          JSON.stringify({
+            error: { message: "Original failed integrity verification" },
+          }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        );
+      },
+    );
+    const archive = await defaultFamilyOperationsAdapter.downloadAgreement(
+      "artifact-one",
+      "export",
+    );
+    expect(new Uint8Array(await archive.arrayBuffer())).toEqual(bytes);
+    await expect(
+      defaultFamilyOperationsAdapter.downloadAgreement(
+        "artifact-one",
+        "original",
+      ),
+    ).rejects.toThrow("Original failed integrity verification");
+  });
+
   it("allows provider-backed mutations to complete beyond the ordinary read timeout", async () => {
     vi.useFakeTimers();
     vi.stubGlobal(

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
@@ -241,16 +241,24 @@ export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter = {
       { allowNonOk: true, skipResume: true, timeoutMs: 10 * 60_000 },
     );
     if (!response.ok) {
-      const payload = await response.json();
+      const failureMessage = `Download failed (${response.status})`;
+      const mediaType = response.headers
+        .get("content-type")
+        ?.split(";", 1)[0]
+        ?.trim()
+        .toLowerCase();
+      if (mediaType !== "application/json" && !mediaType?.endsWith("+json")) {
+        throw new Error(failureMessage);
+      }
+      const payload = await response.json().catch((cause) => {
+        // error-policy:J1 Invalid proxy error bodies retain the HTTP failure.
+        throw new Error(failureMessage, { cause });
+      });
       const message =
         typeof payload?.error === "string"
           ? payload.error
           : payload?.error?.message;
-      throw new Error(
-        typeof message === "string"
-          ? message
-          : `Download failed (${response.status})`,
-      );
+      throw new Error(typeof message === "string" ? message : failureMessage);
     }
     return response.blob();
   },

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
@@ -234,6 +234,27 @@ export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter = {
       ]);
     return { agreements, calendarLinks, school, packets, emailOptions };
   },
+  async downloadAgreement(artifactId, format) {
+    const response = await client.rawRequest(
+      `/api/lifeops/agreements/${encodeURIComponent(artifactId)}/${format === "export" ? "export" : "download"}`,
+      { method: format === "export" ? "POST" : "GET" },
+      { allowNonOk: true, skipResume: true, timeoutMs: 10 * 60_000 },
+    );
+    if (!response.ok) {
+      const payload = await response.json();
+      const message =
+        typeof payload?.error === "string"
+          ? payload.error
+          : payload?.error?.message;
+      throw new Error(
+        typeof message === "string"
+          ? message
+          : `Download failed (${response.status})`,
+      );
+    }
+    return response.blob();
+  },
+
   async uploadAgreement(input) {
     if (input.file.type !== "application/pdf") {
       throw new Error("Agreement must be a PDF.");

--- a/plugins/plugin-personal-assistant/src/components/family-operations/types.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/types.ts
@@ -90,6 +90,10 @@ export interface FamilyOperationsSnapshot {
 export interface FamilyOperationsAdapter {
   load(): Promise<FamilyOperationsSnapshot>;
   uploadAgreement(input: AgreementUploadInput): Promise<void>;
+  downloadAgreement(
+    artifactId: string,
+    format: "original" | "export",
+  ): Promise<Blob>;
   decideObligation(
     obligation: ParentingAgreementObligation,
     decision: "approve" | "reject",

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-audit.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-audit.ts
@@ -1,0 +1,61 @@
+/**
+ * Commits agreement state transitions and their provenance to the canonical
+ * LifeOps audit ledger in one SQL statement. The returned rows are the actual
+ * persisted transition; an audit failure rolls back the mutation as well.
+ */
+import crypto from "node:crypto";
+import { SELF_ENTITY_ID } from "@elizaos/shared";
+import { sqlQuote, sqlText } from "../sql.js";
+
+export type AgreementAuditKind =
+  | "agreement_ingested"
+  | "agreement_obligation_proposed"
+  | "agreement_obligation_decided"
+  | "agreement_pinned"
+  | "agreement_unpinned"
+  | "agreement_granted"
+  | "agreement_revoked";
+
+/** Wrap a repository-owned mutation ending in RETURNING *; never accept client SQL. */
+export function agreementMutationSql(
+  mutation: string,
+  event: {
+    agentId: string;
+    kind: AgreementAuditKind;
+    actorEntityId: string;
+    createdAt: string;
+    artifactRow?: boolean;
+    extractionSha256?: string;
+  },
+): string {
+  const artifact = event.artifactRow
+    ? "SELECT changed.id, changed.version, changed.content_sha256"
+    : `SELECT artifact.id, artifact.version, artifact.content_sha256
+       FROM app_lifeops.life_household_agreement_artifacts AS artifact
+       WHERE artifact.agent_id = ${sqlQuote(event.agentId)}
+         AND artifact.id = changed.artifact_id`;
+  // Scalar source lookups intentionally become NULL on a missing/foreign
+  // artifact. The ledger's non-null owner_id then rejects the whole mutation.
+  return `WITH changed AS (${mutation}), recorded AS (
+    INSERT INTO app_lifeops.life_audit_events (
+      id, agent_id, event_type, owner_type, owner_id, reason,
+      inputs_json, decision_json, actor, created_at
+    ) SELECT
+      ${sqlQuote(`agreement_audit_${crypto.randomUUID()}`)},
+      ${sqlQuote(event.agentId)}, ${sqlQuote(event.kind)},
+      'parenting_agreement',
+      (SELECT source.id FROM (${artifact}) AS source),
+      ${sqlQuote(event.kind)},
+      jsonb_build_object(
+        'schemaVersion', 1,
+        'actorEntityId', ${sqlQuote(event.actorEntityId)},
+        'extractionSha256', ${sqlText(event.extractionSha256 ?? null)},
+        'source', (SELECT to_jsonb(source) FROM (${artifact}) AS source)
+      )::text,
+      to_jsonb(changed)::text,
+      ${sqlQuote(event.actorEntityId === SELF_ENTITY_ID ? "owner" : "agent")},
+      ${sqlQuote(event.createdAt)}
+    FROM changed
+    RETURNING id
+  ) SELECT changed.* FROM changed CROSS JOIN recorded`;
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -895,7 +895,7 @@ describe("parenting-agreement knowledge — real PGlite", () => {
       }),
     ).resolves.toMatchObject({ artifact: { id: artifact.id, version: 1 } });
 
-    await service.revokeGuestRead({
+    const revoked = await service.revokeGuestRead({
       grantId: resourceGrant.id,
       revokedByEntityId: SELF_ENTITY_ID,
       reason: "Owner removed access.",
@@ -912,6 +912,30 @@ describe("parenting-agreement knowledge — real PGlite", () => {
         roomId: "family-chat",
       }),
     ).resolves.toEqual([]);
+    const exported = await restartedService.exportOwnerAgreement({
+      artifactId: artifact.id,
+      ownerEntityId: SELF_ENTITY_ID,
+    });
+    const manifestBytes = readStoredZip(exported.bytes).get("manifest.json");
+    if (!manifestBytes) throw new Error("Export manifest missing");
+    const manifest = JSON.parse(manifestBytes.toString("utf8"));
+    expect(manifest.grants).toContainEqual(revoked);
+    expect(manifest.householdGrants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: guestHouseholdGrantId }),
+      ]),
+    );
+    expect(manifest.householdGrantAudit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ owner_id: guestHouseholdGrantId }),
+      ]),
+    );
+    expect(manifest.audit).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ event_type: "agreement_granted" }),
+        expect.objectContaining({ event_type: "agreement_revoked" }),
+      ]),
+    );
   });
 
   it("fails closed after household-grant revocation or expiry", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -29,8 +29,10 @@ import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../test/helpers/runtime.js";
+import { executeRawSql, sqlQuote } from "../sql.js";
 import {
   AgreementKnowledgeError,
+  AgreementKnowledgeRepository,
   createAgreementKnowledgeService,
   type ParentingAgreementArtifact,
 } from "./agreement-knowledge.js";
@@ -70,6 +72,7 @@ class AgreementTestPdfService extends Service {
         height: 792,
         method: "native" as const,
         nativeText: text,
+        nativePositionedText: [],
         ocrText: null,
         visionText: null,
         text,
@@ -85,6 +88,26 @@ class AgreementTestPdfService extends Service {
 
 function pdf(label: string): Buffer {
   return Buffer.from(`%PDF-1.7\n${label}\n%%EOF\n`, "utf8");
+}
+
+function readStoredZip(bytes: Buffer): Map<string, Buffer> {
+  // Independently read ZIP local records rather than using the archive writer.
+  const files = new Map<string, Buffer>();
+  let offset = 0;
+  while (bytes.readUInt32LE(offset) === 0x04034b50) {
+    if (bytes.readUInt16LE(offset + 8) !== 0)
+      throw new Error("Unsupported ZIP method");
+    const size = bytes.readUInt32LE(offset + 18);
+    const nameSize = bytes.readUInt16LE(offset + 26);
+    const extraSize = bytes.readUInt16LE(offset + 28);
+    const start = offset + 30 + nameSize + extraSize;
+    const name = bytes
+      .subarray(offset + 30, offset + 30 + nameSize)
+      .toString("utf8");
+    files.set(name, bytes.subarray(start, start + size));
+    offset = start + size;
+  }
+  return files;
 }
 
 describe("parenting-agreement knowledge — real PGlite", () => {
@@ -489,6 +512,265 @@ describe("parenting-agreement knowledge — real PGlite", () => {
           : null,
       );
     }
+  });
+
+  it("persists pin provenance atomically and rolls back when the audit ledger rejects it", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const targetId = crypto.randomUUID();
+    const pin = await service.pin({
+      artifactId: artifact.id,
+      targetType: "chat",
+      targetId,
+      pinnedByEntityId: SELF_ENTITY_ID,
+    });
+    const events = await executeRawSql(
+      runtime,
+      `SELECT inputs_json, decision_json FROM app_lifeops.life_audit_events
+       WHERE agent_id = ${sqlQuote(runtime.agentId)}
+         AND owner_type = 'parenting_agreement'
+         AND owner_id = ${sqlQuote(artifact.id)}
+         AND event_type = 'agreement_pinned'
+         AND decision_json::jsonb->>'id' = ${sqlQuote(pin.id)}`,
+    );
+    expect(events).toHaveLength(1);
+    expect(JSON.parse(String(events[0].inputs_json))).toMatchObject({
+      actorEntityId: SELF_ENTITY_ID,
+      source: {
+        id: artifact.id,
+        version: artifact.version,
+        content_sha256: artifact.contentSha256,
+      },
+    });
+    expect(JSON.parse(String(events[0].decision_json))).toMatchObject({
+      id: pin.id,
+      target_id: targetId,
+      unpinned_at: null,
+    });
+    await service.unpin({ pinId: pin.id, unpinnedByEntityId: SELF_ENTITY_ID });
+    await executeRawSql(
+      runtime,
+      `CREATE FUNCTION app_lifeops.reject_agreement_audit_test()
+      RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
+        RAISE EXCEPTION 'audit persistence unavailable';
+      END $$`,
+    );
+    await executeRawSql(
+      runtime,
+      `CREATE TRIGGER reject_agreement_audit_test
+      BEFORE INSERT ON app_lifeops.life_audit_events FOR EACH ROW
+      WHEN (NEW.event_type = 'agreement_pinned')
+      EXECUTE FUNCTION app_lifeops.reject_agreement_audit_test()`,
+    );
+    const rejectedTarget = crypto.randomUUID();
+    try {
+      await expect(
+        service.pin({
+          artifactId: artifact.id,
+          targetType: "chat",
+          targetId: rejectedTarget,
+          pinnedByEntityId: SELF_ENTITY_ID,
+        }),
+      ).rejects.toThrow();
+      const pins = await service.listPins({
+        artifactId: artifact.id,
+        ownerEntityId: SELF_ENTITY_ID,
+      });
+      expect(pins.some((item) => item.targetId === rejectedTarget)).toBe(false);
+    } finally {
+      await executeRawSql(
+        runtime,
+        "DROP TRIGGER reject_agreement_audit_test ON app_lifeops.life_audit_events",
+      );
+      await executeRawSql(
+        runtime,
+        "DROP FUNCTION app_lifeops.reject_agreement_audit_test()",
+      );
+    }
+  });
+
+  it("exports verified originals and complete persisted provenance without granting guest export access", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const original = await service.readOwnerPdf({
+      artifactId: artifact.id,
+      ownerEntityId: SELF_ENTITY_ID,
+    });
+    const exported = await service.exportOwnerAgreement({
+      artifactId: artifact.id,
+      ownerEntityId: SELF_ENTITY_ID,
+    });
+    const files = readStoredZip(exported.bytes);
+    expect(files.get("original.pdf")).toEqual(original.bytes);
+    const manifestBytes = files.get("manifest.json");
+    if (!manifestBytes) throw new Error("Export manifest missing");
+    const manifest = JSON.parse(manifestBytes.toString("utf8"));
+    expect(manifest.artifact).toEqual(artifact);
+    const agreement = (
+      await service.listOwnerAgreements({ ownerEntityId: SELF_ENTITY_ID })
+    ).find((item) => item.artifact.id === artifact.id);
+    if (!agreement) throw new Error("Source agreement missing");
+    expect(manifest.obligations).toEqual(
+      expect.arrayContaining(agreement.obligations),
+    );
+    expect(
+      manifest.extraction.document.pages.every(
+        (page: { text: string }) =>
+          page.text === original.bytes.toString("utf8"),
+      ),
+    ).toBe(true);
+    expect(
+      manifest.pins.some(
+        (pin: { unpinnedAt: string | null }) => pin.unpinnedAt !== null,
+      ),
+    ).toBe(true);
+    const sums = files.get("SHA256SUMS")?.toString("utf8");
+    for (const name of ["original.pdf", "manifest.json"]) {
+      const file = files.get(name);
+      if (!file) throw new Error(`Missing exported ${name}`);
+      expect(sums).toContain(
+        `${crypto.createHash("sha256").update(file).digest("hex")}  ${name}\n`,
+      );
+    }
+    const events = await executeRawSql(
+      runtime,
+      `SELECT decision_json FROM app_lifeops.life_audit_events WHERE agent_id = ${sqlQuote(runtime.agentId)} AND id = ${sqlQuote(manifest.exportId)}`,
+    );
+    expect(events).toHaveLength(1);
+    expect(JSON.parse(String(events[0].decision_json))).toEqual({
+      manifestSha256: crypto
+        .createHash("sha256")
+        .update(manifestBytes)
+        .digest("hex"),
+      archiveSha256: crypto
+        .createHash("sha256")
+        .update(exported.bytes)
+        .digest("hex"),
+    });
+    await expect(
+      service.exportOwnerAgreement({
+        artifactId: artifact.id,
+        ownerEntityId: "verified-co-parent",
+      }),
+    ).rejects.toMatchObject({ code: "AGREEMENT_ACCESS_DENIED" });
+  });
+
+  it("refuses missing or corrupted originals without recording a prepared export", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const file = path.join(mediaStateDir, "media", artifact.mediaFileName);
+    const original = fs.readFileSync(file);
+    const countExports = () =>
+      executeRawSql(
+        runtime,
+        `SELECT id FROM app_lifeops.life_audit_events WHERE agent_id = ${sqlQuote(runtime.agentId)} AND owner_id = ${sqlQuote(artifact.id)} AND event_type = 'agreement_export_prepared' ORDER BY id`,
+      );
+    const before = await countExports();
+    try {
+      fs.writeFileSync(file, Buffer.alloc(original.length, 0));
+      await expect(
+        service.exportOwnerAgreement({
+          artifactId: artifact.id,
+          ownerEntityId: SELF_ENTITY_ID,
+        }),
+      ).rejects.toMatchObject({ code: "AGREEMENT_INVALID_CONTRACT" });
+      fs.unlinkSync(file);
+      await expect(
+        service.exportOwnerAgreement({
+          artifactId: artifact.id,
+          ownerEntityId: SELF_ENTITY_ID,
+        }),
+      ).rejects.toMatchObject({ code: "AGREEMENT_STORAGE_UNAVAILABLE" });
+      expect(await countExports()).toEqual(before);
+    } finally {
+      fs.writeFileSync(file, original);
+    }
+  });
+
+  it("detects altered extraction metadata and identifies legacy history explicitly", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const source = await service.createAgreementVersion({
+      agreementKey: "export-provenance-test",
+      title: "Export provenance",
+      originalFilename: "provenance.pdf",
+      mimeType: "application/pdf",
+      bytes: pdf("export provenance"),
+      uploadedByEntityId: SELF_ENTITY_ID,
+    });
+    await executeRawSql(
+      runtime,
+      `UPDATE memories SET metadata = metadata - 'agreementExtractionJson' WHERE id = ${sqlQuote(source.documentId)} AND agent_id = ${sqlQuote(runtime.agentId)}`,
+    );
+    await expect(
+      service.exportOwnerAgreement({
+        artifactId: source.id,
+        ownerEntityId: SELF_ENTITY_ID,
+      }),
+    ).rejects.toMatchObject({ code: "AGREEMENT_INVALID_CONTRACT" });
+    // Simulate the actual legacy schema state: no extraction map and no ingestion event.
+    await executeRawSql(
+      runtime,
+      `DELETE FROM app_lifeops.life_audit_events WHERE agent_id = ${sqlQuote(runtime.agentId)} AND owner_id = ${sqlQuote(source.id)} AND event_type = 'agreement_ingested'`,
+    );
+    const exported = await service.exportOwnerAgreement({
+      artifactId: source.id,
+      ownerEntityId: SELF_ENTITY_ID,
+    });
+    const bytes = readStoredZip(exported.bytes).get("manifest.json");
+    if (!bytes) throw new Error("Export manifest missing");
+    const manifest = JSON.parse(bytes.toString("utf8"));
+    expect(manifest.extraction).toMatchObject({ status: "unavailable" });
+    expect(manifest.auditCoverage.status).toBe("partial_legacy_history");
+    expect(manifest.audit).toEqual([]);
+    expect(manifest.obligations).toEqual([]);
+  });
+
+  it("keeps concurrent pin transitions and their audit evidence in the same export snapshot", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const repository = new AgreementKnowledgeRepository(
+      runtime,
+      runtime.agentId,
+    );
+    const targetId = crypto.randomUUID();
+    const mutate = async () => {
+      for (let iteration = 0; iteration < 8; iteration += 1) {
+        const pin = await service.pin({
+          artifactId: artifact.id,
+          targetType: "chat",
+          targetId,
+          pinnedByEntityId: SELF_ENTITY_ID,
+        });
+        await service.unpin({
+          pinId: pin.id,
+          unpinnedByEntityId: SELF_ENTITY_ID,
+        });
+      }
+    };
+    const observe = async () => {
+      for (let iteration = 0; iteration < 16; iteration += 1) {
+        const snapshot = await repository.readExportSnapshot(artifact.id);
+        const pin = snapshot.pins.find((item) => item.targetId === targetId);
+        if (!pin) continue;
+        const transitions = snapshot.audit
+          .filter(
+            (event) =>
+              event.event_type ===
+              (pin.unpinnedAt ? "agreement_unpinned" : "agreement_pinned"),
+          )
+          .map((event) => JSON.parse(String(event.decision_json)));
+        expect(transitions).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: pin.id,
+              pinned_at: pin.pinnedAt,
+              unpinned_at: pin.unpinnedAt,
+            }),
+          ]),
+        );
+      }
+    };
+    await Promise.all([mutate(), observe()]);
+    const final = await repository.readExportSnapshot(artifact.id);
+    expect(
+      final.pins.find((item) => item.targetId === targetId)?.unpinnedAt,
+    ).toBeTruthy();
   });
 
   it("requires verified identity plus an exact active household grant", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -611,8 +611,19 @@ describe("parenting-agreement knowledge — real PGlite", () => {
     expect(manifest.obligations).toEqual(
       expect.arrayContaining(agreement.obligations),
     );
+    const extractionBytes = files.get("extraction.json");
+    if (!extractionBytes) throw new Error("Saved extraction missing");
+    const extraction = JSON.parse(extractionBytes.toString("utf8"));
+    const ingestion = manifest.audit.find(
+      (event: { event_type: string }) =>
+        event.event_type === "agreement_ingested",
+    );
+    if (!ingestion) throw new Error("Ingestion audit missing");
     expect(
-      manifest.extraction.document.pages.every(
+      crypto.createHash("sha256").update(extractionBytes).digest("hex"),
+    ).toBe(JSON.parse(ingestion.inputs_json).extractionSha256);
+    expect(
+      extraction.pages.every(
         (page: { text: string }) =>
           page.text === original.bytes.toString("utf8"),
       ),
@@ -623,7 +634,7 @@ describe("parenting-agreement knowledge — real PGlite", () => {
       ),
     ).toBe(true);
     const sums = files.get("SHA256SUMS")?.toString("utf8");
-    for (const name of ["original.pdf", "manifest.json"]) {
+    for (const name of ["original.pdf", "manifest.json", "extraction.json"]) {
       const file = files.get(name);
       if (!file) throw new Error(`Missing exported ${name}`);
       expect(sums).toContain(

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.ts
@@ -11,6 +11,7 @@ import {
   KNOWLEDGE_GRAPH_SERVICE,
   resolveKnowledgeGraphService,
 } from "@elizaos/agent";
+import { createZipArchive } from "@elizaos/agent/api/zip-utils";
 import {
   DocumentService,
   ElizaError,
@@ -22,6 +23,7 @@ import {
 } from "@elizaos/core";
 import type { PdfCompleteDocument, PdfService } from "@elizaos/plugin-pdf";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
+import { z } from "zod";
 import {
   executeRawSql,
   executeRawSqlTx,
@@ -32,6 +34,7 @@ import {
   toText,
   withTransaction,
 } from "../sql.js";
+import { agreementMutationSql } from "./agreement-audit.js";
 import {
   getHouseholdCoordinationService,
   HOUSEHOLD_COORDINATION_SERVICE,
@@ -42,6 +45,35 @@ import {
   HouseholdCoordinationError,
   normalizeHouseholdIdentifier,
 } from "./types.js";
+
+const agreementExtractionSchema = z.strictObject({
+  complete: z.literal(true),
+  pageCount: z.number().int().positive(),
+  text: z.string(),
+  pages: z.array(
+    z.strictObject({
+      pageNumber: z.number().int().positive(),
+      width: z.number().nonnegative(),
+      height: z.number().nonnegative(),
+      method: z.enum(["native", "native+vision", "vision", "blank"]),
+      nativeText: z.string(),
+      nativePositionedText: z.array(
+        z.strictObject({
+          page: z.number().int().positive(),
+          text: z.string(),
+          x: z.number(),
+          y: z.number(),
+          width: z.number(),
+          height: z.number(),
+        }),
+      ),
+      ocrText: z.string().nullable(),
+      visionText: z.string().nullable(),
+      text: z.string(),
+      hasVisualContent: z.boolean(),
+    }),
+  ),
+});
 
 export const HOUSEHOLD_AGREEMENT_KNOWLEDGE_SERVICE =
   "lifeops_household_agreement_knowledge";
@@ -350,7 +382,124 @@ export class AgreementKnowledgeRepository {
     private readonly agentId: string,
   ) {}
 
-  async insertArtifact(input: Omit<ParentingAgreementArtifact, "version">) {
+  /** All mutable export records are read from one PostgreSQL statement snapshot. */
+  async readExportSnapshot(artifactId: string) {
+    const scoped = `agent_id = ${sqlQuote(this.agentId)}`;
+    const artifact = sqlQuote(artifactId);
+    const linkedHouseholdGrants = `SELECT household_grant_id FROM app_lifeops.life_household_knowledge_grants
+      WHERE ${scoped} AND artifact_id = ${artifact}
+      UNION SELECT decision_json::jsonb->>'household_grant_id' FROM app_lifeops.life_audit_events
+      WHERE ${scoped} AND owner_type = 'parenting_agreement' AND owner_id = ${artifact}
+        AND event_type IN ('agreement_granted', 'agreement_revoked')`;
+    const queries = [
+      ["artifact", "life_household_agreement_artifacts", `id = ${artifact}`],
+      [
+        "obligation",
+        "life_household_agreement_obligations",
+        `artifact_id = ${artifact}`,
+      ],
+      ["pin", "life_household_knowledge_pins", `artifact_id = ${artifact}`],
+      ["grant", "life_household_knowledge_grants", `artifact_id = ${artifact}`],
+      [
+        "householdGrant",
+        "life_household_access_grants",
+        `id IN (${linkedHouseholdGrants})`,
+      ],
+      [
+        "householdAudit",
+        "life_audit_events",
+        `owner_type = 'household_grant' AND owner_id IN (${linkedHouseholdGrants})`,
+      ],
+      [
+        "audit",
+        "life_audit_events",
+        `owner_type = 'parenting_agreement' AND owner_id = ${artifact}`,
+      ],
+    ];
+    const rows = await executeRawSql(
+      this.runtime,
+      queries
+        .map(
+          ([kind, table, condition]) =>
+            `SELECT ${sqlQuote(kind)} AS kind, to_jsonb(record)::text AS payload
+       FROM app_lifeops.${table} AS record WHERE ${scoped} AND ${condition}`,
+        )
+        .join(" UNION ALL "),
+    );
+    const records = rows.map((row) => {
+      try {
+        return {
+          kind: requiredText(row.kind, "kind"),
+          row: z
+            .record(z.string(), z.json())
+            .parse(JSON.parse(requiredText(row.payload, "payload"))),
+        };
+      } catch (error) {
+        // error-policy:J2 A corrupt snapshot cannot become a partial export.
+        throw new AgreementKnowledgeError(
+          "Agreement export snapshot is invalid",
+          "AGREEMENT_INVALID_CONTRACT",
+          { artifactId },
+          error,
+        );
+      }
+    });
+    const source = records.find((record) => record.kind === "artifact");
+    if (!source)
+      throw new AgreementKnowledgeError(
+        "Parenting-agreement artifact was not found",
+        "AGREEMENT_ARTIFACT_NOT_FOUND",
+        { artifactId },
+      );
+    const ofKind = (kind: string) =>
+      records
+        .filter((record) => record.kind === kind)
+        .map((record) => record.row)
+        .sort((left, right) => String(left.id).localeCompare(String(right.id)));
+    return {
+      artifact: artifactFromRow(source.row),
+      obligations: ofKind("obligation").map(obligationFromRow),
+      pins: ofKind("pin").map(pinFromRow),
+      grants: ofKind("grant").map(grantFromRow),
+      householdGrants: ofKind("householdGrant"),
+      householdGrantAudit: ofKind("householdAudit"),
+      audit: ofKind("audit").sort(
+        (left, right) =>
+          String(left.created_at).localeCompare(String(right.created_at)) ||
+          String(left.id).localeCompare(String(right.id)),
+      ),
+    };
+  }
+
+  async recordExport(input: {
+    artifact: ParentingAgreementArtifact;
+    exportId: string;
+    ownerEntityId: string;
+    createdAt: string;
+    manifestSha256: string;
+    archiveSha256: string;
+  }) {
+    const rows = await executeRawSql(
+      this.runtime,
+      `INSERT INTO app_lifeops.life_audit_events (
+      id, agent_id, event_type, owner_type, owner_id, reason, inputs_json, decision_json, actor, created_at
+    ) VALUES (${sqlQuote(input.exportId)}, ${sqlQuote(this.agentId)}, 'agreement_export_prepared', 'parenting_agreement', ${sqlQuote(input.artifact.id)},
+      'Verified archive prepared for owner download; client receipt is not asserted',
+      ${sqlQuote(JSON.stringify({ schemaVersion: 1, actorEntityId: input.ownerEntityId, source: { id: input.artifact.id, version: input.artifact.version, content_sha256: input.artifact.contentSha256 } }))},
+      ${sqlQuote(JSON.stringify({ manifestSha256: input.manifestSha256, archiveSha256: input.archiveSha256 }))}, 'owner', ${sqlQuote(input.createdAt)}) RETURNING id`,
+    );
+    if (rows.length !== 1)
+      throw new AgreementKnowledgeError(
+        "Agreement export audit was not persisted",
+        "AGREEMENT_INVALID_CONTRACT",
+      );
+  }
+
+  async insertArtifact(
+    input: Omit<ParentingAgreementArtifact, "version"> & {
+      extractionSha256: string;
+    },
+  ) {
     return await withTransaction(this.runtime, async (tx) => {
       const previousRows = await executeRawSqlTx(
         tx,
@@ -375,7 +524,8 @@ export class AgreementKnowledgeRepository {
       const version = (previous?.version ?? 0) + 1;
       const rows = await executeRawSqlTx(
         tx,
-        `INSERT INTO app_lifeops.life_household_agreement_artifacts (
+        agreementMutationSql(
+          `INSERT INTO app_lifeops.life_household_agreement_artifacts (
            id, agent_id, household_id, agreement_key, version,
            supersedes_artifact_id, title, original_filename, document_id, media_url,
            media_file_name, content_sha256, mime_type, byte_size, page_count,
@@ -391,6 +541,15 @@ export class AgreementKnowledgeRepository {
            ${sqlInteger(input.byteSize)}, ${sqlInteger(input.pageCount)},
            ${sqlQuote(input.uploadedByEntityId)}, ${sqlQuote(input.createdAt)}
          ) RETURNING *`,
+          {
+            agentId: this.agentId,
+            kind: "agreement_ingested",
+            actorEntityId: input.uploadedByEntityId,
+            createdAt: input.createdAt,
+            artifactRow: true,
+            extractionSha256: input.extractionSha256,
+          },
+        ),
       );
       const row = rows[0];
       if (!row) {
@@ -448,7 +607,8 @@ export class AgreementKnowledgeRepository {
   ): Promise<ParentingAgreementObligation> {
     const rows = await executeRawSql(
       this.runtime,
-      `INSERT INTO app_lifeops.life_household_agreement_obligations (
+      agreementMutationSql(
+        `INSERT INTO app_lifeops.life_household_agreement_obligations (
          id, agent_id, artifact_id, title, obligation_text, page_start,
          page_end, citation_text, status, proposed_by_entity_id,
          decided_by_entity_id, decision_reason, decided_at, created_at, updated_at
@@ -461,6 +621,13 @@ export class AgreementKnowledgeRepository {
          ${sqlQuote(obligation.proposedByEntityId)}, NULL, NULL, NULL,
          ${sqlQuote(obligation.createdAt)}, ${sqlQuote(obligation.updatedAt)}
        ) RETURNING *`,
+        {
+          agentId: this.agentId,
+          kind: "agreement_obligation_proposed",
+          actorEntityId: obligation.proposedByEntityId,
+          createdAt: obligation.createdAt,
+        },
+      ),
     );
     const row = rows[0];
     if (!row) {
@@ -481,7 +648,8 @@ export class AgreementKnowledgeRepository {
   }): Promise<ParentingAgreementObligation> {
     const rows = await executeRawSql(
       this.runtime,
-      `UPDATE app_lifeops.life_household_agreement_obligations
+      agreementMutationSql(
+        `UPDATE app_lifeops.life_household_agreement_obligations
           SET status = ${sqlQuote(input.status)},
               decided_by_entity_id = ${sqlQuote(input.decidedByEntityId)},
               decision_reason = ${sqlQuote(input.decisionReason)},
@@ -491,6 +659,13 @@ export class AgreementKnowledgeRepository {
           AND id = ${sqlQuote(input.obligationId)}
           AND status = 'proposed'
       RETURNING *`,
+        {
+          agentId: this.agentId,
+          kind: "agreement_obligation_decided",
+          actorEntityId: input.decidedByEntityId,
+          createdAt: input.decidedAt,
+        },
+      ),
     );
     const row = rows[0];
     if (!row) {
@@ -536,7 +711,8 @@ export class AgreementKnowledgeRepository {
     const id = `hkpin_${crypto.randomUUID()}`;
     const rows = await executeRawSql(
       this.runtime,
-      `INSERT INTO app_lifeops.life_household_knowledge_pins (
+      agreementMutationSql(
+        `INSERT INTO app_lifeops.life_household_knowledge_pins (
          id, agent_id, artifact_id, target_type, target_id,
          pinned_by_entity_id, pinned_at, unpinned_at
        ) VALUES (
@@ -549,6 +725,13 @@ export class AgreementKnowledgeRepository {
                      pinned_at = EXCLUDED.pinned_at,
                      unpinned_at = NULL
        RETURNING *`,
+        {
+          agentId: this.agentId,
+          kind: "agreement_pinned",
+          actorEntityId: input.pinnedByEntityId,
+          createdAt: input.pinnedAt,
+        },
+      ),
     );
     const row = rows[0];
     if (!row) {
@@ -598,16 +781,25 @@ export class AgreementKnowledgeRepository {
 
   async removePin(input: {
     pinId: string;
+    unpinnedByEntityId: string;
     unpinnedAt: string;
   }): Promise<HouseholdKnowledgePin> {
     const rows = await executeRawSql(
       this.runtime,
-      `UPDATE app_lifeops.life_household_knowledge_pins
+      agreementMutationSql(
+        `UPDATE app_lifeops.life_household_knowledge_pins
           SET unpinned_at = ${sqlQuote(input.unpinnedAt)}
         WHERE agent_id = ${sqlQuote(this.agentId)}
           AND id = ${sqlQuote(input.pinId)}
           AND unpinned_at IS NULL
       RETURNING *`,
+        {
+          agentId: this.agentId,
+          kind: "agreement_unpinned",
+          actorEntityId: input.unpinnedByEntityId,
+          createdAt: input.unpinnedAt,
+        },
+      ),
     );
     const row = rows[0];
     if (!row) {
@@ -623,7 +815,8 @@ export class AgreementKnowledgeRepository {
   async upsertGrant(input: HouseholdKnowledgeGrant) {
     const rows = await executeRawSql(
       this.runtime,
-      `INSERT INTO app_lifeops.life_household_knowledge_grants (
+      agreementMutationSql(
+        `INSERT INTO app_lifeops.life_household_knowledge_grants (
          id, agent_id, household_id, artifact_id, principal_entity_id,
          household_grant_id, issued_by_entity_id, revoked_at,
          revoked_by_entity_id, revocation_reason, created_at, updated_at
@@ -642,6 +835,13 @@ export class AgreementKnowledgeRepository {
                      revocation_reason = NULL,
                      updated_at = EXCLUDED.updated_at
        RETURNING *`,
+        {
+          agentId: this.agentId,
+          kind: "agreement_granted",
+          actorEntityId: input.issuedByEntityId,
+          createdAt: input.updatedAt,
+        },
+      ),
     );
     const row = rows[0];
     if (!row) {
@@ -689,7 +889,8 @@ export class AgreementKnowledgeRepository {
   }): Promise<HouseholdKnowledgeGrant> {
     const rows = await executeRawSql(
       this.runtime,
-      `UPDATE app_lifeops.life_household_knowledge_grants
+      agreementMutationSql(
+        `UPDATE app_lifeops.life_household_knowledge_grants
           SET revoked_at = ${sqlQuote(input.revokedAt)},
               revoked_by_entity_id = ${sqlQuote(input.revokedByEntityId)},
               revocation_reason = ${sqlQuote(input.reason)},
@@ -698,6 +899,13 @@ export class AgreementKnowledgeRepository {
           AND id = ${sqlQuote(input.grantId)}
           AND revoked_at IS NULL
       RETURNING *`,
+        {
+          agentId: this.agentId,
+          kind: "agreement_revoked",
+          actorEntityId: input.revokedByEntityId,
+          createdAt: input.revokedAt,
+        },
+      ),
     );
     const row = rows[0];
     if (!row) {
@@ -936,6 +1144,11 @@ export class AgreementKnowledgeService {
       );
     }
     const pageCount = extracted.pageCount;
+    const extractionJson = JSON.stringify(extracted);
+    const extractionSha256 = crypto
+      .createHash("sha256")
+      .update(extractionJson)
+      .digest("hex");
     const artifactId = `hag_${crypto.randomUUID()}`;
     const stored = await fileStorage.storePrivate(bytes, "application/pdf");
     if (
@@ -982,6 +1195,7 @@ export class AgreementKnowledgeService {
         mediaFileName: stored.fileName,
         agreementKey,
         householdId,
+        agreementExtractionJson: extractionJson,
       },
     });
     return await this.deps.repository.insertArtifact({
@@ -1000,6 +1214,7 @@ export class AgreementKnowledgeService {
       byteSize: stored.size,
       pageCount,
       uploadedByEntityId: input.uploadedByEntityId,
+      extractionSha256,
       createdAt: this.now().toISOString(),
     });
   }
@@ -1037,6 +1252,164 @@ export class AgreementKnowledgeService {
       bytes,
       mimeType: artifact.mimeType,
       fileName: artifact.originalFilename,
+    };
+  }
+
+  async exportOwnerAgreement(input: {
+    artifactId: string;
+    ownerEntityId: string;
+  }): Promise<{ bytes: Buffer; mimeType: string; fileName: string }> {
+    this.requireOwner(input.ownerEntityId);
+    // Verify immutable bytes before recording a prepared export. Mutable review,
+    // pin, and grant state is subsequently captured in a single SQL snapshot.
+    const original = await this.readOwnerPdf(input);
+    const snapshot = await this.deps.repository.readExportSnapshot(
+      input.artifactId,
+    );
+    const documents = this.deps.documents();
+    if (!documents)
+      throw new AgreementKnowledgeError(
+        "Agreement document service is unavailable",
+        "AGREEMENT_STORAGE_UNAVAILABLE",
+      );
+    const document = await documents.getDocumentById(
+      snapshot.artifact.documentId as UUID,
+    );
+    if (!document)
+      throw new AgreementKnowledgeError(
+        "Agreement extraction document is unavailable",
+        "AGREEMENT_STORAGE_UNAVAILABLE",
+        { artifactId: input.artifactId },
+      );
+    const extractionJson =
+      document.metadata && "agreementExtractionJson" in document.metadata
+        ? document.metadata.agreementExtractionJson
+        : undefined;
+    let extraction:
+      | {
+          status: "available";
+          document: z.infer<typeof agreementExtractionSchema>;
+        }
+      | { status: "unavailable"; reason: string };
+    const ingestion = snapshot.audit.find(
+      (event) => event.event_type === "agreement_ingested",
+    );
+    let recordedExtractionSha256: string | null = null;
+    if (ingestion) {
+      try {
+        const inputs = z
+          .object({ extractionSha256: z.string().regex(/^[a-f0-9]{64}$/) })
+          .parse(
+            JSON.parse(requiredText(ingestion.inputs_json, "inputs_json")),
+          );
+        recordedExtractionSha256 = inputs.extractionSha256;
+      } catch (error) {
+        // error-policy:J2 Recorded ingestion provenance must remain verifiable.
+        throw new AgreementKnowledgeError(
+          "Agreement ingestion provenance is invalid",
+          "AGREEMENT_INVALID_CONTRACT",
+          { artifactId: input.artifactId },
+          error,
+        );
+      }
+    }
+    if (
+      recordedExtractionSha256 &&
+      (typeof extractionJson !== "string" ||
+        crypto.createHash("sha256").update(extractionJson).digest("hex") !==
+          recordedExtractionSha256)
+    ) {
+      throw new AgreementKnowledgeError(
+        "Agreement extraction failed integrity verification",
+        "AGREEMENT_INVALID_CONTRACT",
+        { artifactId: input.artifactId },
+      );
+    }
+    if (extractionJson === undefined) {
+      extraction = {
+        status: "unavailable",
+        reason:
+          "This version predates persisted extraction page maps; no historical extraction has been reconstructed.",
+      };
+    } else {
+      try {
+        if (typeof extractionJson !== "string")
+          throw new Error("Extraction metadata is not serialized JSON");
+        const parsed = agreementExtractionSchema.parse(
+          JSON.parse(extractionJson),
+        );
+        if (
+          parsed.pageCount !== snapshot.artifact.pageCount ||
+          parsed.pages.length !== parsed.pageCount ||
+          parsed.pages.some((page, index) => page.pageNumber !== index + 1)
+        )
+          throw new Error("Extraction page map is incomplete");
+        extraction = { status: "available", document: parsed };
+      } catch (error) {
+        // error-policy:J2 Invalid saved provenance must fail export visibly.
+        throw new AgreementKnowledgeError(
+          "Agreement extraction provenance is invalid",
+          "AGREEMENT_INVALID_CONTRACT",
+          { artifactId: input.artifactId },
+          error,
+        );
+      }
+    }
+    const exportId = `agreement_export_${crypto.randomUUID()}`;
+    const createdAt = this.now().toISOString();
+    const manifest = Buffer.from(
+      `${JSON.stringify(
+        {
+          schema: "elizaos.agreement-export",
+          schemaVersion: 1,
+          exportId,
+          createdAt,
+          original: {
+            path: "original.pdf",
+            sha256: snapshot.artifact.contentSha256,
+            byteSize: snapshot.artifact.byteSize,
+          },
+          ...snapshot,
+          extraction,
+          auditCoverage: {
+            status: snapshot.audit.some(
+              (event) => event.event_type === "agreement_ingested",
+            )
+              ? "recorded_from_ingestion"
+              : "partial_legacy_history",
+            scope:
+              "Persisted agreement events through the database snapshot. Earlier unrecorded activity is unavailable. This export preparation is recorded after archive construction; successful client receipt is not asserted.",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    const manifestSha256 = crypto
+      .createHash("sha256")
+      .update(manifest)
+      .digest("hex");
+    const bytes = createZipArchive([
+      { name: "original.pdf", data: original.bytes },
+      { name: "manifest.json", data: manifest },
+      {
+        name: "SHA256SUMS",
+        data: `${snapshot.artifact.contentSha256}  original.pdf\n${manifestSha256}  manifest.json\n`,
+      },
+    ]);
+    await this.deps.repository.recordExport({
+      artifact: snapshot.artifact,
+      exportId,
+      ownerEntityId: input.ownerEntityId,
+      createdAt,
+      manifestSha256,
+      archiveSha256: crypto.createHash("sha256").update(bytes).digest("hex"),
+    });
+    return {
+      bytes,
+      mimeType: "application/zip",
+      fileName: `agreement-${snapshot.artifact.id}-v${snapshot.artifact.version}.zip`,
     };
   }
 
@@ -1135,6 +1508,7 @@ export class AgreementKnowledgeService {
     this.requireOwner(input.unpinnedByEntityId);
     return await this.deps.repository.removePin({
       pinId: normalizeHouseholdIdentifier(input.pinId, "pinId"),
+      unpinnedByEntityId: input.unpinnedByEntityId,
       unpinnedAt: this.now().toISOString(),
     });
   }

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.ts
@@ -1285,10 +1285,13 @@ export class AgreementKnowledgeService {
       document.metadata && "agreementExtractionJson" in document.metadata
         ? document.metadata.agreementExtractionJson
         : undefined;
+    let extractionBytes: Buffer | null = null;
     let extraction:
       | {
           status: "available";
-          document: z.infer<typeof agreementExtractionSchema>;
+          path: "extraction.json";
+          sha256: string;
+          pageCount: number;
         }
       | { status: "unavailable"; reason: string };
     const ingestion = snapshot.audit.find(
@@ -1344,7 +1347,18 @@ export class AgreementKnowledgeService {
           parsed.pages.some((page, index) => page.pageNumber !== index + 1)
         )
           throw new Error("Extraction page map is incomplete");
-        extraction = { status: "available", document: parsed };
+        // Export the exact serialized bytes bound at ingestion. Re-encoding
+        // the validated object could change key order and invalidate that hash.
+        extractionBytes = Buffer.from(extractionJson, "utf8");
+        extraction = {
+          status: "available",
+          path: "extraction.json",
+          sha256: crypto
+            .createHash("sha256")
+            .update(extractionBytes)
+            .digest("hex"),
+          pageCount: parsed.pageCount,
+        };
       } catch (error) {
         // error-policy:J2 Invalid saved provenance must fail export visibly.
         throw new AgreementKnowledgeError(
@@ -1393,9 +1407,12 @@ export class AgreementKnowledgeService {
     const bytes = createZipArchive([
       { name: "original.pdf", data: original.bytes },
       { name: "manifest.json", data: manifest },
+      ...(extractionBytes
+        ? [{ name: "extraction.json", data: extractionBytes }]
+        : []),
       {
         name: "SHA256SUMS",
-        data: `${snapshot.artifact.contentSha256}  original.pdf\n${manifestSha256}  manifest.json\n`,
+        data: `${snapshot.artifact.contentSha256}  original.pdf\n${manifestSha256}  manifest.json\n${extraction.status === "available" ? `${extraction.sha256}  extraction.json\n` : ""}`,
       },
     ]);
     await this.deps.repository.recordExport({

--- a/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.ts
@@ -232,6 +232,27 @@ export async function handleAgreementKnowledgeRoutes(
       return true;
     }
 
+    const artifactExport = pathMatch(
+      ctx.pathname,
+      /^\/api\/lifeops\/agreements\/([^/]+)\/export$/,
+    );
+    if (ctx.method === "POST" && artifactExport) {
+      const file = await service.exportOwnerAgreement({
+        artifactId: artifactExport[0] ?? "",
+        ownerEntityId: SELF_ENTITY_ID,
+      });
+      ctx.res.statusCode = 200;
+      ctx.res.setHeader("Content-Type", file.mimeType);
+      ctx.res.setHeader("Cache-Control", "no-store");
+      ctx.res.setHeader(
+        "Content-Disposition",
+        `attachment; filename*=UTF-8''${encodeURIComponent(file.fileName)}`,
+      );
+      ctx.res.setHeader("Content-Length", String(file.bytes.length));
+      ctx.res.end(file.bytes);
+      return true;
+    }
+
     const artifactDownload = pathMatch(
       ctx.pathname,
       /^\/api\/lifeops\/agreements\/([^/]+)\/download$/,

--- a/plugins/plugin-personal-assistant/src/routes/plugin.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.test.ts
@@ -334,6 +334,7 @@ describe("LifeOps raw route owner/admin gate", () => {
   });
 
   it.each([
+    ["POST", "/api/lifeops/agreements/:id/export"],
     ["GET", "/api/lifeops/family-workflows/email-options"],
     [
       "POST",

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -575,6 +575,7 @@ const LIFEOPS_DYNAMIC_ROUTES: RouteSpec[] = [
   { type: "POST", path: "/api/lifeops/relationships/:id/retire" },
   { type: "GET", path: "/api/lifeops/agreements/:id" },
   { type: "GET", path: "/api/lifeops/agreements/:id/download" },
+  { type: "POST", path: "/api/lifeops/agreements/:id/export" },
   {
     type: "GET",
     path: "/api/lifeops/agreements/:id/guest-projection",

--- a/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
+++ b/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
@@ -109,6 +109,7 @@ export function createFamilyPacketFixture(
       document.documentElement.dataset.familyApprovalVersion = String(version);
     },
     uploadAgreement: unsupported,
+    downloadAgreement: unsupported,
     decideObligation: unsupported,
     async listPins() {
       return [];

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -83,6 +83,9 @@ const agentSourceJsToTsPlugin = {
     if (source === "@elizaos/agent/api/connector-account-routes") {
       return path.join(agentSourceRoot, "api", "connector-account-routes.ts");
     }
+    if (source === "@elizaos/agent/api/zip-utils") {
+      return path.join(agentSourceRoot, "api", "zip-utils.ts");
+    }
     if (source === "@elizaos/agent/api/server-helpers") {
       return path.join(agentSourceRoot, "api", "server-helpers.ts");
     }
@@ -453,6 +456,10 @@ export default defineConfig({
       // The owner-scope invariant test exercises the real chat-surface and
       // trust-fallback owner derivations; anchor both to source ahead of the
       // bare `@elizaos/agent` stub alias below.
+      {
+        find: /^@elizaos\/agent\/api\/zip-utils$/,
+        replacement: path.join(agentSourceRoot, "api", "zip-utils.ts"),
+      },
       {
         find: /^@elizaos\/agent\/api\/client-chat-admin$/,
         replacement: path.join(agentSourceRoot, "api", "client-chat-admin.ts"),


### PR DESCRIPTION
Agreement owners can download the original PDF or export one immutable version with its reviewed obligations, citations, pins, grants, and provenance. Previously the agreement surface had no export and review/access mutations did not retain agreement-specific audit history.

The ZIP contains `original.pdf`, `manifest.json`, `SHA256SUMS`, and the exact saved `extraction.json` when available. The extraction file remains independently verifiable against its ingestion audit hash. Export verifies the original bytes and the saved extraction hash, reads mutable records from one database snapshot, and records archive preparation in the canonical LifeOps audit ledger. Ingestion, review, pin, and resource-grant transitions now commit with their audit event atomically. Legacy versions explicitly report missing page maps and incomplete historical coverage. Owner-authenticated download controls expose preparation and errors.

Refs #31162. Part of #30123; workspace-wide export/deletion and the remaining provider-backed MVP acceptance remain separate.

Validation at `f00d7d788f7e147efa0b8852d837af416d16e208`:

- Pinned Bun 1.3.14 / Node 24.15.0 installation passed.
- Root `bun run verify`: 373/373 tasks passed (4m37.745s), including package typecheck and lint.
- Real PGlite agreement integration: 12/12 passed. Covers atomic rollback, concurrent snapshots, corrupt/missing originals, altered extraction, legacy coverage, denied guest export, and export of a revoked resource grant with its household grant and audit history.
- Adapter HTTP tests: 14/14 passed. HTML, plain-text, and malformed JSON error responses retain the HTTP failure instead of surfacing a JSON parsing error.
- Full personal-assistant suite: 2,654 passed, six skipped, 303 files (527.79s). App audit: 226 passed; 220 findings, zero broken/needs-work, zero hover/density/minimalism failures; OCR 208 verified, zero broken, 12 requiring visual review.
- The earlier isolated browser harness passed and its desktop/mobile controls were inspected at rest and hover. Live before-deployment desktop/mobile captures are also inspected; final live export downloads and archive contents are independently verified.

All hosted checks passed for this exact source revision. Combined pilot `58cd2df949d37627131de2427ca043e218385e09` passed all seven Linux gates and is deployed. Its public assets match the build; agreement/packet/control state and the original messaging-service process survived restart. Fresh owner API and authenticated browser exports independently verify the original PDF bytes, raw extraction, page map, three review states, inactive pin, and canonical audit history. The preceding pilot video records upload, review, pin/unpin, original download, and export; final desktop/mobile captures and downloads verify the corrected revision.

Live guest transport acceptance remains outstanding under #31172; #31162 stays open until its live grant-history acceptance is complete. No real guest was contacted. Broader MVP acceptance remains in #30123.

[Reviewed deployment evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/bettina-agreement-export-58cd2df-evidence.zip): before/after desktop/mobile captures, scoped MP4 walkthrough, sanitized network/console and canonical audit records, independently verified synthetic ZIPs, and final deployed-revision download checks. Archive SHA-256: `398f820850c9a87d676685b300744f4868e3218b3a9caa049be436522f0fe5c1`.
