### PR TITLE
fix(ui): complete loopback Cloud account sign-in and requests

### DIFF
--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -160,6 +160,27 @@ describe("cloud api-client transport bridge", () => {
       }
       expect(capacitorMocks.request).not.toHaveBeenCalled();
     });
+    it("preserves the same-origin cookie authority before a CLI key is claimed", async () => {
+      await writeStoredStewardToken(STEWARD_TOKEN);
+      const request = vi.spyOn(globalThis, "fetch").mockImplementation(
+        async () =>
+          new Response("{}", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      );
+      await api("/api/v1/user");
+      expect(request).toHaveBeenCalledWith(
+        "/api/v1/user",
+        expect.objectContaining({
+          credentials: "include",
+        }),
+      );
+      await expectCrossOriginThrow(
+        api("https://api-staging.eliza.app/api/v1/user"),
+      );
+      expect(request).toHaveBeenCalledTimes(1);
+    });
     it.each([
       "https://api.eliza.app/api/v1/user",
       "https://evil.example/api/v1/user",

--- a/packages/ui/src/cloud/lib/api-client.test.ts
+++ b/packages/ui/src/cloud/lib/api-client.test.ts
@@ -39,6 +39,7 @@ import {
   STEWARD_TOKEN_KEY,
   STEWARD_TOKEN_SCOPE_KEY,
   type StewardSessionChangeDetail,
+  writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import { setBootConfig } from "../../config/boot-config";
 import { ApiError, api, apiWithStatus } from "./api-client";
@@ -111,6 +112,64 @@ describe("cloud api-client transport bridge", () => {
   });
 
   // --- WEB: must stay same-origin-only (the load-bearing assertion) ----------
+
+  describe("explicit localhost staging account transport", () => {
+    const originalLocation = window.location;
+    beforeEach(async () => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: {
+          protocol: "http:",
+          hostname: "127.0.0.1",
+          origin: "http://127.0.0.1:21486",
+          href: "http://127.0.0.1:21486/cloud/billing",
+        },
+      });
+      vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+      vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+      configureStoredStewardTokenScope("https://api-staging.eliza.app");
+      await writeStoredStewardToken("eliza_loopback_account_test_key");
+    });
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+      vi.unstubAllEnvs();
+    });
+    it("routes account reads and writes to staging using only the scoped Cloud bearer", async () => {
+      const request = vi.spyOn(globalThis, "fetch").mockImplementation(
+        async () =>
+          new Response("{}", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      );
+      await api("/api/v1/credits/balance");
+      await api("/api/v1/containers/test/resume", { method: "POST", json: {} });
+      expect(request.mock.calls.map(([url]) => url)).toEqual([
+        "https://api-staging.eliza.app/api/v1/credits/balance",
+        "https://api-staging.eliza.app/api/v1/containers/test/resume",
+      ]);
+      for (const [, init] of request.mock.calls) {
+        expect(init?.credentials).toBe("omit");
+        expect(new Headers(init?.headers).get("Authorization")).toBe(
+          "Bearer eliza_loopback_account_test_key",
+        );
+        expect(new Headers(init?.headers).has("x-eliza-csrf")).toBe(false);
+      }
+      expect(capacitorMocks.request).not.toHaveBeenCalled();
+    });
+    it.each([
+      "https://api.eliza.app/api/v1/user",
+      "https://evil.example/api/v1/user",
+      "https://api-staging.eliza.app:444/api/v1/user",
+    ])("rejects credential forwarding to %s", async (url) => {
+      const request = vi.spyOn(globalThis, "fetch");
+      await expectCrossOriginThrow(api(url));
+      expect(request).not.toHaveBeenCalled();
+    });
+  });
 
   describe("web runtime", () => {
     it("STILL throws CROSS_ORIGIN_API_URL on a cross-origin Cloud API URL", async () => {

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -42,6 +42,7 @@ import {
 } from "../../api/direct-cloud-endpoints";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { getBootConfig } from "../../config/boot-config";
+import { isLoopbackStagingStewardDevelopment } from "../../state/loopback-steward-development";
 import { normalizeCloudApiKeyToken } from "./cloud-api-key-token";
 import { decodeJwtPayload } from "./jwt";
 
@@ -98,6 +99,10 @@ export class ApiError extends Error {
 }
 
 function getApiBaseUrl(): string {
+  // The local agent does not own account APIs. The launcher fixes this
+  // loopback lane to staging; never infer its authority from a selected agent.
+  if (isLoopbackStagingStewardDevelopment())
+    return STAGING_DIRECT_CLOUD_API_BASE_URL;
   // Native/Electrobun: the dashboard's WebView origin (`https://localhost`,
   // `file:`, …) fronts the embedded LOCAL agent, not Eliza Cloud, so a
   // same-origin `/api/*` call would hit the wrong backend. Resolve to the single
@@ -126,6 +131,12 @@ function resolveApiUrl(path: string): string {
       // absolute URL still throws, on native exactly as on web, so this never
       // opens a general cross-origin bridge.
       if (isNativeCloudRuntime() && isAllowlistedCloudApiHost(parsed)) {
+        return path;
+      }
+      if (
+        isLoopbackStagingStewardDevelopment() &&
+        parsed.origin === STAGING_DIRECT_CLOUD_API_BASE_URL
+      ) {
         return path;
       }
       if (parsed.origin !== window.location.origin) {
@@ -444,6 +455,7 @@ export async function apiFetch(
   init: ApiRequestInit = {},
 ): Promise<Response> {
   const { json, body, skipAuth, headers: rawHeaders, ...rest } = init;
+  const loopbackCloud = isLoopbackStagingStewardDevelopment();
 
   const headers = new Headers(rawHeaders);
   if (json !== undefined) {
@@ -461,6 +473,7 @@ export async function apiFetch(
   const method = (rest.method ?? "GET").toUpperCase();
   if (
     !isNativeCloudRuntime() &&
+    !loopbackCloud &&
     STATE_CHANGING_METHODS.has(method) &&
     !headers.has(CSRF_HEADER_NAME)
   ) {
@@ -501,7 +514,7 @@ export async function apiFetch(
   } else {
     res = await fetch(url, {
       ...rest,
-      credentials: "include",
+      credentials: loopbackCloud ? "omit" : "include",
       headers,
       body: requestBody,
     });

--- a/packages/ui/src/cloud/lib/api-client.ts
+++ b/packages/ui/src/cloud/lib/api-client.ts
@@ -98,10 +98,19 @@ export class ApiError extends Error {
   }
 }
 
+function usesLoopbackCliAccountTransport(): boolean {
+  // Offline development also advertises staging sign-in. Its cookie-backed
+  // local Cloud API remains authoritative until a CLI Cloud key is claimed.
+  return (
+    isLoopbackStagingStewardDevelopment() &&
+    normalizeCloudApiKeyToken(readStewardToken()) !== null
+  );
+}
+
 function getApiBaseUrl(): string {
   // The local agent does not own account APIs. The launcher fixes this
   // loopback lane to staging; never infer its authority from a selected agent.
-  if (isLoopbackStagingStewardDevelopment())
+  if (usesLoopbackCliAccountTransport())
     return STAGING_DIRECT_CLOUD_API_BASE_URL;
   // Native/Electrobun: the dashboard's WebView origin (`https://localhost`,
   // `file:`, …) fronts the embedded LOCAL agent, not Eliza Cloud, so a
@@ -134,7 +143,7 @@ function resolveApiUrl(path: string): string {
         return path;
       }
       if (
-        isLoopbackStagingStewardDevelopment() &&
+        usesLoopbackCliAccountTransport() &&
         parsed.origin === STAGING_DIRECT_CLOUD_API_BASE_URL
       ) {
         return path;
@@ -455,7 +464,7 @@ export async function apiFetch(
   init: ApiRequestInit = {},
 ): Promise<Response> {
   const { json, body, skipAuth, headers: rawHeaders, ...rest } = init;
-  const loopbackCloud = isLoopbackStagingStewardDevelopment();
+  const loopbackCloud = usesLoopbackCliAccountTransport();
 
   const headers = new Headers(rawHeaders);
   if (json !== undefined) {

--- a/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.test.tsx
@@ -124,6 +124,19 @@ it("retains an explicit chat return when the existing agent binding is preserved
   expect(returnTo.pathname).toBe("/chat");
 });
 
+it.each(["/cloud/billing", "/cloud/agents?filter=idle#agent"])(
+  "claims a CLI return before entering the authenticated account route %s",
+  async (path) => {
+    await begin(`/login?returnTo=${encodeURIComponent(path)}`);
+    await waitFor(() => expect(mocks.assign).toHaveBeenCalledOnce());
+    const handoff = new URL(mocks.assign.mock.calls[0][0]);
+    const returnTo = new URL(requiredReturnTo(handoff));
+    expect(returnTo.pathname).toBe("/settings");
+    expect(returnTo.searchParams.get("elizaCloudLoginReturnTo")).toBe(path);
+    expect(returnTo.searchParams.get("elizaCloudLoginSession")).toBe(sessionId);
+  },
+);
+
 it("preserves a safe app destination and performs explicit account switching on both origins", async () => {
   await begin("/login?switchAccount=1&returnTo=%2Fsettings%23cloud-overview");
   await waitFor(() => expect(mocks.assign).toHaveBeenCalledOnce());

--- a/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/loopback-cloud-login-section.tsx
@@ -75,6 +75,15 @@ export default function LoopbackCloudLoginSection() {
         returnTo.search = "";
         returnTo.hash = "cloud-overview";
       }
+      // The account route's auth gate runs before the app callback consumer.
+      // Claim the one-time CLI credential on an ordinary app route first.
+      if (/^\/cloud(?:\/|$)/.test(returnTo.pathname)) {
+        const accountPath = returnTo.pathname + returnTo.search + returnTo.hash;
+        returnTo.pathname = "/settings";
+        returnTo.search = "";
+        returnTo.hash = "cloud-overview";
+        returnTo.searchParams.set("elizaCloudLoginReturnTo", accountPath);
+      }
       returnTo.searchParams.set("elizaCloudLogin", "complete");
       returnTo.searchParams.set("elizaCloudLoginSession", session.sessionId);
       destination.searchParams.set("returnTo", returnTo.toString());

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.test.tsx
@@ -9,12 +9,14 @@
  */
 
 import {
+  clearStoredStewardToken,
   STEWARD_SESSION_CHANGE_EVENT,
   STEWARD_TOKEN_KEY,
   type StewardSessionChangeDetail,
+  writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { type ReactNode, useContext } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearPendingOnboardingSession,
@@ -24,7 +26,11 @@ import {
 } from "../join/lib/onboarding-continuation";
 import { consumeStewardServerCookieSynced } from "../lib/steward-session-cookie-sync-marker";
 import { syncStewardSessionCookie } from "../public-pages/lib/steward-session";
-import { clearStaleStewardSession } from "./StewardProviderShared";
+import {
+  clearStaleStewardSession,
+  LocalStewardAuthContext,
+  type LocalStewardAuthValue,
+} from "./StewardProviderShared";
 
 // AuthTokenSync's 401 handling is the load-bearing fix for the re-login loop:
 // a 401 from session-sync or refresh must NOT wipe a still-valid token (a
@@ -167,6 +173,130 @@ afterEach(() => {
 });
 
 describe("AuthTokenSync", () => {
+  function configureLoopback() {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        protocol: "http:",
+        hostname: "127.0.0.1",
+        origin: "http://127.0.0.1:21486",
+        href: "http://127.0.0.1:21486/cloud/billing",
+        pathname: "/cloud/billing",
+      },
+    });
+    vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+    vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+  }
+
+  function mountAccount() {
+    const observed: { current: LocalStewardAuthValue | null } = {
+      current: null,
+    };
+    function AccountProbe() {
+      observed.current = useContext(LocalStewardAuthContext);
+      return null;
+    }
+    render(
+      <StewardAuthRuntimeProvider apiUrl="https://staging.eliza.app/steward">
+        <AccountProbe />
+      </StewardAuthRuntimeProvider>,
+    );
+    return observed;
+  }
+
+  it("opens localhost account pages only after Cloud verifies the CLI key, without JWT refresh or repeated identity reads", async () => {
+    configureLoopback();
+    await writeStoredStewardToken("eliza_loopback_test_key");
+    let finish!: (response: Response) => void;
+    const request = vi.fn(
+      (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Promise<Response>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", request);
+    const observed = mountAccount();
+    expect(observed.current?.isAuthenticated).toBe(false);
+    expect(observed.current?.isLoading).toBe(true);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls[0][0]).toBe(
+      "https://api-staging.eliza.app/api/v1/user",
+    );
+    await act(async () =>
+      finish(
+        new Response(
+          JSON.stringify({ id: "verified-owner", email: "owner@example.test" }),
+        ),
+      ),
+    );
+    await waitFor(() =>
+      expect(observed.current?.user?.id).toBe("verified-owner"),
+    );
+    expect(observed.current?.isAuthenticated).toBe(true);
+    expect(observed.current?.user?.email).toBe("owner@example.test");
+    act(() => {
+      window.dispatchEvent(new Event("storage"));
+      window.dispatchEvent(new Event("steward-token-sync"));
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(observed.current?.getToken()).toBe("eliza_loopback_test_key");
+  });
+
+  it.each([401, 403, 503])(
+    "keeps a key-shaped localhost credential signed out when account verification returns %s",
+    async (status) => {
+      configureLoopback();
+      await writeStoredStewardToken("eliza_rejected_test_key");
+      stewardAuthState.isAuthenticated = true;
+      stewardAuthState.user = { id: "previous-sdk-owner" };
+      const request = vi.fn(async () => new Response("{}", { status }));
+      vi.stubGlobal("fetch", request);
+      const observed = mountAccount();
+      await waitFor(() => expect(observed.current?.isLoading).toBe(false));
+      expect(observed.current?.isAuthenticated).toBe(false);
+      expect(observed.current?.user).toBeNull();
+      expect(request).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("cannot restore a localhost session from a validation response that arrives after logout", async () => {
+    configureLoopback();
+    await writeStoredStewardToken("eliza_old_test_key");
+    let finish!: (response: Response) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            finish = resolve;
+          }),
+      ),
+    );
+    const observed = mountAccount();
+    await act(async () => {
+      await clearStoredStewardToken();
+    });
+    await act(async () =>
+      finish(
+        new Response(
+          JSON.stringify({ id: "old-owner", email: "old@example.test" }),
+        ),
+      ),
+    );
+    expect(observed.current?.isAuthenticated).toBe(false);
+    expect(observed.current?.user).toBeNull();
+  });
+
+  it("does not send web or local-agent credentials through the localhost CLI verifier", async () => {
+    configureLoopback();
+    await writeStoredStewardToken("local-agent-bearer");
+    mountAccount();
+    await waitFor(() =>
+      expect(postsTo("steward-refresh").length).toBeGreaterThan(0),
+    );
+    expect(calls.some((call) => call.url.endsWith("/api/v1/user"))).toBe(false);
+  });
+
   it("dedupes a direct-map explicit sync only at the identical endpoint", async () => {
     const token = makeJwt({
       sub: "u1",

--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -40,6 +40,10 @@ import {
   tokenIsExpired,
   tokenSecsRemaining,
 } from "./StewardProviderShared";
+import {
+  loopbackCliToken,
+  useLoopbackCliSession,
+} from "./use-loopback-cli-session";
 
 const REFRESH_CHECK_INTERVAL_MS = 60_000;
 const REFRESH_AHEAD_SECS = 120;
@@ -87,6 +91,9 @@ const ELIZA_STEWARD_THEME: ComponentProps<typeof LoginProvider>["theme"] = {
 
 function AuthTokenSync({ children }: { children: ReactNode }) {
   const auth = useStewardAuth();
+  const cliSession = useLoopbackCliSession();
+  const cliCredential = loopbackCliToken();
+  const cliUser = cliSession.token === cliCredential ? cliSession.user : null;
   const { isAuthenticated, user } = auth;
   const lastSyncedToken = useRef<string | null>(null);
   const wasAuthenticated = useRef(false);
@@ -225,6 +232,8 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
     const checkAndRefresh = async (force = false): Promise<void> => {
       const token = readStoredToken();
       if (!token) return;
+      // A localhost CLI key is verified by Cloud, never refreshed as a JWT.
+      if (loopbackCliToken() === token) return;
       if (!force) {
         const secs = tokenSecsRemaining(token);
         if (secs !== null && secs >= REFRESH_AHEAD_SECS) return;
@@ -343,17 +352,20 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
   // must narrow the MFA-required union before exposing tokens.
   const localAuth = useMemo<LocalStewardAuthValue>(
     () => ({
-      isAuthenticated: auth.isAuthenticated,
-      isLoading: auth.isLoading,
-      user: auth.user
-        ? {
-            id: auth.user.id,
-            email: auth.user.email ?? undefined,
-            walletAddress: auth.user.walletAddress,
-          }
-        : null,
-      session: auth.session,
+      isAuthenticated: cliCredential ? cliUser !== null : auth.isAuthenticated,
+      isLoading: cliCredential ? cliSession.loading : auth.isLoading,
+      user: cliCredential
+        ? cliUser
+        : auth.user
+          ? {
+              id: auth.user.id,
+              email: auth.user.email ?? undefined,
+              walletAddress: auth.user.walletAddress,
+            }
+          : null,
+      session: cliCredential ? null : auth.session,
       signOut: () => {
+        if (loopbackCliToken()) return clearStaleStewardSession();
         // Retire explicit-sync proof before the SDK begins its own fallible
         // sign-out work. A same-token login after any partial teardown must
         // establish the local server cookie again.
@@ -367,7 +379,8 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
         scrubPersistedAgentProfileTokens();
         return auth.signOut();
       },
-      getToken: () => auth.getToken(),
+      getToken: () =>
+        cliCredential ? (cliUser ? cliCredential : null) : auth.getToken(),
       verifyEmailCallback: async (token: string, email: string) => {
         const result = await auth.verifyEmailCallback(token, email);
         if ("mfaRequired" in result) {
@@ -376,7 +389,7 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
         return { token: result.token, refreshToken: result.refreshToken };
       },
     }),
-    [auth],
+    [auth, cliSession.loading, cliCredential, cliUser],
   );
 
   return (

--- a/packages/ui/src/cloud/shell/use-loopback-cli-session.ts
+++ b/packages/ui/src/cloud/shell/use-loopback-cli-session.ts
@@ -1,0 +1,127 @@
+/** Resolve localhost CLI credentials through the real Cloud account authority. */
+import { ELIZA_DOMAIN_CONTRACTS } from "@elizaos/shared/elizacloud";
+import {
+  readStoredStewardToken,
+  STEWARD_SESSION_CHANGE_EVENT,
+} from "@elizaos/shared/steward-session-client";
+import { useEffect, useState } from "react";
+import { isLoopbackStagingStewardDevelopment } from "../../state/loopback-steward-development";
+import { normalizeCloudApiKeyToken } from "../lib/cloud-api-key-token";
+
+/** CLI keys are not JWTs; only the explicitly configured loopback lane uses them here. */
+export function loopbackCliToken(): string | null {
+  return isLoopbackStagingStewardDevelopment()
+    ? normalizeCloudApiKeyToken(readStoredStewardToken())
+    : null;
+}
+
+type CliSession = {
+  loading: boolean;
+  token: string | null;
+  user: { id: string; email: string } | null;
+};
+
+/** A key-shaped string never opens account pages until the server accepts it. */
+export function useLoopbackCliSession(): CliSession {
+  const [session, setSession] = useState<CliSession>(() => ({
+    loading: Boolean(loopbackCliToken()),
+    token: null,
+    user: null,
+  }));
+  useEffect(() => {
+    let active = true;
+    let pending: AbortController | undefined;
+    let observedToken: string | null | undefined;
+    const verify = async () => {
+      const token = loopbackCliToken();
+      if (token === observedToken) return;
+      observedToken = token;
+      pending?.abort();
+      if (!token) {
+        setSession({ loading: false, token: null, user: null });
+        return;
+      }
+      const controller = new AbortController();
+      pending = controller;
+      setSession({ loading: true, token: null, user: null });
+      const timeout = window.setTimeout(() => controller.abort(), 15_000);
+      try {
+        const apiBase = ELIZA_DOMAIN_CONTRACTS.staging.cloudApiOrigin;
+        const response = await fetch(`${apiBase}/api/v1/user`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+          },
+          credentials: "omit",
+          signal: controller.signal,
+        });
+        if (
+          !active ||
+          controller.signal.aborted ||
+          pending !== controller ||
+          loopbackCliToken() !== token
+        )
+          return;
+        if (response.status === 401 || response.status === 403) {
+          throw new Error("Cloud account credential was rejected");
+        }
+        if (!response.ok) throw new Error("Cloud account verification failed");
+        const body = await response.json();
+        const user = body?.data ?? body;
+        if (typeof user?.id !== "string" || !user.id.trim()) {
+          throw new Error("Cloud account identity is missing");
+        }
+        if (
+          active &&
+          !controller.signal.aborted &&
+          pending === controller &&
+          loopbackCliToken() === token
+        ) {
+          setSession({
+            loading: false,
+            token,
+            user: {
+              id: user.id,
+              email: typeof user.email === "string" ? user.email : "",
+            },
+          });
+        }
+      } catch {
+        // error-policy:J4 network/invalid identity stays signed out; normal sign-in remains retryable.
+        if (active && pending === controller) {
+          setSession({ loading: false, token: null, user: null });
+        }
+      } finally {
+        window.clearTimeout(timeout);
+        if (active && pending === controller) {
+          setSession((value) =>
+            value.loading ? { loading: false, token: null, user: null } : value,
+          );
+        }
+      }
+    };
+    const refresh = () => {
+      void verify();
+    };
+    const revalidate = () => {
+      observedToken = undefined;
+      refresh();
+    };
+    refresh();
+    window.addEventListener("storage", refresh);
+    window.addEventListener(STEWARD_SESSION_CHANGE_EVENT, refresh);
+    window.addEventListener("steward-token-sync", refresh);
+    window.addEventListener("steward-unauthorized", revalidate);
+    window.addEventListener("online", revalidate);
+    return () => {
+      active = false;
+      pending?.abort();
+      window.removeEventListener("storage", refresh);
+      window.removeEventListener(STEWARD_SESSION_CHANGE_EVENT, refresh);
+      window.removeEventListener("steward-token-sync", refresh);
+      window.removeEventListener("steward-unauthorized", revalidate);
+      window.removeEventListener("online", revalidate);
+    };
+  }, []);
+  return session;
+}

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -561,6 +561,52 @@ describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", (
     expect(params.setActionNotice).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["/cloud/billing?from=login#receipt", "authenticated", true],
+    ["//evil.example/cloud", "authenticated", false],
+    ["/chat", "authenticated", false],
+    ["/cloudish", "authenticated", false],
+    ["/cloud/agents", "expired", false],
+  ])(
+    "returns to %s only after successful local CLI authentication (%s)",
+    async (destination, status, navigates) => {
+      const replace = vi.fn();
+      const search = `?elizaCloudLogin=complete&elizaCloudLoginSession=account-return&elizaCloudLoginReturnTo=${encodeURIComponent(destination)}`;
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: {
+          href: `http://127.0.0.1:2189/settings${search}`,
+          origin: "http://127.0.0.1:2189",
+          protocol: "http:",
+          hostname: "127.0.0.1",
+          port: "2189",
+          pathname: "/settings",
+          search,
+          assign: assignSpy,
+          replace,
+        },
+      });
+      vi.stubEnv("VITE_STEWARD_API_URL", "https://staging.eliza.app/steward");
+      vi.stubEnv("VITE_STEWARD_TENANT_ID", "elizacloud-staging");
+      setBootConfig({
+        branding: {},
+        cloudApiBase: "https://api-staging.eliza.app",
+      });
+      vi.spyOn(client, "getBaseUrl").mockReturnValue("http://127.0.0.1:31337");
+      cloudLoginPollDirectSpy.mockResolvedValue({
+        status,
+        token: "eliza_account_return_test_key",
+      });
+      const { result } = renderHook(() => useCloudState(makeParams()));
+      await waitFor(() => expect(cloudLoginPollDirectSpy).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(result.current.elizaCloudLoginBusy).toBe(false),
+      );
+      if (navigates) expect(replace).toHaveBeenCalledWith(destination);
+      else expect(replace).not.toHaveBeenCalled();
+    },
+  );
+
   it("claims a hosted staging return once under Strict Mode without replacing the localhost backend", async () => {
     const search =
       "?elizaCloudLogin=complete&elizaCloudLoginSession=staging-return";

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -54,6 +54,7 @@ import {
 } from "../bridge";
 import { isAppModeHost } from "../cloud/app-mode/app-mode";
 import { publishCloudAuthComplete } from "../cloud/auth/cloud-auth-complete-signal";
+import { sanitizeLoginReturnTo } from "../cloud/public-pages/lib/login-return-to";
 import { signOutFromSsoBridgedHost } from "../cloud/sso-bridge/sso-bridge";
 import { getBootConfig, setBootConfig } from "../config/boot-config";
 import { dispatchElizaCloudStatusUpdated } from "../events";
@@ -228,6 +229,7 @@ function clearCloudLoginReturnParams(): void {
     for (const key of [
       ELIZA_CLOUD_LOGIN_COMPLETE_PARAM,
       ELIZA_CLOUD_LOGIN_SESSION_PARAM,
+      "elizaCloudLoginReturnTo",
     ]) {
       if (url.searchParams.has(key)) {
         url.searchParams.delete(key);
@@ -1590,6 +1592,15 @@ export function useCloudState({
       clearCloudLoginReturnParams();
       return;
     }
+    const requestedReturn = sanitizeLoginReturnTo(
+      new URL(window.location.href).searchParams.get("elizaCloudLoginReturnTo"),
+    );
+    const accountReturn =
+      isLoopbackStagingStewardDevelopment() &&
+      requestedReturn &&
+      /^\/cloud(?:\/|[?#]|$)/.test(requestedReturn)
+        ? requestedReturn
+        : null;
     let cancelled = false;
     const sleep = (ms: number) =>
       new Promise((resolve) => window.setTimeout(resolve, ms));
@@ -1645,6 +1656,7 @@ export function useCloudState({
             closeActiveCloudLoginPopup();
             closeReturnedAuthTabIfOpenerStillExists();
             void closeExternalBrowser();
+            if (accountReturn) window.location.replace(accountReturn);
             return;
           }
 


### PR DESCRIPTION
Local `bun run dev` users who completed Cloud sign-in could loop back through login on `/cloud/billing`, then send account requests to the local agent and receive `Not found`. Claim the one-time callback on the app settings route before returning to the requested account page, verify the CLI credential against the staging account authority, and route account requests to that same authority.

This behavior is confined to the explicitly configured loopback staging development lane. Offline cookie-backed local Cloud keeps its same-origin authority until a CLI credential is claimed. Hosted and native authentication, cross-origin restrictions, and the server requirement for interactive billing mutations remain intact. Invalid credentials and stale responses cannot authenticate a different account.

Validation: 91 focused callback, provider, and transport tests passed; UI typecheck, nine-file Biome, and diff checks passed. Root verification completed 373 tasks and repository audits; the later transport/provider changes were covered by the final focused tests and UI typecheck. The real local Billing payment replay, including agent-status503 reload, passed after the offline-cookie routing regression was corrected. Native Chrome testing with the owner profile completed normal Cloud login, restored the existing 41-message conversation, and displayed the correct Billing account, balance, and Dedicated resource.

Closes #31207.
