### PR TITLE
release: reduce Dedicated inference policy lookup round trips

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
@@ -45,6 +45,37 @@ beforeAll(async () => {
 afterAll(async () => {
   await database.closeDatabaseConnectionsForTests();
 });
+test("optional policy rows stay tenant-scoped and missing authority fails closed", async () => {
+  const pg = database.getPgliteClientForTests();
+  const target = "61000000-0000-4000-8000-000000000003";
+  const other = "61000000-0000-4000-8000-000000000004";
+  await pg.exec(`
+    INSERT INTO organizations(id,credit_balance,balance_revision,balance_decrease_revision,settings,is_active,account_lifecycle_state)
+    VALUES('${target}',100,1,0,'{}',true,'active'),('${other}',100,1,0,'{}',true,'active');
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata)
+    VALUES(gen_random_uuid(),'${target}',100,'credit','{}'),(gen_random_uuid(),'${other}',100,'credit','{}');
+  `);
+  const before = await policy.readOrganizationQuotaPolicy(target);
+  await pg.exec(`
+    INSERT INTO org_rate_limit_overrides(organization_id,completions_rpm) VALUES('${other}',71);
+    INSERT INTO organization_config(organization_id,settings) VALUES('${other}','{"max_containers":3}');
+    INSERT INTO org_storage_quota(organization_id,bytes_used,bytes_limit,limit_override_authorized)
+    VALUES('${other}',0,13,true);
+  `);
+  const after = await policy.readOrganizationQuotaPolicy(target);
+  expect(after).toEqual({ ...before, observedAt: after.observedAt });
+  const overridden = await policy.readOrganizationQuotaPolicy(other);
+  expect(policy.requireOrganizationRateTier(overridden).completionsRpm).toBe(71);
+  expect(policy.requireOrganizationResourceLimit(overridden, "containers")).toBe(3n);
+  expect(policy.requireOrganizationResourceLimit(overridden, "storage")).toBe(13n);
+  await pg.exec(
+    `DELETE FROM organization_subscription_authorities WHERE organization_id='${other}'`,
+  );
+  await expect(policy.readOrganizationQuotaPolicy(other)).rejects.toMatchObject({
+    code: "ORGANIZATION_POLICY_UNAVAILABLE",
+    context: { organizationId: other, reason: "missing_account_authority" },
+  });
+});
 test("subscriber RPM survives balance spending and unapproved resource ceilings remain unavailable", async () => {
   const before = await policy.readOrganizationQuotaPolicy(ORG);
   await database

--- a/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
+++ b/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
@@ -131,42 +131,47 @@ export async function readOrganizationQuotaPolicyInTransaction(
   organizationId: string,
   observedAt?: Date,
 ): Promise<OrganizationQuotaPolicy> {
-  const [org] = await tx
+  // These rows are unique per organization. One statement keeps the policy
+  // inputs together without paying a separate database round trip for each.
+  const [inputs] = await tx
     .select({
-      balance: organizations.credit_balance,
-      revision: sql<string>`${organizations.balance_revision}::text`,
-      settings: organizations.settings,
+      org: {
+        balance: organizations.credit_balance,
+        revision: sql<string>`${organizations.balance_revision}::text`,
+        settings: organizations.settings,
+      },
+      association: organizationSubscriptionAuthorities,
+      override: {
+        // The row can exist with null RPM fields; retain its non-null join identity.
+        id: orgRateLimitOverrides.id,
+        completions_rpm: orgRateLimitOverrides.completions_rpm,
+        embeddings_rpm: orgRateLimitOverrides.embeddings_rpm,
+        standard_rpm: orgRateLimitOverrides.standard_rpm,
+        strict_rpm: orgRateLimitOverrides.strict_rpm,
+      },
+      config: { settings: organizationConfig.settings },
+      storage: {
+        bytes_limit: orgStorageQuota.bytes_limit,
+        limit_override_authorized: orgStorageQuota.limit_override_authorized,
+      },
     })
     .from(organizations)
+    .leftJoin(
+      organizationSubscriptionAuthorities,
+      eq(organizationSubscriptionAuthorities.organization_id, organizations.id),
+    )
+    .leftJoin(orgRateLimitOverrides, eq(orgRateLimitOverrides.organization_id, organizations.id))
+    .leftJoin(organizationConfig, eq(organizationConfig.organization_id, organizations.id))
+    .leftJoin(orgStorageQuota, eq(orgStorageQuota.organization_id, organizations.id))
     .where(eq(organizations.id, organizationId));
-  const [association] = await tx
-    .select()
-    .from(organizationSubscriptionAuthorities)
-    .where(eq(organizationSubscriptionAuthorities.organization_id, organizationId));
-  if (!org || !association || association.state === "unavailable")
+  if (!inputs || !inputs.association || inputs.association.state === "unavailable")
     return unavailable(organizationId, "missing_account_authority");
+  const { org, association, override, config, storage } = inputs;
   const balance = Number(org.balance);
   const validBalance =
     typeof org.balance === "string" &&
     /^[+-]?(?:\d+|\d*\.\d+)$/.test(org.balance.trim()) &&
     Number.isFinite(balance);
-  const [override] = await tx
-    .select({
-      completions_rpm: orgRateLimitOverrides.completions_rpm,
-      embeddings_rpm: orgRateLimitOverrides.embeddings_rpm,
-      standard_rpm: orgRateLimitOverrides.standard_rpm,
-      strict_rpm: orgRateLimitOverrides.strict_rpm,
-    })
-    .from(orgRateLimitOverrides)
-    .where(eq(orgRateLimitOverrides.organization_id, organizationId));
-  const [config] = await tx
-    .select({ settings: organizationConfig.settings })
-    .from(organizationConfig)
-    .where(eq(organizationConfig.organization_id, organizationId));
-  const [storage] = await tx
-    .select()
-    .from(orgStorageQuota)
-    .where(eq(orgStorageQuota.organization_id, organizationId));
   const base = {
     overrides: {
       completionsRpm: override?.completions_rpm ?? null,
@@ -216,7 +221,9 @@ export async function readOrganizationQuotaPolicyInTransaction(
         effectiveUntil: null,
       },
       tier: observe(
-        () => resolveOrgTierFromSourceValues(organizationId, credits.total, override).tierData,
+        () =>
+          resolveOrgTierFromSourceValues(organizationId, credits.total, override ?? undefined)
+            .tierData,
       ),
       tierSourceCreditTotal: credits.total,
       subscriptionFunded: false,


### PR DESCRIPTION
Promote #31167, which removes four sequential database round trips from each organization-policy read while retaining the existing tenant scope, policy locks, entitlement validation, generation checks, and database-clock behavior. This is a measured query improvement for Dedicated inference; overall chat responsiveness remains unfinished.

The promotion changes only the policy loader and its real PGlite contract test. Source `e3ed8f7ec7f93c4d26f0dfb68189788bb6e74328`; staging `118cb5142f326322228f1cf2666a6bb850e495e4`; normal merge preview tree `55ae1987e57fbf10e77262d13f818ded4cccfdfa` exactly matches the tested and certified tree.

Validation: 14 real PGlite tests, 13 PostgreSQL tests, package typecheck/lint, and root verification passed. Read-only production comparisons returned identical complete policies, with 1495–1518 ms baseline versus 830–836 ms candidate. Source CI [34714547030](https://github.com/elizaOS/eliza/actions/runs/34714547030) completed successfully, including billing replay, Windows security, subscription PostgreSQL, and static smoke. The separate broad Develop Full run 34714584097 still has failures and is not claimed clean; their relationship to this two-file patch has not been established.

[Staging release 34714679173](https://github.com/elizaOS/eliza/actions/runs/34714679173) succeeded. Canonical certification accepted artifact `10304443711`, digest `sha256:80e0c76efc502a60cf6983daf894828fd3d0c7b0e348a75c17873d57e923954b`, expiring 2026-09-26T19:58:56.655Z.

Live acceptance on the new staging API: one real recall request returned all four saved facts. Submission to runtime finalization was 35.594 seconds (runtime 33.487 seconds); first observed complete in the browser at 42.303 seconds. The earlier staging sample was 53.418 seconds. These are individual observations, not proof that the query patch caused the entire change: cache warming and environment differences remain possible contributors. Embedding recall still took 16.218 seconds. All 35 prior messages plus the new request/reply survived a normal 390×844 reload exactly; desktop retained the same complete 37-message text. The reply and composer were visually inspected, and browser emulation and DevTools were removed afterward.

Production release [34715963361](https://github.com/elizaOS/eliza/actions/runs/34715963361) completed successfully for `a00194febec990d154a406e8b03712705499528f`, with live API commit verified. One real production recall returned the saved code and color. Submission to runtime finalization was 36.050 seconds, versus the earlier 53.978-second production sample; runtime itself was 35.319 seconds. This is an individual before/after observation, not a controlled causal estimate. Embedding recall still consumed 22.257 seconds with retries, so responsiveness remains unresolved. All ten previous messages plus the new request/reply survived ordinary desktop reload exactly, with the final reply and composer visually inspected. Earlier mobile acceptance remains recorded separately; this production request was tested at desktop width. No schema, provider, prompt, model context, provisioning worker, Dedicated runtime image, or paid capacity changes are part of this promotion. Genuine new-account signup remains unverified separately.

| Evidence | Result |
| --- | --- |
| Before screenshots <!-- evidence-row:before-screenshots --> | N/A - backend query change with no rendered UI diff |
| After screenshots <!-- evidence-row:after-screenshots --> | N/A - backend query change with no rendered UI diff |
| Walkthrough video <!-- evidence-row:walkthrough-video --> | N/A - backend query change with no rendered UI diff |
| Backend logs <!-- evidence-row:backend-logs --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31167-dedicated-policy-query-public-backend.log |
| Frontend logs <!-- evidence-row:frontend-logs --> | N/A - no frontend code change |
| LLM trajectory <!-- evidence-row:llm-trajectory --> | N/A - no model, provider, prompt, action, or runtime change; real app outcome recorded above |
| Domain artifacts <!-- evidence-row:domain-artifacts --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31167-dedicated-policy-query-public-domain.json |
| OCR review <!-- evidence-row:ocr-review --> | N/A - backend query change with no rendered UI diff |

<!-- evidence-head:118cb5142f326322228f1cf2666a6bb850e495e4 -->
