### PR TITLE
fix(lifeops): authorize scoped agreement reads for paired guests

### DIFF
--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -247,6 +247,15 @@ Guest views expose approved obligations only. Revoking the relationship-backed
 household grant immediately invalidates every agreement binding that relies on
 it.
 
+A paired guest reads `GET /api/lifeops/agreements/:id/shared` using its machine
+session. The owner must bind that machine identity to a person through
+`POST /api/lifeops/entities/:id/auth-bindings` and explicitly issue the household
+and agreement grants. The shared route derives the person from the verified
+session binding; caller-supplied principal IDs and role headers cannot select
+another reader. It returns approved clauses and limited metadata with no-store
+caching. Original PDF downloads, exports, review history, and mutations remain
+owner-only. Use the normal owner read route for owner requests.
+
 The owner surface is available through `OWNER_AGREEMENT_KNOWLEDGE` and the
 authenticated `/api/lifeops/agreements/*` routes. Grant previews enumerate the
 exact read effects and exclusions before issuance. Active agent/chat pins feed

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -5,10 +5,13 @@
  */
 
 import crypto from "node:crypto";
+import { once } from "node:events";
 import fs from "node:fs";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { resolveKnowledgeGraphService } from "@elizaos/agent";
+import { AuthStore } from "@elizaos/app-core/services/auth-store";
 import {
   type AgentRuntime,
   attestAuthenticatedApiDeliveryAudience,
@@ -23,12 +26,15 @@ import {
 } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { tryHandleRuntimePluginRoute } from "../../../../../packages/agent/src/api/runtime-plugin-routes.ts";
 import { LocalFileStorageService } from "../../../../../packages/agent/src/services/file-storage.js";
+import { createMachineSession } from "../../../../../packages/app-core/src/api/auth/sessions.ts";
 import { composeResponseState } from "../../../../../packages/core/src/services/message/provider-state.js";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../test/helpers/runtime.js";
+import { bindMachineAuthIdentityToEntity } from "../../routes/authenticated-entity-principal.js";
 import { executeRawSql, sqlQuote } from "../sql.js";
 import {
   AgreementKnowledgeError,
@@ -973,6 +979,116 @@ describe("parenting-agreement knowledge — real PGlite", () => {
         principalEntityId: "verified-co-parent",
       }),
     ).rejects.toMatchObject({ code: "AGREEMENT_ACCESS_DENIED" });
+  });
+
+  it("serves only the bound guest projection over HTTP and denies revoked access", async () => {
+    const db = (
+      runtime as AgentRuntime & {
+        adapter: { db: ConstructorParameters<typeof AuthStore>[0] };
+      }
+    ).adapter.db;
+    const auth = new AuthStore(db);
+    const identityId = crypto.randomUUID();
+    await auth.createIdentity({
+      id: identityId,
+      kind: "machine",
+      displayName: "synthetic guest",
+      createdAt: Date.now(),
+      passwordHash: null,
+      cloudUserId: null,
+    });
+    const { session } = await createMachineSession(auth, {
+      identityId,
+      scopes: [],
+    });
+    const service = createAgreementKnowledgeService(runtime);
+    const server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const handled = await tryHandleRuntimePluginRoute({
+        req,
+        res,
+        url,
+        pathname: url.pathname,
+        method: req.method ?? "GET",
+        runtime,
+        isAuthorized: () => true,
+      });
+      if (!handled && !res.headersSent) {
+        res.statusCode = 404;
+        res.end("not found");
+      }
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string")
+      throw new Error("Missing test server address");
+    const base = `http://127.0.0.1:${address.port}/api/lifeops/agreements/${artifact.id}`;
+    // Model the public reverse proxy so loopback operator trust cannot mask guest auth.
+    const headers = {
+      Host: "guest-agreement.example.test",
+      "x-forwarded-for": "203.0.113.20",
+      Authorization: `Bearer ${session.id}`,
+      "x-eliza-entity-id": "self",
+    };
+    try {
+      const unbound = await fetch(`${base}/shared?principalEntityId=self`, {
+        headers,
+      });
+      expect(unbound.status, await unbound.text()).toBe(403);
+      await bindMachineAuthIdentityToEntity({
+        runtime,
+        entityId: "verified-co-parent",
+        authIdentityId: identityId,
+      });
+      expect((await fetch(`${base}/shared`, { headers })).status).toBe(403);
+      const grant = await service.grantGuestRead({
+        artifactId: artifact.id,
+        principalEntityId: "verified-co-parent",
+        householdGrantId: guestHouseholdGrantId,
+        issuedByEntityId: SELF_ENTITY_ID,
+      });
+      const response = await fetch(`${base}/shared?principalEntityId=self`, {
+        headers,
+      });
+      expect(response.status, await response.clone().text()).toBe(200);
+      expect(response.headers.get("cache-control")).toContain("no-store");
+      const payload = await response.json();
+      expect(payload.agreement.obligations).toHaveLength(1);
+      expect(payload.agreement.obligations[0]).toMatchObject({
+        status: "approved",
+        pageStart: 4,
+        pageEnd: 5,
+      });
+      expect(payload.agreement.artifact).not.toHaveProperty("mediaUrl");
+      expect(payload.agreement.obligations[0]).not.toHaveProperty(
+        "decisionReason",
+      );
+      for (const [suffix, method] of [
+        ["", "GET"],
+        ["/download", "GET"],
+        ["/export", "POST"],
+        ["/guest-projection?principalEntityId=self", "GET"],
+      ]) {
+        expect(
+          (await fetch(`${base}${suffix}`, { method, headers })).status,
+        ).toBe(403);
+      }
+      await service.revokeGuestRead({
+        grantId: grant.id,
+        revokedByEntityId: SELF_ENTITY_ID,
+        reason: "Synthetic HTTP acceptance cleanup",
+      });
+      expect((await fetch(`${base}/shared`, { headers })).status).toBe(403);
+      expect(await auth.revokeSession(session.id)).toBe(true);
+      expect((await fetch(`${base}/shared`, { headers })).status).not.toBe(200);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+      await auth.revokeSession(session.id);
+    }
   });
 
   it("rejects non-owner mutations and malformed PDF input", async () => {

--- a/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.test.ts
@@ -16,6 +16,7 @@ function context(input: {
   pathname: string;
   body?: unknown;
   agreements: Record<string, unknown>;
+  requestEntityId?: string;
 }) {
   const responses: Array<{ data: unknown; status: number }> = [];
   const cache = new Map<string, unknown>();
@@ -30,11 +31,15 @@ function context(input: {
   } as unknown as IAgentRuntime;
   const ctx = {
     req: {},
-    res: {},
+    res: { setHeader: vi.fn() },
     method: input.method,
     pathname: input.pathname,
     url: new URL(`http://localhost${input.pathname}`),
-    state: { runtime, adminEntityId: "self" },
+    state: {
+      runtime,
+      adminEntityId: "self",
+      requestEntityId: input.requestEntityId,
+    },
     json: (_res: unknown, data: unknown, status = 200) => {
       responses.push({ data, status });
     },
@@ -46,6 +51,68 @@ function context(input: {
 }
 
 describe("agreement knowledge routes", () => {
+  it("derives shared reads from the gated session rather than a supplied principal", async () => {
+    const readFor = vi.fn(async () => ({ obligations: [] }));
+    const harness = context({
+      method: "GET",
+      pathname:
+        "/api/lifeops/agreements/document/shared?principalEntityId=self",
+      requestEntityId: "bound-guest",
+      agreements: { readFor },
+    });
+    harness.ctx.pathname = harness.ctx.url.pathname;
+    await handleAgreementKnowledgeRoutes(harness.ctx);
+    expect(readFor).toHaveBeenCalledWith({
+      artifactId: "document",
+      principalEntityId: "bound-guest",
+    });
+    expect(harness.responses[0]).toMatchObject({ status: 200 });
+    expect(harness.ctx.res.setHeader).toHaveBeenCalledWith(
+      "Cache-Control",
+      "private, no-store, max-age=0",
+    );
+  });
+
+  it.each([undefined, "self"])(
+    "rejects a shared read without a distinct guest principal (%s)",
+    async (requestEntityId) => {
+      const readFor = vi.fn();
+      const harness = context({
+        method: "GET",
+        pathname: "/api/lifeops/agreements/document/shared",
+        requestEntityId,
+        agreements: { readFor },
+      });
+      await handleAgreementKnowledgeRoutes(harness.ctx);
+      expect(readFor).not.toHaveBeenCalled();
+      expect(harness.responses[0]).toMatchObject({
+        status: 403,
+        data: { error: { code: "AGREEMENT_ACCESS_DENIED" } },
+      });
+    },
+  );
+
+  it("preserves a revoked grant denial on the shared HTTP read", async () => {
+    const harness = context({
+      method: "GET",
+      pathname: "/api/lifeops/agreements/document/shared",
+      requestEntityId: "bound-guest",
+      agreements: {
+        readFor: async () => {
+          throw new AgreementKnowledgeError(
+            "Grant revoked",
+            "AGREEMENT_ACCESS_DENIED",
+          );
+        },
+      },
+    });
+    await handleAgreementKnowledgeRoutes(harness.ctx);
+    expect(harness.responses[0]).toMatchObject({
+      status: 403,
+      data: { error: { code: "AGREEMENT_ACCESS_DENIED" } },
+    });
+  });
+
   it("creates a resumable owner upload without trusting a page count", async () => {
     const harness = context({
       method: "POST",

--- a/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.ts
@@ -1,6 +1,6 @@
 /**
- * Owner-authorized HTTP contract for parenting-agreement versions, reviews,
- * pins, and bounded guest grants. The handler translates typed domain failures
+ * Owner HTTP contract for parenting-agreement versions, reviews, pins, and
+ * grants, plus a verified-session guest projection. The handler translates domain failures
  * into stable JSON errors while all authorization remains in the domain
  * service rather than request-provided role headers.
  */
@@ -270,6 +270,32 @@ export async function handleAgreementKnowledgeRoutes(
       );
       ctx.res.setHeader("Content-Length", String(file.bytes.length));
       ctx.res.end(file.bytes);
+      return true;
+    }
+
+    const sharedRead = pathMatch(
+      ctx.pathname,
+      /^\/api\/lifeops\/agreements\/([^/]+)\/shared$/,
+    );
+    if (ctx.method === "GET" && sharedRead) {
+      const principalEntityId = ctx.state.requestEntityId;
+      if (
+        !principalEntityId ||
+        principalEntityId === SELF_ENTITY_ID ||
+        principalEntityId === ctx.state.adminEntityId
+      ) {
+        throw new AgreementKnowledgeError(
+          "A verified guest session is required for the shared agreement view",
+          "AGREEMENT_ACCESS_DENIED",
+        );
+      }
+      const agreement = await service.readFor({
+        artifactId: sharedRead[0] ?? "",
+        principalEntityId: String(principalEntityId),
+      });
+      ctx.res.setHeader("Cache-Control", "private, no-store, max-age=0");
+      ctx.res.setHeader("Referrer-Policy", "no-referrer");
+      ctx.json(ctx.res, { agreement });
       return true;
     }
 

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -574,6 +574,11 @@ const LIFEOPS_DYNAMIC_ROUTES: RouteSpec[] = [
   { type: "PATCH", path: "/api/lifeops/relationships/:id" },
   { type: "POST", path: "/api/lifeops/relationships/:id/retire" },
   { type: "GET", path: "/api/lifeops/agreements/:id" },
+  {
+    type: "GET",
+    path: "/api/lifeops/agreements/:id/shared",
+    access: "authenticated_entity",
+  },
   { type: "GET", path: "/api/lifeops/agreements/:id/download" },
   { type: "POST", path: "/api/lifeops/agreements/:id/export" },
   {

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -252,6 +252,39 @@ export default defineConfig({
     ...baseConfig.resolve,
     preserveSymlinks: false,
     alias: [
+      {
+        find: /^@elizaos\/app-core\/api\/compat-route-shared$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "app-core",
+          "src",
+          "api",
+          "compat-route-shared.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/app-core\/api\/auth$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "app-core",
+          "src",
+          "api",
+          "auth.ts",
+        ),
+      },
+      {
+        find: /^@elizaos\/app-core\/services\/auth-store$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "app-core",
+          "src",
+          "services",
+          "auth-store.ts",
+        ),
+      },
       // The real agent runtime loads audio-redaction services while this lane
       // boots the OWNER/USER matrix. This specialized alias list replaces the
       // base shared-source aliases, so keep these two package subpaths anchored


### PR DESCRIPTION
Paired guests could be bound to a person and given agreement grants, but every agreement HTTP read still required owner authority. Add `GET /api/lifeops/agreements/:id/shared`, deriving the reader from the canonical machine-session binding and delegating authorization to the existing household/resource grant service.

The shared response contains only limited metadata and approved clauses, with no-store caching. Caller-supplied principal/role fields cannot select another reader. Original downloads, exports, review history, and mutations remain owner-only. Missing bindings, missing/revoked grants, and revoked sessions fail closed.

Refs #31172 and #30123. Live paired-guest acceptance is pending; the separate owner-planner gap in #31176 prevents a complete live household grant lifecycle today. This PR does not bypass that workflow or fabricate grants.

Validation:
- Pinned installation and final rebased root `bun run verify`: 373/373 passed (4m19.588s), including package typecheck/lint.
- Full personal-assistant suite: 2,658 passed, six existing skips, 303 files.
- Real PGlite and HTTP agreement integration: 13 passed, including real DB machine sessions, unique owner-bound identities, scoped grant read, exclusion of owner fields/routes, and revocation denial.
- Focused route boundary tests: eight passed, including forged-principal and missing-session attribution cases.
- README documents the authenticated transport contract. No UI change; app visual audit is N/A.
