### PR TITLE
release: stage Dedicated inference policy query improvement

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
@@ -45,6 +45,37 @@ beforeAll(async () => {
 afterAll(async () => {
   await database.closeDatabaseConnectionsForTests();
 });
+test("optional policy rows stay tenant-scoped and missing authority fails closed", async () => {
+  const pg = database.getPgliteClientForTests();
+  const target = "61000000-0000-4000-8000-000000000003";
+  const other = "61000000-0000-4000-8000-000000000004";
+  await pg.exec(`
+    INSERT INTO organizations(id,credit_balance,balance_revision,balance_decrease_revision,settings,is_active,account_lifecycle_state)
+    VALUES('${target}',100,1,0,'{}',true,'active'),('${other}',100,1,0,'{}',true,'active');
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata)
+    VALUES(gen_random_uuid(),'${target}',100,'credit','{}'),(gen_random_uuid(),'${other}',100,'credit','{}');
+  `);
+  const before = await policy.readOrganizationQuotaPolicy(target);
+  await pg.exec(`
+    INSERT INTO org_rate_limit_overrides(organization_id,completions_rpm) VALUES('${other}',71);
+    INSERT INTO organization_config(organization_id,settings) VALUES('${other}','{"max_containers":3}');
+    INSERT INTO org_storage_quota(organization_id,bytes_used,bytes_limit,limit_override_authorized)
+    VALUES('${other}',0,13,true);
+  `);
+  const after = await policy.readOrganizationQuotaPolicy(target);
+  expect(after).toEqual({ ...before, observedAt: after.observedAt });
+  const overridden = await policy.readOrganizationQuotaPolicy(other);
+  expect(policy.requireOrganizationRateTier(overridden).completionsRpm).toBe(71);
+  expect(policy.requireOrganizationResourceLimit(overridden, "containers")).toBe(3n);
+  expect(policy.requireOrganizationResourceLimit(overridden, "storage")).toBe(13n);
+  await pg.exec(
+    `DELETE FROM organization_subscription_authorities WHERE organization_id='${other}'`,
+  );
+  await expect(policy.readOrganizationQuotaPolicy(other)).rejects.toMatchObject({
+    code: "ORGANIZATION_POLICY_UNAVAILABLE",
+    context: { organizationId: other, reason: "missing_account_authority" },
+  });
+});
 test("subscriber RPM survives balance spending and unapproved resource ceilings remain unavailable", async () => {
   const before = await policy.readOrganizationQuotaPolicy(ORG);
   await database

--- a/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
+++ b/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
@@ -131,42 +131,47 @@ export async function readOrganizationQuotaPolicyInTransaction(
   organizationId: string,
   observedAt?: Date,
 ): Promise<OrganizationQuotaPolicy> {
-  const [org] = await tx
+  // These rows are unique per organization. One statement keeps the policy
+  // inputs together without paying a separate database round trip for each.
+  const [inputs] = await tx
     .select({
-      balance: organizations.credit_balance,
-      revision: sql<string>`${organizations.balance_revision}::text`,
-      settings: organizations.settings,
+      org: {
+        balance: organizations.credit_balance,
+        revision: sql<string>`${organizations.balance_revision}::text`,
+        settings: organizations.settings,
+      },
+      association: organizationSubscriptionAuthorities,
+      override: {
+        // The row can exist with null RPM fields; retain its non-null join identity.
+        id: orgRateLimitOverrides.id,
+        completions_rpm: orgRateLimitOverrides.completions_rpm,
+        embeddings_rpm: orgRateLimitOverrides.embeddings_rpm,
+        standard_rpm: orgRateLimitOverrides.standard_rpm,
+        strict_rpm: orgRateLimitOverrides.strict_rpm,
+      },
+      config: { settings: organizationConfig.settings },
+      storage: {
+        bytes_limit: orgStorageQuota.bytes_limit,
+        limit_override_authorized: orgStorageQuota.limit_override_authorized,
+      },
     })
     .from(organizations)
+    .leftJoin(
+      organizationSubscriptionAuthorities,
+      eq(organizationSubscriptionAuthorities.organization_id, organizations.id),
+    )
+    .leftJoin(orgRateLimitOverrides, eq(orgRateLimitOverrides.organization_id, organizations.id))
+    .leftJoin(organizationConfig, eq(organizationConfig.organization_id, organizations.id))
+    .leftJoin(orgStorageQuota, eq(orgStorageQuota.organization_id, organizations.id))
     .where(eq(organizations.id, organizationId));
-  const [association] = await tx
-    .select()
-    .from(organizationSubscriptionAuthorities)
-    .where(eq(organizationSubscriptionAuthorities.organization_id, organizationId));
-  if (!org || !association || association.state === "unavailable")
+  if (!inputs || !inputs.association || inputs.association.state === "unavailable")
     return unavailable(organizationId, "missing_account_authority");
+  const { org, association, override, config, storage } = inputs;
   const balance = Number(org.balance);
   const validBalance =
     typeof org.balance === "string" &&
     /^[+-]?(?:\d+|\d*\.\d+)$/.test(org.balance.trim()) &&
     Number.isFinite(balance);
-  const [override] = await tx
-    .select({
-      completions_rpm: orgRateLimitOverrides.completions_rpm,
-      embeddings_rpm: orgRateLimitOverrides.embeddings_rpm,
-      standard_rpm: orgRateLimitOverrides.standard_rpm,
-      strict_rpm: orgRateLimitOverrides.strict_rpm,
-    })
-    .from(orgRateLimitOverrides)
-    .where(eq(orgRateLimitOverrides.organization_id, organizationId));
-  const [config] = await tx
-    .select({ settings: organizationConfig.settings })
-    .from(organizationConfig)
-    .where(eq(organizationConfig.organization_id, organizationId));
-  const [storage] = await tx
-    .select()
-    .from(orgStorageQuota)
-    .where(eq(orgStorageQuota.organization_id, organizationId));
   const base = {
     overrides: {
       completionsRpm: override?.completions_rpm ?? null,
@@ -216,7 +221,9 @@ export async function readOrganizationQuotaPolicyInTransaction(
         effectiveUntil: null,
       },
       tier: observe(
-        () => resolveOrgTierFromSourceValues(organizationId, credits.total, override).tierData,
+        () =>
+          resolveOrgTierFromSourceValues(organizationId, credits.total, override ?? undefined)
+            .tierData,
       ),
       tierSourceCreditTotal: credits.total,
       subscriptionFunded: false,


### PR DESCRIPTION
Promote #31167 to staging to measure the Dedicated inference policy-query improvement. Five related organization policy reads now execute in one statement, with the existing locks, policy-generation checks, entitlement validation, and nullable-override behavior preserved.

Reviewed develop source: `b1c042c4a68d546d39c27dfb123c6d6992641eac`. Expected merge tree: `55ae1987e57fbf10e77262d13f818ded4cccfdfa`, identical to the tested source. The source PR contains 27 passing real PGlite/PostgreSQL tests, passing package type/lint and root verification, and a read-only production database comparison with identical policies: approximately 1.50 seconds before and 0.83 seconds after. Hosted source CI is still running; no end-to-end latency improvement is claimed yet.

The staging branch was absent and was restored to the exact last certified staging source `10dd581e538dd340ce16ca9c0903df9fd8912c2b` before this normal promotion. No forced ref update was used.

Run the canonical staging Cloud release, then measure a real Dedicated recall reply and verify full history through the app. No database migration, provisioning-worker deployment, Dedicated restart, or capacity change is needed. First-ever Google signup remains unverified. Evidence: https://github.com/elizaOS/eliza/pull/31167.
