### PR TITLE
test(ui): give the home-screen fixture client the authority subscription (#31198)

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
@@ -26,6 +26,12 @@ export const client = {
   // (installed in the fixture) intercepts.
   getBaseUrl: () => "",
   getRestAuthToken: () => null,
+  // The LifeOps activity-signal capture (started by the shell's renderer
+  // service after first paint) subscribes to base-URL authority changes and
+  // compares revisions before re-probing. The fixture never rebinds its host,
+  // so the revision is constant and the subscription is inert.
+  getAuthorityRevision: () => 0,
+  onAuthorityChange: (_listener: () => void) => () => {},
   // Typed widget requests still pass through the fixture's window.fetch mock;
   // mirror the production client's JSON boundary so constructor-based imports
   // and the shared singleton observe the same seeded responses.


### PR DESCRIPTION
Closes #31198

## What

Give the home-screen e2e fixture's stub `client` the two authority members the shared `ElizaClient` grew in #30989: an inert `onAuthorityChange` subscription and a constant `getAuthorityRevision`.

## Why

The LifeOps activity-signal capture that the shell's renderer service starts after first paint now subscribes to base-URL authority changes through `client.onAuthorityChange` and compares `client.getAuthorityRevision()`. The home-screen bundle swaps the client for `home-screen-fixture.api-stub.ts`, which never had those members, so the capture threw `client.onAuthorityChange is not a function` as a page error before the home screen mounted. `chat-shell`, `ui-core` and the PR-level `ui-e2e-gate` lanes have been red on every develop run since 2026-09-11 (latest: [run 34723784763](https://github.com/elizaOS/eliza/actions/runs/34723784763/job/103634726748)).

The fixture never rebinds its host, so the revision is constant and the subscription is inert; the real widgets still render against the seeded data. Test-fixture-only change.

## Evidence

Before (develop `1fa9dbf22d74`, `bun run --cwd packages/ui test:home-screen-e2e`):

```
  ⚠ pageerror: TypeError: client.onAuthorityChange is not a function
TimeoutError: waitForSelector: Timeout 30000ms exceeded.
  - waiting for locator('[data-testid="home-screen"]') to be visible
      at assertQuietHome (.../run-home-screen-e2e.mjs:565:14)
error: script "test:home-screen-e2e" exited with code 1
```

After (same command, twice):

```
✓ … (119 assertions, mobile quiet home / swipe hint / launcher pager / short-home shade / desktop home)
  📸 01-mobile-home-quiet.png … 10-desktop-home.png
exit 0
```

No page errors in either run. Root `bun run verify` is running on a stack holding this and the receipt-fixture PR; result will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpg1SzympM3Yf5LQvzktqk
