### PR TITLE
fix(core): expose authorized actions before response routing

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -358,6 +358,14 @@ Actions define specific tasks or capabilities the agent can perform. Each action
 
 Actions enable the agent to respond intelligently and perform operations based on user input or internal triggers.
 
+Before routing, the response handler receives an `available_actions` discovery
+catalog containing every eligible action's name, complete description, contexts,
+and aliases. Discovery checks the current actor, delivery audience, connector
+policy, and action validation under the action's declared routing contexts. This
+catalog is rebuilt for each turn and is not part of the shared prompt cache.
+The planner then receives native tools with parameter schemas and checks
+authorization again before executing; discovering an action does not execute it.
+
 Model-facing action, provider, and analytics results preserve complete records.
 For example, detailed `TRUST action=evaluate` results return every evidence
 record, follow-up suggestions return every qualifying contact, relationship

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -7408,8 +7408,11 @@ describe("runV5MessageRuntimeStage1", () => {
 			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
 		});
 
-		expect(validateAllowed).toHaveBeenCalledTimes(2);
-		expect(validateDenied).toHaveBeenCalledTimes(1);
+		expect(validateAllowed).toHaveBeenCalled();
+		expect(validateDenied).toHaveBeenCalled();
+		const discoveryPrompt = JSON.stringify(useModelCalls(runtime)[0]?.[1]);
+		expect(discoveryPrompt).toContain("CHECK_RUNTIME");
+		expect(discoveryPrompt).not.toContain("SKIP_RUNTIME");
 		const firstPlannerParams = useModelCalls(runtime)[1]?.[1] as {
 			tools?: Array<{ name?: string }>;
 			messages?: Array<{ role?: string; content?: string | null }>;

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -57,6 +57,7 @@ function makeState(): State {
 
 interface CannedResponse {
 	body: unknown;
+	inspectInput?: (params: unknown) => void;
 }
 
 function createResponseHandlerFieldRegistry(): ResponseHandlerFieldRegistry {
@@ -120,7 +121,9 @@ function makeRuntime(opts: {
 				if (queue.length === 0) {
 					throw new Error(`Unexpected useModel call: ${String(modelType)}`);
 				}
-				return queue.shift()?.body;
+				const response = queue.shift();
+				response?.inspectInput?.(params);
+				return response?.body;
 			},
 		),
 		logger: {
@@ -320,6 +323,126 @@ describe("v5 tiered action surface", () => {
 			process.env.ACTION_ROLE_POLICY = originalActionRolePolicy;
 		}
 		_resetActionRolePolicyCacheForTests();
+	});
+
+	it("discovers a custom owner action before routing and executes it through the planner", async () => {
+		const handler = vi.fn(async () => ({ success: true, text: "Role bound." }));
+		const description = `${"Complete domain guidance. ".repeat(1500)} Bind the requested household role.`;
+		const action = makeAction({
+			name: "HOUSEHOLD_COORDINATION_BIND_ROLE",
+			description,
+			contexts: ["household"],
+			roleGate: { minRole: "OWNER" },
+			handler,
+		});
+		const runtime = makeRuntime({
+			actions: [action],
+			responses: [
+				{
+					...stage1Response({
+						contexts: ["household"],
+						candidateActionNames: [action.name],
+						replyEffectStatus: "pending",
+					}),
+					inspectInput(params) {
+						const input = JSON.stringify(params);
+						expect(input).toContain("available_actions");
+						expect(input).toContain(action.name);
+						expect(input).toContain(description);
+						expect(handler).not.toHaveBeenCalled();
+					},
+				},
+				plannerToolResponse(action.name),
+				finishEvaluatorResponse("Role bound."),
+				{
+					...stage1Response({
+						contexts: ["simple"],
+						replyText: "Hello.",
+						replyEffectStatus: "none",
+					}),
+					inspectInput(params) {
+						const input = JSON.stringify(params);
+						expect(input).not.toContain(action.name);
+						expect(input).not.toContain(description);
+					},
+				},
+			],
+		});
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: {
+				...makeMessage("Bind the synthetic guest as a caregiver."),
+				entityId: AGENT_ID,
+			},
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(plannerToolNames(runtime)).toContain(action.name);
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("Hello."),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not disclose owner-only, private, or invalid actions during guest discovery", async () => {
+		const handler = vi.fn(async () => ({ success: true }));
+		const actions = [
+			makeAction({
+				name: "CONFIDENTIAL_OWNER_OPERATION",
+				roleGate: { minRole: "OWNER" },
+				handler,
+			}),
+			{
+				...makeAction({ name: "AUTONOMOUS_PRIVATE_OPERATION", handler }),
+				private: true,
+			},
+			{
+				...makeAction({ name: "OWNER_AUDIENCE_OPERATION", handler }),
+				disclosureGate: { require: "owner_exclusive" as const },
+			},
+			makeAction({
+				name: "CONTEXT_DENIED_OPERATION",
+				contexts: ["household"],
+				contextGate: { noneOf: ["household"] },
+				handler,
+			}),
+			makeAction({
+				name: "UNAVAILABLE_DOMAIN_OPERATION",
+				validate: async () => false,
+				handler,
+			}),
+		];
+		const runtime = makeRuntime({
+			actions,
+			responses: [
+				{
+					...stage1Response({
+						contexts: ["simple"],
+						replyText: "Hello.",
+						replyEffectStatus: "none",
+					}),
+					inspectInput(params) {
+						const input = JSON.stringify(params);
+						for (const action of actions)
+							expect(input).not.toContain(action.name);
+					},
+				},
+			],
+		});
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("Hello."),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+		expect(handler).not.toHaveBeenCalled();
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
 	});
 
 	it.each(["none", " NONE "])(

--- a/packages/core/src/services/message/action-surface.ts
+++ b/packages/core/src/services/message/action-surface.ts
@@ -74,6 +74,8 @@ export async function collectV5PlannerCandidateActions(args: {
 	state: State;
 	selectedContexts?: readonly AgentContext[];
 	candidateActions?: readonly string[];
+	/** Discover routable actions before Stage 1 has selected their contexts. */
+	discoverActions?: boolean;
 	userRoles?: readonly RoleGateRole[];
 	/** Out-param: normalized names and reasons for EXPLICIT stage-1 candidates
 	 * rejected by the owner-exclusive disclosure gate.
@@ -280,7 +282,15 @@ export async function collectV5PlannerCandidateActions(args: {
 				.map(({ action }) => action)
 		: allRuntimeActions;
 	for (const action of baseRuntimeActions) {
-		await appendIfAllowed(action, undefined, args.selectedContexts);
+		// Discovery uses the same declared contexts as an explicit candidate hint.
+		// Role, disclosure, private-action, connector, and validation gates still run.
+		await appendIfAllowed(
+			action,
+			undefined,
+			args.discoverActions
+				? mergeAgentContexts(args.selectedContexts, action.contexts)
+				: args.selectedContexts,
+		);
 	}
 
 	const explicitCandidateActions = Array.isArray(args.candidateActions)

--- a/packages/core/src/services/message/context-assembly.ts
+++ b/packages/core/src/services/message/context-assembly.ts
@@ -38,6 +38,8 @@ export async function createV5MessageContextObject(args: {
 	state: State;
 	selectedContexts?: readonly AgentContext[];
 	includeTools?: boolean;
+	/** Per-turn routing catalog for the response handler, which has no action tools. */
+	includeActionDiscovery?: boolean;
 	userRoles?: readonly RoleGateRole[];
 	availableContexts?: readonly ContextDefinition[];
 	extraProviderExclusions?: readonly string[];
@@ -248,6 +250,38 @@ export async function createV5MessageContextObject(args: {
 			stable: false,
 			content:
 				'trigger_automation_policy: The final message:user below is a scheduled automation of yours firing, not a person talking to you. Its "Do this now:" clause is the instruction you must carry out on this turn, and whatever you reply is delivered to the user as the automation\'s output. Produce that output: if the instruction is to remind, the reply IS the reminder addressed to the user — phrase it in your voice so it reads as a reminder arriving (lead with something like "reminder:" or equivalent), never a bare echo of the item text alone; if it is to check or report something, run the needed tools and reply with the result. Never reply with an acknowledgement of the instruction itself ("noted.", "got it", "will do") — the user never sees the instruction, so an acknowledgement reaches them as a bare non-sequitur.',
+		});
+	}
+
+	if (args.includeActionDiscovery) {
+		const actions = await collectV5PlannerCandidateActions({
+			runtime: args.runtime,
+			message: args.message,
+			state: args.state,
+			selectedContexts: args.selectedContexts,
+			userRoles: args.userRoles,
+			discoverActions: true,
+		});
+		// This is a discovery projection, not an execution tool surface. Retain
+		// every authorized name and complete description; Stage 2 supplies the
+		// native parameter schemas and rechecks authorization before execution.
+		events.push({
+			id: "available-actions",
+			type: "segment",
+			source: "message-service",
+			segment: {
+				id: "available-actions",
+				label: "available_actions",
+				stable: false,
+				content: JSON.stringify(
+					actions.map((action) => ({
+						name: action.name,
+						description: action.description,
+						contexts: action.contexts,
+						similes: action.similes,
+					})),
+				),
+			},
 		});
 	}
 

--- a/packages/core/src/services/message/pipeline.ts
+++ b/packages/core/src/services/message/pipeline.ts
@@ -242,6 +242,7 @@ export async function runV5MessageRuntimeStage1(
 		ambientTurn && isStage1AmbientHardGated(args.runtime, args.message);
 	const context = await createV5MessageContextObject({
 		...args,
+		includeActionDiscovery: true,
 		userRoles: [senderRole],
 		availableContexts,
 		ambientTurn,


### PR DESCRIPTION
An authenticated Bettina owner requested a household role binding, but the response handler received only `HANDLE_RESPONSE` and no available-action catalog. It reported that the registered household action was unavailable and never selected it for planning.

Give the response handler a fresh, authorized discovery catalog before routing. Preserve complete descriptions and use the existing role, audience, private-action, connector-policy, context, and validation gates. Native planner tools and execution checks remain authoritative. Regression tests exercise custom-domain execution, owner-to-guest isolation, denied-action omission, and long descriptions.

Refs #31176. Part of #30123.

Validation:
- Core suite: 12,231 passed, 3 existing skips across 936 files.
- Focused routing suites: 272 passed.
- Node, browser, edge, testing, declarations, and packed consumer builds passed.
- Pinned Bun install and rebased root verification: 373/373 tasks passed (4m8.353s), including owning typecheck/lint and repository audits.
- Exact-head hosted checks: all five passed for `9f9355644decade35ba2a80de51ae1adf59b2458`.
- Deployed combined candidate `40bf83d22b150d71632878b3868097cc51ccd713` passed all eight Linux gates. All six PR source blobs match the deployed candidate. Public assets/deep links and runtime readiness were independently verified.
- Real before/after model proof: the same owner request changed from unavailable/relationship 404 to an authorized candidate selection, successful canonical household role binding, durable effect receipt, and independent relationship 200. Tracing was restored and original messaging ingress preserved.
- [Reviewed synthetic model/action and persisted-state evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31181-bettina-action-discovery-evidence.zip), SHA-256 `f4e6f1249107922615c71f8ff8e7cf119aaaf298367f155347ba8d70bdafdfcd`; secret scan passed. Full unrelated private owner context remains private.
- The subsequent grant action selected the correct tool but exposed #31186: explicit empty required subjects are treated as missing. No grant was stored. #31176 remains open for its grant issue/revoke acceptance; #31172/#31162/#30123 remain open for the broader live work.
- UI screenshots/video: N/A for this core routing change; live model/action and persisted-state evidence is linked above.
