### PR TITLE
perf(cloud): stage the bounded legacy policy read optimization

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
@@ -106,6 +106,52 @@ test("canonical legacy accounts keep purchased-credit RPM and distinct eager/non
     policy.requireOrganizationResourceLimit(after, "nonEagerSandboxes"),
   );
 });
+test("legacy credit selection excludes grants, debits and other tenants while retaining empty-credit policy", async () => {
+  const pg = database.getPgliteClientForTests();
+  const target = crypto.randomUUID();
+  const other = crypto.randomUUID();
+  await pg.exec(`
+    INSERT INTO organizations(id,credit_balance,balance_revision,balance_decrease_revision,settings,is_active,account_lifecycle_state)
+    VALUES('${target}',100,1,0,'{}',true,'active'),('${other}',100,1,0,'{}',true,'active');
+  `);
+  const empty = await policy.readOrganizationQuotaPolicy(target);
+  expect(Number(empty.tierSourceCreditTotal)).toBe(0);
+  await pg.exec(`
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata) VALUES
+    (gen_random_uuid(),'${target}',1000,'credit','{"type":"initial_free_credits"}'),
+    (gen_random_uuid(),'${target}',1000,'credit','{"type":"wallet_signup"}'),
+    (gen_random_uuid(),'${target}',1000,'credit','{"type":"signup_code_bonus"}'),
+    (gen_random_uuid(),'${target}',-7,'debit','{}'),
+    (gen_random_uuid(),'${other}',999999,'credit','{}');
+  `);
+  const excluded = await policy.readOrganizationQuotaPolicy(target);
+  expect(excluded.tier).toEqual(empty.tier);
+  expect(Number(excluded.tierSourceCreditTotal)).toBe(0);
+  await pg.exec(`
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata) VALUES
+    (gen_random_uuid(),'${target}',6,'credit','{}'),
+    (gen_random_uuid(),'${target}',4,'credit','{"type":null}');
+  `);
+  const funded = await policy.readOrganizationQuotaPolicy(target);
+  expect(Number(funded.tierSourceCreditTotal)).toBe(10);
+  expect(policy.requireOrganizationRateTier(funded).completionsRpm).toBeGreaterThan(
+    policy.requireOrganizationRateTier(empty).completionsRpm,
+  );
+});
+test("a missing subscription association cannot admit a subscriber as a legacy account", async () => {
+  const pg = database.getPgliteClientForTests();
+  await pg.exec(`UPDATE organization_subscription_authorities
+    SET state='none',subscription_id=NULL WHERE organization_id='${ORG}'`);
+  try {
+    await expect(policy.readOrganizationQuotaPolicy(ORG)).rejects.toMatchObject({
+      code: "ORGANIZATION_POLICY_UNAVAILABLE",
+      context: { organizationId: ORG, reason: "legacy_association_conflict" },
+    });
+  } finally {
+    await pg.exec(`UPDATE organization_subscription_authorities
+      SET state='current',subscription_id='${SUB}' WHERE organization_id='${ORG}'`);
+  }
+});
 test("corrupt purchased balance does not erase independently valid subscriber rate policy", async () => {
   const pg = database.getPgliteClientForTests();
   const before = await policy.readOrganizationQuotaPolicy(ORG);

--- a/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
+++ b/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
@@ -6,6 +6,7 @@ import { readPrimaryOrganizationSubscription } from "../../db/repositories/accou
 import { deriveSubscriptionEntitlementValues } from "../../db/repositories/subscription-entitlements";
 import {
   billingSubscriptionRevisions,
+  billingSubscriptions,
   organizationSubscriptionAuthorities,
 } from "../../db/schemas/billing-subscriptions";
 import { creditTransactions } from "../../db/schemas/credit-transactions";
@@ -154,6 +155,27 @@ export async function readOrganizationQuotaPolicyInTransaction(
         bytes_limit: orgStorageQuota.bytes_limit,
         limit_override_authorized: orgStorageQuota.limit_override_authorized,
       },
+      // Correlated selectors preserve one policy row per organization. The
+      // legacy branch still rejects any persisted subscription, including a
+      // terminal one, and uses the same qualifying credits as the rate policy.
+      legacyHasSubscription: sql<
+        boolean | null
+      >`CASE WHEN ${organizationSubscriptionAuthorities.state} = 'none' THEN EXISTS (
+        SELECT 1 FROM ${billingSubscriptions}
+        WHERE ${billingSubscriptions.organization_id} = ${organizations.id}
+      ) END`,
+      legacyCreditTotal: sql<
+        string | null
+      >`CASE WHEN ${organizationSubscriptionAuthorities.state} = 'none' THEN (
+        SELECT COALESCE(SUM(${creditTransactions.amount}),0)::text
+        FROM ${creditTransactions}
+        WHERE ${creditTransactions.organization_id} = ${organizations.id}
+          AND ${creditTransactions.type} = 'credit'
+          AND COALESCE(${creditTransactions.metadata}->>'type','') NOT IN (${sql.join(
+            ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES.map((value) => sql`${value}`),
+            sql`,`,
+          )})
+      ) END`,
     })
     .from(organizations)
     .leftJoin(
@@ -184,23 +206,11 @@ export async function readOrganizationQuotaPolicyInTransaction(
       : { status: "unavailable" as const, code: "invalid_balance" },
   };
   if (association.state === "none") {
-    const subscription = await readPrimaryOrganizationSubscription(tx, organizationId);
-    if (subscription.state !== "none")
+    if (inputs.legacyHasSubscription !== false)
       return unavailable(organizationId, "legacy_association_conflict");
-    const [credits] = await tx
-      .select({ total: sql<string>`COALESCE(SUM(${creditTransactions.amount}),0)::text` })
-      .from(creditTransactions)
-      .where(
-        and(
-          eq(creditTransactions.organization_id, organizationId),
-          eq(creditTransactions.type, "credit"),
-          sql`COALESCE(${creditTransactions.metadata}->>'type','') NOT IN (${sql.join(
-            ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES.map((value) => sql`${value}`),
-            sql`,`,
-          )})`,
-        ),
-      );
-    if (!credits) return unavailable(organizationId, "missing_legacy_selector");
+    if (inputs.legacyCreditTotal === null)
+      return unavailable(organizationId, "missing_legacy_selector");
+    const creditTotal = inputs.legacyCreditTotal;
     const [clock] = await tx
       .select({ now: sql<Date>`clock_timestamp()` })
       .from(organizations)
@@ -222,10 +232,10 @@ export async function readOrganizationQuotaPolicyInTransaction(
       },
       tier: observe(
         () =>
-          resolveOrgTierFromSourceValues(organizationId, credits.total, override ?? undefined)
+          resolveOrgTierFromSourceValues(organizationId, creditTotal, override ?? undefined)
             .tierData,
       ),
-      tierSourceCreditTotal: credits.total,
+      tierSourceCreditTotal: creditTotal,
       subscriptionFunded: false,
       limits: {
         characters: resource(() =>


### PR DESCRIPTION
Promote only the two-file policy-reader patch from #31183 onto the last certified staging commit `dd929ee7fdeab42206fc541162249e4f3e3bcb37`. Candidate `21619dd7cd369372df7ca64fe3b98d1900da3bd6`, tree `61cd27b42f092d84d910395a81991bcb88f9a19d`, excludes 18 unrelated paths introduced on newer develop. The changed source/test blobs and dependency manifests/lockfile exactly match the validated source. Exact staging-tree root verification and frozen installation passed; no dependency changes and no staging deployment yet.

Dedicated completion and embedding admission reread the legacy subscription association and credit selector through sequential primary-database requests. Combine subscription absence and qualifying credit aggregation into the existing policy-input statement, reducing five policy SELECTs to two. Both organization locks, the final database-clock read and fresh dispatch revalidation remain in place; subscription behavior, credit eligibility, credential checks and model context are unchanged.

Real migrated PGlite tests pass (17), including empty credits, excluded signup grants, debits, tenant isolation and a missing subscription association. Three independent PostgreSQL concurrency tests pass. Package typecheck/lint and root `bun run verify` pass; frozen installation made no dependency changes. Lint reports five existing large-file warnings.

A read-only comparison on the production primary returned identical policies in three alternating same-snapshot runs: 855/345 ms, 837/342 ms and 837/341 ms before/after. These measure the reader from the control-plane host, not Worker or end-to-end chat latency. Actual staged Dedicated reply/history acceptance remains required before production promotion. No deployment is claimed by this source PR. Wider pre-existing Develop Full failures remain outside this patch.

Hosted source CI [34722519055](https://github.com/elizaOS/eliza/actions/runs/34722519055) is still running at merge time and is not claimed passed. The repository owner authorized proceeding with the exact local package, real-database and root validation documented above.

Refs #31182.

| Evidence | Result |
| --- | --- |
| Before screenshots <!-- evidence-row:before-screenshots --> | N/A - backend database-reader change with no rendered UI diff |
| After screenshots <!-- evidence-row:after-screenshots --> | N/A - backend database-reader change with no rendered UI diff |
| Walkthrough video <!-- evidence-row:walkthrough-video --> | N/A - backend database-reader change with no rendered UI diff |
| Backend logs <!-- evidence-row:backend-logs --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31182-legacy-policy-staging-backend.log |
| Frontend logs <!-- evidence-row:frontend-logs --> | N/A - no frontend code change |
| LLM trajectory <!-- evidence-row:llm-trajectory --> | N/A - no model, prompt, provider or runtime handler changes; staged actual chat verification follows deployment |
| Domain artifacts <!-- evidence-row:domain-artifacts --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31182-legacy-policy-staging-domain.json |
| OCR review <!-- evidence-row:ocr-review --> | N/A - no rendered UI diff |

<!-- evidence-head:21619dd7cd369372df7ca64fe3b98d1900da3bd6 -->
