### PR TITLE
perf(cloud): use measured placement to reduce inference gateway delay

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -506,12 +506,12 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 name = "eliza-cloud-api-staging"
 workers_dev = false
 
-# Keep this edge/API Worker in Cloudflare's default caller-local placement.
-# Inference performs authentication and serial Durable Object admission before
-# provider dispatch; moving the whole fetch handler near an inferred HTTP
-# origin adds a cross-region round trip to every stateful phase. If a backend
-# needs placement, split it behind an unplaced edge Worker and certify that
-# boundary independently before changing this contract.
+# Use the explicitly measured region, rather than infer placement from the
+# provider HTTP endpoint. The September 13 control/target/restore probes kept
+# auth, primary policy reads, and Durable Object admission intact: production
+# warm pre-dispatch time fell from 3.6-3.8s to 0.83s. Staging improved similarly.
+# Revalidate live inference and agent-proxy flows when upstream locations change.
+placement = { mode = "targeted", region = "gcp:us-west2" }
 routes = [
   # Canonical browser hosts belong to the eliza-app Pages project. Pages
   # Functions proxy /api and auth protocol paths to this Worker.
@@ -824,12 +824,12 @@ simple = { limit = 120, period = 60 }
 [env.production]
 name = "eliza-cloud-api-prod"
 
-# Keep this edge/API Worker in Cloudflare's default caller-local placement.
-# Inference performs authentication and serial Durable Object admission before
-# provider dispatch; moving the whole fetch handler near an inferred HTTP
-# origin adds a cross-region round trip to every stateful phase. If a backend
-# needs placement, split it behind an unplaced edge Worker and certify that
-# boundary independently before changing this contract.
+# Use the explicitly measured region, rather than infer placement from the
+# provider HTTP endpoint. The September 13 control/target/restore probes kept
+# auth, primary policy reads, and Durable Object admission intact: production
+# warm pre-dispatch time fell from 3.6-3.8s to 0.83s. Staging improved similarly.
+# Revalidate live inference and agent-proxy flows when upstream locations change.
+placement = { mode = "targeted", region = "gcp:us-west2" }
 workers_dev = false
 # Canonical routes serve the API and UUID agents. The cloud.eliza.app browser
 # host belongs to Pages; legacy routes remain redirect ingress during the


### PR DESCRIPTION
Dedicated replies paid roughly four seconds of gateway overhead per model request because admission requires repeated primary-database round trips. Keep those checks intact and configure staging/production fetch handlers in the explicitly measured `gcp:us-west2` region. Only the two placement settings change.

Closes #31204.

Controlled production default/target/restored-default probes used the same prompt, model, account, node and code: warm pre-dispatch 3645–3809ms → 827–846ms → 3339–4347ms. All 12 requests returned HTTP200 and the exact expected reply. A separate staging comparison showed the same improvement. Both temporary experiments restored the original placement and verified all other settings. Cold startup and provider latency still vary; these gateway probes do not establish full-chat latency.

Validation: installed Wrangler schema accepts the explicit region; both environment type generations and staging/production bundle dry runs pass. Parsed TOML comparison proves all other configuration is identical. Repository root verification passed (exit 0), including the workspace build/type/lint checks and root audits. Hosted PR checks continue; PostgreSQL is already green. Staged routing and real Dedicated account/proxy/chat acceptance are required before production promotion.

This supersedes the old caller-local placement comment using measurements that include unchanged authentication, primary policy checks and Durable Object admission. The whole API fetch handler is placed, so agent-proxy routing remains an explicit release check. No new Worker, server, database, or capacity is added. Rollback: remove the two placement declarations through the same release pipeline.
