### PR TITLE
feat(lifeops): export owner family workspace with verified source archives

### DIFF
--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -435,3 +435,17 @@ internals; it consumes the plugin's public exports only. See
 - Prompt-content lint rules: `scripts/lint-default-packs.mjs`.
 - Health domain: `plugins/plugin-health/README.md`.
 - REST routes: `src/routes/`.
+
+### Family workspace export
+
+The owner-only `POST /api/lifeops/family-workflows/export` downloads a ZIP with
+all family agreement versions, retained school PDFs, monthly packet versions
+and drafts, their approval records, and stored provider/school mutation receipts.
+Each member has a SHA-256 checksum. Agreement archives preserve their existing
+source/extraction and review/access provenance; packet and workflow records use
+one database statement snapshot. The manifest records this component-snapshot
+boundary and explicitly identifies uninitialized historical record stores.
+Missing or changed retained PDF bytes fail export rather than producing a
+healthy-looking partial archive. Connection credentials and executor lease
+tokens are excluded. Export records preparation, not receipt by the client,
+and does not revoke access or delete data.

--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.stories.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.stories.tsx
@@ -16,6 +16,9 @@ const adapter = {
     packets: { status: "ready", data: [] },
     emailOptions: { status: "ready", data: { accounts: [], recipients: [] } },
   }),
+  downloadWorkspace: async () => {
+    throw new Error("This preview has no stored workspace to export.");
+  },
   decideObligation: async (obligation: never) => obligation,
   listPins: async () => [],
   pin: async () => null,

