### PR TITLE
test(ui): restore hosted login accessibility fixture

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.a11y.test.tsx
@@ -44,6 +44,7 @@ vi.mock("../../../shell/steward-url", () => ({
 }));
 
 vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardApiUrlOverride: () => null,
   configuredStewardTenantId: () => "elizacloud",
   DEFAULT_STEWARD_TENANT_ID: "elizacloud",
 }));


### PR DESCRIPTION
The existing hosted-login accessibility tests stopped before rendering when the loopback Google handoff added a read of `configuredStewardApiUrlOverride`. Supply the explicit no-override value in that fixture so it continues exercising the normal hosted login page.

This restores the existing checks for the login main landmark, legal-link hit areas and page canvas. The separate loopback handoff tests cover the alternate development route; they do not replace these hosted-page checks. No assertion is removed or weakened, no new test is added, and no product code changes. Follow-up to #31094.

Validation on `afd556516f4dc1aa02a694df09d809d935b52ea6`: the original fixture reproduced two failures before this one-line correction. The corrected accessibility fixture and loopback login suite pass all 12 tests; the full root `bun run verify` gate, including package type/lint checks, passes. Frozen install made no dependency changes. The supported `ELIZA_SKIP_FUSED_INFERENCE_SETUP=1` was used because native inference setup is unrelated to this test repair.

This is a test-only source repair and needs no app deployment. Other failures in broad Develop Full run34714584097 remain separately documented; they are not claimed fixed here. Hosted checks for this PR will be reported as observed, with the owner's existing maintainer merge authorization applying after exact local verification.

| Evidence | Result |
| --- | --- |
| Before screenshots <!-- evidence-row:before-screenshots --> | N/A - test fixture only; no rendered product diff |
| After screenshots <!-- evidence-row:after-screenshots --> | N/A - test fixture only; no rendered product diff |
| Walkthrough video <!-- evidence-row:walkthrough-video --> | N/A - test fixture only; no rendered product diff |
| Backend logs <!-- evidence-row:backend-logs --> | N/A - component fixture repair; no backend service changed or exercised |
| Frontend logs <!-- evidence-row:frontend-logs --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31094-dedicated-login-fixture-tests.log |
| LLM trajectory <!-- evidence-row:llm-trajectory --> | N/A - no model or runtime change |
| Domain artifacts <!-- evidence-row:domain-artifacts --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31094-dedicated-login-fixture-domain.json |
| OCR review <!-- evidence-row:ocr-review --> | N/A - test fixture only; no rendered product diff |

<!-- evidence-head:afd556516f4dc1aa02a694df09d809d935b52ea6 -->
