### PR TITLE
fix: roll back rejected agreement upload sources

### DIFF
--- a/plugins/plugin-personal-assistant/README.md
+++ b/plugins/plugin-personal-assistant/README.md
@@ -235,6 +235,13 @@ persists the media SHA-256, handle, document id, byte size, MIME type, filename,
 parser-derived page count, complete extracted text and page map, and version chain; it does
 not create another permanent file store.
 
+Each immutable agreement owns a distinct document ingestion identity. If artifact
+persistence rejects the upload, ingestion removes that attempt's document,
+derived fragments, and private PDF through the canonical services. A failed
+commit observation preserves the sources for reconciliation; an incomplete
+cleanup returns an explicit storage error and reports the affected artifact
+and source handles to runtime diagnostics.
+
 Owner- or agent-extracted obligations begin as `proposed` and must carry an
 in-range page citation plus the cited source text. Only the owner can make the terminal
 `approved` or `rejected` decision. Agent and chat pins are independent

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.pglite.integration.test.ts
@@ -16,6 +16,7 @@ import {
   type AgentRuntime,
   attestAuthenticatedApiDeliveryAudience,
   ChannelType,
+  DocumentService,
   documentsPluginCore,
   type IAgentRuntime,
   type IFileStorageService,
@@ -25,6 +26,7 @@ import {
   ServiceType,
   type UUID,
 } from "@elizaos/core";
+import type { PdfService } from "@elizaos/plugin-pdf";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { tryHandleRuntimePluginRoute } from "../../../../../packages/agent/src/api/runtime-plugin-routes.ts";
@@ -46,6 +48,7 @@ import { executeRawSql, sqlQuote } from "../sql.js";
 import {
   AgreementKnowledgeError,
   AgreementKnowledgeRepository,
+  AgreementKnowledgeService,
   createAgreementKnowledgeService,
   type ParentingAgreementArtifact,
 } from "./agreement-knowledge.js";
@@ -53,6 +56,7 @@ import {
   getHouseholdCoordinationService,
   type HouseholdCoordinationService,
 } from "./service.js";
+import { DEFAULT_HOUSEHOLD_ID } from "./types.js";
 
 const fileStoragePlugin: Plugin = {
   name: "agreement-knowledge-test-file-storage",
@@ -1355,5 +1359,289 @@ describe("parenting-agreement knowledge — real PGlite", () => {
         uploadedByEntityId: SELF_ENTITY_ID,
       }),
     ).rejects.toMatchObject({ code: "AGREEMENT_INVALID_CONTRACT" });
+  });
+  it.each(["artifact", "document", "fragment"] as const)(
+    "removes private sources when %s persistence rejects the upload",
+    async (boundary) => {
+      const media = path.join(mediaStateDir, "media");
+      fs.mkdirSync(media, { recursive: true });
+      const filesBefore = fs.readdirSync(media).sort();
+      const documentRows = () =>
+        executeRawSql(
+          runtime,
+          `SELECT id FROM memories WHERE agent_id = ${sqlQuote(runtime.agentId)}
+          AND type IN ('documents', 'document_fragments') ORDER BY id`,
+        );
+      const docsBefore = await documentRows();
+      const table =
+        boundary === "artifact"
+          ? "app_lifeops.life_household_agreement_artifacts"
+          : "memories";
+      await executeRawSql(
+        runtime,
+        `CREATE FUNCTION app_lifeops.reject_ingest_acceptance()
+        RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
+          ${boundary !== "artifact" ? `IF NEW.type <> '${boundary === "document" ? "documents" : "document_fragments"}' THEN RETURN NEW; END IF;` : ""}
+          RAISE EXCEPTION 'forced upload persistence rejection'; END; $$`,
+      );
+      await executeRawSql(
+        runtime,
+        `CREATE TRIGGER reject_ingest_acceptance
+        BEFORE INSERT ON ${table} FOR EACH ROW EXECUTE FUNCTION app_lifeops.reject_ingest_acceptance()`,
+      );
+      try {
+        await expect(
+          createAgreementKnowledgeService(runtime).createAgreementVersion({
+            agreementKey: `rollback-${boundary}`,
+            title: "Rollback boundary acceptance",
+            originalFilename: "rollback.pdf",
+            mimeType: "application/pdf",
+            bytes: pdf(`private upload rejected by ${boundary} persistence`),
+            uploadedByEntityId: SELF_ENTITY_ID,
+          }),
+        ).rejects.toThrow();
+        expect(await documentRows()).toEqual(docsBefore);
+        expect(fs.readdirSync(media).sort()).toEqual(filesBefore);
+        expect(
+          await new AgreementKnowledgeRepository(
+            runtime,
+            runtime.agentId,
+          ).getArtifactByContent({
+            householdId: DEFAULT_HOUSEHOLD_ID,
+            agreementKey: `rollback-${boundary}`,
+            contentSha256: crypto
+              .createHash("sha256")
+              .update(pdf(`private upload rejected by ${boundary} persistence`))
+              .digest("hex"),
+          }),
+        ).toBeNull();
+      } finally {
+        await executeRawSql(
+          runtime,
+          `DROP TRIGGER reject_ingest_acceptance ON ${table}`,
+        );
+        await executeRawSql(
+          runtime,
+          `DROP FUNCTION app_lifeops.reject_ingest_acceptance()`,
+        );
+      }
+    },
+  );
+
+  it("keeps identical source PDFs in separate agreement families independently readable", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const bytes = pdf("same source, independently owned agreement families");
+    const input = {
+      title: "Shared source",
+      originalFilename: "shared-source.pdf",
+      mimeType: "application/pdf",
+      bytes,
+      uploadedByEntityId: SELF_ENTITY_ID,
+    };
+    const first = await service.createAgreementVersion({
+      ...input,
+      agreementKey: "independent-source-first",
+    });
+    const second = await service.createAgreementVersion({
+      ...input,
+      agreementKey: "independent-source-second",
+    });
+    expect(second.documentId).not.toBe(first.documentId);
+    for (const artifact of [first, second]) {
+      expect(
+        (
+          await service.readOwnerPdf({
+            artifactId: artifact.id,
+            ownerEntityId: SELF_ENTITY_ID,
+          })
+        ).bytes,
+      ).toEqual(bytes);
+      const document = await runtime.getMemoryById(artifact.documentId as UUID);
+      expect(document?.metadata?.mediaFileName).toBe(artifact.mediaFileName);
+    }
+  });
+
+  it("rolls back a concurrent duplicate without removing the winning agreement sources", async () => {
+    const service = createAgreementKnowledgeService(runtime);
+    const media = path.join(mediaStateDir, "media");
+    fs.mkdirSync(media, { recursive: true });
+    const filesBefore = new Set(fs.readdirSync(media));
+    const bytes = pdf("simultaneous immutable agreement upload");
+    const input = {
+      agreementKey: "concurrent-upload-rollback",
+      title: "Concurrent source",
+      originalFilename: "concurrent-source.pdf",
+      mimeType: "application/pdf",
+      bytes,
+      uploadedByEntityId: SELF_ENTITY_ID,
+    };
+    const results = await Promise.allSettled([
+      service.createAgreementVersion(input),
+      service.createAgreementVersion(input),
+    ]);
+    const fulfilled = results.filter((result) => result.status === "fulfilled");
+    expect(fulfilled).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected"),
+    ).toHaveLength(1);
+    const winner = fulfilled[0];
+    if (!winner) throw new Error("No persisted upload winner");
+    const artifact = winner.value;
+    expect(
+      (
+        await service.readOwnerPdf({
+          artifactId: artifact.id,
+          ownerEntityId: SELF_ENTITY_ID,
+        })
+      ).bytes,
+    ).toEqual(bytes);
+    expect(
+      fs.readdirSync(media).filter((file) => !filesBefore.has(file)),
+    ).toEqual([artifact.mediaFileName]);
+    const documents = await executeRawSql(
+      runtime,
+      `SELECT id FROM memories
+      WHERE agent_id = ${sqlQuote(runtime.agentId)} AND type = 'documents'
+      AND metadata->>'agreementKey' = ${sqlQuote(input.agreementKey)}`,
+    );
+    expect(documents.map((row) => row.id)).toEqual([artifact.documentId]);
+    const document = await runtime.getMemoryById(artifact.documentId as UUID);
+    expect(document?.metadata?.mediaFileName).toBe(artifact.mediaFileName);
+  });
+  it.each(["committed", "unreadable"] as const)(
+    "preserves source data when a lost commit acknowledgement is %s",
+    async (observation) => {
+      class LostAcknowledgementRepository extends AgreementKnowledgeRepository {
+        persisted: ParentingAgreementArtifact | null = null;
+        override async insertArtifact(
+          input: Parameters<AgreementKnowledgeRepository["insertArtifact"]>[0],
+        ) {
+          this.persisted = await super.insertArtifact(input);
+          throw new Error("Simulated lost commit acknowledgement");
+        }
+        override async getArtifact(id: string) {
+          if (observation === "unreadable")
+            throw new Error("Commit observation unavailable");
+          return super.getArtifact(id);
+        }
+      }
+      const repository = new LostAcknowledgementRepository(
+        runtime,
+        runtime.agentId,
+      );
+      const graph = resolveKnowledgeGraphService(runtime);
+      if (!graph) throw new Error("Real graph service unavailable");
+      const service = new AgreementKnowledgeService({
+        runtime,
+        agentId: runtime.agentId,
+        household,
+        entityStore: graph.getEntityStore(runtime.agentId),
+        repository,
+        fileStorage: () =>
+          runtime.getService<IFileStorageService>(ServiceType.REMOTE_FILES),
+        documents: () =>
+          runtime.getService<DocumentService>(DocumentService.serviceType),
+        pdf: () => runtime.getService<PdfService>(ServiceType.PDF),
+      });
+      const bytes = pdf(`persisted upload with ${observation} acknowledgement`);
+      await expect(
+        service.createAgreementVersion({
+          agreementKey: `lost-ack-${observation}`,
+          title: "Commit observation",
+          originalFilename: "commit-observation.pdf",
+          mimeType: "application/pdf",
+          bytes,
+          uploadedByEntityId: SELF_ENTITY_ID,
+        }),
+      ).rejects.toMatchObject({
+        code: "AGREEMENT_INGESTION_RECONCILIATION_REQUIRED",
+      });
+      const persisted = repository.persisted;
+      if (!persisted)
+        throw new Error("The fault must occur after a real commit");
+      const restored = createAgreementKnowledgeService(runtime);
+      expect(
+        (
+          await restored.readOwnerPdf({
+            artifactId: persisted.id,
+            ownerEntityId: SELF_ENTITY_ID,
+          })
+        ).bytes,
+      ).toEqual(bytes);
+      expect(
+        await runtime.getMemoryById(persisted.documentId as UUID),
+      ).not.toBeNull();
+    },
+  );
+
+  it("reports incomplete cleanup when the document store rejects deletion", async () => {
+    const key = "rollback-delete-outage";
+    const documents = runtime.getService<DocumentService>(
+      DocumentService.serviceType,
+    );
+    if (!documents)
+      throw new Error("Real document service unavailable for teardown");
+    const media = path.join(mediaStateDir, "media");
+    fs.mkdirSync(media, { recursive: true });
+    const before = fs.readdirSync(media).sort();
+    await executeRawSql(
+      runtime,
+      `CREATE FUNCTION app_lifeops.reject_rollback_acceptance()
+      RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'forced lifecycle storage outage'; END; $$`,
+    );
+    await executeRawSql(
+      runtime,
+      `CREATE TRIGGER reject_rollback_artifact BEFORE INSERT
+      ON app_lifeops.life_household_agreement_artifacts FOR EACH ROW EXECUTE FUNCTION app_lifeops.reject_rollback_acceptance()`,
+    );
+    await executeRawSql(
+      runtime,
+      `CREATE TRIGGER reject_rollback_document BEFORE DELETE
+      ON memories FOR EACH ROW WHEN (OLD.type = 'documents') EXECUTE FUNCTION app_lifeops.reject_rollback_acceptance()`,
+    );
+    try {
+      await expect(
+        createAgreementKnowledgeService(runtime).createAgreementVersion({
+          agreementKey: key,
+          title: "Cleanup outage",
+          originalFilename: "cleanup-outage.pdf",
+          mimeType: "application/pdf",
+          bytes: pdf("document cleanup unavailable"),
+          uploadedByEntityId: SELF_ENTITY_ID,
+        }),
+      ).rejects.toMatchObject({ code: "AGREEMENT_INGESTION_CLEANUP_FAILED" });
+      expect(fs.readdirSync(media).sort()).toEqual(before);
+      const rows = await executeRawSql(
+        runtime,
+        `SELECT id FROM memories
+        WHERE agent_id = ${sqlQuote(runtime.agentId)} AND type = 'documents'
+        AND metadata->>'agreementKey' = ${sqlQuote(key)}`,
+      );
+      expect(rows).toHaveLength(1);
+    } finally {
+      await executeRawSql(
+        runtime,
+        "DROP TRIGGER reject_rollback_artifact ON app_lifeops.life_household_agreement_artifacts",
+      );
+      await executeRawSql(
+        runtime,
+        "DROP TRIGGER reject_rollback_document ON memories",
+      );
+      await executeRawSql(
+        runtime,
+        "DROP FUNCTION app_lifeops.reject_rollback_acceptance()",
+      );
+      const rows = await executeRawSql(
+        runtime,
+        `SELECT id FROM memories
+        WHERE agent_id = ${sqlQuote(runtime.agentId)} AND type = 'documents'
+        AND metadata->>'agreementKey' = ${sqlQuote(key)}`,
+      );
+      for (const row of rows)
+        await documents.deleteDocumentWithAccessContext(
+          String(row.id) as UUID,
+          { requesterEntityId: runtime.agentId, role: "OWNER" },
+        );
+    }
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/agreement-knowledge.ts
@@ -223,7 +223,9 @@ type AgreementKnowledgeErrorCode =
   | "AGREEMENT_DUPLICATE_CONTENT"
   | "AGREEMENT_INVALID_CONTRACT"
   | "AGREEMENT_OBLIGATION_CONFLICT"
-  | "AGREEMENT_STORAGE_UNAVAILABLE";
+  | "AGREEMENT_STORAGE_UNAVAILABLE"
+  | "AGREEMENT_INGESTION_RECONCILIATION_REQUIRED"
+  | "AGREEMENT_INGESTION_CLEANUP_FAILED";
 
 export class AgreementKnowledgeError extends ElizaError {
   override readonly name = "AgreementKnowledgeError";
@@ -1151,72 +1153,143 @@ export class AgreementKnowledgeService {
       .digest("hex");
     const artifactId = `hag_${crypto.randomUUID()}`;
     const stored = await fileStorage.storePrivate(bytes, "application/pdf");
-    if (
-      stored.hash !== expectedSha256 ||
-      !stored.fileName.startsWith(`${expectedSha256}.`) ||
-      stored.size !== bytes.byteLength
-    ) {
-      throw new AgreementKnowledgeError(
-        "File storage returned metadata that does not match the agreement bytes",
-        "AGREEMENT_INVALID_CONTRACT",
-        { expectedSha256, storedHash: stored.hash },
-      );
-    }
-    const document = await documents.addDocument({
-      agentId: this.deps.agentId as UUID,
-      worldId: this.deps.agentId as UUID,
-      roomId: this.deps.agentId as UUID,
-      entityId: this.deps.agentId as UUID,
-      clientDocumentId: "" as UUID,
-      contentType: "text/plain",
-      originalFilename: `${stored.hash}.txt`,
-      content: [
-        `Parenting agreement: ${title}`,
-        `Source PDF: ${originalFilename}`,
-        `Content SHA-256: ${stored.hash}`,
-        `Pages: ${pageCount}`,
-        "",
-        extracted.text,
-        "",
-        "Agreement obligations are inactive until the owner approves their page-cited review records.",
-      ].join("\n"),
-      scope: "owner-private",
-      addedBy: this.deps.agentId as UUID,
-      addedByRole: "RUNTIME",
-      addedFrom: "lifeops",
-      pinned: false,
-      metadata: {
-        source: "lifeops.parenting-agreement",
+    let documentId: UUID | null = null;
+    try {
+      if (
+        stored.hash !== expectedSha256 ||
+        !stored.fileName.startsWith(`${expectedSha256}.`) ||
+        stored.size !== bytes.byteLength
+      ) {
+        throw new AgreementKnowledgeError(
+          "File storage returned metadata that does not match the agreement bytes",
+          "AGREEMENT_INVALID_CONTRACT",
+          { expectedSha256, storedHash: stored.hash },
+        );
+      }
+      const document = await documents.addDocument({
+        agentId: this.deps.agentId as UUID,
+        worldId: this.deps.agentId as UUID,
+        roomId: this.deps.agentId as UUID,
+        entityId: this.deps.agentId as UUID,
+        clientDocumentId: "" as UUID,
+        contentType: "text/plain",
+        // Each immutable artifact owns its document lifecycle, even when the
+        // same PDF is uploaded concurrently or into another agreement family.
+        originalFilename: `${stored.hash}.${artifactId}.txt`,
+        content: [
+          `Parenting agreement: ${title}`,
+          `Source PDF: ${originalFilename}`,
+          `Content SHA-256: ${stored.hash}`,
+          `Pages: ${pageCount}`,
+          "",
+          extracted.text,
+          "",
+          "Agreement obligations are inactive until the owner approves their page-cited review records.",
+        ].join("\n"),
+        scope: "owner-private",
+        addedBy: this.deps.agentId as UUID,
+        addedByRole: "RUNTIME",
+        addedFrom: "lifeops",
+        pinned: false,
+        metadata: {
+          source: "lifeops.parenting-agreement",
+          title,
+          originalFilename,
+          contentType: "application/pdf",
+          mediaUrl: `/api/lifeops/agreements/${artifactId}/download`,
+          mediaHash: stored.hash,
+          mediaFileName: stored.fileName,
+          agreementKey,
+          householdId,
+          agreementExtractionJson: extractionJson,
+        },
+      });
+      documentId = document.storedDocumentMemoryId;
+      return await this.deps.repository.insertArtifact({
+        id: artifactId,
+        agentId: this.deps.agentId,
+        householdId,
+        agreementKey,
+        supersedesArtifactId: null,
         title,
         originalFilename,
-        contentType: "application/pdf",
+        documentId: document.storedDocumentMemoryId,
         mediaUrl: `/api/lifeops/agreements/${artifactId}/download`,
-        mediaHash: stored.hash,
         mediaFileName: stored.fileName,
-        agreementKey,
-        householdId,
-        agreementExtractionJson: extractionJson,
-      },
-    });
-    return await this.deps.repository.insertArtifact({
-      id: artifactId,
-      agentId: this.deps.agentId,
-      householdId,
-      agreementKey,
-      supersedesArtifactId: null,
-      title,
-      originalFilename,
-      documentId: document.storedDocumentMemoryId,
-      mediaUrl: `/api/lifeops/agreements/${artifactId}/download`,
-      mediaFileName: stored.fileName,
-      contentSha256: stored.hash,
-      mimeType: stored.mimeType,
-      byteSize: stored.size,
-      pageCount,
-      uploadedByEntityId: input.uploadedByEntityId,
-      extractionSha256,
-      createdAt: this.now().toISOString(),
-    });
+        contentSha256: stored.hash,
+        mimeType: stored.mimeType,
+        byteSize: stored.size,
+        pageCount,
+        uploadedByEntityId: input.uploadedByEntityId,
+        extractionSha256,
+        createdAt: this.now().toISOString(),
+      });
+    } catch (error) {
+      // error-policy:J2 Roll back only this attempt; preserve committed or uncertain sources.
+      if (documentId) {
+        let persisted: ParentingAgreementArtifact | null;
+        try {
+          persisted = await this.deps.repository.getArtifact(artifactId);
+        } catch (reconciliationError) {
+          // error-policy:J2 A failed commit observation cannot authorize source deletion.
+          const failure = new AgreementKnowledgeError(
+            "Upload persistence could not be reconciled. Inspect the artifact before retrying or deleting its sources.",
+            "AGREEMENT_INGESTION_RECONCILIATION_REQUIRED",
+            { artifactId, documentId, mediaFileName: stored.fileName },
+            new AggregateError([error, reconciliationError]),
+          );
+          this.deps.runtime.reportError(
+            "AgreementKnowledge.ingestion",
+            failure,
+          );
+          throw failure;
+        }
+        if (persisted) {
+          const failure = new AgreementKnowledgeError(
+            "The agreement was persisted but the upload did not finish normally. Review the existing version before retrying.",
+            "AGREEMENT_INGESTION_RECONCILIATION_REQUIRED",
+            { artifactId, documentId, mediaFileName: stored.fileName },
+            error,
+          );
+          this.deps.runtime.reportError(
+            "AgreementKnowledge.ingestion",
+            failure,
+          );
+          throw failure;
+        }
+      }
+      const cleanup = await Promise.allSettled([
+        ...(documentId
+          ? [
+              documents.deleteDocumentWithAccessContext(documentId, {
+                // requireOwner already verified SELF; documents use the runtime UUID.
+                requesterEntityId: this.deps.agentId as UUID,
+                role: "OWNER",
+                isOwner: true,
+              }),
+            ]
+          : []),
+        fileStorage.deletePrivate(stored.fileName),
+      ]);
+      const failures = cleanup.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (failures.length > 0) {
+        const failure = new AgreementKnowledgeError(
+          "The upload failed and its private-source cleanup is incomplete. Resolve the reported storage failures before retrying.",
+          "AGREEMENT_INGESTION_CLEANUP_FAILED",
+          { artifactId, documentId, mediaFileName: stored.fileName },
+          new AggregateError([
+            error,
+            ...failures.map((result) => result.reason),
+          ]),
+        );
+        this.deps.runtime.reportError("AgreementKnowledge.ingestion", failure);
+        throw failure;
+      }
+      throw error;
+    }
   }
 
   async readOwnerPdf(input: {

--- a/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.ts
+++ b/plugins/plugin-personal-assistant/src/routes/agreement-knowledge-routes.ts
@@ -81,6 +81,8 @@ function statusFor(error: AgreementKnowledgeError): number {
     case "AGREEMENT_OBLIGATION_CONFLICT":
     case "AGREEMENT_DUPLICATE_CONTENT":
       return 409;
+    case "AGREEMENT_INGESTION_RECONCILIATION_REQUIRED":
+    case "AGREEMENT_INGESTION_CLEANUP_FAILED":
     case "AGREEMENT_STORAGE_UNAVAILABLE":
       return 503;
     default:


### PR DESCRIPTION
Agreement uploads could fail while leaving their private PDF and searchable document behind. Artifact persistence happened after both sources were created, and identical PDFs in separate agreement families could also reuse one document identity.

Each immutable artifact now owns its document ingestion identity. Rejected uploads remove only that attempt's document, derived fragments, and private PDF through the canonical services. Commit reconciliation preserves sources when persistence succeeded or cannot be observed; cleanup outages return an explicit storage error instead of hiding incomplete deletion.

Refs #31180. This repairs failed-ingestion lifecycle handling; it does not complete workspace deletion or choose a backup-retention policy.

Validation:

- Real PGlite and canonical private file storage: 24 integration cases passed, including persistence rejection, concurrent duplicate cleanup, independently readable identical PDFs, lost commit acknowledgements, and a real database deletion outage. PDF extraction remains a deterministic fixture.
- Package lint passed across 1,823 files.
- Full package suite: 303 files, 2,660 tests passed; 6 existing skips. Post-build package typecheck passed. Root verification passed all 373 tasks and repository audits.
- Screenshots, video, and live-model trajectories: N/A; this changes storage rollback and failure responses without changing UI or model behavior.

Deployment: not deployed.

<!-- evidence-head:849a3c8b1636fc167f79006dabf11f64ff771a24 -->

<!-- evidence-row:before-screenshots -->
Before screenshots: N/A - no rendered UI changes.

<!-- evidence-row:after-screenshots -->
After screenshots: N/A - no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
Walkthrough video: N/A - storage rollback has no visual interaction change.

<!-- evidence-row:backend-logs -->
Backend logs: [Reviewed storage evidence bundle](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-bettina-agreement-rollback-849a3c8-evidence.zip) includes the before failure and verification summaries from the real PGlite runtime; raw logs containing ephemeral fixture credentials are excluded.

<details><summary>Completed runtime validation transcript</summary>

```text
Real PGlite + canonical private media, source 849a3c8b1636fc167f79006dabf11f64ff771a24:
Test Files  1 passed (1)
Tests       24 passed (24)
Duration    11.98s
Full personal-assistant package: 303 test files passed; 2660 tests passed; 6 skipped.
Root verification: 373 successful tasks, 373 total; 5m18.458s; repository audits passed.
Post-build package typecheck exited 0; package lint checked 1823 files with no fixes.
```
</details>

<!-- evidence-row:frontend-logs -->
Frontend logs: N/A - no frontend execution path changed.

<!-- evidence-row:llm-trajectory -->
Real-LLM trajectory: N/A - no model, prompt, provider or action behavior changed.

<!-- evidence-row:domain-artifacts -->
Domain artifacts: [Direct storage observations](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-bettina-agreement-rollback-849a3c8-storage.json). [Observed database rows and private-file inventories](https://github.com/elizaOS/eliza/releases/download/pr-evidence-12/31180-bettina-agreement-rollback-849a3c8-evidence.zip) cover three rejected-write boundaries, the surviving concurrent upload, committed-source preservation and a deletion outage. The seven JSON receipts and source producer were inspected. Bundle SHA-256: `92d42d56e424fcc30ba622f0efa090f29d06874b7af280fa0a08ab3f28c9221d`.

<details><summary>Inspected storage results</summary>

```text
rejected-artifact.json: before and after document/fragment IDs are identical; private filenames are identical; no artifact row remains.
rejected-document.json: before and after document/fragment IDs are identical; private filenames are identical; no artifact row remains.
rejected-fragment.json: before and after document/fragment IDs are identical; private filenames are identical; no artifact row remains.
concurrent-duplicate.json: one fulfilled and one rejected upload; exactly one new PDF and document remain; original PDF SHA matches the persisted artifact.
lost-ack-committed.json and lost-ack-unreadable.json: committed document exists and PDF read SHA matches the artifact after each injected acknowledgement failure.
cleanup-outage.json: the deliberately rejected document deletion leaves one reported document; the private PDF is removed. Fixture teardown removes the document after dropping the fault trigger.
Public bundle download: identical to local ZIP; CRC and all 11 member SHA-256 entries passed.
```
</details>
