### PR TITLE
fix(cloud): admit cold Dedicated requests using current policy

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
@@ -1,5 +1,6 @@
 /** Exercises transaction-current quota policy, real override mutations and storage reservations against migrated PGlite rows. */
 import { afterAll, beforeAll, expect, setDefaultTimeout, spyOn, test } from "bun:test";
+import type { OrganizationInferenceAdmissionParams } from "../../lib/services/organization-inference-admission";
 import { createBillingSnapshotFixture } from "./account-billing-snapshot-test-fixture";
 
 process.env.DATABASE_URL = "pglite://memory";
@@ -390,11 +391,9 @@ test("the primary limiter converts a stale embedded policy to warming and consum
     consume.mockRestore();
   }
 });
-test("a stale standalone tier cache hydrates without a supplied config and the retry uses current authority", async () => {
+test("a stale standalone tier cache cannot delay or override the locked primary rate policy", async () => {
   const { recalculateOrgTier } = await import("../../lib/services/org-rate-limits");
-  const { enforceOrgRateLimit, OrgRateLimitCacheNotReadyError } = await import(
-    "../../lib/middleware/rate-limit"
-  );
+  const { enforceOrgRateLimit } = await import("../../lib/middleware/rate-limit");
   const gate = await import("../../lib/services/inference-admission-gate");
   const consume = spyOn(gate, "consumeInferenceRateLimit").mockResolvedValue({
     allowed: true,
@@ -413,15 +412,98 @@ test("a stale standalone tier cache hydrates without a supplied config and the r
         cacheOnly: true,
         executionCtx: { waitUntil: (promise) => background.push(promise) },
       }),
-    ).rejects.toBeInstanceOf(OrgRateLimitCacheNotReadyError);
-    expect(consume).not.toHaveBeenCalled();
-    await Promise.all(background);
-    await expect(enforceOrgRateLimit(ORG, "standard", { cacheOnly: true })).resolves.toBeNull();
+    ).resolves.toBeNull();
     expect(consume).toHaveBeenCalledWith(
       expect.objectContaining({ organizationId: ORG, endpointType: "standard", maxRequests: 3 }),
     );
   } finally {
+    await Promise.all(background);
     consume.mockRestore();
+  }
+});
+test("Worker funding uses the primary balance when its projection is absent or overstated", async () => {
+  const { runWithCloudBindingsAsync } = await import("../../lib/runtime/cloud-bindings");
+  const { readOrgBalanceHint, writeOrgBalanceHint } = await import(
+    "../../lib/services/inference-auth-cache"
+  );
+  const { admitOrganizationInference } = await import(
+    "../../lib/services/organization-inference-admission"
+  );
+  const organizationId = "61000000-0000-4000-8000-000000000005";
+  const pg = database.getPgliteClientForTests();
+  await pg.exec(`
+    INSERT INTO organizations(id,credit_balance,balance_revision,balance_decrease_revision,settings,is_active,account_lifecycle_state)
+    VALUES('${organizationId}',2,9,0,'{}',true,'active');
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata)
+    VALUES(gen_random_uuid(),'${organizationId}',2,'credit','{}');
+  `);
+  expect(await readOrgBalanceHint(organizationId)).toBeNull();
+  const dispatched: Array<{ balanceUsd: number; balanceRevision: string }> = [];
+  const background: Promise<unknown>[] = [];
+  try {
+    await runWithCloudBindingsAsync(
+      {
+        INFERENCE_OPTIMISTIC_BILLING: "true",
+        INFERENCE_DEFERRED_ADMISSION: "true",
+        INFERENCE_BILLING_LEDGER: "db",
+        INFERENCE_ADMISSION_GATES: {
+          getByName: (name: string) => {
+            expect(name).toBe(organizationId);
+            return {
+              fetch: async (request: Request) => {
+                const body = (await request.json()) as {
+                  balanceUsd: number;
+                  balanceRevision: string;
+                  estimatedCostUsd: number;
+                };
+                dispatched.push(body);
+                return Response.json({
+                  admitted: true,
+                  dispatched: true,
+                  availableUsd: body.balanceUsd,
+                  requiredUsd: body.estimatedCostUsd,
+                });
+              },
+            };
+          },
+        },
+      },
+      async () => {
+        const params: OrganizationInferenceAdmissionParams = {
+          context: {
+            organizationId,
+            userId: "63000000-0000-4000-8000-000000000001",
+            requestId: "cold-primary-balance",
+            model: "test-model",
+            provider: "openai",
+            billingSource: "openai",
+          },
+          flatCost: { totalCost: 0.25, baseTotalCost: 0.25, platformMarkup: 0 },
+          estimatedInputTokens: 0,
+          estimatedOutputTokens: 0,
+          executionCtx: { waitUntil: (work: Promise<unknown>) => background.push(work) },
+          atomicProviderBoundary: true,
+        };
+        const funded = await admitOrganizationInference(params);
+        await funded.markProviderDispatched?.();
+        expect(dispatched).toEqual([
+          expect.objectContaining({ balanceUsd: 2, balanceRevision: "9" }),
+        ]);
+        await writeOrgBalanceHint(organizationId, 100, Date.now(), "9");
+        await pg.exec(
+          `UPDATE organizations SET credit_balance=0,balance_revision=10 WHERE id='${organizationId}'`,
+        );
+        await expect(
+          admitOrganizationInference({
+            ...params,
+            context: { ...params.context, requestId: "overstated-cached-balance" },
+          }),
+        ).rejects.toMatchObject({ name: "InsufficientCreditsError", available: 0 });
+        expect(dispatched).toHaveLength(1);
+      },
+    );
+  } finally {
+    await Promise.all(background);
   }
 });
 test("same-revision projection corruption cannot grant policy", async () => {

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
@@ -197,7 +197,6 @@ const {
   mcpOrgRateLimitRedisKey,
   rateLimitExceededPayload,
   rateLimitExceededResponse,
-  OrgRateLimitCacheNotReadyError,
   withRateLimit,
 } = await import("./rate-limit");
 
@@ -290,7 +289,7 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     expect(tierReads).toBe(0);
   });
 
