### PR TITLE
ci(test): run the app-core screenshot-quality diagnostics file directly (#31215)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -725,7 +725,9 @@ jobs:
         run: bunx vitest run --config packages/app/vitest.config.ts packages/app/test/screenshot-quality.test.ts
 
       - name: App-core screenshot quality diagnostics coverage
-        run: bun run --cwd packages/app-core test -- test/app/screenshot-quality.test.ts
+        # The package `test` script is a `&&` chain, so `bun run test -- <file>`
+        # appends the path to its last command and vitest runs the whole suite.
+        run: bunx vitest run --config packages/app-core/vitest.config.ts packages/app-core/test/app/screenshot-quality.test.ts
 
   zero-key-scenario-runner:
     name: Zero-Key scenario runner


### PR DESCRIPTION
Closes #31215

## What

In `.github/workflows/test.yml`, run the app-core screenshot-quality diagnostics file directly:

```
bunx vitest run --config packages/app-core/vitest.config.ts packages/app-core/test/app/screenshot-quality.test.ts
```

instead of `bun run --cwd packages/app-core test -- test/app/screenshot-quality.test.ts`, matching the neighbouring app step.

## Why

The app-core `test` script is a `&&` chain, so Bun appends the file path to its last command (`bun run test:script-suites test/app/screenshot-quality.test.ts`) and vitest runs the whole suite. That suite now includes `steward-sidecar-login.test.ts`, which needs the `@elizaos/login` workspace the diagnostics job never builds, so `tests / Zero-Key diagnostics` fails on a test the step was never meant to run (latest: [run 34723784763](https://github.com/elizaOS/eliza/actions/runs/34723784763/job/103635168222): `1 failed | 365 passed`). Workflow-only change.

## Evidence

Expansion of the old invocation (first line Bun prints, locally on develop `1fa9dbf22d74`):

```
$ node ../scripts/run-vitest.mjs run --config vitest.config.ts && bun run test:script-suites test/app/screenshot-quality.test.ts
 RUN  v4.1.10 …/packages/app-core
```

New invocation from the repository root:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  724ms
```

The workflow still parses (PyYAML load; the step's `run` reads as above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpg1SzympM3Yf5LQvzktqk
