### PR TITLE
fix(cloud): stage account management recovery repairs

### DIFF
--- a/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
+++ b/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
@@ -560,6 +560,20 @@ test("lost provider response and duplicate webhook settle exactly once", async (
     await expect(
       invoiceRow.getByRole("button", { name: "View", exact: true }),
     ).toBeVisible();
+
+    // Billing belongs to the authenticated account even when the selected
+    // agent cannot start. Fault the real app's agent-status request across a
+    // reload while keeping the Cloud session and billing API available.
+    backendFaults.setFault({
+      path: "/api/status",
+      status: 503,
+      body: { error: "Agent temporarily unavailable" },
+    });
+    await authenticatedPage.reload();
+    await expect.poll(() => backendFaults.faultHits).toBeGreaterThan(0);
+    await expect(renderedBalance).toBeVisible();
+    await expect(invoiceRow).toHaveCount(1);
+    await expect(invoiceRow.getByText("Paid", { exact: true })).toBeVisible();
   } finally {
     backendFaults.clearFault();
     backendFaults.clearPathRewrites();

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -1505,6 +1505,64 @@ describe("App navigate-view event wiring", () => {
     },
   );
 
+  it.each([
+    "restoring-session",
+    "polling-backend",
+    "pairing-required",
+    "error",
+    "starting-runtime",
+    "ready",
+  ])(
+    "keeps authenticated account management available during agent %s",
+    async (phase) => {
+      registerAppShellPage({
+        id: "cloud",
+        pluginId: "@elizaos/ui",
+        label: "Cloud",
+        path: "/cloud",
+        pathPatterns: ["/cloud/*"],
+        surface: { capabilities: ["navigate"] },
+        Component: () => <div data-testid="managed-cloud-page" />,
+      });
+      cloudSessionState.authenticated = true;
+      authStatusMock.phase = "unauthenticated";
+      appState.startupPhase = phase;
+      appState.backendConnectionState = "disconnected";
+      appState.tab = "cloud";
+      window.history.replaceState(null, "", "/cloud/agents");
+
+      render(<App />);
+
+      await screen.findByTestId("managed-cloud-page");
+      expect(appState.retryStartup).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { authenticated: false, owner: "@elizaos/ui" },
+    { authenticated: true, owner: "@elizaos/plugin-elizacloud" },
+  ])(
+    "keeps agent startup gates for $owner with Cloud auth=$authenticated",
+    ({ authenticated, owner }) => {
+      registerAppShellPage({
+        id: "cloud",
+        pluginId: owner,
+        label: "Cloud",
+        path: "/cloud",
+        pathPatterns: ["/cloud/*"],
+        Component: () => <div data-testid="managed-cloud-page" />,
+      });
+      cloudSessionState.authenticated = authenticated;
+      appState.startupPhase = "polling-backend";
+      appState.tab = "cloud";
+      window.history.replaceState(null, "", "/cloud/agents");
+
+      render(<App />);
+
+      expect(screen.queryByTestId("managed-cloud-page")).toBeNull();
+    },
+  );
+
   it("gives an in-process wallet page a live agent-surface registry", async () => {
     registerAppShellPage({
       id: "wallet.inventory",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3063,6 +3063,17 @@ function AppContent() {
     ? resolvedDynamicPage
     : null;
   const { authenticated: cloudAuthenticated } = useSessionAuth();
+  // Account management is authorized by the Cloud session, independently of
+  // the selected agent. Keep its wake/recovery controls reachable while that
+  // agent is asleep, disconnected, or awaiting pairing.
+  const authenticatedAccountPage = authenticatedCloudDashboardOwnsRoute(
+    findVisibleAppShellPageForRoute(
+      navigationPath,
+      enabledKinds,
+      managedCloudRuntime,
+    ),
+    cloudAuthenticated,
+  );
   const screenBackgroundPolicy = useActiveScreenBackgroundPolicy({
     tab,
     navigationPath,
@@ -3597,7 +3608,10 @@ function AppContent() {
     );
   }
 
-  if (!isShellPaintableNow || bootstrapGateHolds) {
+  if (
+    !authenticatedAccountPage &&
+    (!isShellPaintableNow || bootstrapGateHolds)
+  ) {
     return (
       <BugReportProvider value={bugReport}>
         <StartupScreen />
@@ -3614,6 +3628,7 @@ function AppContent() {
   // primes the probe (primeAuthStatusProbe) so it overlaps backend polling /
   // hydration instead of serializing an extra round-trip after first paint.
   if (
+    !authenticatedAccountPage &&
     isShellPaintableNow &&
     !isPopout &&
     topLevelAuthGateOwnsSurface(

--- a/packages/ui/src/cloud/register-managed-cloud-page.test.ts
+++ b/packages/ui/src/cloud/register-managed-cloud-page.test.ts
@@ -2,12 +2,39 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { listAppShellPages } from "../app-shell-registry";
+import { tabFromPath } from "../navigation";
 import { resetUiRegistryHostForTests } from "../registry-host";
 
 describe("managed Cloud app-shell registration", () => {
   beforeEach(() => {
     resetUiRegistryHostForTests();
     vi.resetModules();
+  });
+
+  it.each(["host-first", "plugin-first"])(
+    "preserves account deep links when registrations load %s",
+    async (order) => {
+      const { registerManagedCloudAppShellPage } = await import(
+        "./register-managed-cloud-page"
+      );
+      if (order === "host-first") registerManagedCloudAppShellPage();
+      await import("../../../../plugins/plugin-elizacloud/src/register");
+      if (order === "plugin-first") registerManagedCloudAppShellPage();
+
+      const cloud = listAppShellPages().filter((entry) => entry.id === "cloud");
+      expect(cloud).toHaveLength(1);
+      expect(cloud[0]?.pluginId).toBe("@elizaos/ui");
+      expect(tabFromPath("/cloud/billing")).toBe("cloud");
+      expect(tabFromPath("/cloud/agents")).toBe("cloud");
+    },
+  );
+
+  it("retains the signed plugin page in hosts without managed account routes", async () => {
+    await import("../../../../plugins/plugin-elizacloud/src/register");
+    const cloud = listAppShellPages().find((entry) => entry.id === "cloud");
+    expect(cloud?.pluginId).toBe("@elizaos/plugin-elizacloud");
+    expect(cloud?.loader).toBeTypeOf("function");
+    expect(tabFromPath("/cloud")).toBe("cloud");
   });
 
   it("grants nested route navigation without widening storage or wallpaper authority", async () => {

--- a/plugins/plugin-elizacloud/src/register.ts
+++ b/plugins/plugin-elizacloud/src/register.ts
@@ -4,22 +4,31 @@
  * contributes the renderer surface for hosts that cannot load remote bundles.
  */
 
-import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
+import {
+  listAppShellPages,
+  registerAppShellPage,
+} from "@elizaos/ui/app-shell-registry";
 
-registerAppShellPage({
-  id: "cloud",
-  pluginId: "@elizaos/plugin-elizacloud",
-  label: "Cloud",
-  icon: "Cloud",
-  path: "/cloud",
-  order: 940,
-  viewKind: "release",
-  surface: {
-    header: "fullscreen",
-    capabilities: ["agent-surface"],
-  },
-  loader: () =>
-    import("./components/cloud/CloudPage.tsx").then((module) => ({
-      default: module.CloudPage,
-    })),
-});
+// The web host owns the authenticated /cloud/* account route family. Its
+// registration can finish before this deferred plugin module loads; replacing
+// it would drop nested routes and send billing/agent links to the launcher.
+// Hosts without that account shell still receive the signed plugin page.
+if (!listAppShellPages().some((page) => page.id === "cloud")) {
+  registerAppShellPage({
+    id: "cloud",
+    pluginId: "@elizaos/plugin-elizacloud",
+    label: "Cloud",
+    icon: "Cloud",
+    path: "/cloud",
+    order: 940,
+    viewKind: "release",
+    surface: {
+      header: "fullscreen",
+      capabilities: ["agent-surface"],
+    },
+    loader: () =>
+      import("./components/cloud/CloudPage.tsx").then((module) => ({
+        default: module.CloudPage,
+      })),
+  });
+}


### PR DESCRIPTION
Account-management links could display Launcher when a late Cloud plugin registration replaced the host route family. They could also remain on Booting when the selected Dedicated agent was asleep or unavailable, hiding the controls needed to recover it.

The plugin now preserves an existing host Cloud registration. The app allows the authenticated, UI-owned account page to render independently of agent startup/password state. Signed-out sessions and plugin-owned agent surfaces retain their startup/auth gates; server authorization and all model, billing and memory policies are unchanged.

Closes #31200. Closes #31203.

Validation: actual-module registration regression failed before repair; both load orders and the standalone fallback pass. Four unavailable-agent component cases failed before repair. After repair: 42 routing/registration tests, 62 navigation/auth cases (including six startup phases and two negative cases), and 15 first-run overlay tests pass. Plugin lint/typecheck and root `bun run verify` pass (373 tasks). The real local billing replay browser test passes, including a reload with agent status503 while Billing still displays the correct balance and single paid invoice. Its screenshot was inspected. Deployed account-page acceptance remains pending.

The earlier route-only billing CI passed on staging; final combined-head CI is running. This is the two-cause account-access repair, kept separate from the already-merged inference read-lock change.
