### PR TITLE
fix(cloud): stage concurrent inference policy reads

### DIFF
--- a/packages/cloud/shared/src/db/repositories/organization-policy-generation.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-policy-generation.ts
@@ -9,11 +9,25 @@ export async function lockOrganizationPolicy(
   tx: DbTransaction,
   organizationId: string,
 ): Promise<void> {
+  return lockPolicyRow(tx, organizationId, "update");
+}
+/** Read-only admission may overlap other readers while still fencing policy and balance writers. */
+export async function lockOrganizationPolicyForRead(
+  tx: DbTransaction,
+  organizationId: string,
+): Promise<void> {
+  return lockPolicyRow(tx, organizationId, "share");
+}
+async function lockPolicyRow(
+  tx: DbTransaction,
+  organizationId: string,
+  strength: "update" | "share",
+): Promise<void> {
   const [organization] = await tx
     .select({ id: organizations.id })
     .from(organizations)
     .where(eq(organizations.id, organizationId))
-    .for("update");
+    .for(strength);
   if (!organization)
     throw new ElizaError("Organization policy authority does not exist", {
       code: "ORGANIZATION_POLICY_UNAVAILABLE",

--- a/packages/cloud/shared/src/db/repositories/organization-policy.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-policy.postgres.integration.test.ts
@@ -59,6 +59,99 @@ describe.skipIf(!databaseUrl)("organization policy primary transaction fences", 
       await writer.end();
     }
   });
+  test("parallel inference policy readers overlap while a policy writer waits and invalidates their stamp", async () => {
+    const { withOrganizationPolicyReadAdmission } = await import(
+      "../../lib/services/organization-policy-admission"
+    );
+    const { requireOrganizationRateTier } = await import(
+      "../../lib/services/organization-quota-policy"
+    );
+    const { orgRateLimitOverridesRepository } = await import("./org-rate-limit-overrides");
+    const entered = [barrier(), barrier()];
+    const release = barrier();
+    const readers = entered.map((ready) =>
+      withOrganizationPolicyReadAdmission(ORG, undefined, async (policy) => {
+        ready.resolve();
+        await release.promise;
+        return policy.authority;
+      }),
+    );
+    let mutation: Promise<unknown> | undefined;
+    try {
+      // Both callbacks must be reached before either releases its transaction.
+      // Exclusive reader locks cannot pass this boundary.
+      await Promise.race([
+        Promise.all(entered.map((ready) => ready.promise)),
+        Bun.sleep(3000).then(() => {
+          throw new Error("Concurrent inference readers serialized behind one another");
+        }),
+      ]);
+      let mutationFinished = false;
+      mutation = orgRateLimitOverridesRepository
+        .upsert({ organization_id: ORG, completions_rpm: 12 }, "admin:postgres-test")
+        .then(() => {
+          mutationFinished = true;
+        });
+      await waitForOrganizationLock();
+      expect(mutationFinished).toBe(false);
+      release.resolve();
+      const stamps = await Promise.all(readers);
+      await mutation;
+      expect(stamps[0]).toEqual(stamps[1]);
+      await expect(
+        withOrganizationPolicyReadAdmission(ORG, stamps[0], async () => "dispatched"),
+      ).rejects.toMatchObject({ code: "ORGANIZATION_POLICY_STALE" });
+      expect(
+        await withOrganizationPolicyReadAdmission(
+          ORG,
+          undefined,
+          async (policy) => requireOrganizationRateTier(policy).completionsRpm,
+        ),
+      ).toBe(12);
+    } finally {
+      release.resolve();
+      await Promise.allSettled(readers);
+      await mutation;
+    }
+  }, 30000);
+  test("an inference reader still fences credit updates and exclusive resource admission", async () => {
+    const { sql } = await import("drizzle-orm");
+    const { withOrganizationPolicyReadAdmission, withOrganizationPolicyAdmission } = await import(
+      "../../lib/services/organization-policy-admission"
+    );
+    for (const operation of ["credit", "resource"] as const) {
+      const entered = barrier(),
+        release = barrier();
+      const reader = withOrganizationPolicyReadAdmission(ORG, undefined, async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      let mutation: Promise<unknown> | undefined;
+      try {
+        await entered.promise;
+        let finished = false;
+        mutation = (
+          operation === "credit"
+            ? database.dbWrite.execute(
+                sql`UPDATE organizations SET credit_balance=credit_balance-1 WHERE id=${ORG}`,
+              )
+            : withOrganizationPolicyAdmission(ORG, undefined, async () => "resource admitted")
+        ).then(() => {
+          finished = true;
+        });
+        await waitForOrganizationLock();
+        expect(finished).toBe(false);
+        release.resolve();
+        await reader;
+        await mutation;
+        expect(finished).toBe(true);
+      } finally {
+        release.resolve();
+        await reader;
+        await mutation;
+      }
+    }
+  }, 30000);
   test("a paused old cache publication cannot overtake a newer committed policy warmer", async () => {
     const { cache } = await import("../../lib/cache/client");
     const { isInferenceAdmissionSnapshot } = await import(

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
@@ -67,16 +67,18 @@ function policyFixture(): OrganizationQuotaPolicy {
     },
   };
 }
+async function withFixturePolicy<T>(
+  _org: string,
+  _expected: OrganizationPolicyStamp | undefined,
+  operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
+): Promise<T> {
+  policyReads++;
+  return operation(policyFixture());
+}
 mock.module("../services/organization-policy-admission", () => ({
   ...policyAdmissionActual,
-  withOrganizationPolicyAdmission: async <T>(
-    _org: string,
-    _expected: OrganizationPolicyStamp | undefined,
-    operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
-  ) => {
-    policyReads++;
-    return operation(policyFixture());
-  },
+  withOrganizationPolicyAdmission: withFixturePolicy,
+  withOrganizationPolicyReadAdmission: withFixturePolicy,
 }));
 
 let redisChecks = 0;

--- a/packages/cloud/shared/src/lib/middleware/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit.ts
@@ -17,7 +17,10 @@ import { warmInferenceAdmissionSnapshot } from "../services/inference-admission-
 import { isHotPathCachesEnabled } from "../services/inference-hot-path-caches";
 import type { EndpointType, OrgRateLimitConfig } from "../services/org-rate-limits";
 import { type OrgTierCacheExecutionContext, recalculateOrgTier } from "../services/org-rate-limits";
-import { withOrganizationPolicyAdmission } from "../services/organization-policy-admission";
+import {
+  withOrganizationPolicyAdmission,
+  withOrganizationPolicyReadAdmission,
+} from "../services/organization-policy-admission";
 import {
   isOrganizationPolicyStamp,
   sameOrganizationPolicyStamp,
@@ -459,7 +462,10 @@ export async function enforceOrgRateLimit(
   } = {},
 ): Promise<Response | null> {
   try {
-    return await withOrganizationPolicyAdmission(
+    const admitOrganizationPolicy = options.cacheOnly
+      ? withOrganizationPolicyReadAdmission
+      : withOrganizationPolicyAdmission;
+    return await admitOrganizationPolicy(
       organizationId,
       options.config?.authority,
       async (policy) => {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -225,6 +225,7 @@ mock.module("../../db/helpers", () => ({
 }));
 mock.module("../../db/repositories/organization-policy-generation", () => ({
   lockOrganizationPolicy: async () => undefined,
+  lockOrganizationPolicyForRead: async () => undefined,
 }));
 mock.module("./organization-quota-policy", () => ({
   readOrganizationQuotaPolicyInTransaction: readPolicy,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -11,7 +11,10 @@
 
 import { ElizaError } from "@elizaos/core";
 import { writeTransaction } from "../../db/helpers";
-import { lockOrganizationPolicy } from "../../db/repositories/organization-policy-generation";
+import {
+  lockOrganizationPolicy,
+  lockOrganizationPolicyForRead,
+} from "../../db/repositories/organization-policy-generation";
 import { calculateCost, normalizeModelName } from "../pricing";
 import { createCreditReservationSettler } from "../utils/credit-reservation";
 import { logger } from "../utils/logger";
@@ -72,7 +75,10 @@ import {
   type InferenceCredentialCheck,
   InferenceCredentialRevokedError,
 } from "./inference-credential-revocation";
-import { withOrganizationPolicyAdmission } from "./organization-policy-admission";
+import {
+  withOrganizationPolicyAdmission,
+  withOrganizationPolicyReadAdmission,
+} from "./organization-policy-admission";
 import { sameOrganizationPolicyStamp } from "./organization-policy-stamp";
 import {
   type OrganizationQuotaPolicy,
@@ -334,8 +340,10 @@ export async function admitOrganizationInference(
 ): Promise<OrganizationInferenceAdmission> {
   // KV/LRU entries are observations, never a CAS fence. Compare policy under
   // the same organization lock that serializes entitlement and override writes.
+  const workerHotPath = typeof params.executionCtx?.waitUntil === "function";
+  const lockPolicy = workerHotPath ? lockOrganizationPolicyForRead : lockOrganizationPolicy;
   const authoritativePolicy = await writeTransaction(async (tx) => {
-    await lockOrganizationPolicy(tx, params.context.organizationId);
+    await lockPolicy(tx, params.context.organizationId);
     return readOrganizationQuotaPolicyInTransaction(tx, params.context.organizationId);
   });
   if (
@@ -360,6 +368,9 @@ export async function admitOrganizationInference(
   }
   const admission = await admitWithFundingPolicy(params, authoritativePolicy);
   const previousDispatch = admission.markProviderDispatched;
+  const admitDispatch = workerHotPath
+    ? withOrganizationPolicyReadAdmission
+    : withOrganizationPolicyAdmission;
   let dispatched = false;
   let dispatch: Promise<void> | undefined;
   return {
@@ -367,7 +378,7 @@ export async function admitOrganizationInference(
     markProviderDispatched: () => {
       if (dispatched) return Promise.resolve();
       if (dispatch) return dispatch;
-      dispatch = withOrganizationPolicyAdmission(
+      dispatch = admitDispatch(
         params.context.organizationId,
         authoritativePolicy.authority,
         async (current) => {

--- a/packages/cloud/shared/src/lib/services/organization-policy-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-policy-admission.ts
@@ -1,7 +1,10 @@
 /** Serializes authoritative policy admission with organization lifecycle and override publication. */
 import { ElizaError } from "@elizaos/core";
 import { writeTransaction } from "../../db/helpers";
-import { lockOrganizationPolicy } from "../../db/repositories/organization-policy-generation";
+import {
+  lockOrganizationPolicy,
+  lockOrganizationPolicyForRead,
+} from "../../db/repositories/organization-policy-generation";
 import {
   isOrganizationPolicyStamp,
   sameOrganizationPolicyStamp,
@@ -16,8 +19,29 @@ export async function withOrganizationPolicyAdmission<T>(
   expected: OrganizationPolicyStamp | undefined,
   operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
 ): Promise<T> {
+  return admitUnderPolicyLock(organizationId, expected, operation, lockOrganizationPolicy);
+}
+/**
+ * Fences read-only inference checks against policy writers without serializing readers.
+ * The callback must not mutate Postgres; rate and spend transitions must have
+ * their own authoritative Durable Object serialization. Resource admission
+ * and cache publication retain the exclusive admission function above.
+ */
+export async function withOrganizationPolicyReadAdmission<T>(
+  organizationId: string,
+  expected: OrganizationPolicyStamp | undefined,
+  operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
+): Promise<T> {
+  return admitUnderPolicyLock(organizationId, expected, operation, lockOrganizationPolicyForRead);
+}
+async function admitUnderPolicyLock<T>(
+  organizationId: string,
+  expected: OrganizationPolicyStamp | undefined,
+  operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
+  lock: typeof lockOrganizationPolicy,
+): Promise<T> {
   return writeTransaction(async (tx) => {
-    await lockOrganizationPolicy(tx, organizationId);
+    await lock(tx, organizationId);
     const policy = await readOrganizationQuotaPolicyInTransaction(tx, organizationId);
     if (
       expected !== undefined &&


### PR DESCRIPTION
Parallel model requests from the same Dedicated agent serialize on exclusive organization-row locks even when the guarded operation only reads policy and calls the authoritative rate or spend Durable Object. Worker inference now uses shared row locks for those checks, allowing readers to overlap while policy changes, credit updates and resource admission retain their existing fences. Final policy-generation, rate, credential and billing checks remain in place.

Staging-only promotion of #31193 for #31191. The change is limited to the rate check, initial inference policy read and final dispatch check. Non-Worker admission, resource allocation and cache publication retain exclusive locks. Model context, provider selection and database schema are unchanged.

Source validation at `298a12862f6` (identical seven changed files):

- Real PostgreSQL: all five integration cases pass. Temporarily restoring the old exclusive reader lock makes the new concurrent-reader case fail with `Concurrent inference readers serialized behind one another`; restoring the candidate passes. The tests also prove override publication invalidates the old stamp and credit/resource writers wait.
- Existing focused rate/inference contracts: 23 tests pass.
- Shared package typecheck and lint pass; root `bun run verify` passes.
- Five suites interrupted by a concurrent dependency rebuild were rerun after the build: 108 pass, one existing Docker opt-in skip, zero failures. The complete shared package rerun is still running; its result will be recorded here.

Production baseline from the same QA node and configured Qwen model: four correct responses took 4.1–4.9 seconds, including 3.9–4.6 seconds before provider dispatch. This PR removes reader contention; the remaining serial database/network cost still needs live measurement and follow-up. No latency improvement or deployment is claimed yet.

The staging tree contains exactly this seven-file patch over the currently served staging SHA `342569fcaef58dbd58b79eff2f17a1996b149d80`; unrelated develop changes are excluded. Production promotion remains dependent on staged live validation.
