### PR TITLE
test(app): let the onboarding smoke harness confirm remote adoption (#31212)

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -296,6 +296,25 @@ export async function injectFullCapabilityHost(page: Page): Promise<void> {
 // network boundary (the single `persistFirstRun` funnel in first-run-finish.ts).
 export interface OnboardingRouteState {
   firstRunPosts: unknown[];
+  /**
+   * Bodies of every `PUT /api/config` the page issued. Remote adoption completes
+   * first-run on the host with a `meta.firstRunComplete` patch (see
+   * `adopt-remote-first-run.ts`) instead of `POST /api/first-run`, so the
+   * first-run status route derives completion from both writes.
+   */
+  configWrites: Record<string, unknown>[];
+}
+
+/** True once a config write carried the host first-run completion marker. */
+export function hostFirstRunCompleted(state: OnboardingRouteState): boolean {
+  return state.configWrites.some((write) => {
+    const meta = write.meta;
+    return (
+      typeof meta === "object" &&
+      meta !== null &&
+      (meta as { firstRunComplete?: unknown }).firstRunComplete === true
+    );
+  });
 }
 
 async function routeFirstRunIncomplete(
@@ -328,7 +347,7 @@ async function routeFirstRunIncomplete(
       return;
     }
     await fulfillJson(route, {
-      complete: state.firstRunPosts.length > 0,
+      complete: state.firstRunPosts.length > 0 || hostFirstRunCompleted(state),
       cloudProvisioned: false,
     });
   });
@@ -349,22 +368,32 @@ async function routeFirstRunIncomplete(
 export async function installHomeRoutes(
   page: Page,
 ): Promise<OnboardingRouteState> {
-  const state: OnboardingRouteState = { firstRunPosts: [] };
+  const state: OnboardingRouteState = { firstRunPosts: [], configWrites: [] };
   await installDefaultAppRoutes(page);
   await routeFirstRunIncomplete(page, state);
 
+  const homeConfig = {
+    cloud: { enabled: false },
+    media: {},
+    plugins: { entries: {} },
+    ui: { avatarIndex: 1 },
+    wallet: {},
+  };
   await page.route("**/api/config", async (route) => {
-    if (route.request().method() !== "GET") {
+    const method = route.request().method();
+    if (method === "PUT") {
+      // The real route merges the patch into the host config; the harness only
+      // needs the completion marker to become visible to /api/first-run/status.
+      const patch = route.request().postDataJSON() as Record<string, unknown>;
+      state.configWrites.push(patch);
+      await fulfillJson(route, { ...homeConfig, ...patch });
+      return;
+    }
+    if (method !== "GET") {
       await route.fallback();
       return;
     }
-    await fulfillJson(route, {
-      cloud: { enabled: false },
-      media: {},
-      plugins: { entries: {} },
-      ui: { avatarIndex: 1 },
-      wallet: {},
-    });
+    await fulfillJson(route, homeConfig);
   });
 
   await page.route("**/api/stream/settings", async (route) => {
@@ -998,7 +1027,7 @@ export async function completeOnboardingToHome(
   page: Page,
   click: (locator: Locator) => Promise<void>,
   opts: { state: OnboardingRouteState; tutorial?: "start" | "skip" } = {
-    state: { firstRunPosts: [] },
+    state: { firstRunPosts: [], configWrites: [] },
   },
 ): Promise<{ surface: Locator }> {
   const { state, tutorial = "skip" } = opts;
@@ -1342,6 +1371,24 @@ export async function connectRemoteFirstRunToHome(
   const apiBase =
     opts.apiBase ??
     (await page.evaluate(() => window.location.origin.toString()));
+
+  // Adoption probes the host before writing its completion marker and refuses
+  // one that is not running and able to respond; the default smoke status
+  // omits `canRespond`, so present the adopted host as ready. Later routes win.
+  await page.route("**/api/status", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, {
+      state: "running",
+      canRespond: true,
+      agentName: "Playwright Smoke",
+      model: "ui-smoke",
+      startedAt: Date.now() - 60_000,
+      uptime: 60_000,
+    });
+  });
 
   await page.evaluate((gatewayUrl) => {
     document.dispatchEvent(


### PR DESCRIPTION
Closes #31212

## What

Teach `packages/app/test/ui-smoke/onboarding-to-home.shared.ts` the writes remote adoption performs since #30989:

- `OnboardingRouteState` records every `PUT /api/config` body (`configWrites`), and `/api/first-run/status` reports `complete` when either the legacy `POST /api/first-run` fired or a config write carried `meta.firstRunComplete: true` (`hostFirstRunCompleted`).
- `installHomeRoutes` answers `PUT /api/config` with the merged config instead of falling through to the static server.
- `connectRemoteFirstRunToHome` presents the adopted host as `state: "running", canRespond: true`, which the adoption probe requires; the default smoke status omits `canRespond`.

## Why

`adoptRemoteAgentFirstRun` now probes host status, writes the completion marker through the config patch API, and re-reads first-run status to confirm it. With the old mocks the probe rejected the host, so first-run never completed, the runtime chooser stayed on screen, and `scenarios / Zero-Key app browser core` has been red on every develop run since 2026-09-11 (latest: [run 34723784763](https://github.com/elizaOS/eliza/actions/runs/34723784763/job/103635554387)). Test-harness-only change; the real-server adoption coverage from #30989 is untouched.

## Evidence

Negative control, develop's harness at `1fa9dbf22d74` (`bun run --cwd packages/app test:e2e test/ui-smoke/onboarding-to-home.spec.ts --project=chromium -g "Remote connect"`):

```
  ✘  1 [chromium] › test/ui-smoke/onboarding-to-home.spec.ts:215:3 › … › Remote connect adopts a host and replaces onboarding without the old screen
    Error: expect(locator).toBeVisible() failed
  1 failed
```

With this change, the whole spec:

```
  ✓  1 … Local onboarding lands on home and opens the Launcher pager
  ✓  2 … Cloud onboarding connects, binds an agent, and lands on the home
  ✓  3 … Local cloud-inference onboarding completes in chat
  ✓  4 … Other provider completes in chat and hands off to Settings without model download
  ✓  5 … Remote connect adopts a host and replaces onboarding without the old screen
  ✓  6 … tutorial CHOICE 'Take the tutorial' completes onboarding and launches the tour
  6 passed (44.2s)
```

Run on Node 24.15.0 with the pinned Bun 1.3.14 (the ui-smoke lane refuses older Node). `bunx biome check` on the file: clean. Root `bun run verify` is running on a stack with #31211; result will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpg1SzympM3Yf5LQvzktqk