--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.test.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.test.tsx
@@ -132,6 +132,9 @@ function adapter(data = snapshot()): FamilyOperationsAdapter {
     generatePacket: vi.fn(async () => undefined),
     uploadAgreement: vi.fn(async () => undefined),
     downloadAgreement: vi.fn(async () => new Blob()),
+    downloadWorkspace: vi.fn(
+      async () => new Blob([], { type: "application/zip" }),
+    ),
     createPacketDraft: vi.fn(async () => undefined),
     revisePacketDraft: vi.fn(async () => undefined),
     requestPacketApproval: vi.fn(async () => undefined),
@@ -139,6 +142,42 @@ function adapter(data = snapshot()): FamilyOperationsAdapter {
 }
 
 describe("FamilyOperationsView", () => {
+  it("blocks duplicate workspace exports while preparing and restores the control after a denied request", async () => {
+    const local = adapter();
+    let rejectExport: (error: Error) => void = () => {
+      throw new Error("Export has not started");
+    };
+    local.downloadWorkspace = vi.fn(
+      () =>
+        new Promise<Blob>((_resolve, reject) => {
+          rejectExport = reject;
+        }),
+    );
+    render(<FamilyOperationsView adapter={local} />);
+    const button = await screen.findByRole("button", {
+      name: "Export workspace",
+    });
+    await waitFor(() =>
+      expect((button as HTMLButtonElement).disabled).toBe(false),
+    );
+    fireEvent.click(button);
+    const pending = screen.getByRole("button", {
+      name: "Preparing workspace export…",
+    });
+    expect((pending as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(pending);
+    expect(local.downloadWorkspace).toHaveBeenCalledTimes(1);
+    rejectExport(new Error("Owner access is required"));
+    expect(await screen.findByText("Owner access is required")).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Export workspace",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    expect(screen.queryByText("Workspace download started.")).toBeNull();
+  });
   it("saves the selected school level and standing update policy before running", async () => {
     const local = adapter();
     const data = await local.load();

--- a/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/FamilyOperationsView.tsx
@@ -1281,6 +1281,34 @@ export function FamilyOperationsView({
   );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportNotice, setExportNotice] = useState<string | null>(null);
+  const exportWorkspace = async () => {
+    if (exporting) return;
+    setExporting(true);
+    setExportError(null);
+    setExportNotice(null);
+    try {
+      const blob = await adapter.downloadWorkspace();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "family-workspace.zip";
+      document.body.append(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+      setExportNotice("Workspace download started.");
+    } catch (cause) {
+      // error-policy:J1 A failed export remains visible and can be retried.
+      setExportError(
+        cause instanceof Error ? cause.message : "Workspace export failed",
+      );
+    } finally {
+      setExporting(false);
+    }
+  };
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -1342,6 +1370,17 @@ export function FamilyOperationsView({
             Review the parenting agreement, calendar synchronization, school
             dates, and monthly coordination email.
           </p>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={loading || exporting}
+            onClick={() => void exportWorkspace()}
+            style={{ marginTop: 12 }}
+          >
+            {exporting ? "Preparing workspace export…" : "Export workspace"}
+          </Button>
+          {exportError ? <Unavailable message={exportError} /> : null}
+          {exportNotice ? <p role="status">{exportNotice}</p> : null}
         </header>
         <nav
           aria-label="Family Operations sections"

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.test.ts
@@ -61,12 +61,25 @@ describe("defaultFamilyOperationsAdapter", () => {
       "export",
     );
     expect(new Uint8Array(await archive.arrayBuffer())).toEqual(bytes);
+    const workspace = await defaultFamilyOperationsAdapter.downloadWorkspace();
+    expect(new Uint8Array(await workspace.arrayBuffer())).toEqual(bytes);
     await expect(
       defaultFamilyOperationsAdapter.downloadAgreement(
         "artifact-one",
         "original",
       ),
     ).rejects.toThrow("Original failed integrity verification");
+  });
+
+  it("rejects a successful HTTP response that is not a workspace archive", async () => {
+    vi.stubGlobal(
+      "fetch",
+      async () =>
+        new Response("{}", { headers: { "content-type": "application/json" } }),
+    );
+    await expect(
+      defaultFamilyOperationsAdapter.downloadWorkspace(),
+    ).rejects.toThrow("The server did not return a workspace archive.");
   });
 
   it.each([

--- a/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/adapter.ts
@@ -213,6 +213,42 @@ async function loadPackets(): Promise<Loadable<FamilyPacketView[]>> {
   }
 }
 
+async function downloadFile(
+  path: string,
+  method: "GET" | "POST",
+): Promise<Blob> {
+  const response = await client.rawRequest(
+    path,
+    { method },
+    {
+      allowNonOk: true,
+      skipResume: true,
+      timeoutMs: 10 * 60_000,
+    },
+  );
+  if (!response.ok) {
+    const failureMessage = `Download failed (${response.status})`;
+    const mediaType = response.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (mediaType !== "application/json" && !mediaType?.endsWith("+json")) {
+      throw new Error(failureMessage);
+    }
+    const payload = await response.json().catch((cause) => {
+      // error-policy:J1 Invalid proxy error bodies retain the HTTP failure.
+      throw new Error(failureMessage, { cause });
+    });
+    const message =
+      typeof payload?.error === "string"
+        ? payload.error
+        : payload?.error?.message;
+    throw new Error(typeof message === "string" ? message : failureMessage);
+  }
+  return response.blob();
+}
+
 export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter = {
   async load(): Promise<FamilyOperationsSnapshot> {
     const [agreements, calendarLinks, school, packets, emailOptions] =
@@ -235,32 +271,19 @@ export const defaultFamilyOperationsAdapter: FamilyOperationsAdapter = {
     return { agreements, calendarLinks, school, packets, emailOptions };
   },
   async downloadAgreement(artifactId, format) {
-    const response = await client.rawRequest(
+    return downloadFile(
       `/api/lifeops/agreements/${encodeURIComponent(artifactId)}/${format === "export" ? "export" : "download"}`,
-      { method: format === "export" ? "POST" : "GET" },
-      { allowNonOk: true, skipResume: true, timeoutMs: 10 * 60_000 },
+      format === "export" ? "POST" : "GET",
     );
-    if (!response.ok) {
-      const failureMessage = `Download failed (${response.status})`;
-      const mediaType = response.headers
-        .get("content-type")
-        ?.split(";", 1)[0]
-        ?.trim()
-        .toLowerCase();
-      if (mediaType !== "application/json" && !mediaType?.endsWith("+json")) {
-        throw new Error(failureMessage);
-      }
-      const payload = await response.json().catch((cause) => {
-        // error-policy:J1 Invalid proxy error bodies retain the HTTP failure.
-        throw new Error(failureMessage, { cause });
-      });
-      const message =
-        typeof payload?.error === "string"
-          ? payload.error
-          : payload?.error?.message;
-      throw new Error(typeof message === "string" ? message : failureMessage);
-    }
-    return response.blob();
+  },
+  async downloadWorkspace() {
+    const blob = await downloadFile(
+      "/api/lifeops/family-workflows/export",
+      "POST",
+    );
+    if (blob.type !== "application/zip")
+      throw new Error("The server did not return a workspace archive.");
+    return blob;
   },
 
   async uploadAgreement(input) {

--- a/plugins/plugin-personal-assistant/src/components/family-operations/types.ts
+++ b/plugins/plugin-personal-assistant/src/components/family-operations/types.ts
@@ -89,6 +89,7 @@ export interface FamilyOperationsSnapshot {
 
 export interface FamilyOperationsAdapter {
   load(): Promise<FamilyOperationsSnapshot>;
+  downloadWorkspace(): Promise<Blob>;
   uploadAgreement(input: AgreementUploadInput): Promise<void>;
   downloadAgreement(
     artifactId: string,

--- a/plugins/plugin-personal-assistant/src/lifeops/family-workflows/workspace-export.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/family-workflows/workspace-export.ts
@@ -1,0 +1,275 @@
+/**
+ * Builds an owner-private family workspace archive from retained source bytes,
+ * immutable agreement exports and one snapshot of packet/workflow records.
+ * Approval receipts are exported as recorded evidence, never as inferred sends.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { createZipArchive } from "@elizaos/agent/api/zip-utils";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  type IFileStorageService,
+  ServiceType,
+} from "@elizaos/core";
+import { z } from "zod";
+import { getAgreementKnowledgeService } from "../household/agreement-knowledge.js";
+import { executeRawSql, sqlQuote } from "../sql.js";
+
+const recordSchema = z.record(z.string(), z.json());
+type ExportRecord = z.infer<typeof recordSchema>;
+
+// Explicit projections keep executor leases and connection credentials outside
+// the portable owner record even when the underlying schemas grow.
+const SOURCES = [
+  {
+    key: "packets",
+    table: "app_lifeops.life_family_packets",
+    columns:
+      "packet_id,period_key,internal_version,content_sha256,packet_json,created_at",
+  },
+  {
+    key: "drafts",
+    table: "app_lifeops.life_family_packet_drafts",
+    columns:
+      "packet_id,internal_version,draft_version,recipient,recipient_entity_id,calendar_privacy_mode,included_claim_ids_json,body,body_sha256,transformations_json,email_json,created_at",
+  },
+  {
+    key: "packetApprovals",
+    table: "app_lifeops.life_family_packet_approvals",
+    columns: "packet_id,draft_version,draft_sha256,approval_id,created_at",
+  },
+  {
+    key: "workflowRuns",
+    table: "app_lifeops.life_family_workflow_runs",
+    columns:
+      "period_key,run_id,state,trigger_kind,result_json,created_at,updated_at",
+  },
+  {
+    key: "schoolSources",
+    table: "app_lifeops.life_school_calendar_sources",
+    columns:
+      "source_id,config_json,last_content_sha256,last_media_url,calendar_contract_version,created_at,updated_at",
+  },
+  {
+    key: "schoolRuns",
+    table: "app_lifeops.life_school_calendar_runs",
+    columns:
+      "run_id,source_id,state,trigger_kind,discovered_pdf_url,content_sha256,media_url,semantic_sha256,plan_json,error_code,error_message,created_at,updated_at",
+  },
+  {
+    key: "schoolEvents",
+    table: "app_lifeops.life_school_calendar_events",
+    columns:
+      "source_id,event_key,semantic_json,provider_event_id,provider_version,active,updated_at",
+  },
+  {
+    key: "schoolMutations",
+    table: "app_lifeops.life_school_calendar_apply_operations",
+    columns:
+      "run_id,operation_index,event_key,kind,change_json,state,receipt_json,error_code,error_message,created_at,updated_at",
+  },
+] as const;
+
+function failure(message: string, code: string): never {
+  throw new ElizaError(`[FamilyWorkspaceExport] ${message}`, { code });
+}
+
+function sha256(bytes: Buffer | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function readRecords(runtime: IAgentRuntime) {
+  const available = await executeRawSql(
+    runtime,
+    SOURCES.map(
+      (source) =>
+        `SELECT ${sqlQuote(source.key)} AS kind, to_regclass(${sqlQuote(source.table)}) IS NOT NULL AS available`,
+    ).join(" UNION ALL "),
+  );
+  const missing = SOURCES.filter(
+    (source) =>
+      !available.some(
+        (row) => row.kind === source.key && row.available === true,
+      ),
+  );
+  const present = SOURCES.filter((source) => !missing.includes(source));
+  const scoped = `agent_id = ${sqlQuote(runtime.agentId)}`;
+  const queries = present.map(
+    (source) =>
+      `SELECT ${sqlQuote(source.key)} AS kind, to_jsonb(record)::text AS payload FROM (SELECT ${source.columns} FROM ${source.table} WHERE ${scoped}) AS record`,
+  );
+  if (present.some((source) => source.key === "packetApprovals")) {
+    queries.push(`SELECT 'approvals' AS kind, to_jsonb(record)::text AS payload FROM (
+      SELECT id,state,requested_by,subject_user_id,action,payload,channel,reason,expires_at,resolved_at,resolved_by,resolution_reason,execution_provider,dispatch_started_at,provider_receipt,execution_error,reconciliation_resolved_at,reconciliation_reason,created_at,updated_at
+      FROM approval_requests WHERE ${scoped} AND id::text IN (
+        SELECT approval_id FROM app_lifeops.life_family_packet_approvals WHERE ${scoped}
+      )) AS record`);
+  }
+  const records: Record<string, ExportRecord[]> = {};
+  for (const source of present) records[source.key] = [];
+  if (present.some((source) => source.key === "packetApprovals"))
+    records.approvals = [];
+  if (queries.length) {
+    for (const row of await executeRawSql(
+      runtime,
+      queries.join(" UNION ALL "),
+    )) {
+      const key = z.string().parse(row.kind);
+      const destination = records[key];
+      if (!destination)
+        failure(
+          "Unexpected workspace record category",
+          "FAMILY_EXPORT_INVALID_RECORD",
+        );
+      try {
+        destination.push(
+          recordSchema.parse(JSON.parse(z.string().parse(row.payload))),
+        );
+      } catch (cause) {
+        // error-policy:J2 Corrupt persisted records cannot become a partial archive.
+        throw new ElizaError(
+          "[FamilyWorkspaceExport] A persisted workspace record is invalid",
+          {
+            code: "FAMILY_EXPORT_INVALID_RECORD",
+            cause,
+            context: { category: key },
+          },
+        );
+      }
+    }
+  }
+  for (const rows of Object.values(records))
+    rows.sort((left, right) =>
+      JSON.stringify(left).localeCompare(JSON.stringify(right)),
+    );
+  return {
+    records,
+    unavailable: missing.map((source) => ({
+      category: source.key,
+      reason:
+        "This component has no initialized record store; historical activity is unavailable.",
+    })),
+  };
+}
+
+export async function exportFamilyWorkspace(
+  runtime: IAgentRuntime,
+  ownerEntityId: string,
+): Promise<{ bytes: Buffer; mimeType: string; fileName: string }> {
+  const agreements = getAgreementKnowledgeService(runtime);
+  if (!agreements)
+    failure(
+      "Agreement knowledge service is unavailable",
+      "FAMILY_EXPORT_UNAVAILABLE",
+    );
+  // The domain service validates the owner before any workspace records or
+  // private source bytes are read. Caller-supplied household IDs cannot widen it.
+  const captureStartedAt = new Date().toISOString();
+  const sources = await agreements.listOwnerAgreements({ ownerEntityId });
+  const snapshot = await readRecords(runtime);
+  const files: Array<{ name: string; data: Buffer | string }> = [];
+  const sourceArchives = [];
+  for (const source of sources) {
+    const archive = await agreements.exportOwnerAgreement({
+      artifactId: source.artifact.id,
+      ownerEntityId,
+    });
+    const name = `agreements/${sha256(source.artifact.id)}.zip`;
+    files.push({ name, data: archive.bytes });
+    sourceArchives.push({
+      artifactId: source.artifact.id,
+      householdId: source.artifact.householdId,
+      agreementKey: source.artifact.agreementKey,
+      version: source.artifact.version,
+      contentSha256: source.artifact.contentSha256,
+      path: name,
+      archiveSha256: sha256(archive.bytes),
+    });
+  }
+  const schoolFiles = [];
+  const retained = new Set<string>();
+  const schoolRuns = snapshot.records.schoolRuns;
+  if (schoolRuns !== undefined)
+    for (const row of schoolRuns) {
+      if (row.content_sha256 === null) continue;
+      const digest = z
+        .string()
+        .regex(/^[a-f0-9]{64}$/)
+        .parse(row.content_sha256);
+      if (retained.has(digest)) continue;
+      const url = z
+        .string()
+        .regex(/^\/api\/media\/[a-f0-9]{64}\.pdf$/)
+        .parse(row.media_url);
+      const fileName = url.replace("/api/media/", "");
+      if (fileName !== `${digest}.pdf`)
+        failure(
+          "Retained school source reference does not match its recorded hash",
+          "FAMILY_EXPORT_SOURCE_INTEGRITY",
+        );
+      const storage = runtime.getService<IFileStorageService>(
+        ServiceType.REMOTE_FILES,
+      );
+      if (!storage)
+        failure(
+          "Canonical file storage service is unavailable",
+          "FAMILY_EXPORT_UNAVAILABLE",
+        );
+      const bytes = await storage.read(fileName);
+      if (!bytes || sha256(bytes) !== digest)
+        failure(
+          "Retained school PDF is missing or failed integrity verification",
+          "FAMILY_EXPORT_SOURCE_INTEGRITY",
+        );
+      const name = `school/${digest}.pdf`;
+      files.push({ name, data: bytes });
+      schoolFiles.push({ path: name, sha256: digest, byteSize: bytes.length });
+      retained.add(digest);
+    }
+  const exportId = `family_export_${randomUUID()}`;
+  const manifest = Buffer.from(
+    `${JSON.stringify(
+      {
+        schema: "elizaos.family-workspace-export",
+        schemaVersion: 1,
+        exportId,
+        agentId: runtime.agentId,
+        captureStartedAt,
+        captureCompletedAt: new Date().toISOString(),
+        scope:
+          "All family agreement versions, school workflow records and monthly packets owned by this agent. Unrelated calendars, inboxes and connection credentials are excluded.",
+        consistency:
+          "Packet and workflow records share one database statement snapshot. Each nested agreement archive records its own review/access snapshot and source-byte checksums.",
+        sourceArchives,
+        schoolFiles,
+        ...snapshot,
+        receiptCoverage:
+          "Only stored approval states, provider receipts and school mutation receipts are included. Missing receipts do not establish delivery. This preparation does not assert successful client download.",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  files.push({ name: "manifest.json", data: manifest });
+  const sums = files
+    .map((file) => `${sha256(file.data)}  ${file.name}\n`)
+    .join("");
+  const bytes = createZipArchive([
+    ...files,
+    { name: "SHA256SUMS", data: sums },
+  ]);
+  const at = new Date().toISOString();
+  await executeRawSql(
+    runtime,
+    `INSERT INTO app_lifeops.life_audit_events (id,agent_id,event_type,owner_type,owner_id,reason,inputs_json,decision_json,actor,created_at) VALUES (
+    ${sqlQuote(exportId)},${sqlQuote(runtime.agentId)},'family_workspace_export_prepared','family_workspace',${sqlQuote(runtime.agentId)},
+    'Verified workspace archive prepared for owner download; client receipt is not asserted',
+    ${sqlQuote(JSON.stringify({ ownerEntityId, sourceArtifactIds: sourceArchives.map((source) => source.artifactId) }))},
+    ${sqlQuote(JSON.stringify({ manifestSha256: sha256(manifest), archiveSha256: sha256(bytes) }))},'owner',${sqlQuote(at)})`,
+  );
+  return {
+    bytes,
+    mimeType: "application/zip",
+    fileName: `family-workspace-${exportId}.zip`,
+  };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -18,6 +18,7 @@ import {
   ChannelType,
   documentsPluginCore,
   type IAgentRuntime,
+  type IFileStorageService,
   type Memory,
   type Plugin,
   Service,
@@ -28,13 +29,19 @@ import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { tryHandleRuntimePluginRoute } from "../../../../../packages/agent/src/api/runtime-plugin-routes.ts";
 import { LocalFileStorageService } from "../../../../../packages/agent/src/services/file-storage.js";
-import { createMachineSession } from "../../../../../packages/app-core/src/api/auth/sessions.ts";
+import {
+  createBrowserSession,
+  createMachineSession,
+} from "../../../../../packages/app-core/src/api/auth/sessions.ts";
 import { composeResponseState } from "../../../../../packages/core/src/services/message/provider-state.js";
 import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../test/helpers/runtime.js";
 import { bindMachineAuthIdentityToEntity } from "../../routes/authenticated-entity-principal.js";
+import { MonthlyFamilyPacketService } from "../family-coordination/monthly-packet.js";
+import { exportFamilyWorkspace } from "../family-workflows/workspace-export.js";
+import { SchoolCalendarWorkflow } from "../school/calendar-workflow.js";
 import { executeRawSql, sqlQuote } from "../sql.js";
 import {
   AgreementKnowledgeError,
@@ -594,6 +601,198 @@ describe("parenting-agreement knowledge — real PGlite", () => {
     }
   });
 
+  it("exports the owner workspace with real packet records and verified nested source archives while denying guests", async () => {
+    const packets = new MonthlyFamilyPacketService(runtime);
+    const packet = await packets.buildInternal(
+      {
+        key: "2026-11",
+        startsOn: "2026-11-01",
+        endsOnExclusive: "2026-12-01",
+        timeZone: "UTC",
+      },
+      [
+        {
+          claimId: "workspace-export-question",
+          stableKey: "workspace-export-question",
+          section: "unanswered",
+          statement: "Confirm the synthetic library pickup date.",
+          visibility: "owner_only",
+          provenance: [
+            {
+              source: "knowledge",
+              sourceId: artifact.id,
+              observedAt: artifact.createdAt,
+              contentSha256: artifact.contentSha256,
+            },
+          ],
+          dates: [],
+          requests: ["Confirm the pickup date"],
+          urgency: null,
+          commitments: [],
+          accountability: [],
+          unanswered: true,
+        },
+      ],
+    );
+    await expect(
+      exportFamilyWorkspace(runtime, "unverified-guest"),
+    ).rejects.toMatchObject({ code: "AGREEMENT_ACCESS_DENIED" });
+    const exported = await exportFamilyWorkspace(runtime, SELF_ENTITY_ID);
+    const files = readStoredZip(exported.bytes);
+    const manifestBytes = files.get("manifest.json");
+    const sums = files.get("SHA256SUMS");
+    if (!manifestBytes || !sums)
+      throw new Error("Workspace archive is incomplete");
+    const manifest = JSON.parse(manifestBytes.toString("utf8"));
+    const packetRow = manifest.records.packets.find(
+      (row: { packet_id: string }) => row.packet_id === packet.packetId,
+    );
+    expect(JSON.parse(packetRow.packet_json)).toEqual(packet);
+    const source = manifest.sourceArchives.find(
+      (row: { artifactId: string }) => row.artifactId === artifact.id,
+    );
+    const nested = files.get(source.path);
+    if (!nested) throw new Error("Workspace source archive is missing");
+    expect(crypto.createHash("sha256").update(nested).digest("hex")).toBe(
+      source.archiveSha256,
+    );
+    const original = readStoredZip(nested).get("original.pdf");
+    if (!original) throw new Error("Original source bytes are missing");
+    expect(crypto.createHash("sha256").update(original).digest("hex")).toBe(
+      artifact.contentSha256,
+    );
+    for (const line of sums.toString("utf8").trim().split("\n")) {
+      const [digest, name] = line.split("  ");
+      const bytes = files.get(name);
+      if (!bytes) throw new Error("Checksummed workspace member is missing");
+      expect(crypto.createHash("sha256").update(bytes).digest("hex")).toBe(
+        digest,
+      );
+    }
+    const audit = await executeRawSql(
+      runtime,
+      `SELECT decision_json FROM app_lifeops.life_audit_events WHERE agent_id=${sqlQuote(runtime.agentId)} AND id=${sqlQuote(manifest.exportId)}`,
+    );
+    expect(JSON.parse(String(audit[0].decision_json))).toEqual({
+      manifestSha256: crypto
+        .createHash("sha256")
+        .update(manifestBytes)
+        .digest("hex"),
+      archiveSha256: crypto
+        .createHash("sha256")
+        .update(exported.bytes)
+        .digest("hex"),
+    });
+  });
+
+  it("exports retained school bytes without executor leases or another agent's records and fails on missing source bytes", async () => {
+    await new SchoolCalendarWorkflow(runtime).ensureSchema();
+    const storage = runtime.getService<IFileStorageService>(
+      ServiceType.REMOTE_FILES,
+    );
+    if (!storage) throw new Error("Canonical file storage is unavailable");
+    const bytes = pdf(
+      "Synthetic retained school calendar for workspace export",
+    );
+    const stored = await storage.store(bytes, "application/pdf");
+    const runId = crypto.randomUUID();
+    const foreignId = crypto.randomUUID();
+    const at = new Date().toISOString();
+    for (const [agentId, sourceId] of [
+      [runtime.agentId, "workspace-school"],
+      [foreignId, "other-agent-private-school"],
+    ]) {
+      await executeRawSql(
+        runtime,
+        `INSERT INTO app_lifeops.life_school_calendar_runs (agent_id,run_id,source_id,state,trigger_kind,content_sha256,media_url,apply_lease_token,created_at,updated_at) VALUES (${sqlQuote(agentId)},${sqlQuote(runId)},${sqlQuote(sourceId)},'unchanged','manual',${sqlQuote(stored.hash)},${sqlQuote(stored.url)},'internal-executor-lease-canary',${sqlQuote(at)},${sqlQuote(at)})`,
+      );
+    }
+    const exported = readStoredZip(
+      (await exportFamilyWorkspace(runtime, SELF_ENTITY_ID)).bytes,
+    );
+    expect(exported.get(`school/${stored.hash}.pdf`)).toEqual(bytes);
+    const manifest = exported.get("manifest.json");
+    if (!manifest) throw new Error("Workspace manifest is missing");
+    expect(manifest.toString("utf8")).not.toContain(
+      "internal-executor-lease-canary",
+    );
+    expect(manifest.toString("utf8")).not.toContain(
+      "other-agent-private-school",
+    );
+    const auditCount = async () =>
+      executeRawSql(
+        runtime,
+        `SELECT count(*)::integer AS count FROM app_lifeops.life_audit_events WHERE agent_id=${sqlQuote(runtime.agentId)} AND event_type='family_workspace_export_prepared'`,
+      );
+    const before = await auditCount();
+    try {
+      await storage.delete(stored.url.replace("/api/media/", ""));
+      await expect(
+        exportFamilyWorkspace(runtime, SELF_ENTITY_ID),
+      ).rejects.toMatchObject({ code: "FAMILY_EXPORT_SOURCE_INTEGRITY" });
+      expect(await auditCount()).toEqual(before);
+    } finally {
+      await storage.store(bytes, "application/pdf");
+    }
+  });
+
+  it("preserves packet-bound stored delivery receipts without including unrelated approval payloads", async () => {
+    const packet = await new MonthlyFamilyPacketService(runtime).latest(
+      "2026-11",
+    );
+    if (!packet) throw new Error("Workspace test packet is unavailable");
+    const approvalId = crypto.randomUUID();
+    const unrelatedId = crypto.randomUUID();
+    const body = "Synthetic packet delivery record for export verification.";
+    const bodyHash = crypto.createHash("sha256").update(body).digest("hex");
+    const at = new Date().toISOString();
+    // Historical provider evidence is a database fixture; this test sends no message.
+    const receipt = {
+      provider: "fixture-provider",
+      messageId: "stored-message-receipt",
+      acceptedAt: at,
+    };
+    for (const [id, content] of [
+      [approvalId, body],
+      [unrelatedId, "unrelated-approval-body-canary"],
+    ]) {
+      await executeRawSql(
+        runtime,
+        `INSERT INTO approval_requests (id,agent_id,state,requested_by,subject_user_id,action,payload,channel,reason,expires_at,provider_receipt) VALUES (${sqlQuote(id)},${sqlQuote(runtime.agentId)},'executed','self','self','send_message',${sqlQuote(JSON.stringify({ action: "send_message", recipient: "+15555550101", body: content }))}::jsonb,'imessage','Synthetic historical fixture','2099-01-01T00:00:00Z',${sqlQuote(JSON.stringify(receipt))}::jsonb)`,
+      );
+    }
+    await executeRawSql(
+      runtime,
+      `INSERT INTO app_lifeops.life_family_packet_drafts (agent_id,packet_id,internal_version,draft_version,recipient,body,body_sha256,transformations_json,created_at) VALUES (${sqlQuote(runtime.agentId)},${sqlQuote(packet.packetId)},${packet.version},1,'+15555550101',${sqlQuote(body)},${sqlQuote(bodyHash)},'[]',${sqlQuote(at)})`,
+    );
+    await executeRawSql(
+      runtime,
+      `INSERT INTO app_lifeops.life_family_packet_approvals (agent_id,packet_id,draft_version,draft_sha256,approval_id,created_at) VALUES (${sqlQuote(runtime.agentId)},${sqlQuote(packet.packetId)},1,${sqlQuote(bodyHash)},${sqlQuote(approvalId)},${sqlQuote(at)})`,
+    );
+    const manifestBytes = readStoredZip(
+      (await exportFamilyWorkspace(runtime, SELF_ENTITY_ID)).bytes,
+    ).get("manifest.json");
+    if (!manifestBytes) throw new Error("Workspace manifest is unavailable");
+    const manifest = JSON.parse(manifestBytes.toString("utf8"));
+    expect(manifest.records.approvals).toEqual([
+      expect.objectContaining({
+        id: approvalId,
+        state: "executed",
+        provider_receipt: receipt,
+      }),
+    ]);
+    expect(manifest.records.drafts).toEqual([
+      expect.objectContaining({
+        packet_id: packet.packetId,
+        body,
+        body_sha256: bodyHash,
+      }),
+    ]);
+    expect(manifestBytes.toString("utf8")).not.toContain(
+      "unrelated-approval-body-canary",
+    );
+  });
+
   it("exports verified originals and complete persisted provenance without granting guest export access", async () => {
     const service = createAgreementKnowledgeService(runtime);
     const original = await service.readOwnerPdf({
@@ -1001,6 +1200,21 @@ describe("parenting-agreement knowledge — real PGlite", () => {
       identityId,
       scopes: [],
     });
+    const ownerIdentityId = crypto.randomUUID();
+    await auth.createIdentity({
+      id: ownerIdentityId,
+      kind: "owner",
+      displayName: "synthetic export owner",
+      createdAt: Date.now(),
+      passwordHash: null,
+      cloudUserId: null,
+    });
+    const { session: ownerSession } = await createBrowserSession(auth, {
+      identityId: ownerIdentityId,
+      ip: null,
+      userAgent: null,
+      rememberDevice: false,
+    });
     const service = createAgreementKnowledgeService(runtime);
     const server = createServer(async (req, res) => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -1032,6 +1246,33 @@ describe("parenting-agreement knowledge — real PGlite", () => {
       "x-eliza-entity-id": "self",
     };
     try {
+      const workspaceUrl = `http://127.0.0.1:${address.port}/api/lifeops/family-workflows/export`;
+      expect(
+        (await fetch(workspaceUrl, { method: "POST", headers })).status,
+      ).toBe(403);
+      const workspace = await fetch(workspaceUrl, {
+        method: "POST",
+        headers: { ...headers, Authorization: `Bearer ${ownerSession.id}` },
+      });
+      expect(workspace.status, await workspace.clone().text()).toBe(200);
+      expect(workspace.headers.get("content-type")).toBe("application/zip");
+      expect(workspace.headers.get("cache-control")).toContain("no-store");
+      const workspaceFiles = readStoredZip(
+        Buffer.from(await workspace.arrayBuffer()),
+      );
+      const workspaceManifest = workspaceFiles.get("manifest.json");
+      if (!workspaceManifest)
+        throw new Error("HTTP workspace archive is incomplete");
+      expect(
+        JSON.parse(workspaceManifest.toString("utf8")).sourceArchives,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            artifactId: artifact.id,
+            contentSha256: artifact.contentSha256,
+          }),
+        ]),
+      );
       const unbound = await fetch(`${base}/shared?principalEntityId=self`, {
         headers,
       });
@@ -1088,6 +1329,7 @@ describe("parenting-agreement knowledge — real PGlite", () => {
         server.close((error) => (error ? reject(error) : resolve())),
       );
       await auth.revokeSession(session.id);
+      await auth.revokeSession(ownerSession.id);
     }
   });
 

--- a/plugins/plugin-personal-assistant/src/routes/family-workflows.ts
+++ b/plugins/plugin-personal-assistant/src/routes/family-workflows.ts
@@ -3,11 +3,13 @@
  * family packet generation, review, drafting, and canonical approval enqueue.
  */
 
+import { SELF_ENTITY_ID } from "@elizaos/shared";
 import type {
   FamilyPacketEmailDelivery,
   FamilyPacketPeriod,
 } from "../lifeops/family-coordination/index.js";
 import { getFamilyWorkflowRuntimeService } from "../lifeops/family-workflows/index.js";
+import { exportFamilyWorkspace } from "../lifeops/family-workflows/workspace-export.js";
 import { CONCORD_SCHOOL_CALENDAR_SOURCE } from "../lifeops/school/calendar-workflow.js";
 import type { LifeOpsRouteContext } from "./lifeops-routes.js";
 
@@ -33,6 +35,24 @@ export async function handleFamilyWorkflowRoutes(
   const runtimeService = service(ctx);
   if (!runtimeService) return true;
   try {
+    if (
+      method === "POST" &&
+      pathname === "/api/lifeops/family-workflows/export"
+    ) {
+      const runtime = ctx.state.runtime;
+      if (!runtime) throw new Error("Agent runtime is unavailable");
+      const file = await exportFamilyWorkspace(runtime, SELF_ENTITY_ID);
+      res.statusCode = 200;
+      res.setHeader("Content-Type", file.mimeType);
+      res.setHeader("Cache-Control", "no-store");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename*=UTF-8''${encodeURIComponent(file.fileName)}`,
+      );
+      res.setHeader("Content-Length", String(file.bytes.length));
+      res.end(file.bytes);
+      return true;
+    }
     if (
       method === "GET" &&
       pathname === "/api/lifeops/family-workflows/email-options"

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -465,6 +465,7 @@ const LIFEOPS_STATIC_ROUTES: RouteSpec[] = [
   { type: "POST", path: "/api/lifeops/family-workflows/school/run" },
   { type: "POST", path: "/api/lifeops/family-workflows/school/apply" },
   { type: "POST", path: "/api/lifeops/family-workflows/run-now" },
+  { type: "POST", path: "/api/lifeops/family-workflows/export" },
   { type: "GET", path: "/api/lifeops/family-workflows/email-options" },
   { type: "GET", path: "/api/lifeops/family-workflows/packets" },
   { type: "POST", path: "/api/lifeops/family-workflows/packets" },

--- a/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
+++ b/plugins/plugin-personal-assistant/test/browser-e2e/family-packet-fixture.ts
@@ -110,6 +110,7 @@ export function createFamilyPacketFixture(
     },
     uploadAgreement: unsupported,
     downloadAgreement: unsupported,
+    downloadWorkspace: unsupported,
     decideObligation: unsupported,
     async listPins() {
       return [];


### PR DESCRIPTION
Owners can download a family workspace ZIP from Family Operations. It contains versioned agreement archives, packet-bound drafts and approval receipts, available school records, and retained school source bytes, with manifests and checksums. Authorization and source-integrity failures return errors; unrelated approval records and executor lease data are excluded.

Related to #31180. This PR implements export only. Dependency preview, deletion/purge, and live pilot acceptance remain open and are not claimed complete.

Validation on `b6d1f16897217726ccc73fe88b89d8e122e1bd9d`, based on `1fa9dbf22d741d5c0c0940b8cbd4eafc1403ad73`:

- Root `bun run verify`: 373 tasks passed; full personal-assistant tests: 2,660 passed, 6 skipped.
- Real storage/HTTP integration: 16 passed; adapter/component tests: 25 passed. The HTTP regression exercises real owner and guest AuthStore sessions.
- Desktop/mobile browser runs use the actual view, production adapter, route and PGlite/storage service. Actual downloaded ZIPs passed independent outer/nested checksums and source-byte verification. Loading, success, and denied states were inspected.
- Required app audit: 226 capture tests passed. OCR: 220 views, 208 verified, no broken views; family mobile views requiring inspection were manually reviewed.

Evidence limitations: browser recordings use the local operator-trust boundary and synthetic data, including deterministic PDF extraction and historical stored provider receipt fixtures. No external message or calendar mutation occurred. Before screenshots reconstruct the committed baseline view through the same renderer configuration. Videos include 1.5 seconds of transport delay to expose loading. The archive is explicit about component snapshot boundaries; it does not claim a transaction spanning every component. Public pilot acceptance is pending.

<!-- evidence-head:b6d1f16897217726ccc73fe88b89d8e122e1bd9d -->

<!-- evidence-row:before-screenshots -->
- [x] ![desktop before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-desktop-before.png) ![mobile before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-mobile-before.png)

<!-- evidence-row:after-screenshots -->
- [x] ![desktop after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-desktop-rest.png) ![mobile after](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-mobile-rest.png)

<!-- evidence-row:walkthrough-video -->
- [x] [desktop walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-desktop-walkthrough.mp4) [mobile walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-mobile-walkthrough.mp4)

<!-- evidence-row:backend-logs -->
- [x] [b6d1f16-browser-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-browser-backend.log)

<!-- evidence-row:frontend-logs -->
- [x] [b6d1f16-frontend-console.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-frontend-console.json) [b6d1f16-frontend-network.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-frontend-network.json) Expected HTTP 401 diagnostics occur only in the denied test; no browser page exceptions.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - export does not change model, prompt, provider, or action behavior.

<!-- evidence-row:domain-artifacts -->
- [x] [Complete reviewed artifacts and actual downloads](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-bettina-workspace-export-b6d1f16-evidence.zip) [Independent ZIP verification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-domain-verification.json)

<!-- evidence-row:ocr-review -->
- [x] [OCR and manual family-view review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-b6d1f16-ocr-review.json)

Native/device evidence: N/A - this change adds a browser export; no native implementation changes.
