### PR TITLE
fix(cloud): release certified Dedicated latency and account repairs

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -506,12 +506,12 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 name = "eliza-cloud-api-staging"
 workers_dev = false
 
-# Keep this edge/API Worker in Cloudflare's default caller-local placement.
-# Inference performs authentication and serial Durable Object admission before
-# provider dispatch; moving the whole fetch handler near an inferred HTTP
-# origin adds a cross-region round trip to every stateful phase. If a backend
-# needs placement, split it behind an unplaced edge Worker and certify that
-# boundary independently before changing this contract.
+# Use the explicitly measured region, rather than infer placement from the
+# provider HTTP endpoint. The September 13 control/target/restore probes kept
+# auth, primary policy reads, and Durable Object admission intact: production
+# warm pre-dispatch time fell from 3.6-3.8s to 0.83s. Staging improved similarly.
+# Revalidate live inference and agent-proxy flows when upstream locations change.
+placement = { mode = "targeted", region = "gcp:us-west2" }
 routes = [
   # Canonical browser hosts belong to the eliza-app Pages project. Pages
   # Functions proxy /api and auth protocol paths to this Worker.
@@ -824,12 +824,12 @@ simple = { limit = 120, period = 60 }
 [env.production]
 name = "eliza-cloud-api-prod"
 
-# Keep this edge/API Worker in Cloudflare's default caller-local placement.
-# Inference performs authentication and serial Durable Object admission before
-# provider dispatch; moving the whole fetch handler near an inferred HTTP
-# origin adds a cross-region round trip to every stateful phase. If a backend
-# needs placement, split it behind an unplaced edge Worker and certify that
-# boundary independently before changing this contract.
+# Use the explicitly measured region, rather than infer placement from the
+# provider HTTP endpoint. The September 13 control/target/restore probes kept
+# auth, primary policy reads, and Durable Object admission intact: production
+# warm pre-dispatch time fell from 3.6-3.8s to 0.83s. Staging improved similarly.
+# Revalidate live inference and agent-proxy flows when upstream locations change.
+placement = { mode = "targeted", region = "gcp:us-west2" }
 workers_dev = false
 # Canonical routes serve the API and UUID agents. The cloud.eliza.app browser
 # host belongs to Pages; legacy routes remain redirect ingress during the

--- a/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
+++ b/packages/cloud/e2e/tests/billing-payment-replay.spec.ts
@@ -560,6 +560,20 @@ test("lost provider response and duplicate webhook settle exactly once", async (
     await expect(
       invoiceRow.getByRole("button", { name: "View", exact: true }),
     ).toBeVisible();
+
+    // Billing belongs to the authenticated account even when the selected
+    // agent cannot start. Fault the real app's agent-status request across a
+    // reload while keeping the Cloud session and billing API available.
+    backendFaults.setFault({
+      path: "/api/status",
+      status: 503,
+      body: { error: "Agent temporarily unavailable" },
+    });
+    await authenticatedPage.reload();
+    await expect.poll(() => backendFaults.faultHits).toBeGreaterThan(0);
+    await expect(renderedBalance).toBeVisible();
+    await expect(invoiceRow).toHaveCount(1);
+    await expect(invoiceRow.getByText("Paid", { exact: true })).toBeVisible();
   } finally {
     backendFaults.clearFault();
     backendFaults.clearPathRewrites();

--- a/packages/cloud/shared/src/db/repositories/organization-policy-generation.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-policy-generation.ts
@@ -9,11 +9,25 @@ export async function lockOrganizationPolicy(
   tx: DbTransaction,
   organizationId: string,
 ): Promise<void> {
+  return lockPolicyRow(tx, organizationId, "update");
+}
+/** Read-only admission may overlap other readers while still fencing policy and balance writers. */
+export async function lockOrganizationPolicyForRead(
+  tx: DbTransaction,
+  organizationId: string,
+): Promise<void> {
+  return lockPolicyRow(tx, organizationId, "share");
+}
+async function lockPolicyRow(
+  tx: DbTransaction,
+  organizationId: string,
+  strength: "update" | "share",
+): Promise<void> {
   const [organization] = await tx
     .select({ id: organizations.id })
     .from(organizations)
     .where(eq(organizations.id, organizationId))
-    .for("update");
+    .for(strength);
   if (!organization)
     throw new ElizaError("Organization policy authority does not exist", {
       code: "ORGANIZATION_POLICY_UNAVAILABLE",

--- a/packages/cloud/shared/src/db/repositories/organization-policy.postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/organization-policy.postgres.integration.test.ts
@@ -59,6 +59,99 @@ describe.skipIf(!databaseUrl)("organization policy primary transaction fences", 
       await writer.end();
     }
   });
+  test("parallel inference policy readers overlap while a policy writer waits and invalidates their stamp", async () => {
+    const { withOrganizationPolicyReadAdmission } = await import(
+      "../../lib/services/organization-policy-admission"
+    );
+    const { requireOrganizationRateTier } = await import(
+      "../../lib/services/organization-quota-policy"
+    );
+    const { orgRateLimitOverridesRepository } = await import("./org-rate-limit-overrides");
+    const entered = [barrier(), barrier()];
+    const release = barrier();
+    const readers = entered.map((ready) =>
+      withOrganizationPolicyReadAdmission(ORG, undefined, async (policy) => {
+        ready.resolve();
+        await release.promise;
+        return policy.authority;
+      }),
+    );
+    let mutation: Promise<unknown> | undefined;
+    try {
+      // Both callbacks must be reached before either releases its transaction.
+      // Exclusive reader locks cannot pass this boundary.
+      await Promise.race([
+        Promise.all(entered.map((ready) => ready.promise)),
+        Bun.sleep(3000).then(() => {
+          throw new Error("Concurrent inference readers serialized behind one another");
+        }),
+      ]);
+      let mutationFinished = false;
+      mutation = orgRateLimitOverridesRepository
+        .upsert({ organization_id: ORG, completions_rpm: 12 }, "admin:postgres-test")
+        .then(() => {
+          mutationFinished = true;
+        });
+      await waitForOrganizationLock();
+      expect(mutationFinished).toBe(false);
+      release.resolve();
+      const stamps = await Promise.all(readers);
+      await mutation;
+      expect(stamps[0]).toEqual(stamps[1]);
+      await expect(
+        withOrganizationPolicyReadAdmission(ORG, stamps[0], async () => "dispatched"),
+      ).rejects.toMatchObject({ code: "ORGANIZATION_POLICY_STALE" });
+      expect(
+        await withOrganizationPolicyReadAdmission(
+          ORG,
+          undefined,
+          async (policy) => requireOrganizationRateTier(policy).completionsRpm,
+        ),
+      ).toBe(12);
+    } finally {
+      release.resolve();
+      await Promise.allSettled(readers);
+      await mutation;
+    }
+  }, 30000);
+  test("an inference reader still fences credit updates and exclusive resource admission", async () => {
+    const { sql } = await import("drizzle-orm");
+    const { withOrganizationPolicyReadAdmission, withOrganizationPolicyAdmission } = await import(
+      "../../lib/services/organization-policy-admission"
+    );
+    for (const operation of ["credit", "resource"] as const) {
+      const entered = barrier(),
+        release = barrier();
+      const reader = withOrganizationPolicyReadAdmission(ORG, undefined, async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      let mutation: Promise<unknown> | undefined;
+      try {
+        await entered.promise;
+        let finished = false;
+        mutation = (
+          operation === "credit"
+            ? database.dbWrite.execute(
+                sql`UPDATE organizations SET credit_balance=credit_balance-1 WHERE id=${ORG}`,
+              )
+            : withOrganizationPolicyAdmission(ORG, undefined, async () => "resource admitted")
+        ).then(() => {
+          finished = true;
+        });
+        await waitForOrganizationLock();
+        expect(finished).toBe(false);
+        release.resolve();
+        await reader;
+        await mutation;
+        expect(finished).toBe(true);
+      } finally {
+        release.resolve();
+        await reader;
+        await mutation;
+      }
+    }
+  }, 30000);
   test("a paused old cache publication cannot overtake a newer committed policy warmer", async () => {
     const { cache } = await import("../../lib/cache/client");
     const { isInferenceAdmissionSnapshot } = await import(

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
@@ -67,16 +67,18 @@ function policyFixture(): OrganizationQuotaPolicy {
     },
   };
 }
+async function withFixturePolicy<T>(
+  _org: string,
+  _expected: OrganizationPolicyStamp | undefined,
+  operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
+): Promise<T> {
+  policyReads++;
+  return operation(policyFixture());
+}
 mock.module("../services/organization-policy-admission", () => ({
   ...policyAdmissionActual,
-  withOrganizationPolicyAdmission: async <T>(
-    _org: string,
-    _expected: OrganizationPolicyStamp | undefined,
-    operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
-  ) => {
-    policyReads++;
-    return operation(policyFixture());
-  },
+  withOrganizationPolicyAdmission: withFixturePolicy,
+  withOrganizationPolicyReadAdmission: withFixturePolicy,
 }));
 
 let redisChecks = 0;

--- a/packages/cloud/shared/src/lib/middleware/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit.ts
@@ -17,7 +17,10 @@ import { warmInferenceAdmissionSnapshot } from "../services/inference-admission-
 import { isHotPathCachesEnabled } from "../services/inference-hot-path-caches";
 import type { EndpointType, OrgRateLimitConfig } from "../services/org-rate-limits";
 import { type OrgTierCacheExecutionContext, recalculateOrgTier } from "../services/org-rate-limits";
-import { withOrganizationPolicyAdmission } from "../services/organization-policy-admission";
+import {
+  withOrganizationPolicyAdmission,
+  withOrganizationPolicyReadAdmission,
+} from "../services/organization-policy-admission";
 import {
   isOrganizationPolicyStamp,
   sameOrganizationPolicyStamp,
@@ -459,7 +462,10 @@ export async function enforceOrgRateLimit(
   } = {},
 ): Promise<Response | null> {
   try {
-    return await withOrganizationPolicyAdmission(
+    const admitOrganizationPolicy = options.cacheOnly
+      ? withOrganizationPolicyReadAdmission
+      : withOrganizationPolicyAdmission;
+    return await admitOrganizationPolicy(
       organizationId,
       options.config?.authority,
       async (policy) => {

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.fixture.mts
@@ -225,6 +225,7 @@ mock.module("../../db/helpers", () => ({
 }));
 mock.module("../../db/repositories/organization-policy-generation", () => ({
   lockOrganizationPolicy: async () => undefined,
+  lockOrganizationPolicyForRead: async () => undefined,
 }));
 mock.module("./organization-quota-policy", () => ({
   readOrganizationQuotaPolicyInTransaction: readPolicy,

--- a/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-inference-admission.ts
@@ -11,7 +11,10 @@
 
 import { ElizaError } from "@elizaos/core";
 import { writeTransaction } from "../../db/helpers";
-import { lockOrganizationPolicy } from "../../db/repositories/organization-policy-generation";
+import {
+  lockOrganizationPolicy,
+  lockOrganizationPolicyForRead,
+} from "../../db/repositories/organization-policy-generation";
 import { calculateCost, normalizeModelName } from "../pricing";
 import { createCreditReservationSettler } from "../utils/credit-reservation";
 import { logger } from "../utils/logger";
@@ -72,7 +75,10 @@ import {
   type InferenceCredentialCheck,
   InferenceCredentialRevokedError,
 } from "./inference-credential-revocation";
-import { withOrganizationPolicyAdmission } from "./organization-policy-admission";
+import {
+  withOrganizationPolicyAdmission,
+  withOrganizationPolicyReadAdmission,
+} from "./organization-policy-admission";
 import { sameOrganizationPolicyStamp } from "./organization-policy-stamp";
 import {
   type OrganizationQuotaPolicy,
@@ -334,8 +340,10 @@ export async function admitOrganizationInference(
 ): Promise<OrganizationInferenceAdmission> {
   // KV/LRU entries are observations, never a CAS fence. Compare policy under
   // the same organization lock that serializes entitlement and override writes.
+  const workerHotPath = typeof params.executionCtx?.waitUntil === "function";
+  const lockPolicy = workerHotPath ? lockOrganizationPolicyForRead : lockOrganizationPolicy;
   const authoritativePolicy = await writeTransaction(async (tx) => {
-    await lockOrganizationPolicy(tx, params.context.organizationId);
+    await lockPolicy(tx, params.context.organizationId);
     return readOrganizationQuotaPolicyInTransaction(tx, params.context.organizationId);
   });
   if (
@@ -360,6 +368,9 @@ export async function admitOrganizationInference(
   }
   const admission = await admitWithFundingPolicy(params, authoritativePolicy);
   const previousDispatch = admission.markProviderDispatched;
+  const admitDispatch = workerHotPath
+    ? withOrganizationPolicyReadAdmission
+    : withOrganizationPolicyAdmission;
   let dispatched = false;
   let dispatch: Promise<void> | undefined;
   return {
@@ -367,7 +378,7 @@ export async function admitOrganizationInference(
     markProviderDispatched: () => {
       if (dispatched) return Promise.resolve();
       if (dispatch) return dispatch;
-      dispatch = withOrganizationPolicyAdmission(
+      dispatch = admitDispatch(
         params.context.organizationId,
         authoritativePolicy.authority,
         async (current) => {

--- a/packages/cloud/shared/src/lib/services/organization-policy-admission.ts
+++ b/packages/cloud/shared/src/lib/services/organization-policy-admission.ts
@@ -1,7 +1,10 @@
 /** Serializes authoritative policy admission with organization lifecycle and override publication. */
 import { ElizaError } from "@elizaos/core";
 import { writeTransaction } from "../../db/helpers";
-import { lockOrganizationPolicy } from "../../db/repositories/organization-policy-generation";
+import {
+  lockOrganizationPolicy,
+  lockOrganizationPolicyForRead,
+} from "../../db/repositories/organization-policy-generation";
 import {
   isOrganizationPolicyStamp,
   sameOrganizationPolicyStamp,
@@ -16,8 +19,29 @@ export async function withOrganizationPolicyAdmission<T>(
   expected: OrganizationPolicyStamp | undefined,
   operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
 ): Promise<T> {
+  return admitUnderPolicyLock(organizationId, expected, operation, lockOrganizationPolicy);
+}
+/**
+ * Fences read-only inference checks against policy writers without serializing readers.
+ * The callback must not mutate Postgres; rate and spend transitions must have
+ * their own authoritative Durable Object serialization. Resource admission
+ * and cache publication retain the exclusive admission function above.
+ */
+export async function withOrganizationPolicyReadAdmission<T>(
+  organizationId: string,
+  expected: OrganizationPolicyStamp | undefined,
+  operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
+): Promise<T> {
+  return admitUnderPolicyLock(organizationId, expected, operation, lockOrganizationPolicyForRead);
+}
+async function admitUnderPolicyLock<T>(
+  organizationId: string,
+  expected: OrganizationPolicyStamp | undefined,
+  operation: (policy: OrganizationQuotaPolicy) => Promise<T>,
+  lock: typeof lockOrganizationPolicy,
+): Promise<T> {
   return writeTransaction(async (tx) => {
-    await lockOrganizationPolicy(tx, organizationId);
+    await lock(tx, organizationId);
     const policy = await readOrganizationQuotaPolicyInTransaction(tx, organizationId);
     if (
       expected !== undefined &&

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -1505,6 +1505,64 @@ describe("App navigate-view event wiring", () => {
     },
   );
 
+  it.each([
+    "restoring-session",
+    "polling-backend",
+    "pairing-required",
+    "error",
+    "starting-runtime",
+    "ready",
+  ])(
+    "keeps authenticated account management available during agent %s",
+    async (phase) => {
+      registerAppShellPage({
+        id: "cloud",
+        pluginId: "@elizaos/ui",
+        label: "Cloud",
+        path: "/cloud",
+        pathPatterns: ["/cloud/*"],
+        surface: { capabilities: ["navigate"] },
+        Component: () => <div data-testid="managed-cloud-page" />,
+      });
+      cloudSessionState.authenticated = true;
+      authStatusMock.phase = "unauthenticated";
+      appState.startupPhase = phase;
+      appState.backendConnectionState = "disconnected";
+      appState.tab = "cloud";
+      window.history.replaceState(null, "", "/cloud/agents");
+
+      render(<App />);
+
+      await screen.findByTestId("managed-cloud-page");
+      expect(appState.retryStartup).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { authenticated: false, owner: "@elizaos/ui" },
+    { authenticated: true, owner: "@elizaos/plugin-elizacloud" },
+  ])(
+    "keeps agent startup gates for $owner with Cloud auth=$authenticated",
+    ({ authenticated, owner }) => {
+      registerAppShellPage({
+        id: "cloud",
+        pluginId: owner,
+        label: "Cloud",
+        path: "/cloud",
+        pathPatterns: ["/cloud/*"],
+        Component: () => <div data-testid="managed-cloud-page" />,
+      });
+      cloudSessionState.authenticated = authenticated;
+      appState.startupPhase = "polling-backend";
+      appState.tab = "cloud";
+      window.history.replaceState(null, "", "/cloud/agents");
+
+      render(<App />);
+
+      expect(screen.queryByTestId("managed-cloud-page")).toBeNull();
+    },
+  );
+
   it("gives an in-process wallet page a live agent-surface registry", async () => {
     registerAppShellPage({
       id: "wallet.inventory",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3063,6 +3063,17 @@ function AppContent() {
     ? resolvedDynamicPage
     : null;
   const { authenticated: cloudAuthenticated } = useSessionAuth();
+  // Account management is authorized by the Cloud session, independently of
+  // the selected agent. Keep its wake/recovery controls reachable while that
+  // agent is asleep, disconnected, or awaiting pairing.
+  const authenticatedAccountPage = authenticatedCloudDashboardOwnsRoute(
+    findVisibleAppShellPageForRoute(
+      navigationPath,
+      enabledKinds,
+      managedCloudRuntime,
+    ),
+    cloudAuthenticated,
+  );
   const screenBackgroundPolicy = useActiveScreenBackgroundPolicy({
     tab,
     navigationPath,
@@ -3597,7 +3608,10 @@ function AppContent() {
     );
   }
 
-  if (!isShellPaintableNow || bootstrapGateHolds) {
+  if (
+    !authenticatedAccountPage &&
+    (!isShellPaintableNow || bootstrapGateHolds)
+  ) {
     return (
       <BugReportProvider value={bugReport}>
         <StartupScreen />
@@ -3614,6 +3628,7 @@ function AppContent() {
   // primes the probe (primeAuthStatusProbe) so it overlaps backend polling /
   // hydration instead of serializing an extra round-trip after first paint.
   if (
+    !authenticatedAccountPage &&
     isShellPaintableNow &&
     !isPopout &&
     topLevelAuthGateOwnsSurface(

--- a/packages/ui/src/cloud/register-managed-cloud-page.test.ts
+++ b/packages/ui/src/cloud/register-managed-cloud-page.test.ts
@@ -2,12 +2,39 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { listAppShellPages } from "../app-shell-registry";
+import { tabFromPath } from "../navigation";
 import { resetUiRegistryHostForTests } from "../registry-host";
 
 describe("managed Cloud app-shell registration", () => {
   beforeEach(() => {
     resetUiRegistryHostForTests();
     vi.resetModules();
+  });
+
+  it.each(["host-first", "plugin-first"])(
+    "preserves account deep links when registrations load %s",
+    async (order) => {
+      const { registerManagedCloudAppShellPage } = await import(
+        "./register-managed-cloud-page"
+      );
+      if (order === "host-first") registerManagedCloudAppShellPage();
+      await import("../../../../plugins/plugin-elizacloud/src/register");
+      if (order === "plugin-first") registerManagedCloudAppShellPage();
+
+      const cloud = listAppShellPages().filter((entry) => entry.id === "cloud");
+      expect(cloud).toHaveLength(1);
+      expect(cloud[0]?.pluginId).toBe("@elizaos/ui");
+      expect(tabFromPath("/cloud/billing")).toBe("cloud");
+      expect(tabFromPath("/cloud/agents")).toBe("cloud");
+    },
+  );
+
+  it("retains the signed plugin page in hosts without managed account routes", async () => {
+    await import("../../../../plugins/plugin-elizacloud/src/register");
+    const cloud = listAppShellPages().find((entry) => entry.id === "cloud");
+    expect(cloud?.pluginId).toBe("@elizaos/plugin-elizacloud");
+    expect(cloud?.loader).toBeTypeOf("function");
+    expect(tabFromPath("/cloud")).toBe("cloud");
   });
 
   it("grants nested route navigation without widening storage or wallpaper authority", async () => {

--- a/plugins/plugin-elizacloud/src/register.ts
+++ b/plugins/plugin-elizacloud/src/register.ts
@@ -4,22 +4,31 @@
  * contributes the renderer surface for hosts that cannot load remote bundles.
  */
 
-import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
+import {
+  listAppShellPages,
+  registerAppShellPage,
+} from "@elizaos/ui/app-shell-registry";
 
-registerAppShellPage({
-  id: "cloud",
-  pluginId: "@elizaos/plugin-elizacloud",
-  label: "Cloud",
-  icon: "Cloud",
-  path: "/cloud",
-  order: 940,
-  viewKind: "release",
-  surface: {
-    header: "fullscreen",
-    capabilities: ["agent-surface"],
-  },
-  loader: () =>
-    import("./components/cloud/CloudPage.tsx").then((module) => ({
-      default: module.CloudPage,
-    })),
-});
+// The web host owns the authenticated /cloud/* account route family. Its
+// registration can finish before this deferred plugin module loads; replacing
+// it would drop nested routes and send billing/agent links to the launcher.
+// Hosts without that account shell still receive the signed plugin page.
+if (!listAppShellPages().some((page) => page.id === "cloud")) {
+  registerAppShellPage({
+    id: "cloud",
+    pluginId: "@elizaos/plugin-elizacloud",
+    label: "Cloud",
+    icon: "Cloud",
+    path: "/cloud",
+    order: 940,
+    viewKind: "release",
+    surface: {
+      header: "fullscreen",
+      capabilities: ["agent-surface"],
+    },
+    loader: () =>
+      import("./components/cloud/CloudPage.tsx").then((module) => ({
+        default: module.CloudPage,
+      })),
+  });
+}


### PR DESCRIPTION
Dedicated requests were spending several seconds on each Cloud policy admission, and account pages could disappear behind agent startup or be replaced by a plugin fallback. Promote the certified staging tree with read-only policy locks, measured targeted Worker placement, and UI-owned account-page registration/startup fixes.

This candidate changes exactly 13 paths (+322/-48) from production `7fdcfbaecf5153961505b63c3a0c35ab804a518d`. Its tree is byte-identical to staging `d0bb8cc28580c058fef0b73cd9bd0d3b7c547d81`: `5761598e4fcdbc2b9aa85e638ef30f1a359db985`. No other develop changes are included.

Staging Cloud CF run 34733346627 passed, including deployed API and Pages checks, and emitted certificate artifact 10309709997. Read-lock validation included 12,681 shared tests and five real PostgreSQL concurrency cases; account validation included the real Billing payment replay and startup/unavailable-agent tests. Root validation completed 373 tasks plus repository audits.

Controlled same-production probes reduced warm gateway admission from 3.6–3.8 seconds to approximately 0.83 seconds with targeted placement; the temporary experiment was restored before this release. Deployed staging admission measured 0.75–1.21 seconds warm. A real app memory-write reply completed in 13.966 seconds inside the runtime and executed MEMORY_CREATE; this is a different context from the original 37.852-second trace and is not a controlled whole-chat percentage comparison. Authorization, rate limits, billing serialization, memory, and provider selection remain enabled.

Production release must use the normal Cloud CF workflow from main and its staging tree certificate. Local-only account callback repairs are handled separately in #31208.
