### PR TITLE
fix(cloud): promote certified Dedicated policy-read optimization

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-quota-policy.pglite.test.ts
@@ -106,6 +106,52 @@ test("canonical legacy accounts keep purchased-credit RPM and distinct eager/non
     policy.requireOrganizationResourceLimit(after, "nonEagerSandboxes"),
   );
 });
+test("legacy credit selection excludes grants, debits and other tenants while retaining empty-credit policy", async () => {
+  const pg = database.getPgliteClientForTests();
+  const target = crypto.randomUUID();
+  const other = crypto.randomUUID();
+  await pg.exec(`
+    INSERT INTO organizations(id,credit_balance,balance_revision,balance_decrease_revision,settings,is_active,account_lifecycle_state)
+    VALUES('${target}',100,1,0,'{}',true,'active'),('${other}',100,1,0,'{}',true,'active');
+  `);
+  const empty = await policy.readOrganizationQuotaPolicy(target);
+  expect(Number(empty.tierSourceCreditTotal)).toBe(0);
+  await pg.exec(`
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata) VALUES
+    (gen_random_uuid(),'${target}',1000,'credit','{"type":"initial_free_credits"}'),
+    (gen_random_uuid(),'${target}',1000,'credit','{"type":"wallet_signup"}'),
+    (gen_random_uuid(),'${target}',1000,'credit','{"type":"signup_code_bonus"}'),
+    (gen_random_uuid(),'${target}',-7,'debit','{}'),
+    (gen_random_uuid(),'${other}',999999,'credit','{}');
+  `);
+  const excluded = await policy.readOrganizationQuotaPolicy(target);
+  expect(excluded.tier).toEqual(empty.tier);
+  expect(Number(excluded.tierSourceCreditTotal)).toBe(0);
+  await pg.exec(`
+    INSERT INTO credit_transactions(id,organization_id,amount,type,metadata) VALUES
+    (gen_random_uuid(),'${target}',6,'credit','{}'),
+    (gen_random_uuid(),'${target}',4,'credit','{"type":null}');
+  `);
+  const funded = await policy.readOrganizationQuotaPolicy(target);
+  expect(Number(funded.tierSourceCreditTotal)).toBe(10);
+  expect(policy.requireOrganizationRateTier(funded).completionsRpm).toBeGreaterThan(
+    policy.requireOrganizationRateTier(empty).completionsRpm,
+  );
+});
+test("a missing subscription association cannot admit a subscriber as a legacy account", async () => {
+  const pg = database.getPgliteClientForTests();
+  await pg.exec(`UPDATE organization_subscription_authorities
+    SET state='none',subscription_id=NULL WHERE organization_id='${ORG}'`);
+  try {
+    await expect(policy.readOrganizationQuotaPolicy(ORG)).rejects.toMatchObject({
+      code: "ORGANIZATION_POLICY_UNAVAILABLE",
+      context: { organizationId: ORG, reason: "legacy_association_conflict" },
+    });
+  } finally {
+    await pg.exec(`UPDATE organization_subscription_authorities
+      SET state='current',subscription_id='${SUB}' WHERE organization_id='${ORG}'`);
+  }
+});
 test("corrupt purchased balance does not erase independently valid subscriber rate policy", async () => {
   const pg = database.getPgliteClientForTests();
   const before = await policy.readOrganizationQuotaPolicy(ORG);

--- a/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
+++ b/packages/cloud/shared/src/lib/services/organization-quota-policy.ts
@@ -6,6 +6,7 @@ import { readPrimaryOrganizationSubscription } from "../../db/repositories/accou
 import { deriveSubscriptionEntitlementValues } from "../../db/repositories/subscription-entitlements";
 import {
   billingSubscriptionRevisions,
+  billingSubscriptions,
   organizationSubscriptionAuthorities,
 } from "../../db/schemas/billing-subscriptions";
 import { creditTransactions } from "../../db/schemas/credit-transactions";
@@ -154,6 +155,27 @@ export async function readOrganizationQuotaPolicyInTransaction(
         bytes_limit: orgStorageQuota.bytes_limit,
         limit_override_authorized: orgStorageQuota.limit_override_authorized,
       },
+      // Correlated selectors preserve one policy row per organization. The
+      // legacy branch still rejects any persisted subscription, including a
+      // terminal one, and uses the same qualifying credits as the rate policy.
+      legacyHasSubscription: sql<
+        boolean | null
+      >`CASE WHEN ${organizationSubscriptionAuthorities.state} = 'none' THEN EXISTS (
+        SELECT 1 FROM ${billingSubscriptions}
+        WHERE ${billingSubscriptions.organization_id} = ${organizations.id}
+      ) END`,
+      legacyCreditTotal: sql<
+        string | null
+      >`CASE WHEN ${organizationSubscriptionAuthorities.state} = 'none' THEN (
+        SELECT COALESCE(SUM(${creditTransactions.amount}),0)::text
+        FROM ${creditTransactions}
+        WHERE ${creditTransactions.organization_id} = ${organizations.id}
+          AND ${creditTransactions.type} = 'credit'
+          AND COALESCE(${creditTransactions.metadata}->>'type','') NOT IN (${sql.join(
+            ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES.map((value) => sql`${value}`),
+            sql`,`,
+          )})
+      ) END`,
     })
     .from(organizations)
     .leftJoin(
@@ -184,23 +206,11 @@ export async function readOrganizationQuotaPolicyInTransaction(
       : { status: "unavailable" as const, code: "invalid_balance" },
   };
   if (association.state === "none") {
-    const subscription = await readPrimaryOrganizationSubscription(tx, organizationId);
-    if (subscription.state !== "none")
+    if (inputs.legacyHasSubscription !== false)
       return unavailable(organizationId, "legacy_association_conflict");
-    const [credits] = await tx
-      .select({ total: sql<string>`COALESCE(SUM(${creditTransactions.amount}),0)::text` })
-      .from(creditTransactions)
-      .where(
-        and(
-          eq(creditTransactions.organization_id, organizationId),
-          eq(creditTransactions.type, "credit"),
-          sql`COALESCE(${creditTransactions.metadata}->>'type','') NOT IN (${sql.join(
-            ORG_TIER_EXCLUDED_CREDIT_METADATA_TYPES.map((value) => sql`${value}`),
-            sql`,`,
-          )})`,
-        ),
-      );
-    if (!credits) return unavailable(organizationId, "missing_legacy_selector");
+    if (inputs.legacyCreditTotal === null)
+      return unavailable(organizationId, "missing_legacy_selector");
+    const creditTotal = inputs.legacyCreditTotal;
     const [clock] = await tx
       .select({ now: sql<Date>`clock_timestamp()` })
       .from(organizations)
@@ -222,10 +232,10 @@ export async function readOrganizationQuotaPolicyInTransaction(
       },
       tier: observe(
         () =>
-          resolveOrgTierFromSourceValues(organizationId, credits.total, override ?? undefined)
+          resolveOrgTierFromSourceValues(organizationId, creditTotal, override ?? undefined)
             .tierData,
       ),
-      tierSourceCreditTotal: credits.total,
+      tierSourceCreditTotal: creditTotal,
       subscriptionFunded: false,
       limits: {
         characters: resource(() =>


### PR DESCRIPTION
Promote the certified Dedicated policy-read fix from #31183 and #31185. The diff from current production contains exactly two files, reducing five legacy policy SELECTs to two while preserving admission locks, current credit/subscription decisions, rate limits and dispatch revalidation. Eighteen unrelated develop paths are excluded.

Staging commit `342569fcaef58dbd58b79eff2f17a1996b149d80`, tree `61cd27b42f092d84d910395a81991bcb88f9a19d`, passed [release and certification](https://github.com/elizaOS/eliza/actions/runs/34723066410). The production merge preview produces that identical tree. A temporary promotion branch preserves the canonical staging branch.

Validation: 17 real PGlite policy tests, three real PostgreSQL concurrency tests, package checks and root verification passed. [Source CI](https://github.com/elizaOS/eliza/actions/runs/34722519055) is terminal success. Exact staging-tree frozen install/root verification passed. Production-primary read-only comparisons returned identical policies in three runs, reducing the reader from 837–855ms to 341–345ms.

Actual app acceptance used the ordinary local Bun app connected to the existing staging Dedicated agent. The agent correctly recalled the project, kickoff day, saved code and color. The reply was visible at 29.161s and finalized at 28.763s; all 39 earlier messages plus the new pair (41 total) survived desktop and 390×844 reload exactly. Earlier staging finalized at 37.444s, but these are individual samples across app surfaces, not a controlled benchmark. Embedding remains about 13s; no model/context/credit/capacity changes accompany this patch. First-time Cloud signup remains unverified. Production [release 34724211690](https://github.com/elizaOS/eliza/actions/runs/34724211690) is now terminal SUCCESS at `7fdcfbaecf5153961505b63c3a0c35ab804a518d`, with the identical certified tree. The actual hosted agent correctly recalled Harbor-917 and teal; the request finalized in 21.728 seconds versus the prior 28.609-second sample. All 14 previous messages plus the new pair (16 total) survived desktop and 390×844 reload exactly. Native screenshots were inspected, desktop restored and DevTools closed. First-time Google signup remains unverified.

Refs #31182. The repository owner authorized this exact promotion and deployment. Wider pre-existing repository CI failures are outside this patch.

Broad [Develop Full run34723028149](https://github.com/elizaOS/eliza/actions/runs/34723028149) is not green: seven failures were observed before promotion. Three inspected jobs show the existing chat fixture missing `client.onAuthorityChange`, a staging-continuity fixture violating its existing closed schema, and an outdated importer-path assertion. The receipt/contract and workspace-resolution files are byte-identical to current production; neither patch file changes these contracts. The remaining failed jobs are not fully classified. That broad repeat run was subsequently cancelled with 15 failed jobs recorded; its logs and job states are retained. Exact source CI, real database checks, staged certification and actual Dedicated app acceptance above passed. The owner authorized this bounded promotion with the wider failures explicitly retained.

| Evidence | Result |
| --- | --- |
| Before screenshots <!-- evidence-row:before-screenshots --> | N/A - backend policy-reader change with no rendered UI diff |
| After screenshots <!-- evidence-row:after-screenshots --> | N/A - backend policy-reader change with no rendered UI diff |
| Walkthrough video <!-- evidence-row:walkthrough-video --> | N/A - backend policy-reader change with no rendered UI diff |
| Backend logs <!-- evidence-row:backend-logs --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31182-legacy-policy-production-backend.log |
| Frontend logs <!-- evidence-row:frontend-logs --> | N/A - no frontend code change |
| LLM trajectory <!-- evidence-row:llm-trajectory --> | N/A - no model, prompt, provider or runtime handler changes; actual app reply and runtime timings are recorded in domain evidence |
| Domain artifacts <!-- evidence-row:domain-artifacts --> | https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31182-legacy-policy-production-domain.json |
| OCR review <!-- evidence-row:ocr-review --> | N/A - no rendered UI diff |

<!-- evidence-head:342569fcaef58dbd58b79eff2f17a1996b149d80 -->