-  test("cache-only mode uses the cached tier and Durable Object without Redis", async () => {
+  test("Worker mode uses the primary tier and Durable Object without Redis", async () => {
     process.env.REDIS_RATE_LIMITING = "false";
     const org = uid();
     expect(
@@ -299,7 +298,7 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
         executionCtx: { waitUntil: () => undefined },
       }),
     ).toBeNull();
-    expect(tierReads).toBe(1);
+    expect(tierReads).toBe(0);
     expect(admissionChecks).toBe(1);
     expect(admissionRequests).toEqual([
       {
@@ -312,18 +311,17 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     expect(redisChecks).toBe(0);
   });
 
-  test("cache-only mode surfaces warming without contacting Redis", async () => {
+  test("a cold auxiliary tier does not reject a current primary-policy decision", async () => {
     tierCacheResolution = { kind: "warming", cacheRead: "miss" };
-    const result = enforceOrgRateLimit(uid(), "completions", {
-      cacheOnly: true,
-      executionCtx: { waitUntil: () => undefined },
-    });
-    await expect(result).rejects.toBeInstanceOf(OrgRateLimitCacheNotReadyError);
-    await expect(result).rejects.toMatchObject({
-      state: "warming",
-      cacheRead: "invalid",
-    });
-    expect(admissionChecks).toBe(0);
+    await expect(
+      enforceOrgRateLimit(uid(), "completions", {
+        cacheOnly: true,
+        executionCtx: { waitUntil: () => undefined },
+      }),
+    ).resolves.toBeNull();
+    expect(admissionRequests[0]?.maxRequests).toBe(policyRpm);
+    expect(admissionChecks).toBe(1);
+    expect(tierReads).toBe(0);
     expect(redisChecks).toBe(0);
   });
 
@@ -447,7 +445,7 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     expect(redisChecks).toBe(0);
     expect(admissionChecks).toBe(0);
   });
-  test("stale cache-only stamp warms current observations and retry uses the changed policy", async () => {
+  test("without a supplied observation the first request uses changed primary policy", async () => {
     policyAuthority = { ...initialAuthority, generation: "2" };
     policyRpm = 3;
     const org = uid();
@@ -456,16 +454,12 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
       cacheOnly: true,
       executionCtx: { waitUntil: (work: Promise<unknown>) => background.push(work) },
     };
-    await expect(enforceOrgRateLimit(org, "completions", options)).rejects.toMatchObject({
-      state: "warming",
-      cacheRead: "invalid",
-    });
-    expect(admissionChecks).toBe(0);
+    await expect(enforceOrgRateLimit(org, "completions", options)).resolves.toBeNull();
+    expect(admissionChecks).toBe(1);
     expect(redisChecks).toBe(0);
     await Promise.all(background);
-    expect(regenerations).toBe(1);
-    expect(snapshotWarms).toBe(1);
-    expect(await enforceOrgRateLimit(org, "completions", options)).toBeNull();
+    expect(regenerations).toBe(0);
+    expect(snapshotWarms).toBe(0);
     expect(admissionRequests.map((request) => request.maxRequests)).toEqual([3]);
   });
 

--- a/packages/cloud/shared/src/lib/middleware/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit.ts
@@ -2,7 +2,7 @@
  * Rate-limit policies for public callers and organization inference.
  *
  * Worker inference consumes exact per-organization windows from a Durable
- * Object after cache-only tier resolution. Non-Worker production surfaces keep
+ * Object using the locked primary policy. Non-Worker production surfaces keep
  * Redis compatibility, while local development uses an in-memory fallback.
  */
 
@@ -16,11 +16,7 @@ import {
 import { warmInferenceAdmissionSnapshot } from "../services/inference-admission-snapshot";
 import { isHotPathCachesEnabled } from "../services/inference-hot-path-caches";
 import type { EndpointType, OrgRateLimitConfig } from "../services/org-rate-limits";
-import {
-  getOrgRpmForEndpointCacheOnly,
-  type OrgTierCacheExecutionContext,
-  recalculateOrgTier,
-} from "../services/org-rate-limits";
+import { type OrgTierCacheExecutionContext, recalculateOrgTier } from "../services/org-rate-limits";
 import { withOrganizationPolicyAdmission } from "../services/organization-policy-admission";
 import {
   isOrganizationPolicyStamp,
@@ -473,19 +469,15 @@ export async function enforceOrgRateLimit(
           authority: policy.authority,
         };
         if (options.cacheOnly) {
-          const config = options.config
-            ? options.config
-            : await getOrgRpmForEndpointCacheOnly(organizationId, endpointType, {
-                executionCtx: options.executionCtx,
-              });
-          if ("kind" in config && config.kind !== "ready") {
-            throw new OrgRateLimitCacheNotReadyError(config.kind, config.cacheRead);
-          }
-          const cachedConfig = "kind" in config ? config.config : config;
+          // A supplied observation must still agree with current authority.
+          // With no observation, the locked primary read already owns the
+          // decision; a separate cold tier projection cannot make it safer.
+          const cachedConfig = options.config;
           if (
-            !isOrganizationPolicyStamp(cachedConfig.authority) ||
-            !sameOrganizationPolicyStamp(cachedConfig.authority, policy.authority) ||
-            cachedConfig.maxRequests !== authoritativeConfig.maxRequests
+            cachedConfig &&
+            (!isOrganizationPolicyStamp(cachedConfig.authority) ||
+              !sameOrganizationPolicyStamp(cachedConfig.authority, policy.authority) ||
+              cachedConfig.maxRequests !== authoritativeConfig.maxRequests)
           )
             throw new OrgRateLimitCacheNotReadyError("warming", "invalid");
           const { windowMs, maxRequests } = authoritativeConfig;

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -1,10 +1,10 @@
 /**
- * Cache-gated admission for organization-funded inference.
+ * Policy-gated admission for organization-funded inference.
  *
- * Admission reads current subscription authority first. Non-subscribers then
- * use pricing, affiliate-policy, and balance caches before acquiring a Durable
- * Object lease. The revision-aware lease, not isolate-local cache projection
- * state, is the dispatch fence. Post-provider accounting replays one
+ * Admission reads current subscription authority first. Workers then use its
+ * revisioned balance plus pricing and affiliate-policy caches before acquiring
+ * a Durable Object lease. The revision-aware lease, not isolate-local cache
+ * projection state, is the dispatch fence. Post-provider accounting replays one
  * deterministic debit identity; the lease alarm is the durable backstop when
  * a response-side task disappears.
  */
@@ -75,7 +75,9 @@ import {
 import { withOrganizationPolicyAdmission } from "./organization-policy-admission";
 import { sameOrganizationPolicyStamp } from "./organization-policy-stamp";
 import {
+  type OrganizationQuotaPolicy,
   readOrganizationQuotaPolicyInTransaction,
+  requireOrganizationPolicyBalance,
   requireOrganizationRateTier,
 } from "./organization-quota-policy";
 
@@ -356,7 +358,7 @@ export async function admitOrganizationInference(
       context: { organizationId: params.context.organizationId, reason: "stale_policy_snapshot" },
     });
   }
-  const admission = await admitWithFundingPolicy(params, authoritativePolicy.subscriptionFunded);
+  const admission = await admitWithFundingPolicy(params, authoritativePolicy);
   const previousDispatch = admission.markProviderDispatched;
   let dispatched = false;
   let dispatch: Promise<void> | undefined;
@@ -392,13 +394,13 @@ export async function admitOrganizationInference(
 }
 async function admitWithFundingPolicy(
   params: OrganizationInferenceAdmissionParams,
-  subscriptionFunded: boolean,
+  policy: OrganizationQuotaPolicy,
 ): Promise<OrganizationInferenceAdmission> {
   const executionCtx = params.executionCtx;
   const workerHotPath = typeof executionCtx?.waitUntil === "function";
   const affiliateMarked = Boolean(params.affiliateCode?.trim());
 
-  if (subscriptionFunded) {
+  if (policy.subscriptionFunded) {
     return await reserveSynchronously(params, true);
   }
   if (!workerHotPath && affiliateMarked) {
@@ -429,6 +431,10 @@ async function admitWithFundingPolicy(
   let balanceHint: GateBalanceSnapshot;
   let affiliateAttribution: AffiliateBillingAttribution | null = null;
   try {
+    // The primary policy read already captured the balance and revision.
+    // Requiring a separate projection here would reject a valid cold request
+    // or let an older balance replace that observation before the lease fence.
+    const workerBalance = canDefer ? requireOrganizationPolicyBalance(policy) : undefined;
     const [cost, gateBalance, resolvedAffiliateAttribution] = await Promise.all([
       params.flatCost
         ? Promise.resolve(params.flatCost)
@@ -443,12 +449,18 @@ async function admitWithFundingPolicy(
               executionCtx: params.executionCtx,
             },
           ),
-      params.admissionSnapshot
-        ? Promise.resolve(params.admissionSnapshot.balance)
-        : getGateBalanceHint(params.context.organizationId, {
-            executionCtx: params.executionCtx,
-            cacheOnly: canDefer,
-          }),
+      workerBalance
+        ? Promise.resolve({
+            balanceUsd: workerBalance.balanceUsd,
+            balanceRevision: workerBalance.revision,
+            balanceAt: Date.parse(policy.observedAt),
+          })
+        : params.admissionSnapshot
+          ? Promise.resolve(params.admissionSnapshot.balance)
+          : getGateBalanceHint(params.context.organizationId, {
+              executionCtx: params.executionCtx,
+              cacheOnly: canDefer,
+            }),
       affiliateMarked && params.executionCtx
         ? getCachedInferenceAffiliateAttribution({
             affiliateCode: params.affiliateCode,


### PR DESCRIPTION
Promote #31174 to production to stop rejecting valid Dedicated inference solely because a separate tier or balance cache is cold after current organization policy has already been read from the primary database.

The normal merge preview changes four files and is exactly certified tree `61a10a26df59ec94d85c6d68745f602a22c149f7`, from staging `dd929ee7fdeab42206fc541162249e4f3e3bcb37`. This is a correctness fix for false cache-warming refusals; it is not a claim of faster overall chat.

Supplied observations retain generation and RPM checks. Organization locks, Durable Object rate enforcement, credit revisions, dispatch revalidation, subscription funding and non-Worker compatibility are preserved. No schema, provider, model, prompt, context, runtime image, provisioning-worker or capacity change is included.

Both real migrated PGlite regressions failed before the patch and pass afterward. Final validation passed: 15 PGlite policy tests, 22 rate-limit contracts, the isolated admission contract, package typecheck/lint and root `bun run verify`. The five lint warnings pre-exist. Source CI [34717727704](https://github.com/elizaOS/eliza/actions/runs/34717727704) is terminal success, including static smoke, billing replay, subscription PostgreSQL and Windows security. Separate broad repository failures are documented and are not claimed resolved by this patch.

[Staging release 34717834319](https://github.com/elizaOS/eliza/actions/runs/34717834319) succeeded. The canonical verifier accepted artifact `10305048554`, digest `sha256:327a66b555b71b521de88d74e955376594fba6d43ba99c87db961caaca14995a`, expiring `2026-09-26T21:00:51.607Z`.

One real app request on the new staging API correctly recalled all four saved details. All 37 prior messages plus the new pair remained exact through an ordinary desktop reload; the final reply and composer were visually inspected. Submission to runtime finalization was **37.444 seconds**, versus **35.594 seconds** in the prior staging sample. Embedding work decreased from 16.218 to 10.633 seconds, while response generation and evaluation increased; there is **no measured overall speed win**. The first browser observation of completion at 47.848 seconds is an upper bound, not exact latency. The earlier mobile 37-message check remains separate; this backend-only patch was checked through the desktop app.

After the day audit, the owner explicitly requested continuing to finish the work before handoff. Production [release34718976693](https://github.com/elizaOS/eliza/actions/runs/34718976693) succeeded at `7814f42e01c34defc518e1ba89b0ce923abf7697`; live API source was verified before the request. The normal eliza.app Sign in entry reached the saved Dedicated app. One actual request correctly recalled the saved code and color, preserving all 12 prior messages plus the new pair after desktop and 390×844 mobile reload. Submission to runtime finalization was 28.609 seconds versus the previous production sample of 36.050 seconds; these are individual observations, not a controlled benchmark. The reply and composer fit the mobile viewport. Browser observation was delayed by focus changes, so runtime records supply the timing. First-ever Google signup remains unverified separately because the authorized identity already has an account.

Refs #31171.

| Evidence | Result |
| --- | --- |
| Before screenshots <!-- evidence-row:before-screenshots --> | N/A - backend admission change with no rendered UI diff |
| After screenshots <!-- evidence-row:after-screenshots --> | N/A - backend admission change with no rendered UI diff |
| Walkthrough video <!-- evidence-row:walkthrough-video --> | N/A - backend admission change with no rendered UI diff |
| Backend logs <!-- evidence-row:backend-logs --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31171-dedicated-cold-admission-backend.log |
| Frontend logs <!-- evidence-row:frontend-logs --> | N/A - no frontend code change |
| LLM trajectory <!-- evidence-row:llm-trajectory --> | N/A - no agent, model, provider, prompt or runtime handler change; actual app outcome recorded above |
| Domain artifacts <!-- evidence-row:domain-artifacts --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31171-dedicated-cold-admission-domain.json |
| OCR review <!-- evidence-row:ocr-review --> | N/A - backend admission change with no rendered UI diff |

<!-- evidence-head:dd929ee7fdeab42206fc541162249e4f3e3bcb37 -->
