### PR TITLE
test(ui): anchor the wallet-section e2e on the tab strip, not the retired title row (#31210)

### DIFF
--- a/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
+++ b/packages/ui/src/components/chat/widgets/__e2e__/run-wallet-widget-e2e.mjs
@@ -272,7 +272,10 @@ try {
   await desktopPage.goto(
     `file://${htmlPath}?surface=wallet-section&state=default`,
   );
-  await desktopPage.waitForSelector('[data-testid="wallet-section-header-inset"]', {
+  // ViewHeader renders nothing without trailing actions (views stopped
+  // repeating a title row), so the header inset is an empty, zero-height div;
+  // the section tab strip is the surface's visible anchor.
+  await desktopPage.waitForSelector('[data-testid="section-nav-wallet"]', {
     state: "visible",
     timeout: WIDGET_TIMEOUT_MS,
   });
@@ -287,10 +290,15 @@ try {
     "WALLET SECTION surface renders the real section tab strip",
   );
   assert(
+    (await desktopPage.locator('[data-testid="wallet-section-header-inset"]').count()) ===
+      1,
+    "WALLET SECTION surface keeps the safe-area header inset",
+  );
+  assert(
     (await desktopPage
-      .locator('[data-testid="view-header"] h1, [data-testid="view-header"]')
-      .count()) >= 1,
-    "WALLET SECTION surface renders the Wallet view header",
+      .locator('[data-testid="view-header"], [data-testid="view-actions"]')
+      .count()) === 0,
+    "WALLET SECTION surface does not repeat a title header row",
   );
   await desktopPage.screenshot({
     path: join(outDir, "wallet-section-desktop.png"),
@@ -313,7 +321,7 @@ try {
   await mobilePage.goto(
     `file://${htmlPath}?surface=wallet-section&state=held`,
   );
-  await mobilePage.waitForSelector('[data-testid="wallet-section-header-inset"]', {
+  await mobilePage.waitForSelector('[data-testid="section-nav-wallet"]', {
     state: "visible",
     timeout: WIDGET_TIMEOUT_MS,
   });


### PR DESCRIPTION
Closes #31210

## What

In `run-wallet-widget-e2e.mjs`, anchor the wallet-section step on the real `section-nav-wallet` tab strip instead of waiting for `wallet-section-header-inset` to be visible, and replace the "renders the Wallet view header" assertion with the current contract: the safe-area inset stays attached, and no `view-header` / `view-actions` row is repeated above the section.

## Why

Since `3038df42bfdf`, `ViewHeader` renders nothing without trailing actions (views stopped repeating a title and launcher-back row). `WalletSectionNav` still wraps that header in the inset div, so the inset is an empty zero-height element and Playwright's `state: "visible"` wait never resolves. `ui-extended / fixture-e2e` on develop has been red on every run since 2026-09-07 (latest: [run 34723784763](https://github.com/elizaOS/eliza/actions/runs/34723784763/job/103634726799)). `de39b4ce727a` already dropped the same expectations from the unit suite; this brings the e2e runner in line. Test-runner-only change.

## Evidence

Before (develop `1fa9dbf22d74`, `bun run --cwd packages/ui test:wallet-widget-e2e`):

```
✓ UNAVAILABLE state shows no fabricated default rows (got 0)
TimeoutError: waitForSelector: Timeout 30000ms exceeded.
  - waiting for locator('[data-testid="wallet-section-header-inset"]') to be visible
    63 × locator resolved to hidden <div class="" data-testid="wallet-section-header-inset"></div>
error: script "test:wallet-widget-e2e" exited with code 1
```

After:

```
✓ WALLET SECTION surface does not duplicate the wallet balance widget
✓ WALLET SECTION surface renders the real section tab strip
✓ WALLET SECTION surface keeps the safe-area header inset
✓ WALLET SECTION surface does not repeat a title header row
  📸 wallet-section-desktop.png/.jpg
✓ WALLET SECTION (mobile) does not duplicate the wallet balance widget
  📸 wallet-section-mobile.png/.jpg
✓ no page errors (0)
✓ default OCR is available … ✓ unavailable contains no blue palette bleed (0.0%)
All wallet-widget assertions passed.
```

Root `bun run verify` will run on a stack with the other develop-red repairs and be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpg1SzympM3Yf5LQvzktqk
