### PR TITLE
fix(app-core): authenticate owner browser WebSocket sessions

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -183,6 +183,7 @@ export {
 // exported through `./api/server.js`.
 export {
   getConfiguredApiToken,
+  isCredentialedCorsOrigin,
   isTrustedLocalRequest,
 } from "./api/server-helpers-auth.ts";
 // `server-types.ts` is the canonical source for conversation/server type

--- a/packages/app-core/README.md
+++ b/packages/app-core/README.md
@@ -41,6 +41,14 @@ bun run --cwd packages/app-core lint         # Biome
 
 This package supplies host integration to the `packages/app` shell and app-facing plugins. It targets Node `>=24`, with `react`/`react-dom`/`three` as peer dependencies and the `@elizaos/capacitor-*` mobile bridges as optional dependencies.
 
+On the self-hosted dashboard, an owner browser session can authenticate a
+WebSocket without exposing its HttpOnly session cookie to JavaScript. Cookie
+admission uses the canonical session store, requires an owner identity and a
+credentialed browser origin, and checks expiry and revocation on each new
+connection. Broad cloud or wildcard-bind CORS reachability does not grant
+cookie access. Explicit bearer and paired-device authentication retain their
+existing transport contracts.
+
 ## Isolated local development
 
 Give each concurrent instance distinct `ELIZA_UI_PORT`, `ELIZA_API_PORT`,

--- a/packages/app-core/src/api/server-browser-session-ws.test.ts
+++ b/packages/app-core/src/api/server-browser-session-ws.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Exercises owner browser-cookie admission through the real app-core HTTP and
+ * WebSocket server with PGlite-backed identities, sessions, expiry and revocation.
+ * The transport must agree with the session authority without admitting ambient
+ * cookies from missing or untrusted origins or granting owner streams to guests.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { AgentRuntime } from "@elizaos/core";
+import {
+  createDatabaseAdapter,
+  plugin as sqlPlugin,
+} from "@elizaos/plugin-sql";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import { AuthStore, type DrizzleDatabase } from "../services/auth-store";
+import {
+  BROWSER_SESSION_TTL_MS,
+  createBrowserSession,
+  createMachineSession,
+} from "./auth/sessions";
+import { startApiServer } from "./server";
+
+type Probe =
+  | { type: "pong" }
+  | { code: number }
+  | { httpStatus: number }
+  | { error: string };
+
+const API_TOKEN = "browser-cookie-ws-test-static-token";
+let stateDir: string;
+let adapter: ReturnType<typeof createDatabaseAdapter>;
+let store: AuthStore;
+let server: Awaited<ReturnType<typeof startApiServer>>;
+let activeCookie: string;
+let expiredCookie: string;
+let revokedCookie: string;
+let guestCookie: string;
+
+function ping(headers: Record<string, string>): Promise<Probe> {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/ws`, { headers });
+    let settled = false;
+    const finish = (result: Probe) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws.terminate();
+      resolve(result);
+    };
+    const timer = setTimeout(() => finish({ error: "timeout" }), 10_000);
+    ws.on("open", () => ws.send(JSON.stringify({ type: "ping" })));
+    ws.on("message", (data) => {
+      const frame = JSON.parse(String(data)) as { type?: string };
+      if (frame.type === "pong") finish({ type: "pong" });
+    });
+    ws.on("close", (code) => finish({ code }));
+    ws.on("unexpected-response", (_request, response) => {
+      response.resume();
+      finish({ httpStatus: response.statusCode ?? 0 });
+    });
+    ws.on("error", (error) => finish({ error: error.message }));
+  });
+}
+
+function cookieHeaders(sessionId: string): Record<string, string> {
+  return {
+    Origin: `http://127.0.0.1:${server.port}`,
+    Cookie: `eliza_session=${encodeURIComponent(sessionId)}`,
+  };
+}
+
+describe.sequential("owner browser session WebSocket admission", () => {
+  beforeAll(async () => {
+    stateDir = await mkdtemp(path.join(tmpdir(), "eliza-cookie-ws-"));
+    vi.stubEnv("ELIZA_STATE_DIR", stateDir);
+    vi.stubEnv("ELIZA_CONFIG_PATH", path.join(stateDir, "eliza.json"));
+    vi.stubEnv("ELIZA_PERSIST_CONFIG_PATH", path.join(stateDir, "eliza.json"));
+    vi.stubEnv("ELIZA_API_BIND", "127.0.0.1");
+    vi.stubEnv("ELIZA_API_BIND_HOST", "127.0.0.1");
+    vi.stubEnv("ELIZA_REQUIRE_LOCAL_AUTH", "1");
+    vi.stubEnv("ELIZA_API_TOKEN", API_TOKEN);
+    vi.stubEnv("ELIZA_API_AUTH_TOKEN", "");
+    vi.stubEnv("ELIZA_CLOUD_PROVISIONED", "0");
+    vi.stubEnv("ELIZA_ALLOW_WS_QUERY_TOKEN", "0");
+    const agentId = randomUUID();
+    adapter = createDatabaseAdapter(
+      { dataDir: path.join(stateDir, "db") },
+      agentId,
+    );
+    await adapter.initialize();
+    const db = adapter.db;
+    if (!db) throw new Error("PGlite adapter did not expose its database");
+    if (!adapter.runPluginMigrations) {
+      throw new Error("PGlite adapter did not expose its migration runner");
+    }
+    await adapter.runPluginMigrations([sqlPlugin]);
+    store = new AuthStore(db as DrizzleDatabase);
+    const owner = await store.createIdentity({
+      id: randomUUID(),
+      kind: "owner",
+      displayName: "Synthetic owner",
+      createdAt: Date.now(),
+    });
+    const guest = await store.createIdentity({
+      id: randomUUID(),
+      kind: "machine",
+      displayName: "Synthetic guest",
+      createdAt: Date.now(),
+    });
+    const options = {
+      identityId: owner.id,
+      ip: null,
+      userAgent: null,
+      rememberDevice: false,
+    };
+    activeCookie = (await createBrowserSession(store, options)).session.id;
+    expiredCookie = (
+      await createBrowserSession(store, {
+        ...options,
+        now: Date.now() - 2 * BROWSER_SESSION_TTL_MS,
+      })
+    ).session.id;
+    revokedCookie = (await createBrowserSession(store, options)).session.id;
+    await store.revokeSession(revokedCookie, Date.now());
+    guestCookie = (
+      await createMachineSession(store, {
+        identityId: guest.id,
+        scopes: ["guest"],
+        ip: null,
+      })
+    ).session.id;
+    const runtime = new AgentRuntime({
+      agentId,
+      character: { name: "Cookie transport test" },
+      adapter,
+      disableBasicCapabilities: true,
+    });
+    server = await startApiServer({
+      runtime,
+      port: 0,
+      skipDeferredStartupWork: true,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (server) await server.close();
+    if (adapter) await adapter.close();
+    if (stateDir)
+      await rm(stateDir, { recursive: true, force: true, maxRetries: 5 });
+    vi.unstubAllEnvs();
+  });
+
+  it("returns a pong for the owner's browser cookie without a bearer", async () => {
+    expect(await ping(cookieHeaders(activeCookie))).toEqual({ type: "pong" });
+  });
+
+  it("retains explicit bearer authentication without ambient cookies", async () => {
+    expect(await ping({ Authorization: `Bearer ${API_TOKEN}` })).toEqual({
+      type: "pong",
+    });
+  });
+
+  it("rejects unknown, expired, revoked and non-owner cookie sessions", async () => {
+    for (const cookie of [
+      randomUUID(),
+      expiredCookie,
+      revokedCookie,
+      guestCookie,
+    ]) {
+      expect(await ping(cookieHeaders(cookie))).toEqual({ code: 1008 });
+    }
+  });
+
+  it("rejects malformed cookies and cookies without a browser origin", async () => {
+    expect(
+      await ping({ Origin: "http://localhost", Cookie: "eliza_session=%ZZ" }),
+    ).toEqual({ code: 1008 });
+    expect(await ping({ Cookie: `eliza_session=${activeCookie}` })).toEqual({
+      code: 1008,
+    });
+  });
+
+  it("keeps untrusted origins denied even when cloud CORS reflects them", async () => {
+    expect(
+      await ping({
+        ...cookieHeaders(activeCookie),
+        Origin: "https://untrusted.example",
+      }),
+    ).toEqual({ httpStatus: 403 });
+    vi.stubEnv("ELIZA_CLOUD_PROVISIONED", "1");
+    try {
+      expect(
+        await ping({
+          ...cookieHeaders(activeCookie),
+          Origin: "https://untrusted.example",
+        }),
+      ).toEqual({ httpStatus: 401 });
+    } finally {
+      vi.stubEnv("ELIZA_CLOUD_PROVISIONED", "0");
+    }
+    vi.stubEnv("ELIZA_API_BIND", "0.0.0.0");
+    vi.stubEnv("ELIZA_API_BIND_HOST", "0.0.0.0");
+    try {
+      expect(
+        await ping({
+          ...cookieHeaders(activeCookie),
+          Origin: "https://untrusted.example",
+        }),
+      ).toEqual({ code: 1008 });
+    } finally {
+      vi.stubEnv("ELIZA_API_BIND", "127.0.0.1");
+      vi.stubEnv("ELIZA_API_BIND_HOST", "127.0.0.1");
+    }
+  });
+
+  it("denies the next connection immediately after owner session revocation", async () => {
+    expect(await ping(cookieHeaders(activeCookie))).toEqual({ type: "pong" });
+    await store.revokeSession(activeCookie, Date.now());
+    expect(await ping(cookieHeaders(activeCookie))).toEqual({ code: 1008 });
+  });
+});

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -32,6 +32,7 @@ import {
   handleRuntimeModeRemoteForward,
   isAllowedHost,
   isAuthorized,
+  isCredentialedCorsOrigin,
   loadEffectiveElizaConfig,
   loadElizaConfig,
   normalizeWsClientId,
@@ -56,7 +57,8 @@ import { resolveLinkedAccountsInConfig } from "@elizaos/shared/contracts/first-r
 import { resetDefaultAccountPoolAfterCredentialReset } from "../services/account-pool";
 import { AuthStore } from "../services/auth-store";
 import { handleAccountPoolStatusRoute } from "./account-pool-status-routes";
-import { findActiveSession } from "./auth/sessions";
+import { readCookie, resolveSessionTokenRole } from "./auth";
+import { findActiveSession, SESSION_COOKIE_NAME } from "./auth/sessions";
 import {
   ensureCompatSensitiveRouteAuthorized,
   ensureRouteAuthorized,
@@ -1140,6 +1142,20 @@ export async function startApiServer(
       });
     },
     authorizeWebSocket: async (request, url) => {
+      const cookie = readCookie(request, SESSION_COOKIE_NAME);
+      const origin =
+        typeof request.headers.origin === "string"
+          ? request.headers.origin
+          : undefined;
+      // Ambient browser credentials require the narrower credentialed-origin
+      // policy; wildcard/cloud CORS reachability alone does not authorize them.
+      if (cookie && isCredentialedCorsOrigin(origin)) {
+        const session = await resolveSessionTokenRole(cookie, {
+          state: compatState,
+          scope: "appCore.webSocketCookieAuth",
+        });
+        if (session?.role === "OWNER") return true;
+      }
       const sessionToken =
         url.searchParams.get("token")?.trim() ||
         url.searchParams.get("apiKey")?.trim() ||


### PR DESCRIPTION
A self-hosted owner can sign in successfully over HTTPS while the browser WebSocket is repeatedly rejected as unauthorized. App-core now authenticates the browser session cookie against the canonical session store, requiring an active owner session and a credentialed origin. Existing explicit bearer and device-token paths remain available. Revocation and expiry are checked on new connections.

Refs #31184 and #30123.

Validation at `daabf99ed6cf9`: rebased pinned install and root `bun run verify` passed all 373 tasks. The full app-core lane passed 4,615 tests with 25 skips plus its script suites. Real agent transport tests passed 18 tests across three files. Six real HTTP/WebSocket tests with PGlite-backed sessions cover owner admission, expiry, revocation, guest denial, missing and untrusted origins, permissive wildcard CORS, and existing bearer admission. Biome and diff checks passed.

The public pilot reproduced owner-cookie WebSocket rejection on `917f68d490923502a866c7800e56eb2b6493578a` and now returns a real ping/pong response on `5d169f8050fbf2212249dc59b63a8270a473f675`. Both observations use the same probe and a normal password-authenticated owner browser session, without query credentials or injected cookies. The deployed candidate preserves intake changes and contains this PR's identical WebSocket patch plus the independent empty-subject fix. Public build assets were verified against the Linux build receipt. All required Linux build/test stages passed, and all five hosted checks passed for this PR head.

<!-- evidence-head:daabf99ed6cf9d67d28c6246d9c4f386ae042ca3 -->

<!-- evidence-row:before-screenshots -->
N/A - Transport authentication does not alter rendered UI.

<!-- evidence-row:after-screenshots -->
N/A - Transport authentication does not alter rendered UI.

<!-- evidence-row:walkthrough-video -->
N/A - No rendered interaction changed; the real browser transport receipt is below.

<!-- evidence-row:backend-logs -->
Sanitized server deployment verification receipt; private state and account identifiers omitted.

<details><summary>Server verification</summary>

```json
{
  "commit": "5d169f8050fbf2212249dc59b63a8270a473f675",
  "originalIngressPreserved": true,
  "trajectoryConfigurationPreserved": true,
  "agreementStatePreserved": true,
  "controlPreserved": true,
  "monthlyPacketPreserved": true
}
```

</details>

<!-- evidence-row:frontend-logs -->
Real public browser probe output before and after, using the same probe SHA-256 `a32f3694c503bc6d84adf9a743bed3ddb0aedd44815c6906d042ee54783d8021`.

<details><summary>Browser transport observations</summary>

```json
{
  "before": {
    "authMeHttp": 200,
    "canRespond": true,
    "origin": "https://ovh-eliza.tail4e11f5.ts.net:8443",
    "ownerRole": "OWNER",
    "ownerStatusHttp": 200,
    "pendingRestart": false,
    "sessionKind": "browser",
    "transport": {
      "code": 1008,
      "outcome": "closed",
      "reason": "Unauthorized"
    },
    "observedPilotRevision": "917f68d490923502a866c7800e56eb2b6493578a",
    "probeSha256": "a32f3694c503bc6d84adf9a743bed3ddb0aedd44815c6906d042ee54783d8021"
  },
  "after": {
    "authMeHttp": 200,
    "canRespond": true,
    "origin": "https://ovh-eliza.tail4e11f5.ts.net:8443",
    "ownerRole": "OWNER",
    "ownerStatusHttp": 200,
    "pendingRestart": false,
    "sessionKind": "browser",
    "transport": {
      "outcome": "pong"
    }
  }
}
```

</details>

<!-- evidence-row:llm-trajectory -->
N/A - No model or action behavior changes in this transport authentication PR.

<!-- evidence-row:domain-artifacts -->
N/A - Read-only transport admission produces no persisted domain records. The browser network receipt above captures the observable result.

<!-- evidence-row:ocr-review -->
N/A - No rendered UI changes.
