### PR TITLE
perf(cloud): batch organization policy reads for Dedicated inference

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
@@ -45,6 +45,37 @@ beforeAll(async () => {
 afterAll(async () => {
   await database.closeDatabaseConnectionsForTests();
 });
+test("optional policy rows stay tenant-scoped and missing authority fails closed", async () => {
+  const pg = database.getPgliteClientForTests();
+  const target = "61000000-0000-4000-8000-000000000003";
+  const other = "61000000-0000-4000-8000-000000000004";
+  await pg.exec(`
+    INSERT INTO organizations(id,credit_balance,balance_revision,balance_decrease_revision,settings,is_active,account_lifecycle_state)
+    VALUES('${target}',100,1,0,'{}',true,'active'),('${other}',100,1,0,'{}',true,'active');
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata)
+    VALUES(gen_random_uuid(),'${target}',100,'credit','{}'),(gen_random_uuid(),'${other}',100,'credit','{}');
+  `);
+  const before = await policy.readOrganizationQuotaPolicy(target);
+  await pg.exec(`
+    INSERT INTO org_rate_limit_overrides(organization_id,completions_rpm) VALUES('${other}',71);
+    INSERT INTO organization_config(organization_id,settings) VALUES('${other}','{"max_containers":3}');
+    INSERT INTO org_storage_quota(organization_id,bytes_used,bytes_limit,limit_override_authorized)
+    VALUES('${other}',0,13,true);
+  `);
+  const after = await policy.readOrganizationQuotaPolicy(target);
+  expect(after).toEqual({ ...before, observedAt: after.observedAt });
+  const overridden = await policy.readOrganizationQuotaPolicy(other);
+  expect(policy.requireOrganizationRateTier(overridden).completionsRpm).toBe(71);
+  expect(policy.requireOrganizationResourceLimit(overridden, "containers")).toBe(3n);
+  expect(policy.requireOrganizationResourceLimit(overridden, "storage")).toBe(13n);
+  await pg.exec(
+    `DELETE FROM organization_subscription_authorities WHERE organization_id='${other}'`,
+  );
+  await expect(policy.readOrganizationQuotaPolicy(other)).rejects.toMatchObject({
+    code: "ORGANIZATION_POLICY_UNAVAILABLE",
+    context: { organizationId: other, reason: "missing_account_authority" },
+  });
+});
 test("subscriber RPM survives balance spending and unapproved resource ceilings remain unavailable", async () => {
   const before = await policy.readOrganizationQuotaPolicy(ORG);
   await database

--- a/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
+++ b/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
@@ -131,42 +131,47 @@ export async function readOrganizationQuotaPolicyInTransaction(
   organizationId: string,
   observedAt?: Date,
 ): Promise<OrganizationQuotaPolicy> {
-  const [org] = await tx
+  // These rows are unique per organization. One statement keeps the policy
+  // inputs together without paying a separate database round trip for each.
+  const [inputs] = await tx
     .select({
-      balance: organizations.credit_balance,
-      revision: sql<string>`${organizations.balance_revision}::text`,
-      settings: organizations.settings,
+      org: {
+        balance: organizations.credit_balance,
+        revision: sql<string>`${organizations.balance_revision}::text`,
+        settings: organizations.settings,
+      },
+      association: organizationSubscriptionAuthorities,
+      override: {
+        // The row can exist with null RPM fields; retain its non-null join identity.
+        id: orgRateLimitOverrides.id,
+        completions_rpm: orgRateLimitOverrides.completions_rpm,
+        embeddings_rpm: orgRateLimitOverrides.embeddings_rpm,
+        standard_rpm: orgRateLimitOverrides.standard_rpm,
+        strict_rpm: orgRateLimitOverrides.strict_rpm,
+      },
+      config: { settings: organizationConfig.settings },
+      storage: {
+        bytes_limit: orgStorageQuota.bytes_limit,
+        limit_override_authorized: orgStorageQuota.limit_override_authorized,
+      },
     })
     .from(organizations)
+    .leftJoin(
+      organizationSubscriptionAuthorities,
+      eq(organizationSubscriptionAuthorities.organization_id, organizations.id),
+    )
+    .leftJoin(orgRateLimitOverrides, eq(orgRateLimitOverrides.organization_id, organizations.id))
+    .leftJoin(organizationConfig, eq(organizationConfig.organization_id, organizations.id))
+    .leftJoin(orgStorageQuota, eq(orgStorageQuota.organization_id, organizations.id))
     .where(eq(organizations.id, organizationId));
-  const [association] = await tx
-    .select()
-    .from(organizationSubscriptionAuthorities)
-    .where(eq(organizationSubscriptionAuthorities.organization_id, organizationId));
-  if (!org || !association || association.state === "unavailable")
+  if (!inputs || !inputs.association || inputs.association.state === "unavailable")
     return unavailable(organizationId, "missing_account_authority");
+  const { org, association, override, config, storage } = inputs;
   const balance = Number(org.balance);
   const validBalance =
     typeof org.balance === "string" &&
     /^[+-]?(?:\d+|\d*\.\d+)$/.test(org.balance.trim()) &&
     Number.isFinite(balance);
-  const [override] = await tx
-    .select({
-      completions_rpm: orgRateLimitOverrides.completions_rpm,
-      embeddings_rpm: orgRateLimitOverrides.embeddings_rpm,
-      standard_rpm: orgRateLimitOverrides.standard_rpm,
-      strict_rpm: orgRateLimitOverrides.strict_rpm,
-    })
-    .from(orgRateLimitOverrides)
-    .where(eq(orgRateLimitOverrides.organization_id, organizationId));
-  const [config] = await tx
-    .select({ settings: organizationConfig.settings })
-    .from(organizationConfig)
-    .where(eq(organizationConfig.organization_id, organizationId));
-  const [storage] = await tx
-    .select()
-    .from(orgStorageQuota)
-    .where(eq(orgStorageQuota.organization_id, organizationId));
   const base = {
     overrides: {
       completionsRpm: override?.completions_rpm ?? null,
@@ -216,7 +221,9 @@ export async function readOrganizationQuotaPolicyInTransaction(
         effectiveUntil: null,
       },
       tier: observe(
-        () => resolveOrgTierFromSourceValues(organizationId, credits.total, override).tierData,
+        () =>
+          resolveOrgTierFromSourceValues(organizationId, credits.total, override ?? undefined)
+            .tierData,
       ),
       tierSourceCreditTotal: credits.total,
       subscriptionFunded: false,


### PR DESCRIPTION
Fixes #31166.

Dedicated inference repeatedly reads the same organization policy inputs through five sequential database statements. Combine the organization, authority, optional rate overrides, configuration, and storage rows into one tenant-scoped query. Existing transaction ownership, organization locks, generation checks, entitlement validation, and database-clock handling remain in place. Preserve the non-null identity of optional override rows so a null completion limit cannot hide a configured embedding or standard limit.

The final query was compared with the deployed implementation in three read-only production PostgreSQL snapshot transactions for the test account. Full policies matched at the same observation time: baseline 1518/1498/1495 ms, candidate 836/831/830 ms. This measures the policy reader from the control plane; the end-to-end Worker and Dedicated chat improvement still requires staging deployment.

Validation at `e3ed8f7ec7f93c4d26f0dfb68189788bb6e74328`:

- 14 real PGlite policy tests passed, including nullable overrides, tenant isolation, absent authority, stale policy, and current resource admission.
- 13 PostgreSQL 17.10 tests passed, exercising independent writers, lifecycle races, settlement, cache publication, storage downgrade, and provisioning locks. The temporary local server was stopped afterward.
- Cloud-shared typecheck and read-only lint passed; lint reported five existing oversized-file warnings. Bun 1.3.14 and Node 24.15.0 were used. Frozen install made no dependency changes.
- Root `bun run verify` passed. Hosted CI and deployment have not run for this change.

The change affects a shared policy reader, so subscription and resource behavior are the material regression risks. No schema, policy, provider, model, or runtime configuration changes are included. Ship through staging and compare a real Dedicated reply before production promotion.

<!-- evidence-head:e3ed8f7ec7f93c4d26f0dfb68189788bb6e74328 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - database query change; no rendered source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - database query change; hosted chat measurement is a deployment gate.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI, native, or device implementation change.
<!-- evidence-row:backend-logs -->
- [x] [31167-dedicated-policy-query-public-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31167-dedicated-policy-query-public-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser code or response contract changed; hosted latency measurement follows staging deployment.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [31167-dedicated-policy-query-public-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31167-dedicated-policy-query-public-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered component or layout change.

