### PR TITLE
test(scripts): build the receipt proof fixture with the continuity contract (#31196)

### DIFF
--- a/packages/scripts/__tests__/staging-cloud-receipt.test.ts
+++ b/packages/scripts/__tests__/staging-cloud-receipt.test.ts
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createCloudLiveContinuityEvidence } from "../../app/test/cloud-live-continuity-contract";
+import {
+  createCloudLiveContinuityEvidence,
+  parseCloudLiveContinuityEvidence,
+} from "../../app/test/cloud-live-continuity-contract";
 import {
   createDeployedRendererProof,
   DEPLOYED_BROWSER_SMOKE_SCHEMA,
@@ -164,6 +167,20 @@ function deployedProofFile(
 }
 
 describe("staging Cloud live receipt", () => {
+  test("builds the deployed proof from the closed continuity contract", () => {
+    const evidence = continuity();
+    // The contract injects the schema version and lane; the proof builder
+    // rejects anything but this exact closed record.
+    expect(evidence).toMatchObject({
+      schemaVersion: 2,
+      lane: "app-live-e2e-cloud-staging",
+      forbiddenAgentMutationCount: 0,
+      cleanupDisposition: "no-test-owned-agent",
+      conversationHistoryDisposition: "preserved",
+    });
+    expect(parseCloudLiveContinuityEvidence(evidence)).toEqual(evidence);
+  });
+
   test("binds successful evidence to the exact SHA, run, duration, and fixed annotations", () => {
     expect(createStagingCloudReceipt(args())).toEqual({
       schemaVersion: 2,

--- a/packages/scripts/__tests__/staging-cloud-receipt.test.ts
+++ b/packages/scripts/__tests__/staging-cloud-receipt.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createCloudLiveContinuityEvidence } from "../../app/test/cloud-live-continuity-contract";
 import {
   createDeployedRendererProof,
   DEPLOYED_BROWSER_SMOKE_SCHEMA,
@@ -39,6 +40,44 @@ function args(overrides: Record<string, string> = {}): string[] {
     `--${name}`,
     value,
   ]);
+}
+
+function continuity() {
+  return createCloudLiveContinuityEvidence({
+    challengeTurnCount: 1,
+    noAdditionalChatSendAfterChallenge: true,
+    personalIdentityEndpointPassed: true,
+    reload: {
+      historyGetSucceeded: true,
+      challengeUserLinePresent: true,
+      challengeAssistantLinePresent: true,
+    },
+    freshContext: {
+      historyGetSucceeded: true,
+      challengeUserLinePresent: true,
+      challengeAssistantLinePresent: true,
+      createdWithoutStorageState: true,
+      serviceWorkersBlocked: true,
+    },
+    bindingReuse: {
+      personalIdentityReused: true,
+      runtimeBindingReused: true,
+      apiBaseReused: true,
+    },
+    dedicatedMutationProof: {
+      approvalGrantedCount: 1,
+      confirmationClickCount: 0,
+      confirmationKind: "none",
+      adoptionConfirmationPostCount: 0,
+      activationPostCount: 0,
+      cutoverPostCount: 0,
+      forbiddenAgentMutationCount: 0,
+      approvalBindingPresent: false,
+      lifecycleBindingMismatchCount: 0,
+    },
+    cleanupDisposition: "no-test-owned-agent",
+    conversationHistoryDisposition: "preserved",
+  });
 }
 
 function deployedProofFile(
@@ -108,21 +147,7 @@ function deployedProofFile(
         "composer-send-click-to-settled-valid-assistant-turn: starts immediately before the UI send click; ends after the same fresh non-empty assistant row settles and passes the liveness contract; not first-token latency",
       firstTurnLatencyMs: overrides.latency ?? 12345,
     },
-    continuity: {
-      schemaVersion: 1,
-      lane: "app-live-e2e-cloud-staging",
-      challengeTurnCount: 1,
-      noAdditionalChatSendAfterChallenge: true,
-      personalIdentityEndpointPassed: true,
-      reloadHistoryPassed: true,
-      freshContextHistoryPassed: true,
-      personalIdentityReused: true,
-      runtimeBindingReused: true,
-      apiBaseReused: true,
-      forbiddenAgentMutationCount: 0,
-      cleanupDisposition: "no-test-owned-agent",
-      conversationHistoryDisposition: "preserved",
-    },
+    continuity: continuity(),
     postflight: {
       schema: PAGES_PUBLIC_CHECK_SCHEMA,
       phase: "postflight",

--- a/packages/scripts/__tests__/staging-cloud-receipt.test.ts
+++ b/packages/scripts/__tests__/staging-cloud-receipt.test.ts
@@ -5,10 +5,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  createCloudLiveContinuityEvidence,
-  parseCloudLiveContinuityEvidence,
-} from "../../app/test/cloud-live-continuity-contract";
+import { createCloudLiveContinuityEvidence } from "../../app/test/cloud-live-continuity-contract";
 import {
   createDeployedRendererProof,
   DEPLOYED_BROWSER_SMOKE_SCHEMA,
@@ -167,20 +164,6 @@ function deployedProofFile(
 }
 
 describe("staging Cloud live receipt", () => {
-  test("builds the deployed proof from the closed continuity contract", () => {
-    const evidence = continuity();
-    // The contract injects the schema version and lane; the proof builder
-    // rejects anything but this exact closed record.
-    expect(evidence).toMatchObject({
-      schemaVersion: 2,
-      lane: "app-live-e2e-cloud-staging",
-      forbiddenAgentMutationCount: 0,
-      cleanupDisposition: "no-test-owned-agent",
-      conversationHistoryDisposition: "preserved",
-    });
-    expect(parseCloudLiveContinuityEvidence(evidence)).toEqual(evidence);
-  });
-
   test("binds successful evidence to the exact SHA, run, duration, and fixed annotations", () => {
     expect(createStagingCloudReceipt(args())).toEqual({
       schemaVersion: 2,


### PR DESCRIPTION
Closes #31196

## What

Build the deployed-renderer proof fixture in `packages/scripts/__tests__/staging-cloud-receipt.test.ts` with `createCloudLiveContinuityEvidence` from the cloud-live continuity contract instead of a hand-copied `schemaVersion: 1` literal.

## Why

Since `7e9e3f946a0e`, `createDeployedRendererProof` validates its `continuity` input through `parseCloudLiveContinuityEvidence`, which requires the closed `schemaVersion: 2` record with the Dedicated mutation keys. The receipt test still passed the retired shape, so `deployedProofFile()` threw `artifact must use the exact closed schema` before either receipt assertion ran, and `tests / Script Tests (Linux)` on develop has been red since 2026-09-11 (latest: [run 34723784763](https://github.com/elizaOS/eliza/actions/runs/34723784763/job/103635168326)). The sibling `pages-deployment-authority.test.ts` already builds the record the same way.

Test-only change; no runtime code touched.

## Evidence

Before (develop `1fa9dbf22d74`, `bun test __tests__/staging-cloud-receipt.test.ts` in `packages/scripts`):

```
error: [cloud-live-continuity] artifact must use the exact closed schema
      at createDeployedRendererProof (packages/cloud/scripts/pages-deployment-authority.mjs:836:22)
      at deployedProofFile (packages/scripts/__tests__/staging-cloud-receipt.test.ts:72:17)
(fail) staging Cloud live receipt > persists closed correlation in receipt v4 from a validated proof file
(fail) staging Cloud live receipt > rejects boolean claims and proof/source/latency mismatches
 6 pass
 2 fail
```

After:

```
 8 pass
 0 fail
Ran 8 tests across 1 file. [42.00ms]
```

The mismatch cases still reach their intended rejections ("does not match the receipt source/run identity", "latency does not match"), since the fixture now parses and the receipt writer's own checks run.

`bunx biome check` on the file: clean. Root `bun run verify` is running on a stack holding this and #31199; result will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpg1SzympM3Yf5LQvzktqk

