### PR TITLE
fix(lifeops): preserve explicit empty household grant subjects

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,6 +23,12 @@ fail closed.
 - **Plugin system:** `Plugin` objects contribute actions/providers/evaluators/services to the runtime.
 - **Built-in bundle:** Foundational capabilities ship as `basicCapabilities` (and `basicActions` / `basicProviders` / `basicEvaluators` / `basicServices`); there is no `corePlugin` singleton.
 
+`resolveActionArgs` treats a required empty array as missing unless its
+`SubactionSpec.allowEmptyArrays` names that parameter. This opt-in preserves
+an explicitly supplied or extracted `[]` through argument resolution; it never
+defaults an omitted or null value to an empty list. The owning action must still
+validate element types, permissions and domain constraints.
+
 ## Computer-use adapter contract
 
 `contracts/computer-use.ts` is the provider-neutral boundary shared by browser

--- a/packages/core/src/actions/resolve-action-args.test.ts
+++ b/packages/core/src/actions/resolve-action-args.test.ts
@@ -48,6 +48,131 @@ function makeMessage(text: string): Memory {
 }
 
 describe("resolveActionArgs", () => {
+	it("preserves an explicitly empty required array without model extraction when its contract allows it", async () => {
+		const runtime = makeMockRuntime();
+		const result = await resolveActionArgs({
+			runtime,
+			message: makeMessage(
+				"Issue a knowledge-only grant with no subject filter",
+			),
+			actionName: "GRANT",
+			subactions: {
+				ISSUE: {
+					description: "Issue a scoped grant",
+					descriptionCompressed: "issue grant",
+					required: ["subjectIds"],
+					allowEmptyArrays: ["subjectIds"],
+				},
+			},
+			options: { parameters: { action: "ISSUE", subjectIds: [] } },
+		});
+		expect(result).toEqual({
+			ok: true,
+			subaction: "ISSUE",
+			params: { action: "ISSUE", subjectIds: [] },
+		});
+		expect(runtime.useModel).not.toHaveBeenCalled();
+	});
+
+	it("retains an explicit empty array while extracting another missing parameter", async () => {
+		const runtime = makeMockRuntime(
+			JSON.stringify({
+				action: "ISSUE",
+				params: {
+					principalId: "caregiver",
+					subjectIds: ["unrequested-subject"],
+				},
+				missing: [],
+				confidence: 0.95,
+			}),
+		);
+		const result = await resolveActionArgs({
+			runtime,
+			message: makeMessage("Issue this knowledge-only grant to the caregiver"),
+			actionName: "GRANT",
+			subactions: {
+				ISSUE: {
+					description: "Issue a scoped grant",
+					descriptionCompressed: "issue grant",
+					required: ["principalId", "subjectIds"],
+					allowEmptyArrays: ["subjectIds"],
+				},
+			},
+			options: { parameters: { action: "ISSUE", subjectIds: [] } },
+		});
+		expect(result).toEqual({
+			ok: true,
+			subaction: "ISSUE",
+			params: { principalId: "caregiver", subjectIds: [] },
+		});
+	});
+
+	it("accepts an allowed empty array extracted from the request", async () => {
+		const runtime = makeMockRuntime(
+			JSON.stringify({
+				action: "ISSUE",
+				params: { subjectIds: [] },
+				missing: [],
+				confidence: 0.95,
+			}),
+		);
+		const result = await resolveActionArgs({
+			runtime,
+			message: makeMessage(
+				"Issue a knowledge-only grant with an explicitly empty subject list",
+			),
+			actionName: "GRANT",
+			subactions: {
+				ISSUE: {
+					description: "Issue a scoped grant",
+					descriptionCompressed: "issue grant",
+					required: ["subjectIds"],
+					allowEmptyArrays: ["subjectIds"],
+				},
+			},
+		});
+		expect(result).toEqual({
+			ok: true,
+			subaction: "ISSUE",
+			params: { subjectIds: [] },
+		});
+	});
+
+	it("still rejects omitted and null arrays, and empty arrays without an explicit allowance", async () => {
+		for (const input of [
+			{ parameters: { action: "ISSUE" }, allowEmptyArrays: ["subjectIds"] },
+			{
+				parameters: { action: "ISSUE", subjectIds: null },
+				allowEmptyArrays: ["subjectIds"],
+			},
+			{ parameters: { action: "ISSUE", subjectIds: [] }, allowEmptyArrays: [] },
+		]) {
+			const runtime = makeMockRuntime(
+				JSON.stringify({
+					action: "ISSUE",
+					params: {},
+					missing: ["subjectIds"],
+					confidence: 0.95,
+				}),
+			);
+			const result = await resolveActionArgs({
+				runtime,
+				message: makeMessage("Issue a grant"),
+				actionName: "GRANT",
+				subactions: {
+					ISSUE: {
+						description: "Issue a scoped grant",
+						descriptionCompressed: "issue grant",
+						required: ["subjectIds"],
+						allowEmptyArrays: input.allowEmptyArrays,
+					},
+				},
+				options: { parameters: input.parameters },
+			});
+			expect(result).toMatchObject({ ok: false, missing: ["subjectIds"] });
+		}
+	});
+
 	it("preserves an explicit description clear while extracting a missing goal ID", async () => {
 		const runtime = makeMockRuntime(
 			JSON.stringify({

--- a/packages/core/src/actions/resolve-action-args.ts
+++ b/packages/core/src/actions/resolve-action-args.ts
@@ -27,6 +27,8 @@ export interface SubactionSpec<TParams = Record<string, unknown>> {
 	descriptionCompressed: string;
 	/** Required parameter keys; missing any -> triggers extraction. */
 	required: ReadonlyArray<keyof TParams & string>;
+	/** Required array keys whose explicit empty value is valid; omission is still missing. */
+	allowEmptyArrays?: ReadonlyArray<keyof TParams & string>;
 	/** Optional keys; surfaced to extractor as "may extract if obvious". */
 	optional?: ReadonlyArray<keyof TParams & string>;
 }
@@ -82,7 +84,7 @@ function nonEmptyString(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0;
 }
 
-function valueIsPresent(value: unknown): boolean {
+function valueIsPresent(value: unknown, allowEmptyArray = false): boolean {
 	if (value === null || value === undefined) {
 		return false;
 	}
@@ -90,7 +92,7 @@ function valueIsPresent(value: unknown): boolean {
 		return value.trim().length > 0;
 	}
 	if (Array.isArray(value)) {
-		return value.length > 0;
+		return allowEmptyArray || value.length > 0;
 	}
 	return true;
 }
@@ -113,9 +115,10 @@ function missingRequiredKeys<TSubaction extends string>(
 	params: Record<string, unknown>,
 ): string[] {
 	const required = subactions[subaction]?.required ?? [];
+	const allowEmptyArrays = subactions[subaction]?.allowEmptyArrays;
 	const missing: string[] = [];
 	for (const key of required) {
-		if (!valueIsPresent(params[key])) {
+		if (!valueIsPresent(params[key], allowEmptyArrays?.includes(key))) {
 			missing.push(key);
 		}
 	}
@@ -141,7 +144,8 @@ function pickKnownParams<TSubaction extends string>(
 		if (
 			allowed.has(key) &&
 			value !== undefined &&
-			(!spec.required.includes(key) || valueIsPresent(value))
+			(!spec.required.includes(key) ||
+				valueIsPresent(value, spec.allowEmptyArrays?.includes(key)))
 		) {
 			result[key] = value;
 		}
@@ -180,6 +184,11 @@ function describeSubactionsForPrompt<TSubaction extends string>(
 				`- ${key}: ${spec.description}`,
 				`  required: ${required}`,
 				`  optional: ${optional}`,
+				...(spec.allowEmptyArrays?.length
+					? [
+							`  explicit empty arrays are valid for: ${spec.allowEmptyArrays.join(", ")}; do not default omitted values to []`,
+						]
+					: []),
 			].join("\n"),
 		);
 	}

--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -247,6 +247,12 @@ Guest views expose approved obligations only. Revoking the relationship-backed
 household grant immediately invalidates every agreement binding that relies on
 it.
 
+A knowledge-only household grant may explicitly supply `subjectEntityIds: []`.
+Omitting the field remains an invalid action request. The canonical scope
+expansion includes basic `household.visibility` with `knowledge.read`; it adds
+no calendar authority. Non-owner calendar grants still require at least one
+subject from the principal's household relationship.
+
 A paired guest reads `GET /api/lifeops/agreements/:id/shared` using its machine
 session. The owner must bind that machine identity to a person through
 `POST /api/lifeops/entities/:id/auth-bindings` and explicitly issue the household

--- a/plugins/plugin-personal-assistant/src/actions/household-coordination.ts
+++ b/plugins/plugin-personal-assistant/src/actions/household-coordination.ts
@@ -92,6 +92,7 @@ const SUBACTIONS: SubactionsMap<HouseholdOwnerSubaction> = {
       "subjectEntityIds",
       "scopes",
     ],
+    allowEmptyArrays: ["subjectEntityIds"],
     optional: ["expiresAt"],
   },
   revoke_grant: {

--- a/plugins/plugin-personal-assistant/src/lifeops/household/household-coordination.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/household-coordination.integration.test.ts
@@ -9,7 +9,11 @@ import {
   resolveKnowledgeGraphService,
 } from "@elizaos/agent";
 import type { AgentRuntime } from "@elizaos/core";
-import { AgentEventService, createMessageMemory } from "@elizaos/core";
+import {
+  AgentEventService,
+  createMessageMemory,
+  promoteSubactionsToActions,
+} from "@elizaos/core";
 import {
   getScheduledTaskRunner,
   type ScheduledTaskRunnerHandle,
@@ -237,6 +241,118 @@ describe("household coordination — real PGlite", () => {
       reason: "I approve this exact time and custody plan.",
     });
   }
+
+  it("issues and revokes a knowledge-only grant through promoted actions with explicit empty subjects", async () => {
+    const principalEntityId = await person("knowledge-only-caregiver");
+    const householdId = `knowledge-only-${randomUUID()}`;
+    await service().bindRole({
+      entityId: principalEntityId,
+      role: "caregiver",
+      householdId,
+      subjectEntityIds: [],
+      evidence: "Synthetic knowledge-only household access acceptance.",
+      boundByEntityId: SELF_ENTITY_ID,
+    });
+    const actions = promoteSubactionsToActions(householdCoordinationAction);
+    const issue = actions.find(
+      (action) => action.name === "HOUSEHOLD_COORDINATION_ISSUE_GRANT",
+    );
+    const revoke = actions.find(
+      (action) => action.name === "HOUSEHOLD_COORDINATION_REVOKE_GRANT",
+    );
+    if (!issue || !revoke)
+      throw new Error("Household grant actions are unavailable");
+    const message = createMessageMemory({
+      entityId: runtime.agentId,
+      agentId: runtime.agentId,
+      roomId: runtime.agentId,
+      content: {
+        text: "Issue the explicitly requested knowledge-only grant.",
+        source: "client_chat",
+      },
+    });
+    const parameters = {
+      householdId,
+      principalEntityId,
+      role: "caregiver",
+      subjectEntityIds: [],
+      scopes: ["knowledge.read"],
+    };
+    const result = await issue.handler(runtime, message, undefined, {
+      parameters,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      data: { action: "issue_grant" },
+    });
+    const grants = await householdRepository.listGrants(
+      principalEntityId,
+      householdId,
+    );
+    expect(grants).toEqual([
+      expect.objectContaining({
+        principalEntityId,
+        householdId,
+        role: "caregiver",
+        subjectEntityIds: [],
+        scopes: ["household.visibility", "knowledge.read"],
+        revokedAt: null,
+      }),
+    ]);
+    const grant = grants[0];
+    if (!grant)
+      throw new Error("Issued knowledge-only grant was not persisted");
+    expect(result).toMatchObject({
+      effectReceipts: [
+        {
+          outcome: "applied",
+          resource: { id: grant.id },
+          commit: { kind: "durable" },
+        },
+      ],
+    });
+
+    const { subjectEntityIds: _subjects, ...withoutSubjects } = parameters;
+    expect(
+      await issue.handler(runtime, message, undefined, {
+        parameters: withoutSubjects,
+      }),
+    ).toMatchObject({
+      success: false,
+      data: {
+        error: "MISSING_HOUSEHOLD_PARAMETERS",
+      },
+    });
+    await expect(
+      issue.handler(runtime, message, undefined, {
+        parameters: { ...parameters, subjectEntityIds: [42] },
+      }),
+    ).rejects.toMatchObject({ code: "HOUSEHOLD_INVALID_CONTRACT" });
+    await expect(
+      issue.handler(runtime, message, undefined, {
+        parameters: { ...parameters, scopes: ["calendar.freebusy"] },
+      }),
+    ).rejects.toMatchObject({ code: "HOUSEHOLD_INVALID_CONTRACT" });
+    expect(
+      await householdRepository.listGrants(principalEntityId, householdId),
+    ).toEqual(grants);
+
+    expect(
+      await revoke.handler(runtime, message, undefined, {
+        parameters: {
+          grantId: grant.id,
+          reason: "Synthetic knowledge-only grant acceptance complete.",
+        },
+      }),
+    ).toMatchObject({ success: true });
+    const revoked = await householdRepository.listGrants(
+      principalEntityId,
+      householdId,
+    );
+    expect(revoked).toEqual([
+      expect.objectContaining({ id: grant.id, revokedAt: expect.any(String) }),
+    ]);
+  });
 
   it("exposes safe owner operations without an affected-party impersonation verb", async () => {
     const actionParameter = householdCoordinationAction.parameters?.find(


### PR DESCRIPTION
A knowledge-only household grant explicitly uses `subjectEntityIds: []`, but action argument resolution discarded the empty array and rejected the live owner request as missing a parameter. Allow subactions to explicitly accept empty arrays for named parameters, and enable that contract only for the household grant subject list. Omitted and null values remain missing; household scope and subject validation still reject malformed or unscoped calendar grants.

Refs #31186, #31176, #31172, #31162, #30123.

Validation: root `bun run verify` passed all 373 tasks; full core suite passed 12,235 tests with 3 skips; full personal-assistant suite passed 2,658 tests with 6 skips. The real PGlite household integration suite passed all 28 tests, including promoted grant issuance, durable receipt and stored authority inspection, revocation, and rejection without an extra persisted grant. Biome and diff checks passed.

Live acceptance on combined candidate `5d169f8050fbf2212249dc59b63a8270a473f675` passed: a recorded real model action preserved `subjectEntityIds: []` and produced the persisted knowledge grant. A paired guest then read only the approved clause, was denied owner reads/downloads/exports, lost access after resource revocation, and had its session revoked. Active and revoked export archives passed independent member/source hash verification. The first candidate attempt is included: the model substituted a subject ID and the service rejected it without creating a grant; a clarified request succeeded. This is evidence of the explicit-empty-array contract, not a claim that arbitrary model arguments always follow the request.

All Linux candidate validation/build stages and the five hosted checks for the exact PR head passed. [Recorded synthetic model interaction](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31186-bettina-empty-subjects-live-model-5d169f8-v2.json).

<!-- evidence-head:ad91a80a5ae9f01a1663586266f0a631f2aa382e -->

<!-- evidence-row:before-screenshots -->
N/A - No rendered UI changes.

<!-- evidence-row:after-screenshots -->
N/A - No rendered UI changes.

<!-- evidence-row:walkthrough-video -->
N/A - No rendered UI changes; actual model and HTTP acceptance are recorded below.

<!-- evidence-row:backend-logs -->
<details><summary>Live server lifecycle observations</summary>

```json
{
  "unboundGuest": 403,
  "ownerBinding": 201,
  "boundWithoutResourceGrant": 403,
  "grantPreview": 200,
  "resourceGrantCreated": 201,
  "sharedRead": 200,
  "ownerReadDenied": 403,
  "originalDownloadDenied": 403,
  "ownerExportDenied": 403,
  "resourceGrantRevoked": 200,
  "revokedRead": 403
}
```

</details>

<!-- evidence-row:frontend-logs -->
N/A - The changed action argument contract was exercised through authenticated HTTP and real model execution; it changes no browser client.

<!-- evidence-row:llm-trajectory -->
[Recorded real-model input, observable tool execution, output, and runtime provider/model labels](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31186-bettina-empty-subjects-live-model-5d169f8-v2.json). Both the rejected first attempt and successful clarified request are included unchanged; the data are synthetic, the running service and model calls are real.

<!-- evidence-row:domain-artifacts -->
<details><summary>Persisted grant and verified export integrity</summary>

```json
{
  "grant": {
    "id": "hgrant_9cba4b43-515c-43ab-a472-04ce3327f908",
    "agentId": "b850bc30-45f8-0041-a00a-83df46d8555d",
    "householdId": "household:default",
    "principalEntityId": "ent_396914b8-d19b-4f96-8adb-96788583a697",
    "relationshipId": "hrole_75784905fb23729695c179d2b40720293cf191a1e72e42a0ef9de584ab8281a9",
    "role": "caregiver",
    "subjectEntityIds": [],
    "scopes": [
      "household.visibility",
      "knowledge.read"
    ],
    "issuedByEntityId": "self",
    "expiresAt": null,
    "revokedAt": null,
    "revokedByEntityId": null,
    "revocationReason": null,
    "createdAt": "2026-09-13T02:22:26.619Z",
    "updatedAt": "2026-09-13T02:22:26.619Z"
  },
  "archiveVerification": {
    "5d169f8-active-guest-export.zip": {
      "verified": true,
      "archiveSha256": "6c13df6a470ae1d02109c8d7366f9985d7931f610f69c5c2832e95199bb96b98",
      "originalSha256": "2e3cb50fb96c48666081c94631c072814bc6a71136f46c4210537531f724ae01",
      "manifestSha256": "b686131a599d09bad5c5796387545a7fdd3e7982e08ef5f7f37a2a360ec05c4e",
      "pageCount": 3,
      "extractionStatus": "available",
      "auditCoverage": "recorded_from_ingestion",
      "obligations": 3,
      "pins": 1,
      "grants": 1,
      "auditEvents": 15,
      "preparationReceiptVerified": false
    },
    "5d169f8-revoked-guest-export.zip": {
      "verified": true,
      "archiveSha256": "53f74e0a2405b5d0ffd08c50a6d4720fb8b87b2a692ce344a5bac25bb76bf12e",
      "originalSha256": "2e3cb50fb96c48666081c94631c072814bc6a71136f46c4210537531f724ae01",
      "manifestSha256": "0fab29b797b2681803454fd7a29df094a9c66dee3985b90425f8333493226082",
      "pageCount": 3,
      "extractionStatus": "available",
      "auditCoverage": "recorded_from_ingestion",
      "obligations": 3,
      "pins": 1,
      "grants": 1,
      "auditEvents": 17,
      "preparationReceiptVerified": false
    }
  },
  "sessionRevoked": true,
  "resourceRevoked": true
}
```

</details>

<!-- evidence-row:ocr-review -->
N/A - No rendered UI changes.
